### PR TITLE
feat: add lightweight CNN divergence diagnostics (#835)

### DIFF
--- a/configs/scenarios/lightweight_cnn_issue_835_repro.yaml
+++ b/configs/scenarios/lightweight_cnn_issue_835_repro.yaml
@@ -1,0 +1,28 @@
+# Focused LightweightCNNExtractor reproduction config for issue #835.
+#
+# Reproduces the issue-193 32 K PPO run with the same seed and hardware class,
+# but isolates the lightweight_cnn path and enables training diagnostics.
+
+run:
+  run_id: "issue_835_lightweight_cnn_repro"
+  worker_mode: "single-thread"
+  num_envs: 1
+  total_timesteps: 32000
+  eval_freq: 4000
+  save_freq: 16000
+  n_eval_episodes: 5
+  device: "cuda"
+  seed: 42
+  baseline_extractor: "lightweight_cnn"
+  convergence_fraction: 0.9
+  notes:
+    - "Issue 835: reproduce lightweight_cnn divergence from issue 193"
+    - "Diagnostics enabled: gradient norms and feature statistics"
+
+extractors:
+  - name: "lightweight_cnn"
+    preset: "lightweight_cnn"
+    description: "Issue 835 reproduction path with training diagnostics enabled"
+    expected_resources: "gpu"
+    parameters:
+      record_feature_stats: true

--- a/configs/scenarios/lightweight_cnn_issue_835_repro.yaml
+++ b/configs/scenarios/lightweight_cnn_issue_835_repro.yaml
@@ -15,6 +15,8 @@ run:
   seed: 42
   baseline_extractor: "lightweight_cnn"
   convergence_fraction: 0.9
+  training_diagnostics: true
+  diagnostics_start_timestep: 20000
   notes:
     - "Issue 835: reproduce lightweight_cnn divergence from issue 193"
     - "Diagnostics enabled: gradient norms and feature statistics"

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -95,6 +95,10 @@ knowledge, not every transient iteration detail.
   4 M-step SLURM sweep infrastructure, DB classification, and April 20 final pre-screen analysis;
   `feat_sweep_4m_array.db` is the current evidence surface, with longer 10 M+ validation still
   required before promotion.
+- [Issue #835 Lightweight CNN Divergence Triage](./issue_835_lightweight_cnn_divergence.md)
+  bounded 32 K rerun with PPO gradient and feature diagnostics; the issue-193 catastrophic
+  `lightweight_cnn` final drop did not reproduce, so the extractor remains experimental without an
+  immediate architecture change.
 - [Issue #850 PPO Collision Failures](./issue_850_ppo_collision_failures.md)
   follow-up diagnostics for the issue-193 `dyn_large_med` hold-out collision failures and the
   config-first safety-reward mitigation candidate.

--- a/docs/context/issue_835_lightweight_cnn_divergence.md
+++ b/docs/context/issue_835_lightweight_cnn_divergence.md
@@ -1,0 +1,83 @@
+# Issue #835 Lightweight CNN Divergence Triage
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/835>
+
+## Goal
+
+Issue #193 reported a catastrophic `lightweight_cnn` final-eval drop at 32 K PPO steps
+(`-64.09` final reward after a `-4.20` best checkpoint). Issue #835 is the bounded follow-up:
+reproduce that curve shape, capture gradient and feature-scale diagnostics during the suspected
+20-32 K window, and decide whether the extractor needs an immediate stabilization change or should
+remain experimental.
+
+## Implementation Surface
+
+- `configs/scenarios/lightweight_cnn_issue_835_repro.yaml` isolates the `lightweight_cnn` preset
+  with seed `42`, 32 K PPO steps, 4 K eval cadence, RTX-class CUDA execution, and diagnostics from
+  20 K onward.
+- `robot_sf/training/ppo_diagnostics.py` adds an opt-in `DiagnosticPPO` wrapper that records
+  gradient norms at the PPO clipping point and appends per-update JSONL summaries.
+- `robot_sf/feature_extractors/lightweight_cnn_extractor.py` can opt into forward-pass feature
+  statistics with `record_feature_stats: true`.
+- `scripts/multi_extractor_training.py` keeps normal PPO as the default and switches to
+  `DiagnosticPPO` only when `run.training_diagnostics: true`.
+
+## Validation Run
+
+Command:
+
+```bash
+uv run python scripts/multi_extractor_training.py \
+  --config configs/scenarios/lightweight_cnn_issue_835_repro.yaml \
+  --output-root tmp/issue_835_repro \
+  --verbose
+```
+
+Environment:
+
+- Date: 2026-04-29
+- GPU: NVIDIA GeForce RTX 3070
+- CUDA: 12.8
+- Python: 3.12.8
+- Worker mode: `single-thread`
+- Duration: 401.1 seconds
+
+Eval curve:
+
+| Step | Mean reward | Std reward |
+| ---: | ----------: | ---------: |
+| 4,000 | -53.57 | 54.06 |
+| 8,000 | -33.00 | 48.85 |
+| 12,000 | 3.38 | 11.08 |
+| 16,000 | -11.01 | 12.32 |
+| 20,000 | 3.79 | 9.89 |
+| 24,000 | -4.45 | 13.66 |
+| 28,000 | -4.40 | 7.74 |
+| 32,000 | -8.37 | 6.10 |
+
+Diagnostic window summary:
+
+| Timestep | Total grad mean | Total grad max | Extractor grad mean | Combined feature mean abs | Combined feature std | Combined feature max abs |
+| -------: | --------------: | -------------: | ------------------: | ------------------------: | -------------------: | -----------------------: |
+| 20,480 | 19.402 | 43.956 | 10.057 | 0.479 | 0.767 | 14.293 |
+| 22,528 | 22.867 | 56.800 | 11.975 | 0.453 | 0.749 | 12.976 |
+| 30,720 | 16.859 | 42.388 | 9.004 | 0.450 | 0.751 | 13.148 |
+| 32,768 | 13.714 | 38.585 | 7.259 | 0.450 | 0.747 | 13.504 |
+
+## Conclusion
+
+The issue-193 catastrophic final drop did **not** reproduce on the same seed and 32 K budget in
+this rerun. The extractor remained noisy and still ended below its best checkpoint, but the final
+reward was `-8.37`, not a collapse near `-64`. Feature magnitudes stayed stable through the
+diagnostic window, and gradient norms did not show a late-run spike that explains the original
+cliff.
+
+Current verdict: keep `lightweight_cnn` experimental and do not promote it, but treat the issue-193
+cliff as a high-variance early-training outcome rather than a deterministic architecture failure.
+The bounded triage does not justify an architecture change or learning-rate mitigation yet.
+
+## Follow-Up Boundary
+
+The next useful evidence would be a multi-seed comparison at a longer budget. That belongs in the
+broader feature-extractor campaign, not this issue. This issue should close with diagnostics and a
+documented non-reproduction verdict.

--- a/robot_sf/feature_extractors/lightweight_cnn_extractor.py
+++ b/robot_sf/feature_extractors/lightweight_cnn_extractor.py
@@ -35,6 +35,7 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
         num_filters: List of filter counts for each conv layer
         kernel_sizes: List of kernel sizes for each conv layer
         dropout_rate: Dropout rate for regularization
+        record_feature_stats: Whether to retain forward-pass feature scale diagnostics
     """
 
     def __init__(
@@ -46,15 +47,16 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
         drive_hidden_dims: list[int] | None = None,
         record_feature_stats: bool = False,
     ):
-        """TODO docstring. Document this function.
+        """Initialize the extractor architecture and optional feature telemetry.
 
         Args:
-            observation_space: TODO docstring.
-            num_filters: TODO docstring.
-            kernel_sizes: TODO docstring.
-            dropout_rate: TODO docstring.
-            drive_hidden_dims: TODO docstring.
-            record_feature_stats: TODO docstring.
+            observation_space: Dict observation space with ray and drive-state entries.
+            num_filters: Conv1d output channel counts for the ray pathway.
+            kernel_sizes: Conv1d kernel sizes paired with ``num_filters``.
+            dropout_rate: Dropout probability used in ray and drive-state pathways.
+            drive_hidden_dims: Hidden layer sizes for the drive-state MLP.
+            record_feature_stats: Capture lightweight activation statistics after each forward
+                pass for training diagnostics. Disabled by default to avoid host synchronization.
         """
         if num_filters is None:
             num_filters = [32, 16]

--- a/robot_sf/feature_extractors/lightweight_cnn_extractor.py
+++ b/robot_sf/feature_extractors/lightweight_cnn_extractor.py
@@ -44,6 +44,7 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
         kernel_sizes: list[int] | None = None,
         dropout_rate: float = 0.1,
         drive_hidden_dims: list[int] | None = None,
+        record_feature_stats: bool = False,
     ):
         """TODO docstring. Document this function.
 
@@ -53,6 +54,7 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
             kernel_sizes: TODO docstring.
             dropout_rate: TODO docstring.
             drive_hidden_dims: TODO docstring.
+            record_feature_stats: TODO docstring.
         """
         if num_filters is None:
             num_filters = [32, 16]
@@ -107,6 +109,8 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
         )
 
         self.ray_extractor = nn.Sequential(*ray_layers)
+        self._record_feature_stats = bool(record_feature_stats)
+        self._latest_feature_stats: dict[str, float] = {}
 
         # Build drive state processing MLP
         drive_layers = []
@@ -118,6 +122,10 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
             )
 
         self.drive_state_extractor = nn.Sequential(nn.Flatten(), *drive_layers)
