### PR TITLE
fix: fail early with clear error on unresolvable map_file in scenarios (#830)

### DIFF
--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1365,10 +1365,26 @@ def _apply_map_pool(
     scenario: Mapping[str, Any],
     scenario_path: Path,
 ) -> None:
-    """Load a scenario map file into the config map pool."""
+    """Load a scenario map file into the config map pool.
+
+    Raises:
+        ValueError: When ``map_file`` is explicitly specified in the scenario but
+            the file cannot be resolved or loaded.  Failing early here prevents
+            the silent fallback to the default map pool — which would either use
+            an unrelated map (``uni_campus_big``) or raise a confusing
+            ``"Map pool is empty!"`` error much later during the first scenario
+            reset (the original issue #830 failure mode on long SLURM runs).
+    """
     map_file = scenario.get("map_file")
     map_def = resolve_map_definition(map_file, scenario_path=scenario_path)
     if map_def is None:
+        if map_file:
+            scenario_name = scenario.get("name") or scenario.get("scenario_id") or "unknown"
+            raise ValueError(
+                f"Scenario '{scenario_name}': map_file '{map_file}' could not be "
+                f"resolved or loaded from scenario_path='{scenario_path}'. "
+                "Check the map_file path or manifest map_search_paths."
+            )
         return
     map_id = scenario.get("map_id")
     map_name = str(map_id) if isinstance(map_id, str) and map_id.strip() else None

--- a/tests/test_scenario_loader_route_overrides.py
+++ b/tests/test_scenario_loader_route_overrides.py
@@ -122,9 +122,9 @@ def test_load_scenarios_rebases_route_override_paths_from_included_archetypes() 
 def test_build_robot_config_applies_bicycle_robot_overrides() -> None:
     """Scenario robot_config should instantiate bicycle settings and selected fields."""
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
+    # No map_file: these tests target robot_config overrides, not map loading.
     scenario = {
         "name": "demo",
-        "map_file": "maps/svg_maps/classic_overtaking.svg",
         "robot_config": {
             "type": "bicycle_drive",
             "max_velocity": 1.2,
@@ -142,7 +142,6 @@ def test_build_robot_config_applies_holonomic_overrides() -> None:
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
     scenario = {
         "name": "demo",
-        "map_file": "maps/svg_maps/classic_overtaking.svg",
         "robot_config": {
             "type": "holonomic",
             "max_speed": 1.5,
@@ -160,7 +159,6 @@ def test_build_robot_config_rejects_unknown_robot_type() -> None:
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
     scenario = {
         "name": "demo",
-        "map_file": "maps/svg_maps/classic_overtaking.svg",
         "robot_config": {"type": "unknown_type"},
     }
     with pytest.raises(ValueError, match="robot_config.type"):
@@ -172,7 +170,6 @@ def test_build_robot_config_parses_allow_backwards_string_booleans() -> None:
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
     scenario = {
         "name": "demo",
-        "map_file": "maps/svg_maps/classic_overtaking.svg",
         "robot_config": {
             "type": "differential_drive",
             "allow_backwards": "false",
@@ -187,7 +184,6 @@ def test_build_robot_config_rejects_invalid_allow_backwards_string() -> None:
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
     scenario = {
         "name": "demo",
-        "map_file": "maps/svg_maps/classic_overtaking.svg",
         "robot_config": {
             "type": "bicycle_drive",
             "allow_backwards": "maybe",

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from robot_sf.training import scenario_loader
-from robot_sf.training.scenario_loader import load_scenarios
+from robot_sf.training.scenario_loader import (
+    build_robot_config_from_scenario,
+    load_scenarios,
+    resolve_map_definition,
+)
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -370,3 +374,96 @@ scenarios:
     scenarios = load_scenarios(manifest, base_dir=manifest)
     scenario_loader._load_map_registry.cache_clear()
     assert scenarios[0]["map_file"] == "../maps/demo.svg"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #830: empty map-pool crash in long-run PPO jobs
+# ---------------------------------------------------------------------------
+
+
+def test_build_robot_config_raises_early_on_missing_map_file(tmp_path: Path) -> None:
+    """build_robot_config_from_scenario must raise a clear ValueError when the
+    map_file in the scenario does not exist, rather than silently falling back
+    to the default map pool (which causes a confusing 'Map pool is empty!' error
+    much later during scenario reset — the original issue #830 failure mode).
+    """
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: missing_map_scenario
+    map_file: does_not_exist.svg
+""",
+    )
+
+    scenarios = load_scenarios(manifest)
+    assert len(scenarios) == 1
+
+    with pytest.raises(ValueError, match="does_not_exist.svg"):
+        build_robot_config_from_scenario(scenarios[0], scenario_path=manifest)
+
+
+def test_build_robot_config_raises_early_on_unresolvable_relative_map_file(
+    tmp_path: Path,
+) -> None:
+    """Relative map_file paths that cannot be resolved should also fail fast."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: unresolvable_scenario
+    map_file: subdir/nonexistent.svg
+""",
+    )
+
+    scenarios = load_scenarios(manifest)
+    with pytest.raises(ValueError, match="nonexistent.svg"):
+        build_robot_config_from_scenario(scenarios[0], scenario_path=manifest)
+
+
+def test_build_robot_config_with_no_map_file_does_not_raise(tmp_path: Path) -> None:
+    """Scenarios without any map_file should not raise; they rely on the default pool."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: no_map_scenario
+""",
+    )
+
+    scenarios = load_scenarios(manifest)
+    # Should not raise — no map_file means the caller uses the default map pool.
+    cfg = build_robot_config_from_scenario(scenarios[0], scenario_path=manifest)
+    assert cfg is not None
+
+
+def test_classic_interactions_francis2023_manifest_resolves_all_maps() -> None:
+    """All scenarios in the combined issue-791 manifest must resolve to real map files.
+
+    This is the direct regression guard for issue #830: if any map_file in the
+    classic_interactions_francis2023 scenario chain is broken, this test catches
+    it before a long SLURM allocation is consumed.
+    """
+    manifest = Path("configs/scenarios/classic_interactions_francis2023.yaml")
+    if not manifest.exists():
+        pytest.skip("Combined manifest not found; run from repo root.")
+
+    scenarios = load_scenarios(manifest)
+    assert scenarios, "Manifest loaded no scenarios"
+
+    missing: list[str] = []
+    for scenario in scenarios:
+        map_file = scenario.get("map_file")
+        if not map_file:
+            continue
+        result = resolve_map_definition(map_file, scenario_path=manifest)
+        if result is None:
+            missing.append(f"{scenario.get('name')}: {map_file}")
+
+    assert not missing, (
+        f"The following scenarios in classic_interactions_francis2023.yaml could not "
+        f"resolve their map_file from '{manifest}':\n" + "\n".join(missing)
+    )


### PR DESCRIPTION
## Summary

- `_apply_map_pool` now raises `ValueError` immediately when `map_file` is explicitly set in a scenario but `resolve_map_definition` returns `None`, instead of silently falling back to the default map pool.
- Fixes the confusing `"Map pool is empty!"` or wrong-map error that appeared late during scenario reset in long-running issue-791 SLURM jobs.
- Added 4 new regression tests: 2 that fail before the fix and pass after (verified), 1 that guards the no-map-file fallback path, and 1 integration test verifying all 47 scenarios in `classic_interactions_francis2023.yaml` resolve correctly.
- Fixed 5 existing robot_config-override tests in `test_scenario_loader_route_overrides.py` that relied on the old silent-failure behavior (they passed a relative `map_file` that resolved to a wrong path from `configs/scenarios/`, but only tested robot_config fields).

## Test plan

- [x] `test_build_robot_config_raises_early_on_missing_map_file` — fails before fix, passes after
- [x] `test_build_robot_config_raises_early_on_unresolvable_relative_map_file` — fails before fix, passes after
- [x] `test_build_robot_config_with_no_map_file_does_not_raise` — no-map-file fallback still works
- [x] `test_classic_interactions_francis2023_manifest_resolves_all_maps` — all 47 combined-manifest scenarios resolve
- [x] Full parallel suite: 2908 passed, 14 skipped (`uv run scripts/dev/run_tests_parallel.sh`)

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)