### PR TITLE
test: add planner sanity benchmark matrix

### DIFF
--- a/configs/benchmarks/planner_sanity_matrix_v1.yaml
+++ b/configs/benchmarks/planner_sanity_matrix_v1.yaml
@@ -1,0 +1,57 @@
+name: planner_sanity_matrix_v1
+paper_facing: false
+scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
+
+workers: 2
+horizon: 100
+stop_on_failure: false
+resume: true
+record_forces: true
+bootstrap_samples: 100
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback

--- a/configs/scenarios/planner_sanity_matrix_v1.yaml
+++ b/configs/scenarios/planner_sanity_matrix_v1.yaml
@@ -1,0 +1,2 @@
+include:
+  - single/planner_sanity_simple.yaml

--- a/configs/scenarios/single/planner_sanity_simple.yaml
+++ b/configs/scenarios/single/planner_sanity_simple.yaml
@@ -1,0 +1,17 @@
+scenarios:
+- name: planner_sanity_simple
+  map_file: ../../../maps/svg_maps/planner_sanity_open.svg
+  simulation_config:
+    max_episode_steps: 300
+    ped_density: 0.0
+  single_pedestrians: []
+  robot_config: {}
+  metadata:
+    archetype: sanity_simple
+    flow: none
+    behavior: none
+    purpose: planner_sanity_check
+  seeds:
+  - 101
+  - 102
+  - 103

--- a/maps/svg_maps/planner_sanity_open.svg
+++ b/maps/svg_maps/planner_sanity_open.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="10"
+   viewBox="0 0 20 10"
+   version="1.1"
+   id="svg_planner_sanity_open"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd">
+  <g id="layer1" inkscape:label="Layer 1">
+    <rect
+       id="wall_left"
+       x="0"
+       y="0"
+       width="0.5"
+       height="10"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_right"
+       x="19.5"
+       y="0"
+       width="0.5"
+       height="10"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_top"
+       x="0"
+       y="0"
+       width="20"
+       height="0.5"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_bottom"
+       x="0"
+       y="9.5"
+       width="20"
+       height="0.5"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+
+    <rect
+       id="spawn_zone"
+       x="1.5"
+       y="4.0"
+       width="2.0"
+       height="2.0"
+       style="fill:#ffdf00;stroke-width:0"
+       inkscape:label="robot_spawn_zone" />
+    <rect
+       id="goal_zone"
+       x="16.5"
+       y="4.0"
+       width="2.0"
+       height="2.0"
+       style="fill:#ff6c00;stroke-width:0"
+       inkscape:label="robot_goal_zone" />
+
+    <path
+       id="robot_route"
+       d="M 2.5,5.0 17.5,5.0"
+       style="fill:none;stroke:#0310b4;stroke-width:0.2;stroke-opacity:0.5"
+       inkscape:label="robot_route_0_0" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a trivial open-space planner sanity SVG and single-scenario config
- add a tiny camera-ready benchmark matrix that runs all current planners on that scenario
- provide a benchmark surface to distinguish "planner cannot solve anything" from "planner fails on the paper matrix"

## Why
Three planners currently show zero success on the paper matrix. That is suspicious, but it does not tell us whether they are fundamentally broken or just outside the useful operating regime of the benchmark scenarios. This PR adds a minimal sanity benchmark to answer that question quickly.

## Validation
- `uv run python scripts/validation/svg_inspect.py maps/svg_maps/planner_sanity_open.svg --show-routes`
- `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/planner_sanity_matrix_v1.yaml --label planner_sanity_open_space --log-level INFO`
- `uv run python scripts/tools/analyze_camera_ready_campaign.py --campaign-root output/benchmarks/camera_ready/planner_sanity_matrix_v1_planner_sanity_open_space_20260318_151135`

## Result
On the trivial open-space sanity scenario:
- `orca`, `ppo`, `prediction_planner`, and `socnav_sampling` each reached `1.0` success over 3/3 seeds
- `goal`, `social_force`, and `sacadrl` remained at `0.0` success and timed out at `max_steps`

That means the paper-matrix zero-success results are not a universal benchmark artifact. We now have a compact regression surface for debugging the remaining three planners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new planner sanity matrix benchmark configuration supporting multiple planning algorithms across core and experimental groups with flexible configuration options.
  * Added a new scenario configuration for planner sanity check validation with adjustable simulation parameters, episode steps, and random seeds for reproducible testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->