### PR TITLE
docs: add layered agent memory system (#812)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,9 @@ It is everyones guide on how to use this repository effectively.
 - For the repository's cross-agent compatibility stance (retrieval → planning → execution →
   verification discipline, accepted and rejected external concepts), see
   `docs/context/issue_728_coding_agents_compatibility.md`.
+- For stable cross-session repo memory, start with `memory/MEMORY.md`, then open only the relevant
+  linked topic files under `memory/`. Use `docs/context/` for issue-specific execution notes rather
+  than storing those narratives in `memory/`.
 - For context discovery, use `.agents/skills/context-map/SKILL.md` before multi-file changes and
   `.agents/skills/what-context-needed/SKILL.md` when the task is underspecified.
 - For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ Use `.vscode/tasks.json` as thin wrappers around those scripts.
 Treat the following files as the repository-native context stack for Codex-style agents:
 
 - `AGENTS.md`: top-level execution rules, repo structure, and workflow defaults.
+- `CLAUDE.md`: Claude Code entrypoint that imports `AGENTS.md` plus the repo-local memory index.
+- `memory/MEMORY.md`: concise repo-local memory index for stable cross-session facts and links to
+  detailed topic files under `memory/`.
 - `code_review.md`: benchmark-facing review criteria, provenance checks, and regression traps.
 - `.agent/PLANS.md`: plan-writing convention for non-trivial work so intent, scope, and validation stay explicit.
 - `.agents/skills/`: canonical skill tree for execution workflows and repo-local context packs,
@@ -24,9 +27,16 @@ Read only the surfaces relevant to the task. Prefer these repo-local files over 
 Treat `docs/context/` as the repository's Markdown knowledge base for agent handoff, not as a dump
 of incidental scratch notes.
 
+Treat `memory/` as the complementary repo-local memory layer for stable cross-session facts:
+architecture summaries, durable decisions, reusable experiment outcomes, known failure modes, and
+benchmark memory boundaries. Keep `memory/MEMORY.md` concise and update linked topic files for
+detail instead of turning the index into another full instruction document.
+
 - For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and
   handoff context in Markdown when that context would otherwise be trapped in chat, PR text, or
   issue comments.
+- Use `docs/context/` for issue-specific execution history and validation detail; use `memory/`
+  for knowledge that should be reused across multiple future sessions.
 - Prefer updating an existing canonical note when it already covers the same topic. Create a new
   note only when the subject is distinct enough that merging would hide the decision trail.
 - Link notes to the related issue/PR, relevant canonical docs, proof artifacts, and any predecessor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a repo-local agent memory layer with `CLAUDE.md` startup imports, a canonical
+  `memory/MEMORY.md` index, typed memory subdirectories (`architecture`, `decisions`,
+  `experiments`, `failures`, `benchmarks`), example notes for each type, and linked guidance in
+  `AGENTS.md`, `docs/dev_guide.md`, `docs/README.md`, and the AI-facing overview/deferral docs.
 * Added canonical `classic_cross_trap_*` scenario IDs and manifests for the former
 `classic_crossing_*` cross-shaped local-minimum trap scenarios, with legacy
   compatibility aliases and migration notes for existing configs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+@AGENTS.md
+@memory/MEMORY.md
+
+## Claude Code
+
+- Treat `AGENTS.md` as the canonical repository workflow guide.
+- Treat `memory/MEMORY.md` as the concise repo-local memory index; open linked topic files on
+  demand instead of expanding the whole tree into startup context.
+- Before coding, read the relevant entries under `memory/architecture/`,
+  `memory/decisions/`, and `memory/failures/` when the task touches workflow, experiments, or
+  benchmark behavior.
+- Use `docs/context/` for issue-specific execution notes and `memory/` for stable cross-session
+  facts, reusable experiment summaries, and durable failure patterns.

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * **[AI Context Packing Decision](./ai/context_packing.md)** - Current decision and rationale for using Repomix as the default focused-context bundler
 * **[Awesome Copilot Adaptation](./ai/awesome_copilot_adaptation.md)** - Selective adaptation plan for Codex skills, including `autoresearch`,  `auto-improvement`, context-discovery, quality, and doc-sync skills
 * **[AI Retrieval Deferral Note](./ai/retrieval_deferral.md)** - Why MCP/retrieval layers stay out of scope until a real context boundary appears