+
+    def latest_feature_stats(self) -> dict[str, float]:
+        """Return a copy of the most recent forward-pass feature statistics."""
+        return self._latest_feature_stats.copy()
 
     def forward(self, obs: dict) -> th.Tensor:
         """
@@ -131,4 +139,18 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
         """
         ray_features = self.ray_extractor(obs[OBS_RAYS])
         drive_features = self.drive_state_extractor(obs[OBS_DRIVE_STATE])
-        return th.cat([ray_features, drive_features], dim=1)
+        combined_features = th.cat([ray_features, drive_features], dim=1)
+
+        if self._record_feature_stats:
+            with th.no_grad():
+                self._latest_feature_stats = {
+                    "ray_mean_abs": float(ray_features.abs().mean().item()),
+                    "ray_std": float(ray_features.std(unbiased=False).item()),
+                    "drive_mean_abs": float(drive_features.abs().mean().item()),
+                    "drive_std": float(drive_features.std(unbiased=False).item()),
+                    "combined_mean_abs": float(combined_features.abs().mean().item()),
+                    "combined_std": float(combined_features.std(unbiased=False).item()),
+                    "combined_max_abs": float(combined_features.abs().max().item()),
+                }
+
+        return combined_features

--- a/robot_sf/feature_extractors/lightweight_cnn_extractor.py
+++ b/robot_sf/feature_extractors/lightweight_cnn_extractor.py
@@ -145,14 +145,25 @@ class LightweightCNNExtractor(BaseFeaturesExtractor):
 
         if self._record_feature_stats:
             with th.no_grad():
