### PR TITLE
fix: harden pyrvo2 build and JSON summaries

### DIFF
--- a/scripts/training/train_dreamerv3_rllib.py
+++ b/scripts/training/train_dreamerv3_rllib.py
@@ -853,6 +853,15 @@ def _json_safe_scalar(value: Any) -> Any:
     return value
 
 
+def _json_safe_value(value: Any) -> Any:
+    """Recursively convert nested values into strict-JSON-safe primitives."""
+    if isinstance(value, dict):
+        return {key: _json_safe_value(nested) for key, nested in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe_value(nested) for nested in value]
+    return _json_safe_scalar(value)
+
+
 def _is_finite_scalar(value: Any) -> bool:
     """Return True when value is an int/float and finite."""
     return isinstance(value, int | float) and math.isfinite(float(value))
@@ -1212,7 +1221,7 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
     """Write JSON payload with stable formatting."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2, sort_keys=True)
+        json.dump(_json_safe_value(payload), handle, allow_nan=False, indent=2, sort_keys=True)
         handle.write("\n")
 
 

--- a/scripts/training/train_dreamerv3_rllib.py
+++ b/scripts/training/train_dreamerv3_rllib.py
@@ -854,14 +854,30 @@ def _json_safe_scalar(value: Any) -> Any:
 
 
 def _json_safe_value(value: Any) -> Any:
-    """Recursively convert nested payloads into strict-JSON-safe values."""
-    if isinstance(value, dict):
-        return {key: _json_safe_value(nested) for key, nested in value.items()}
-    if isinstance(value, list):
-        return [_json_safe_value(nested) for nested in value]
-    if isinstance(value, tuple):
-        return [_json_safe_value(nested) for nested in value]
-    return _json_safe_scalar(value)
+    """Iteratively convert nested payloads into strict-JSON-safe values."""
+    root = [value]
+    stack: list[tuple[dict[Any, Any] | list[Any], Any]] = [(root, 0)]
+    while stack:
+        parent, key = stack.pop()
+        item = parent[key]
+        if isinstance(item, dict):
+            converted = {str(nested_key): nested_value for nested_key, nested_value in item.items()}
+            parent[key] = converted
+            stack.extend((converted, nested_key) for nested_key in converted)
+        elif isinstance(item, list | tuple):
+            converted = list(item)
+            parent[key] = converted
+            stack.extend((converted, index) for index in range(len(converted)))
+        elif isinstance(item, np.ndarray):
+            parent[key] = item.tolist()
+            stack.append((parent, key))
+        elif isinstance(item, np.generic):
+            parent[key] = _json_safe_scalar(item.item())
+        elif isinstance(item, Path):
+            parent[key] = str(item)
+        else:
+            parent[key] = _json_safe_scalar(item)
+    return root[0]
 
 
 def _is_finite_scalar(value: Any) -> bool:

--- a/tests/training/test_train_dreamerv3_rllib_runtime.py
+++ b/tests/training/test_train_dreamerv3_rllib_runtime.py
@@ -576,6 +576,41 @@ algorithm:
     assert diagnostics["nonfinite_scalars"]
 
 
+def test_json_safe_value_handles_numpy_paths_and_deep_payloads() -> None:
+    """JSON sanitization should avoid recursion and handle common RLlib payload leaves."""
+    json_safe_value = _dreamer_callable("_json_safe_value")
+    payload = {
+        "array": np.array([1.0, np.nan], dtype=np.float32),
+        "scalar": np.float64(np.inf),
+        "tuple": (np.int64(2),),
+        Path("artifact_path"): Path("output/dreamerv3"),
+    }
+
+    safe_payload = json_safe_value(payload)
+
+    assert safe_payload["array"] == [1.0, "nan"]
+    assert safe_payload["scalar"] == "inf"
+    assert safe_payload["tuple"] == [2]
+    assert safe_payload["artifact_path"] == "output/dreamerv3"
+    json.dumps(safe_payload, allow_nan=False)
+
+    deep_payload: dict[str, Any] = {}
+    cursor = deep_payload
+    depth = 1_500
+    for _ in range(depth):
+        nested: dict[str, Any] = {}
+        cursor["next"] = nested
+        cursor = nested
+    cursor["value"] = float("-inf")
+
+    safe_deep_payload = json_safe_value(deep_payload)
+
+    cursor = safe_deep_payload
+    for _ in range(depth):
+        cursor = cursor["next"]
+    assert cursor["value"] == "-inf"
+
+
 def test_run_training_cleans_up_ray_and_algo_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/third_party/python-rvo2/pyproject.toml
+++ b/third_party/python-rvo2/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
   "setuptools>=65",
   "wheel",
   "Cython>=3.0.0",
+  "cmake>=3.27",
 ]
 build-backend = "setuptools.build_meta"

--- a/third_party/python-rvo2/setup.py
+++ b/third_party/python-rvo2/setup.py
@@ -60,6 +60,7 @@ class BuildRvo2Ext(_build_ext):
         build_dir = os.path.abspath('build/RVO2')
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
+        if not os.path.exists(os.path.join(build_dir, 'CMakeCache.txt')):
             subprocess.check_call(['cmake', '../..', '-DCMAKE_CXX_FLAGS=-fPIC'],
                                   cwd=build_dir)
         subprocess.check_call(['cmake', '--build', '.'], cwd=build_dir)


### PR DESCRIPTION
## Summary
Make the vendored `pyrvo2` ORCA extra build reliably in isolated `uv` environments, and keep DreamerV3 run summaries strict-JSON-safe when nested diagnostics contain non-finite scalars.

## Linked Issues
- Closes #<id>: N/A
- Relates to #<id>: N/A

## What Changed
- Added `cmake>=3.27` to `third_party/python-rvo2` build requirements so `uv` can provide CMake during isolated wheel builds.
- Reconfigured the vendored RVO2 CMake build when `build/RVO2` exists without `CMakeCache.txt`, covering interrupted or failed prior builds.
- Added recursive JSON sanitization for DreamerV3 summary/diagnostic writes and enabled `allow_nan=False` for strict output.

## Why It Matters
- Added value: fresh worktrees can run `uv sync --all-extras` without requiring a preinstalled system `cmake` binary for `pyrvo2`.
- Expected impact: ORCA optional dependencies become easier to install reproducibly, and DreamerV3 summaries avoid invalid JSON tokens.
- Why this is worth merging now: the change unblocks the documented all-extras bootstrap path and fixes the readiness failure found while preparing this PR.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run python -c "import rvo2; print('rvo2 import ok')"`
  - `uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_env; print('robot_sf import ok')"`
  - `uv run pytest tests/training/test_train_dreamerv3_rllib_runtime.py::test_run_training_records_nonfinite_reward_diagnostics -q`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here: `uv sync --all-extras` completed, `rvo2` imported successfully, and the full readiness run passed with `2989 passed, 19 skipped`.
- Benchmarks or smoke tests, if applicable: targeted DreamerV3 non-finite diagnostics test passed.

## Risks / Rollout
- Compatibility risks: the vendored `pyrvo2` build now downloads/uses the Python `cmake` build dependency inside isolated builds when system CMake is absent.
- Failure modes: machines without a working C++ toolchain can still fail the native `pyrvo2` build; this PR only removes the missing-CMake blocker and interrupted-configure blocker.
- Rollback or fallback plan: revert the two commits; ORCA installs would again require system CMake and manual cleanup of stale CMake build directories.

## Docs / Provenance
- Updated docs: N/A.
- Relevant design or provenance notes: follows the existing vendored `third_party/python-rvo2` source contract and the repo PR readiness workflow.
- Any assumptions that need to be preserved: generated `output/` validation artifacts remain local/ignored and are not part of durable source state.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that adding `cmake` to the vendored package build requirements is acceptable for isolated `uv` builds.
- The DreamerV3 JSON change was included because the full PR readiness gate exposed the strict JSON regression on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization to reliably handle deeply nested structures, NumPy arrays/scalars, special numeric values (NaN/Infinity), tuples, and path-like objects to prevent serialization failures.

* **Tests**
  * Added a runtime test to validate robust, recursion-safe JSON-safe conversion for representative payloads.

* **Chores**
  * Require CMake >= 3.27 for builds and use conditional CMake configuration to speed incremental rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->