### PR TITLE
164 refactored pedestrian environment not working

### DIFF
--- a/robot_sf/gym_env/abstract_envs.py
+++ b/robot_sf/gym_env/abstract_envs.py
@@ -103,10 +103,10 @@ class SingleAgentEnv(BaseSimulationEnv, ABC):
     """
 
     def __init__(self, config: BaseSimulationConfig, **kwargs):
-        super().__init__(config, **kwargs)
         self.state = None
         self.simulator = None
         self.last_action = None
+        super().__init__(config, **kwargs)
 
     @abstractmethod
     def _setup_simulator(self) -> None:

--- a/robot_sf/gym_env/abstract_envs.py
+++ b/robot_sf/gym_env/abstract_envs.py
@@ -106,6 +106,8 @@ class SingleAgentEnv(BaseSimulationEnv, ABC):
         self.state = None
         self.simulator = None
         self.last_action = None
+        # Call super().__init__() after initializing instance variables
+        # because parent's _setup_environment() may depend on these attributes
         super().__init__(config, **kwargs)
 
     @abstractmethod

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -118,11 +118,6 @@ class EnvironmentFactory:
         if config is None:
             config = PedestrianSimulationConfig()
 
-        if reward_func is None:
-            from robot_sf.gym_env.reward import simple_ped_reward
-
-            reward_func = simple_ped_reward
-
         config.peds_have_obstacle_forces = peds_have_obstacle_forces
 
         from robot_sf.gym_env.pedestrian_env_refactored import RefactoredPedestrianEnv

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -118,12 +118,17 @@ class EnvironmentFactory:
         if config is None:
             config = PedestrianSimulationConfig()
 
+        if reward_func is None:
+            from robot_sf.gym_env.reward import simple_ped_reward
+
+            reward_func = simple_ped_reward
+
         config.peds_have_obstacle_forces = peds_have_obstacle_forces
 
-        from robot_sf.gym_env.pedestrian_env import PedestrianEnv
+        from robot_sf.gym_env.pedestrian_env_refactored import RefactoredPedestrianEnv
 
-        return PedestrianEnv(
-            env_config=config,
+        return RefactoredPedestrianEnv(
+            config=config,
             robot_model=robot_model,
             reward_func=reward_func,
             debug=debug,

--- a/robot_sf/gym_env/pedestrian_env_refactored.py
+++ b/robot_sf/gym_env/pedestrian_env_refactored.py
@@ -70,7 +70,11 @@ class RefactoredPedestrianEnv(SingleAgentEnv):
         self.robot_model = robot_model
 
         # Store reward function
-        self.reward_func = reward_func
+        if reward_func is None:
+            logger.warning("No reward function provided, using default simple_ped_reward.")
+            self.reward_func = simple_ped_reward
+        else:
+            self.reward_func = reward_func
 
         # Update config
         config.peds_have_obstacle_forces = peds_have_obstacle_forces


### PR DESCRIPTION
Fix: demo_pedestrian_updated is now working with the refactored Environment

Moved super call in SingleAgentEnv to bottom -> self.simulator gets initialized properly

Using new  RefactoredPedEnv in the factory function

Initializing basic reward function in environment, because otherwise 'None' gets propagated by the factory function.
I think it could also be initialized in the create_environment:
https://github.com/ll7/robot_sf_ll7/blob/0ccb59fb305b8daae30537e188ad360113008d1c/robot_sf/gym_env/environment_factory.py#L93-L97

like here:
https://github.com/ll7/robot_sf_ll7/blob/0ccb59fb305b8daae30537e188ad360113008d1c/robot_sf/gym_env/pedestrian_env_refactored.py#L47-L47



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The pedestrian environment now provides a warning and defaults to a standard reward function if none is specified.
- **Chores**
  - The pedestrian environment creation now uses an updated, refactored implementation.
- **Refactor**
  - Improved initialization order for environment classes to enhance reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->