### PR TITLE
Create map where the spawn zones are in an obstacle

### DIFF
--- a/docs/MAP_EDITOR_USAGE.md
+++ b/docs/MAP_EDITOR_USAGE.md
@@ -1,5 +1,9 @@
-
 # robot-sf
+
+**DEPRECATED**
+
+> [!CAUTION]
+> DEPRECATED: This method is no longer supported! Use [svg editor](./SVG_MAP_EDITOR.md) instead.
 
 ## Map Editor
 

--- a/docs/svg_maps.md
+++ b/docs/svg_maps.md
@@ -1,3 +1,0 @@
-
-best unit is `px` (pixels) for SVGs.
-

--- a/maps/svg_maps/README.md
+++ b/maps/svg_maps/README.md
@@ -1,0 +1,3 @@
+# SVG Maps
+
+How do edit SVG maps can be found in the [SVG editor](../../docs/SVG_MAP_EDITOR.md) documentation.

--- a/maps/svg_maps/test_spawn_in_obstacle.svg
+++ b/maps/svg_maps/test_spawn_in_obstacle.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="226.28032"
+   height="200"
+   viewBox="22 4 226.28021 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   sodipodi:docname="test_spawn_in_obstacle.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="8.6114228"
+     inkscape:cx="32.340765"
+     inkscape:cy="129.07275"
+     inkscape:window-width="1512"
+     inkscape:window-height="888"
+     inkscape:window-x="534"
+     inkscape:window-y="1478"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer2" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Obstacles"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.362328;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8"
+       width="6.3858247"
+       height="21.196085"
+       x="86.860977"
+       y="147.32242"
+       ry="0.49187183"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.411815;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3"
+       width="8.0351553"
+       height="21.760977"
+       x="65.240463"
+       y="111.67897"
+       ry="0.50498062"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.262473;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-3"
+       width="15.931643"
+       height="4.4583769"
+       x="62.253448"
+       y="72.562027"
+       ry="0.10346015"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.914661;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-3-8"
+       width="31.02787"
+       height="27.799467"
+       x="55.593891"
+       y="34.562683"
+       ry="0.64510852"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.262473;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-08"
+       width="15.931643"
+       height="4.4583769"
+       x="177.81821"
+       y="70.238884"
+       ry="0.10346015"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.616538;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9"
+       width="15.815518"
+       height="24.780222"
+       x="55.954319"
+       y="139.366"
+       ry="0.57504457"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.231607;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-0"
+       width="3.7385361"
+       height="14.793487"
+       x="163.29935"
+       y="115.67815"
+       ry="0.3432945"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.616538;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-03"
+       width="15.815518"
+       height="24.780222"
+       x="155.63901"
+       y="156.97881"
+       ry="0.57504457"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.616538;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-8"
+       width="15.815518"
+       height="24.780222"
+       x="178.4446"
+       y="138.20702"
+       ry="0.57504457"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.262473;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1"
+       width="15.931643"
+       height="4.4583769"
+       x="176.07762"
+       y="128.65097"
+       ry="0.10346015"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.262473;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-8"
+       width="15.931643"
+       height="4.4583769"
+       x="176.40013"
+       y="112.32315"
+       ry="0.10346015"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.203466;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-0"
+       width="3.1579115"
+       height="13.516113"
+       x="195.48973"
+       y="115.97411"
+       ry="0.31365204"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.616538;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-0"
+       width="15.815518"
+       height="24.780222"
+       x="82.858772"
+       y="119.11481"
+       ry="0.57504457"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.370466;stroke-linejoin:bevel"
+       id="rect1"
+       width="199.62953"
+       height="4.6295338"
+       x="32.185234"
+       y="14.185233"
+       ry="0.48456806"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.437945;stroke-linejoin:bevel"
+       id="rect2"
+       width="4.5620556"
+       height="179.56206"
+       x="32.218971"
+       y="14.218972"
+       ry="0.42304352"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.470731;stroke-linejoin:bevel"
+       id="rect3"
+       width="4.5292687"
+       height="179.52927"
+       x="227.23537"
+       y="14.235366"
+       ry="0.42334527"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.384112;stroke-linejoin:bevel"
+       id="rect4"
+       width="199.61589"
+       height="4.6158881"
+       x="32.192055"
+       y="189.19206"
+       ry="0.51684546"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.22061;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-3-8-8"
+       width="48.562721"
+       height="31.631586"
+       x="107.51626"
+       y="103.11547"
+       ry="0.73403585"
+       inkscape:label="obstacle" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.914661;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect8-3-9-1-3-8-5"
+       width="31.02787"
+       height="27.799467"
+       x="170.30858"
+       y="34.548767"
+       ry="0.64510852"
+       inkscape:label="obstacle" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Robot">
+    <rect
+       style="fill:#ffdf00;fill-opacity:1;stroke:none;stroke-width:0.520881;stroke-linejoin:bevel"
+       id="rect5"
+       width="21.627651"
+       height="21.263462"
+       x="60.294907"
+       y="37.805527"
+       ry="0.70196432"
+       inkscape:label="robot_spawn_zone" />
+    <rect
+       style="fill:#ffdf00;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:bevel"
+       id="rect6"
+       width="20.377197"
+       height="18.198069"
+       x="173.86391"
+       y="38.37925"
+       ry="0.70196432"
+       inkscape:label="robot_spawn_zone" />
+    <rect
+       style="fill:#ff6c00;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:bevel"
+       id="rect7"
+       width="35.827557"
+       height="20.101845"
+       x="109.25112"
+       y="157.40776"
+       ry="0.70196432"
+       inkscape:label="robot_goal_zone" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#0300d5;stroke-width:0.252183;stroke-linejoin:bevel;stroke-opacity:1"
+       d="M 186.73485,57.933537 186.05179,170.77506 146.39598,170.84983"
+       id="path7"
+       inkscape:label="robot_route_1_0" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#0078d5;stroke-width:0.28412;stroke-linejoin:bevel;stroke-opacity:1"
+       d="M 69.536994,62.532824 68.914684,71.522867 69.00334,83.594482 68.730256,92.321242 68.764316,104.26407 68.860491,120.04559 68.653811,129.71686 68.013134,142.70214 68.04129,155.53326 V 163.89873 L 83.551508,164.51627 83.939991,151.58654 97.864588,151.90315 97.660533,164.8142 107.21094,165.41467"
+       id="path8"
+       inkscape:label="robot_route_0_0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Pedestrian">
+    <rect
+       style="fill:#23ff00;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect9"
+       width="39.646561"
+       height="21.503529"
+       x="112.09963"
+       y="109.32568"
+       ry="0.70196432"
+       inkscape:label="ped_spawn_zone" />
+    <rect
+       style="fill:#107400;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect11"
+       width="12.703018"
+       height="18.008301"
+       x="43.447605"
+       y="113.94087"
+       ry="0.70196432"
+       inkscape:label="ped_goal_zone" />
+    <rect
+       style="fill:#107400;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:bevel;stroke-opacity:1"
+       id="rect10"
+       width="13.423531"
+       height="18.390186"
+       x="209.29146"
+       y="117.43608"
+       ry="0.70196432"
+       inkscape:label="ped_goal_zone" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#c40202;stroke-width:0.407515;stroke-linejoin:bevel;stroke-opacity:1"
+       d="M 107.71947,117.47589 56.915775,120.90339"
+       id="path11"
+       inkscape:label="ped_route_0_0" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#c40202;stroke-width:0.382495;stroke-linejoin:bevel;stroke-opacity:1"
+       d="M 154.76357,123.37183 206.1968,124.3307"
+       id="path12"
+       inkscape:label="ped_route_0_1" />
+  </g>
+</svg>

