### PR TITLE
Extend paper matrix seed schedule comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added issue-832 paper-matrix extended seed schedules (`paper_eval_s5`, `paper_eval_s10`,
+  `paper_eval_s20`), S5/S10 paper-matrix sibling configs that preserve the frozen
+  `paper-matrix-v1` contract, and `scripts/tools/compare_seed_schedule_campaigns.py` for
+  reproducible S3-vs-higher-seed CI-width, mean-drift, ranking, and scenario-winner comparisons.
+
 * Added fail-fast SoNIC / GenSafeNav benchmark wrapper aliases for the model-only checkpoint path: base aliases `sonic_crowdnav`, `gensafenav_ours_gst`, and `gensafenav_gst_predictor_rand`, plus guarded variants `ours_gst_guarded` and `gst_predictor_rand_guarded` with short-horizon guard telemetry (`guard_stats`) and goal fallback. This exposes the adapter surface explicitly for users and benchmark configs while keeping remaining risks visible: the base wrappers are still prototype-level model-only integrations, guarded behavior exists only on the guarded aliases, and guarded holonomic `vx_vy` runs now fail closed until the guard can preserve upstream ActionXY without a lossy `(v, w)` round-trip.
 
 * Recorded-step playback analyzer for issue #585: telemetry replay now records per-step reward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added issue-832 paper-matrix extended seed schedules (`paper_eval_s5`, `paper_eval_s10`,
   `paper_eval_s20`), S5/S10 paper-matrix sibling configs that preserve the frozen
-  `paper-matrix-v1` contract, and `scripts/tools/compare_seed_schedule_campaigns.py` for
-  reproducible S3-vs-higher-seed CI-width, mean-drift, ranking, and scenario-winner comparisons.
+  `paper-matrix-v1` contract, `run_camera_ready_benchmark.py --campaign-id` for resumable fixed
+  campaign roots, and `scripts/tools/compare_seed_schedule_campaigns.py` for reproducible
+  S3-vs-higher-seed CI-width, mean-drift, ranking, and scenario-winner comparisons.
 
 * Added fail-fast SoNIC / GenSafeNav benchmark wrapper aliases for the model-only checkpoint path: base aliases `sonic_crowdnav`, `gensafenav_ours_gst`, and `gensafenav_gst_predictor_rand`, plus guarded variants `ours_gst_guarded` and `gst_predictor_rand_guarded` with short-horizon guard telemetry (`guard_stats`) and goal fallback. This exposes the adapter surface explicitly for users and benchmark configs while keeping remaining risks visible: the base wrappers are still prototype-level model-only integrations, guarded behavior exists only on the guarded aliases, and guarded holonomic `vx_vy` runs now fail closed until the guard can preserve upstream ActionXY without a lossy `(v, w)` round-trip.
 

--- a/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml
@@ -1,0 +1,98 @@
+name: paper_experiment_matrix_v1_extended_seeds_s10
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s10
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+# Keep the canonical camera-ready release single-worker to avoid ordering variance.
+workers: 1
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback

--- a/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml
@@ -1,0 +1,98 @@
+name: paper_experiment_matrix_v1_extended_seeds_s5
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s5
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+# Keep the canonical camera-ready release single-worker to avoid ordering variance.
+workers: 1
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback

--- a/configs/benchmarks/seed_sets_v1.yaml
+++ b/configs/benchmarks/seed_sets_v1.yaml
@@ -11,3 +11,47 @@ eval:
   - 111
   - 112
   - 113
+
+# Paper-facing matrix seed-count extensions.  Keep the S3 `eval` set unchanged:
+# these named schedules only extend the frozen paper matrix for seed-sensitivity
+# checks while preserving the original first three seeds.
+paper_eval_s5:
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+
+paper_eval_s10:
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+  - 116
+  - 117
+  - 118
+  - 119
+  - 120
+
+paper_eval_s20:
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+  - 116
+  - 117
+  - 118
+  - 119
+  - 120
+  - 121
+  - 122
+  - 123
+  - 124
+  - 125
+  - 126
+  - 127
+  - 128
+  - 129
+  - 130

--- a/configs/validation/minimal.yaml
+++ b/configs/validation/minimal.yaml
@@ -1,5 +1,7 @@
 # Minimal scenario matrix for telemetry performance smoke tests.
 # Keeps geometry simple and short to make perf checks quick and deterministic.
