### PR TITLE
refactor(benchmark): split full-classic episode record orchestration

### DIFF
--- a/.codex/skills/pr-ready-check/SKILL.md
+++ b/.codex/skills/pr-ready-check/SKILL.md
@@ -41,5 +41,5 @@ Run the same PR validation pipeline used by local VS Code tasks, but via reusabl
 
 6. Commit and PR
    - Once all checks pass, commit your changes with a clear message.
-   - Verify the issue addressed is acutally resolved by the changes.
+   - Verify the issue addressed is actually resolved by the changes.
    - Push to your branch and create/update the PR referencing related issues.


### PR DESCRIPTION
## Summary
Refactors full-classic benchmark episode record creation into smaller helpers to reduce complexity and improve maintainability, and updates the PR-ready-check skill guidance to require commit/PR follow-through.

## Linked issues
- #506

## Changes
- Extracted fast-stub record creation into `_make_stub_episode_record`.
- Extracted real episode orchestration into `_orchestrate_real_episode`.
- Extracted replay payload packaging into `_attach_replay_payload`.
- Simplified `_make_episode_record` to orchestrate helper calls and removed the `PLR0915` waiver there.
- Added helper-level separation for scenario validation, metric sanitization, and status derivation.
- Updated `.codex/skills/pr-ready-check/SKILL.md` to explicitly require committing, pushing, and creating/updating PRs after green checks.

## Tests
- `uv run pytest -n auto tests/benchmark_full tests/benchmark/test_orchestrator_metadata.py`
  - Result: `37 passed`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - Ruff fix/format/check: passed
  - Parallel pytest: `1843 passed, 11 skipped`
  - Changed-files coverage gate: passed minimum (`robot_sf/benchmark/full_classic/orchestrator.py` at `85.3%`, goal warning only)
  - Touched-definition docstring TODO gate: passed

## Demo
- N/A (no UI behavior changes)

## Risks / rollout
- Low risk: refactor-only changes intended to preserve existing output/schema behavior.
- Replay and metric packaging paths are now helperized; contract tests were run to guard regressions.

## Docs
- Updated: `.codex/skills/pr-ready-check/SKILL.md`

## Validation
- Local PR-ready pipeline green with full test suite and gates.

## Future Tasks
- None required for this scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions for the final PR workflow step: commit messaging, verify issue resolution, and create/update the PR referencing related issues.

* **Improvements**
  * Orchestration now supports a fast-path stub episode for quicker runs and preserves real-episode behavior.
  * Improved replay capture integration, sanitized metric handling, and explicit episode status determination for more reliable records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->