### PR TITLE
docs: add coding-agents compatibility note and discoverability gate (#728)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,9 @@ It is everyones guide on how to use this repository effectively.
 - For measurement-driven improvement loops, use `.agents/skills/autoresearch/SKILL.md`.
   For shorter refinement passes, use `.agents/skills/auto-improvement/SKILL.md`.
   See `docs/ai/awesome_copilot_adaptation.md` for the selection guide.
+- For the repository's cross-agent compatibility stance (retrieval → planning → execution →
+  verification discipline, accepted and rejected external concepts), see
+  `docs/context/issue_728_coding_agents_compatibility.md`.
 - For context discovery, use `.agents/skills/context-map/SKILL.md` before multi-file changes and
   `.agents/skills/what-context-needed/SKILL.md` when the task is underspecified.
 - For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,15 @@ of incidental scratch notes.
   `docs/context/README.md` and use `.agents/skills/context-note-maintainer/SKILL.md` when creating
   or refreshing context notes.
 
+## Cross-Agent Compatibility
+
+For the repository's stance on adapting external agent-workflow sources (coding-agents, Awesome
+Copilot, etc.) and the retrieval → planning → execution → verification discipline, see:
+
+- `docs/context/issue_728_coding_agents_compatibility.md` — canonical accept/reject record for
+  `vultuk/coding-agents` concepts and the four-phase agent loop mapped to Robot SF skills.
+- `docs/ai/awesome_copilot_adaptation.md` — decisions for the Awesome Copilot List adaptation.
+
 ## Project Structure & Module Organization
 Core simulation code lives in `robot_sf/` with key subpackages: `gym_env` for Gymnasium bindings, `sim` for physics glue, `nav` for path planning, and `render` for playback tooling. Training and evaluation entry points sit in `scripts/`, while curated demos and notebooks live under `examples/`. Tests are split between `tests/` (unit and integration), `test_pygame/` (GUI regressions), and the `fast-pysf/` subtree. Assets and checkpoints are versioned under `maps/svg_maps/` and `model/`; the canonical (git-ignored) artifact root for generated outputs is `output/` (legacy `results/` has been migrated there).
 

