### PR TITLE
Read video fps from env config

### DIFF
--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -56,7 +56,7 @@ class RobotEnv(Env):
         recording_enabled: bool = False,
         record_video: bool = False,
         video_path: str = None,
-        video_fps: int = 10,  # TODO: Read from env settings
+        video_fps: float = None,
         peds_have_obstacle_forces: bool = False,
     ):
         """
@@ -75,6 +75,11 @@ class RobotEnv(Env):
 
         # Environment configuration details
         self.env_config = env_config
+
+        # Set video FPS if not provided
+        if video_fps is None:
+            video_fps = 1/self.env_config.sim_config.time_per_step_in_secs
+            logger.info(f"Video FPS not provided, setting to {video_fps}")
 
         # Extract first map definition; currently only supports using the first map
         self.map_def = env_config.map_pool.choose_random_map()

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -96,7 +96,7 @@ class SimulationView:
     focus_on_ego_ped: bool = False
     record_video: bool = False
     video_path: str = None
-    video_fps: int = 10
+    video_fps: float = 10.0
     frames: List[np.ndarray] = field(default_factory=list)
 
     # Add UI state fields

--- a/tests/test_video_recording.py
+++ b/tests/test_video_recording.py
@@ -39,8 +39,7 @@ def test_video_recording(
         debug=True,
         recording_enabled=True,
         record_video=True,
-        video_path=str(video_path),
-        video_fps=int(1 / env_config.sim_config.time_per_step_in_secs),
+        video_path=str(video_path)
     )
 
     try:


### PR DESCRIPTION
Update the video_fps parameter to accept a float and set a default value based on the simulation configuration. This change addresses the issue of reading video FPS from environment settings.

Fixes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced video frame rate precision with `video_fps` now supporting float values.
  - New UI features to toggle the display of robot information and help text.

- **Bug Fixes**
  - Improved logging for simulation view initialization and frame recording limits.

- **Documentation**
  - Updated logging statements to provide clearer insights into the system's behavior.

- **Tests**
  - Adjusted test cases to align with the updated `video_fps` parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->