### PR TITLE
chore: Update action version in CI workflow to use @main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       # clone the source code containing the package version generation script
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           submodules: true
 
       # make sure python is set up properly
       - name: Install Python (with dependencies)
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@main
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Fixes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use the latest versions of `actions/checkout` and `actions/setup-python`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->