### PR TITLE
Add docstring guidelines to core principles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,13 @@ Use this as the single source of truth for this repo. Prefer these rules over ge
 - Keep public behavior backward‑compatible unless explicitly stated.
 - Write comprehensive unit tests for new features and bug fixes (GUI tests in `test_pygame/`).
 
+#### Docstrings
+- Every public module, function, class, and method should have a docstring.
+- Docstrings should use triple double quotes (""").
+- The first line should be a short summary of the object’s purpose, starting with a capital letter and ending with a period.
+- If more detail is needed, leave a blank line after the summary, then continue with a longer description.
+- For functions/methods: document parameters, return values, exceptions raised, and side effects.
+
 ### Always ask clarifying questions (with options)
 - Before implementing, confirm requirements with targeted questions.
 - Prefer multiple‑choice options to speed decisions; group by scope, interfaces, data, UX, performance.


### PR DESCRIPTION
Introduce guidelines for writing docstrings for public modules, functions, classes, and methods to enhance code clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docstring guidelines under Core principles.
  * Requires docstrings for all public modules, classes, functions, and methods.
  * Specifies triple double quotes, a concise first-line summary with proper capitalization and period, and optional extended descriptions.
  * For functions/methods, mandates documenting parameters, return values, exceptions, and side effects.
  * No functional, API, or runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->