+                stats_values = th.stack(
+                    [
+                        ray_features.abs().mean(),
+                        ray_features.std(unbiased=False),
+                        drive_features.abs().mean(),
+                        drive_features.std(unbiased=False),
+                        combined_features.abs().mean(),
+                        combined_features.std(unbiased=False),
+                        combined_features.abs().max(),
+                    ]
+                ).tolist()
                 self._latest_feature_stats = {
-                    "ray_mean_abs": float(ray_features.abs().mean().item()),
-                    "ray_std": float(ray_features.std(unbiased=False).item()),
-                    "drive_mean_abs": float(drive_features.abs().mean().item()),
-                    "drive_std": float(drive_features.std(unbiased=False).item()),
-                    "combined_mean_abs": float(combined_features.abs().mean().item()),
-                    "combined_std": float(combined_features.std(unbiased=False).item()),
-                    "combined_max_abs": float(combined_features.abs().max().item()),
+                    "ray_mean_abs": float(stats_values[0]),
+                    "ray_std": float(stats_values[1]),
+                    "drive_mean_abs": float(stats_values[2]),
+                    "drive_std": float(stats_values[3]),
+                    "combined_mean_abs": float(stats_values[4]),
+                    "combined_std": float(stats_values[5]),
+                    "combined_max_abs": float(stats_values[6]),
                 }
 
         return combined_features

--- a/robot_sf/training/ppo_diagnostics.py
+++ b/robot_sf/training/ppo_diagnostics.py
@@ -1,0 +1,131 @@
+"""Training-time diagnostics for PPO-based feature extractor studies."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import torch as th
+from stable_baselines3 import PPO
+
+
+def _grad_l2_norm(parameters: Iterable[th.nn.Parameter]) -> float:
+    """Compute the L2 norm across all currently populated gradients."""
+    squared_norm = 0.0
+    has_grad = False
+    for parameter in parameters:
+        gradient = parameter.grad
+        if gradient is None:
+            continue
+        has_grad = True
+        grad_norm = float(gradient.detach().norm(2).item())
+        squared_norm += grad_norm * grad_norm
+    if not has_grad:
+        return 0.0
+    return math.sqrt(squared_norm)
+
+
+def _module_grad_norm(module: Any) -> float:
+    """Compute the gradient norm for a module when present."""
+    if module is None:
+        return 0.0
+    return _grad_l2_norm(module.parameters())
+
+
+def _summarize_samples(samples: list[dict[str, float]]) -> dict[str, float]:
+    """Aggregate per-mini-batch diagnostics into one PPO-update summary."""
+    if not samples:
+        return {}
+
+    summary: dict[str, float] = {"mini_batch_count": float(len(samples))}
+    metric_names = sorted({name for sample in samples for name in sample})
+
+    for metric_name in metric_names:
+        values = [sample[metric_name] for sample in samples if metric_name in sample]
+        if not values:
+            continue
+        summary[f"{metric_name}_mean"] = float(sum(values) / len(values))
+        summary[f"{metric_name}_max"] = float(max(values))
+
+    return summary
+
+
+class DiagnosticPPO(PPO):
+    """PPO variant that records gradient and feature statistics per update."""
+
+    def __init__(
+        self,
+        *args,
+        diagnostics_path: str | Path | None = None,
+        diagnostics_start_timestep: int = 0,
+        **kwargs,
+    ) -> None:
+        self._diagnostics_path = Path(diagnostics_path) if diagnostics_path is not None else None
+        self._diagnostics_start_timestep = int(diagnostics_start_timestep)
+        self.last_training_diagnostics: dict[str, float] = {}
+        super().__init__(*args, **kwargs)
+
+    def _collect_batch_diagnostics(self, parameters: Iterable[th.nn.Parameter]) -> dict[str, float]:
+        policy = self.policy
+        mlp_extractor = getattr(policy, "mlp_extractor", None)
+        action_net = getattr(policy, "action_net", None)
+        value_net = getattr(policy, "value_net", None)
+
+        diagnostics = {
+            "grad_norm_total": _grad_l2_norm(parameters),
+            "grad_norm_features_extractor": _module_grad_norm(
+                getattr(policy, "features_extractor", None)
+            ),
+            "grad_norm_policy_net": _module_grad_norm(getattr(mlp_extractor, "policy_net", None)),
+            "grad_norm_value_net": _module_grad_norm(getattr(mlp_extractor, "value_net", None)),
+            "grad_norm_action_head": _module_grad_norm(action_net),
+            "grad_norm_value_head": _module_grad_norm(value_net),
+        }
+
+        feature_extractor = getattr(policy, "features_extractor", None)
+        feature_stats_getter = getattr(feature_extractor, "latest_feature_stats", None)
+        if callable(feature_stats_getter):
+            for name, value in feature_stats_getter().items():
+                diagnostics[f"feature_{name}"] = float(value)
+
+        return diagnostics
+
+    def _append_training_diagnostics(self, payload: dict[str, float]) -> None:
+        """Append one training-update diagnostics record as JSONL."""
+        if self._diagnostics_path is None:
+            return
+        self._diagnostics_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._diagnostics_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    def train(self) -> None:
+        """Run one PPO update while capturing gradient and feature statistics."""
+        collected_samples: list[dict[str, float]] = []
+        original_clip_grad_norm = th.nn.utils.clip_grad_norm_
+
+        def _patched_clip_grad_norm_(
+            parameters: Iterable[th.nn.Parameter],
+            max_norm: float,
+            *args: Any,
+            **kwargs: Any,
+        ) -> th.Tensor:
+            parameter_list = list(parameters)
+            collected_samples.append(self._collect_batch_diagnostics(parameter_list))
+            return original_clip_grad_norm(parameter_list, max_norm, *args, **kwargs)
+
+        th.nn.utils.clip_grad_norm_ = _patched_clip_grad_norm_
+        try:
+            super().train()
+        finally:
+            th.nn.utils.clip_grad_norm_ = original_clip_grad_norm
+
+        summary = _summarize_samples(collected_samples)
+        summary["num_timesteps"] = float(self.num_timesteps)
+        summary["n_updates"] = float(self._n_updates)
+        self.last_training_diagnostics = summary
+
+        if collected_samples and self.num_timesteps >= self._diagnostics_start_timestep:
+            self._append_training_diagnostics(summary)

--- a/robot_sf/training/ppo_diagnostics.py
+++ b/robot_sf/training/ppo_diagnostics.py
@@ -4,16 +4,22 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch as th
 from stable_baselines3 import PPO
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 def _grad_l2_norm(parameters: Iterable[th.nn.Parameter]) -> float:
-    """Compute the L2 norm across all currently populated gradients."""
+    """Compute the L2 norm across all currently populated gradients.
+
+    Returns:
+        L2 norm over parameters with non-empty gradients.
+    """
     squared_norm = 0.0
     has_grad = False
     for parameter in parameters:
@@ -29,14 +35,22 @@ def _grad_l2_norm(parameters: Iterable[th.nn.Parameter]) -> float:
 
 
 def _module_grad_norm(module: Any) -> float:
-    """Compute the gradient norm for a module when present."""
+    """Compute the gradient norm for a module when present.
+
+    Returns:
+        Module parameter gradient norm, or zero when the module is absent.
+    """
     if module is None:
         return 0.0
     return _grad_l2_norm(module.parameters())
 
 
 def _summarize_samples(samples: list[dict[str, float]]) -> dict[str, float]:
-    """Aggregate per-mini-batch diagnostics into one PPO-update summary."""
+    """Aggregate per-mini-batch diagnostics into one PPO-update summary.
+
+    Returns:
+        Summary metrics with per-key mean and max values.
+    """
     if not samples:
         return {}
 
@@ -45,8 +59,6 @@ def _summarize_samples(samples: list[dict[str, float]]) -> dict[str, float]:
 
     for metric_name in metric_names:
         values = [sample[metric_name] for sample in samples if metric_name in sample]
-        if not values:
-            continue
         summary[f"{metric_name}_mean"] = float(sum(values) / len(values))
         summary[f"{metric_name}_max"] = float(max(values))
 
@@ -63,6 +75,14 @@ class DiagnosticPPO(PPO):
         diagnostics_start_timestep: int = 0,
         **kwargs,
     ) -> None:
+        """Initialize the PPO wrapper.
+
+        Args:
+            *args: Positional arguments forwarded to ``stable_baselines3.PPO``.
+            diagnostics_path: Optional JSONL path for per-update diagnostics.
+            diagnostics_start_timestep: First timestep at which diagnostics are persisted.
+            **kwargs: Keyword arguments forwarded to ``stable_baselines3.PPO``.
+        """
         self._diagnostics_path = Path(diagnostics_path) if diagnostics_path is not None else None
         self._diagnostics_start_timestep = int(diagnostics_start_timestep)
         self.last_training_diagnostics: dict[str, float] = {}

--- a/robot_sf/training/ppo_diagnostics.py
+++ b/robot_sf/training/ppo_diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,18 +21,14 @@ def _grad_l2_norm(parameters: Iterable[th.nn.Parameter]) -> float:
     Returns:
         L2 norm over parameters with non-empty gradients.
     """
