### PR TITLE
Refactor PedestrianEnv and enable robot focus in SimulationView

### DIFF
--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -324,7 +324,6 @@ class PedestrianEnv(Env):
         # only save if there are recorded states
         if len(self.recorded_states) == 0:
             logger.warning("No states recorded, skipping save")
-            # TODO: First env.reset will always have no recorded states
             return
 
         os.makedirs(os.path.dirname(filename), exist_ok=True)

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -92,7 +92,7 @@ class SimulationView:
     map_def: MapDefinition = field(default_factory=MapDefinition)
     obstacles: List[Obstacle] = field(default_factory=list)
     caption: str = "RobotSF Simulation"
-    focus_on_robot: bool = False
+    focus_on_robot: bool = True
     focus_on_ego_ped: bool = False
     record_video: bool = False
     video_path: str = None


### PR DESCRIPTION
Remove an outdated TODO comment in the PedestrianEnv class and set the default focus on the robot in the SimulationView.

Fixes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added an `exit` method for improved control over simulation UI cleanup.
  - Introduced new attributes in the simulation view to manage robot information and help text display.

- **Enhancements**
  - Default view now focuses on the robot when the simulation starts.
  - Updated error handling for recording states to provide better user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->