### PR TITLE
docs: refresh Alyassi planner family coverage matrix

### DIFF
--- a/docs/ai/planner_zoo_context.md
+++ b/docs/ai/planner_zoo_context.md
@@ -23,22 +23,22 @@ Implemented and benchmarkable families today:
 - `goal`
 - `social_force`
 - `orca`
+- `ppo` when provenance and quality-gate requirements are satisfied
 
 Implemented but experimental families today:
 
-- `ppo`
-
-Conceptually adjacent only or testing-only entries:
-
 - `guarded_ppo`
 - `prediction_planner`
-- `predictive_mppi`
-- `risk_dwa`
-- `mppi_social`
-- `hybrid_portfolio`
-- `stream_gap`
-- `gap_prediction`
-- legacy/model-sensitive adapters such as `sacadrl`, `socnav_sampling`, `socnav_bench`
+- testing-only planners such as `predictive_mppi`, `risk_dwa`, `mppi_social`,
+  `hybrid_portfolio`, `stream_gap`, and `gap_prediction`
+- legacy/model-sensitive adapters such as `sacadrl` and `socnav_sampling`
+
+Conceptually adjacent only entries:
+
+- `socnav_bench`
+- DreamerV3 challenger-family training support without a frozen planner row
+- external-family anchors documented for benchmark interpretation only: CrowdNav / SoNIC, Go-MPC,
+  Pred2Nav, and gym-collision-avoidance / CADRL
 
 ## What Makes A Planner Integration Credible
 

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -7,6 +7,7 @@ Canonical benchmark fallback policy:
 
 - [Issue #691 Benchmark Fallback Policy](./context/issue_691_benchmark_fallback_policy.md)
 - [Experimental Planner Guardrails](./benchmark_experimental_planners.md)
+- [Planner-Family Coverage Matrix](./benchmark_planner_family_coverage.md)
 
 ## Entry Point
 

--- a/docs/benchmark_planner_family_coverage.md
+++ b/docs/benchmark_planner_family_coverage.md
@@ -1,8 +1,8 @@
 # Benchmark Planner-Family Coverage Matrix
 
-This document maps the current `robot_sf_ll7` planner/config stack to Alyassi-style planner families
-for benchmark-facing use. It is intended to prevent manuscript-side repos from overclaiming support
-that is only partial, experimental, or still roadmap-only.
+This document maps the current `robot_sf_ll7` planner/config stack to Alyassi-style planner
+families for benchmark-facing use. It is intended to prevent manuscript-side repos from overclaiming
+support that is only partial, experimental, or still roadmap-only.
 
 Use this matrix conservatively:
 
@@ -10,37 +10,61 @@ Use this matrix conservatively:
   benchmark support.
 - Treat `implemented but experimental` rows as available for controlled benchmark experiments, but
   not baseline-ready by default.
-- Treat `conceptually adjacent only` rows as partial proxies or preparatory infrastructure, not as
-  evidence that the corresponding literature family is fully covered.
+- Treat `conceptually adjacent only` rows as partial proxies, external anchors, or preparatory
+  infrastructure, not as evidence that the corresponding literature family is fully covered.
 - Treat `missing` rows as roadmap items only.
 
 The matrix is benchmark-facing. It reflects current entrypoints, config surfaces, readiness guards,
 and kinematics/adapters in this repository, not a generic literature survey.
 
-## Matrix
+## How To Use This Matrix
+
+- Current in-repo runnable support appears only in the `Current In-Repo Support` section below.
+- External-family anchor rows are useful for manuscript interpretation and benchmark-roadmap
+  context, but they must not be cited as implemented in-repo benchmark support.
+- Conceptual adjacency is not a support claim. If a row depends on a source-harness reproduction,
+  wrapper spike, or design overlap rather than a current repo entrypoint, keep the claim boundary
+  conservative.
+
+## Current In-Repo Support
 
 | Alyassi-style family | Coverage status | Planner / config entrypoint | Planner-facing input / observation contract | Kinematics / adapter status | Benchmark note |
 | --- | --- | --- | --- | --- | --- |
 | Goal-following heuristic baseline | implemented and benchmarkable | `algo=goal`; no planner-specific config path | Structured state: robot pose/velocity/goal/radius, agent pose/velocity/radius, obstacle segments | Native unicycle command output; differential-drive compatible in the frozen paper profile | Baseline-ready; canonical paper baseline |
 | Force-based interaction baseline | implemented and benchmarkable | `algo=social_force`; adapter metadata emitted by benchmark runner | Same structured state fields as `goal`; force-based interaction adapter | Adapter emits unicycle commands; differential-drive compatible in the frozen paper profile | Baseline-ready; canonical paper baseline |
 | Reciprocal-avoidance interaction baseline | implemented and benchmarkable | `algo=orca`; adapter metadata emitted by benchmark runner | Same structured state fields as `goal`; reciprocal-avoidance adapter | Adapter emits unicycle commands; differential-drive compatible in the frozen paper profile | Baseline-ready; canonical paper baseline, dependency-sensitive to `rvo2` availability |
-| End-to-end learned navigation baseline | implemented and benchmarkable | `algo=ppo`; canonical benchmark configs under `configs/training/ppo/` and benchmark algo config under `configs/baselines/ppo_15m_grid_socnav.yaml` | Dict observation keyed to the trained model input contract, for example `occupancy_grid`, `goal_current`, `robot_position`, and optional predictive foresight fields | Native mixed command path with adapter support; benchmark output contract normalizes to unicycle semantics; differential-drive compatible in the frozen paper profile | Benchmarkable, but still treated as experimental in readiness metadata unless provenance and quality-gate requirements are met |
-| Safety-aware learned navigation | implemented but experimental | `algo=guarded_ppo`; canonical benchmark config under `configs/algos/guarded_ppo_camera_ready.yaml` | PPO dict observation contract plus short-horizon safety veto metadata | Mixed native/adapter path; differential-drive compatible in current benchmark stack | Useful challenger family, but not baseline-ready and not yet paper-frozen as a primary family |
+| End-to-end learned navigation baseline | implemented and benchmarkable | `algo=ppo`; canonical benchmark configs under `configs/training/ppo/` and benchmark algo config under `configs/baselines/ppo_15m_grid_socnav.yaml` | Dict observation keyed to the trained model input contract, for example `occupancy_grid`, `goal_current`, `robot_position`, and optional predictive foresight fields | Native mixed command path with adapter support; benchmark output contract normalizes to unicycle semantics; differential-drive compatible in the frozen paper profile | Benchmarkable when provenance and quality-gate requirements are met; still tracked conservatively in generic readiness metadata |
+| Safety-aware learned navigation | implemented but experimental | `algo=guarded_ppo`; canonical benchmark config under `configs/algos/guarded_ppo_camera_ready.yaml` | PPO dict observation contract plus short-horizon safety veto metadata | Mixed native/adapter path; differential-drive compatible in current benchmark stack | Internal experimental safety-aware representative only; not a justified SoNIC-family equivalence claim |
 | Prediction-aware local planning | implemented but experimental | `algo=prediction_planner`; canonical config `configs/algos/prediction_planner_camera_ready.yaml` | Structured state plus predictive-planning parameters such as horizon, clearance, TTC, rollout lattice, and predictive checkpoint id | Adapter emits unicycle commands; differential-drive compatible in the frozen paper profile | Implemented and benchmark-runnable, but still experimental and checkpoint-dependent |
 | Prediction-aware sequence optimization | implemented but experimental | `algo=predictive_mppi`; config `configs/algos/predictive_mppi_camera_ready.yaml` | Structured state plus learned prediction rollout terms and short sequence-optimization controls | Adapter emits unicycle commands; differential-drive compatible in principle | Explicit testing-only planner; blocked unless `allow_testing_algorithms: true` |
 | Non-learning dynamic-window / sampling local planning | implemented but experimental | `algo=risk_dwa`, `algo=mppi_social`, `algo=hybrid_portfolio`, `algo=stream_gap`, `algo=gap_prediction`; configs under `configs/algos/` | Structured state plus planner-specific local risk, TTC, lattice, or veto parameters | Adapter emits unicycle commands; differential-drive compatible in principle | Implemented for controlled R&D, but guarded as testing-only because benchmark value is still unstable |
 | Human-state-aware / crowd-aware deep RL proxies | implemented but experimental | `algo=sacadrl`, `algo=socnav_sampling`; no paper-facing frozen config | Structured state through legacy adapter/model-specific contracts | Adapter emits unicycle commands; differential-drive compatibility depends on adapter path | Present as adapter/model-sensitive legacy baselines, but not part of the frozen paper-facing matrix |
 | SocNavBench adapter family | conceptually adjacent only | `algo=socnav_bench`; dependency-sensitive adapter path | External benchmark-style observation/adapter contract | Adapter emits unicycle commands when dependencies are present | Present as a bridge/proxy, not as fully integrated benchmark-facing family support |
 | World-model RL challenger family | conceptually adjacent only | DreamerV3 BR-08 configs under `configs/training/rllib_dreamerv3/` | RLlib observation contract (`drive_state + rays` and benchmark-aligned `socnav_struct + occupancy_grid` challenger profiles) | Uses RLlib env-runner stack rather than the PPO rollout stack; no frozen paper-facing planner row yet | Training and parity support exist, but benchmark evidence is still pending; do not claim benchmarked family support yet |
+
+## External Family Anchors / Prototype References
+
+| Alyassi-style family | Coverage status | Planner / config entrypoint | Planner-facing input / observation contract | Kinematics / adapter status | Benchmark note |
+| --- | --- | --- | --- | --- | --- |
+| CrowdNav family | conceptually adjacent only | `docs/context/issue_601_crowdnav_feasibility_note.md` | CrowdNav-family joint robot/human state packing with source-simulator normalization and temporal context | Adapter-heavy; source policy semantics are simulator-native rather than Robot SF `unicycle_vw` | External anchor only; historical family anchor, not current in-repo benchmark support |
+| SoNIC safety-aware family | conceptually adjacent only | `docs/context/issue_601_crowdnav_feasibility_note.md`, `docs/context/issue_602_guarded_ppo_profile.md` | SoNIC-family model-specific observation stack with bundled predictor/policy checkpoints; not the same as internal PPO dict observations | Adapter-heavy; source semantics remain model/simulator-specific, while internal `guarded_ppo` stays native `unicycle_vw` with a reactive guard | Prototype only; do not treat internal `guarded_ppo` as SoNIC-family support |
+| Go-MPC | conceptually adjacent only | `docs/context/issue_599_go_mpc_assessment.md` | Kinodynamic MPC stack requiring robot state `(x, y, theta, v, w)` plus ordered obstacle states and RL guidance inputs | Solver-locked and adapter-heavy; differential-drive / kinodynamic family shape, but tied to FORCESPro runtime | Reference only; not current repo support and not pursued now |
+| Pred2Nav | conceptually adjacent only | `docs/context/issue_604_pred2nav_assessment.md` | Legacy crowd-simulation state with trajectory-history-aware predictive rollout scoring and predictor-pluggable controller terms | Holonomic / `ActionXY` controller boundary with explicit projection burden to Robot SF `unicycle_vw` | Reference only; license-blocked and not current repo support |
+| gym-collision-avoidance / CADRL family | conceptually adjacent only | `docs/context/issue_605_gym_collision_avoidance_reference_note.md` | Source-specific per-agent structured state dict with exact state ordering, normalization, and nearby-agent clipping | Unicycle-like but adapter-heavy; source policy uses `[speed, delta_heading]` rather than Robot SF `unicycle_vw` | Prototype only; canonical external CADRL-family reference, not current benchmark support |
+
+## Missing Families
+
+| Alyassi-style family | Coverage status | Planner / config entrypoint | Planner-facing input / observation contract | Kinematics / adapter status | Benchmark note |
+| --- | --- | --- | --- | --- | --- |
 | Diffusion / transformer / multimodal social trajectory planners | missing | none | none | none | No current in-repo benchmark-facing implementation |
 | Full MCTS / long-horizon belief-space predictive planning | missing | none | none | none | Not currently implemented; only partial short-horizon predictive planning exists |
 
-## Notes on interpretation
+## Notes On Interpretation
 
 - `baseline-ready` in the benchmark stack currently means `goal`, `social_force`, and `orca`.
-- `ppo` is benchmarkable and paper-facing when provenance and quality-gate requirements are satisfied,
-  but it is still tracked as `experimental` in the generic readiness catalog because the benchmark
-  stack distinguishes generic availability from paper-grade promotion.
+- `ppo` is benchmarkable and paper-facing when provenance and quality-gate requirements are
+  satisfied, but it is still tracked conservatively in the generic readiness catalog because the
+  benchmark stack distinguishes generic availability from paper-grade promotion.
 - Testing-only planners (`risk_dwa`, `mppi_social`, `predictive_mppi`, `hybrid_portfolio`,
   `stream_gap`, `gap_prediction`) are intentionally guarded by
   `allow_testing_algorithms: true` to prevent accidental inclusion in broad or paper-facing runs.


### PR DESCRIPTION
## Summary
- refresh the benchmark planner-family coverage matrix for issue 603
- add conservative external-family anchor rows without promoting them to in-repo support
- align planner-zoo and camera-ready docs with the matrix wording

## Validation
- cross-checked changed rows against existing `docs/context/issue_*.md` evidence notes
- `git diff --check -- docs/benchmark_planner_family_coverage.md docs/ai/planner_zoo_context.md docs/benchmark_camera_ready.md`

Closes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planner family classification guidance, clarifying which planners are production-ready versus experimental or testing-only.
  * Enhanced the planner coverage matrix with a new "How To Use This Matrix" section providing stricter citation and interpretation guidelines.
  * Expanded documentation with sections for external family anchors and missing planner families.
  * Refined readiness language for baseline planners to reflect current provenance and quality-gate requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->