-    squared_norm = 0.0
-    has_grad = False
-    for parameter in parameters:
-        gradient = parameter.grad
-        if gradient is None:
-            continue
-        has_grad = True
-        grad_norm = float(gradient.detach().norm(2).item())
-        squared_norm += grad_norm * grad_norm
-    if not has_grad:
+    squared_sums = [
+        th.sum(parameter.grad.detach() ** 2)
+        for parameter in parameters
+        if parameter.grad is not None
+    ]
+    if not squared_sums:
         return 0.0
-    return math.sqrt(squared_norm)
+    return math.sqrt(float(th.sum(th.stack(squared_sums)).item()))
 
 
 def _module_grad_norm(module: Any) -> float:
@@ -63,6 +60,30 @@ def _summarize_samples(samples: list[dict[str, float]]) -> dict[str, float]:
         summary[f"{metric_name}_max"] = float(max(values))
 
     return summary
+
+
+@contextmanager
+def _patched_clip_grad_norm(
+    callback: Any,
+):
+    """Patch ``clip_grad_norm_`` for the lifetime of the context only."""
+    original_clip_grad_norm = th.nn.utils.clip_grad_norm_
+
+    def _patched(
+        parameters: Iterable[th.nn.Parameter],
+        max_norm: float,
+        *args: Any,
+        **kwargs: Any,
+    ) -> th.Tensor:
+        parameter_list = list(parameters)
+        callback(parameter_list)
+        return original_clip_grad_norm(parameter_list, max_norm, *args, **kwargs)
+
+    th.nn.utils.clip_grad_norm_ = _patched
+    try:
+        yield
+    finally:
+        th.nn.utils.clip_grad_norm_ = original_clip_grad_norm
 
 
 class DiagnosticPPO(PPO):
@@ -124,23 +145,12 @@ class DiagnosticPPO(PPO):
     def train(self) -> None:
         """Run one PPO update while capturing gradient and feature statistics."""
         collected_samples: list[dict[str, float]] = []