--- a/test_pygame/test_spawn_in_obstacle.py
+++ b/test_pygame/test_spawn_in_obstacle.py
@@ -1,0 +1,30 @@
+"""
+Test what happens if pedestrian and robot spwan in an obstacle.
+"""
+
+from robot_sf.gym_env.robot_env_with_pedestrian_obstacle_forces import (
+    RobotEnvWithPedestrianObstacleForces,
+)
+from robot_sf.nav.svg_map_parser import convert_map
+from loguru import logger
+
+def test_spawn_in_obstacle():
+    logger.info("Testing Spawn in Obstacle")
+    map_def = convert_map("maps/svg_maps/test_spawn_in_obstacle.svg")
+    logger.debug(f"type map_def: {type(map_def)}")
+    env = RobotEnvWithPedestrianObstacleForces(map_def=map_def, debug=True)
+    logger.info("created environment")
+    env.reset()
+    for _ in range(1000):
+        rand_action = env.action_space.sample()
+        _, _, done, _, _ = env.step(rand_action)
+        env.render()
+        if done:
+            env.reset()
+    env.close()
+
+
+if __name__ == "__main__":
+    logger.info("Testing Pedestrian and Obstacle forces")
+    test_spawn_in_obstacle()
+    logger.info("All tests passed")

--- a/test_pygame/test_spawn_in_obstacle.py
+++ b/test_pygame/test_spawn_in_obstacle.py
@@ -1,5 +1,5 @@
 """
-Test what happens if pedestrian and robot spwan in an obstacle.
+Test what happens if pedestrian and robot spawn in an obstacle.
 """
 
 from robot_sf.gym_env.robot_env_with_pedestrian_obstacle_forces import (
@@ -25,6 +25,6 @@ def test_spawn_in_obstacle():
 
 
 if __name__ == "__main__":
-    logger.info("Testing Pedestrian and Obstacle forces")
+    logger.info("Testing Spawn in Obstacle")
     test_spawn_in_obstacle()
     logger.info("All tests passed")


### PR DESCRIPTION
Introduce a new SVG map for testing robot and pedestrian spawn zones in obstacles. Include unit tests to validate the functionality of the new map.

Remove obsolete documentation, mark certain files as deprecated. 

Fixes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated map editing instructions now include a deprecation notice directing users to the recommended SVG editor.
  - Removed outdated guidance on unit measurements for SVG graphics.
  - Introduced a new guide for SVG maps with clear editing instructions referencing the updated documentation.
- **Tests**
  - Added a new test to evaluate the behavior of robots and pedestrians when spawning in obstacles within a simulated environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->