### PR TITLE
Refactor: remove simulation UI display calls from environment classes

### DIFF
--- a/robot_sf/gym_env/empty_robot_env.py
+++ b/robot_sf/gym_env/empty_robot_env.py
@@ -96,9 +96,6 @@ class EmptyRobotEnv(Env):
                 goal_radius=env_config.sim_config.goal_radius,
             )
 
-            # Display the simulation UI
-            self.sim_ui.show()
-
     def step(self, action):
         """
         Execute one time step within the environment.

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -147,9 +147,6 @@ class PedestrianEnv(Env):
                 goal_radius=env_config.sim_config.goal_radius,
             )
 
-            # Display the simulation UI
-            self.sim_ui.show()
-
     def step(self, action):
         """
         Execute one time step within the environment.

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -136,10 +136,6 @@ class RobotEnv(Env):
                 video_fps=video_fps,
             )
 
-            # Only show window if in debug mode
-            if debug:
-                self.sim_ui.show()
-
     def step(self, action):
         """
         Execute one time step within the environment.

--- a/robot_sf/render/playback_recording.py
+++ b/robot_sf/render/playback_recording.py
@@ -34,7 +34,6 @@ def visualize_states(states: List[VisualizableSimState], map_def: MapDefinition)
     on the recorded map defintion
     """
     sim_view = SimulationView(map_def=map_def, caption="RobotSF Recording")
-    sim_view.show()  # to activate key_events
     for state in states:
         sim_view.render(state)
 


### PR DESCRIPTION
Remove unnecessary simulation UI display calls from environment classes to streamline the code and improve performance.

Fixes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated `reset` method in `PedestrianEnv` and `RobotEnv` to return additional information alongside the initial observation.
  
- **Changes**
  - Removed automatic display of the simulation UI in `EmptyRobotEnv`, `PedestrianEnv`, and `RobotEnv`, requiring users to invoke rendering explicitly.
  
- **Bug Fixes**
  - Clarified handling of the `truncated` variable in the `PedestrianEnv` class. 

These changes enhance control over the simulation environment and improve the clarity of method outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->