### PR TITLE
feat(planner): improve global plan visualization resolution (#377)

### DIFF
--- a/robot_sf/planner/classic_global_planner.py
+++ b/robot_sf/planner/classic_global_planner.py
@@ -43,8 +43,8 @@ from robot_sf.planner.theta_star_v2 import HighPerformanceThetaStar
 if TYPE_CHECKING:
     from robot_sf.nav.map_config import MapDefinition
 
-DEFAULT_VISUALIZATION_DPI = 300
-MAX_VISUALIZATION_DPI = 3000
+DEFAULT_VISUALIZATION_DPI: int = 300
+MAX_VISUALIZATION_DPI: int = 3000
 
 
 class ClassicPlanVisualizer(Visualizer):
@@ -279,12 +279,27 @@ def _normalize_output_dpi(output_dpi: int | float) -> int:
 
     Returns:
         Positive integer DPI value.
+
+    Raises:
+        TypeError: If `output_dpi` is not numeric.
+        ValueError: If `output_dpi` is non-finite, out of range, or not an integer value.
     """
-    dpi_value = int(output_dpi)
-    if dpi_value <= 0 or dpi_value > MAX_VISUALIZATION_DPI:
+    try:
+        raw_value = float(output_dpi)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"output_dpi must be numeric, got {output_dpi!r}") from exc
+
+    if not math.isfinite(raw_value):
+        raise ValueError(f"output_dpi must be finite, got {output_dpi}")
+
+    if raw_value <= 0 or raw_value > MAX_VISUALIZATION_DPI:
         raise ValueError(
             f"output_dpi must be in range (0, {MAX_VISUALIZATION_DPI}], got {output_dpi}"
         )
+
+    dpi_value = int(raw_value)
+    if not math.isclose(raw_value, dpi_value):
+        raise ValueError(f"output_dpi must be an integer value, got {output_dpi}")
     return dpi_value
 
 
@@ -993,7 +1008,7 @@ class ClassicGlobalPlanner:
             equal_aspect: Whether to enforce equal aspect ratio.
             output_dpi: Export resolution for saved figures.
         """
-        render_grid(
+        visualize_grid(
             self.grid,
             output_path=output_path,
             title=title,
@@ -1058,7 +1073,7 @@ class ClassicGlobalPlanner:
                 )
 
         path_grid = [self._world_to_grid(x, y) for x, y in path_world]
-        render_path(
+        visualize_path(
             grid,
             path_grid,
             output_path=output_path,
@@ -1072,11 +1087,9 @@ class ClassicGlobalPlanner:
         )
 
 
-render_grid = visualize_grid
-render_path = visualize_path
-
-
 __all__ = [
+    "DEFAULT_VISUALIZATION_DPI",
+    "MAX_VISUALIZATION_DPI",
     "ClassicGlobalPlanner",
     "ClassicPlanVisualizer",
     "ClassicPlannerConfig",

--- a/tests/test_classic_global_planner_unit.py
+++ b/tests/test_classic_global_planner_unit.py
@@ -104,7 +104,7 @@ def test_visualize_path_calls_fill_expands(monkeypatch, tmp_path):
         captured["grid"] = grid
         captured["path"] = path
 
-    monkeypatch.setattr("robot_sf.planner.classic_global_planner.render_path", fake_render_path)
+    monkeypatch.setattr("robot_sf.planner.classic_global_planner.visualize_path", fake_render_path)
 
     path_world = [(0.5, 0.5), (1.5, 0.5)]
     expands = {"node": types.SimpleNamespace()}


### PR DESCRIPTION
## Summary
Improve classic global-plan visualization output quality so large planning grids are inspectable instead of pixelated in saved images.

## Linked issues
- Closes #377

## Changes
- Added high-detail export DPI support to planner visualization helpers in `robot_sf/planner/classic_global_planner.py`.
- Introduced `DEFAULT_VISUALIZATION_DPI = 300` for saved planner figures.
- Added `output_dpi` parameter to:
  - module helpers: `visualize_grid`, `visualize_path`
  - class methods: `ClassicGlobalPlanner.visualize_grid`, `ClassicGlobalPlanner.visualize_path`
- Added `_normalize_output_dpi` validation (reject non-positive DPI values).
- Kept behavior unchanged for interactive display paths.

## Tests
- `uv run ruff check robot_sf/planner/classic_global_planner.py tests/test_motion_planning_adapter.py`
- `uv run pytest -q tests/test_motion_planning_adapter.py tests/test_classic_global_planner_unit.py`
  - Result: `15 passed`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - Result: `1952 passed, 11 skipped`

## Demo
- Repro command:
  - `uv run python examples/advanced/27_motion_planning_adapter_test.py`
- Output images now use higher export DPI by default (`300`) for finer grid detail.

## Risks / rollout
- Low risk: change is scoped to visualization export only.
- Backward compatible API: new `output_dpi` params are optional with defaults.

## Docs
- Inline docstrings updated for new `output_dpi` parameter.

## Validation
- Full repository readiness gate passed on this branch.

## Future Tasks
- If needed, follow up with adaptive figure-size heuristics tied to grid dimensions for extremely large maps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable DPI parameter for saved grid and path visualizations (default 300 DPI).
  * DPI setting is validated and coerced to a positive integer within allowed range.

* **Tests**
  * Added tests to verify DPI is forwarded to saved images and that invalid (non‑positive) DPI values raise an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->