### PR TITLE
docs: streamline agent instruction guidance (#844)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Use `AGENTS.md`, `.specify/memory/constitution.md`, and `docs/dev_guide.md` to g
 This document covers briefly the repository structure, coding style, testing workflow, and contributor conventions.
 Prefer reusable shell entry points under `scripts/dev/` for automation and AI skills.
 Use `.vscode/tasks.json` as thin wrappers around those scripts.
+Keep prompts, instructions, and handoff notes as streamlined and token-efficient as possible while preserving the same meaning and constraints.
 
 ## Agent Context Stack
 Treat the following files as the repository-native context stack for Agent-style agents:


### PR DESCRIPTION
## Summary
Tighten `AGENTS.md` with a concise instruction to keep prompts, instructions, and handoff notes streamlined and token-efficient while preserving meaning and constraints.

## Linked Issues
- Relates to #844

## What Changed
- Added one sentence to `AGENTS.md` near the top-level repository guidance.
- Kept the scope limited to the instruction intent requested by the issue.

## Why It Matters
- Added value: clearer repository guidance for future agent-facing edits.
- Expected impact: nudges contributors toward concise, lower-duplication wording without changing policy.
- Why this is worth merging now: the repo already carries a large instruction stack, so the style guidance belongs in the canonical entry point.

## Validation / Proof
- Commands run: `git diff --check`, `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: the repo readiness gate passed on the rebased branch.
- Benchmarks or smoke tests, if applicable: not applicable for this docs-only change.

## Risks / Rollout
- Compatibility risks: none beyond wording alignment.
- Failure modes: over-compression of later edits if authors interpret the guidance too aggressively.
- Rollback or fallback plan: revert the single-line `AGENTS.md` change if needed.

## Docs / Provenance
- Updated docs: `AGENTS.md`
- Relevant design or provenance notes: issue #844 requested streamlined, token-efficient instructions.
- Any assumptions that need to be preserved: meaning and constraints must stay intact even when wording is compressed.