--- a/docs/context/issue_728_coding_agents_compatibility.md
+++ b/docs/context/issue_728_coding_agents_compatibility.md
@@ -1,0 +1,106 @@
+# Coding-Agents Compatibility Note
+
+**Issue**: [#728](https://github.com/ll7/robot_sf_ll7/issues/728)
+**Date**: 2026-04-12
+**Status**: Adopted
+
+## Purpose
+
+This note records which concepts from the external `vultuk/coding-agents` reference repository Robot
+SF adopts, why each decision was made, and which ideas are explicitly rejected. It serves as the
+single canonical source for cross-agent portability decisions in this repository.
+
+A contributor or AI assistant can read this note plus the linked entry points (`AGENTS.md`,
+`.github/copilot-instructions.md`, `docs/dev_guide.md`) to understand the full cross-agent
+compatibility stance without having to reconstruct it from issue comments or PR text.
+
+## Concepts Adopted
+
+### 1. Retrieval → Planning → Execution → Verification discipline
+
+`vultuk/coding-agents` makes explicit a four-phase agent loop that is easy to skip under time
+pressure. Robot SF maps each phase to concrete, repo-local skills so the discipline is enforced
+through tooling rather than informal convention:
+
+| Phase | Robot SF mapping |
+|---|---|
+| **Retrieval** | `context-map`, `what-context-needed`, `benchmark-overview`, `experiment-context` |
+| **Planning** | `quality-playbook`, `gh-issue-clarifier`, `.agent/PLANS.md` convention |
+| **Execution** | `gh-issue-autopilot`, `autoresearch`, `auto-improvement` |
+| **Verification** | `implementation-verification`, `pr-ready-check`, `review-benchmark-change` |
+
+No phase is optional for non-trivial work. Skipping retrieval produces misscoped implementations;
+skipping verification produces unproven claims. The `quality-playbook` skill enforces this sequence
+end-to-end for high-risk changes.
+
+### 2. Per-source compatibility notes
+
+For each significant external source of workflow inspiration (Awesome Copilot, coding-agents, etc.),
+a dedicated note in `docs/context/` captures the accept/reject decisions. This prevents drift where
+agent instructions absorb upstream phrasing without explicit rationale.
+
+- `docs/ai/awesome_copilot_adaptation.md` covers Awesome Copilot List adaptation decisions.
+- This note (`docs/context/issue_728_coding_agents_compatibility.md`) covers `vultuk/coding-agents`.
+
+### 3. Separation of prompts / skills / agents in a canonical directory
+
+`vultuk/coding-agents` separates these three artifact types cleanly so tool-specific compatibility
+paths can be derived from a single canonical source. Robot SF already adopted this via issue `#705`:
+`.agents/` is the canonical source tree, and symlinks project it into `.codex/`, `.opencode/`,
+`.claude/`, `.github/`, and `.gemini/` compatibility paths.
+
+Validation and repair:
+
+```bash
+uv run python scripts/tools/sync_ai_config.py --check   # detect stale mirrors
+uv run python scripts/tools/sync_ai_config.py --fix     # repair symlinks
+```
+
+### 4. Explicit entry-point linking
+
+The compatibility note is only useful if agents can discover it. `vultuk/coding-agents` emphasizes
+surfacing canonical docs from every agent entry point. For this note, the required links are:
+
+- `AGENTS.md` — top-level execution rules entry point
+- `.github/copilot-instructions.md` — Copilot-facing pointer
+- `docs/dev_guide.md` — contributor workflow reference
+
+## Concepts Rejected
+
+### Wholesale migration to the `coding-agents` directory layout
+
+Robot SF has an established `.agents/` canonical structure with functioning symlinks. Migrating to a
+different layout would invalidate existing compatibility paths and produce churn without net gain.
+
+### Generator / compiler framework for syncing
+
+`vultuk/coding-agents` uses an external generator or build step to produce tool-specific files.
+Robot SF uses lightweight symlinks managed by `scripts/tools/sync_ai_config.py`. The symlink
+approach has fewer moving parts and does not introduce an external dependency.
+
+### Cross-agent runtime assumptions
+
+Robot SF does not assume any agent runtime beyond what `AGENTS.md` and tool-specific thin-pointer
+files convey. Concepts that require a specific runtime (prompt injection hooks, context-window
+managers, session memory) are out of scope for the compatibility layer.
+
+### Verbatim upstream text
+
+Where an upstream concept is worth adopting, the preferred form is a concise repo-native restatement
+rather than a verbatim copy. Verbatim copies create maintenance debt and obscure where the original
+concept came from.
+
+## Maintenance Rule
+
+When a new external agent-workflow source is evaluated for adoption, create a parallel note in
+`docs/context/` before changing any instruction file. Keep one note per source. Link the new note
+from `AGENTS.md`, `.github/copilot-instructions.md`, and `docs/dev_guide.md`. Update this note if
+the accept/reject decisions change.
+
+## Related
+
+- Issue `#705` — Unify AI assistant rules, prompts, and sync workflow (canonical `.agents/` structure)
+- Issue `#713` — Batch-first issue workflow note (`docs/context/issue_713_batch_first_issue_workflow.md`)
+- `docs/ai/awesome_copilot_adaptation.md` — prior per-source adaptation note
+- `AGENTS.md` — top-level execution rules
+- `.agents/README.md` — canonical surface registry and maintenance commands

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -346,6 +346,9 @@ from robot_sf.common import Vec2D, RobotPose, set_global_seed
   - LLM Constitution and guides can be found here:
     - `.specify/memory/constitution.md`
     - `AGENTS.md`
+  - For the repository's cross-agent compatibility stance and the retrieval → planning → execution
+    → verification discipline mapped to repo-local skills, see
+    `docs/context/issue_728_coding_agents_compatibility.md`.
 - Clarify exact requirements before starting implementation.
 - If necessary, ask clarifying questions (with options) to confirm scope, interfaces, data handling, UX, and performance.
   - Discuss possible options and trade-offs.

--- a/tests/test_ai_prompt_surfaces.py
+++ b/tests/test_ai_prompt_surfaces.py
@@ -13,6 +13,8 @@ DEV_GUIDE = ROOT / "docs" / "dev_guide.md"
 REPO_OVERVIEW = ROOT / "docs" / "ai" / "repo_overview.md"
 COPILOT_INSTRUCTIONS = ROOT / ".github" / "copilot-instructions.md"
 ADAPTATION_NOTE = ROOT / "docs" / "ai" / "awesome_copilot_adaptation.md"
+CODING_AGENTS_NOTE = ROOT / "docs" / "context" / "issue_728_coding_agents_compatibility.md"
+AGENTS_MD = ROOT / "AGENTS.md"
 
 
 def test_ai_skill_files_exist() -> None:
@@ -143,3 +145,30 @@ def test_ai_docs_reference_the_new_skill_surfaces() -> None:
     assert "agentic-eval" in adaptation_text
     assert "review-and-refactor" in adaptation_text
     assert "update-docs-on-code-change" in adaptation_text
+
+
+def test_coding_agents_compatibility_note_is_discoverable() -> None:
+    """The coding-agents compatibility note must exist and be linked from the three agent entry points.
+
+    Verifies that a contributor or AI assistant can find the cross-agent compatibility stance
+    and the retrieval -> planning -> execution -> verification discipline by reading AGENTS.md,
+    .github/copilot-instructions.md, or docs/dev_guide.md.
+    """
+
+    assert CODING_AGENTS_NOTE.exists(), (
+        "canonical coding-agents compatibility note missing: "
+        "docs/context/issue_728_coding_agents_compatibility.md"
+    )
+
+    note_ref = "issue_728_coding_agents_compatibility.md"
+
+    agents_text = AGENTS_MD.read_text(encoding="utf-8")
+    assert note_ref in agents_text, (
+        f"{note_ref!r} not linked from AGENTS.md; add it to the Cross-Agent Compatibility section"
+    )
+
+    copilot_text = COPILOT_INSTRUCTIONS.read_text(encoding="utf-8")
+    assert note_ref in copilot_text, f"{note_ref!r} not linked from .github/copilot-instructions.md"
+
+    dev_guide_text = DEV_GUIDE.read_text(encoding="utf-8")
+    assert note_ref in dev_guide_text, f"{note_ref!r} not linked from docs/dev_guide.md"


### PR DESCRIPTION
## Summary

Adds the canonical cross-agent compatibility note for `vultuk/coding-agents` concepts,
maps the retrieval → planning → execution → verification discipline to repo-local skills,
and adds a regression test that guards discoverability from the three agent entry points.

## Linked Issues
- Closes #728
- Relates to #705

## What Changed
- `docs/context/issue_728_coding_agents_compatibility.md` — new canonical note recording
  adopted concepts (R→P→E→V discipline, per-source notes, `.agents/` separation) and
  explicitly rejected ones (vultuk layout, generator framework, cross-agent runtime assumptions).
- `AGENTS.md` — new "Cross-Agent Compatibility" section linking the note.
- `.github/copilot-instructions.md` — pointer to the note for Copilot-facing entry point.
- `docs/dev_guide.md` — link to the note next to the AI assistant section.
- `tests/test_ai_prompt_surfaces.py` — new `test_coding_agents_compatibility_note_is_discoverable`
  test verifying the note exists and is linked from all three entry points.

## Why It Matters
- Added value: Contributor or AI assistant can understand the repo's cross-agent stance from one
  canonical note rather than reconstructing it from issue comments.
- Expected impact: Reduces instruction drift; future AI workflow changes can reference this note.
- Why now: Companion to #705 unification work; captures decisions before surfaces drift further.

## Validation / Proof
- `uv run pytest tests/test_ai_prompt_surfaces.py -v` → 5 passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → 2779 passed, 14 skipped, all checks passed

## Risks / Rollout
- Compatibility risks: Low — docs/instructions only, no runtime behavior changed.
- Failure modes: Stale note if adopted skills are renamed; the discoverability test catches that.
- Rollback: Revert commit; test will fail until note and links are restored.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `.github/copilot-instructions.md`, `docs/dev_guide.md`
- New context note: `docs/context/issue_728_coding_agents_compatibility.md`
- Related prior note: `docs/ai/awesome_copilot_adaptation.md`

## Follow-Up Issues
- None required; deferred scope (multi-ecosystem compatibility matrix) recorded in the note.

## Reviewer Notes
- The note's accept/reject boundary is intentionally conservative; expanding adoption is a
  separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive cross-agent compatibility guidance documenting the repository's stance on adapting external agent workflows
  * Updated agent-facing and contributor documentation files with references to new compatibility standards

* **Tests**
  * Added test to ensure compatibility documentation is discoverable through all relevant documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->