+map_search_paths:
+  - ../..
 scenarios:
   - name: perf_minimal
     map_file: "maps/svg_maps/debug_06.svg"

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * **[Benchmark Spec (Classic Interactions)](./benchmark_spec.md)** - Scenario split + seeds, baseline categories, reproducible commands, and metric caveats
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
 * **[Issue #595 Seed-Variability Contract](./context/issue_595_seed_variability_contract.md)** - Frozen camera-ready artifact contract and pilot slice for paper-side seed variability analysis
+* **[Issue #832 Paper-Matrix Extended Seed Schedule](./context/issue_832_paper_matrix_extended_seed_schedule.md)** - Staged S5/S10/S20 seed extension policy, runtime estimates, tmux commands, and comparison artifact contract for the frozen paper matrix
 * **[Issue #750 Paper Results Handoff](./context/issue_750_paper_results_handoff.md)** - Deterministic paper-facing JSON/CSV handoff contract for frozen benchmark bundles with CI metadata and provenance fields
 * **[Benchmark Release 0.0.2 Execution Log](./context/benchmark_release_0_0_2_2026-04-13.md)** - All-planners release manifest/config decisions, tmux execution path, assumptions, and follow-up publish steps
 * **[Issue #692 Scenario Difficulty Analysis](./context/issue_692_scenario_difficulty_analysis.md)** - Artifact-driven camera-ready workflow for consensus ranking, planner residuals, and verified-simple subset assessment

--- a/docs/README.md
+++ b/docs/README.md
@@ -553,4 +553,4 @@ When contributing to the project:
 
 ---
 
-_Last updated: February 2026 - Cold/warm performance regression suite added_
+_Last updated: April 2026 - Paper-matrix extended seed schedule context added_

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -147,8 +147,8 @@ Expected tree:
     seed_variability_by_scenario.csv
     seed_episode_rows.csv
     statistical_sufficiency.json
-    seed_schedule_comparison.json
-    seed_schedule_comparison.md
+    seed_schedule_comparison.json       # optional comparison-script output
+    seed_schedule_comparison.md         # optional comparison-script output
     snqi_diagnostics.json
     snqi_diagnostics.md
     snqi_sensitivity.csv

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -87,6 +87,14 @@ Current promoted all-planners baseline run:
   + `paper_interpretation_profile=baseline-ready-core` means the matrix is paper-facing and
     anchored to the core baseline set, while still allowing experimental challenger rows for
     comparison
+* `configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml`
+  + stage-1 paper-matrix seed extension using `paper_eval_s5=[111..115]`
+  + preserves the v1 scenario matrix, planner grouping, differential-drive kinematics, SNQI assets,
+    and publication/export contract; only the named seed set changes
+* `configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml`
+  + escalation target using `paper_eval_s10=[111..120]`
+  + use when the S5 comparison still shows material interval width, ranking, or scenario-winner
+    instability
 
 * `configs/algos/prediction_planner_camera_ready.yaml`
   + explicit `prediction_planner` camera-ready profile used by all-planners presets
@@ -139,6 +147,8 @@ Expected tree:
     seed_variability_by_scenario.csv
     seed_episode_rows.csv
     statistical_sufficiency.json
+    seed_schedule_comparison.json
+    seed_schedule_comparison.md
     snqi_diagnostics.json
     snqi_diagnostics.md
     snqi_sensitivity.csv
@@ -306,6 +316,52 @@ bootstrap_confidence: 0.95
 bootstrap_seed: 123
 ```
 
+For full paper-matrix seed-count extensions, use the named seed sets in
+`configs/benchmarks/seed_sets_v1.yaml`:
+
+* `eval` / S3: `[111,112,113]`, the frozen paper-facing baseline.
+* `paper_eval_s5` / S5: `[111,112,113,114,115]`, the first staged full-matrix extension.
+* `paper_eval_s10` / S10: `[111..120]`, the escalation target when S5 is still unstable.
+* `paper_eval_s20` / S20: `[111..130]`, a high-cost reference schedule for later variance
+  power checks.
+
+Interpret extended-seed comparisons with the following default decision criteria:
+
+* CI-width reduction target: at least 20% relative reduction in mean CI width per metric, while
+  accepting unchanged zero-width intervals as already tight.
+* Aggregate mean drift: flag planner/metric rows whose absolute drift exceeds
+  `max(0.02, 5% of the S3 mean)`.
+* Ranking stability: flag if Kendall tau on planner-level `snqi_mean` falls below `0.8`.
+* Scenario-winner stability: flag if more than 10% of comparable scenarios change winner under
+  scenario-level `snqi`.
+
+Staged stopping rule:
+
+* Run S5 first under the same matrix, planner, kinematics, SNQI, bootstrap, and export settings as
+  S3.
+* Stop at S5 when planner ranking is stable, scenario-winner changes are within threshold, and no
+  aggregate drift trigger changes the interpretation. CI-width target misses are reported as
+  precision caveats, not automatic headline changes.
+* Escalate to S10 when S5 crosses the ranking, scenario-winner, or aggregate-drift thresholds.
+* Reserve S20 for a dedicated high-cost reference run when S10 still leaves manuscript-relevant
+  uncertainty.
+
+Canonical S5 preflight:
+
+```bash
+uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml \
+  --mode preflight \
+  --label issue832_s5_preflight
+```
+
+Canonical resumable S5 run in tmux:
+
+```bash
+tmux new -d -s issue832_s5 -- \
+  zsh -lc 'cd /path/to/robot_sf_ll7 && source .venv/bin/activate && LOGURU_LEVEL=INFO uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --label issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
+```
+
 Grouping semantics:
 
 * raw per-planner `runs/<planner>/episodes.jsonl` remain the execution records
@@ -423,6 +479,20 @@ uv run python scripts/tools/compare_camera_ready_campaigns.py \
 
 Use this to validate quality changes (for example predictive planner success/collision deltas)
 after compatibility or config fixes.
+
+Seed-schedule comparison helper:
+
+```bash
+uv run python scripts/tools/compare_seed_schedule_campaigns.py \
+  --base-campaign-root output/benchmarks/camera_ready/<s3_campaign_id> \
+  --candidate-campaign-root output/benchmarks/camera_ready/<s5_or_s10_campaign_id> \
+  --output-json output/benchmarks/camera_ready/<s5_or_s10_campaign_id>/reports/seed_schedule_comparison.json \
+  --output-md output/benchmarks/camera_ready/<s5_or_s10_campaign_id>/reports/seed_schedule_comparison.md
+```
+
+Use the seed-schedule comparison for issue-832-style stability checks. It consumes the versioned
+campaign outputs and reports CI-width changes, aggregate mean drift, planner ranking correlation,
+scenario-level winner changes, and a conservative `stable` / `review` interpretation.
 
 Analyzer findings now also include portability checks, including detection of
 absolute `scenario_params.map_file` paths in episodes (these should be

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -359,8 +359,11 @@ Canonical resumable S5 run in tmux:
 
 ```bash
 tmux new -d -s issue832_s5 -- \
-  zsh -lc 'cd /path/to/robot_sf_ll7 && source .venv/bin/activate && LOGURU_LEVEL=INFO uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --label issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
+  zsh -lc 'cd /path/to/robot_sf_ll7 && source .venv/bin/activate && caffeinate -dimsu uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --campaign-id issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
 ```
+
+Re-run the same command to resume an interrupted root; `--campaign-id` keeps the output directory
+stable and `resume: true` skips completed episode ids.
 
 Grouping semantics:
 

--- a/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
+++ b/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
@@ -1,0 +1,134 @@
+# Issue 832 Paper-Matrix Extended Seed Schedule
+
+Date: 2026-04-16
+
+Related:
+- Upstream issue: `ll7/robot_sf_ll7#832`
+- Frozen paper matrix: `docs/context/issue_535_paper_matrix_freeze.md`
+- Fixed-scenario seed pilot: `docs/context/issue_751_seed_variability_pilot_execution.md`
+- Fallback policy: `docs/context/issue_691_benchmark_fallback_policy.md`
+
+## Goal
+
+Extend the paper-facing full benchmark matrix beyond the frozen S3 eval schedule while preserving
+the v1 matrix contract: same scenario matrix, planner set, planner grouping, differential-drive
+kinematics, SNQI assets, bootstrap settings, and publication/export layout.
+
+This note is benchmark-side evidence guidance only. It does not retroactively replace the
+manuscript's frozen S3 reported numbers.
+
+## Selected Seed Policy
+
+The baseline remains:
+
+- S3 / `eval`: `[111, 112, 113]`
+
+The selected staged extension policy is:
+
+- S5 / `paper_eval_s5`: `[111, 112, 113, 114, 115]`
+- S10 / `paper_eval_s10`: `[111, 112, 113, 114, 115, 116, 117, 118, 119, 120]`
+- S20 / `paper_eval_s20`: `[111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130]`
+
+Rationale:
+
+- Contiguous deterministic seeds avoid hidden seed-selection bias.
+- S5 is the first full-matrix extension and keeps runtime manageable on local hardware.
+- S10 is the next escalation target if S5 changes planner ranking, scenario winners, or aggregate
+  means enough to alter the paper interpretation.
+- S20 is a later high-cost reference schedule, not the default first execution.
+
+Versioned surfaces:
+
+- `configs/benchmarks/seed_sets_v1.yaml`
+- `configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml`
+- `configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml`
+- `scripts/tools/compare_seed_schedule_campaigns.py`
+
+## Decision Criteria
+
+The comparison artifact uses these defaults:
+
+- CI-width reduction target: at least `20%` relative reduction in mean CI width per metric.
+- Aggregate mean drift flag: absolute drift greater than `max(0.02, 5% of the S3 mean)`.
+- Ranking stability flag: planner-level Kendall tau on `snqi_mean` below `0.8`.
+- Scenario-winner flag: more than `10%` of comparable scenarios change winner under scenario-level
+  `snqi`.
+
+CI-width target misses are precision caveats. The conservative headline interpretation changes only
+when ranking, scenario-winner, or aggregate mean-drift triggers fire.
+
+## Runtime Estimate
+
+Reference S3 run:
+
+- Campaign: `paper_experiment_matrix_v1_release_rehearsal_latest_20260409_20260409_120154`
+- Episodes: `987`
+- Runtime: `728.7301911249997` seconds
+- Throughput: `1.354410743537726` episodes/second
+
+Linear seed-count estimates under the same worker count:
+
+| Schedule | Seeds | Estimated episodes | Estimated runtime |
+|---|---:|---:|---:|
+| S3 | 3 | 987 | 12.1 min observed |
+| S5 | 5 | 1645 | 20.2 min |
+| S10 | 10 | 3290 | 40.5 min |
+| S20 | 20 | 6580 | 81.0 min |
+
+Local machine context on `LeLuMBP24` says to keep CPU workloads conservative and use capped
+concurrency. The paper matrix configs keep `workers: 1`, and long/staged executions should run in
+tmux so they can be reattached.
+
+## Canonical Commands
+
+S5 preflight:
+
+```bash
+uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml \
+  --mode preflight \
+  --label issue832_s5_preflight
+```
+
+S5 run in tmux:
+
+```bash
+tmux new -d -s issue832_s5 -- \
+  zsh -lc 'cd /Users/lennart/git/robot_sf_ll7 && source .venv/bin/activate && LOGURU_LEVEL=INFO uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --label issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
+```
+
+Analyzer:
+
+```bash
+uv run python scripts/tools/analyze_camera_ready_campaign.py \
+  --campaign-root output/benchmarks/camera_ready/<s5_campaign_id>
+```
+
+Comparison:
+
+```bash
+uv run python scripts/tools/compare_seed_schedule_campaigns.py \
+  --base-campaign-root output/benchmarks/camera_ready/<s3_campaign_id> \
+  --candidate-campaign-root output/benchmarks/camera_ready/<s5_campaign_id> \
+  --output-json output/benchmarks/camera_ready/<s5_campaign_id>/reports/seed_schedule_comparison.json \
+  --output-md output/benchmarks/camera_ready/<s5_campaign_id>/reports/seed_schedule_comparison.md
+```
+
+## Interpretation Guidance
+
+Use the S5 comparison as a full-matrix staged extension, not as a replacement for the frozen S3
+publication bundle. If the comparison verdict is `stable`, downstream paper text can keep the S3
+numbers while saying a higher-seed full-matrix check did not change the ranking or scenario-level
+interpretation under the configured thresholds.
+
+If the verdict is `review`, paper consumers should inspect the flagged planner/metric rows and
+changed scenarios before strengthening or narrowing manuscript claims. Do not describe fallback or
+degraded planner execution as successful benchmark evidence.
+
+## Validation Log
+
+Pending commands for this branch:
+
+- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py -k 'seed_schedule or extended_seed or preflight_mode'`
+- `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --mode preflight --label issue832_s5_preflight`
+- S5 tmux run, analyzer, and seed-schedule comparison commands above.

--- a/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
+++ b/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
@@ -174,7 +174,7 @@ episode counts. The regeneration pass used `resume: true` and did not re-execute
 ids; this is why `campaign.runtime_sec` in the final JSON files reflects the short report
 regeneration invocation rather than total benchmark wall time.
 
-Analysis/export artifacts:
+## Analysis/export artifacts:
 
 - S3:
   - `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae/reports/campaign_analysis.json`
@@ -189,7 +189,7 @@ Analysis/export artifacts:
   - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.json`
   - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.md`
 
-Comparison result:
+## Comparison result:
 
 - Verdict: `review`
 - Ranking stability: stable (`Kendall tau = 1.0`, `Spearman rho = 1.0`)
@@ -197,7 +197,7 @@ Comparison result:
 - Aggregate mean drift flags: `9 / 35` planner-metric rows
 - CI-width target misses: `success`, `near_misses`, `time_to_goal_norm`, `snqi`
 
-Interpretation:
+## Interpretation:
 
 - The S5 extension does not change the aggregate SNQI planner ordering.
 - The S5 extension does change enough scenario-level winners and aggregate means that downstream
@@ -205,3 +205,5 @@ Interpretation:
 - The current paper-facing S3 numbers can remain a bounded initial full-matrix protocol, but this
   benchmark-side follow-up should be cited as a caution that broader seeding preserves ranking while
   exposing scenario-level and mean-drift sensitivity.
+
+The S5 comparison is best read as a robustness check on the frozen S3 publication bundle, not as a replacement for it. The main positive result is that the overall planner ranking does not change, which means the headline ordering is stable even when more seeds are added. The main caution is that the benchmark is still sensitive at a finer scale: a meaningful share of scenarios change winner, and several planner-metric means shift enough to cross the configured drift thresholds. In practical terms, the paper can keep the S3 numbers as the official reference, while describing the S5 run as evidence that the ranking is durable but some scenario-level outcomes remain seed-sensitive. The CI-width misses should be treated as a precision warning, not as evidence that the benchmark is invalid.

--- a/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
+++ b/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
@@ -130,8 +130,78 @@ degraded planner execution as successful benchmark evidence.
 
 ## Validation Log
 
-Pending commands for this branch:
+Code/config validation:
 
-- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py -k 'seed_schedule or extended_seed or preflight_mode'`
-- `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --mode preflight --label issue832_s5_preflight`
-- S5 tmux run, analyzer, and seed-schedule comparison commands above.
+- `uv run ruff check scripts/tools/compare_seed_schedule_campaigns.py tests/tools/test_compare_seed_schedule_campaigns.py tests/benchmark/test_camera_ready_campaign.py`
+- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/benchmark/test_camera_ready_campaign.py -k 'seed_schedule or extended_seed'`
+- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py`
+- `uv run ruff check scripts/tools/run_camera_ready_benchmark.py robot_sf/benchmark/camera_ready_campaign.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py`
+- `uv run pytest -o addopts='' tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py -k 'campaign_id or run_mode or extended_seed'`
+- `uv run pytest -o addopts='' tests/benchmark/test_camera_ready_campaign.py -k 'planner_report_row_counts_existing_records_after_resume or campaign_id or extended_seed'`
+- `git diff --check`
+
+Preflight:
+
+- S5:
+  `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --mode preflight --label issue832_s5_preflight_committed`
+- S10:
+  `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml --mode preflight --label issue832_s10_preflight_committed`
+
+Executed campaigns:
+
+- S3 reference root:
+  `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae`
+  - episode execution commit: `bd60bae4401d075fc67436b42da6f5f4deb95aa7`
+  - final report-generation commit: `b993fd11cbeb91c44f7329b0f853ab76cc27a488`
+  - episodes: `987`
+  - runs: `7/7` successful
+  - SNQI contract: `pass`
+  - tmux session: `issue832_s3_bd60bae`
+  - execution wall clock: about `10.7` min (`11:52:14` to `12:02:56`)
+- S5 extended root:
+  `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae`
+  - episode execution commit: `bd60bae4401d075fc67436b42da6f5f4deb95aa7`
+  - final report-generation commit: `b993fd11cbeb91c44f7329b0f853ab76cc27a488`
+  - episodes: `1645`
+  - runs: `7/7` successful
+  - SNQI contract: `warn` with `snqi_contract.enforcement=warn`
+  - tmux sessions: `issue832_s5_bd60bae`, then `issue832_s5_bd60bae_resume1`
+  - execution wall clock including manual restart gap: about `22.9` min (`11:52:14` to `12:15:12`)
+  - active execution time estimate from logs excluding the restart gap: about `18.1` min
+
+The final reports were regenerated after adding fixed campaign ids and correcting resumed planner
+episode counts. The regeneration pass used `resume: true` and did not re-execute completed episode
+ids; this is why `campaign.runtime_sec` in the final JSON files reflects the short report
+regeneration invocation rather than total benchmark wall time.
+
+Analysis/export artifacts:
+
+- S3:
+  - `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae/reports/campaign_analysis.json`
+  - `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae/reports/campaign_analysis.md`
+  - `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae/reports/scenario_difficulty_analysis.json`
+  - `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae/reports/scenario_difficulty_analysis.md`
+- S5:
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/campaign_analysis.json`
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/campaign_analysis.md`
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/scenario_difficulty_analysis.json`
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/scenario_difficulty_analysis.md`
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.json`
+  - `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.md`
+
+Comparison result:
+
+- Verdict: `review`
+- Ranking stability: stable (`Kendall tau = 1.0`, `Spearman rho = 1.0`)
+- Scenario winner changes: `7 / 47` scenarios (`14.9%`), above the `10%` threshold
+- Aggregate mean drift flags: `9 / 35` planner-metric rows
+- CI-width target misses: `success`, `near_misses`, `time_to_goal_norm`, `snqi`
+
+Interpretation:
+
+- The S5 extension does not change the aggregate SNQI planner ordering.
+- The S5 extension does change enough scenario-level winners and aggregate means that downstream
+  paper text should avoid strengthening seed-stability claims from the frozen S3 bundle.
+- The current paper-facing S3 numbers can remain a bounded initial full-matrix protocol, but this
+  benchmark-side follow-up should be cited as a caution that broader seeding preserves ranking while
+  exposing scenario-level and mean-drift sensitivity.

--- a/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
+++ b/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
@@ -93,8 +93,9 @@ uv run python scripts/tools/run_camera_ready_benchmark.py \
 S5 run in tmux:
 
 ```bash
+REPO_ROOT="$(pwd)"
 tmux new -d -s issue832_s5 -- \
-  zsh -lc 'cd /Users/lennart/git/robot_sf_ll7 && source .venv/bin/activate && caffeinate -dimsu uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --campaign-id issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
+  zsh -lc "cd \"$REPO_ROOT\" && source .venv/bin/activate && caffeinate -dimsu uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --campaign-id issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log"
 ```
 
 If the session stops early, re-run the same tmux command. The fixed `--campaign-id` targets the

--- a/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
+++ b/docs/context/issue_832_paper_matrix_extended_seed_schedule.md
@@ -94,8 +94,11 @@ S5 run in tmux:
 
 ```bash
 tmux new -d -s issue832_s5 -- \
-  zsh -lc 'cd /Users/lennart/git/robot_sf_ll7 && source .venv/bin/activate && LOGURU_LEVEL=INFO uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --label issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
+  zsh -lc 'cd /Users/lennart/git/robot_sf_ll7 && source .venv/bin/activate && caffeinate -dimsu uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml --campaign-id issue832_s5_stage 2>&1 | tee output/benchmarks/camera_ready/issue832_s5_stage.log'
 ```
+
+If the session stops early, re-run the same tmux command. The fixed `--campaign-id` targets the
+same campaign root and the config's `resume: true` skips already-written episode ids.
 
 Analyzer:
 

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -2185,6 +2185,11 @@ def _planner_report_row(  # noqa: C901
                 continue
             if not math.isfinite(resolved_metrics[field_name]):
                 resolved_metrics[field_name] = _episode_metric_mean(records, metric_name)
+    episode_count = (
+        len(records)
+        if records is not None
+        else int(summary.get("episodes_total", summary.get("written", 0)))
+    )
 
     row = {
         "planner_key": planner.key,
@@ -2192,7 +2197,7 @@ def _planner_report_row(  # noqa: C901
         "planner_group": planner.planner_group,
         "kinematics": kinematics,
         "status": status,
-        "episodes": int(summary.get("written", 0)),
+        "episodes": int(episode_count),
         "started_at_utc": str(summary.get("started_at_utc", "unknown")),
         "finished_at_utc": str(summary.get("finished_at_utc", "unknown")),
         "runtime_sec": _safe_float(summary.get("runtime_sec")),

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -736,6 +736,25 @@ def _campaign_id(cfg: CampaignConfig, *, label: str | None = None) -> str:
     return f"{base}_{stamp}"
 
 
+def _resolve_campaign_id(
+    cfg: CampaignConfig,
+    *,
+    label: str | None = None,
+    campaign_id: str | None = None,
+) -> str:
+    """Resolve the output campaign identifier.
+
+    Returns:
+        Explicit sanitized campaign id when provided, otherwise a timestamped id.
+    """
+    if campaign_id is not None:
+        normalized = _sanitize_name(campaign_id)
+        if not normalized:
+            raise ValueError("campaign_id must contain at least one alphanumeric character")
+        return normalized
+    return _campaign_id(cfg, label=label)
+
+
 def _resolve_path(raw_path: str | None, *, base_dir: Path) -> Path | None:
     """Resolve optional paths relative to ``base_dir``.
 
@@ -1803,6 +1822,7 @@ def prepare_campaign_preflight(
     *,
     output_root: Path | None = None,
     label: str | None = None,
+    campaign_id: str | None = None,
     invoked_command: str | None = None,
 ) -> dict[str, Any]:
     """Prepare campaign preflight artifacts and matrix-definition summary.
@@ -1812,7 +1832,7 @@ def prepare_campaign_preflight(
     """
     _validate_campaign_config(cfg)
     ensure_canonical_tree(categories=("benchmarks",))
-    campaign_id = _campaign_id(cfg, label=label)
+    campaign_id = _resolve_campaign_id(cfg, label=label, campaign_id=campaign_id)
     base_dir = (
         output_root.resolve()
         if output_root
@@ -2606,6 +2626,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     *,
     output_root: Path | None = None,
     label: str | None = None,
+    campaign_id: str | None = None,
     skip_publication_bundle: bool = False,
     invoked_command: str | None = None,
 ) -> dict[str, Any]:
@@ -2624,6 +2645,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         cfg,
         output_root=output_root,
         label=label,
+        campaign_id=campaign_id,
         invoked_command=invoked_command,
     )
     campaign_id = str(prepared["campaign_id"])
@@ -2769,6 +2791,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             records: list[dict[str, Any]] = []
             if status != "failed" and episodes_path.exists() and episodes_path.stat().st_size > 0:
                 records = read_jsonl(str(episodes_path))
+                summary["episodes_total"] = len(records)
                 if status == "ok":
                     for record in records:
                         annotated = dict(record)
@@ -3106,7 +3129,15 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
 
     campaign_finished_at_utc = _utc_now()
     runtime_sec = float(max(1e-9, time.perf_counter() - start))
-    total_episodes = sum(int(entry.get("summary", {}).get("written", 0)) for entry in run_entries)
+    total_episodes = sum(
+        int(
+            entry.get("summary", {}).get(
+                "episodes_total",
+                entry.get("summary", {}).get("written", 0),
+            )
+        )
+        for entry in run_entries
+    )
     successful_runs = sum(1 for entry in run_entries if str(entry.get("status", "")) == "ok")
     benchmark_success = len(run_entries) > 0 and successful_runs == len(run_entries)
     confidence_settings = {

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -2794,7 +2794,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             _write_json(planner_dir / "summary.json", summary)
 
             records: list[dict[str, Any]] = []
-            if status != "failed" and episodes_path.exists() and episodes_path.stat().st_size > 0:
+            if episodes_path.exists() and episodes_path.stat().st_size > 0:
                 records = read_jsonl(str(episodes_path))
                 summary["episodes_total"] = len(records)
                 if status == "ok":

--- a/scripts/tools/compare_seed_schedule_campaigns.py
+++ b/scripts/tools/compare_seed_schedule_campaigns.py
@@ -1,0 +1,847 @@
+#!/usr/bin/env python3
+"""Compare paper-matrix benchmark campaigns with different seed schedules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_SEED_METRICS: tuple[str, ...] = (
+    "success",
+    "collisions",
+    "near_misses",
+    "time_to_goal_norm",
+    "snqi",
+)
+_LOWER_IS_BETTER = {
+    "collisions",
+    "near_misses",
+    "time_to_goal_norm",
+    "comfort_exposure",
+    "jerk",
+    "jerk_mean",
+}
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return float(sum(values) / len(values))
+
+
+def _fmt(value: Any, digits: int = 4) -> str:
+    numeric = _safe_float(value)
+    if numeric is None:
+        return "n/a"
+    return f"{numeric:.{digits}f}"
+
+
+def _metric_direction(metric: str) -> str:
+    return "lower" if metric in _LOWER_IS_BETTER else "higher"
+
+
+def _metric_summary(row: dict[str, Any], metric: str) -> dict[str, Any]:
+    summary = row.get("summary")
+    if not isinstance(summary, dict):
+        return {}
+    metric_summary = summary.get(metric)
+    return dict(metric_summary) if isinstance(metric_summary, dict) else {}
+
+
+def _metric_mean(row: dict[str, Any], metric: str) -> float | None:
+    return _safe_float(_metric_summary(row, metric).get("mean"))
+
+
+def _metric_ci(row: dict[str, Any], metric: str) -> tuple[float | None, float | None]:
+    summary = _metric_summary(row, metric)
+    low = _safe_float(summary.get("ci_low"))
+    high = _safe_float(summary.get("ci_high"))
+    return low, high
+
+
+def _ci_width(row: dict[str, Any], metric: str) -> float | None:
+    low, high = _metric_ci(row, metric)
+    if low is None or high is None:
+        return None
+    return float(max(0.0, high - low))
+
+
+def _ci_overlap(
+    base_row: dict[str, Any], candidate_row: dict[str, Any], metric: str
+) -> bool | None:
+    base_low, base_high = _metric_ci(base_row, metric)
+    candidate_low, candidate_high = _metric_ci(candidate_row, metric)
+    if None in (base_low, base_high, candidate_low, candidate_high):
+        return None
+    return bool(base_low <= candidate_high and candidate_low <= base_high)
+
+
+def _seed_row_key(row: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(row.get("scenario_id", "unknown")),
+        str(row.get("planner_key", "unknown")),
+        str(row.get("kinematics", "unknown")),
+    )
+
+
+def _planner_key(row: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(row.get("planner_key", "unknown")),
+        str(row.get("kinematics", "unknown")),
+    )
+
+
+def _load_campaign(campaign_root: Path) -> dict[str, Any]:
+    summary = _read_json(campaign_root / "reports" / "campaign_summary.json")
+    seed_variability = _read_json(campaign_root / "reports" / "seed_variability_by_scenario.json")
+    matrix_path = campaign_root / "reports" / "matrix_summary.json"
+    matrix_summary = _read_json(matrix_path) if matrix_path.exists() else {}
+    return {
+        "root": campaign_root,
+        "summary": summary,
+        "seed_variability": seed_variability,
+        "matrix_summary": matrix_summary,
+    }
+
+
+def _campaign_metadata(campaign: dict[str, Any]) -> dict[str, Any]:
+    summary = dict(campaign.get("summary") or {})
+    campaign_block = dict(summary.get("campaign") or {})
+    matrix_rows = (
+        (campaign.get("matrix_summary") or {}).get("rows")
+        if isinstance(campaign.get("matrix_summary"), dict)
+        else None
+    )
+    first_matrix_row = matrix_rows[0] if isinstance(matrix_rows, list) and matrix_rows else {}
+    return {
+        "campaign_id": campaign_block.get("campaign_id", campaign["root"].name),
+        "campaign_root": str(campaign["root"]),
+        "config_name": campaign_block.get("name"),
+        "scenario_matrix": campaign_block.get("scenario_matrix"),
+        "scenario_matrix_hash": campaign_block.get("scenario_matrix_hash"),
+        "paper_profile_version": campaign_block.get("paper_profile_version"),
+        "paper_interpretation_profile": campaign_block.get("paper_interpretation_profile"),
+        "total_episodes": campaign_block.get("total_episodes"),
+        "total_runs": campaign_block.get("total_runs"),
+        "successful_runs": campaign_block.get("successful_runs"),
+        "benchmark_success": campaign_block.get("benchmark_success"),
+        "runtime_sec": campaign_block.get("runtime_sec"),
+        "git_hash": campaign_block.get("git_hash"),
+        "resolved_seeds": first_matrix_row.get("resolved_seeds"),
+        "repeats": first_matrix_row.get("repeats"),
+        "seed_policy_mode": first_matrix_row.get("seed_policy.mode"),
+        "seed_policy_seed_set": first_matrix_row.get("seed_policy.seed_set"),
+    }
+
+
+def _seed_rows_by_key(campaign: dict[str, Any]) -> dict[tuple[str, str, str], dict[str, Any]]:
+    payload = campaign.get("seed_variability")
+    rows = payload.get("rows") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    out: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        if isinstance(row, dict):
+            out[_seed_row_key(row)] = row
+    return out
+
+
+def _planner_rows_by_key(campaign: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    summary = campaign.get("summary")
+    rows = summary.get("planner_rows") if isinstance(summary, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        if isinstance(row, dict):
+            out[_planner_key(row)] = row
+    return out
+
+
+def _relative_change(base: float | None, candidate: float | None) -> float | None:
+    if base is None or candidate is None or abs(base) <= 1e-12:
+        return None
+    return float((candidate - base) / abs(base))
+
+
+def _build_interval_width_rows(
+    base_rows: dict[tuple[str, str, str], dict[str, Any]],
+    candidate_rows: dict[tuple[str, str, str], dict[str, Any]],
+    metrics: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key in sorted(set(base_rows) & set(candidate_rows)):
+        base_row = base_rows[key]
+        candidate_row = candidate_rows[key]
+        for metric in metrics:
+            base_width = _ci_width(base_row, metric)
+            candidate_width = _ci_width(candidate_row, metric)
+            base_mean = _metric_mean(base_row, metric)
+            candidate_mean = _metric_mean(candidate_row, metric)
+            rows.append(
+                {
+                    "scenario_id": key[0],
+                    "planner_key": key[1],
+                    "kinematics": key[2],
+                    "metric": metric,
+                    "base_seed_count": base_row.get("seed_count"),
+                    "candidate_seed_count": candidate_row.get("seed_count"),
+                    "base_mean": base_mean,
+                    "candidate_mean": candidate_mean,
+                    "mean_delta": (
+                        None
+                        if base_mean is None or candidate_mean is None
+                        else candidate_mean - base_mean
+                    ),
+                    "base_ci_width": base_width,
+                    "candidate_ci_width": candidate_width,
+                    "ci_width_delta": (
+                        None
+                        if base_width is None or candidate_width is None
+                        else candidate_width - base_width
+                    ),
+                    "ci_width_relative_change": _relative_change(base_width, candidate_width),
+                    "ci_width_reduction_fraction": (
+                        None
+                        if base_width is None or candidate_width is None or abs(base_width) <= 1e-12
+                        else (base_width - candidate_width) / base_width
+                    ),
+                    "ci_overlap": _ci_overlap(base_row, candidate_row, metric),
+                }
+            )
+    return rows
+
+
+def _summarize_interval_widths(
+    interval_rows: list[dict[str, Any]],
+    metrics: tuple[str, ...],
+    *,
+    target_reduction: float,
+) -> dict[str, Any]:
+    by_metric: dict[str, dict[str, Any]] = {}
+    for metric in metrics:
+        metric_rows = [row for row in interval_rows if row.get("metric") == metric]
+        base_widths = [
+            width
+            for row in metric_rows
+            if (width := _safe_float(row.get("base_ci_width"))) is not None
+        ]
+        candidate_widths = [
+            width
+            for row in metric_rows
+            if (width := _safe_float(row.get("candidate_ci_width"))) is not None
+        ]
+        base_mean_width = _mean(base_widths)
+        candidate_mean_width = _mean(candidate_widths)
+        reduction = (
+            None
+            if base_mean_width is None
+            or candidate_mean_width is None
+            or abs(base_mean_width) <= 1e-12
+            else (base_mean_width - candidate_mean_width) / base_mean_width
+        )
+        target_met = (
+            bool(reduction >= target_reduction)
+            if reduction is not None
+            else bool(base_mean_width == 0.0 and candidate_mean_width == 0.0)
+        )
+        by_metric[metric] = {
+            "common_rows": len(metric_rows),
+            "base_mean_ci_width": base_mean_width,
+            "candidate_mean_ci_width": candidate_mean_width,
+            "mean_reduction_fraction": reduction,
+            "target_relative_reduction": target_reduction,
+            "target_met": target_met,
+        }
+    return by_metric
+
+
+def _aggregate_metric_means(
+    base_rows: dict[tuple[str, str, str], dict[str, Any]],
+    candidate_rows: dict[tuple[str, str, str], dict[str, Any]],
+    metrics: tuple[str, ...],
+    *,
+    relative_threshold: float,
+    absolute_floor: float,
+) -> dict[str, Any]:
+    grouped: dict[tuple[str, str], dict[str, dict[str, list[float]]]] = defaultdict(
+        lambda: {"base": defaultdict(list), "candidate": defaultdict(list)}
+    )
+    for scenario_id, planner_key, kinematics in sorted(set(base_rows) & set(candidate_rows)):
+        planner_group_key = (planner_key, kinematics)
+        base_row = base_rows[(scenario_id, planner_key, kinematics)]
+        candidate_row = candidate_rows[(scenario_id, planner_key, kinematics)]
+        for metric in metrics:
+            base_mean = _metric_mean(base_row, metric)
+            candidate_mean = _metric_mean(candidate_row, metric)
+            if base_mean is not None and candidate_mean is not None:
+                grouped[planner_group_key]["base"][metric].append(base_mean)
+                grouped[planner_group_key]["candidate"][metric].append(candidate_mean)
+
+    rows: list[dict[str, Any]] = []
+    flagged_rows: list[dict[str, Any]] = []
+    for (planner_key, kinematics), values in sorted(grouped.items()):
+        for metric in metrics:
+            base_mean = _mean(list(values["base"].get(metric, [])))
+            candidate_mean = _mean(list(values["candidate"].get(metric, [])))
+            if base_mean is None or candidate_mean is None:
+                continue
+            delta = candidate_mean - base_mean
+            relative_delta = _relative_change(base_mean, candidate_mean)
+            threshold = max(absolute_floor, abs(base_mean) * relative_threshold)
+            flagged = abs(delta) > threshold
+            row = {
+                "planner_key": planner_key,
+                "kinematics": kinematics,
+                "metric": metric,
+                "base_mean": base_mean,
+                "candidate_mean": candidate_mean,
+                "delta": delta,
+                "absolute_delta": abs(delta),
+                "relative_delta": relative_delta,
+                "flag_threshold": threshold,
+                "flagged": flagged,
+            }
+            rows.append(row)
+            if flagged:
+                flagged_rows.append(row)
+    return {
+        "relative_threshold": relative_threshold,
+        "absolute_floor": absolute_floor,
+        "rows": rows,
+        "flagged_rows": flagged_rows,
+        "flagged_count": len(flagged_rows),
+    }
+
+
+def _rank_values(
+    values: dict[tuple[str, str], float], *, higher_is_better: bool
+) -> dict[tuple[str, str], float]:
+    ordered = sorted(
+        values.items(),
+        key=lambda item: (-item[1] if higher_is_better else item[1], item[0][0], item[0][1]),
+    )
+    ranks: dict[tuple[str, str], float] = {}
+    index = 0
+    while index < len(ordered):
+        value = ordered[index][1]
+        tie_end = index + 1
+        while tie_end < len(ordered) and ordered[tie_end][1] == value:
+            tie_end += 1
+        average_rank = (index + 1 + tie_end) / 2.0
+        for tied_index in range(index, tie_end):
+            ranks[ordered[tied_index][0]] = average_rank
+        index = tie_end
+    return ranks
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float | None:
+    if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    x_mean = sum(xs) / len(xs)
+    y_mean = sum(ys) / len(ys)
+    x_centered = [value - x_mean for value in xs]
+    y_centered = [value - y_mean for value in ys]
+    numerator = sum(x * y for x, y in zip(x_centered, y_centered, strict=True))
+    x_den = math.sqrt(sum(x * x for x in x_centered))
+    y_den = math.sqrt(sum(y * y for y in y_centered))
+    if x_den <= 1e-12 or y_den <= 1e-12:
+        return None
+    return float(numerator / (x_den * y_den))
+
+
+def _spearman(
+    base_values: dict[tuple[str, str], float],
+    candidate_values: dict[tuple[str, str], float],
+    *,
+    higher_is_better: bool,
+) -> float | None:
+    common = sorted(set(base_values) & set(candidate_values))
+    if len(common) < 2:
+        return None
+    base_ranks = _rank_values(
+        {key: base_values[key] for key in common},
+        higher_is_better=higher_is_better,
+    )
+    candidate_ranks = _rank_values(
+        {key: candidate_values[key] for key in common},
+        higher_is_better=higher_is_better,
+    )
+    return _pearson([base_ranks[key] for key in common], [candidate_ranks[key] for key in common])
+
+
+def _kendall_tau(
+    base_values: dict[tuple[str, str], float],
+    candidate_values: dict[tuple[str, str], float],
+    *,
+    higher_is_better: bool,
+) -> float | None:
+    common = sorted(set(base_values) & set(candidate_values))
+    if len(common) < 2:
+        return None
+    concordant = 0
+    discordant = 0
+    multiplier = 1.0 if higher_is_better else -1.0
+    for index, left in enumerate(common):
+        for right in common[index + 1 :]:
+            base_delta = multiplier * (base_values[left] - base_values[right])
+            candidate_delta = multiplier * (candidate_values[left] - candidate_values[right])
+            if abs(base_delta) <= 1e-12 or abs(candidate_delta) <= 1e-12:
+                continue
+            if base_delta * candidate_delta > 0:
+                concordant += 1
+            else:
+                discordant += 1
+    total = concordant + discordant
+    if total == 0:
+        return None
+    return float((concordant - discordant) / total)
+
+
+def _ranking_stability(
+    base_planner_rows: dict[tuple[str, str], dict[str, Any]],
+    candidate_planner_rows: dict[tuple[str, str], dict[str, Any]],
+    *,
+    metric: str,
+    min_tau: float,
+) -> dict[str, Any]:
+    higher_is_better = _metric_direction(metric.replace("_mean", "")) == "higher"
+    common = sorted(set(base_planner_rows) & set(candidate_planner_rows))
+    base_values = {
+        key: value
+        for key in common
+        if (value := _safe_float(base_planner_rows[key].get(metric))) is not None
+    }
+    candidate_values = {
+        key: value
+        for key in common
+        if (value := _safe_float(candidate_planner_rows[key].get(metric))) is not None
+    }
+    common_metric_keys = sorted(set(base_values) & set(candidate_values))
+    base_values = {key: base_values[key] for key in common_metric_keys}
+    candidate_values = {key: candidate_values[key] for key in common_metric_keys}
+    base_order = [
+        {"planner_key": key[0], "kinematics": key[1], "value": base_values[key]}
+        for key in sorted(
+            common_metric_keys,
+            key=lambda item: (
+                -base_values[item] if higher_is_better else base_values[item],
+                item[0],
+                item[1],
+            ),
+        )
+    ]
+    candidate_order = [
+        {"planner_key": key[0], "kinematics": key[1], "value": candidate_values[key]}
+        for key in sorted(
+            common_metric_keys,
+            key=lambda item: (
+                -candidate_values[item] if higher_is_better else candidate_values[item],
+                item[0],
+                item[1],
+            ),
+        )
+    ]
+    tau = _kendall_tau(base_values, candidate_values, higher_is_better=higher_is_better)
+    rho = _spearman(base_values, candidate_values, higher_is_better=higher_is_better)
+    status = "insufficient_data"
+    if tau is not None:
+        status = "stable" if tau >= min_tau else "unstable"
+    return {
+        "metric": metric,
+        "direction": "higher" if higher_is_better else "lower",
+        "common_planner_count": len(common_metric_keys),
+        "spearman_rho": rho,
+        "kendall_tau": tau,
+        "min_kendall_tau": min_tau,
+        "status": status,
+        "base_order": base_order,
+        "candidate_order": candidate_order,
+    }
+
+
+def _scenario_winner_stability(
+    base_rows: dict[tuple[str, str, str], dict[str, Any]],
+    candidate_rows: dict[tuple[str, str, str], dict[str, Any]],
+    *,
+    metric: str,
+    change_threshold: float,
+) -> dict[str, Any]:
+    direction = _metric_direction(metric)
+    grouped: dict[tuple[str, str], dict[str, dict[str, float]]] = defaultdict(
+        lambda: {"base": {}, "candidate": {}}
+    )
+    for scenario_id, planner_key, kinematics in sorted(set(base_rows) & set(candidate_rows)):
+        base_mean = _metric_mean(base_rows[(scenario_id, planner_key, kinematics)], metric)
+        candidate_mean = _metric_mean(
+            candidate_rows[(scenario_id, planner_key, kinematics)],
+            metric,
+        )
+        if base_mean is None or candidate_mean is None:
+            continue
+        grouped[(scenario_id, kinematics)]["base"][planner_key] = base_mean
+        grouped[(scenario_id, kinematics)]["candidate"][planner_key] = candidate_mean
+
+    changed: list[dict[str, Any]] = []
+    compared = 0
+    for (scenario_id, kinematics), values in sorted(grouped.items()):
+        common_planners = sorted(set(values["base"]) & set(values["candidate"]))
+        if len(common_planners) < 2:
+            continue
+        compared += 1
+        reverse = direction == "higher"
+        base_winner = sorted(
+            common_planners,
+            key=lambda planner: (
+                -values["base"][planner] if reverse else values["base"][planner],
+                planner,
+            ),
+        )[0]
+        candidate_winner = sorted(
+            common_planners,
+            key=lambda planner: (
+                -values["candidate"][planner] if reverse else values["candidate"][planner],
+                planner,
+            ),
+        )[0]
+        if base_winner != candidate_winner:
+            changed.append(
+                {
+                    "scenario_id": scenario_id,
+                    "kinematics": kinematics,
+                    "base_winner": base_winner,
+                    "candidate_winner": candidate_winner,
+                    "base_winner_value": values["base"][base_winner],
+                    "candidate_winner_value": values["candidate"][candidate_winner],
+                }
+            )
+    changed_fraction = (len(changed) / compared) if compared else None
+    status = "insufficient_data"
+    if changed_fraction is not None:
+        status = "stable" if changed_fraction <= change_threshold else "unstable"
+    return {
+        "metric": metric,
+        "direction": direction,
+        "common_scenario_count": compared,
+        "changed_count": len(changed),
+        "changed_fraction": changed_fraction,
+        "change_threshold": change_threshold,
+        "status": status,
+        "changed_scenarios": changed,
+    }
+
+
+def _interpretation(
+    *,
+    interval_summary: dict[str, Any],
+    mean_drift: dict[str, Any],
+    ranking: dict[str, Any],
+    scenario_winners: dict[str, Any],
+) -> dict[str, Any]:
+    notes: list[str] = []
+    ranking_changed = ranking.get("status") == "unstable"
+    scenario_changed = scenario_winners.get("status") == "unstable"
+    drift_flagged = int(mean_drift.get("flagged_count", 0) or 0) > 0
+    interval_misses = [
+        metric
+        for metric, row in interval_summary.items()
+        if isinstance(row, dict) and row.get("target_met") is False
+    ]
+    if ranking_changed:
+        notes.append("Planner ranking stability fell below the configured Kendall tau threshold.")
+    if scenario_changed:
+        notes.append("Scenario-level winner changes exceeded the configured threshold.")
+    if drift_flagged:
+        notes.append("Aggregate planner mean drift exceeded the configured drift threshold.")
+    if interval_misses:
+        notes.append(
+            "CI-width reduction target was not met for: " + ", ".join(sorted(interval_misses))
+        )
+    if not notes:
+        notes.append(
+            "No ranking, scenario-winner, or aggregate-drift trigger changed the headline interpretation."
+        )
+    headline_changes = bool(ranking_changed or scenario_changed or drift_flagged)
+    return {
+        "status": "review" if headline_changes else "stable",
+        "headline_interpretation_changes": headline_changes,
+        "ci_width_target_missed_metrics": interval_misses,
+        "notes": notes,
+    }
+
+
+def compare_seed_schedules(  # noqa: PLR0913
+    base_campaign_root: Path,
+    candidate_campaign_root: Path,
+    *,
+    interval_reduction_target: float = 0.20,
+    mean_drift_relative_threshold: float = 0.05,
+    mean_drift_absolute_floor: float = 0.02,
+    ranking_metric: str = "snqi_mean",
+    ranking_min_tau: float = 0.80,
+    scenario_winner_metric: str = "snqi",
+    scenario_winner_change_threshold: float = 0.10,
+) -> dict[str, Any]:
+    """Compare two camera-ready campaigns that differ only by seed schedule."""
+    base = _load_campaign(base_campaign_root.resolve())
+    candidate = _load_campaign(candidate_campaign_root.resolve())
+    metrics = tuple(
+        metric
+        for metric in _SEED_METRICS
+        if metric in set(base["seed_variability"].get("metrics", []))
+        and metric in set(candidate["seed_variability"].get("metrics", []))
+    )
+    base_seed_rows = _seed_rows_by_key(base)
+    candidate_seed_rows = _seed_rows_by_key(candidate)
+    base_planner_rows = _planner_rows_by_key(base)
+    candidate_planner_rows = _planner_rows_by_key(candidate)
+
+    interval_rows = _build_interval_width_rows(base_seed_rows, candidate_seed_rows, metrics)
+    interval_summary = _summarize_interval_widths(
+        interval_rows,
+        metrics,
+        target_reduction=interval_reduction_target,
+    )
+    mean_drift = _aggregate_metric_means(
+        base_seed_rows,
+        candidate_seed_rows,
+        metrics,
+        relative_threshold=mean_drift_relative_threshold,
+        absolute_floor=mean_drift_absolute_floor,
+    )
+    ranking = _ranking_stability(
+        base_planner_rows,
+        candidate_planner_rows,
+        metric=ranking_metric,
+        min_tau=ranking_min_tau,
+    )
+    scenario_winners = _scenario_winner_stability(
+        base_seed_rows,
+        candidate_seed_rows,
+        metric=scenario_winner_metric,
+        change_threshold=scenario_winner_change_threshold,
+    )
+    interpretation = _interpretation(
+        interval_summary=interval_summary,
+        mean_drift=mean_drift,
+        ranking=ranking,
+        scenario_winners=scenario_winners,
+    )
+    return {
+        "schema_version": "benchmark-seed-schedule-comparison.v1",
+        "generated_at_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "base_campaign": _campaign_metadata(base),
+        "candidate_campaign": _campaign_metadata(candidate),
+        "decision_criteria": {
+            "interval_reduction_target": interval_reduction_target,
+            "mean_drift_relative_threshold": mean_drift_relative_threshold,
+            "mean_drift_absolute_floor": mean_drift_absolute_floor,
+            "ranking_metric": ranking_metric,
+            "ranking_min_kendall_tau": ranking_min_tau,
+            "scenario_winner_metric": scenario_winner_metric,
+            "scenario_winner_change_threshold": scenario_winner_change_threshold,
+        },
+        "coverage": {
+            "base_seed_rows": len(base_seed_rows),
+            "candidate_seed_rows": len(candidate_seed_rows),
+            "common_seed_rows": len(set(base_seed_rows) & set(candidate_seed_rows)),
+            "missing_in_base": [
+                list(key) for key in sorted(set(candidate_seed_rows) - set(base_seed_rows))
+            ],
+            "missing_in_candidate": [
+                list(key) for key in sorted(set(base_seed_rows) - set(candidate_seed_rows))
+            ],
+        },
+        "interval_width": {
+            "metrics": list(metrics),
+            "aggregate": interval_summary,
+            "rows": interval_rows,
+        },
+        "mean_drift": mean_drift,
+        "ranking_stability": ranking,
+        "scenario_winner_stability": scenario_winners,
+        "interpretation": interpretation,
+    }
+
+
+def _build_markdown(payload: dict[str, Any]) -> str:
+    base = payload.get("base_campaign", {})
+    candidate = payload.get("candidate_campaign", {})
+    interpretation = payload.get("interpretation", {})
+    lines = [
+        "# Seed Schedule Comparison",
+        "",
+        f"- Base campaign: `{base.get('campaign_id', 'unknown')}`",
+        f"- Candidate campaign: `{candidate.get('campaign_id', 'unknown')}`",
+        f"- Base seeds: `{base.get('resolved_seeds', [])}`",
+        f"- Candidate seeds: `{candidate.get('resolved_seeds', [])}`",
+        f"- Verdict: `{interpretation.get('status', 'unknown')}`",
+        f"- Headline interpretation changes: `{interpretation.get('headline_interpretation_changes', 'unknown')}`",
+        "",
+        "## Decision Criteria",
+        "",
+    ]
+    criteria = payload.get("decision_criteria", {})
+    for key, value in criteria.items():
+        lines.append(f"- `{key}`: `{value}`")
+
+    lines.extend(["", "## Interpretation", ""])
+    for note in interpretation.get("notes", []):
+        lines.append(f"- {note}")
+
+    lines.extend(
+        [
+            "",
+            "## CI Width Reduction",
+            "",
+            "| metric | base mean width | candidate mean width | reduction | target met |",
+            "|---|---:|---:|---:|---|",
+        ]
+    )
+    for metric, row in (payload.get("interval_width", {}).get("aggregate") or {}).items():
+        lines.append(
+            "| "
+            f"{metric} | {_fmt(row.get('base_mean_ci_width'))} | "
+            f"{_fmt(row.get('candidate_mean_ci_width'))} | "
+            f"{_fmt(row.get('mean_reduction_fraction'))} | "
+            f"{'yes' if row.get('target_met') else 'no'} |"
+        )
+
+    drift = payload.get("mean_drift", {})
+    lines.extend(
+        [
+            "",
+            "## Aggregate Mean Drift",
+            "",
+            f"- Flagged rows: `{drift.get('flagged_count', 0)}`",
+            "",
+            "| planner | metric | base | candidate | delta | relative delta | flagged |",
+            "|---|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    drift_rows = drift.get("flagged_rows") or drift.get("rows") or []
+    for row in drift_rows[:40]:
+        lines.append(
+            "| "
+            f"{row.get('planner_key')} | {row.get('metric')} | "
+            f"{_fmt(row.get('base_mean'))} | {_fmt(row.get('candidate_mean'))} | "
+            f"{_fmt(row.get('delta'))} | {_fmt(row.get('relative_delta'))} | "
+            f"{'yes' if row.get('flagged') else 'no'} |"
+        )
+    if len(drift_rows) > 40:
+        lines.append(f"| ... | ... | ... | ... | ... | ... | {len(drift_rows) - 40} more rows |")
+
+    ranking = payload.get("ranking_stability", {})
+    lines.extend(
+        [
+            "",
+            "## Ranking Stability",
+            "",
+            f"- Metric: `{ranking.get('metric', 'unknown')}`",
+            f"- Kendall tau: `{_fmt(ranking.get('kendall_tau'))}`",
+            f"- Spearman rho: `{_fmt(ranking.get('spearman_rho'))}`",
+            f"- Status: `{ranking.get('status', 'unknown')}`",
+        ]
+    )
+
+    winners = payload.get("scenario_winner_stability", {})
+    lines.extend(
+        [
+            "",
+            "## Scenario Winner Stability",
+            "",
+            f"- Metric: `{winners.get('metric', 'unknown')}`",
+            f"- Changed scenarios: `{winners.get('changed_count', 0)}` / `{winners.get('common_scenario_count', 0)}`",
+            f"- Changed fraction: `{_fmt(winners.get('changed_fraction'))}`",
+            f"- Status: `{winners.get('status', 'unknown')}`",
+        ]
+    )
+    changed = winners.get("changed_scenarios") or []
+    if changed:
+        lines.extend(
+            [
+                "",
+                "| scenario | base winner | candidate winner |",
+                "|---|---|---|",
+            ]
+        )
+        for row in changed[:40]:
+            lines.append(
+                "| "
+                f"{row.get('scenario_id')} | {row.get('base_winner')} | "
+                f"{row.get('candidate_winner')} |"
+            )
+        if len(changed) > 40:
+            lines.append(f"| ... | ... | {len(changed) - 40} more scenarios |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _resolve_safe_output_path(path: Path, safe_root: Path) -> Path:
+    resolved = path.resolve()
+    if not resolved.is_relative_to(safe_root):
+        raise ValueError(f"Unsafe output path outside {safe_root}: {path}")
+    return resolved
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-campaign-root", type=Path, required=True)
+    parser.add_argument("--candidate-campaign-root", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--output-md", type=Path, required=True)
+    parser.add_argument("--interval-reduction-target", type=float, default=0.20)
+    parser.add_argument("--mean-drift-relative-threshold", type=float, default=0.05)
+    parser.add_argument("--mean-drift-absolute-floor", type=float, default=0.02)
+    parser.add_argument("--ranking-metric", default="snqi_mean")
+    parser.add_argument("--ranking-min-tau", type=float, default=0.80)
+    parser.add_argument("--scenario-winner-metric", default="snqi")
+    parser.add_argument("--scenario-winner-change-threshold", type=float, default=0.10)
+    return parser
+
+
+def main() -> int:
+    """CLI entry point for seed-schedule campaign comparison."""
+    args = _build_parser().parse_args()
+    payload = compare_seed_schedules(
+        args.base_campaign_root,
+        args.candidate_campaign_root,
+        interval_reduction_target=args.interval_reduction_target,
+        mean_drift_relative_threshold=args.mean_drift_relative_threshold,
+        mean_drift_absolute_floor=args.mean_drift_absolute_floor,
+        ranking_metric=args.ranking_metric,
+        ranking_min_tau=args.ranking_min_tau,
+        scenario_winner_metric=args.scenario_winner_metric,
+        scenario_winner_change_threshold=args.scenario_winner_change_threshold,
+    )
+    safe_root = Path.cwd().resolve()
+    output_json = _resolve_safe_output_path(args.output_json, safe_root)
+    output_md = _resolve_safe_output_path(args.output_md, safe_root)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    output_md.write_text(_build_markdown(payload) + "\n", encoding="utf-8")
+    print(json.dumps({"output_json": str(output_json), "output_md": str(output_md)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/compare_seed_schedule_campaigns.py
+++ b/scripts/tools/compare_seed_schedule_campaigns.py
@@ -746,7 +746,10 @@ def _build_markdown(payload: dict[str, Any]) -> str:
             f"{'yes' if row.get('flagged') else 'no'} |"
         )
     if len(drift_rows) > 40:
-        lines.append(f"| ... | ... | ... | ... | ... | ... | {len(drift_rows) - 40} more rows |")
+        lines.append(
+            "| Table truncated | ... | ... | ... | ... | ... | "
+            f"{len(drift_rows) - 40} more rows not shown |"
+        )
 
     ranking = payload.get("ranking_stability", {})
     lines.extend(
@@ -789,7 +792,9 @@ def _build_markdown(payload: dict[str, Any]) -> str:
                 f"{row.get('candidate_winner')} |"
             )
         if len(changed) > 40:
-            lines.append(f"| ... | ... | {len(changed) - 40} more scenarios |")
+            lines.append(
+                f"| Table truncated | ... | {len(changed) - 40} more scenarios not shown |"
+            )
 
     lines.append("")
     return "\n".join(lines)

--- a/scripts/tools/run_camera_ready_benchmark.py
+++ b/scripts/tools/run_camera_ready_benchmark.py
@@ -47,6 +47,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional label suffix embedded into campaign_id.",
     )
     parser.add_argument(
+        "--campaign-id",
+        type=str,
+        default=None,
+        help=(
+            "Optional exact campaign directory id. Use with resume-enabled configs to continue "
+            "an interrupted campaign root."
+        ),
+    )
+    parser.add_argument(
         "--skip-publication-bundle",
         action="store_true",
         help="Skip publication bundle export even if enabled in config.",
@@ -82,6 +91,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             cfg,
             output_root=args.output_root,
             label=args.label,
+            campaign_id=args.campaign_id,
             invoked_command=invoked_command,
         )
         result = {
@@ -109,6 +119,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             cfg,
             output_root=args.output_root,
             label=args.label,
+            campaign_id=args.campaign_id,
             skip_publication_bundle=bool(args.skip_publication_bundle),
             invoked_command=invoked_command,
         )

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -261,9 +261,7 @@ def test_paper_extended_seed_configs_preserve_v1_matrix_contract() -> None:
         assert cfg.kinematics_matrix == base_cfg.kinematics_matrix == ("differential_drive",)
         assert cfg.seed_policy.mode == "seed-set"
         assert cfg.seed_policy.seed_set == seed_set
-        assert [(p.key, p.algo, p.planner_group) for p in cfg.planners] == [
-            (p.key, p.algo, p.planner_group) for p in base_cfg.planners
-        ]
+        assert cfg.planners == base_cfg.planners
         assert _resolved_seed_inventory(_load_campaign_scenarios(cfg)) == expected_seeds
 
 
@@ -952,6 +950,85 @@ def test_run_campaign_continues_after_failure_when_stop_disabled(
     assert any(
         "most_likely_reason='worker crash'" in warning for warning in summary_payload["warnings"]
     )
+
+
+def test_run_campaign_counts_existing_records_when_resumed_attempt_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Existing episode records should stay visible when a resumed attempt fails."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "campaign_resume_failure.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: test_campaign_resume_failure",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                "resume: true",
+                "stop_on_failure: false",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+
+    def _fake_run_batch(
+        scenarios_or_path,
+        out_path,
+        schema_path,
+        *,
+        algo,
+        benchmark_profile,
+        **kwargs,
+    ):
+        del scenarios_or_path, schema_path, algo, benchmark_profile, kwargs
+        Path(out_path).write_text(
+            json.dumps(
+                {
+                    "scenario_id": "smoke",
+                    "seed": 111,
+                    "termination_reason": "success",
+                    "metrics": {"success": 1.0, "collisions": 0.0, "snqi": 0.5},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "status": "failed",
+            "total_jobs": 1,
+            "written": 0,
+            "failed_jobs": 1,
+            "failures": [{"scenario_id": "smoke", "seed": 111, "error": "resume crash"}],
+            "preflight": {
+                "status": "ok",
+                "learned_policy_contract": {"status": "not_applicable"},
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+
+    result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="resume_failure")
+    summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
+    planner_row = summary_payload["planner_rows"][0]
+
+    assert planner_row["status"] == "failed"
+    assert planner_row["episodes"] == 1
+    assert planner_row["most_likely_failure_reason"] == "resume crash"
 
 
 def test_write_campaign_report_escapes_markdown_cells(tmp_path: Path) -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -21,6 +21,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     _jsonable_repo_relative,
     _load_campaign_scenarios,
     _planner_report_row,
+    _resolved_seed_inventory,
     _sanitize_csv_cell,
     _sanitize_git_remote,
     _sanitize_name,
@@ -237,6 +238,33 @@ def test_load_holonomic_camera_ready_campaign_config() -> None:
 
     ppo_cfg = yaml.safe_load(planners["ppo"].algo_config_path.read_text(encoding="utf-8"))
     assert ppo_cfg["fallback_to_goal"] is False
+
+
+def test_paper_extended_seed_configs_preserve_v1_matrix_contract() -> None:
+    """Extended seed configs should change only the named seed schedule."""
+    base_cfg = load_campaign_config(Path("configs/benchmarks/paper_experiment_matrix_v1.yaml"))
+    s5_cfg = load_campaign_config(
+        Path("configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s5.yaml")
+    )
+    s10_cfg = load_campaign_config(
+        Path("configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml")
+    )
+
+    for cfg, seed_set, expected_seeds in (
+        (s5_cfg, "paper_eval_s5", [111, 112, 113, 114, 115]),
+        (s10_cfg, "paper_eval_s10", [111, 112, 113, 114, 115, 116, 117, 118, 119, 120]),
+    ):
+        assert cfg.paper_facing is True
+        assert cfg.paper_profile_version == base_cfg.paper_profile_version == "paper-matrix-v1"
+        assert cfg.scenario_matrix_path == base_cfg.scenario_matrix_path
+        assert cfg.comparability_mapping_path == base_cfg.comparability_mapping_path
+        assert cfg.kinematics_matrix == base_cfg.kinematics_matrix == ("differential_drive",)
+        assert cfg.seed_policy.mode == "seed-set"
+        assert cfg.seed_policy.seed_set == seed_set
+        assert [(p.key, p.algo, p.planner_group) for p in cfg.planners] == [
+            (p.key, p.algo, p.planner_group) for p in base_cfg.planners
+        ]
+        assert _resolved_seed_inventory(_load_campaign_scenarios(cfg)) == expected_seeds
 
 
 def test_sha256_file_raises_clear_error_for_unreadable_path(tmp_path: Path) -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1102,6 +1102,35 @@ def test_planner_report_row_backfills_collision_means_from_termination_reason() 
     assert row["collision_ci_high"] == "nan"
 
 
+def test_planner_report_row_counts_existing_records_after_resume() -> None:
+    """Resumed campaign rows should report total records, not only newly written rows."""
+    planner = PlannerSpec(key="goal", algo="goal")
+    summary = {
+        "status": "ok",
+        "written": 0,
+        "episodes_total": 2,
+        "runtime_sec": 1.0,
+        "episodes_per_second": 0.0,
+        "algorithm_readiness": {"tier": "baseline-ready"},
+        "preflight": {"status": "ok", "learned_policy_contract": {"status": "not_applicable"}},
+        "algorithm_metadata_contract": {},
+    }
+    records = [
+        {"termination_reason": "success", "metrics": {"success": 1.0, "snqi": -0.1}},
+        {"termination_reason": "timeout", "metrics": {"success": 0.0, "snqi": -0.2}},
+    ]
+
+    row = _planner_report_row(
+        planner,
+        summary,
+        aggregates=None,
+        kinematics="differential_drive",
+        records=records,
+    )
+
+    assert row["episodes"] == 2
+
+
 def test_planner_report_row_uses_episode_ci_placeholders_when_means_are_backfilled() -> None:
     """Backfilled success/collision means should not keep stale aggregate CIs."""
     planner = PlannerSpec(key="ppo", algo="ppo")

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1844,6 +1844,42 @@ def test_prepare_campaign_preflight_writes_matrix_summary(tmp_path: Path) -> Non
     assert first["kinematics"] == "differential_drive"
 
 
+def test_prepare_campaign_preflight_accepts_fixed_campaign_id(tmp_path: Path) -> None:
+    """Fixed campaign ids should make interrupted campaign roots resumable."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: fixed_id",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+    prepared = prepare_campaign_preflight(
+        cfg,
+        output_root=tmp_path / "out",
+        label="ignored",
+        campaign_id="Issue 832 S5 Resume",
+    )
+
+    assert prepared["campaign_id"] == "issue_832_s5_resume"
+    assert Path(prepared["campaign_root"]).name == "issue_832_s5_resume"
+
+
 def test_prepare_campaign_preflight_emits_route_clearance_warnings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_compare_seed_schedule_campaigns.py
+++ b/tests/tools/test_compare_seed_schedule_campaigns.py
@@ -1,0 +1,261 @@
+"""Tests for paper-matrix seed-schedule comparison helper."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.tools.compare_seed_schedule_campaigns import (
+    _build_markdown,
+    compare_seed_schedules,
+    main,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _campaign_summary(campaign_id: str, rows: list[dict]) -> dict:
+    return {
+        "campaign": {
+            "campaign_id": campaign_id,
+            "name": campaign_id,
+            "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+            "scenario_matrix_hash": "matrix-hash",
+            "paper_profile_version": "paper-matrix-v1",
+            "paper_interpretation_profile": "baseline-ready-core",
+            "total_episodes": 10,
+            "total_runs": 2,
+            "successful_runs": 2,
+            "benchmark_success": True,
+            "runtime_sec": 12.0,
+            "git_hash": "abc123",
+        },
+        "planner_rows": rows,
+    }
+
+
+def _matrix_summary(seed_set: str, seeds: list[int]) -> dict:
+    return {
+        "rows": [
+            {
+                "resolved_seeds": seeds,
+                "repeats": len(seeds),
+                "seed_policy.mode": "seed-set",
+                "seed_policy.seed_set": seed_set,
+            }
+        ]
+    }
+
+
+def _seed_row(
+    scenario_id: str,
+    planner_key: str,
+    *,
+    seed_count: int,
+    success: float,
+    snqi: float,
+    snqi_ci_half_width: float,
+) -> dict:
+    return {
+        "scenario_id": scenario_id,
+        "planner_key": planner_key,
+        "algo": planner_key,
+        "planner_group": "core",
+        "kinematics": "differential_drive",
+        "benchmark_profile": "baseline-safe",
+        "seed_count": seed_count,
+        "summary": {
+            "success": {
+                "mean": success,
+                "ci_low": success - 0.10,
+                "ci_high": success + 0.10,
+                "ci_half_width": 0.10,
+            },
+            "snqi": {
+                "mean": snqi,
+                "ci_low": snqi - snqi_ci_half_width,
+                "ci_high": snqi + snqi_ci_half_width,
+                "ci_half_width": snqi_ci_half_width,
+            },
+        },
+    }
+
+
+def _seed_payload(rows: list[dict]) -> dict:
+    return {
+        "schema_version": "benchmark-seed-variability-by-scenario.v1",
+        "metrics": ["success", "snqi"],
+        "rows": rows,
+    }
+
+
+def _write_campaign(
+    root: Path,
+    *,
+    campaign_id: str,
+    seed_set: str,
+    seeds: list[int],
+    planner_rows: list[dict],
+    seed_rows: list[dict],
+) -> None:
+    _write_json(
+        root / "reports" / "campaign_summary.json", _campaign_summary(campaign_id, planner_rows)
+    )
+    _write_json(root / "reports" / "matrix_summary.json", _matrix_summary(seed_set, seeds))
+    _write_json(root / "reports" / "seed_variability_by_scenario.json", _seed_payload(seed_rows))
+
+
+def test_compare_seed_schedules_reports_stable_extension(tmp_path: Path) -> None:
+    """Narrower CIs with unchanged ranking and winners should produce a stable verdict."""
+    base = tmp_path / "base"
+    candidate = tmp_path / "candidate"
+    _write_campaign(
+        base,
+        campaign_id="base-s3",
+        seed_set="eval",
+        seeds=[111, 112, 113],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.4"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.2"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=3, success=0.8, snqi=0.4, snqi_ci_half_width=0.20),
+            _seed_row("s1", "orca", seed_count=3, success=0.7, snqi=0.2, snqi_ci_half_width=0.20),
+            _seed_row("s2", "goal", seed_count=3, success=0.9, snqi=0.5, snqi_ci_half_width=0.20),
+            _seed_row("s2", "orca", seed_count=3, success=0.6, snqi=0.1, snqi_ci_half_width=0.20),
+        ],
+    )
+    _write_campaign(
+        candidate,
+        campaign_id="candidate-s5",
+        seed_set="paper_eval_s5",
+        seeds=[111, 112, 113, 114, 115],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.42"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.22"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=5, success=0.8, snqi=0.41, snqi_ci_half_width=0.10),
+            _seed_row("s1", "orca", seed_count=5, success=0.7, snqi=0.2, snqi_ci_half_width=0.10),
+            _seed_row("s2", "goal", seed_count=5, success=0.9, snqi=0.51, snqi_ci_half_width=0.10),
+            _seed_row("s2", "orca", seed_count=5, success=0.6, snqi=0.12, snqi_ci_half_width=0.10),
+        ],
+    )
+
+    payload = compare_seed_schedules(base, candidate)
+
+    assert payload["candidate_campaign"]["resolved_seeds"] == [111, 112, 113, 114, 115]
+    assert payload["interval_width"]["aggregate"]["snqi"]["target_met"] is True
+    assert payload["ranking_stability"]["status"] == "stable"
+    assert payload["scenario_winner_stability"]["status"] == "stable"
+    assert payload["interpretation"]["status"] == "stable"
+    markdown = _build_markdown(payload)
+    assert "Seed Schedule Comparison" in markdown
+    assert "paper_eval_s5" in json.dumps(payload)
+
+
+def test_compare_seed_schedules_flags_ranking_and_winner_drift(tmp_path: Path) -> None:
+    """Ranking and scenario-winner changes should be surfaced as review triggers."""
+    base = tmp_path / "base"
+    candidate = tmp_path / "candidate"
+    _write_campaign(
+        base,
+        campaign_id="base-s3",
+        seed_set="eval",
+        seeds=[111, 112, 113],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.4"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.2"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=3, success=0.8, snqi=0.4, snqi_ci_half_width=0.2),
+            _seed_row("s1", "orca", seed_count=3, success=0.7, snqi=0.2, snqi_ci_half_width=0.2),
+        ],
+    )
+    _write_campaign(
+        candidate,
+        campaign_id="candidate-s5",
+        seed_set="paper_eval_s5",
+        seeds=[111, 112, 113, 114, 115],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.1"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.5"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=5, success=0.8, snqi=0.1, snqi_ci_half_width=0.1),
+            _seed_row("s1", "orca", seed_count=5, success=0.7, snqi=0.5, snqi_ci_half_width=0.1),
+        ],
+    )
+
+    payload = compare_seed_schedules(base, candidate)
+
+    assert payload["ranking_stability"]["status"] == "unstable"
+    assert payload["scenario_winner_stability"]["changed_count"] == 1
+    assert payload["interpretation"]["headline_interpretation_changes"] is True
+
+
+def test_main_writes_comparison_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI should write JSON and Markdown artifacts under the current working directory."""
+    base = tmp_path / "base"
+    candidate = tmp_path / "candidate"
+    _write_campaign(
+        base,
+        campaign_id="base-s3",
+        seed_set="eval",
+        seeds=[111, 112, 113],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.4"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.2"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=3, success=0.8, snqi=0.4, snqi_ci_half_width=0.2),
+            _seed_row("s1", "orca", seed_count=3, success=0.7, snqi=0.2, snqi_ci_half_width=0.2),
+        ],
+    )
+    _write_campaign(
+        candidate,
+        campaign_id="candidate-s5",
+        seed_set="paper_eval_s5",
+        seeds=[111, 112, 113, 114, 115],
+        planner_rows=[
+            {"planner_key": "goal", "kinematics": "differential_drive", "snqi_mean": "0.4"},
+            {"planner_key": "orca", "kinematics": "differential_drive", "snqi_mean": "0.2"},
+        ],
+        seed_rows=[
+            _seed_row("s1", "goal", seed_count=5, success=0.8, snqi=0.4, snqi_ci_half_width=0.1),
+            _seed_row("s1", "orca", seed_count=5, success=0.7, snqi=0.2, snqi_ci_half_width=0.1),
+        ],
+    )
+    out_json = tmp_path / "reports" / "comparison.json"
+    out_md = tmp_path / "reports" / "comparison.md"
+    monkeypatch.setattr("pathlib.Path.cwd", lambda: tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "compare_seed_schedule_campaigns.py",
+            "--base-campaign-root",
+            str(base),
+            "--candidate-campaign-root",
+            str(candidate),
+            "--output-json",
+            str(out_json),
+            "--output-md",
+            str(out_md),
+        ],
+    )
+
+    assert main() == 0
+    assert json.loads(out_json.read_text(encoding="utf-8"))["schema_version"] == (
+        "benchmark-seed-schedule-comparison.v1"
+    )
+    assert "Seed Schedule Comparison" in out_md.read_text(encoding="utf-8")

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -27,8 +27,8 @@ def test_main_preflight_mode_emits_preflight_payload(
         return sentinel_cfg
 
     def _fake_prepare_campaign_preflight(cfg, **kwargs):
-        del kwargs
         assert cfg is sentinel_cfg
+        assert kwargs["campaign_id"] == "fixed-campaign"
         called["preflight"] = True
         return {
             "campaign_id": "cid",
@@ -83,7 +83,14 @@ def test_main_preflight_mode_emits_preflight_payload(
     monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run_campaign)
 
     exit_code = run_camera_ready_benchmark.main(
-        ["--config", str(config_path), "--mode", "preflight"],
+        [
+            "--config",
+            str(config_path),
+            "--mode",
+            "preflight",
+            "--campaign-id",
+            "fixed-campaign",
+        ],
     )
     assert exit_code == 0
     assert called["preflight"] is True
@@ -122,6 +129,7 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
     def _fake_run_campaign(cfg, **kwargs):
         assert cfg is sentinel_cfg
         assert isinstance(kwargs.get("invoked_command"), str)
+        assert kwargs["campaign_id"] == "fixed-campaign"
         called["run"] = True
         return {
             "campaign_id": "cid",
@@ -139,7 +147,9 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
     )
     monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run_campaign)
 
-    exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+    exit_code = run_camera_ready_benchmark.main(
+        ["--config", str(config_path), "--campaign-id", "fixed-campaign"]
+    )
     assert exit_code == 0
     assert called["run"] is True
     assert called["preflight"] is False


### PR DESCRIPTION
## Summary

Closes #832.

Adds a paper-facing extended seed policy while preserving the frozen v1 matrix contract:

- keeps `eval` as the frozen S3 seed set `[111, 112, 113]`
- adds explicit S5/S10/S20 seed sets in `configs/benchmarks/seed_sets_v1.yaml`
- adds S5 and S10 sibling configs for the unchanged paper matrix
- adds `scripts/tools/compare_seed_schedule_campaigns.py` for S3-vs-extended comparison artifacts
- adds fixed `--campaign-id` support so interrupted camera-ready campaign roots can be resumed with `resume: true`
- records the execution provenance and conservative interpretation in `docs/context/issue_832_paper_matrix_extended_seed_schedule.md`

## Benchmark Evidence

Generated under the fixed paper matrix and differential-drive v1 contract:

- S3 reference: `output/benchmarks/camera_ready/issue832_s3_reference_bd60bae`
- S5 extension: `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae`
- Comparison JSON: `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.json`
- Comparison MD: `output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.md`

Result: `review`, not `stable`.

- Aggregate SNQI ranking remained stable: Kendall tau `1.0`, Spearman rho `1.0`
- Scenario winner changes: `7 / 47` scenarios (`14.9%`), above the `10%` threshold
- Aggregate mean drift flags: `9 / 35` planner-metric rows
- CI-width target missed for `success`, `near_misses`, `time_to_goal_norm`, and `snqi`

Interpretation: the S5 run preserves aggregate ranking but exposes enough scenario-level and mean-drift sensitivity that downstream paper text should avoid strengthening seed-stability claims from the frozen S3 bundle.

## Validation

- `uv run ruff check scripts/tools/compare_seed_schedule_campaigns.py tests/tools/test_compare_seed_schedule_campaigns.py tests/benchmark/test_camera_ready_campaign.py`
- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/benchmark/test_camera_ready_campaign.py -k 'seed_schedule or extended_seed'`
- `uv run pytest -o addopts='' tests/tools/test_compare_seed_schedule_campaigns.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py`
- `uv run ruff check scripts/tools/run_camera_ready_benchmark.py robot_sf/benchmark/camera_ready_campaign.py tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py`
- `uv run pytest -o addopts='' tests/tools/test_run_camera_ready_benchmark.py tests/benchmark/test_camera_ready_campaign.py -k 'campaign_id or run_mode or extended_seed'`
- `uv run pytest -o addopts='' tests/benchmark/test_camera_ready_campaign.py -k 'planner_report_row_counts_existing_records_after_resume or campaign_id or extended_seed'`
- S5 preflight via `scripts/tools/run_camera_ready_benchmark.py --mode preflight`
- S10 preflight via `scripts/tools/run_camera_ready_benchmark.py --mode preflight`
- S3 and S5 benchmark evaluations in tmux sessions with fixed campaign ids
- `uv run python scripts/tools/analyze_camera_ready_campaign.py --campaign-root output/benchmarks/camera_ready/issue832_s3_reference_bd60bae`
- `uv run python scripts/tools/analyze_camera_ready_campaign.py --campaign-root output/benchmarks/camera_ready/issue832_s5_stage_bd60bae`
- `uv run python scripts/tools/compare_seed_schedule_campaigns.py --base-campaign-root output/benchmarks/camera_ready/issue832_s3_reference_bd60bae --candidate-campaign-root output/benchmarks/camera_ready/issue832_s5_stage_bd60bae --output-json output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.json --output-md output/benchmarks/camera_ready/issue832_s5_stage_bd60bae/reports/seed_schedule_comparison.md`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=7 scripts/dev/pr_ready_check.sh` (`2913 passed, 15 skipped, 1 warning`; changed-file coverage warning only: `robot_sf/benchmark/camera_ready_campaign.py` at `89.8%`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended seed schedules (S5, S10, S20) added for improved benchmark reproducibility and stability validation.
  * New seed-schedule comparison tool for analyzing confidence interval reduction, mean drift, and planner ranking stability.
  * Campaign ID specification support for explicit benchmark run identification.

* **Documentation**
  * Added comprehensive guide for extended seed schedule workflows and interpretation criteria.
  * Updated benchmark documentation with new configuration presets and analysis commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->