### PR TITLE
fix: dedupe svg and model cache log spam (#863)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * **[BR-07 Evening Run: Predictive Planner Refresh](./training/br07_predictive_evening_run.md)** - Reproducible evening-run checklist for predictive planner refresh, evaluation, and promotion artifacts.
 * **[Issue 708 Main-Based PPO Retrain Campaign](./context/issue_708_main_based_ppo_retrain_campaign.md)** - Canonical issue-708 PPO retrain config, SLURM submission path, deterministic eval surface, and promotion checklist.
 * **[Issue 791 Promotion Campaign](./context/issue_791_promotion_campaign_128k_256k.md)** - Medium- and long-horizon ablation campaign status, GPU predictive-foresight fix, active long runs, and follow-up boundaries.
+* **[Issue 863 SVG/Model Log Spam](./context/issue_863_svg_model_log_spam.md)** - Log dedupe and PPO evaluation phase-marker decision for issue-791 long-run triage.
 * **[Issue 739 PPO Ablation Stage 1](./context/issue_739_ppo_ablation_stage1.md)** - Early reward/observation screening matrix and conservative next-step recommendation for PPO issue-708 follow-up work.
 * **[Predictive Planner Complete Tutorial](./training/predictive_planner_complete_tutorial.md)** - Full concept-to-code tutorial (model, scoring, risk-adaptive search, diagnostics, and reproducibility)
 * **[DreamerV3 RLlib Runbook (`drive_state` + `rays`)](./training/dreamerv3_rllib_drive_state_rays.md)** - Config-first training flow for RLlib DreamerV3 without image observations.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -102,6 +102,8 @@ knowledge, not every transient iteration detail.
 - [Issue #850 PPO Collision Failures](./issue_850_ppo_collision_failures.md)
   follow-up diagnostics for the issue-193 `dyn_large_med` hold-out collision failures and the
   config-first safety-reward mitigation candidate.
+- [Issue #863 SVG/Model Log Spam](./issue_863_svg_model_log_spam.md)
+  log dedupe and PPO evaluation phase-marker decision for issue-791 long-run triage.
 
 ## Planner Integration Notes
 

--- a/docs/context/issue_863_svg_model_log_spam.md
+++ b/docs/context/issue_863_svg_model_log_spam.md
@@ -1,0 +1,48 @@
+# Issue 863 SVG/Model Log Spam
+
+## Goal
+
+Reduce repeated observability noise seen in issue-791 PPO long runs without changing map geometry,
+model resolution, or benchmark semantics.
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/863>
+
+## Evidence
+
+- `robot_sf/nav/svg_map_parser.py` repaired invalid obstacle polygons during SVG conversion and
+  logged the same warning/info pair every time the same map was reparsed.
+- `robot_sf/models/registry.py` logged `Using cached model artifact` on every W&B cache hit, which
+  can repeat in predictive-planner or reset-heavy workflows.
+- `scripts/training/train_ppo.py` evaluates PPO checkpoints by constructing a fresh environment for
+  each evaluation episode in `_evaluate_policy`; that path can reparse SVG maps during long
+  evaluation phases.
+- Issue-reported configs:
+  - `configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22.yaml`
+  - `configs/training/ppo/ablations/expert_ppo_issue_791_asymmetric_critic_promotion_10m_env22.yaml`
+
+## Decision
+
+- Deduplicate SVG obstacle repair diagnostics once per process, SVG filename, path id, and event
+  type. The first warning/info remains visible so invalid geometry is not hidden.
+- Deduplicate cached-model hit logs once per process and resolved cache path. Downloads and errors
+  are unchanged.
+- Add compact PPO evaluation phase markers: start, completion, and progress every 10 episodes plus
+  the final episode. This keeps long evaluation/reset-heavy sections distinguishable from stalls
+  without replacing SB3 training progress output.
+
+## Validation
+
+Targeted proof:
+
+```bash
+uv run pytest tests/test_svg_obstacle_self_intersection.py tests/models/test_registry.py tests/training/test_train_expert_ppo_contract.py -q
+```
+
+Result on 2026-04-30: `32 passed`.
+
+## Remaining Risk
+
+The issue evidence suggests repeated environment construction may also affect throughput. This
+change only addresses log volume and phase observability. Any optimization to cache parsed maps or
+reuse evaluation environments should be handled separately because it can affect reset isolation and
+benchmark reproducibility.

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -16,6 +16,7 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional depend
     wandb = None  # type: ignore[assignment]
 
 DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")
+_LOGGED_CACHED_MODEL_ARTIFACTS: set[Path] = set()
 
 
 def _local_only_resolution_error(
@@ -275,7 +276,10 @@ def _download_from_wandb(entry: dict[str, Any], *, cache_dir: str | Path | None)
 
     cached_path = cache_root / file_name
     if cached_path.exists():
-        logger.info("Using cached model artifact: {}", cached_path)
+        resolved_cached_path = cached_path.resolve()
+        if resolved_cached_path not in _LOGGED_CACHED_MODEL_ARTIFACTS:
+            _LOGGED_CACHED_MODEL_ARTIFACTS.add(resolved_cached_path)
+            logger.info("Using cached model artifact: {}", cached_path)
         return cached_path
 
     logger.info("Downloading model artifact {} from {}", file_name, run_path)

--- a/robot_sf/nav/svg_map_parser.py
+++ b/robot_sf/nav/svg_map_parser.py
@@ -56,18 +56,21 @@ _LOGGED_OBSTACLE_PATH_EVENTS: set[tuple[str, str, str]] = set()
 
 def _log_obstacle_path_event_once(
     event: str,
-    svg_name: str,
+    svg_path: str | Path | None,
     path_id: str,
     level: str,
     message: str,
     **kwargs,
 ) -> None:
     """Emit noisy obstacle repair diagnostics once per process, SVG, path, and event."""
-    key = (event, svg_name, path_id)
+    if not svg_path:
+        return
+    path_obj = Path(svg_path)
+    key = (event, str(path_obj.resolve()), path_id)
     if key in _LOGGED_OBSTACLE_PATH_EVENTS:
         return
     _LOGGED_OBSTACLE_PATH_EVENTS.add(key)
-    getattr(logger, level)(message, svg=svg_name, pid=path_id, **kwargs)
+    getattr(logger, level)(message, svg=path_obj.name, pid=path_id, **kwargs)
 
 
 class SvgMapConverter:
@@ -767,12 +770,11 @@ class SvgMapConverter:
         """
         # SvgPath.coordinates is a Tuple[Vec2D]; convert to list of tuples
         vertices = list(path.coordinates)
-        svg_name = Path(self.svg_file_str).name
 
         if not np.array_equal(vertices[0], vertices[-1]):
             _log_obstacle_path_event_once(
                 "close_polygon",
-                svg_name,
+                self.svg_file_str,
                 str(path.id),
                 "warning",
                 "SVG file '{svg}' closing polygon: first and last vertices of obstacle <{pid}> differ",
@@ -784,7 +786,7 @@ class SvgMapConverter:
         if not poly.is_valid or poly.is_empty:
             _log_obstacle_path_event_once(
                 "invalid_polygon",
-                svg_name,
+                self.svg_file_str,
                 str(path.id),
                 "warning",
                 "SVG file '{svg}' obstacle path id={pid} produced invalid polygon (valid={valid}, empty={empty}): {reason}",
@@ -796,7 +798,7 @@ class SvgMapConverter:
             if repaired is not None:
                 _log_obstacle_path_event_once(
                     "repaired_polygon",
-                    svg_name,
+                    self.svg_file_str,
                     str(path.id),
                     "info",
                     "SVG file '{svg}' repaired invalid obstacle path id={pid} via make_valid (area={area:.3f}, polygons={count}).",
@@ -807,7 +809,7 @@ class SvgMapConverter:
             else:
                 _log_obstacle_path_event_once(
                     "repair_failed",
-                    svg_name,
+                    self.svg_file_str,
                     str(path.id),
                     "warning",
                     "SVG file '{svg}' failed to repair invalid obstacle path id={pid}; using raw vertices.",

--- a/robot_sf/nav/svg_map_parser.py
+++ b/robot_sf/nav/svg_map_parser.py
@@ -51,6 +51,24 @@ from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
 from robot_sf.nav.nav_types import SvgCircle, SvgPath, SvgRectangle
 from robot_sf.nav.obstacle import Obstacle, obstacle_from_svgrectangle
 
+_LOGGED_OBSTACLE_PATH_EVENTS: set[tuple[str, str, str]] = set()
+
+
+def _log_obstacle_path_event_once(
+    event: str,
+    svg_name: str,
+    path_id: str,
+    level: str,
+    message: str,
+    **kwargs,
+) -> None:
+    """Emit noisy obstacle repair diagnostics once per process, SVG, path, and event."""
+    key = (event, svg_name, path_id)
+    if key in _LOGGED_OBSTACLE_PATH_EVENTS:
+        return
+    _LOGGED_OBSTACLE_PATH_EVENTS.add(key)
+    getattr(logger, level)(message, svg=svg_name, pid=path_id, **kwargs)
+
 
 class SvgMapConverter:
     """Manages conversion of labeled SVG maps to MapDefinition objects.
@@ -752,39 +770,47 @@ class SvgMapConverter:
         svg_name = Path(self.svg_file_str).name
 
         if not np.array_equal(vertices[0], vertices[-1]):
-            logger.warning(
+            _log_obstacle_path_event_once(
+                "close_polygon",
+                svg_name,
+                str(path.id),
+                "warning",
                 "SVG file '{svg}' closing polygon: first and last vertices of obstacle <{pid}> differ",
-                svg=svg_name,
-                pid=path.id,
             )
             vertices.append(vertices[0])
 
         # Validate obstacle geometry to flag self-intersections or degenerate shapes early.
         poly = Polygon(vertices)
         if not poly.is_valid or poly.is_empty:
-            logger.warning(
+            _log_obstacle_path_event_once(
+                "invalid_polygon",
+                svg_name,
+                str(path.id),
+                "warning",
                 "SVG file '{svg}' obstacle path id={pid} produced invalid polygon (valid={valid}, empty={empty}): {reason}",
-                svg=svg_name,
-                pid=path.id,
                 valid=poly.is_valid,
                 empty=poly.is_empty,
                 reason=explain_validity(poly),
             )
             repaired = self._repair_invalid_obstacle_geometry(poly)
             if repaired is not None:
-                logger.info(
+                _log_obstacle_path_event_once(
+                    "repaired_polygon",
+                    svg_name,
+                    str(path.id),
+                    "info",
                     "SVG file '{svg}' repaired invalid obstacle path id={pid} via make_valid (area={area:.3f}, polygons={count}).",
-                    svg=svg_name,
-                    pid=path.id,
                     area=repaired.area,
                     count=len(Obstacle.from_geometry(repaired).iter_polygons()),
                 )
                 return Obstacle.from_geometry(repaired)
             else:
-                logger.warning(
+                _log_obstacle_path_event_once(
+                    "repair_failed",
+                    svg_name,
+                    str(path.id),
+                    "warning",
                     "SVG file '{svg}' failed to repair invalid obstacle path id={pid}; using raw vertices.",
-                    svg=svg_name,
-                    pid=path.id,
                 )
 
         return Obstacle(vertices)

--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -2406,6 +2406,14 @@ def _evaluate_policy(
             strategy=sampler_strategy,
         )
     scenario_cycle_length = max(1, len(sampler.scenario_ids))
+    progress_interval = 10 if episodes > 10 else 1
+    logger.info(
+        "PPO evaluation phase start step={} episodes={} scenarios={} seed_mode={}",
+        eval_step if eval_step is not None else "final",
+        episodes,
+        len(sampler.scenario_ids),
+        "random" if use_random else "deterministic",
+    )
 
     for episode_idx in range(episodes):
         seed = (
@@ -2464,7 +2472,22 @@ def _evaluate_policy(
                 "metrics": metric_row,
             },
         )
+        if (episode_idx + 1) % progress_interval == 0 or episode_idx + 1 == episodes:
+            logger.info(
+                "PPO evaluation progress step={} episode={}/{} scenario={} steps={} success={:.3f}",
+                eval_step if eval_step is not None else "final",
+                episode_idx + 1,
+                episodes,
+                scenario_name,
+                steps,
+                metric_row["success_rate"],
+            )
 
+    logger.info(
+        "PPO evaluation phase complete step={} episodes={}",
+        eval_step if eval_step is not None else "final",
+        episodes,
+    )
     return metrics, episode_records
 
 

--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -2406,7 +2406,6 @@ def _evaluate_policy(
             strategy=sampler_strategy,
         )
     scenario_cycle_length = max(1, len(sampler.scenario_ids))
-    progress_interval = 10 if episodes > 10 else 1
     logger.info(
         "PPO evaluation phase start step={} episodes={} scenarios={} seed_mode={}",
         eval_step if eval_step is not None else "final",
@@ -2472,11 +2471,12 @@ def _evaluate_policy(
                 "metrics": metric_row,
             },
         )
-        if (episode_idx + 1) % progress_interval == 0 or episode_idx + 1 == episodes:
+        episode_num = episode_idx + 1
+        if episode_num == episodes or episode_num % 10 == 0:
             logger.info(
                 "PPO evaluation progress step={} episode={}/{} scenario={} steps={} success={:.3f}",
                 eval_step if eval_step is not None else "final",
-                episode_idx + 1,
+                episode_num,
                 episodes,
                 scenario_name,
                 steps,

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -260,6 +260,7 @@ def test_resolve_model_path_rejects_missing_local_only_entry_with_migration_guid
 
 def test_download_from_wandb_uses_cached_path(monkeypatch, tmp_path: Path) -> None:
     """Cached W&B downloads should be reused without hitting the API."""
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
     cache_dir = tmp_path / "cache"
     cached = cache_dir / "demo" / "model.zip"
     cached.parent.mkdir(parents=True)
@@ -279,6 +280,43 @@ def test_download_from_wandb_uses_cached_path(monkeypatch, tmp_path: Path) -> No
     )
     assert resolved == cached
     assert api_called["value"] is False
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
+
+
+def test_download_from_wandb_logs_cached_path_once(monkeypatch, tmp_path: Path) -> None:
+    """Repeated cache hits for the same artifact should emit only one info log."""
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
+    cache_dir = tmp_path / "cache"
+    cached = cache_dir / "demo" / "model.zip"
+    cached.parent.mkdir(parents=True)
+    cached.write_text("checkpoint", encoding="utf-8")
+    messages: list[str] = []
+
+    def _fake_info(message: str, *args) -> None:
+        messages.append(message.format(*args) if args else message)
+
+    class _Api:
+        def run(self, path: str):
+            raise AssertionError(path)
+
+    monkeypatch.setattr(registry, "wandb", SimpleNamespace(Api=_Api))
+    monkeypatch.setattr(registry.logger, "info", _fake_info)
+
+    for _ in range(3):
+        assert (
+            registry._download_from_wandb(
+                {
+                    "model_id": "demo",
+                    "wandb_run_path": "ll7/robot_sf/demo",
+                    "wandb_file": "model.zip",
+                },
+                cache_dir=cache_dir,
+            )
+            == cached
+        )
+
+    assert messages == [f"Using cached model artifact: {cached}"]
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
 
 
 def test_download_from_wandb_builds_run_path_from_split_fields(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_svg_obstacle_self_intersection.py
+++ b/tests/test_svg_obstacle_self_intersection.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from loguru import logger
 from shapely.geometry import GeometryCollection, Polygon
 
+from robot_sf.nav import svg_map_parser
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.nav.svg_map_parser import SvgMapConverter
 
@@ -42,6 +43,7 @@ def test_self_intersecting_obstacle_paths_are_repaired() -> None:
 
 def test_self_intersecting_obstacle_warnings_include_svg_filename() -> None:
     """Obstacle repair warnings should name the SVG map file that triggered them."""
+    svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
     repo_root = Path(__file__).resolve().parents[1]
     svg_fixture = (
         repo_root / "maps" / "obstacle_svg_maps" / "uni_campus_with_lake_as_obstacle_and_routes.svg"
@@ -58,6 +60,43 @@ def test_self_intersecting_obstacle_warnings_include_svg_filename() -> None:
 
     assert any(svg_fixture.name in message for message in messages)
     assert any("invalid polygon" in message and svg_fixture.name in message for message in messages)
+
+
+def test_self_intersecting_obstacle_repair_logs_once_per_path() -> None:
+    """Repeated reparsing should not spam the same obstacle repair warning/info lines."""
+    svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
+    repo_root = Path(__file__).resolve().parents[1]
+    svg_fixture = (
+        repo_root / "maps" / "obstacle_svg_maps" / "uni_campus_with_lake_as_obstacle_and_routes.svg"
+    )
+    converter = SvgMapConverter(str(svg_fixture))
+    svg_path = _get_path_by_id(converter, "path3")
+    svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
+
+    messages: list[tuple[str, str]] = []
+    sink_id = logger.add(
+        lambda message: messages.append((message.record["level"].name, message.record["message"])),
+        level="INFO",
+    )
+    try:
+        converter._process_obstacle_path(svg_path)
+        converter._process_obstacle_path(svg_path)
+    finally:
+        logger.remove(sink_id)
+        svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
+
+    invalid_warnings = [
+        message
+        for level, message in messages
+        if level == "WARNING" and "invalid polygon" in message
+    ]
+    repair_infos = [
+        message
+        for level, message in messages
+        if level == "INFO" and "repaired invalid obstacle path" in message
+    ]
+    assert len(invalid_warnings) == 1
+    assert len(repair_infos) == 1
 
 
 def test_compound_obstacle_paths_preserve_detached_members(tmp_path: Path) -> None:

--- a/tests/test_svg_obstacle_self_intersection.py
+++ b/tests/test_svg_obstacle_self_intersection.py
@@ -99,6 +99,38 @@ def test_self_intersecting_obstacle_repair_logs_once_per_path() -> None:
     assert len(repair_infos) == 1
 
 
+def test_obstacle_log_dedupe_distinguishes_same_filename_in_different_dirs(
+    tmp_path: Path,
+) -> None:
+    """Obstacle log dedupe should key by full path while keeping filename-only output."""
+    svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
+    first_svg = tmp_path / "first" / "same.svg"
+    second_svg = tmp_path / "second" / "same.svg"
+    first_svg.parent.mkdir()
+    second_svg.parent.mkdir()
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        for svg_path in (first_svg, second_svg, first_svg):
+            svg_map_parser._log_obstacle_path_event_once(
+                "invalid_polygon",
+                svg_path,
+                "obstacle_13",
+                "warning",
+                "SVG file '{svg}' obstacle path id={pid} produced invalid polygon",
+            )
+    finally:
+        logger.remove(sink_id)
+        svg_map_parser._LOGGED_OBSTACLE_PATH_EVENTS.clear()
+
+    assert messages == [
+        "SVG file 'same.svg' obstacle path id=obstacle_13 produced invalid polygon",
+        "SVG file 'same.svg' obstacle path id=obstacle_13 produced invalid polygon",
+    ]
+
+
 def test_compound_obstacle_paths_preserve_detached_members(tmp_path: Path) -> None:
     """Compound SVG obstacle paths should keep all detached polygon members."""
     svg_file = tmp_path / "compound_obstacles.svg"

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -332,8 +332,8 @@ def test_write_perf_summary_writes_expected_keys(tmp_path: Path, monkeypatch) ->
     assert payload["eval_sec_per_checkpoint"] == 3.0
 
 
-def test_evaluate_policy_logs_compact_phase_progress(monkeypatch, tmp_path: Path) -> None:
-    """Evaluation should emit sparse phase markers so long reset-heavy runs remain readable."""
+def _capture_evaluate_policy_info_logs(monkeypatch, tmp_path: Path, *, episodes: int) -> list[str]:
+    """Run a fake PPO evaluation and capture info logs."""
     messages: list[str] = []
 
     def _fake_info(message: str, *args) -> None:
@@ -371,7 +371,7 @@ def test_evaluate_policy_logs_compact_phase_progress(monkeypatch, tmp_path: Path
         ),
         evaluation=EvaluationSchedule(
             frequency_episodes=0,
-            evaluation_episodes=12,
+            evaluation_episodes=episodes,
             step_schedule=((None, 60_000),),
             randomize_seeds=False,
         ),
@@ -397,9 +397,29 @@ def test_evaluate_policy_logs_compact_phase_progress(monkeypatch, tmp_path: Path
         eval_step=60_000,
     )
 
+    return messages
+
+
+def test_evaluate_policy_logs_compact_phase_progress(monkeypatch, tmp_path: Path) -> None:
+    """Evaluation should emit sparse phase markers so long reset-heavy runs remain readable."""
+    messages = _capture_evaluate_policy_info_logs(monkeypatch, tmp_path, episodes=12)
+
     progress_messages = [message for message in messages if "PPO evaluation progress" in message]
     assert any("PPO evaluation phase start step=60000 episodes=12" in msg for msg in messages)
     assert any("PPO evaluation phase complete step=60000 episodes=12" in msg for msg in messages)
     assert len(progress_messages) == 2
     assert progress_messages[0].startswith("PPO evaluation progress step=60000 episode=10/12")
     assert progress_messages[-1].startswith("PPO evaluation progress step=60000 episode=12/12")
+
+
+def test_evaluate_policy_logs_single_progress_marker_for_ten_episodes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Exactly 10 evaluation episodes should log only the episode-10 final marker."""
+    messages = _capture_evaluate_policy_info_logs(monkeypatch, tmp_path, episodes=10)
+
+    progress_messages = [message for message in messages if "PPO evaluation progress" in message]
+    assert progress_messages == [
+        "PPO evaluation progress step=60000 episode=10/10 scenario=scenario_a steps=1 success=0.000"
+    ]

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -14,6 +14,7 @@ from robot_sf.training.imitation_config import (
     ExpertTrainingConfig,
 )
 from robot_sf.training.ppo_policy import AsymmetricGridSocNavPolicy
+from robot_sf.training.snqi_utils import default_training_snqi_context
 from scripts.training import train_ppo
 
 if TYPE_CHECKING:
@@ -329,3 +330,76 @@ def test_write_perf_summary_writes_expected_keys(tmp_path: Path, monkeypatch) ->
     assert payload["total_wall_clock_sec"] == 12.0
     assert payload["train_env_steps_per_sec_mean"] == 100.0
     assert payload["eval_sec_per_checkpoint"] == 3.0
+
+
+def test_evaluate_policy_logs_compact_phase_progress(monkeypatch, tmp_path: Path) -> None:
+    """Evaluation should emit sparse phase markers so long reset-heavy runs remain readable."""
+    messages: list[str] = []
+
+    def _fake_info(message: str, *args) -> None:
+        messages.append(message.format(*args) if args else message)
+
+    class _FakeState:
+        max_sim_steps = 2
+
+    class _FakeEnv:
+        state = _FakeState()
+
+        def reset(self):
+            return [0.0], {}
+
+        def step(self, _action):
+            return [0.0], 1.0, True, False, {"success": True}
+
+        def close(self) -> None:
+            return None
+
+    class _FakeModel:
+        def predict(self, obs, deterministic: bool):
+            assert deterministic is True
+            return 0, None
+
+    config = ExpertTrainingConfig.from_raw(
+        scenario_config=tmp_path / "scenarios.yaml",
+        seeds=(123,),
+        total_timesteps=120_000,
+        policy_id="ppo_eval_progress_test",
+        convergence=ConvergenceCriteria(
+            success_rate=0.9,
+            collision_rate=0.05,
+            plateau_window=1000,
+        ),
+        evaluation=EvaluationSchedule(
+            frequency_episodes=0,
+            evaluation_episodes=12,
+            step_schedule=((None, 60_000),),
+            randomize_seeds=False,
+        ),
+    )
+
+    monkeypatch.setattr(train_ppo.logger, "info", _fake_info)
+    monkeypatch.setattr(
+        train_ppo,
+        "build_robot_config_from_scenario",
+        lambda scenario, *, scenario_path: object(),
+    )
+    monkeypatch.setattr(train_ppo, "_apply_env_overrides", lambda env_config, overrides: None)
+    monkeypatch.setattr(train_ppo, "make_robot_env", lambda **kwargs: _FakeEnv())
+
+    train_ppo._evaluate_policy(
+        _FakeModel(),
+        config,
+        scenario_definitions=({"id": "scenario_a", "name": "scenario_a"},),
+        scenario_path=tmp_path / "scenarios.yaml",
+        scenario_id=None,
+        hold_out_scenarios=(),
+        snqi_context=default_training_snqi_context(),
+        eval_step=60_000,
+    )
+
+    progress_messages = [message for message in messages if "PPO evaluation progress" in message]
+    assert any("PPO evaluation phase start step=60000 episodes=12" in msg for msg in messages)
+    assert any("PPO evaluation phase complete step=60000 episodes=12" in msg for msg in messages)
+    assert len(progress_messages) == 2
+    assert progress_messages[0].startswith("PPO evaluation progress step=60000 episode=10/12")
+    assert progress_messages[-1].startswith("PPO evaluation progress step=60000 episode=12/12")


### PR DESCRIPTION
## Summary
Deduplicate repeated SVG obstacle repair and cached-model hit logs while keeping the first actionable diagnostic visible. Add compact PPO evaluation phase/progress markers for long reset-heavy sections.

## Linked Issues
- Closes #863
- Relates to #791

## What Changed
- Added process-level log-once guards for invalid SVG obstacle close/repair events keyed by SVG filename, path id, and event type.
- Added process-level log-once behavior for W&B cached model artifact hits keyed by resolved cache path.
- Added PPO evaluation start/progress/complete markers, with progress every 10 episodes plus the final episode.
- Added regression tests for SVG log dedupe, model cache-hit log dedupe, and PPO evaluation progress logging.
- Added `docs/context/issue_863_svg_model_log_spam.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: long issue-791 PPO logs should remain readable when maps or predictive model caches are touched repeatedly.
- Expected impact: the first geometry repair/cache-hit event remains visible, but repeated identical lines no longer bury training/evaluation progress.
- Why this is worth merging now: it improves cluster triage without changing map geometry, model resolution, or benchmark semantics.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_svg_obstacle_self_intersection.py tests/models/test_registry.py tests/training/test_train_expert_ppo_contract.py -q`
  - `uv run ruff check robot_sf/nav/svg_map_parser.py robot_sf/models/registry.py scripts/training/train_ppo.py tests/test_svg_obstacle_self_intersection.py tests/models/test_registry.py tests/training/test_train_expert_ppo_contract.py`
  - `uv run ruff format --check robot_sf/nav/svg_map_parser.py robot_sf/models/registry.py scripts/training/train_ppo.py tests/test_svg_obstacle_self_intersection.py tests/models/test_registry.py tests/training/test_train_expert_ppo_contract.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted tests: `32 passed`.
  - Post-sync PR-ready gate: `2973 passed, 16 skipped, 3 warnings in 366.71s`.
  - Changed-file coverage warnings only: `robot_sf/models/registry.py` 94.3%, `robot_sf/nav/svg_map_parser.py` 86.6%; both above the 80% minimum.
- Benchmarks or smoke tests, if applicable: no benchmark run; this is a logging/observability change with focused regression tests.

## Risks / Rollout
- Compatibility risks: low. Runtime behavior is unchanged except duplicate log suppression and additional sparse PPO evaluation markers.
- Failure modes: a repeated identical SVG repair/cache-hit event after the first occurrence is suppressed for the rest of the process.
- Rollback or fallback plan: revert the log-once guard changes and progress markers.

## Docs / Provenance
- Updated docs: `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_863_svg_model_log_spam.md`.
- Any assumptions that need to be preserved: repeated evaluation environment creation may still affect throughput; this PR only addresses log volume and phase observability.

## Follow-Up Issues
- Deferred work: measure and optimize possible PPO evaluation map/model reload overhead in #867.
- Issues opened for follow-up: #867 (`technical-debt`, `performance`; Project #5 `Tracked`, priority `Medium`).

## Reviewer Notes
- Verify the log-once keys preserve the first diagnostic per map/path/event and per cache path.
- Known limitation: this does not prove or fix the poor effective throughput observed in job 12190.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added reference documentation for Issue #863 detailing log deduplication and evaluation progress visibility improvements.

* **Bug Fixes**
  * Eliminated duplicate log messages for cached model artifacts.
  * Reduced duplicate log messages from obstacle repair diagnostics.

* **New Features**
  * Added compact progress indicators during policy evaluation phases.

* **Tests**
  * Added regression tests validating log deduplication and phase-marker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->