### PR TITLE
38 add an example for recording and playback of a simulation

### DIFF
--- a/examples/view_recording.py
+++ b/examples/view_recording.py
@@ -1,0 +1,71 @@
+"""Simulate a random policy with a map defined in SVG format and view the recording."""
+import os
+from pathlib import Path
+
+import numpy as np
+from loguru import logger
+
+from robot_sf.nav.svg_map_parser import SvgMapConverter
+from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
+from robot_sf.gym_env.env_config import SimulationSettings, EnvSettings
+from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.sensor.sensor_fusion import OBS_RAYS, OBS_DRIVE_STATE
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+from robot_sf.render.playback_recording import load_states_and_visualize
+
+
+
+
+logger.info("Simulate a random policy with a map defined in SVG format.")
+
+def test_simulation(map_definition: MapDefinition):
+    """Test the simulation with a random policy."""
+
+    logger.info("Creating the environment.")
+    env_config = EnvSettings(
+        map_pool=MapDefinitionPool(map_defs={"my_map": map_definition})
+        )
+    env = RobotEnv(env_config, debug=True, recording_enabled=True)  # Activate recording
+
+    env.reset()
+
+    logger.info("Simulating the random policy.")
+    for _ in range(1000):
+        action = env.action_space.sample()
+        env.step(action)
+        env.render()
+
+    env.reset()  # Save the recording
+    env.exit()
+
+def convert_map(svg_file: str):
+    """Create MapDefinition from svg file."""
+
+    logger.info("Converting SVG map to MapDefinition object.")
+    logger.info(f"SVG file: {svg_file}")
+
+    converter = SvgMapConverter(svg_file)
+    return converter.map_definition
+
+def get_file():
+    """Get the latest recorded file."""
+
+    filename = max(
+        os.listdir('recordings'), key=lambda x: os.path.getctime(os.path.join('recordings', x)))
+    return Path('recordings', filename)
+
+
+
+def main():
+    """Simulate a random policy with a map defined in SVG format and view the recording."""
+
+    # Create example recording
+    map_def = convert_map("maps/svg_maps/02_simple_maps.svg")
+    test_simulation(map_def)
+
+    # Load the states from the file and view the recording
+    load_states_and_visualize(get_file())
+
+
+if __name__ == "__main__":
+    main()

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -63,6 +63,7 @@ class RobotEnv(Env):
             a dictionary as input and returns a float as reward.
         - debug (bool): If True, enables debugging information such as 
             visualizations.
+        - recording_enabled (bool): If True, enables recording of the simulation
         """
 
         # Environment configuration details

--- a/robot_sf/render/playback_recording.py
+++ b/robot_sf/render/playback_recording.py
@@ -37,9 +37,12 @@ def visualize_states(
     use the SimulationView to render a list of states
     on the recorded map defintion
     """
-    sim_view = SimulationView(map_def=map_def)
+    sim_view = SimulationView(map_def=map_def, caption='RobotSF Recording')
+    sim_view.show() # to activate key_events
     for state in states:
         sim_view.render(state)
+
+    sim_view.exit() # to automatically close the window
 
 def load_states_and_visualize(filename: str):
     """

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -93,7 +93,6 @@ class SimulationView:
             (self.width, self.height), pygame.RESIZABLE)
         pygame.display.set_caption(self.caption)
         self.font = pygame.font.SysFont('Consolas', 14)
-        self.surface_obstacles = self.preprocess_obstacles()
         self.clear()
 
     def _scale_tuple(self, tup: Tuple[float, float]) -> Tuple[float, float]:
@@ -101,39 +100,6 @@ class SimulationView:
         x = tup[0] * self.scaling + self.offset[0]
         y = tup[1] * self.scaling + self.offset[1]
         return (x, y)
-
-    def preprocess_obstacles(self) -> pygame.Surface:
-        # Scale the vertices of the obstacles
-        obst_vertices = [o.vertices_np * self.scaling for o in self.map_def.obstacles]
-
-        # Initialize the minimum and maximum x and y coordinates
-        min_x, max_x, min_y, max_y = np.inf, -np.inf, np.inf, -np.inf
-
-        # Find the minimum and maximum x and y coordinates among all the obstacles
-        for vertices in obst_vertices:
-            min_x = min(np.min(vertices[:, 0]), min_x)
-            max_x = max(np.max(vertices[:, 0]), max_x)
-            min_y = min(np.min(vertices[:, 1]), min_y)
-            max_y = max(np.max(vertices[:, 1]), max_y)
-
-        # Calculate the width and height of the surface needed to draw the obstacles
-        width, height = max_x - min_x, max_y - min_y
-
-        # Create a new surface with the calculated width and height
-        surface = pygame.Surface((width, height), pygame.SRCALPHA)
-
-        # Fill the surface with a transparent background color
-        surface.fill(BACKGROUND_COLOR_TRANSP)
-
-        # Draw each obstacle on the surface
-        for vertices in obst_vertices:
-            # Shift the vertices so that the minimum x and y coordinates are 0
-            shifted_vertices = vertices - [min_x, min_y]
-            # Draw the obstacle as a polygon with the shifted vertices
-            pygame.draw.polygon(surface, OBSTACLE_COLOR, [(x, y) for x, y in shifted_vertices])
-
-        # Return the surface with the drawn obstacles
-        return surface
 
     def show(self):
         """
@@ -231,7 +197,6 @@ class SimulationView:
             self._resize_window()
             self.size_changed = False
         if self.redraw_needed:
-            self.surface_obstacles = self.preprocess_obstacles()
             self.redraw_needed = False
 
         # Adjust the view based on the focus

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -76,6 +76,7 @@ class SimulationView:
     font: pygame.font.Font = field(init=False)
     redraw_needed: bool = field(init=False, default=False)
     offset: np.array = field(init=False, default=np.array([0, 0]))
+    caption: str='RobotSF Simulation'
     """The offset is already uses `scaling` as a factor."""
 
     @property
@@ -88,7 +89,7 @@ class SimulationView:
         pygame.font.init()
         self.screen = pygame.display.set_mode(
             (self.width, self.height), pygame.RESIZABLE)
-        pygame.display.set_caption('RobotSF Simulation')
+        pygame.display.set_caption(self.caption)
         self.font = pygame.font.SysFont('Consolas', 14)
         self.surface_obstacles = self.preprocess_obstacles()
         self.clear()


### PR DESCRIPTION
An example to showcase how to record and view the simulation has been added.

Also the key events for the recording have been activated and the caption of the window changes if the record is viewed.

fixes: #38 #33 

Also the Focus_on_robot key and a help display have been added

fixes: #29 

Furthermore the obsolete preprocess_obstacles function has been removed