+* **[Agent Memory Index](../memory/MEMORY.md)** - Repo-local Markdown memory taxonomy for durable agent context, with linked architecture, decision, experiment, failure, and benchmark notes
 * **[Observation Contract](./dev/observation_contract.md)** - Observation schemas, shapes, and normalization conventions
 * **[Holonomic Action Contract](./dev/holonomic_action_contract.md)** - Exact holonomic action-space semantics, heading behavior, and benchmark bridge rules
 * **[Training Protocol Template](./dev/training_protocol_template.md)** - Fill-in template for documenting training/evaluation runs

--- a/docs/ai/awesome_copilot_adaptation.md
+++ b/docs/ai/awesome_copilot_adaptation.md
@@ -58,10 +58,13 @@ These upstream ideas were kept because they add direct value to this repository'
 
 ## Concepts Rejected
 
-- a new retrieval database or MCP-backed memory layer,
+- a new retrieval database or MCP-managed memory store separate from repo Markdown,
 - a public Copilot marketplace clone,
 - prompt copies that depend on GitHub-specific runtime behavior,
 - copying upstream text verbatim when a shorter repo-native version is enough.
+
+Optional MCP exposure of repo-local Markdown under `memory/` is acceptable when it remains a thin
+file-access layer rather than a new knowledge service.
 
 ## Skill Selection Guide
 

--- a/docs/ai/awesome_copilot_adaptation.md
+++ b/docs/ai/awesome_copilot_adaptation.md
@@ -1,6 +1,7 @@
 # Awesome Copilot Adaptation
 
 Date: 2026-04-02
+Updated: 2026-04-13
 
 ## Decision
 

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -21,10 +21,12 @@ delivery rather than generic robotics breadth.
 Start here before expanding:
 
 1. `AGENTS.md`
-2. `.specify/memory/constitution.md`
-3. `docs/dev_guide.md`
-4. `code_review.md`
-5. `.agent/PLANS.md` for non-trivial work
+2. `CLAUDE.md` when the agent runtime supports it
+3. `memory/MEMORY.md` for stable repo-local memory
+4. `.specify/memory/constitution.md`
+5. `docs/dev_guide.md`
+6. `code_review.md`
+7. `.agent/PLANS.md` for non-trivial work
 
 Then branch by task type:
 
@@ -50,6 +52,7 @@ Then branch by task type:
 - `scripts/`: runnable entrypoints and validation helpers
 - `output/`: git-ignored canonical artifact root
 - `docs/context/`: linked execution notes, issue-specific evidence logs, and agent handoff context
+- `memory/`: repo-local Markdown memory tree for stable cross-session facts and concise retrieval
 
 ### Existing agent workflow surfaces
 
@@ -61,6 +64,8 @@ Then branch by task type:
   for locating the right files or requesting the minimum missing context
 - `.agents/skills/context-note-maintainer/`: note-creation and stale-note-maintenance workflow for
   durable Markdown handoff context
+- `CLAUDE.md` + `memory/MEMORY.md`: startup-oriented memory/index pair for agent runtimes that
+  support imported project instructions
 - `.agents/skills/quality-playbook/`, `.agents/skills/agentic-eval/`,
   `.agents/skills/review-and-refactor/`, and `.agents/skills/update-docs-on-code-change/`: quality
   and maintenance skills for proof-first changes, AI-output evaluation, narrow refactors, and

--- a/docs/ai/retrieval_deferral.md
+++ b/docs/ai/retrieval_deferral.md
@@ -13,6 +13,11 @@ Specifically deferred:
 - `Chroma MCP`
 - any persistent semantic-memory or vector-database layer
 
+Allowed:
+
+- repo-local Markdown memory under `memory/`
+- optional MCP exposure of those Markdown files without adding a separate database
+
 ## Rationale
 
 The repository already has a strong local-context baseline:
