### PR TITLE
Add markdown linting to CI and improve documentation quality

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Use this as the single source of truth for this repo. Prefer these rules over ge
 - Security & network policy
 - Large files & artifacts policy
 - Quick reference and TL;DR checklist
+ - Markdown linting (docs quality)
 
 ---
 
@@ -339,6 +340,50 @@ docker compose build && docker compose run robotsf-cuda python ./scripts/trainin
 ### Docker issues
 - Docker build fails → often network related in CI; usually fine locally
 - GPU support → see `docs/GPU_SETUP.md` for NVIDIA Docker setup
+
+---
+
+## Markdown linting (docs quality)
+Documentation consistency matters for fast onboarding and automation. A non-blocking Markdown lint job runs in CI to surface style and structure issues without failing the main pipeline.
+
+### Tooling
+- Config file: `.markdownlint.json` (enforces 110 char soft wrap, fenced code blocks, consistent emphasis, relaxed heading duplication rules, allows inline HTML disabled by default).
+- CLI (local optional): `markdownlint-cli2` (Node-based). Install globally or run via npx.
+
+### Running locally (optional)
+```bash
+npm install -g markdownlint-cli2 # or: npx markdownlint-cli2 "**/*.md" "#fast-pysf/**"
+markdownlint-cli2 "**/*.md" "#fast-pysf/**"
+```
+Exclude the `fast-pysf/` submodule to avoid external churn.
+
+### When to fix warnings
+- P0/P1 feature / refactor PRs touching docs: fix or justify.
+- Drive-by doc edits: fix obvious issues (heading order, code fence style).
+- Bulk rewrites: run locally before commit to reduce noise in CI artifact.
+
+### Adding exceptions
+Prefer targeted fixes over disabling rules. If necessary, add an inline ignore comment:
+```
+<!-- markdownlint-disable-next-line MD013 -->
+```
+Document rationale briefly.
+
+### Quality gate philosophy
+- Lint is informative (non-blocking) until overall doc debt is reduced.
+- We may later gate on zero critical markdown issues; track decision in a design note if changed.
+
+### Common remediation patterns
+- Long lines → break at clause boundaries; leave code blocks untouched.
+- Mixed emphasis markers → standardize on backticks for code, `*` for emphasis.
+- Redundant top-level heading → remove duplicates (project title appears once in README).
+
+### Future improvements (candidates)
+- Add VS Code task: "Markdown: Lint" (npx invocation) for one-click checks.
+- Add pre-commit hook (optional) running markdownlint on staged `.md` files.
+- Integrate link checker (e.g., lychee) in a separate job.
+
+---
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,26 @@ jobs:
 
       - name: Unit tests
         run: uv run pytest -q
+
+  markdown-lint:
+    runs-on: ubuntu-latest
+    name: Markdown Lint (non-blocking)
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint
+        run: |
+          markdownlint-cli2 "**/*.md" "#fast-pysf/**" || true
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: markdownlint-report
+          path: .

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,15 @@
+{
+  "default": true,
+  "MD013": { "line_length": 300, "code_blocks": false, "tables": false },
+  "MD033": false,
+  "MD041": false,
+  "MD046": { "style": "fenced" },
+  "MD007": { "indent": 2 },
+  "MD024": { "siblings_only": true },
+  "MD025": { "front_matter_title": "" },
+  "MD026": { "punctuation": ".,;:!" },
+  "MD029": { "style": "one" },
+  "MD031": { "list_items": false },
+  "no-inline-html": true,
+  "MD049": { "style": "consistent" }
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,15 +1,35 @@
 {
   "default": true,
-  "MD013": { "line_length": 300, "code_blocks": false, "tables": false },
+  "MD013": {
+    "line_length": 300,
+    "code_blocks": false,
+    "tables": false
+  },
   "MD033": false,
   "MD041": false,
-  "MD046": { "style": "fenced" },
-  "MD007": { "indent": 2 },
-  "MD024": { "siblings_only": true },
-  "MD025": { "front_matter_title": "" },
-  "MD026": { "punctuation": ".,;:!" },
-  "MD029": { "style": "one" },
-  "MD031": { "list_items": false },
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD007": {
+    "indent": 2
+  },
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD025": {
+    "front_matter_title": ""
+  },
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
+  "MD029": {
+    "style": "one"
+  },
+  "MD031": {
+    "list_items": false
+  },
   "no-inline-html": true,
-  "MD049": { "style": "consistent" }
+  "MD049": {
+    "style": "consistent"
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,8 +61,7 @@
 			"command": "uvx ty check . --exit-zero",
 			"problemMatcher": [],
 			"group": "test"
-		}
-		,
+		},
 		{
 			"label": "Markdown: Lint",
 			"type": "shell",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -62,5 +62,12 @@
 			"problemMatcher": [],
 			"group": "test"
 		}
+		,
+		{
+			"label": "Markdown: Lint",
+			"type": "shell",
+			"command": "npx --yes markdownlint-cli2 \"**/*.md\" \"#fast-pysf/**\"",
+			"problemMatcher": []
+		}
 	]
 }


### PR DESCRIPTION
Introduce a non-blocking markdown linting job in the CI workflow, establish markdown linting guidelines, and add a configuration file to enhance documentation quality. Additionally, format the configuration for better readability and remove an unnecessary comma in the tasks file.