### PR TITLE
Fix demos + QoL change

### DIFF
--- a/examples/demo_defensive.py
+++ b/examples/demo_defensive.py
@@ -50,15 +50,15 @@ def run_simulation():
         ray_state = np.squeeze(ray_state)
         return np.concatenate((ray_state, drive_state), axis=0)
 
-    obs = env.reset()
+    obs, _ = env.reset()
     for _ in range(10000):
         obs = obs_adapter(obs)
         action, _ = model.predict(obs, deterministic=True)
-        obs, _, done, _ = env.step(action)
+        obs, _, done, _, _ = env.step(action)
         env.render()
 
         if done:
-            obs = env.reset()
+            obs, _ = env.reset()
             env.render()
     env.exit()
 

--- a/examples/demo_offensive.py
+++ b/examples/demo_offensive.py
@@ -9,17 +9,17 @@ def training():
     env_config = EnvSettings(
         sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.02]),
         robot_config=BicycleDriveSettings(radius=0.5, max_accel=3.0, allow_backwards=True))
-    env = RobotEnv(env_config, debug=True, recording_enabled=True)
+    env = RobotEnv(env_config, debug=True, recording_enabled=False)
     model = PPO.load("./model/run_043", env=env)
 
-    obs = env.reset()
+    obs, _ = env.reset()
     for _ in range(10000):
         action, _ = model.predict(obs, deterministic=True)
-        obs, _, done, _ = env.step(action)
+        obs, _, done, _, _ = env.step(action)
         env.render()
 
         if done:
-            obs = env.reset()
+            obs, _ = env.reset()
             env.render()
     env.exit()
 

--- a/examples/ego_ped_example.py
+++ b/examples/ego_ped_example.py
@@ -30,7 +30,7 @@ def test_simulation(map_definition: MapDefinition):
 
     env = PedestrianEnv(env_config, robot_model=robot_model, debug=True, recording_enabled=True)
 
-    obs = env.reset()
+    obs, _ = env.reset()
 
     logger.info("Simulating the random policy.")
     for _ in range(10000):
@@ -39,7 +39,7 @@ def test_simulation(map_definition: MapDefinition):
         env.render()
 
         if done:
-            obs = env.reset()
+            obs, _ = env.reset()
             env.render()
 
     env.reset()
@@ -56,7 +56,7 @@ def get_file():
 
 def main():
 
-    map_def = convert_map("maps/svg_maps/debug_03.svg")
+    map_def = convert_map("maps/svg_maps/debug_06.svg")
 
     test_simulation(map_def)
 

--- a/examples/simulate_with_svg_map.py
+++ b/examples/simulate_with_svg_map.py
@@ -40,16 +40,16 @@ def test_simulation(map_definition: MapDefinition):
         ray_state = np.squeeze(ray_state)
         return np.concatenate((ray_state, drive_state), axis=0)
 
-    obs = env.reset()
+    obs, _ = env.reset()
     logger.info("Simulating the random policy.")
     for _ in range(10000):
         obs = obs_adapter(obs)
         action = env.action_space.sample()
-        obs, _, done, _ = env.step(action)
+        obs, _, done, _, _ = env.step(action)
         env.render()
 
         if done:
-            obs = env.reset()
+            obs, _ = env.reset()
             env.render()
     env.exit()
 
@@ -58,9 +58,7 @@ def main():
     """Simulate a random policy with a map defined in SVG format."""
     logger.info("Simulating a random policy with the map.")
 
-    # svg_file = "maps/svg_maps/02_simple_maps.svg"
-    # svg_file = "maps/svg_maps/03_mid_object.svg"
-    svg_file = "maps/svg_maps/04_small_mid_object.svg"
+    svg_file = "maps/svg_maps/debug_06.svg"
 
     logger.info("Converting SVG map to MapDefinition object.")
     logger.info(f"SVG file: {svg_file}")

--- a/examples/view_recording.py
+++ b/examples/view_recording.py
@@ -2,15 +2,12 @@
 import os
 from pathlib import Path
 
-import numpy as np
 from loguru import logger
 
 from robot_sf.nav.svg_map_parser import SvgMapConverter
 from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
-from robot_sf.gym_env.env_config import SimulationSettings, EnvSettings
+from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv
-from robot_sf.sensor.sensor_fusion import OBS_RAYS, OBS_DRIVE_STATE
-from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.render.playback_recording import load_states_and_visualize
 
 

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -205,6 +205,9 @@ class PedestrianEnv(Env):
         - obs: The initial observation after resetting the environment.
         """
         super().reset(seed=seed, options=options)
+        # Reset last actions
+        self.last_action_robot = None
+        self.last_action_ped = None
         # Reset internal simulator state
         self.simulator.reset_state()
         # Reset the environment's state and return the initial observation


### PR DESCRIPTION
Fixed multiple Demos in example directory,  + sim_view changes for only viewing the robot.

Deleted draw_timestep, because timestep is included in the info text.

Added toggle feature (press q) for the info_display: no_info -> robot_info -> pedestrian_info -> no_info -> ... 

Fixes: #67 and #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced environment reset functionality for both `RobotEnv` and `PedestrianEnv` to ensure a clean state at the start of each episode.
	- Improved rendering options in `SimulationView`, allowing for multiple states of robot information display.
	- Updated example scripts to handle new observation structures and improved simulation configurations.

- **Bug Fixes**
	- Adjusted handling of returned values in `env.reset()` and `env.step(action)` methods for consistency.

- **Refactor**
	- Renamed attributes for clarity and updated method signatures for better type handling in simulation classes.
	- Streamlined import statements in example scripts for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->