@@ -37,9 +42,10 @@ Revisit retrieval only if a real boundary appears, such as:
 Until then, prefer:
 
 1. repo-local instructions,
-2. focused docs under `docs/ai/`,
-3. `.agents/skills/` context packs,
-4. manual or scripted context bundles via the chosen packer.
+2. `memory/MEMORY.md` plus linked topic files,
+3. focused docs under `docs/ai/`,
+4. `.agents/skills/` context packs,
+5. manual or scripted context bundles via the chosen packer.
 
 ## What This Prevents
 

--- a/docs/ai/retrieval_deferral.md
+++ b/docs/ai/retrieval_deferral.md
@@ -1,6 +1,7 @@
 # Retrieval And MCP Deferral Note
 
 Date: 2026-03-19
+Updated: 2026-04-13
 
 ## Decision
 

--- a/docs/context/issue_812_layered_agent_memory.md
+++ b/docs/context/issue_812_layered_agent_memory.md
@@ -1,0 +1,50 @@
+# Issue 812 Layered Agent Memory Rollout
+
+- GitHub issue: [#812](https://github.com/ll7/robot_sf_ll7/issues/812)
+- Related guidance:
+  - [AGENTS.md](../../AGENTS.md)
+  - [CLAUDE.md](../../CLAUDE.md)
+  - [docs/dev_guide.md](../dev_guide.md)
+  - [docs/README.md](../README.md)
+  - [docs/ai/repo_overview.md](../ai/repo_overview.md)
+  - [docs/ai/retrieval_deferral.md](../ai/retrieval_deferral.md)
+  - [memory/MEMORY.md](../../memory/MEMORY.md)
+
+## Goal
+
+Add a repo-local Markdown memory layer that agents can reuse across sessions while keeping the
+existing no-database retrieval policy intact.
+
+## Key Decisions
+
+- The canonical startup pattern for Claude Code is now `CLAUDE.md` importing `AGENTS.md` and
+  `memory/MEMORY.md`.
+- `memory/` is reserved for stable cross-session facts; `docs/context/` remains the issue and
+  validation note knowledge base.
+- Optional MCP integration is limited to exposing repository Markdown files, not adding a separate
+  semantic-memory store.
+- `memory/MEMORY.md` stays concise and points to topic files for detail, following the same
+  index-plus-topic-file shape Claude Code documents for its own auto memory.
+
+## Validation
+
+Commands and checks used for this rollout:
+
+- Verify Anthropic's current Claude Code memory model and `AGENTS.md` import guidance from the
+  official docs page on project memory.
+- Confirm the new file surfaces exist and cross-link correctly:
+  - `CLAUDE.md`
+  - `memory/MEMORY.md`
+  - `memory/architecture/layered_agent_memory_architecture.md`
+  - `memory/decisions/2026-04-13_repo_local_memory_layer.md`
+  - `memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md`
+  - `memory/failures/2026-04-13_memory_misuse_and_staleness.md`
+  - `memory/benchmarks/2026-04-13_benchmark_memory_scope.md`
+- Run the repository readiness gate after syncing docs changes.
+
+## Current Boundary
+
+This rollout adds the Markdown taxonomy, startup wiring, and documentation surfaces. It does not
+introduce automated memory capture or a live retrieval backend. The round-trip example is a
+documented dry run; live Claude Code `/memory` verification is tracked separately in
+[#816](https://github.com/ll7/robot_sf_ll7/issues/816).

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -157,6 +157,24 @@ handoff context in Markdown instead of leaving them trapped in chat or PR histor
 - Use `.agents/skills/context-note-maintainer/SKILL.md` when the task includes creating or
   refreshing context notes.
 
+### Agent memory conventions
+
+The repository now keeps a repo-local Markdown memory layer under `memory/` for stable cross-session
+agent context.
+
+- Start with `memory/MEMORY.md`, which acts as the concise index.
+- Store reusable memory in typed subdirectories such as `memory/architecture/`,
+  `memory/decisions/`, `memory/experiments/`, `memory/failures/`, and `memory/benchmarks/`.
+- Use the experiment naming pattern `memory/experiments/YYYY-MM-DD_<topic>.md`.
+- Keep `memory/MEMORY.md` short and push detail into linked topic files so it stays compatible with
+  Claude-style startup loading.
+- Use `docs/context/` for issue execution history and validation detail; use `memory/` only for
+  knowledge worth reusing across future sessions.
+- If Claude Code is in use, `CLAUDE.md` imports both `AGENTS.md` and `memory/MEMORY.md` so the
+  shared instructions and memory index load together.
+- Optional MCP integration should expose the Markdown files directly; do not add a retrieval
+  database or vector store unless the repository's retrieval-deferral policy changes.
+
 On macOS, `scripts/dev/run_tests_parallel.sh` uses a bounded fixed xdist worker count by
 default instead of `-n auto`, because the unbounded auto worker selection can leave local
 validation wrappers hanging after child processes should have exited. Override with

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,65 @@
+# Repository Memory Index
+
+This directory is the repo-local memory layer for stable cross-session agent context in
+`robot_sf_ll7`.
+
+It mirrors Claude Code's auto-memory shape on purpose: keep this `MEMORY.md` file short and use it
+as the startup index, then put details in linked topic files that agents read on demand.
+
+## Retrieval Order
+
+1. Read this file first.
+2. Open only the linked topic files relevant to the current task.
+3. Prefer `architecture/` and `decisions/` before making workflow or design changes.
+4. Consult `failures/`, `benchmarks/`, and `experiments/` when the task depends on prior outcomes
+   or known pitfalls.
+
+## Write Rules
+
+- Use `memory/` for reusable knowledge that should survive across sessions.
+- Use `docs/context/` for issue execution history, validation notes, and handoff details that are
+  specific to one change or investigation.
+- Keep this file under Claude-style startup limits in practice: concise, under roughly 200 lines,
+  and free of duplicated detail.
+- Prefer updating an existing memory note over creating a near-duplicate.
+- When a memory note becomes stale, update it or remove its index entry instead of stacking
+  contradictory summaries.
+
+## Directory Map
+
+### `architecture/`
+
+- [layered_agent_memory_architecture.md](architecture/layered_agent_memory_architecture.md)
+  Layer boundaries, `CLAUDE.md` import path, optional MCP exposure, and the retrieval-deferral
+  boundary.
+
+### `decisions/`
+
+- [2026-04-13_repo_local_memory_layer.md](decisions/2026-04-13_repo_local_memory_layer.md)
+  Adopt a Markdown-first repo-local memory tree and keep retrieval/database infrastructure out of
+  scope.
+
+### `experiments/`
+
+- [2026-04-13_agent_memory_roundtrip_dry_run.md](experiments/2026-04-13_agent_memory_roundtrip_dry_run.md)
+  Example session log showing how a new memory entry should be indexed and replayed in a new
+  session.
+
+### `failures/`
+
+- [2026-04-13_memory_misuse_and_staleness.md](failures/2026-04-13_memory_misuse_and_staleness.md)
+  Known failure modes for this memory layer: stale summaries, duplicated notes, and mixing issue
+  logs into stable memory.
+
+### `benchmarks/`
+
+- [2026-04-13_benchmark_memory_scope.md](benchmarks/2026-04-13_benchmark_memory_scope.md)
+  What benchmark-facing evidence belongs in memory, what must stay in `docs/context/`, and why
+  fallback/degraded outcomes cannot be stored as success claims.
+
+## Maintenance
+
+- `CLAUDE.md` imports this file so Claude Code can see the index at session start.
+- Other agents should treat this directory as optional but preferred startup context for durable
+  repo facts.
+- If the tree grows large, keep this index concise and move detail into additional topic files.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -29,31 +29,31 @@ as the startup index, then put details in linked topic files that agents read on
 
 ### `architecture/`
 
-- [layered_agent_memory_architecture.md](architecture/layered_agent_memory_architecture.md)
+- [Layered Agent Memory Architecture](architecture/layered_agent_memory_architecture.md)
   Layer boundaries, `CLAUDE.md` import path, optional MCP exposure, and the retrieval-deferral
   boundary.
 
 ### `decisions/`
 
-- [2026-04-13_repo_local_memory_layer.md](decisions/2026-04-13_repo_local_memory_layer.md)
+- [Decision: Adopt A Repo-Local Markdown Memory Layer](decisions/2026-04-13_repo_local_memory_layer.md)
   Adopt a Markdown-first repo-local memory tree and keep retrieval/database infrastructure out of
   scope.
 
 ### `experiments/`
 
-- [2026-04-13_agent_memory_roundtrip_dry_run.md](experiments/2026-04-13_agent_memory_roundtrip_dry_run.md)
+- [Experiment: Agent Memory Round-Trip Dry Run](experiments/2026-04-13_agent_memory_roundtrip_dry_run.md)
   Example session log showing how a new memory entry should be indexed and replayed in a new
   session.
 
 ### `failures/`
 
-- [2026-04-13_memory_misuse_and_staleness.md](failures/2026-04-13_memory_misuse_and_staleness.md)
+- [Failure Patterns: Memory Misuse And Staleness](failures/2026-04-13_memory_misuse_and_staleness.md)
   Known failure modes for this memory layer: stale summaries, duplicated notes, and mixing issue
   logs into stable memory.
 
 ### `benchmarks/`
 
-- [2026-04-13_benchmark_memory_scope.md](benchmarks/2026-04-13_benchmark_memory_scope.md)
+- [Benchmark Memory Scope](benchmarks/2026-04-13_benchmark_memory_scope.md)
   What benchmark-facing evidence belongs in memory, what must stay in `docs/context/`, and why
   fallback/degraded outcomes cannot be stored as success claims.
 

--- a/memory/architecture/layered_agent_memory_architecture.md
+++ b/memory/architecture/layered_agent_memory_architecture.md
@@ -1,0 +1,47 @@
+# Layered Agent Memory Architecture
+
+## Goal
+
+Provide a passive, versioned memory layer for coding agents without introducing a retrieval
+database, vector store, or background service that needs operational ownership.
+
+## Layers
+
+1. `AGENTS.md`, `docs/dev_guide.md`, and other repo instructions define workflow rules.
+2. `CLAUDE.md` imports `AGENTS.md` and `memory/MEMORY.md` so Claude Code gets both startup
+   instructions and the memory index.
+3. `memory/` stores reusable cross-session facts:
+   - architecture summaries,
+   - stable decisions,
+   - reusable experiment outcomes,
+   - known failure patterns,
+   - benchmark memory boundaries.
+4. `docs/context/` remains the broader execution-note knowledge base for issue history, validation
+   detail, and handoff context.
+
+## Optional MCP Integration Path
+
+The supported integration path is file exposure, not a new database:
+
+- Use a filesystem-oriented or Markdown-aware MCP server to expose `memory/` read-only to agents.
+- A server such as `gnosis-mcp` or an equivalent local-Markdown MCP is acceptable only when it
+  serves the repo files directly.
+- Prefer exposing `memory/` first and add `docs/context/` only if the agent needs wider issue
+  history.
+- Keep writeback manual unless the team deliberately opts into automated note generation later.
+
+## Hybrid Retrieval Boundary
+
+Hybrid retrieval is optional and constrained:
+
+- Default flow: read `memory/MEMORY.md`, then open the few linked files that match the task.
+- Optional enhancement: let an MCP server help locate the right Markdown file quickly.
+- Still out of scope: embeddings, vector search, knowledge graphs, or any memory source that is
+  not plainly auditable from versioned Markdown in this repository.
+
+## Authoring Rules
+
+- Keep `memory/MEMORY.md` concise and index-like.
+- Put durable details into topic files with stable filenames.
+- Prefer dated experiment and failure notes when the content is chronological.
+- Link out to canonical docs or context notes instead of copying large validation narratives here.

--- a/memory/benchmarks/2026-04-13_benchmark_memory_scope.md
+++ b/memory/benchmarks/2026-04-13_benchmark_memory_scope.md
@@ -1,0 +1,23 @@
+# Benchmark Memory Scope
+
+Date: 2026-04-13
+
+## What Belongs In Memory
+
+- stable benchmark workflow rules
+- recurring interpretation caveats
+- known failure modes that matter across multiple benchmark tasks
+- links to canonical proof notes or release docs
+
+## What Should Stay Elsewhere
+
+- full execution logs and issue-specific investigation details: `docs/context/`
+- generated artifacts and raw outputs: `output/`
+- transient benchmark experiments that are not yet stable enough to reuse as memory
+
+## Fail-Closed Reminder
+
+Memory notes must not present fallback, degraded, or partial-failure benchmark outcomes as success.
+When a benchmark result matters, memory should summarize the reusable lesson and link to the
+canonical evidence, such as `docs/context/issue_691_benchmark_fallback_policy.md` or a benchmark
+issue note.

--- a/memory/decisions/2026-04-13_repo_local_memory_layer.md
+++ b/memory/decisions/2026-04-13_repo_local_memory_layer.md
@@ -1,0 +1,34 @@
+# Decision: Adopt A Repo-Local Markdown Memory Layer
+
+Date: 2026-04-13
+
+## Decision
+
+Adopt a repo-local `memory/` tree with a concise `memory/MEMORY.md` index and topic files for
+architecture, decisions, experiments, failures, and benchmark-specific memory guidance.
+
+## Why
+
+- Agents in this repository need stable cross-session recall for design and experiment context.
+- The repository already prefers auditable Markdown knowledge over opaque external state.
+- A Markdown tree is easy to review, diff, and update alongside code and docs.
+
+## What This Includes
+
+- `CLAUDE.md` importing both `AGENTS.md` and `memory/MEMORY.md`
+- a stable `memory/` taxonomy
+- one example note per memory type
+- contributor guidance in `docs/dev_guide.md`
+
+## What This Excludes
+
+- vector databases
+- embedding pipelines
+- knowledge graphs
+- automatic summarization daemons
+- benchmark or training code changes
+
+## Status
+
+Current repository policy allows optional MCP exposure of these Markdown files, but the files
+themselves remain the source of truth.

--- a/memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md
+++ b/memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md
@@ -1,0 +1,32 @@
+# Experiment: Agent Memory Round-Trip Dry Run
+
+Date: 2026-04-13
+Status: documented dry run
+
+## Goal
+
+Show the intended write -> index -> recall loop for repo-local memory entries.
+
+## Steps
+
+1. Write or update a topic note in `memory/experiments/`.
+2. Add a one-line entry for it in `memory/MEMORY.md`.
+3. Ensure `CLAUDE.md` imports `memory/MEMORY.md`.
+4. In a fresh agent session, start from `CLAUDE.md` or `memory/MEMORY.md`, then open the linked
+   experiment note on demand.
+
+## Example Recall Target
+
+This note records that the repository memory layer is designed around a concise index plus
+on-demand topic files rather than a monolithic instruction file.
+
+## Validation Notes
+
+- `CLAUDE.md` imports `memory/MEMORY.md`, so the index is part of Claude Code startup context.
+- The index links this file directly, so a fresh session has a deterministic path to the note.
+
+## Boundary
+
+This is a documented dry run, not an automated live Claude Code session test. If future work needs
+tool-specific proof, run a manual `/memory` check in Claude Code and record the result here or in a
+linked `docs/context/` note. Follow-up tracker: issue `#816`.

--- a/memory/failures/2026-04-13_memory_misuse_and_staleness.md
+++ b/memory/failures/2026-04-13_memory_misuse_and_staleness.md
@@ -1,0 +1,23 @@
+# Failure Patterns: Memory Misuse And Staleness
+
+Date: 2026-04-13
+
+## Anti-Patterns
+
+- Storing issue-specific execution logs in `memory/` instead of `docs/context/`
+- Letting `memory/MEMORY.md` grow into a second `AGENTS.md`
+- Copying benchmark claims into memory without linking the validating artifact or note
+- Leaving stale summaries in place after the underlying workflow changes
+- Creating multiple near-identical notes for the same stable fact
+
+## Mitigations
+
+- Keep `memory/MEMORY.md` as an index, not a dump.
+- Put validation-heavy narratives in `docs/context/`.
+- Update the canonical note instead of adding another one.
+- Link benchmark-sensitive memory notes to the proof surface that justifies them.
+
+## Retrieval Warning
+
+Agents should treat `memory/` as helpful context, not as an override for newer canonical docs or
+freshly validated benchmark evidence.


### PR DESCRIPTION
## Summary
Add a repo-local Markdown memory layer for coding agents, including a Claude-compatible startup path, a canonical `memory/MEMORY.md` index, typed memory note examples, and linked contributor/AI-facing documentation.

## Linked Issues
- Closes #812
- Relates to #816

## What Changed
- Added `CLAUDE.md` that imports `AGENTS.md` and `memory/MEMORY.md` for Claude Code startup context.
- Added `memory/` with a concise `MEMORY.md` index plus example notes under `architecture/`, `decisions/`, `experiments/`, `failures/`, and `benchmarks/`.
- Updated `AGENTS.md`, `.github/copilot-instructions.md`, `docs/dev_guide.md`, `docs/README.md`, and `docs/ai/*` to document the new memory layer and keep the retrieval-deferral policy consistent.
- Added `docs/context/issue_812_layered_agent_memory.md` as the canonical rollout note.
- Added changelog coverage for the new agent-memory surface.

## Why It Matters
- Added value: gives agents a stable, versioned place to recover reusable repo knowledge across sessions.
- Expected impact: reduces repeated re-contextualization while keeping memory auditable in Markdown.
- Why this is worth merging now: the repository already relies on durable handoff notes and AI-facing guidance, so this adds a structured memory layer without introducing new infrastructure.

## Validation / Proof
- Commands run:
  - `source .venv/bin/activate && BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `git diff --check`
- Evidence that the change works here:
  - `CLAUDE.md` imports `AGENTS.md` and `memory/MEMORY.md`.
  - `memory/MEMORY.md` is concise (65 lines) and links deterministic topic files.
  - The new memory/doc surfaces all exist and cross-link correctly.
- Benchmarks or smoke tests, if applicable:
  - `pr_ready_check.sh` failed on an unrelated pre-existing assertion in `tests/baselines/test_sac_planner.py::test_step_vector_mode_uses_model_prediction_and_fallback_action` (`0.7853981633974482` vs `0.7853981633974483`). This docs-only branch does not touch the planner code under test.

## Risks / Rollout
- Compatibility risks: low; the change adds Markdown and guidance only.
- Failure modes: stale memory notes or misuse of `memory/` for issue logs instead of stable facts.
- Rollback or fallback plan: remove `CLAUDE.md` and `memory/` plus the linked doc references if the team decides not to keep the memory layer.

## Docs / Provenance
- Updated docs:
  - `AGENTS.md`
  - `.github/copilot-instructions.md`
  - `docs/dev_guide.md`
  - `docs/README.md`
  - `docs/ai/repo_overview.md`
  - `docs/ai/retrieval_deferral.md`
  - `docs/ai/awesome_copilot_adaptation.md`
  - `docs/context/issue_812_layered_agent_memory.md`
- Relevant design or provenance notes:
  - Anthropic Claude Code memory documentation informed the `CLAUDE.md` import path and concise `MEMORY.md` index shape.
- Any assumptions that need to be preserved:
  - Optional MCP support is limited to exposing repo Markdown directly, not adding a separate retrieval database.

## Follow-Up Issues
- Deferred work:
  - live Claude Code `/memory` round-trip verification
- Issues opened for follow-up:
  - #816

## Reviewer Notes
- Anything a reviewer should verify closely:
  - the boundary between `memory/` and `docs/context/`
  - the wording change in the retrieval-deferral docs so it still rejects database-backed memory infrastructure
- Any known limitations:
  - the round-trip example is a documented dry run until #816 is executed in a live Claude Code session.