-        original_clip_grad_norm = th.nn.utils.clip_grad_norm_
-
-        def _patched_clip_grad_norm_(
-            parameters: Iterable[th.nn.Parameter],
-            max_norm: float,
-            *args: Any,
-            **kwargs: Any,
-        ) -> th.Tensor:
-            parameter_list = list(parameters)
-            collected_samples.append(self._collect_batch_diagnostics(parameter_list))
-            return original_clip_grad_norm(parameter_list, max_norm, *args, **kwargs)
-
-        th.nn.utils.clip_grad_norm_ = _patched_clip_grad_norm_
-        try:
+        with _patched_clip_grad_norm(
+            lambda parameter_list: collected_samples.append(
+                self._collect_batch_diagnostics(parameter_list)
+            )
+        ):
             super().train()
-        finally:
-            th.nn.utils.clip_grad_norm_ = original_clip_grad_norm
 
         summary = _summarize_samples(collected_samples)
         summary["num_timesteps"] = float(self.num_timesteps)

--- a/scripts/multi_extractor_training.py
+++ b/scripts/multi_extractor_training.py
@@ -79,13 +79,13 @@ class RunSettings:
 
     @classmethod
     def from_mapping(cls, payload: dict[str, Any]) -> RunSettings:
-        """TODO docstring. Document this function.
+        """Build run settings from the YAML configuration payload.
 
         Args:
-            payload: TODO docstring.
+            payload: Parsed scenario configuration mapping.
 
         Returns:
-            TODO docstring.
+            Normalized run settings with validation applied to user-provided overrides.
         """
         options = payload.get("run", {})
         settings = cls()

--- a/scripts/multi_extractor_training.py
+++ b/scripts/multi_extractor_training.py
@@ -46,6 +46,7 @@ from robot_sf.training.multi_extractor_analysis import (
     load_eval_history,
     sample_efficiency_ratio,
 )
+from robot_sf.training.ppo_diagnostics import DiagnosticPPO
 
 if TYPE_CHECKING:
     from robot_sf.feature_extractors.config import FeatureExtractorConfig
@@ -495,7 +496,6 @@ def _run_sb3_training(
         TODO docstring.
     """
     try:
-        from stable_baselines3 import PPO
         from stable_baselines3.common.callbacks import (
             CallbackList,
             CheckpointCallback,
@@ -541,10 +541,13 @@ def _run_sb3_training(
             vec_env_cls=DummyVecEnv,
         )
 
-        model = PPO(
+        diagnostics_path = extractor_dir / "training_diagnostics.jsonl"
+
+        model = DiagnosticPPO(
             "MultiInputPolicy",
             train_env,
             tensorboard_log=str(extractor_dir / "tensorboard"),
+            diagnostics_path=diagnostics_path,
             policy_kwargs=config.get_policy_kwargs(),
             verbose=0,
             device=context.settings.device,
@@ -581,6 +584,9 @@ def _run_sb3_training(
         checkpoints_dir = extractor_dir / "checkpoints"
         if checkpoints_dir.exists() and any(checkpoints_dir.iterdir()):
             artifacts["checkpoints"] = str(checkpoints_dir.relative_to(context.run_dir))
+
+        if diagnostics_path.exists():
+            artifacts["training_diagnostics"] = str(diagnostics_path.relative_to(context.run_dir))
 
         total_parameters = sum(p.numel() for p in model.policy.parameters())
         trainable_parameters = sum(p.numel() for p in model.policy.parameters() if p.requires_grad)

--- a/scripts/multi_extractor_training.py
+++ b/scripts/multi_extractor_training.py
@@ -46,7 +46,6 @@ from robot_sf.training.multi_extractor_analysis import (
     load_eval_history,
     sample_efficiency_ratio,
 )
-from robot_sf.training.ppo_diagnostics import DiagnosticPPO
 
 if TYPE_CHECKING:
     from robot_sf.feature_extractors.config import FeatureExtractorConfig
@@ -75,6 +74,8 @@ class RunSettings:
     notes: list[str] = field(default_factory=list)
     baseline_extractor: str | None = None
     convergence_fraction: float = 0.95
+    training_diagnostics: bool = False
+    diagnostics_start_timestep: int = 0
 
     @classmethod
     def from_mapping(cls, payload: dict[str, Any]) -> RunSettings:
@@ -102,6 +103,12 @@ class RunSettings:
         settings.convergence_fraction = float(
             options.get("convergence_fraction", settings.convergence_fraction)
         )
+        settings.training_diagnostics = bool(
+            options.get("training_diagnostics", settings.training_diagnostics)
+        )
+        settings.diagnostics_start_timestep = int(
+            options.get("diagnostics_start_timestep", settings.diagnostics_start_timestep)
+        )
 
         if settings.worker_mode not in {"single-thread", "vectorized"}:
             raise ValueError(f"Unknown worker_mode: {settings.worker_mode}")
@@ -114,6 +121,8 @@ class RunSettings:
             raise ValueError(f"Unsupported device requested: {settings.device}")
         if not (0.0 < settings.convergence_fraction <= 1.0):
             raise ValueError("convergence_fraction must be in (0, 1].")
+        if settings.diagnostics_start_timestep < 0:
+            raise ValueError("diagnostics_start_timestep must be non-negative.")
         return settings
 
     def effective_timesteps(self, *, test_mode: bool) -> int:
@@ -380,6 +389,42 @@ def _resolve_feature_config(profile: ExtractorConfigurationProfile) -> FeatureEx
     return config
 
 
+def _make_ppo_model(
+    *,
+    train_env: Any,
+    tensorboard_log: Path,
+    policy_kwargs: dict[str, Any],
+    device: str,
+    diagnostics_path: Path | None,
+    diagnostics_start_timestep: int,
+) -> Any:
+    """Create a normal PPO model or the diagnostics-enabled PPO variant."""
+    from stable_baselines3 import PPO
+
+    if diagnostics_path is None:
+        return PPO(
+            "MultiInputPolicy",
+            train_env,
+            tensorboard_log=str(tensorboard_log),
+            policy_kwargs=policy_kwargs,
+            verbose=0,
+            device=device,
+        )
+
+    from robot_sf.training.ppo_diagnostics import DiagnosticPPO
+
+    return DiagnosticPPO(
+        "MultiInputPolicy",
+        train_env,
+        tensorboard_log=str(tensorboard_log),
+        diagnostics_path=diagnostics_path,
+        diagnostics_start_timestep=diagnostics_start_timestep,
+        policy_kwargs=policy_kwargs,
+        verbose=0,
+        device=device,
+    )
+
+
 def _gpu_available() -> bool:
     """TODO docstring. Document this function.
 
@@ -482,18 +527,18 @@ def _run_sb3_training(
     start_time_iso: str,
     start_wall: float,
 ) -> ExtractorRunRecord:
-    """TODO docstring. Document this function.
+    """Train one feature extractor with SB3 PPO and collect run artifacts.
 
     Args:
-        profile: TODO docstring.
-        context: TODO docstring.
-        extractor_dir: TODO docstring.
-        artifacts: TODO docstring.
-        start_time_iso: TODO docstring.
-        start_wall: TODO docstring.
+        profile: Extractor profile being trained.
+        context: Resolved run context with hardware, settings, and output paths.
+        extractor_dir: Directory where model, eval, checkpoint, and metric artifacts are written.
+        artifacts: Mutable artifact map carried into the run record.
+        start_time_iso: ISO timestamp captured before the run started.
+        start_wall: Monotonic wall-clock timestamp captured before the run started.
 
     Returns:
-        TODO docstring.
+        Extractor run record with status, metrics, artifacts, and failure reason when applicable.
     """
     try:
         from stable_baselines3.common.callbacks import (
@@ -541,16 +586,19 @@ def _run_sb3_training(
             vec_env_cls=DummyVecEnv,
         )
 
-        diagnostics_path = extractor_dir / "training_diagnostics.jsonl"
+        diagnostics_path = (
+            extractor_dir / "training_diagnostics.jsonl"
+            if context.settings.training_diagnostics
+            else None
+        )
 
-        model = DiagnosticPPO(
-            "MultiInputPolicy",
-            train_env,
-            tensorboard_log=str(extractor_dir / "tensorboard"),
-            diagnostics_path=diagnostics_path,
+        model = _make_ppo_model(
+            train_env=train_env,
+            tensorboard_log=extractor_dir / "tensorboard",
             policy_kwargs=config.get_policy_kwargs(),
-            verbose=0,
             device=context.settings.device,
+            diagnostics_path=diagnostics_path,
+            diagnostics_start_timestep=context.settings.diagnostics_start_timestep,
         )
 
         eval_callback = EvalCallback(
@@ -585,7 +633,7 @@ def _run_sb3_training(
         if checkpoints_dir.exists() and any(checkpoints_dir.iterdir()):
             artifacts["checkpoints"] = str(checkpoints_dir.relative_to(context.run_dir))
 
-        if diagnostics_path.exists():
+        if diagnostics_path is not None and diagnostics_path.exists():
             artifacts["training_diagnostics"] = str(diagnostics_path.relative_to(context.run_dir))
 
         total_parameters = sum(p.numel() for p in model.policy.parameters())

--- a/tests/test_ppo_diagnostics.py
+++ b/tests/test_ppo_diagnostics.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
+import torch as th
+from gymnasium import spaces
 
 from robot_sf.feature_extractors.lightweight_cnn_extractor import LightweightCNNExtractor
 from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv
-from robot_sf.training.ppo_diagnostics import DiagnosticPPO
+from robot_sf.sensor.sensor_fusion import OBS_DRIVE_STATE, OBS_RAYS
+from robot_sf.training.ppo_diagnostics import (
+    DiagnosticPPO,
+    _grad_l2_norm,
+    _module_grad_norm,
+    _summarize_samples,
+)
 
 
 def _require_sb3():
@@ -26,6 +35,110 @@ def _build_fast_config() -> EnvSettings:
     config.sim_config.time_per_step_in_secs = 0.02
     config.sim_config.sim_time_in_secs = 1
     return config
+
+
+def _observation_space() -> spaces.Dict:
+    """Return the compact dict space used by diagnostics unit tests."""
+    return spaces.Dict(
+        {
+            OBS_DRIVE_STATE: spaces.Box(low=-10, high=10, shape=(5, 5), dtype=float),
+            OBS_RAYS: spaces.Box(low=0, high=10, shape=(5, 64), dtype=float),
+        }
+    )
+
+
+def _sample_observation(batch_size: int = 2) -> dict[str, th.Tensor]:
+    """Return a deterministic observation batch for feature-stat assertions."""
+    return {
+        OBS_DRIVE_STATE: th.ones(batch_size, 5, 5),
+        OBS_RAYS: th.linspace(0.0, 1.0, steps=batch_size * 5 * 64).reshape(batch_size, 5, 64),
+    }
+
+
+def test_lightweight_cnn_records_feature_stats():
+    """Feature-stat recording should be opt-in and expose a defensive copy."""
+    extractor = LightweightCNNExtractor(
+        _observation_space(),
+        num_filters=[16, 8],
+        kernel_sizes=[3, 3],
+        dropout_rate=0.0,
+        drive_hidden_dims=[8],
+        record_feature_stats=True,
+    )
+    features = extractor(_sample_observation())
+
+    assert features.shape == (2, extractor.features_dim)
+    stats = extractor.latest_feature_stats()
+    assert stats["combined_mean_abs"] > 0.0
+    assert stats["combined_std"] >= 0.0
+    assert stats["combined_max_abs"] >= stats["combined_mean_abs"]
+
+    stats["combined_mean_abs"] = -1.0
+    assert extractor.latest_feature_stats()["combined_mean_abs"] > 0.0
+
+
+def test_diagnostic_helpers_cover_empty_and_populated_gradients(tmp_path):
+    """Low-level helpers should handle empty gradients and aggregate populated values."""
+    linear = th.nn.Linear(2, 1)
+    assert _grad_l2_norm(linear.parameters()) == 0.0
+    assert _module_grad_norm(None) == 0.0
+    assert _summarize_samples([]) == {}
+
+    output = linear(th.ones(1, 2)).sum()
+    output.backward()
+    assert _grad_l2_norm(linear.parameters()) > 0.0
+    assert _module_grad_norm(linear) > 0.0
+
+    summary = _summarize_samples(
+        [{"grad_norm_total": 2.0}, {"grad_norm_total": 4.0, "feature_scale": 3.0}]
+    )
+    assert summary["mini_batch_count"] == 2.0
+    assert summary["grad_norm_total_mean"] == 3.0
+    assert summary["grad_norm_total_max"] == 4.0
+    assert summary["feature_scale_mean"] == 3.0
+
+    model = object.__new__(DiagnosticPPO)
+    model._diagnostics_path = None
+    model._append_training_diagnostics({"ignored": 1.0})
+
+    model._diagnostics_path = tmp_path / "diagnostics.jsonl"
+    model._append_training_diagnostics({"step": 1.0})
+    assert json.loads(model._diagnostics_path.read_text(encoding="utf-8")) == {"step": 1.0}
+
+
+def test_diagnostic_collect_batch_includes_feature_stats():
+    """Batch diagnostics should include module gradient norms and extractor stats when available."""
+    model = object.__new__(DiagnosticPPO)
+    feature_extractor = LightweightCNNExtractor(
+        _observation_space(),
+        num_filters=[16, 8],
+        kernel_sizes=[3, 3],
+        dropout_rate=0.0,
+        record_feature_stats=True,
+    )
+    _ = feature_extractor(_sample_observation())
+    action_head = th.nn.Linear(feature_extractor.features_dim, 1)
+    value_head = th.nn.Linear(feature_extractor.features_dim, 1)
+    policy_net = th.nn.Linear(feature_extractor.features_dim, 2)
+    value_net = th.nn.Linear(feature_extractor.features_dim, 2)
+    model.policy = SimpleNamespace(
+        features_extractor=feature_extractor,
+        mlp_extractor=SimpleNamespace(policy_net=policy_net, value_net=value_net),
+        action_net=action_head,
+        value_net=value_head,
+    )
+
+    modules = [feature_extractor, action_head, value_head, policy_net, value_net]
+    loss = sum(parameter.sum() for module in modules for parameter in module.parameters())
+    loss.backward()
+
+    diagnostics = model._collect_batch_diagnostics(
+        parameter for module in modules for parameter in module.parameters()
+    )
+    assert diagnostics["grad_norm_total"] > 0.0
+    assert diagnostics["grad_norm_features_extractor"] > 0.0
+    assert diagnostics["grad_norm_policy_net"] > 0.0
+    assert diagnostics["feature_combined_mean_abs"] > 0.0
 
 
 def test_diagnostic_ppo_writes_grad_and_feature_stats(tmp_path):

--- a/tests/test_ppo_diagnostics.py
+++ b/tests/test_ppo_diagnostics.py
@@ -17,6 +17,7 @@ from robot_sf.training.ppo_diagnostics import (
     DiagnosticPPO,
     _grad_l2_norm,
     _module_grad_norm,
+    _patched_clip_grad_norm,
     _summarize_samples,
 )
 
@@ -104,6 +105,22 @@ def test_diagnostic_helpers_cover_empty_and_populated_gradients(tmp_path):
     model._diagnostics_path = tmp_path / "diagnostics.jsonl"
     model._append_training_diagnostics({"step": 1.0})
     assert json.loads(model._diagnostics_path.read_text(encoding="utf-8")) == {"step": 1.0}
+
+
+def test_patched_clip_grad_norm_restores_original_function():
+    """The clip-grad patch should be scoped to the context manager lifetime."""
+    original = th.nn.utils.clip_grad_norm_
+    seen: list[int] = []
+    parameter = th.nn.Parameter(th.tensor([1.0], requires_grad=True))
+    parameter.grad = th.tensor([2.0])
+
+    with _patched_clip_grad_norm(lambda params: seen.append(len(params))):
+        patched = th.nn.utils.clip_grad_norm_
+        assert patched is not original
+        _ = patched([parameter], 1.0)
+
+    assert seen == [1]
+    assert th.nn.utils.clip_grad_norm_ is original
 
 
 def test_diagnostic_collect_batch_includes_feature_stats():

--- a/tests/test_ppo_diagnostics.py
+++ b/tests/test_ppo_diagnostics.py
@@ -1,0 +1,75 @@
+"""Focused tests for PPO diagnostics used in feature extractor triage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robot_sf.feature_extractors.lightweight_cnn_extractor import LightweightCNNExtractor
+from robot_sf.gym_env.env_config import EnvSettings
+from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.training.ppo_diagnostics import DiagnosticPPO
+
+
+def _require_sb3():
+    """Import StableBaselines3 dependencies or skip tests cleanly."""
+    pytest.importorskip("stable_baselines3", reason="StableBaselines3 not installed")
+    from stable_baselines3.common.env_util import make_vec_env
+
+    return make_vec_env
+
+
+def _build_fast_config() -> EnvSettings:
+    """Return a small environment config for PPO smoke tests."""
+    config = EnvSettings()
+    config.sim_config.time_per_step_in_secs = 0.02
+    config.sim_config.sim_time_in_secs = 1
+    return config
+
+
+def test_diagnostic_ppo_writes_grad_and_feature_stats(tmp_path):
+    """Verify diagnostics JSONL captures gradient and feature statistics."""
+    make_vec_env = _require_sb3()
+    config = _build_fast_config()
+
+    def make_env():
+        """Create the smoke-test environment."""
+        return RobotEnv(config)
+
+    env = make_vec_env(make_env, n_envs=1)
+    diagnostics_path = tmp_path / "training_diagnostics.jsonl"
+    model = DiagnosticPPO(
+        "MultiInputPolicy",
+        env,
+        policy_kwargs={
+            "features_extractor_class": LightweightCNNExtractor,
+            "features_extractor_kwargs": {
+                "num_filters": [16, 8],
+                "record_feature_stats": True,
+            },
+        },
+        diagnostics_path=diagnostics_path,
+        n_steps=8,
+        batch_size=8,
+        n_epochs=1,
+        gamma=0.95,
+        learning_rate=3e-4,
+        verbose=0,
+    )
+
+    try:
+        model.learn(total_timesteps=8)
+    finally:
+        env.close()
+
+    assert diagnostics_path.exists()
+    lines = diagnostics_path.read_text(encoding="utf-8").splitlines()
+    assert lines
+
+    payload = json.loads(lines[-1])
+    assert payload["num_timesteps"] >= 8
+    assert payload["mini_batch_count"] >= 1
+    assert payload["grad_norm_total_mean"] > 0.0
+    assert payload["grad_norm_features_extractor_mean"] > 0.0
+    assert payload["feature_combined_max_abs_mean"] > 0.0


### PR DESCRIPTION
## Summary
Adds an opt-in PPO diagnostics path for `lightweight_cnn` triage and records the issue #835 32 K rerun verdict: the issue-193 catastrophic final drop did not reproduce on the RTX 3070 rerun.

## Linked Issues
- Closes #835
- Relates to #193

## What Changed
- Added `DiagnosticPPO` to capture PPO gradient norms at clipping time and optional feature statistics from `LightweightCNNExtractor`.
- Added `configs/scenarios/lightweight_cnn_issue_835_repro.yaml` as the focused 32 K reproduction config with diagnostics enabled from 20 K onward.
- Kept diagnostics opt-in in `scripts/multi_extractor_training.py`, so normal multi-extractor runs still use plain SB3 `PPO`.
- Added focused tests for feature-stat telemetry, diagnostic helper behavior, JSONL writing, and the PPO smoke path.
- Added `docs/context/issue_835_lightweight_cnn_divergence.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: turns the `lightweight_cnn` divergence from a vague open question into a reproducible diagnostic workflow plus a documented bounded verdict.
- Expected impact: reviewers can rerun the exact config and inspect `training_diagnostics.jsonl` without changing default training behavior.
- Why this is worth merging now: it prevents repeated investigation of the issue-193 cliff while preserving the extractor as experimental rather than promoting or removing it prematurely.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_ppo_diagnostics.py tests/test_feature_extractors.py::TestFeatureExtractors::test_lightweight_cnn_extractor_forward -q`
  - `ROBOT_SF_MULTI_EXTRACTOR_TEST_MODE=1 uv run python scripts/multi_extractor_training.py --config configs/scenarios/lightweight_cnn_issue_835_repro.yaml --output-root tmp/issue_835_test_mode`
  - `uv run python scripts/multi_extractor_training.py --config configs/scenarios/lightweight_cnn_issue_835_repro.yaml --output-root tmp/issue_835_repro --verbose`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Full readiness gate: `2967 passed, 18 skipped, 3 warnings`; changed-file coverage was 100% for `robot_sf/feature_extractors/lightweight_cnn_extractor.py` and `robot_sf/training/ppo_diagnostics.py`.
  - 32 K RTX 3070 rerun completed successfully in 401.1 s.
  - Eval curve did not reproduce the `-64.09` cliff: best mean reward `3.79` at 20 K, final mean reward `-8.37` at 32 K.
  - Diagnostics from 20 K onward showed stable feature scale and no late gradient spike matching the original collapse.

## Risks / Rollout
- Compatibility risks: low; diagnostics are opt-in via `run.training_diagnostics`, and `LightweightCNNExtractor` feature stats are opt-in via `record_feature_stats`.
- Failure modes: diagnostics add host synchronization when feature stats are enabled, so they should stay off for production-scale runs unless needed for triage.
- Rollback or fallback plan: use the existing non-diagnostic multi-extractor configs, or disable `training_diagnostics` and `record_feature_stats` in the issue config.

## Docs / Provenance
- Updated docs: `docs/context/issue_835_lightweight_cnn_divergence.md`, `docs/context/README.md`.
- Relevant design or provenance notes: issue #193 remains the source of the original observed cliff; issue #835 records the bounded non-reproduction rerun.
- Assumption preserved: a single 32 K rerun is enough to reject deterministic reproduction, not enough to promote `lightweight_cnn`.

## Follow-Up Issues
- Deferred work: longer multi-seed feature-extractor comparison remains the useful next evidence, but it belongs to the broader feature-extractor campaign rather than this issue.
- Issues opened for follow-up: none; this PR documents the boundary instead of creating new scope.

## Reviewer Notes
- Verify that diagnostics remain opt-in for regular multi-extractor runs.
- The extractor should remain experimental; this PR does not claim it is stable or promotion-ready.
