### PR TITLE
docs: clarify durable artifact handling (#862)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,16 @@ Copilot, etc.) and the retrieval → planning → execution → verification dis
 ## Project Structure & Module Organization
 Core simulation code lives in `robot_sf/` with key subpackages: `gym_env` for Gymnasium bindings, `sim` for physics glue, `nav` for path planning, and `render` for playback tooling. Training and evaluation entry points sit in `scripts/`, while curated demos and notebooks live under `examples/`. Tests are split between `tests/` (unit and integration), `test_pygame/` (GUI regressions), and the `fast-pysf/` subtree. Assets and checkpoints are versioned under `maps/svg_maps/` and `model/`; the canonical (git-ignored) artifact root for generated outputs is `output/` (legacy `results/` has been migrated there).
 
+## Durable Artifacts & Worktree Output
+
+- Treat `output/` as temporary, worktree-local, and generally untracked. Do not assume files under `output/` exist in another checkout, worktree, or machine.
+- Do not rely on worktree-local `output/` contents for durable dependencies unless the launcher can hydrate them from a canonical source.
+- Any artifact required by future runs, benchmarks, reports, or release workflows must be promoted to a durable location before downstream steps depend on it.
+- Prefer durable publication through W&B artifacts/model uploads or another explicit persistent store with enough metadata to recover the exact artifact later.
+- Keep lightweight tracked manifests or registry entries when they describe how to retrieve, validate, or identify a durable artifact.
+- Worktree launchers that need `output/model_cache/...` inputs should either hydrate them from a canonical cache or artifact reference, or fail with an actionable error that names the missing durable source.
+- Avoid committing bulky generated outputs directly unless the file is intentionally small, reviewable, and part of the source contract.
+
 ## Build, Test & Development Commands
 Set up dependencies with `uv sync --all-extras` and install hooks via `uv run pre-commit install`. Format and lint using `uv run ruff check .` followed by `uv run ruff format .`. Run the main suite with `uv run pytest tests`; add `-m "not slow"` to skip long benches. Headless GUI checks use `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest test_pygame`. Validate the SocialForce backend with `uv run python -m pytest fast-pysf/tests -v`. Typical training workflows call `uv run python scripts/training/train_ppo.py --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml`.
 
@@ -92,7 +102,7 @@ Prefer a config-first workflow for reproducibility and reviewability. Add or upd
 The project enforces Ruff with a 4-space indent, 100-character lines, and double-quoted strings (`pyproject.toml`). Prefer type-annotated interfaces and keep factory functions (`environment_factory.make_*`) as the public entry point. Modules and files use `snake_case`; classes and dataclasses follow `PascalCase`. Name tests `test_<feature>.py` and keep fixtures under `conftest.py`. Avoid ad-hoc prints in library code—use the existing structured logging. Prefer to use more docstrings (for private methods also) and inline comments for clarity, especially in complex algorithms or data flows.
 
 ## Testing Guidelines
-Target the full `tests/` suite before pushing changes and rerun targeted slow markers when behavior or performance may shift. GUI and physics suites are mandatory for changes touching rendering, SocialForce integration, or pedestrian dynamics. Record notable validation runs with committed artifacts in `output/` when benchmarks change. Update or add smoke tests under `scripts/validation/` when introducing new critical workflows.
+Target the full `tests/` suite before pushing changes and rerun targeted slow markers when behavior or performance may shift. GUI and physics suites are mandatory for changes touching rendering, SocialForce integration, or pedestrian dynamics. Record notable validation runs in `docs/context/` or other tracked notes when benchmarks change, and only keep small explicit manifests or reviewable artifacts under version control. Do not treat worktree-local `output/` as the durable record. Update or add smoke tests under `scripts/validation/` when introducing new critical workflows.
 
 ## Proof-First Validation
 
@@ -141,6 +151,10 @@ screenshots or short GIFs when UI or playback output changes, and note any new a
 the feature branch, and then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`; readiness
 proof from before that sync is stale and must not be used for PR creation. Ensure CI stays green by
 resolving lint or test failures locally before requesting review.
+- Before creating a PR, inspect newly created `output/*` files, including ignored paths via
+  `git status --ignored --short output`. Decide whether each output is disposable, should remain
+  ignored, should be represented by a tracked manifest or registry entry, or must be uploaded to a
+  durable artifact store before the branch is handed off.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ When working in a linked Git worktree, detect bootstrap state before running exp
   `ln -s ../../robot_sf_ll7/local.machine.md .`
 - After the machine-context symlink is in place, run `uv sync --all-extras`, then
   `source .venv/bin/activate` before using Python tooling.
+- If the current branch is not `main`, fetch the latest `origin/main` and merge it into the current
+  branch early in the work cycle so the branch benefits from repository-wide fixes and workflow
+  improvements before local changes diverge. Typical command sequence:
+  `git fetch origin main && git merge origin/main`.
 - Do not create divergent per-worktree machine context files unless the worktree really needs
   machine-specific behavior that should not be inherited from the main checkout.
 
@@ -171,6 +175,9 @@ screenshots or short GIFs when UI or playback output changes, and note any new a
 the feature branch, and then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`; readiness
 proof from before that sync is stale and must not be used for PR creation. Ensure CI stays green by
 resolving lint or test failures locally before requesting review.
+- Do not wait until PR creation to pick up `main` branch improvements on long-lived branches.
+  Merge the latest `origin/main` into the current branch at the start of active work, and repeat
+  that sync before PR creation so validation covers the newest shared baseline.
 - Before creating a PR, inspect newly created `output/*` files, including ignored paths via
   `git status --ignored --short output`. Decide whether each output is disposable, should remain
   ignored, should be represented by a tracked manifest or registry entry, or must be uploaded to a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ When working in a linked Git worktree, detect bootstrap state before running exp
 - In a fresh worktree, find the main repository root from the common Git dir before bootstrapping:
   `MAIN_REPO_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"`.
 - If `local.machine.md` is absent in the worktree and present in the main repository root, create a
-  symlink instead of copying the file. Typical sibling-worktree example:
-  `ln -s ../../robot_sf_ll7/local.machine.md .`
+  symlink instead of copying the file. Example:
+  `ln -s "$MAIN_REPO_ROOT/local.machine.md" .`
 - After the machine-context symlink is in place, run `uv sync --all-extras`, then
   `source .venv/bin/activate` before using Python tooling.
 - If the current branch is not `main`, fetch the latest `origin/main` and merge it into the current
@@ -179,7 +179,7 @@ resolving lint or test failures locally before requesting review.
   Merge the latest `origin/main` into the current branch at the start of active work, and repeat
   that sync before PR creation so validation covers the newest shared baseline.
 - Before creating a PR, inspect newly created `output/*` files, including ignored paths via
-  `git status --ignored --short output`. Decide whether each output is disposable, should remain
+  `git status --ignored --short -uall output`. Decide whether each output is disposable, should remain
   ignored, should be represented by a tracked manifest or registry entry, or must be uploaded to a
   durable artifact store before the branch is handed off.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,26 @@ Execution rules:
 - If no local machine context exists, use conservative defaults and repository-safe commands.
 - Never store secrets in local machine context files.
 
+## Fresh Worktree Bootstrap
+
+When working in a linked Git worktree, detect bootstrap state before running expensive commands.
+
+- Treat the checkout as a linked worktree when `.git` is a file pointing into `.git/worktrees/...`,
+  or when `git rev-parse --git-common-dir` resolves to a different path than
+  `git rev-parse --git-dir`.
+- Treat the worktree as fresh only when that linked-worktree signal is present and the root is
+  missing both `local.machine.md` and `.venv` (plus any other team-specific initialized marker).
+  If either already exists, assume bootstrap has already happened and reuse the existing setup.
+- In a fresh worktree, find the main repository root from the common Git dir before bootstrapping:
+  `MAIN_REPO_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"`.
+- If `local.machine.md` is absent in the worktree and present in the main repository root, create a
+  symlink instead of copying the file. Typical sibling-worktree example:
+  `ln -s ../../robot_sf_ll7/local.machine.md .`
+- After the machine-context symlink is in place, run `uv sync --all-extras`, then
+  `source .venv/bin/activate` before using Python tooling.
+- Do not create divergent per-worktree machine context files unless the worktree really needs
+  machine-specific behavior that should not be inherited from the main checkout.
+
 ## Knowledge Capture & Context Notes
 
 Treat `docs/context/` as the repository's Markdown knowledge base for agent handoff, not as a dump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Documented durable artifact and worktree-output handling rules in `AGENTS.md`, clarifying that `output/` is temporary/local by default, durable dependencies must be promoted to a persistent store or tracked registry entry, and PR preparation now includes reviewing ignored `output/*` files before handoff.
+* Documented durable artifact, linked-worktree bootstrap, and worktree-output handling rules in `AGENTS.md` and `docs/dev_guide.md`, clarifying that `output/` is temporary/local by default, fresh linked worktrees should detect the shared main checkout before symlinking `local.machine.md`, a worktree counts as fresh only when both `local.machine.md` and `.venv` are absent, and PR preparation now includes reviewing ignored `output/*` files before handoff.
 
 * Promoted the issue-791 Wave-5 leader (job 11724, WandB `ll7/robot_sf/ibo3aqus`,
   best success 0.929 / collision 0.071 / SNQI 0.353 on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Documented durable artifact, linked-worktree bootstrap, and worktree-output handling rules in `AGENTS.md` and `docs/dev_guide.md`, clarifying that `output/` is temporary/local by default, fresh linked worktrees should detect the shared main checkout before symlinking `local.machine.md`, a worktree counts as fresh only when both `local.machine.md` and `.venv` are absent, and PR preparation now includes reviewing ignored `output/*` files before handoff.
+* Documented durable artifact, linked-worktree bootstrap, branch-sync, and worktree-output handling rules in `AGENTS.md` and `docs/dev_guide.md`, clarifying that `output/` is temporary/local by default, fresh linked worktrees should detect the shared main checkout before symlinking `local.machine.md`, a worktree counts as fresh only when both `local.machine.md` and `.venv` are absent, active feature branches should merge latest `origin/main` early and again before PR creation, and PR preparation now includes reviewing ignored `output/*` files before handoff.
 
 * Promoted the issue-791 Wave-5 leader (job 11724, WandB `ll7/robot_sf/ibo3aqus`,
   best success 0.929 / collision 0.071 / SNQI 0.353 on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Documented durable artifact, linked-worktree bootstrap, branch-sync, and worktree-output handling rules in `AGENTS.md` and `docs/dev_guide.md`, clarifying that `output/` is temporary/local by default, fresh linked worktrees should detect the shared main checkout before symlinking `local.machine.md`, a worktree counts as fresh only when both `local.machine.md` and `.venv` are absent, active feature branches should merge latest `origin/main` early and again before PR creation, and PR preparation now includes reviewing ignored `output/*` files before handoff.
+* Documented durable artifact, linked-worktree bootstrap, branch-sync, and
+  worktree-output handling rules in `AGENTS.md` and `docs/dev_guide.md`,
+  clarifying that `output/` is temporary/local by default; fresh linked
+  worktrees should detect the shared main checkout before symlinking
+  `local.machine.md`; a worktree counts as fresh only when both
+  `local.machine.md` and `.venv` are absent; active feature branches should
+  merge latest `origin/main` early and again before PR creation; and PR
+  preparation now includes reviewing ignored `output/*` files before handoff.
 
 * Promoted the issue-791 Wave-5 leader (job 11724, WandB `ll7/robot_sf/ibo3aqus`,
   best success 0.929 / collision 0.071 / SNQI 0.353 on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Documented durable artifact and worktree-output handling rules in `AGENTS.md`, clarifying that `output/` is temporary/local by default, durable dependencies must be promoted to a persistent store or tracked registry entry, and PR preparation now includes reviewing ignored `output/*` files before handoff.
+
 * Promoted the issue-791 Wave-5 leader (job 11724, WandB `ll7/robot_sf/ibo3aqus`,
   best success 0.929 / collision 0.071 / SNQI 0.353 on
   `ppo_full_maintained_eval_v1`) into the canonical PPO baseline at

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -27,6 +27,41 @@ uv run pre-commit install
 uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_env; print('Import successful')"
 ```
 
+### Fresh linked-worktree bootstrap
+
+When creating a new linked worktree, bootstrap the local machine context before using Python tools.
+You can detect a linked worktree because `.git` is a file that points into
+`<main checkout>/.git/worktrees/<worktree-name>`, and `git rev-parse --git-common-dir` resolves to
+the main checkout's `.git` directory instead of the worktree-local Git dir.
+
+Treat the worktree as fresh only if both `local.machine.md` and `.venv` are absent. If either
+already exists, assume the worktree has already been bootstrapped and reuse the existing setup.
+
+A cheap fresh-worktree check is:
+
+```bash
+[ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] \
+  && [ ! -e local.machine.md ] \
+  && [ ! -d .venv ]
+```
+
+Use this order for a fresh worktree:
+
+```bash
+MAIN_REPO_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
+ln -s ../../robot_sf_ll7/local.machine.md .
+uv sync --all-extras
+source .venv/bin/activate
+```
+
+Notes:
+
+- The `ln -s ../../robot_sf_ll7/local.machine.md .` example assumes the common layout used in this
+  repository, where linked worktrees live next to the main checkout under a sibling directory.
+- If the worktree path differs, derive the correct source from `$MAIN_REPO_ROOT/local.machine.md`.
+- Reuse the symlinked `local.machine.md` instead of copying it so machine-specific limits stay in
+  sync across worktrees.
+
 ### Critical dependencies and setup: Fast-pysf integration
 
 The `fast-pysf/` directory contains the optimized SocialForce physics engine and is now integrated as a **git subtree** (previously a submodule). After cloning the repository, the fast-pysf code is automatically available—no additional initialization steps required.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -49,15 +49,15 @@ Use this order for a fresh worktree:
 
 ```bash
 MAIN_REPO_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
-ln -s ../../robot_sf_ll7/local.machine.md .
+ln -s "$MAIN_REPO_ROOT/local.machine.md" .
 uv sync --all-extras
 source .venv/bin/activate
 ```
 
 Notes:
 
-- The `ln -s ../../robot_sf_ll7/local.machine.md .` example assumes the common layout used in this
-  repository, where linked worktrees live next to the main checkout under a sibling directory.
+- The symlink target should point at the main checkout's local machine context, not a copied
+  per-worktree file.
 - If the worktree path differs, derive the correct source from `$MAIN_REPO_ROOT/local.machine.md`.
 - Reuse the symlinked `local.machine.md` instead of copying it so machine-specific limits stay in
   sync across worktrees.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -61,6 +61,14 @@ Notes:
 - If the worktree path differs, derive the correct source from `$MAIN_REPO_ROOT/local.machine.md`.
 - Reuse the symlinked `local.machine.md` instead of copying it so machine-specific limits stay in
   sync across worktrees.
+- If you are starting work on a feature branch, merge the latest `origin/main` into the current
+  branch early so you inherit repository-wide fixes and workflow improvements before your local
+  changes diverge. Typical command sequence:
+
+```bash
+git fetch origin main
+git merge origin/main
+```
 
 ### Critical dependencies and setup: Fast-pysf integration
 
@@ -170,6 +178,9 @@ Before opening a PR, fetch the latest `origin/main`, integrate it into the featu
 either merge or rebase, and only then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
 The `BASE_REF` value tells the readiness gate what to compare against; it does not update the
 feature branch by itself, so validation from before the latest-main sync is stale for PR creation.
+Do not wait until PR creation to pick up `main` branch improvements on long-lived feature branches;
+merge latest `origin/main` into the current branch when active work starts, then sync again before
+opening the PR.
 
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 


### PR DESCRIPTION
## Summary
Clarify the repo-root agent guidance for durable artifacts versus worktree-local output. The PR now adds explicit AGENTS and dev guide rules for when `output/` is disposable, how to detect a fresh linked worktree, when to merge latest `origin/main` into the current branch, and what to review before opening a PR.

## Linked Issues
- Fixes to #862

## What Changed
- Added a dedicated `Durable Artifacts & Worktree Output` section to `AGENTS.md`.
- Added a `Fresh Worktree Bootstrap` section to `AGENTS.md` with explicit linked-worktree and fresh-worktree detection rules.
- Added guidance to merge the latest `origin/main` into active feature branches early, and to repeat that sync before PR creation.
- Added a matching fresh linked-worktree bootstrap section to `docs/dev_guide.md`, including the standard `local.machine.md` symlink -> `uv sync --all-extras` -> `source .venv/bin/activate` order.
- Added a pre-PR checklist item requiring review of ignored `output/*` files.
- Updated the AGENTS testing guidance so it no longer treats worktree-local `output/` as the durable validation record.
- Added an `Unreleased` changelog entry for the contributor-facing guidance update.

## Why It Matters
- Added value: makes artifact persistence, worktree bootstrap, and branch-sync expectations explicit across worktrees and machines.
- Expected impact: reduces brittle runs that silently depend on local `output/` contents or assume a feature branch can wait until PR time to inherit upstream fixes.
- Why this is worth merging now: the rule belongs in `main` so active worktrees and long-lived branches inherit the same baseline workflow.

## Validation / Proof
- Commands run: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Commands run: linked-worktree detection check based on `git rev-parse --git-common-dir`, `git rev-parse --git-dir`, `local.machine.md`, and `.venv`
- Evidence that the change works here: the readiness gate passed after the final doc edits, and the live checkout was correctly detected as a linked worktree but not a fresh one because both `.venv` and the `local.machine.md` symlink already exist.
- Benchmarks or smoke tests, if applicable: not applicable for this documentation-only change.

## Risks / Rollout
- Compatibility risks: low; this is guidance-only and does not change runtime behavior.
- Failure modes: teams may still need follow-up implementation work for automatic cache hydration, but the contract is now explicit.
- Rollback or fallback plan: revert the doc changes if the wording needs to be reworked.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/dev_guide.md`, `CHANGELOG.md`
- Relevant design or provenance notes: issue #862 documents the durable-artifact/worktree failure mode that motivated the change.
- Any assumptions that need to be preserved: `output/` remains the canonical local artifact root, but not the durable source of truth; a linked worktree is only treated as fresh when both `local.machine.md` and `.venv` are absent; and long-lived feature branches should merge latest `origin/main` early and again before PR creation.

## Follow-Up Issues
- Deferred work: none opened in this PR.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the new AGENTS guidance is internally consistent with the existing setup, testing, and PR workflow sections.
- Any known limitations: this PR documents the contract; it does not add cache hydration helpers or registry automation.
