### PR TITLE
docs: live agent memory round-trip validation (#816)

### DIFF
--- a/docs/context/issue_812_layered_agent_memory.md
+++ b/docs/context/issue_812_layered_agent_memory.md
@@ -51,8 +51,9 @@ Issue #816 performed the live agent round-trip that this rollout deferred. Findi
   correctly guided task execution without re-reading the entire `memory/` tree.
 - **Multi-agent coverage**: Copilot via `.github/copilot-instructions.md`, Codex via `AGENTS.md`
   Codex Context Stack section, and GitHub agents via `.agents/agents/github/` all have structural
-  pointers or references. Opencode has no dedicated entrypoint but `docs/ai/repo_overview.md`
-  lists `memory/MEMORY.md` in "First Files To Read".
+  pointers or references. Opencode uses `opencode.json` as its configuration entrypoint; `docs/ai/repo_overview.md`
+  lists `memory/MEMORY.md` in "First Files To Read". The gap is that `opencode.json` does not
+  explicitly import `memory/MEMORY.md` in its `instructions` array; tracked as a known limitation.
 - **Auto-memory distinction clarified**: Claude Code's user-level auto-memory
   (`~/.claude/projects/`) is separate from this repo-local `memory/` layer and is not committed to
   the repository. Both coexist without conflict.

--- a/docs/context/issue_812_layered_agent_memory.md
+++ b/docs/context/issue_812_layered_agent_memory.md
@@ -42,9 +42,26 @@ Commands and checks used for this rollout:
   - `memory/benchmarks/2026-04-13_benchmark_memory_scope.md`
 - Run the repository readiness gate after syncing docs changes.
 
+## Live Round-Trip Validation (2026-04-14, issue #816)
+
+Issue #816 performed the live agent round-trip that this rollout deferred. Findings:
+
+- **Claude Code** (model `claude-sonnet-4-6`): `CLAUDE.md` loaded both `@AGENTS.md` and
+  `@memory/MEMORY.md` at session startup. All five typed topic files were reachable. The index
+  correctly guided task execution without re-reading the entire `memory/` tree.
+- **Multi-agent coverage**: Copilot via `.github/copilot-instructions.md`, Codex via `AGENTS.md`
+  Codex Context Stack section, and GitHub agents via `.agents/agents/github/` all have structural
+  pointers or references. Opencode has no dedicated entrypoint but `docs/ai/repo_overview.md`
+  lists `memory/MEMORY.md` in "First Files To Read".
+- **Auto-memory distinction clarified**: Claude Code's user-level auto-memory
+  (`~/.claude/projects/`) is separate from this repo-local `memory/` layer and is not committed to
+  the repository. Both coexist without conflict.
+
+Full validation record: `memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md`
+Updated architecture note: `memory/architecture/layered_agent_memory_architecture.md`
+
 ## Current Boundary
 
 This rollout adds the Markdown taxonomy, startup wiring, and documentation surfaces. It does not
-introduce automated memory capture or a live retrieval backend. The round-trip example is a
-documented dry run; live Claude Code `/memory` verification is tracked separately in
-[#816](https://github.com/ll7/robot_sf_ll7/issues/816).
+introduce automated memory capture or a live retrieval backend. Opencode lacks a dedicated
+instruction entrypoint that explicitly imports `memory/MEMORY.md`; tracked as a known gap.

--- a/memory/architecture/layered_agent_memory_architecture.md
+++ b/memory/architecture/layered_agent_memory_architecture.md
@@ -8,8 +8,9 @@ database, vector store, or background service that needs operational ownership.
 ## Layers
 
 1. `AGENTS.md`, `docs/dev_guide.md`, and other repo instructions define workflow rules.
+   These are human-readable first; agents are secondary consumers.
 2. `CLAUDE.md` imports `AGENTS.md` and `memory/MEMORY.md` so Claude Code gets both startup
-   instructions and the memory index.
+   instructions and the memory index at session start.
 3. `memory/` stores reusable cross-session facts:
    - architecture summaries,
    - stable decisions,
@@ -18,6 +19,35 @@ database, vector store, or background service that needs operational ownership.
    - benchmark memory boundaries.
 4. `docs/context/` remains the broader execution-note knowledge base for issue history, validation
    detail, and handoff context.
+
+## Multi-Agent Startup Map
+
+| Agent         | Primary instruction entrypoint             | memory/MEMORY.md path                        | Status             |
+|---------------|--------------------------------------------|----------------------------------------------|--------------------|
+| Claude Code   | `CLAUDE.md` (`@AGENTS.md`, `@memory/MEMORY.md`) | direct import at startup                 | ✅ live validated   |
+| Copilot       | `.github/copilot-instructions.md`          | explicit pointer in instructions file        | ✅ documented       |
+| Codex         | `AGENTS.md` (Codex Context Stack section)  | listed in stack; agent reads on demand       | ✅ documented       |
+| GitHub agents | `.agents/agents/github/` agent files       | not directly referenced; reads `AGENTS.md`   | ⚠️ indirect only   |
+| Opencode      | `AGENTS.md` via `docs/ai/repo_overview.md` | listed in "First Files To Read"              | ⚠️ no entrypoint   |
+
+**Opencode gap**: Opencode has `.opencode/skills/` (mirrored from `.agents/skills/`) and
+`.opencode/tools/` but no dedicated instruction entrypoint that imports `memory/MEMORY.md`.
+It relies on reading `AGENTS.md` and `docs/ai/repo_overview.md`, which list the memory index.
+This is sufficient for agents that read those files; a dedicated `opencode.md` or similar config
+would make the path explicit. Tracked as a known gap, not a critical failure.
+
+## Auto-Memory Distinction
+
+Claude Code's user-level auto-memory (written to `~/.claude/projects/<repo-slug>/memory/`) is
+**separate** from this repo-local `memory/` layer:
+
+- **User-level auto-memory**: private to the user's local Claude Code install; contains session
+  notes, preferences, and per-user context. Not committed to the repository.
+- **Repo-local memory** (`memory/`): committed to the repository; shared across all agents and
+  contributors; authoritative for stable cross-session facts.
+
+Both layers can coexist. The repo-local layer is the canonical shared source; user-level memory
+adds personal context on top. Do not duplicate repo-level decisions in user-level memory.
 
 ## Optional MCP Integration Path
 
@@ -28,7 +58,7 @@ The supported integration path is file exposure, not a new database:
   serves the repo files directly.
 - Prefer exposing `memory/` first and add `docs/context/` only if the agent needs wider issue
   history.
-- Keep writeback manual unless the team deliberately opts into automated note generation later.
+- Keep writeback manual; automated note generation is opt-in and requires explicit team decision.
 
 ## Hybrid Retrieval Boundary
 
@@ -45,3 +75,6 @@ Hybrid retrieval is optional and constrained:
 - Put durable details into topic files with stable filenames.
 - Prefer dated experiment and failure notes when the content is chronological.
 - Link out to canonical docs or context notes instead of copying large validation narratives here.
+- Most context should live in human-readable docs (`AGENTS.md`, `docs/`) rather than agent-only
+  memory files. `memory/` is for stable facts that agents benefit from recalling across sessions
+  but that also serve as project documentation for contributors.

--- a/memory/architecture/layered_agent_memory_architecture.md
+++ b/memory/architecture/layered_agent_memory_architecture.md
@@ -28,13 +28,14 @@ database, vector store, or background service that needs operational ownership.
 | Copilot       | `.github/copilot-instructions.md`          | explicit pointer in instructions file        | ✅ documented       |
 | Codex         | `AGENTS.md` (Codex Context Stack section)  | listed in stack; agent reads on demand       | ✅ documented       |
 | GitHub agents | `.agents/agents/github/` agent files       | not directly referenced; reads `AGENTS.md`   | ⚠️ indirect only   |
-| Opencode      | `AGENTS.md` via `docs/ai/repo_overview.md` | listed in "First Files To Read"              | ⚠️ no entrypoint   |
+| Opencode      | `opencode.json` (imports `AGENTS.md`)     | listed in "First Files To Read"              | ⚠️ indirect only   |
 
-**Opencode gap**: Opencode has `.opencode/skills/` (mirrored from `.agents/skills/`) and
-`.opencode/tools/` but no dedicated instruction entrypoint that imports `memory/MEMORY.md`.
-It relies on reading `AGENTS.md` and `docs/ai/repo_overview.md`, which list the memory index.
-This is sufficient for agents that read those files; a dedicated `opencode.md` or similar config
-would make the path explicit. Tracked as a known gap, not a critical failure.
+**Opencode gap**: Opencode uses `opencode.json` (repository root) as its configuration
+entrypoint, which currently imports `AGENTS.md` but does not explicitly list
+`memory/MEMORY.md` in its `instructions` array. It can still discover the memory index via
+`AGENTS.md` or `docs/ai/repo_overview.md`. Adding `memory/MEMORY.md` explicitly to
+`opencode.json`'s instructions would make the startup path explicit. Tracked as a known gap,
+not a critical failure.
 
 ## Auto-Memory Distinction
 

--- a/memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md
+++ b/memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md
@@ -1,11 +1,12 @@
-# Experiment: Agent Memory Round-Trip Dry Run
+# Experiment: Agent Memory Round-Trip Dry Run → Live Validation
 
-Date: 2026-04-13
-Status: documented dry run
+Date: 2026-04-13 (dry run), 2026-04-14 (live validation)
+Status: **live validated** — issue #816
 
 ## Goal
 
-Show the intended write -> index -> recall loop for repo-local memory entries.
+Show the intended write → index → recall loop for repo-local memory entries, then confirm the
+loop with a real Claude Code session.
 
 ## Steps
 
@@ -15,18 +16,38 @@ Show the intended write -> index -> recall loop for repo-local memory entries.
 4. In a fresh agent session, start from `CLAUDE.md` or `memory/MEMORY.md`, then open the linked
    experiment note on demand.
 
+## Live Round-Trip Result (2026-04-14, issue #816)
+
+Session: Claude Code, model `claude-sonnet-4-6`, invoked via Codex worktree
+Branch: `816-validate-live-agent-round-trip-for-repo-local-memory-layer`
+
+**What was loaded at startup:**
+- `CLAUDE.md` — visible in `system-reminder` startup context
+- `@AGENTS.md` — imported via CLAUDE.md; content confirmed in session context
+- `@memory/MEMORY.md` — imported via CLAUDE.md; index confirmed readable
+
+**What was validated during the session:**
+- All five typed topic files (`architecture/`, `decisions/`, `experiments/`, `failures/`,
+  `benchmarks/`) were reachable via direct `Read` calls
+- `docs/context/issue_812_layered_agent_memory.md` was reachable and used to understand prior
+  issue-812 rollout scope
+- Linked memory entries in the index were followed without any broken paths
+- The memory files remained concise and did not replicate content already in `AGENTS.md`
+
+**What was NOT validated in this session:**
+- Automated memory writeback (repo-local `memory/` files are written manually; Claude Code's
+  user-level auto-memory writes to `~/.claude/projects/`, a separate store)
+- Opencode and raw-Codex live sessions — no direct evidence that those agents loaded the index;
+  only structural coverage was confirmed (see architecture note)
+
 ## Example Recall Target
 
 This note records that the repository memory layer is designed around a concise index plus
 on-demand topic files rather than a monolithic instruction file.
 
-## Validation Notes
-
-- `CLAUDE.md` imports `memory/MEMORY.md`, so the index is part of Claude Code startup context.
-- The index links this file directly, so a fresh session has a deterministic path to the note.
-
 ## Boundary
 
-This is a documented dry run, not an automated live Claude Code session test. If future work needs
-tool-specific proof, run a manual `/memory` check in Claude Code and record the result here or in a
-linked `docs/context/` note. Follow-up tracker: issue `#816`.
+The live round-trip proves that the Claude Code startup path correctly loads `memory/MEMORY.md`
+and that topic files are reachable. Automated memory capture and non-Claude agent live tests
+remain future work. See `memory/architecture/layered_agent_memory_architecture.md` for the
+multi-agent coverage map.


### PR DESCRIPTION
## Summary

Records the live Claude Code session (model `claude-sonnet-4-6`) that validated the repo-local memory layer introduced in issue #812. Confirms `CLAUDE.md` correctly loads `@memory/MEMORY.md` at startup, all five typed topic files are reachable, and the auto-memory distinction is clear.

## Linked Issues
- Closes #816
- Relates to #812

## What Changed
- `memory/experiments/2026-04-13_agent_memory_roundtrip_dry_run.md`: upgraded from dry-run to live-validated; added full round-trip result section documenting session context, what was loaded, what was validated, and what remains out of scope.
- `memory/architecture/layered_agent_memory_architecture.md`: added multi-agent startup map table (Claude Code ✅, Copilot ✅, Codex ✅, GitHub agents ⚠️ indirect, Opencode ⚠️ no entrypoint); added auto-memory distinction section; updated authoring rules.
- `docs/context/issue_812_layered_agent_memory.md`: added "Live Round-Trip Validation (2026-04-14, issue #816)" section with findings; updated "Current Boundary" section to reference Opencode gap.

## Why It Matters
- Proves the startup wiring (`CLAUDE.md` → `@memory/MEMORY.md`) works in a real session, not just structurally.
- Documents the Opencode gap (no dedicated entrypoint that imports `memory/MEMORY.md`) as a known gap to track.
- Clarifies that Claude Code's user-level auto-memory (`~/.claude/projects/`) and the repo-local `memory/` layer coexist without conflict.

## Validation / Proof
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 2866 passed, 11 skipped, exit 0
- Live session: Claude Code, `claude-sonnet-4-6`, branch `816-validate-live-agent-round-trip-for-repo-local-memory-layer`; all five topic files reachable via `Read` calls; index followed without broken paths

## Risks / Rollout
- Documentation-only change; no runtime or test impact.
- Opencode gap noted but not fixed here — tracked as known limitation.

## Docs / Provenance
- Updated: `memory/experiments/`, `memory/architecture/`, `docs/context/issue_812_layered_agent_memory.md`
- Predecessor rollout: issue #812

## Follow-Up Issues
- Opencode dedicated entrypoint (explicit `memory/MEMORY.md` import) is a known gap; could be addressed as a follow-up.

## Reviewer Notes
- All changes are Markdown docs; no Python changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent memory architecture documentation with completed live round-trip validation results
  * Clarified how multiple agents locate and access the repository's memory index at startup
  * Documented the distinction between user-level auto-memory and shared repository memory layers
  * Added guidance on memory authoring boundaries and identified configuration gaps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->