### PR TITLE
Remove Codex terminology and adjust issue branch naming

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,6 +1,6 @@
 # Robot SF Skills
 
-This directory contains repo-local skills for Codex-style agents. Use this file as a quick index;
+This directory contains repo-local skills for Coding Agents. Use this file as a quick index;
 read the specific `SKILL.md` before applying a skill.
 
 ## Selection Guide

--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -10,7 +10,7 @@ description: "Autonomous iterative experimentation loop for measurable Robot SF 
 Use this skill when the task has a measurable metric and the user wants an autonomous improvement
 loop rather than a single pass fix.
 
-This is the Codex-compatible version of the upstream `autoresearch` idea adapted to Robot SF's
+This is the Agent-compatible version of the upstream `autoresearch` idea adapted to Robot SF's
 repo-local workflow, validation gates, and benchmark conservatism.
 
 ## Read First

--- a/.agents/skills/context-skills/README.md
+++ b/.agents/skills/context-skills/README.md
@@ -1,7 +1,7 @@
 # Context Skills
 
 These repo-local skills complement the execution-oriented workflows already present under
-`.codex/skills/`.
+`.agents/skills/`.
 
 Use them when the task is mainly about gathering the right repository context, reviewing
 benchmark-sensitive changes, or drafting benchmark/planner-facing docs without re-deriving the same

--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -23,7 +23,6 @@ Typical invocation:
 - Repository: `ll7/robot_sf_ll7`
 - Project: `ll7` Project `#5`
 - Base branch: `main`
-- Branch prefix: `codex/`
 - Validation gate: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
 - Batch-first workflow note: `docs/context/issue_713_batch_first_issue_workflow.md`
 
@@ -86,9 +85,9 @@ Use GitHub MCP / GitHub app tools as the source of truth when available before f
 
 6. Create and checkout issue branch
    - Preferred:
-     - `gh issue develop <n> --base main --checkout --name "codex/<n>-<slug>"`
+     - `gh issue develop <n> --base main --checkout --name "<n>-<slug>"`
    - Fallback:
-     - `git switch -c codex/<n>-<slug>`
+     - `git switch -c <n>-<slug>`
 
 7. Implement
    - Keep scope tight to issue acceptance criteria.

--- a/.agents/skills/gh-issue-priority-assessor/SKILL.md
+++ b/.agents/skills/gh-issue-priority-assessor/SKILL.md
@@ -22,7 +22,7 @@ adjacent batching.
 - `.github/ISSUE_TEMPLATE/enhancement.md`
 - `.github/ISSUE_TEMPLATE/benchmark_experiment.md`
 - `scripts/tools/project_priority_score.py`
-- `.codex/skills/gh-issue-template-auditor/SKILL.md`
+- `.agents/skills/gh-issue-template-auditor/SKILL.md`
 
 ## Workflow
 

--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -25,7 +25,7 @@ metadata cleanup.
 - `.github/ISSUE_TEMPLATE/planner_integration.md`
 - `.github/ISSUE_TEMPLATE/benchmark_experiment.md`
 - `scripts/tools/issue_template_audit.py`
-- `.codex/skills/gh-issue-clarifier/SKILL.md`
+- `.agents/skills/gh-issue-clarifier/SKILL.md`
 - `docs/context/issue_713_batch_first_issue_workflow.md`
 
 ## What to Check

--- a/.agents/skills/pr-ready-check/SKILL.md
+++ b/.agents/skills/pr-ready-check/SKILL.md
@@ -8,7 +8,7 @@ description: "Run the repository PR readiness pipeline using shared scripts/dev 
 ## Overview
 
 Run the same PR validation pipeline used by local VS Code tasks, but via reusable
-`scripts/dev` commands that are stable for Codex automation.
+`scripts/dev` commands that are stable for Agent automation.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ This document covers briefly the repository structure, coding style, testing wor
 Prefer reusable shell entry points under `scripts/dev/` for automation and AI skills.
 Use `.vscode/tasks.json` as thin wrappers around those scripts.
 
-## Codex Context Stack
-Treat the following files as the repository-native context stack for Codex-style agents:
+## Agent Context Stack
+Treat the following files as the repository-native context stack for Agent-style agents:
 
 - `AGENTS.md`: top-level execution rules, repo structure, and workflow defaults.
 - `CLAUDE.md`: Claude Code entrypoint that imports `AGENTS.md` plus the repo-local memory index.

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -1,6 +1,6 @@
 # AI Repo Overview
 
-This document is the shortest reliable orientation for Codex-style agents working in
+This document is the shortest reliable orientation for Coding Agents working in
 `robot_sf_ll7`.
 
 ## Mission


### PR DESCRIPTION
## Summary
Updated documentation to replace "Codex" terminology with "Agent" and removed the branch prefix from issue branch naming in GitHub Issue Autopilot.

## Linked Issues
- Closes #<id>
- Relates to #<id>

## What Changed
- Replaced instances of "Codex" with "Agent" in various documentation files.
- Modified issue branch naming convention to eliminate the "codex/" prefix.

## Why It Matters
- Added value: Ensures consistency in terminology across documentation.
- Expected impact: Improves clarity for users transitioning to the new Agent framework.
- Why this is worth merging now: Aligns documentation with current project standards.

## Validation / Proof
- Commands run: Documentation reviewed for accuracy.
- Evidence that the change works here: All references to "Codex" have been successfully updated.

## Risks / Rollout
- Compatibility risks: Minimal, as changes are primarily documentation-focused.
- Failure modes: Potential confusion if users reference outdated documentation.
- Rollback or fallback plan: Previous documentation versions are available in the repository history.

## Docs / Provenance
- Updated docs: All relevant documentation files have been revised.
- Relevant design or provenance notes: Changes reflect the shift from Codex to Agent terminology.

## Follow-Up Issues
- Deferred work: None identified at this time.
- Issues opened for follow-up: None identified at this time.

## Reviewer Notes
- Anything a reviewer should verify closely: Ensure all instances of "Codex" have been replaced.
- Any known limitations: None identified.

