### PR TITLE
feat: add recorded-step playback analyzer (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Recorded-step playback analyzer for issue #585: telemetry replay now records per-step reward
+  terms plus selected step metrics with episode IDs, JSONL episode metadata can link back to the
+  corresponding telemetry stream, and interactive playback can show a synchronized analyzer overlay
+  with reward tables, visible-metric filtering, and a scrub-aligned metric timeline while remaining
+  backward compatible with older recordings.
+
 * TEB corridor-commitment planner improvements for issue #805 (second iteration): fixed corner-cutting by tuning embedded route-guide `waypoint_lookahead_cells` to 5 (1.0 m target at 0.2 m/cell, full 0.9 m/s speed without diagonal clipping), increased `obstacle_inflation_cells` to 3 for 0.6 m corner clearance, added `stop_distance=0.5` for earlier front-clearance stops, and added `_rescue_or_stop` so all-blocked commitment falls back to the route guide rather than driving into obstacles; `plan()` refactored into `_try_route_command`, `_commitment_step`, and `_rescue_or_stop` helpers to satisfy the complexity limit.
 * TEB corridor-commitment planner improvements for issue #805 (first iteration): multi-step corridor occupancy scoring, escalated lateral commitment gains, blocked-side flip fallback, route-waypoint guidance integration, and reproducible topology-slice artifacts (`configs/scenarios/sets/issue_805_teb_topology_slice.yaml`,  `docs/context/issue_805_teb_corridor_commitment_iteration.md`).
 

--- a/docs/context/issue_585_recorded_step_analyzer.md
+++ b/docs/context/issue_585_recorded_step_analyzer.md
@@ -1,0 +1,56 @@
+# Issue 585 Recorded-Step Analyzer
+
+Related issue: `#585`
+
+## Goal
+
+Add a recorded-scenario playback analyzer that keeps the rendered frame aligned with the reward
+decomposition and step-level metrics that produced that frame's score.
+
+## Key Decision
+
+Keep recorded state playback and telemetry replay as separate artifact streams, then link them
+through additive episode metadata:
+
+- telemetry JSONL keeps per-step analyzer payloads (`reward_terms`, `reward_total`,
+  `step_metrics`, `episode_id`) without changing the live-pane contract,
+- JSONL episode sidecars record `telemetry_path` plus `telemetry_episode_id`,
+- playback loads those telemetry samples lazily and offsets frame indices when multiple episodes are
+  combined into one interactive session.
+
+This keeps older recordings readable and avoids retrofitting analysis-only fields into
+`VisualizableSimState`.
+
+## Implementation Surface
+
+- `robot_sf/gym_env/robot_env.py`
+  - emit episode-scoped telemetry payloads with reward-term and selected step-metric fields.
+- `robot_sf/render/jsonl_recording.py`
+  - persist telemetry linkage in episode metadata.
+- `robot_sf/render/jsonl_playback.py`
+  - load telemetry samples back into `PlaybackEpisode` when metadata provides a link.
+- `robot_sf/telemetry/history.py`
+  - normalize raw telemetry samples into a structured replay snapshot for analyzer consumers.
+- `robot_sf/render/interactive_playback.py`
+  - render the analyzer overlay and support visible-metric filtering.
+
+## Validation
+
+Focused contract checks:
+
+```bash
+uv run pytest tests/telemetry/test_replay.py tests/test_jsonl_recording.py tests/test_interactive_playback_enhanced.py
+uv run ruff check robot_sf/telemetry/history.py robot_sf/render/jsonl_recording.py robot_sf/gym_env/base_env.py robot_sf/gym_env/robot_env.py robot_sf/render/jsonl_playback.py robot_sf/render/interactive_playback.py tests/telemetry/test_replay.py tests/test_jsonl_recording.py tests/test_interactive_playback_enhanced.py
+```
+
+Broad readiness gate after latest-main sync:
+
+```bash
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Remaining Risk
+
+The analyzer assumes telemetry recording was enabled for the original run. Older or minimal
+recordings remain playable but will not show analyzer content because there is no telemetry stream
+to align against.

--- a/docs/trajectory_visualization.md
+++ b/docs/trajectory_visualization.md
@@ -13,6 +13,9 @@ The trajectory visualization feature allows you to display movement trails of en
 - **Configurable trail length**: Adjust how many previous positions to show in the trail
 - **Color-coded trails**: Different colors for different entity types
 - **Interactive controls**: Toggle display on/off and adjust settings during playback
+- **Recorded-step analyzer**: When the episode metadata links a telemetry JSONL stream, playback
+  shows the current frame alongside reward terms, selected step metrics, and a scrub-synced metric
+  timeline for debugging reward/metric behavior.
 
 ## Controls
 
@@ -31,6 +34,11 @@ The trajectory visualization feature allows you to display movement trails of en
 - **K**: Speed up playback
 - **J**: Slow down playback
 - **H**: Show help with all controls
+
+### Analyzer Controls
+- **]**: Select next metric key
+- **[**: Select previous metric key
+- **F**: Toggle the selected metric key in the analyzer timeline/table
 
 ## Usage
 
@@ -60,6 +68,17 @@ A complete demo is available in `examples/trajectory_demo.py`:
 ```bash
 python examples/trajectory_demo.py path/to/recording.pkl
 ```
+
+### Recorded-Step Analyzer Workflow
+
+The analyzer is optional and backward compatible. It activates only when:
+
+1. telemetry recording is enabled for the run, and
+2. the JSONL episode metadata records the telemetry path and episode identifier.
+
+For new JSONL recordings created from `RobotEnv`, the metadata link is written automatically when
+both recording systems are enabled. Older recordings still load normally; they simply omit the
+analyzer overlay.
 
 ## Visual Elements
 
@@ -135,6 +154,7 @@ Tests cover:
 - Length limiting functionality
 - Trajectory clearing
 - Display toggle behavior
+- Telemetry replay alignment and metric filtering for the recorded-step analyzer
 
 ## Future Enhancements
 

--- a/robot_sf/gym_env/base_env.py
+++ b/robot_sf/gym_env/base_env.py
@@ -214,10 +214,20 @@ class BaseEnv(Env):
             logger.info("Reset state list")
             self.recorded_states = []
 
-    def start_episode_recording(self, config_hash: str = "unknown") -> None:
+    def start_episode_recording(
+        self,
+        config_hash: str = "unknown",
+        *,
+        telemetry_path: str | None = None,
+        telemetry_episode_id: int | None = None,
+    ) -> None:
         """Start recording a new episode with JSONL recorder."""
         if self.jsonl_recorder is not None:
-            self.jsonl_recorder.start_episode(config_hash=config_hash)
+            self.jsonl_recorder.start_episode(
+                config_hash=config_hash,
+                telemetry_path=telemetry_path,
+                telemetry_episode_id=telemetry_episode_id,
+            )
 
     def record_simulation_step(self, state: VisualizableSimState) -> None:
         """Record a single simulation step to both recording systems."""

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -62,6 +62,12 @@ _DEFAULT_COLLISION_DIST = 0.25
 _DEFAULT_NEAR_MISS_DIST = 0.50
 _DEFAULT_COMFORT_FORCE_THRESHOLD = 2.0
 _SNQI_THRESHOLD_CACHE: tuple[float, float, float] | None = None
+_TELEMETRY_ANALYZER_STEP_METRIC_KEYS: tuple[str, ...] = (
+    "near_misses",
+    "force_exceed_events",
+    "comfort_exposure",
+    "jerk_mean",
+)
 
 
 @dataclass(slots=True)
@@ -243,6 +249,53 @@ def _build_step_info(meta: dict[str, Any]) -> dict[str, Any]:
         "success": success,
         "is_success": success,
     }
+
+
+def _coerce_finite_float(value: Any) -> float | None:
+    """Return ``value`` as a finite float when possible."""
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(result):
+        return None
+    return result
+
+
+def _extract_reward_terms(meta: dict[str, Any]) -> dict[str, float]:
+    """Extract finite reward-term scalars for telemetry replay.
+
+    Returns:
+        dict[str, float]: Weighted reward-term values suitable for analyzer replay.
+    """
+
+    reward_terms = meta.get("reward_terms")
+    if not isinstance(reward_terms, dict):
+        return {}
+    extracted: dict[str, float] = {}
+    for key, value in reward_terms.items():
+        if not isinstance(key, str):
+            continue
+        numeric = _coerce_finite_float(value)
+        if numeric is not None:
+            extracted[key] = numeric
+    return extracted
+
+
+def _extract_step_metrics(meta: dict[str, Any]) -> dict[str, float]:
+    """Select analyzer-friendly numeric step metrics from reward metadata.
+
+    Returns:
+        dict[str, float]: Numeric step metrics exposed to the recorded-step analyzer.
+    """
+
+    extracted: dict[str, float] = {}
+    for key in _TELEMETRY_ANALYZER_STEP_METRIC_KEYS:
+        numeric = _coerce_finite_float(meta.get(key))
+        if numeric is not None:
+            extracted[key] = numeric
+    return extracted
 
 
 def _extract_robot_xy(robot_pose: Any) -> np.ndarray:
@@ -498,6 +551,7 @@ class RobotEnv(BaseEnv):
         self._init_telemetry(env_config)
         self._last_wall_time = time.perf_counter()
         self._frame_idx = 0
+        self._telemetry_episode_id = -1
         self._snqi_proxy_state = _StepSNQIProxyState()
         self._prime_snqi_proxy_state()
 
@@ -742,7 +796,7 @@ class RobotEnv(BaseEnv):
         self.last_action = action
 
         # Telemetry update
-        self._emit_telemetry(reward, term, False, action)
+        self._emit_telemetry(reward, term, False, action, reward_dict)
         self._latest_observation = obs
 
         # if recording is enabled, record the state
@@ -770,6 +824,7 @@ class RobotEnv(BaseEnv):
             tuple: ``(obs, info)`` with the initial observation and placeholder info dict.
         """
         super().reset(seed=seed, options=options)
+        self._telemetry_episode_id += 1
         # Reset last_action
         self.last_action = None
         # Reset internal simulator state
@@ -833,7 +888,17 @@ class RobotEnv(BaseEnv):
                 ):  # pragma: no cover - safe if none active
                     pass
                 config_hash = _stable_config_hash(self.env_config)
-                self.start_episode_recording(config_hash=config_hash)
+                telemetry_path = None
+                if self._telemetry_session is not None and self.env_config.telemetry_record:
+                    telemetry_path = str(self._telemetry_session.telemetry_path)
+                telemetry_episode_id = (
+                    self._telemetry_episode_id if telemetry_path is not None else None
+                )
+                self.start_episode_recording(
+                    config_hash=config_hash,
+                    telemetry_path=telemetry_path,
+                    telemetry_episode_id=telemetry_episode_id,
+                )
             else:
                 # Legacy pickle recording
                 self.save_recording()
@@ -851,6 +916,7 @@ class RobotEnv(BaseEnv):
         terminated: bool,
         truncated: bool,
         action: Any,
+        meta: dict[str, Any] | None = None,
     ) -> None:
         """Record telemetry and update live pane if enabled."""
         if self._telemetry_session is None:
@@ -890,9 +956,18 @@ class RobotEnv(BaseEnv):
         payload = {
             "timestamp_ms": int(time.time() * 1000),
             "frame_idx": self._frame_idx,
+            "episode_id": self._telemetry_episode_id,
             "status": status,
             "metrics": metrics,
+            "reward_total": float(reward) if reward is not None else None,
         }
+        if meta is not None:
+            reward_terms = _extract_reward_terms(meta)
+            if reward_terms:
+                payload["reward_terms"] = reward_terms
+            step_metrics = _extract_step_metrics(meta)
+            if step_metrics:
+                payload["step_metrics"] = step_metrics
         self._frame_idx += 1
         self._telemetry_session.append(payload)
 

--- a/robot_sf/render/interactive_playback.py
+++ b/robot_sf/render/interactive_playback.py
@@ -29,6 +29,7 @@ from robot_sf.render.sim_view import (
     SimulationView,
     VisualizableSimState,
 )
+from robot_sf.telemetry.history import TelemetryReplay, TelemetryReplaySnapshot
 
 # Trajectory visualization colors
 ROBOT_TRAJECTORY_COLOR = (0, 100, 255)  # Blue
@@ -37,6 +38,13 @@ EGO_PED_TRAJECTORY_COLOR = (200, 0, 200)  # Magenta
 
 # UI frame rate target (Hz)
 UI_FPS = 60
+_ANALYZER_TIMELINE_COLORS = (
+    (59, 130, 246),
+    (16, 185, 129),
+    (245, 158, 11),
+    (239, 68, 68),
+    (168, 85, 247),
+)
 
 
 class InteractivePlayback(SimulationView):
@@ -78,6 +86,7 @@ class InteractivePlayback(SimulationView):
         caption: str = "RobotSF Interactive Playback",
         # New episode-aware parameters
         episodes: list[PlaybackEpisode] | None = None,
+        telemetry_replay: TelemetryReplay | None = None,
     ):
         """
         Initialize the interactive playback viewer.
@@ -88,6 +97,7 @@ class InteractivePlayback(SimulationView):
             sleep_time: Time to sleep between frames (default: 0.1s)
             caption: Window caption
             episodes: Optional list of episodes for batch playback
+            telemetry_replay: Optional replay-aligned telemetry stream for analyzer overlays.
         """
         super().__init__(map_def=map_def, caption=caption)
         self.states = states
@@ -114,12 +124,18 @@ class InteractivePlayback(SimulationView):
 
         # Episode-aware attributes
         self.episodes = episodes
+        self.telemetry_replay = telemetry_replay
         self.current_episode_idx = 0
         self.episode_boundaries = []
         self.reset_points = []
+        self.current_snapshot: TelemetryReplaySnapshot | None = None
+        self.available_metric_keys: list[str] = []
+        self.visible_metric_keys: set[str] = set()
+        self.selected_metric_idx = 0
 
         # Initialize episode boundaries and reset points
         self._initialize_episode_data()
+        self._initialize_analyzer_state()
 
         # Add playback controls to the help text
         self._extend_help_text()
@@ -158,7 +174,30 @@ class InteractivePlayback(SimulationView):
             "b: Increase trail length",
             "c: Decrease trail length",
             "x: Clear trajectories",
+            "--- Analyzer Controls ---",
+            "]: Next metric",
+            "[: Previous metric",
+            "f: Toggle selected metric",
         ]
+
+    def _initialize_analyzer_state(self) -> None:
+        """Initialize analyzer metric selection state from telemetry samples."""
+
+        if self.telemetry_replay is None:
+            return
+        metric_keys: set[str] = set()
+        for sample in self.telemetry_replay.samples:
+            if isinstance(sample.get("step_metrics"), dict):
+                metric_keys.update(key for key in sample["step_metrics"] if isinstance(key, str))
+            if isinstance(sample.get("metrics"), dict):
+                metric_keys.update(
+                    key
+                    for key in sample["metrics"]
+                    if isinstance(key, str) and key not in {"fps", "reward"}
+                )
+        self.available_metric_keys = sorted(metric_keys)
+        self.visible_metric_keys = set(self.available_metric_keys[:4])
+        self.selected_metric_idx = 0
 
     def _add_help_text(self):
         """Override the help text method to include playback controls."""
@@ -205,6 +244,9 @@ class InteractivePlayback(SimulationView):
 
         # Trajectory controls
         if self._handle_trajectory_key(e):
+            return
+
+        if self._handle_analyzer_key(e):
             return
 
         # If not a playback control key, let parent handle it
@@ -286,6 +328,38 @@ class InteractivePlayback(SimulationView):
         if e.key == pygame.K_x:
             self._clear_trajectories()
             logger.info("Trajectories cleared")
+            return True
+
+        return False
+
+    def _handle_analyzer_key(self, e) -> bool:
+        """Handle metric-filter controls for the recorded-step analyzer.
+
+        Returns:
+            bool: True when the key event was consumed by analyzer controls.
+        """
+
+        if not self.available_metric_keys:
+            return False
+
+        if e.key == pygame.K_RIGHTBRACKET:
+            self.selected_metric_idx = (self.selected_metric_idx + 1) % len(
+                self.available_metric_keys
+            )
+            return True
+
+        if e.key == pygame.K_LEFTBRACKET:
+            self.selected_metric_idx = (self.selected_metric_idx - 1) % len(
+                self.available_metric_keys
+            )
+            return True
+
+        if e.key == pygame.K_f:
+            selected = self.available_metric_keys[self.selected_metric_idx]
+            if selected in self.visible_metric_keys:
+                self.visible_metric_keys.remove(selected)
+            else:
+                self.visible_metric_keys.add(selected)
             return True
 
         return False
@@ -459,6 +533,7 @@ class InteractivePlayback(SimulationView):
         """Render the current frame at a smooth UI framerate."""
         if 0 <= self.current_frame < len(self.states):
             current_state = self.states[self.current_frame]
+            self.current_snapshot = self._scrub_analyzer_snapshot()
 
             # Update trajectories with current state
             self._update_trajectories(current_state)
@@ -468,11 +543,179 @@ class InteractivePlayback(SimulationView):
 
             # Draw trajectories on top of everything else before finalizing
             self._draw_all_trajectories()
+            self._render_analyzer_panel()
 
             # Finalize at UI FPS (avoid using sleep_time as FPS)
             self._finalize_frame(UI_FPS)
         else:
             logger.error(f"Invalid frame index: {self.current_frame}")
+
+    def _scrub_analyzer_snapshot(self) -> TelemetryReplaySnapshot | None:
+        """Return the telemetry snapshot nearest the currently displayed frame."""
+
+        if self.telemetry_replay is None:
+            return None
+        try:
+            return self.telemetry_replay.scrub_snapshot_to_frame(self.current_frame, tolerance=1)
+        except ValueError:
+            return None
+
+    def _render_analyzer_panel(self) -> None:
+        """Render a recorded-step analyzer overlay when telemetry replay is available."""
+
+        snapshot = self.current_snapshot
+        if snapshot is None:
+            return
+
+        panel_w = min(460, max(320, self.width // 2))
+        panel_h = min(280, max(220, self.height // 3))
+        panel = pygame.Surface((panel_w, panel_h), pygame.SRCALPHA)
+        panel.fill((0, 0, 0, 180))
+
+        header = (
+            f"Analyzer frame={snapshot.frame_idx} "
+            f"episode={snapshot.episode_id if snapshot.episode_id is not None else '-'} "
+            f"status={snapshot.status or 'unknown'}"
+        )
+        panel.blit(self.font.render(header, True, TEXT_COLOR), (8, 8))
+
+        selected_metric = (
+            self.available_metric_keys[self.selected_metric_idx]
+            if self.available_metric_keys
+            else None
+        )
+        if selected_metric is not None:
+            metric_hint = f"selected={selected_metric} visible={'yes' if selected_metric in self.visible_metric_keys else 'no'}"
+            panel.blit(self.font.render(metric_hint, True, TEXT_COLOR), (8, 26))
+
+        reward_total = "n/a" if snapshot.reward_total is None else f"{snapshot.reward_total:.3f}"
+        reward_title = self.font.render(f"Reward total: {reward_total}", True, TEXT_COLOR)
+        panel.blit(reward_title, (8, 48))
+        self._blit_mapping_rows(
+            panel,
+            rows=snapshot.reward_terms,
+            origin=(8, 68),
+            empty_label="No reward terms",
+        )
+
+        metric_rows = {
+            key: value
+            for key, value in snapshot.step_metrics.items()
+            if not self.visible_metric_keys or key in self.visible_metric_keys
+        }
+        metric_panel_x = panel_w // 2
+        panel.blit(self.font.render("Step metrics", True, TEXT_COLOR), (metric_panel_x, 48))
+        self._blit_mapping_rows(
+            panel,
+            rows=metric_rows,
+            origin=(metric_panel_x, 68),
+            empty_label="No visible metrics",
+        )
+
+        timeline_rect = pygame.Rect(8, panel_h - 92, panel_w - 16, 80)
+        pygame.draw.rect(panel, (255, 255, 255, 50), timeline_rect, width=1)
+        self._draw_metric_timeline(panel, timeline_rect, snapshot.frame_idx)
+
+        self.screen.blit(panel, (8, self.height - panel_h - 8))
+
+    def _blit_mapping_rows(
+        self,
+        surface: pygame.Surface,
+        *,
+        rows: dict[str, float],
+        origin: tuple[int, int],
+        empty_label: str,
+    ) -> None:
+        """Render a small key-value table into the analyzer overlay."""
+
+        x, y = origin
+        if not rows:
+            surface.blit(self.font.render(empty_label, True, TEXT_COLOR), (x, y))
+            return
+        for idx, (key, value) in enumerate(sorted(rows.items())):
+            line = f"{key}: {value:.3f}"
+            surface.blit(self.font.render(line, True, TEXT_COLOR), (x, y + idx * 18))
+
+    def _draw_metric_timeline(
+        self,
+        surface: pygame.Surface,
+        rect: pygame.Rect,
+        current_frame: int,
+    ) -> None:
+        """Draw a simple metric timeline aligned to the current playback frame."""
+
+        if self.telemetry_replay is None or not self.visible_metric_keys:
+            label = self.font.render("Timeline: no visible metrics", True, TEXT_COLOR)
+            surface.blit(label, (rect.x + 6, rect.y + 6))
+            return
+
+        pygame.draw.line(
+            surface,
+            (255, 255, 255, 80),
+            (rect.x, rect.bottom - 16),
+            (rect.right, rect.bottom - 16),
+            1,
+        )
+
+        max_frame = max(
+            (
+                sample.get("frame_idx", 0)
+                for sample in self.telemetry_replay.samples
+                if isinstance(sample.get("frame_idx"), int)
+            ),
+            default=0,
+        )
+        frame_span = max(max_frame, 1)
+
+        for color_idx, key in enumerate(sorted(self.visible_metric_keys)):
+            series = self._timeline_series_for_key(key)
+            if len(series) < 2:
+                continue
+
+            values = [value for _, value in series]
+            min_val = min(values)
+            max_val = max(values)
+            denom = max(max_val - min_val, 1e-6)
+            color = _ANALYZER_TIMELINE_COLORS[color_idx % len(_ANALYZER_TIMELINE_COLORS)]
+            points = []
+            for frame_idx, value in series:
+                x = rect.x + int((frame_idx / frame_span) * max(rect.width - 1, 1))
+                normalized = (value - min_val) / denom
+                y = rect.bottom - 18 - int(normalized * max(rect.height - 24, 1))
+                points.append((x, y))
+            if len(points) >= 2:
+                pygame.draw.lines(surface, color, False, points, 2)
+                label = self.font.render(key, True, color)
+                surface.blit(label, (rect.x + 6, rect.y + 6 + color_idx * 16))
+
+        marker_x = rect.x + int((current_frame / frame_span) * max(rect.width - 1, 1))
+        pygame.draw.line(surface, (255, 255, 255), (marker_x, rect.y), (marker_x, rect.bottom), 1)
+
+    def _timeline_series_for_key(self, key: str) -> list[tuple[int, float]]:
+        """Collect numeric timeline values for one metric key.
+
+        Returns:
+            list[tuple[int, float]]: Ordered ``(frame_idx, value)`` pairs for ``key``.
+        """
+
+        if self.telemetry_replay is None:
+            return []
+        series: list[tuple[int, float]] = []
+        for sample in self.telemetry_replay.samples:
+            frame_idx = sample.get("frame_idx")
+            if not isinstance(frame_idx, int):
+                continue
+            value = None
+            if isinstance(sample.get("step_metrics"), dict):
+                value = sample["step_metrics"].get(key)
+            if value is None and isinstance(sample.get("metrics"), dict):
+                value = sample["metrics"].get(key)
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                continue
+            series.append((frame_idx, numeric))
+        return series
 
     def update(self):
         """Update the playback state and render the current frame."""
@@ -641,10 +884,26 @@ def create_interactive_playback_from_batch(batch: BatchPlayback) -> InteractiveP
     """
     # Concatenate all episode states
     states = []
+    telemetry_samples = []
+    frame_offset = 0
     for episode in batch.episodes:
         states.extend(episode.states)
+        for sample in episode.telemetry_samples or []:
+            merged = dict(sample)
+            frame_idx = merged.get("frame_idx")
+            if isinstance(frame_idx, int):
+                merged["frame_idx"] = frame_idx + frame_offset
+            merged.setdefault("episode_id", episode.episode_id)
+            telemetry_samples.append(merged)
+        frame_offset += len(episode.states)
 
-    return InteractivePlayback(states, batch.map_def, episodes=batch.episodes)
+    telemetry_replay = TelemetryReplay(samples=telemetry_samples) if telemetry_samples else None
+    return InteractivePlayback(
+        states,
+        batch.map_def,
+        episodes=batch.episodes,
+        telemetry_replay=telemetry_replay,
+    )
 
 
 if __name__ == "__main__":

--- a/robot_sf/render/interactive_playback.py
+++ b/robot_sf/render/interactive_playback.py
@@ -38,6 +38,9 @@ EGO_PED_TRAJECTORY_COLOR = (200, 0, 200)  # Magenta
 
 # UI frame rate target (Hz)
 UI_FPS = 60
+DEFAULT_VISIBLE_METRICS = 4
+MAX_OVERLAY_ROWS = 8
+ROW_HEIGHT = 18
 _ANALYZER_TIMELINE_COLORS = (
     (59, 130, 246),
     (16, 185, 129),
@@ -132,6 +135,8 @@ class InteractivePlayback(SimulationView):
         self.available_metric_keys: list[str] = []
         self.visible_metric_keys: set[str] = set()
         self.selected_metric_idx = 0
+        self._metric_series: dict[str, list[tuple[int, float]]] = {}
+        self._max_telemetry_frame = 0
 
         # Initialize episode boundaries and reset points
         self._initialize_episode_data()
@@ -181,23 +186,46 @@ class InteractivePlayback(SimulationView):
         ]
 
     def _initialize_analyzer_state(self) -> None:
-        """Initialize analyzer metric selection state from telemetry samples."""
+        """Initialize analyzer metric selection state and pre-calculate series."""
 
         if self.telemetry_replay is None:
             return
+
         metric_keys: set[str] = set()
         for sample in self.telemetry_replay.samples:
-            if isinstance(sample.get("step_metrics"), dict):
-                metric_keys.update(key for key in sample["step_metrics"] if isinstance(key, str))
-            if isinstance(sample.get("metrics"), dict):
-                metric_keys.update(
-                    key
-                    for key in sample["metrics"]
-                    if isinstance(key, str) and key not in {"fps", "reward"}
-                )
+            frame_idx = sample.get("frame_idx")
+            if not isinstance(frame_idx, int):
+                continue
+            self._max_telemetry_frame = max(self._max_telemetry_frame, frame_idx)
+            self._collect_sample_metric_series(sample, frame_idx, metric_keys)
+
         self.available_metric_keys = sorted(metric_keys)
-        self.visible_metric_keys = set(self.available_metric_keys[:4])
+        self.visible_metric_keys = set(self.available_metric_keys[:DEFAULT_VISIBLE_METRICS])
         self.selected_metric_idx = 0
+
+    def _collect_sample_metric_series(
+        self,
+        sample: dict,
+        frame_idx: int,
+        metric_keys: set[str],
+    ) -> None:
+        """Accumulate analyzer metric series from one telemetry sample."""
+
+        for source in ("step_metrics", "metrics"):
+            data = sample.get(source)
+            if not isinstance(data, dict):
+                continue
+            for key, value in data.items():
+                if not isinstance(key, str):
+                    continue
+                if source == "metrics" and key in {"fps", "reward"}:
+                    continue
+                try:
+                    numeric = float(value)
+                except (TypeError, ValueError):
+                    continue
+                metric_keys.add(key)
+                self._metric_series.setdefault(key, []).append((frame_idx, numeric))
 
     def _add_help_text(self):
         """Override the help text method to include playback controls."""
@@ -596,6 +624,7 @@ class InteractivePlayback(SimulationView):
             rows=snapshot.reward_terms,
             origin=(8, 68),
             empty_label="No reward terms",
+            max_rows=MAX_OVERLAY_ROWS,
         )
 
         metric_rows = {
@@ -610,6 +639,7 @@ class InteractivePlayback(SimulationView):
             rows=metric_rows,
             origin=(metric_panel_x, 68),
             empty_label="No visible metrics",
+            max_rows=MAX_OVERLAY_ROWS,
         )
 
         timeline_rect = pygame.Rect(8, panel_h - 92, panel_w - 16, 80)
@@ -625,6 +655,7 @@ class InteractivePlayback(SimulationView):
         rows: dict[str, float],
         origin: tuple[int, int],
         empty_label: str,
+        max_rows: int = MAX_OVERLAY_ROWS,
     ) -> None:
         """Render a small key-value table into the analyzer overlay."""
 
@@ -632,9 +663,16 @@ class InteractivePlayback(SimulationView):
         if not rows:
             surface.blit(self.font.render(empty_label, True, TEXT_COLOR), (x, y))
             return
-        for idx, (key, value) in enumerate(sorted(rows.items())):
+
+        sorted_items = sorted(rows.items())
+        for idx, (key, value) in enumerate(sorted_items[:max_rows]):
             line = f"{key}: {value:.3f}"
-            surface.blit(self.font.render(line, True, TEXT_COLOR), (x, y + idx * 18))
+            surface.blit(self.font.render(line, True, TEXT_COLOR), (x, y + idx * ROW_HEIGHT))
+        if len(sorted_items) > max_rows:
+            surface.blit(
+                self.font.render("...", True, TEXT_COLOR),
+                (x, y + max_rows * ROW_HEIGHT),
+            )
 
     def _draw_metric_timeline(
         self,
@@ -657,15 +695,7 @@ class InteractivePlayback(SimulationView):
             1,
         )
 
-        max_frame = max(
-            (
-                sample.get("frame_idx", 0)
-                for sample in self.telemetry_replay.samples
-                if isinstance(sample.get("frame_idx"), int)
-            ),
-            default=0,
-        )
-        frame_span = max(max_frame, 1)
+        frame_span = max(self._max_telemetry_frame, 1)
 
         for color_idx, key in enumerate(sorted(self.visible_metric_keys)):
             series = self._timeline_series_for_key(key)
@@ -697,25 +727,7 @@ class InteractivePlayback(SimulationView):
         Returns:
             list[tuple[int, float]]: Ordered ``(frame_idx, value)`` pairs for ``key``.
         """
-
-        if self.telemetry_replay is None:
-            return []
-        series: list[tuple[int, float]] = []
-        for sample in self.telemetry_replay.samples:
-            frame_idx = sample.get("frame_idx")
-            if not isinstance(frame_idx, int):
-                continue
-            value = None
-            if isinstance(sample.get("step_metrics"), dict):
-                value = sample["step_metrics"].get(key)
-            if value is None and isinstance(sample.get("metrics"), dict):
-                value = sample["metrics"].get(key)
-            try:
-                numeric = float(value)
-            except (TypeError, ValueError):
-                continue
-            series.append((frame_idx, numeric))
-        return series
+        return self._metric_series.get(key, [])
 
     def update(self):
         """Update the playback state and render the current frame."""

--- a/robot_sf/render/jsonl_playback.py
+++ b/robot_sf/render/jsonl_playback.py
@@ -32,6 +32,7 @@ from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.render.sim_view import VisualizableSimState
+from robot_sf.telemetry.history import load_telemetry_stream
 
 logger = loguru.logger
 
@@ -44,6 +45,7 @@ class PlaybackEpisode:
     states: list[VisualizableSimState]
     metadata: dict[str, Any] | None = None
     reset_points: list[int] | None = None  # Step indices where resets occurred
+    telemetry_samples: list[dict[str, Any]] | None = None
 
 
 @dataclass
@@ -337,6 +339,32 @@ class JSONLPlaybackLoader:
             logger.warning(f"Failed to load metadata from {metadata_file}: {err}")
             return None
 
+    def _load_episode_telemetry(
+        self, metadata: dict[str, Any] | None
+    ) -> list[dict[str, Any]] | None:
+        """Load telemetry samples linked from episode metadata when available.
+
+        Returns:
+            list[dict[str, Any]] | None: Filtered episode telemetry samples when linked.
+        """
+
+        if not isinstance(metadata, dict):
+            return None
+        telemetry_path = metadata.get("telemetry_path")
+        if not isinstance(telemetry_path, str) or not telemetry_path:
+            return None
+        try:
+            samples = load_telemetry_stream(telemetry_path)
+        except (FileNotFoundError, OSError, json.JSONDecodeError) as err:
+            logger.warning(f"Failed to load telemetry from {telemetry_path}: {err}")
+            return None
+
+        episode_id = metadata.get("telemetry_episode_id")
+        if isinstance(episode_id, int):
+            filtered = [sample for sample in samples if sample.get("episode_id") == episode_id]
+            return filtered
+        return samples
+
     def load_single_episode(
         self, file_path: Union[str, Path]
     ) -> tuple[PlaybackEpisode, MapDefinition]:
@@ -404,6 +432,7 @@ class JSONLPlaybackLoader:
 
         # Load metadata
         metadata = self._load_episode_metadata(file_path)
+        telemetry_samples = self._load_episode_telemetry(metadata)
 
         # Create episode
         episode = PlaybackEpisode(
@@ -411,6 +440,7 @@ class JSONLPlaybackLoader:
             states=states,
             metadata=metadata,
             reset_points=reset_points,
+            telemetry_samples=telemetry_samples,
         )
 
         # Reconstruct MapDefinition from metadata or fallback to minimal dummy

--- a/robot_sf/render/jsonl_playback.py
+++ b/robot_sf/render/jsonl_playback.py
@@ -69,6 +69,7 @@ class JSONLPlaybackLoader:
     def __init__(self):
         """Initialize the playback loader."""
         self.schema_version = "1.0"
+        self._telemetry_cache: dict[str, list[dict[str, Any]]] = {}
 
     def _deserialize_state(
         self, state_dict: dict[str, Any], timestep: int = 0
@@ -354,7 +355,10 @@ class JSONLPlaybackLoader:
         if not isinstance(telemetry_path, str) or not telemetry_path:
             return None
         try:
-            samples = load_telemetry_stream(telemetry_path)
+            samples = self._telemetry_cache.get(telemetry_path)
+            if samples is None:
+                samples = load_telemetry_stream(telemetry_path)
+                self._telemetry_cache[telemetry_path] = samples
         except (FileNotFoundError, OSError, json.JSONDecodeError) as err:
             logger.warning(f"Failed to load telemetry from {telemetry_path}: {err}")
             return None

--- a/robot_sf/render/jsonl_recording.py
+++ b/robot_sf/render/jsonl_recording.py
@@ -47,6 +47,8 @@ class EpisodeMetadata:
     start_time: float | None = None
     end_time: float | None = None
     total_steps: int | None = None
+    telemetry_path: str | None = None
+    telemetry_episode_id: int | None = None
 
 
 @dataclass
@@ -298,11 +300,19 @@ class JSONLRecorder:
             self.current_file.flush()
             self._records_since_flush = 0
 
-    def start_episode(self, config_hash: str = "unknown") -> None:
+    def start_episode(
+        self,
+        config_hash: str = "unknown",
+        *,
+        telemetry_path: str | None = None,
+        telemetry_episode_id: int | None = None,
+    ) -> None:
         """Start recording a new episode.
 
         Args:
             config_hash: Hash of environment configuration
+            telemetry_path: Optional telemetry JSONL file for analyzer replay.
+            telemetry_episode_id: Optional episode identifier used to filter telemetry samples.
         """
         # Close previous episode if open
         if self.current_file is not None:
@@ -319,6 +329,8 @@ class JSONLRecorder:
             config_hash=config_hash,
             schema_version=self.schema_version,
             start_time=time.time(),
+            telemetry_path=telemetry_path,
+            telemetry_episode_id=telemetry_episode_id,
         )
 
         # Open new episode file

--- a/robot_sf/telemetry/history.py
+++ b/robot_sf/telemetry/history.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -222,6 +223,15 @@ class TelemetryReplay:
             raise ValueError("No telemetry samples loaded")
         return self.samples[self.current_index]
 
+    def current_snapshot(self) -> TelemetryReplaySnapshot:
+        """Return the current telemetry sample as a structured snapshot.
+
+        Returns:
+            TelemetryReplaySnapshot: Normalized analyzer payload for the current sample.
+        """
+
+        return _snapshot_from_sample(self.current())
+
     def scrub_to_frame(self, target_frame: int, *, tolerance: int = 1) -> dict[str, Any]:
         """Seek to the sample closest to target_frame within tolerance; else raise.
 
@@ -248,6 +258,17 @@ class TelemetryReplay:
         self.current_index = best_idx
         return self.samples[self.current_index]
 
+    def scrub_snapshot_to_frame(
+        self, target_frame: int, *, tolerance: int = 1
+    ) -> TelemetryReplaySnapshot:
+        """Return a structured snapshot for the telemetry sample nearest ``target_frame``.
+
+        Returns:
+            TelemetryReplaySnapshot: Nearest telemetry sample normalized for analyzer use.
+        """
+
+        return _snapshot_from_sample(self.scrub_to_frame(target_frame, tolerance=tolerance))
+
 
 def replay_episode(telemetry_path: str | Path) -> TelemetryReplay:
     """Convenience constructor for TelemetryReplay.
@@ -258,6 +279,77 @@ def replay_episode(telemetry_path: str | Path) -> TelemetryReplay:
 
     samples = load_telemetry_stream(telemetry_path)
     return TelemetryReplay(samples=samples)
+
+
+@dataclass(slots=True)
+class TelemetryReplaySnapshot:
+    """Structured view of a replay-aligned telemetry sample."""
+
+    frame_idx: int
+    status: str | None = None
+    episode_id: int | None = None
+    metrics: dict[str, float] = field(default_factory=dict)
+    reward_terms: dict[str, float] = field(default_factory=dict)
+    step_metrics: dict[str, float] = field(default_factory=dict)
+    reward_total: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Return ``value`` as a finite float when possible."""
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(result):
+        return None
+    return result
+
+
+def _coerce_float_mapping(values: Any) -> dict[str, float]:
+    """Keep only finite scalar members from a mapping-like payload.
+
+    Returns:
+        dict[str, float]: Mapping containing only finite numeric entries.
+    """
+
+    if not isinstance(values, dict):
+        return {}
+    coerced: dict[str, float] = {}
+    for key, value in values.items():
+        if not isinstance(key, str):
+            continue
+        numeric = _coerce_float(value)
+        if numeric is not None:
+            coerced[key] = numeric
+    return coerced
+
+
+def _snapshot_from_sample(sample: dict[str, Any]) -> TelemetryReplaySnapshot:
+    """Normalize a raw telemetry sample into a structured replay snapshot.
+
+    Returns:
+        TelemetryReplaySnapshot: Structured analyzer snapshot derived from ``sample``.
+    """
+
+    frame_idx = sample.get("frame_idx")
+    if not isinstance(frame_idx, int):
+        frame_idx = 0
+    episode_id = sample.get("episode_id")
+    if not isinstance(episode_id, int):
+        episode_id = None
+    reward_total = _coerce_float(sample.get("reward_total"))
+    return TelemetryReplaySnapshot(
+        frame_idx=frame_idx,
+        status=sample.get("status") if isinstance(sample.get("status"), str) else None,
+        episode_id=episode_id,
+        metrics=_coerce_float_mapping(sample.get("metrics")),
+        reward_terms=_coerce_float_mapping(sample.get("reward_terms")),
+        step_metrics=_coerce_float_mapping(sample.get("step_metrics")),
+        reward_total=reward_total,
+        raw=dict(sample),
+    )
 
 
 def _build_entry(

--- a/tests/telemetry/test_replay.py
+++ b/tests/telemetry/test_replay.py
@@ -20,6 +20,31 @@ def test_replay_alignment_within_tolerance():
     assert snap["frame_idx"] == 5
 
 
+def test_replay_snapshot_surfaces_reward_terms_and_step_metrics():
+    """Structured replay snapshots should expose analyzer-ready scalar fields."""
+    samples = [
+        {
+            "episode_id": 3,
+            "frame_idx": 4,
+            "status": "running",
+            "metrics": {"reward": 1.5, "collisions": 0, "fps": 10.0},
+            "reward_total": 1.5,
+            "reward_terms": {"progress": 0.7, "living": -0.1},
+            "step_metrics": {"near_misses": 1.0, "comfort_exposure": 0.25},
+        }
+    ]
+    replay = TelemetryReplay(samples=samples)
+
+    snapshot = replay.current_snapshot()
+
+    assert snapshot.episode_id == 3
+    assert snapshot.frame_idx == 4
+    assert snapshot.reward_total == 1.5
+    assert snapshot.reward_terms["progress"] == 0.7
+    assert snapshot.step_metrics["near_misses"] == 1.0
+    assert snapshot.metrics["collisions"] == 0.0
+
+
 def test_export_combined_image(tmp_path):
     """Combined export writes a PNG with both view and pane content."""
     main = np.zeros((100, 150, 4), dtype=np.uint8)

--- a/tests/test_interactive_playback_enhanced.py
+++ b/tests/test_interactive_playback_enhanced.py
@@ -2,11 +2,27 @@
 
 import tempfile
 
+import numpy as np
+
 from robot_sf.render.interactive_playback import (
     create_interactive_playback_from_batch,
 )
-from robot_sf.render.jsonl_playback import JSONLPlaybackLoader
+from robot_sf.render.jsonl_playback import BatchPlayback, JSONLPlaybackLoader, PlaybackEpisode
 from robot_sf.render.jsonl_recording import JSONLRecorder
+from robot_sf.render.sim_view import VisualizableSimState
+
+
+def _state(x: float, y: float, timestep: int = 0) -> VisualizableSimState:
+    """Build a minimal playback state for tests."""
+
+    return VisualizableSimState(
+        timestep=timestep,
+        robot_action=None,
+        robot_pose=((x, y), 0.0),
+        pedestrian_positions=np.array([]),
+        ray_vecs=np.array([]),
+        ped_actions=np.array([]),
+    )
 
 
 def test_episode_boundary_detection():
@@ -27,19 +43,8 @@ def test_episode_boundary_detection():
             recorder.current_episode_id = ep_idx
             recorder.start_episode()
 
-            import numpy as np
-
-            from robot_sf.render.sim_view import VisualizableSimState
-
             for step in range(num_states):
-                state = VisualizableSimState(
-                    timestep=step,
-                    robot_action=None,
-                    robot_pose=((step * 1.0, ep_idx * 5.0), 0.0),  # Different position per episode
-                    pedestrian_positions=np.array([]),
-                    ray_vecs=np.array([]),
-                    ped_actions=np.array([]),
-                )
+                state = _state(step * 1.0, ep_idx * 5.0, timestep=step)
                 recorder.record_step(state)
 
             recorder.end_episode()
@@ -75,20 +80,9 @@ def test_trajectory_clearing_at_boundaries():
             recorder.current_episode_id = ep_idx
             recorder.start_episode()
 
-            import numpy as np
-
-            from robot_sf.render.sim_view import VisualizableSimState
-
             # Add 2 states per episode
             for step in range(2):
-                state = VisualizableSimState(
-                    timestep=step,
-                    robot_action=None,
-                    robot_pose=((step + ep_idx * 10, step + ep_idx * 10), 0.0),
-                    pedestrian_positions=np.array([]),
-                    ray_vecs=np.array([]),
-                    ped_actions=np.array([]),
-                )
+                state = _state(step + ep_idx * 10, step + ep_idx * 10, timestep=step)
                 recorder.record_step(state)
 
             recorder.end_episode()
@@ -118,6 +112,48 @@ def test_trajectory_clearing_at_boundaries():
         # Update trajectories (should clear due to boundary)
         player._update_trajectories(player.states[2])
         assert len(player.robot_trajectory) == 1  # Should be cleared and restarted
+
+
+def test_batch_playback_merges_episode_telemetry_for_analyzer():
+    """Batch playback should offset telemetry frames and expose metric filtering state."""
+    episode_one = PlaybackEpisode(
+        episode_id=0,
+        states=[_state(0.0, 0.0, 0), _state(1.0, 0.0, 1)],
+        telemetry_samples=[
+            {
+                "episode_id": 0,
+                "frame_idx": 0,
+                "reward_total": 1.0,
+                "reward_terms": {"progress": 0.5},
+                "step_metrics": {"near_misses": 0.0},
+            }
+        ],
+    )
+    episode_two = PlaybackEpisode(
+        episode_id=1,
+        states=[_state(5.0, 5.0, 0)],
+        telemetry_samples=[
+            {
+                "episode_id": 1,
+                "frame_idx": 0,
+                "reward_total": 2.0,
+                "reward_terms": {"progress": 1.0},
+                "step_metrics": {"comfort_exposure": 0.2},
+            }
+        ],
+    )
+    batch = BatchPlayback(
+        episodes=[episode_one, episode_two],
+        map_def=JSONLPlaybackLoader._default_map_definition(),
+        total_episodes=2,
+        total_steps=3,
+    )
+
+    player = create_interactive_playback_from_batch(batch)
+
+    assert player.telemetry_replay is not None
+    assert [sample["frame_idx"] for sample in player.telemetry_replay.samples] == [0, 2]
+    assert sorted(player.available_metric_keys) == ["comfort_exposure", "near_misses"]
 
 
 if __name__ == "__main__":

--- a/tests/test_jsonl_recording.py
+++ b/tests/test_jsonl_recording.py
@@ -212,5 +212,57 @@ def test_legacy_pickle_compatibility():
     assert episode.reset_points is not None
 
 
+def test_jsonl_playback_loader_reads_episode_telemetry_sidecar(tmp_path: Path) -> None:
+    """Episode playback should load telemetry samples linked from metadata."""
+    recorder = JSONLRecorder(
+        output_dir=str(tmp_path),
+        suite="telemetry",
+        scenario="linked",
+        algorithm="manual",
+        seed=7,
+    )
+    telemetry_path = tmp_path / "telemetry.jsonl"
+    telemetry_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"episode_id": 2, "frame_idx": 0, "metrics": {"reward": 1.0}}),
+                json.dumps({"episode_id": 2, "frame_idx": 1, "metrics": {"reward": 1.5}}),
+                json.dumps({"episode_id": 9, "frame_idx": 0, "metrics": {"reward": 9.0}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    recorder.current_episode_id = 2
+    recorder.start_episode(
+        telemetry_path=str(telemetry_path),
+        telemetry_episode_id=2,
+    )
+
+    import numpy as np
+
+    from robot_sf.render.sim_view import VisualizableSimState
+
+    recorder.record_step(
+        VisualizableSimState(
+            timestep=0,
+            robot_action=None,
+            robot_pose=((0.0, 0.0), 0.0),
+            pedestrian_positions=np.array([]),
+            ray_vecs=np.array([]),
+            ped_actions=np.array([]),
+        )
+    )
+    recorder.end_episode()
+
+    loader = JSONLPlaybackLoader()
+    episode_path = tmp_path / "telemetry_linked_manual_7_ep0002.jsonl"
+    episode, _ = loader.load_single_episode(episode_path)
+
+    assert episode.telemetry_samples is not None
+    assert [sample["frame_idx"] for sample in episode.telemetry_samples] == [0, 1]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
Add a recorded-step playback analyzer that keeps interactive JSONL playback aligned with reward decomposition and selected step metrics from telemetry, while keeping older recordings playable.

## Linked Issues
- Closes #585

## What Changed
- Added episode-scoped telemetry replay payloads for `reward_terms`, `reward_total`, selected step metrics, and `episode_id` in `robot_sf/gym_env/robot_env.py`.
- Linked JSONL episode metadata to telemetry artifacts in `robot_sf/render/jsonl_recording.py` and loaded that telemetry back through `robot_sf/render/jsonl_playback.py`.
- Added a structured `TelemetryReplaySnapshot` model in `robot_sf/telemetry/history.py`.
- Extended `robot_sf/render/interactive_playback.py` with an analyzer overlay, visible-metric filtering, and scrub-aligned timeline rendering.
- Updated targeted tests, the trajectory/playback doc, changelog, and issue context note.

## Why It Matters
- Added value: recorded runs can now be debugged step-by-step with the score explanation visible next to the rendered frame.
- Expected impact: reward shaping and metric regressions should be much easier to diagnose without ad hoc log spelunking.
- Why now: the repo already had telemetry + playback separately, but not a reliable bridge between them.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/telemetry/test_replay.py tests/test_jsonl_recording.py tests/test_interactive_playback_enhanced.py`
  - `uv run ruff check robot_sf/telemetry/history.py robot_sf/render/jsonl_recording.py robot_sf/gym_env/base_env.py robot_sf/gym_env/robot_env.py robot_sf/render/jsonl_playback.py robot_sf/render/interactive_playback.py tests/telemetry/test_replay.py tests/test_jsonl_recording.py tests/test_interactive_playback_enhanced.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused analyzer/recording tests passed (`12 passed`).
  - Broad readiness gate passed (`2883 passed, 12 skipped, 1 known warning`).

## Risks / Rollout
- Compatibility risks: analyzer overlays only appear when telemetry recording was enabled for the original run.
- Failure modes: recordings with missing or stale telemetry links still load, but without analyzer content.
- Rollback or fallback plan: playback remains backward compatible because the telemetry linkage is additive and optional.

## Docs / Provenance
- Updated docs:
  - `docs/trajectory_visualization.md`
  - `docs/context/issue_585_recorded_step_analyzer.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - The implementation keeps state playback and telemetry replay as separate streams linked through episode metadata to avoid overloading `VisualizableSimState` with analysis-only fields.

## Follow-Up Issues
- Deferred work: none opened in this pass.

## Reviewer Notes
- Verify the analyzer overlay behavior in interactive playback with a JSONL recording created while telemetry recording is enabled.
- Known limitation: older recordings remain playable but cannot show analyzer data because they do not carry telemetry linkage metadata.