### PR TITLE
fix: backfill policy analysis collision split metrics

### DIFF
--- a/scripts/tools/policy_analysis_run.py
+++ b/scripts/tools/policy_analysis_run.py
@@ -1413,7 +1413,7 @@ def _collect_episode_trajectories(  # noqa: PLR0913
     )
 
 
-def _build_episode_record(  # noqa: PLR0913,PLR0915
+def _build_episode_record(  # noqa: C901,PLR0913,PLR0915
     scenario: Mapping[str, Any],
     *,
     seed: int,
@@ -1494,28 +1494,30 @@ def _build_episode_record(  # noqa: PLR0913,PLR0915
         ped_collision_count = float(metrics.get("ped_collision_count", 0.0) or 0.0)
         obstacle_collision_count = float(metrics.get("obstacle_collision_count", 0.0) or 0.0)
         agent_collision_count = float(metrics.get("agent_collision_count", 0.0) or 0.0)
-        if (
-            ped_collision_count <= 0.0
-            and obstacle_collision_count <= 0.0
-            and agent_collision_count <= 0.0
-        ):
-            inferred_ped_collision = float(bool(meta.get("is_pedestrian_collision")))
-            inferred_obstacle_collision = float(bool(meta.get("is_obstacle_collision")))
-            inferred_agent_collision = float(bool(meta.get("is_robot_collision")))
+        inferred_ped_collision = float(bool(meta.get("is_pedestrian_collision")))
+        inferred_obstacle_collision = float(bool(meta.get("is_obstacle_collision")))
+        inferred_agent_collision = float(bool(meta.get("is_robot_collision")))
+        updated_split = False
+        if ped_collision_count <= 0.0 and inferred_ped_collision > 0.0:
+            metrics["ped_collision_count"] = inferred_ped_collision
+            updated_split = True
+        if obstacle_collision_count <= 0.0 and inferred_obstacle_collision > 0.0:
+            metrics["obstacle_collision_count"] = inferred_obstacle_collision
+            metrics["wall_collisions"] = inferred_obstacle_collision
+            updated_split = True
+        if agent_collision_count <= 0.0 and inferred_agent_collision > 0.0:
+            metrics["agent_collision_count"] = inferred_agent_collision
+            updated_split = True
+        if updated_split:
             inferred_total = (
                 inferred_ped_collision + inferred_obstacle_collision + inferred_agent_collision
             )
-            if inferred_total > 0.0:
-                metrics["ped_collision_count"] = inferred_ped_collision
-                metrics["obstacle_collision_count"] = inferred_obstacle_collision
-                metrics["agent_collision_count"] = inferred_agent_collision
-                metrics["wall_collisions"] = inferred_obstacle_collision
-                metrics["success"] = False
-                if "success_rate" in metrics:
-                    metrics["success_rate"] = 0.0
-                if total_collision <= 0.0:
-                    metrics["collisions"] = inferred_total
-                    metrics["total_collision_count"] = inferred_total
+            metrics["success"] = False
+            if "success_rate" in metrics:
+                metrics["success_rate"] = 0.0
+            if total_collision <= 0.0 and inferred_total > 0.0:
+                metrics["collisions"] = inferred_total
+                metrics["total_collision_count"] = inferred_total
     # Canonical episode collision: event-stream collision OR metric-level collision evidence.
     # This keeps success/outcome semantics aligned with benchmark metrics.
     metric_collisions = float(metrics.get("collisions", 0.0) or 0.0)

--- a/tests/tools/test_policy_analysis_run.py
+++ b/tests/tools/test_policy_analysis_run.py
@@ -579,6 +579,71 @@ def test_build_episode_record_backfills_split_metrics_when_total_collision_is_pr
     assert record["metrics"]["success"] is False
 
 
+def test_build_episode_record_backfills_missing_terminal_split_when_other_splits_exist(
+    monkeypatch,
+) -> None:
+    """Terminal collision subtype should backfill even if another split counter is already present."""
+
+    monkeypatch.setattr(
+        policy_analysis_run,
+        "compute_all_metrics",
+        lambda *args, **kwargs: {
+            "success": 0.0,
+            "collisions": 2.0,
+            "ped_collision_count": 1.0,
+            "obstacle_collision_count": 0.0,
+            "agent_collision_count": 0.0,
+            "wall_collisions": 0.0,
+            "time_to_goal_norm": 1.0,
+        },
+    )
+    monkeypatch.setattr(
+        policy_analysis_run,
+        "post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+    monkeypatch.setattr(policy_analysis_run, "sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(policy_analysis_run, "compute_shortest_path_length", lambda *args: 1.0)
+
+    class _Map:
+        obstacles = []
+        bounds = ((0.0, 0.0), (1.0, 1.0))
+
+    traj = policy_analysis_run.EpisodeTrajectory(
+        robot_positions=[np.array([0.0, 0.0], dtype=float), np.array([1.0, 0.0], dtype=float)],
+        ped_positions=[],
+        ped_forces=[],
+    )
+    record = policy_analysis_run._build_episode_record(
+        {"id": "s1"},
+        seed=15,
+        policy_name="goal",
+        map_def=_Map(),
+        goal_vec=np.array([1.0, 0.0], dtype=float),
+        trajectory=traj,
+        reached_goal_step=None,
+        wall_time=1.0,
+        max_steps=10,
+        dt=0.1,
+        robot_max_speed=1.0,
+        robot_radius=1.0,
+        ped_radius=0.4,
+        ts_start="2026-03-02T00:00:00+00:00",
+        video_path=None,
+        terminated=True,
+        truncated=False,
+        last_info={"meta": {"is_route_complete": False, "is_obstacle_collision": True}},
+        reached_max_steps=False,
+    )
+
+    assert record["termination_reason"] == "collision"
+    assert record["metrics"]["collisions"] == pytest.approx(2.0)
+    assert record["metrics"]["ped_collision_count"] == pytest.approx(1.0)
+    assert record["metrics"]["obstacle_collision_count"] == pytest.approx(1.0)
+    assert record["metrics"]["wall_collisions"] == pytest.approx(1.0)
+    assert record["metrics"]["success"] is False
+
+
 def test_collect_episode_trajectories_snapshots_mutable_simulator_buffers() -> None:
     """Trajectory collection must copy mutable simulator arrays per timestep."""
 


### PR DESCRIPTION
## Summary
- backfill policy-analysis collision split metrics from terminal `last_info.meta` when raw counters are missing
- keep policy-analysis collision subtype summaries aligned with collision terminations
- add a regression test for the missing-metrics collision case

## Why
This is the clean `#615` follow-up after `#617`.
`#617` fixed benchmark-gate collision/max-steps accounting, but `scripts/tools/policy_analysis_run.py` could still underreport collision subtype metrics when terminal records had collision flags in `meta` but zeroed metric counters. This PR fixes that policy-analysis-side gap before the `#580` artifact rerun.

## Validation
- `uv run pytest -q tests/tools/test_policy_analysis_run.py -k 'collision_split_metrics_from_meta or summarize_records or build_episode_record'`
- `uv run ruff check scripts/tools/policy_analysis_run.py tests/tools/test_policy_analysis_run.py`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision accounting: when per-type collision counts are missing or non-positive, the system infers and reconciles pedestrian/obstacle/agent collision splits and aggregate totals, and correctly marks collision termination outcomes.

* **Tests**
  * Added tests validating collision metric backfilling and reconciliation across scenarios with zeroed, partial, or aggregate-only metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->