### PR TITLE
test(teb_commitment): deterministic side-choice and progress-recovery tests (#721)

### DIFF
--- a/tests/planner/test_teb_commitment.py
+++ b/tests/planner/test_teb_commitment.py
@@ -99,3 +99,77 @@ def test_teb_blocked_commit_ttl_ages_each_blocked_step() -> None:
     assert planner._commit_ttl == 1
     planner.plan(obs)
     assert planner._commit_ttl == 2
+
+
+def test_teb_symmetry_bias_drives_deterministic_side_choice() -> None:
+    """Positive symmetry_bias should commit left (side=1) in a symmetric, obstacle-free stall."""
+    planner = TEBCommitmentPlannerAdapter(
+        TEBCommitmentConfig(
+            symmetry_bias=0.3,
+            commit_persistence_steps=2,
+            low_speed_threshold=0.15,
+            progress_epsilon=0.05,
+        )
+    )
+    # Obstacle-free scene: symmetry_bias is the only side-score contributor.
+    obs = _obs(goal=(3.0, 0.0), speed=0.05)
+    planner.plan(obs)  # prime _last_goal_distance
+    planner.plan(obs)  # stall detected → _choose_side called with score = symmetry_bias
+
+    # Positive bias with no grid asymmetry → left (side=1) must be committed.
+    assert planner._commit_side == 1
+
+
+def test_teb_negative_symmetry_bias_commits_right() -> None:
+    """Negative symmetry_bias should commit right (side=-1) in a symmetric, obstacle-free stall."""
+    planner = TEBCommitmentPlannerAdapter(
+        TEBCommitmentConfig(
+            symmetry_bias=-0.3,
+            commit_persistence_steps=2,
+            low_speed_threshold=0.15,
+            progress_epsilon=0.05,
+        )
+    )
+    obs = _obs(goal=(3.0, 0.0), speed=0.05)
+    planner.plan(obs)
+    planner.plan(obs)
+
+    assert planner._commit_side == -1
+
+
+def test_teb_stall_triggers_progress_recovery_commitment() -> None:
+    """A low-speed, no-progress stall should activate side commitment even without obstacles."""
+    planner = TEBCommitmentPlannerAdapter(
+        TEBCommitmentConfig(
+            symmetry_bias=0.1,
+            commit_persistence_steps=4,
+            low_speed_threshold=0.15,
+            progress_epsilon=0.05,
+        )
+    )
+    # First step primes _last_goal_distance; robot moves slowly.
+    obs = _obs(goal=(3.0, 0.0), speed=0.05)
+    planner.plan(obs)
+    assert planner._commit_ttl == 0  # no stall yet on first step
+
+    # Second step: same distance, same low speed → stalled → should commit.
+    planner.plan(obs)
+
+    assert planner._commit_ttl > 0
+    assert planner._commit_side != 0
+
+
+def test_teb_reset_clears_stall_and_commitment_state() -> None:
+    """reset() must wipe all per-episode state so a fresh episode starts clean."""
+    planner = TEBCommitmentPlannerAdapter(
+        TEBCommitmentConfig(commit_persistence_steps=5, symmetry_bias=0.1)
+    )
+    obs = _obs(goal=(3.0, 0.0), obstacle_cells=[(2, 3)])
+    planner.plan(obs)
+    planner.plan(obs)  # build up state
+
+    planner.reset()
+
+    assert planner._commit_ttl == 0
+    assert planner._commit_side == 0
+    assert planner._last_goal_distance is None


### PR DESCRIPTION
## Summary
Adds four targeted unit tests for the existing `TEBCommitmentPlannerAdapter` covering the missing DoD items from issue #721: deterministic side-choice driven by `symmetry_bias`, progress-recovery commitment on stall, and complete state reset across episodes.

## Linked Issues
- Closes #721

## What Changed
- `tests/planner/test_teb_commitment.py`: four new tests
  - `test_teb_symmetry_bias_drives_deterministic_side_choice` — positive bias always commits left in an obstacle-free stall
  - `test_teb_negative_symmetry_bias_commits_right` — negative bias always commits right
  - `test_teb_stall_triggers_progress_recovery_commitment` — low-speed / no-progress stall activates side commitment without obstacles
  - `test_teb_reset_clears_stall_and_commitment_state` — `reset()` wipes all per-episode state

The planner implementation (`robot_sf/planner/teb_commitment.py`), benchmark integration, and `requires_explicit_opt_in=True` gate are unchanged — they were already in place from earlier work on the residual topology planner track.

## Why It Matters
- Added value: closes the proof-surface gap the issue identified; the three residual scenarios (`line_wall_detour`, `narrow_passage`, `symmetry_ambiguous_choice`) now have deterministic, inspectable commitment behaviour with direct test coverage.
- Expected impact: no runtime change; tests only.
- Why this is worth merging now: the planner is already integrated and gated; these tests are the last open DoD item before the issue can be closed.

## Validation / Proof
- Commands run: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Result: 2769 passed, 13 skipped, 0 failures
- New test suite: `uv run pytest tests/planner/test_teb_commitment.py -v` → 9/9 passed

## Risks / Rollout
- Compatibility risks: none — tests only, no production code changed.
- Failure modes: n/a
- Rollback or fallback plan: n/a

## Docs / Provenance
- The `TEBCommitmentPlannerAdapter` opt-in gate is documented in `robot_sf/benchmark/algorithm_readiness.py` (`requires_explicit_opt_in=True`).

## Follow-Up Issues
- Benchmark-slice validation with camera-ready artifacts (empirical go/no-go verdict) is a natural follow-up once the planner is used in a focused campaign.

## Reviewer Notes
- The symmetry-bias tests use the stall path rather than the forward-blocked path because the default grid geometry places the forward-probe center and the left side-probe at the same cell; stall avoids that coupling and isolates `symmetry_bias` cleanly.