### PR TITLE
docs: add linked context note workflow for agent handoffs (#796)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -13,6 +13,7 @@ read the specific `SKILL.md` before applying a skill.
 - Run only the standard gate: `pr-ready-check`
 - Review benchmark-sensitive changes: `review-benchmark-change`
 - Update docs after code changes: `update-docs-on-code-change`
+- Create or refresh linked context notes: `context-note-maintainer`
 - Gather repository context before editing: `context-map`, `benchmark-overview`, or
   `experiment-context`
 
@@ -57,6 +58,7 @@ read the specific `SKILL.md` before applying a skill.
 | `benchmark-overview` | Getting fast benchmark-faithful orientation for scenario splits, baselines, metrics, and artifacts. |
 | `clean-up` | Tidying the current branch with Ruff, tests, changed-file gates, and docstring TODO checks. |
 | `context-map` | Building a focused map of relevant files, docs, commands, and risks before multi-file work. |
+| `context-note-maintainer` | Creating or refreshing linked `docs/context/` notes so reusable agent knowledge stays discoverable and current. |
 | `experiment-context` | Finding canonical config-first training/evaluation paths, artifact lineage, and validation gates. |
 | `gh-issue-autopilot` | Selecting or executing an issue through implementation, validation, push, and draft PR. |
 | `gh-issue-clarifier` | Tightening ambiguous GitHub issues and marking decision-required items when needed. |

--- a/.agents/skills/context-note-maintainer/SKILL.md
+++ b/.agents/skills/context-note-maintainer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: context-note-maintainer
+description: "Create or refresh linked docs/context notes so reusable agent knowledge stays discoverable, current, and easy to hand off."
+---
+
+# Context Note Maintainer
+
+## Overview
+
+Use this skill when work produces non-trivial reusable insights, decisions, reasoning, or
+validation context that should be preserved in Markdown, or when an existing `docs/context/` note
+has become stale, superseded, or hard to discover.
+
+This skill is for durable handoff knowledge, not transient scratch notes.
+
+## Read First
+
+- `AGENTS.md`
+- `docs/context/README.md`
+- `docs/dev_guide.md`
+- `docs/README.md`
+- `docs/ai/repo_overview.md`
+
+## Workflow
+
+1. Identify the canonical note surface
+   - Prefer updating the existing note when it already covers the same issue, workflow, planner
+     family, or decision boundary.
+   - Create a new note only when the topic is distinct enough that merging would blur the source of
+     truth.
+
+2. Capture the reusable context
+   - Persist the goal, key decisions, reasoning, validation commands, current conclusion, and
+     follow-up boundary.
+   - Keep the note concise, but include enough context that another agent can resume work without
+     re-deriving the same conclusions.
+
+3. Clean up stale content
+   - If touched content is outdated, update it, remove it, or mark it clearly as superseded with a
+     pointer to the replacement note.
+   - Do not leave contradictory statements in place without a status marker.
+
+4. Link for discoverability
+   - Link the note to the related issue or PR, the canonical docs/configs, and the proof artifacts
+     or commands that justify the conclusion.
+   - If the note changes workflow guidance, make sure a normal entry point such as `docs/README.md`,
+     `docs/dev_guide.md`, `AGENTS.md`, or `docs/ai/repo_overview.md` points to it.
+
+5. Validate references
+   - Check that referenced paths and commands exist.
+   - Run `uv run python scripts/dev/check_skills.py` if skill docs were changed.
+
+## Output
+
+Always report which note was updated or created, why that was the canonical surface, what stale
+content was cleaned up, and which entry points now link to it.
+
+## Guardrails
+
+- Do not create duplicate notes when an existing canonical note can be updated.
+- Do not leave touched stale content ambiguous.
+- Do not treat `docs/context/` as a scratchpad or dump of raw terminal output.
+- Do not rely on chat-only context for decisions that future agents will need to reuse.

--- a/.agents/skills/context-skills/README.md
+++ b/.agents/skills/context-skills/README.md
@@ -10,6 +10,7 @@ navigation notes each time.
 Available skills:
 
 - `benchmark-overview`
+- `context-note-maintainer`
 - `experiment-context`
 - `planner-integration`
 - `paper-facing-docs`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,10 @@ It is everyones guide on how to use this repository effectively.
   See `docs/ai/awesome_copilot_adaptation.md` for the selection guide.
 - For context discovery, use `.agents/skills/context-map/SKILL.md` before multi-file changes and
   `.agents/skills/what-context-needed/SKILL.md` when the task is underspecified.
+- For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and
+  handoff context in linked Markdown notes under `docs/context/` when that context would otherwise
+  be lost. Prefer updating the canonical existing note over creating a duplicate, and use
+  `.agents/skills/context-note-maintainer/SKILL.md` when creating or refreshing those notes.
 - For proof-first quality work, use `.agents/skills/quality-playbook/SKILL.md` for non-trivial
   changes, `.agents/skills/agentic-eval/SKILL.md` for AI-workflow artifacts, and
   `.agents/skills/review-and-refactor/SKILL.md` for narrow review-then-refactor passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,24 @@ Treat the following files as the repository-native context stack for Codex-style
 
 Read only the surfaces relevant to the task. Prefer these repo-local files over ad-hoc summaries in issue comments.
 
+## Knowledge Capture & Context Notes
+
+Treat `docs/context/` as the repository's Markdown knowledge base for agent handoff, not as a dump
+of incidental scratch notes.
+
+- For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and
+  handoff context in Markdown when that context would otherwise be trapped in chat, PR text, or
+  issue comments.
+- Prefer updating an existing canonical note when it already covers the same topic. Create a new
+  note only when the subject is distinct enough that merging would hide the decision trail.
+- Link notes to the related issue/PR, relevant canonical docs, proof artifacts, and any predecessor
+  or successor note when a document is superseded.
+- If a touched note contains outdated or superseded statements, update them, remove them, or mark
+  them clearly with a pointer to the current source of truth.
+- Keep note names and links discoverable from normal contributor entry points. Start with
+  `docs/context/README.md` and use `.agents/skills/context-note-maintainer/SKILL.md` when creating
+  or refreshing context notes.
+
 ## Project Structure & Module Organization
 Core simulation code lives in `robot_sf/` with key subpackages: `gym_env` for Gymnasium bindings, `sim` for physics glue, `nav` for path planning, and `render` for playback tooling. Training and evaluation entry points sit in `scripts/`, while curated demos and notebooks live under `examples/`. Tests are split between `tests/` (unit and integration), `test_pygame/` (GUI regressions), and the `fast-pysf/` subtree. Assets and checkpoints are versioned under `maps/svg_maps/` and `model/`; the canonical (git-ignored) artifact root for generated outputs is `output/` (legacy `results/` has been migrated there).
 
@@ -145,6 +163,7 @@ understanding or reviewing benchmark/planner context rather than executing GitHu
 automation:
 
 - `.agents/skills/benchmark-overview/SKILL.md`
+- `.agents/skills/context-note-maintainer/SKILL.md`
 - `.agents/skills/experiment-context/SKILL.md`
 - `.agents/skills/planner-integration/SKILL.md`
 - `.agents/skills/paper-facing-docs/SKILL.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added canonical `classic_cross_trap_*` scenario IDs and manifests for the former
   `classic_crossing_*` cross-shaped local-minimum trap scenarios, with legacy
   compatibility aliases and migration notes for existing configs.
+* Added a canonical Markdown context-note workflow under `docs/context/README.md`, explicit
+  `AGENTS.md` / Copilot / dev-guide guidance for linked handoff notes, a new
+  `context-note-maintainer` repo-local skill, and an issue-796 policy note so reusable agent
+  knowledge is easier to preserve, discover, and update without adding external infrastructure.
 
 * Paper results handoff export (`robot_sf.benchmark.paper_results_handoff`) now emits interval-inclusive planner-summary rows from frozen publication bundles, with CLI wrapper (`scripts/tools/paper_results_handoff.py`), confidence-interval metadata, seed/repeat provenance, deterministic JSON/CSV outputs, and contract documentation in `docs/context/issue_750_paper_results_handoff.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 ### Getting Started
 
 * **[Development Guide](./dev_guide.md)** - Primary reference for development workflows, setup, testing, quality gates, and coding standards
+* **[Context Notes Workflow](./context/README.md)** - Canonical rules for linked Markdown handoff notes, note updates vs new notes, stale-note handling, and discoverability
 * **[Project Prioritization](./project_prioritization.md)** - Priority-score model, Project #5 field semantics, and the local/manual score-sync workflow
 * **[GitHub Workflow Batching](./context/issue_713_batch_first_issue_workflow.md)** - Batch issue cleanup first, defer Project #5 routing, and run derived score sync last
 * **[Agent Index](./AGENT_INDEX.md)** - Agent-oriented index of training, benchmarking, observations, and artifacts

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -31,7 +31,8 @@ Then branch by task type:
 - benchmark semantics: `docs/benchmark_spec.md`, `docs/benchmark.md`
 - planner family support: `docs/benchmark_planner_family_coverage.md`
 - training/eval workflow: `docs/AGENT_INDEX.md`, `docs/training/`
-- issue execution history: `docs/context/`
+- issue execution history and handoff knowledge base: `docs/context/`
+- context note workflow: `docs/context/README.md`
 
 ## Key Repository Areas
 
@@ -48,7 +49,7 @@ Then branch by task type:
 - `configs/`: canonical YAML configs for training, benchmarks, scenarios, and baselines
 - `scripts/`: runnable entrypoints and validation helpers
 - `output/`: git-ignored canonical artifact root
-- `docs/context/`: execution notes and issue-specific evidence logs
+- `docs/context/`: linked execution notes, issue-specific evidence logs, and agent handoff context
 
 ### Existing agent workflow surfaces
 
@@ -58,6 +59,8 @@ Then branch by task type:
   measurable improvement loops and smaller refinement passes
 - `.agents/skills/context-map/` and `.agents/skills/what-context-needed/`: context-gathering skills
   for locating the right files or requesting the minimum missing context
+- `.agents/skills/context-note-maintainer/`: note-creation and stale-note-maintenance workflow for
+  durable Markdown handoff context
 - `.agents/skills/quality-playbook/`, `.agents/skills/agentic-eval/`,
   `.agents/skills/review-and-refactor/`, and `.agents/skills/update-docs-on-code-change/`: quality
   and maintenance skills for proof-first changes, AI-output evaluation, narrow refactors, and

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -28,7 +28,8 @@ would blur ownership or make the reasoning harder to locate.
 Prefer these naming patterns:
 
 - `issue_<number>_<topic>.md` for issue-scoped notes,
-- `<topic>_<date>.md` for cross-issue audits, release notes, or bounded investigations.
+- `<topic>_<date>.md` using `YYYY-MM-DD` for cross-issue audits, release notes, or bounded
+  investigations.
 
 ## Required Linking
 
@@ -72,12 +73,13 @@ knowledge, not every transient iteration detail.
 
 ## Skills And Entry Points
 
-- Repository rule: `AGENTS.md`
-- Contributor workflow: `docs/dev_guide.md`
-- Docs index entry: `docs/README.md`
-- AI-facing orientation: `docs/ai/repo_overview.md`
-- Note-maintenance skill: `.agents/skills/context-note-maintainer/SKILL.md`
+- Repository rule: [AGENTS.md](../../AGENTS.md)
+- Contributor workflow: [docs/dev_guide.md](../dev_guide.md)
+- Docs index entry: [docs/README.md](../README.md)
+- AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
+- Note-maintenance skill:
+  [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 
 ## Example
 
-- `docs/context/issue_796_agent_knowledge_capture_policy.md`
+- [docs/context/issue_796_agent_knowledge_capture_policy.md](issue_796_agent_knowledge_capture_policy.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,83 @@
+# Context Notes Workflow
+
+`docs/context/` is the repository's Markdown knowledge base for issue execution history, durable
+agent handoff, and reusable reasoning that should not be trapped in chat or PR text.
+
+Use this directory for non-trivial insights, decisions, tradeoffs, validation notes, and execution
+context that future contributors or agents are likely to need again.
+
+## When To Update An Existing Note
+
+Prefer updating an existing note when:
+
+- the same issue, planner family, workflow, or benchmark surface is already documented there,
+- the new work changes or clarifies an existing conclusion,
+- or splitting the note would make the decision trail harder to follow.
+
+When you update a note, preserve the current source of truth and remove ambiguity:
+
+- replace outdated statements when the old wording is no longer useful,
+- add dated outcome updates when historical context still matters,
+- and link to the validation commands, artifacts, or follow-up notes that justify the new state.
+
+## When To Create A New Note
+
+Create a new note when the subject is distinct enough that merging it into an existing document
+would blur ownership or make the reasoning harder to locate.
+
+Prefer these naming patterns:
+
+- `issue_<number>_<topic>.md` for issue-scoped notes,
+- `<topic>_<date>.md` for cross-issue audits, release notes, or bounded investigations.
+
+## Required Linking
+
+Every durable context note should link to the smallest useful set of related surfaces:
+
+- the GitHub issue or PR that motivated the work,
+- canonical docs or configs that define the contract,
+- validation commands, artifacts, or output paths that support the conclusion,
+- predecessor or successor notes when a document is continued or superseded.
+
+If the note changes repository guidance, also link it from a normal entry point such as
+`docs/README.md`, `docs/dev_guide.md`, `AGENTS.md`, or `docs/ai/repo_overview.md`.
+
+## Outdated And Superseded Content
+
+Touched notes must not leave stale conclusions ambiguous.
+
+If a note is still the canonical surface, update it in place.
+
+If a note should remain for history but is no longer current, mark that clearly near the top:
+
+```md
+> Status: superseded by `docs/context/issue_999_new_note.md` on 2026-04-09.
+> Keep this note only for historical context.
+```
+
+If the note is no longer useful even as history, remove the outdated statement instead of stacking
+contradictory prose.
+
+## Lightweight Structure
+
+Use the smallest structure that keeps the note reusable. Most notes should include:
+
+- the goal or decision,
+- the key evidence or reasoning,
+- the validation path,
+- the current conclusion or follow-up boundary.
+
+Avoid turning `docs/context/` into a scratchpad. Capture what future readers need to reuse the
+knowledge, not every transient iteration detail.
+
+## Skills And Entry Points
+
+- Repository rule: `AGENTS.md`
+- Contributor workflow: `docs/dev_guide.md`
+- Docs index entry: `docs/README.md`
+- AI-facing orientation: `docs/ai/repo_overview.md`
+- Note-maintenance skill: `.agents/skills/context-note-maintainer/SKILL.md`
+
+## Example
+
+- `docs/context/issue_796_agent_knowledge_capture_policy.md`

--- a/docs/context/issue_796_agent_knowledge_capture_policy.md
+++ b/docs/context/issue_796_agent_knowledge_capture_policy.md
@@ -1,0 +1,50 @@
+# Issue 796 Agent Knowledge Capture Policy
+
+- GitHub issue: `#796`
+- Canonical workflow: `docs/context/README.md`
+- Related repo guidance:
+  - `AGENTS.md`
+  - `.github/copilot-instructions.md`
+  - `docs/dev_guide.md`
+  - `docs/README.md`
+  - `docs/ai/repo_overview.md`
+  - `.agents/skills/context-note-maintainer/SKILL.md`
+
+## Goal
+
+Make linked Markdown knowledge capture an explicit repository contract for non-trivial agent work so
+important context does not remain trapped in chat, PR text, or issue comments.
+
+## Decisions Implemented
+
+- `docs/context/` is now treated as the repository's Markdown knowledge base for durable handoff
+  context, not just as a loose collection of execution notes.
+- Agents should persist non-trivial reusable insights, decisions, reasoning, and validation notes in
+  Markdown when that context would otherwise be lost.
+- Existing canonical notes should be updated in preference to creating duplicates.
+- Touched stale or superseded notes must be updated, removed, or clearly marked with a pointer to
+  the current source of truth.
+- Notes should cross-link to issues, PRs, canonical docs, validation commands, and successor notes
+  to keep the repository discoverable without adding a database.
+
+## Rollout Surface
+
+- Policy rule in `AGENTS.md`
+- Copilot-facing mirror in `.github/copilot-instructions.md`
+- Contributor workflow pointer in `docs/dev_guide.md`
+- Docs index entry in `docs/README.md`
+- AI-facing discoverability update in `docs/ai/repo_overview.md`
+- Dedicated note-maintenance workflow in `.agents/skills/context-note-maintainer/SKILL.md`
+
+## Validation
+
+- Verify all referenced files exist.
+- Run `uv run python scripts/dev/check_skills.py`.
+- Run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
+
+## Current Boundary
+
+This rollout defines the rule, the discoverability surfaces, and one dedicated skill. It does not
+attempt a full historical cleanup of every old note in `docs/context/`; retroactive cleanup remains
+incremental and should happen when older notes are touched or when a high-value stale surface is
+identified.

--- a/docs/context/issue_796_agent_knowledge_capture_policy.md
+++ b/docs/context/issue_796_agent_knowledge_capture_policy.md
@@ -1,14 +1,14 @@
 # Issue 796 Agent Knowledge Capture Policy
 
-- GitHub issue: `#796`
-- Canonical workflow: `docs/context/README.md`
+- GitHub issue: [#796](https://github.com/ll7/robot_sf_ll7/issues/796)
+- Canonical workflow: [docs/context/README.md](README.md)
 - Related repo guidance:
-  - `AGENTS.md`
-  - `.github/copilot-instructions.md`
-  - `docs/dev_guide.md`
-  - `docs/README.md`
-  - `docs/ai/repo_overview.md`
-  - `.agents/skills/context-note-maintainer/SKILL.md`
+  - [AGENTS.md](../../AGENTS.md)
+  - [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+  - [docs/dev_guide.md](../dev_guide.md)
+  - [docs/README.md](../README.md)
+  - [docs/ai/repo_overview.md](../ai/repo_overview.md)
+  - [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 
 ## Goal
 
@@ -29,12 +29,13 @@ important context does not remain trapped in chat, PR text, or issue comments.
 
 ## Rollout Surface
 
-- Policy rule in `AGENTS.md`
-- Copilot-facing mirror in `.github/copilot-instructions.md`
-- Contributor workflow pointer in `docs/dev_guide.md`
-- Docs index entry in `docs/README.md`
-- AI-facing discoverability update in `docs/ai/repo_overview.md`
-- Dedicated note-maintenance workflow in `.agents/skills/context-note-maintainer/SKILL.md`
+- Policy rule in [AGENTS.md](../../AGENTS.md)
+- Copilot-facing mirror in [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+- Contributor workflow pointer in [docs/dev_guide.md](../dev_guide.md)
+- Docs index entry in [docs/README.md](../README.md)
+- AI-facing discoverability update in [docs/ai/repo_overview.md](../ai/repo_overview.md)
+- Dedicated note-maintenance workflow in
+  [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 
 ## Validation
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -136,6 +136,19 @@ For GitHub issue batches and Project #5 updates, follow the batch-first workflow
 - Clean up issues first, then route Project #5 metadata, then run derived score sync once at the end.
 - Cache project and field IDs once per shell session instead of rediscovering them for every issue.
 
+### Context note workflow
+
+For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and
+handoff context in Markdown instead of leaving them trapped in chat or PR history.
+
+- Use `docs/context/README.md` as the canonical workflow and naming guide.
+- Prefer updating an existing canonical note before creating a new one.
+- If a touched note is outdated or superseded, update it, remove it, or mark it clearly with a
+  pointer to the current source.
+- Link notes to the related issue/PR, canonical docs, validation commands, and replacement notes.
+- Use `.agents/skills/context-note-maintainer/SKILL.md` when the task includes creating or
+  refreshing context notes.
+
 On macOS, `scripts/dev/run_tests_parallel.sh` uses a bounded fixed xdist worker count by
 default instead of `-n auto`, because the unbounded auto worker selection can leave local
 validation wrappers hanging after child processes should have exited. Override with


### PR DESCRIPTION
## Summary
Make linked Markdown context notes an explicit repository workflow for non-trivial agent work, and add a canonical note-maintenance skill plus discoverability entry points.

## Linked Issues
- Closes #796

## What Changed
- Added explicit knowledge-capture and stale-note handling rules to `AGENTS.md`.
- Added contributor and Copilot-facing pointers in `docs/dev_guide.md` and `.github/copilot-instructions.md`.
- Added a canonical `docs/context/README.md` workflow and an issue-scoped example note at `docs/context/issue_796_agent_knowledge_capture_policy.md`.
- Added `.agents/skills/context-note-maintainer/SKILL.md` and updated the skill indexes and AI repo overview.
- Added a narrow `CHANGELOG.md` entry for the new workflow.

## Why It Matters
- Added value: reusable decisions and validation context no longer have to remain trapped in chat or PR history.
- Expected impact: future agents and contributors can find, update, and hand off context notes through normal repo entry points.
- Why this is worth merging now: the repository already relies on `docs/context/`; this makes that workflow explicit and maintainable instead of implicit.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `git fetch origin main && git rebase origin/main && BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - skill metadata/index validation passed
  - full post-sync readiness gate passed after rebasing onto current `origin/main`
- Benchmarks or smoke tests, if applicable:
  - not applicable beyond the standard repository gate

## Risks / Rollout
- Compatibility risks:
  - low; this is a docs/skills workflow change
- Failure modes:
  - contributors may still create duplicate notes if they skip the canonical workflow doc
- Rollback or fallback plan:
  - revert the docs/skill additions if the workflow proves too noisy or unclear

## Docs / Provenance
- Updated docs:
  - `AGENTS.md`
  - `.github/copilot-instructions.md`
  - `docs/dev_guide.md`
  - `docs/README.md`
  - `docs/ai/repo_overview.md`
  - `docs/context/README.md`
  - `docs/context/issue_796_agent_knowledge_capture_policy.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - `docs/context/issue_796_agent_knowledge_capture_policy.md`
- Any assumptions that need to be preserved:
  - `docs/context/` remains the Markdown knowledge base; no external database is introduced

## Follow-Up Issues
- Deferred work:
  - none
- Issues opened for follow-up:
  - none

## Reviewer Notes
- Anything a reviewer should verify closely:
  - whether the new context-note rule is scoped tightly enough to avoid note spam while still preserving reusable handoff context
- Any known limitations:
  - this rollout only does targeted discoverability cleanup; it does not attempt a full historical audit of old `docs/context/` notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canonical context-notes workflow for capturing and maintaining reusable agent knowledge.
  * Added a context-note-maintainer skill to create and refresh durable handoff notes.

* **Documentation**
  * Added comprehensive docs describing the context-notes workflow, naming, linking, and stale-note handling.
  * Updated agent guidance and developer documentation to reference the new knowledge-capture workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->