### PR TITLE
Fix docstring typo in PedSimulator

### DIFF
--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -248,7 +248,7 @@ def init_simulators(
 @dataclass
 class PedSimulator(Simulator):
     """
-    A pedestrian simulator, whic extends the base simulator.
+    A pedestrian simulator, which extends the base simulator.
 
     Args:
         ego_ped (UnicycleDrivePedestrian): The ego pedestrian in the environment.


### PR DESCRIPTION
## Summary
- fix typo in the `PedSimulator` docstring

## Testing
- `ruff check robot_sf/sim/simulator.py`
- `ruff format robot_sf/sim/simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_685418401d908330b8d19664c0c4e502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typo in the class description for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->