### PR TITLE
docs: move local machine template into docs/templates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,10 @@ It is everyones guide on how to use this repository effectively.
 
 ## Additional Instructions
 
+- For machine-specific limits and execution routing, check local machine context files at repo
+  root when present: `local.machine.md` or `local.machine.<name>.md` (template:
+  `docs/templates/local.machine.example.md`). If absent, use conservative defaults.
+
 - Use scriptable interfaces instead of cli interfaces when possible.
 - Make everything reproducible.
 - In benchmark work, use the canonical fail-closed fallback policy in

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ dist/
 !.env.example
 .vscode/mcp.json
 
+# Local machine context for agents (template in docs/templates)
+/local.machine*.md
+
 .gemini/
 gha-creds-*.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,22 @@ Treat the following files as the repository-native context stack for Codex-style
 
 Read only the surfaces relevant to the task. Prefer these repo-local files over ad-hoc summaries in issue comments.
 
+## Local Machine Context (Gitignored)
+
+To support multi-machine workflows, agents may consume machine-specific guidance from local-only
+files at the repository root.
+
+- Committed template: `docs/templates/local.machine.example.md`
+- Local overrides (gitignored): `local.machine.md` or `local.machine.<name>.md`
+
+Execution rules:
+
+- If a local machine context file exists, read it before running expensive commands.
+- Follow local limits for concurrency and execution location (for example CPU worker caps, tmux
+  requirements, GPU-only jobs, or SLURM submission constraints).
+- If no local machine context exists, use conservative defaults and repository-safe commands.
+- Never store secrets in local machine context files.
+
 ## Knowledge Capture & Context Notes
 
 Treat `docs/context/` as the repository's Markdown knowledge base for agent handoff, not as a dump

--- a/docs/templates/local.machine.example.md
+++ b/docs/templates/local.machine.example.md
@@ -1,0 +1,39 @@
+# Local Machine Context Template
+
+Purpose: Machine-specific execution hints for coding agents in this repository.
+
+How to use:
+- Copy this file to `local.machine.md` (or `local.machine.<name>.md`).
+- Keep values local; do not commit machine-specific files.
+- Never store secrets, tokens, or private keys here.
+
+## Machine Identity
+- machine_name: <short machine name>
+- role: <main-laptop|gpu-worker|slurm-login|other>
+- os: <macos|linux|windows>
+
+## Resource Limits
+- cpu_test_workers_max: <int>
+- cpu_build_workers_max: <int>
+- memory_notes: <optional notes>
+
+## Execution Policy
+- allow_long_training_local: <true|false>
+- require_tmux_for_long_jobs: <true|false>
+- allow_gpu_jobs: <true|false>
+- gpu_description: <e.g., rtx-3070>
+- allow_slurm_submission: <true|false>
+
+## Preferred Commands
+- test_command: <repo command>
+- long_job_prefix: <e.g., tmux new -d -s run_name -->
+- slurm_submit_command: <optional command>
+
+## Do/Do Not
+- do:
+  - <short bullet>
+- do_not:
+  - <short bullet>
+
+## Last Updated
+- yyyy-mm-dd: <what changed>


### PR DESCRIPTION
## Summary
Move the local machine context template into docs/templates and update agent instructions and ignore rules to use the new canonical location.

## Linked Issues
- Closes: none specified.
- Relates to: none specified.

## What Changed
- Added `docs/templates/local.machine.example.md` as the committed template location.
- Updated `AGENTS.md` to reference `docs/templates/local.machine.example.md`.
- Updated `.github/copilot-instructions.md` to reference `docs/templates/local.machine.example.md`.
- Updated `.gitignore` to ignore root-local `local.machine*.md` overrides while keeping the docs template committed.

## Why It Matters
- Added value: machine-specific local context is now discoverable in the shared docs template location.
- Expected impact: agents and contributors use a single canonical template path while keeping local override files private.
- Why this is worth merging now: prevents path drift and keeps local-machine workflow instructions consistent.

## Validation / Proof
- Commands run:
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
  - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - PR readiness checks passed.
  - Freshness stamp for this exact HEAD is marked `fresh: true`.
- Benchmarks or smoke tests, if applicable:
  - Not applicable (docs/instructions + ignore-rule change).

## Risks / Rollout
- Compatibility risks: low; path reference updates only.
- Failure modes: if any tool still references the old root template path, it may miss the template.
- Rollback or fallback plan: revert this PR or reintroduce a compatibility reference at the old path.

## Docs / Provenance
- Updated docs:
  - `AGENTS.md`
  - `.github/copilot-instructions.md`
  - `docs/templates/local.machine.example.md`
- Relevant design or provenance notes:
  - Follows repository guidance for machine-specific local context files.
- Any assumptions that need to be preserved:
  - Local override files remain at repository root and stay gitignored.

## Follow-Up Issues
- Deferred work:
  - None.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - No remaining references to `local.machine.example.md` at repository root.
  - Ignore rule behavior for `/local.machine*.md`.
- Any known limitations:
  - Scope is intentionally limited to docs/instruction/path alignment.
