### PR TITLE
Fix docstring typo

### DIFF
--- a/robot_sf/nav/occupancy.py
+++ b/robot_sf/nav/occupancy.py
@@ -278,7 +278,7 @@ class EgoPedContinuousOccupancy(ContinuousOccupancy):
     @property
     def distance_to_robot(self) -> float:
         """
-        Gets the euklidean distance to the robot.
+        Gets the Euclidean distance to the robot.
 
         Returns
         -------


### PR DESCRIPTION
## Summary
- correct Euclidean spelling in `distance_to_robot` property docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_6854182aa760833088511389fec63cf0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the docstring, changing "euklidean" to "Euclidean" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->