### PR TITLE
docs: refine big-picture strategy into two horizons

### DIFF
--- a/docs/plan/plan_big_picture_2026-04-30.md
+++ b/docs/plan/plan_big_picture_2026-04-30.md
@@ -1,532 +1,256 @@
-# Robot-SF improvement strategy — 2026-04-30
+# Robot-SF two-horizon improvement strategy - 2026-04-30
 
-Core recommendation
+## Core recommendation
 
-The project should not optimize for “one best local policy” first. It should optimize for a layered, falsification-driven local-navigation stack whose failures are attributable to perception, prediction, decision, control, or scenario infeasibility.
+Robot-SF should optimize for two linked horizons:
 
-The current repository is already more than a simple simulator. It provides a Gymnasium-compatible training environment with Stable-Baselines3-oriented reinforcement-learning support, SocialForce pedestrian simulation, e-scooter kinematics, OSM-based maps, a refactored environment factory, a documented adversarial-pedestrian extension, a Zenodo-backed benchmark artifact, and a sizeable test suite.  ￼ The internal documentation also shows that the project already has a social-navigation benchmark platform, SNQI tooling, baseline runners, bootstrap aggregation, planner-readiness profiles, atomic scenario sets, and scenario-difficulty analysis infrastructure.  ￼  ￼  ￼
+1. **Near-term paper delivery:** protect a defensible camera-ready benchmark story with clear
+   provenance, SNQI contract evidence, baseline boundaries, and durable artifacts.
+2. **Long-term research roadmap:** build a certified, adversarially tested, layered local-navigation
+   stack after the benchmark claim is stable.
 
-The missing piece is therefore not “add another planner.” The missing piece is a policy-improvement loop:
+The near-term target is not a single promoted local policy. It is a falsifiable benchmark claim:
 
+> A strong Robot-SF policy and baseline set evaluated on the maintained scenario matrix, with
+> clear planner provenance, seed/bootstrap uncertainty, SNQI diagnostics, and no fallback execution
+> counted as benchmark success.
+
+The long-term target is a policy-improvement loop:
+
+```text
 scenario generator
-  -> solvability certificate
+  -> scenario certificate
   -> policy sweep
   -> failure attribution
   -> adversarial search
   -> counterexample replay set
   -> training / planner update
   -> frozen holdout evaluation
+```
 
-1. What to improve for the best local policy
+## Current evidence that changes the priority order
 
-Strategic target
+- `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md` shows that
+  eval-aligned PPO training explains most of the observed lift to the current strong policy. Do not
+  credit architecture, curriculum, or foresight as the dominant driver without new evidence.
+- `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md` fixes the paper framing:
+  benchmark-set performance across the scenario matrix, not OOD generalization or transfer.
+- `docs/context/dreamerv3_program_close_out_2026_04_30.md` closes and deprioritizes the DreamerV3
+  track for camera-ready scope after repeated no-eval runs, NaNs, and OOM.
+- `docs/benchmark_planner_family_coverage.md` is the claim boundary for planner families. Only
+  implemented-and-benchmarkable rows should support current benchmark claims.
+- `docs/benchmark_camera_ready.md`, `docs/benchmark_release_protocol.md`, and
+  `docs/benchmark_release_reproducibility.md` define the paper-facing benchmark, SNQI, release,
+  and artifact obligations.
+- `docs/context/issue_691_benchmark_fallback_policy.md` is the fallback boundary: fallback or
+  degraded execution is a caveat or exclusion reason, not evidence of benchmark success.
 
-Build a portfolio local policy rather than a monolithic PPO, ORCA, SocialForce, or Dreamer policy. The best near-term architecture is:
+## Horizon A - near-term paper delivery
 
-global route / topology
+The paper track is the first execution priority. It should produce a claim that a reviewer can
+audit from committed configs, benchmark artifacts, and context notes.
+
+### A1. Protect the claim language
+
+Use this public framing:
+
+- strong policy on a broad maintained scenario matrix,
+- comparison against baseline-ready planners under the same benchmark contract,
+- seed/bootstrap uncertainty and SNQI diagnostics reported with the result.
+
+Avoid this framing unless a separate study exists:
+
+- OOD generalization,
+- transfer to unseen environments,
+- architecture-driven lift beyond the eval-aligned PPO evidence,
+- DreamerV3 as a promoted benchmark competitor.
+
+### A2. Preserve benchmark and SNQI evidence
+
+Paper-facing benchmark evidence must include:
+
+- canonical benchmark command or release workflow,
+- planner list and kinematics mode,
+- SNQI weights, baseline assets, diagnostics, and sensitivity status,
+- bootstrap or seed-variance evidence,
+- artifact paths or durable artifact references,
+- explicit fallback/degraded/not-available status for planners that fail their contract.
+
+### A3. Keep planner-family claims conservative
+
+Use `docs/benchmark_planner_family_coverage.md` as the support boundary:
+
+- benchmarkable: current paper-facing support when provenance and dependencies are valid,
+- implemented but experimental: controlled experiments only,
+- conceptually adjacent: background or roadmap only,
+- missing: future work only.
+
+### A4. Treat semantic blockers as paper risks
+
+Resolve or caveat these before using failures as policy evidence:
+
+- route handoff or first-waypoint errors,
+- invalid SVG obstacle conversion,
+- SNQI or metric-contract drift,
+- missing optional planner dependencies,
+- fallback or degraded execution,
+- worktree-local artifacts that have not been promoted to durable evidence.
+
+### Horizon A proof obligations
+
+| Claim type | Required proof |
+| --- | --- |
+| PPO benchmark result | canonical config, model artifact provenance, benchmark run, seed/bootstrap evidence, SNQI diagnostics |
+| Baseline planner result | implemented benchmark entrypoint, dependency availability, native/adapter mode, non-fallback execution |
+| SNQI conclusion | versioned weights, baseline normalization assets, contract diagnostics, sensitivity or ablation status |
+| Release artifact | durable artifact reference or tracked manifest, plus enough metadata to recover the exact input |
+| Failure attribution | scenario validity, planner mode, route/geometry sanity, and reproducible episode or counterexample bundle |
+
+## Horizon B - long-term research roadmap
+
+After the paper track is stable, Robot-SF should become a fast falsification and policy-development
+platform. The roadmap remains a layered local-navigation stack, but every promotion step must pass
+through executable Robot-SF evidence before it supports a manuscript or benchmark claim.
+
+### B1. Scenario certification
+
+Add a `scenario_cert.v1` concept before expanding adversarial scenario generation. The certificate
+should classify scenarios as invalid, geometrically infeasible, kinodynamically infeasible,
+dynamically overconstrained, knife-edge, or hard-but-solvable.
+
+The first useful certificate should cover:
+
+- inflated collision-free path existence,
+- minimum static clearance,
+- route validity for robot and pedestrians,
+- kinodynamic feasibility checks for turning, acceleration, and braking,
+- dynamic-agent plausibility,
+- oracle or high-budget baseline success evidence,
+- difficulty labels that distinguish universal hardness from planner-specific mismatch.
+
+### B2. Adversarial falsification
+
+Adversarial pedestrians and static scenarios should be development stress tools before they become
+frozen benchmark cases.
+
+Recommended sequence:
+
+1. black-box parameter search over starts, goals, timing, speed, and seeds;
+2. scripted adversarial families such as crossing, bottleneck blocker, mirror avoidance, group
+   squeeze, late stop, cutoff, and occluded emergence;
+3. counterexample replay bundles with scenario, certificate, episodes, trajectory, attribution, and
+   video;
+4. learned multi-agent adversaries only after plausibility constraints and replay evidence exist.
+
+### B3. Layered policy portfolio
+
+The long-term local policy should be a portfolio stack rather than a monolithic policy:
+
+```text
+route / topology
   -> scene graph + local free-space representation
   -> pedestrian / occupancy prediction
   -> candidate trajectory generation
   -> risk-aware trajectory scoring
   -> safety shield
   -> robot-specific controller
-
-This matches the broader social-navigation literature. A 2025 review classifies learning-based social-navigation methods into end-to-end, human-position-based, human-attention-based, human-prediction-based, and safety-aware methods, and notes that these methods function as local planners requiring global-planner integration for long-horizon navigation.  ￼ It also emphasizes that social navigation must go beyond obstacle avoidance to human-motion interpretation, social norms, realistic training environments, accurate anticipation of human motion, and evaluation methods that capture real-world complexity.  ￼
-
-Priority order
-
-Layer	Current risk	Improvement
-Shared route semantics	Local policies may fail because route handoff is ill-posed rather than because the planner is weak.	Fix first-waypoint / spawn / segment-progress handling before policy claims. This aligns with the known issue #730￼.
-Static geometry handling	Invalid SVG obstacle geometry or narrow-passage ambiguity can contaminate planner evaluation.	Add geometry-certification and parser-regression tests before adversarial static-scenario generation. See #837￼.
-Perception representation	Flattened occupancy grids or purely structured states lose spatial structure.	Use a two-branch observation model: structured state plus CNN-encoded local occupancy / semantic map. This is consistent with the direction in #789￼.
-Scene understanding	Current policies may see pedestrians as independent moving discs rather than agents with interaction context.	Build a scene graph with robot, pedestrians, groups, obstacle segments, bottlenecks, route topology, and right-of-way features.
-Prediction	Pedestrian prediction without obstacle context is weak near walls, corners, doors, queues, and bottlenecks.	Add obstacle-conditioned prediction: nearest-obstacle distance, obstacle normal, free-space sectors, then graph + occupancy-grid fusion. This is already aligned with #592￼.
-Decision making	Reactive methods solve many geometric cases but fail in deadlocks, timing traps, and bottlenecks.	Use candidate generation from ORCA/HRVO/DWA/TEB/MPPI/PPO proposals, then rank with risk, progress, comfort, and uncertainty.
-Control	Policy outputs may be feasible in abstract but not for e-scooter / differential-drive dynamics.	Track acceleration, jerk, braking distance, command projection, curvature, and actuator saturation as first-class metrics.
-Training objective	Optimizing a proxy metric can diverge from benchmark quality.	Unify SNQI between training and evaluation; #455￼ should be treated as a prerequisite for fair learned-policy comparison.
-
-2. State of the art and what it implies for Robot-SF
-
-Classical and optimization-based local planning
-
-ORCA remains a strong baseline because it gives reciprocal collision-avoidance guarantees under its assumptions, distributes pairwise avoidance responsibility, and reduces each agent’s action choice to a low-dimensional linear program.  ￼ HRVO extends reciprocal velocity-obstacle reasoning with explicit oscillation reduction for multi-agent navigation.  ￼ DWA remains relevant because it derives the admissible control set directly from robot dynamics, while TEB is relevant because it optimizes local trajectories for execution time, obstacle separation, and kinodynamic constraints.  ￼
-
-For Robot-SF, this means ORCA/HRVO/DWA/TEB should not be treated as outdated baselines. They should be used as trajectory proposal generators and diagnostic references inside a layered stack. The repository’s own planner-family coverage matrix already separates benchmark-ready planners from experimental and conceptually adjacent families; that distinction should remain strict.  ￼
-
-Learning-based social navigation
-
-The SOTA trend is not simply “bigger RL.” It is structured learning with prediction and safety. The 2025 Frontiers review explicitly identifies prediction-based and safety-aware families as central categories.  ￼ Recent methods such as SCOPE emphasize stochastic occupancy prediction conditioned on robot motion, dynamic-object motion, and static geometry, while future-aware social-navigation methods such as Falcon explicitly predict human trajectories and penalize actions that block future human paths.  ￼
-
-For Robot-SF, the practical SOTA-informed direction is:
-
-do not train policy(state) -> action only
-train / design policy(scene, route, prediction, uncertainty) -> short trajectory or command
-
-Benchmarking and evaluation
-
-The social-navigation evaluation literature warns that fair evaluation is hard because it includes static geometry, dynamic humans, and human perception of robot behavior. Francis et al. define social navigation in terms of safety, comfort, legibility, politeness, social competency, agent understanding, proactivity, and responsiveness to context.  ￼ SocNavBench addresses the same evaluation problem through photorealistic simulation, curated scenarios grounded in pedestrian data, and a metric suite for interpretable comparison.  ￼ BARN is a useful static-obstacle analogue: it shows that even metric ground navigation remains difficult in tightly constrained spaces, and it evaluates navigation using success, traversal time, and environment difficulty.  ￼
-
-Robot-SF should therefore keep a strict separation between:
-
-training scenarios
-development / adversarial scenarios
-frozen benchmark scenarios
-invalid or unsolvable fixtures
-
-The existing atomic scenario suite and verified-simple subset are a good foundation for this. The internal docs already define full runnable atomic scenarios, a verified-simple subset, validation-only fixtures, and scenario metadata such as purpose, expected behavior, pass criteria, failure modes, and primary capability.  ￼  ￼
-
-3. Proposed “best local policy” architecture
-
-I would implement policy_stack_v1 as a policy portfolio:
-
-Route layer:
-  visibility / Theta* / graph route
-  spawn-aware waypoint rebasing
-  local subgoal selection
-Scene layer:
-  robot state
-  pedestrian tracks
-  obstacle polygons / occupancy grid
-  bottleneck / corridor / doorway labels
-  local route topology
-Prediction layer:
-  constant-velocity baseline
-  SocialForce baseline
-  obstacle-conditioned graph predictor
-  stochastic occupancy-grid predictor
-Candidate layer:
-  ORCA / HRVO proposal
-  DWA / TEB / MPPI proposal
-  learned PPO / Dreamer proposal
-  stop / yield / backoff / commit maneuvers
-Risk layer:
-  collision probability
-  TTC
-  min-distance quantiles
-  comfort exposure
-  deadlock probability
-  route progress
-  uncertainty CVaR
-Safety layer:
-  hard clearance filter
-  braking-distance check
-  command feasibility check
-  emergency stop / yield policy
-Control layer:
-  unicycle / bicycle / e-scooter controller
-  acceleration and jerk limits
-  projection diagnostics
-
-The policy output should be a short trajectory or command sequence, not only an instantaneous (v, ω) action. Instantaneous commands are too weak for bottlenecks, head-on interactions, overtaking, and timing-sensitive pedestrian crossings.
-
-Minimal viable implementation
-
-Start with a non-learning stack:
-
-global path
-  + obstacle-aware local subgoal
-  + ORCA/HRVO/DWA candidate set
-  + TTC / distance / progress scoring
-  + braking-distance safety shield
-  + unicycle controller
-
-Then add learning only where it is most useful:
-
-1. learned pedestrian / occupancy prediction;
-2. learned risk scoring;
-3. learned proposal policy;
-4. end-to-end policy only as an ablation.
-
-This avoids a common failure mode: training an RL policy to compensate for missing route semantics, missing prediction, or invalid scenario geometry.
-
-4. Adversarial pedestrians
-
-The repository already contains the concept of a pedestrian as an adversarial agent that searches for weak points in the robot policy.  ￼ I would extend that into three levels.
-
-Level A — black-box parameter adversary
-
-Search over scenario parameters:
-
-robot_start: [x, y, theta]
-robot_goal: [x, y]
-ped_start: [x, y]
-ped_goal: [x, y]
-ped_spawn_time: t
-ped_speed: v
-ped_delay: dt
-ped_policy_seed: seed
-
-Objective:
-
-maximize:
-  robot_failure
-  + delay
-  + near_miss exposure
-  + comfort violation
-  + deadlock duration
-subject to:
-  pedestrian remains physically plausible
-  pedestrian has a valid route
-  pedestrian does not teleport
-  pedestrian does not intentionally collide from an impossible configuration
-
-This is close to adaptive stress testing. AST formulates failure search as a Markov decision process and uses reinforcement learning or MCTS-like methods to find likely failure trajectories in black-box simulators.  ￼
-
-Level B — scripted adversarial pedestrian families
-
-Implement reusable adversarial templates:
-
-Template	Failure mode
-ttc_crossing	pedestrian enters path at minimum time-to-collision margin
-doorway_blocker	pedestrian occupies the bottleneck exactly when robot commits
-head_on_mirror	pedestrian mirrors robot’s avoidance side, inducing oscillation
-group_squeeze	two pedestrians create a narrowing dynamic gap
-late_stop	pedestrian stops after the robot has committed
-overtake_cutoff	pedestrian moves parallel, then cuts across robot path
-shadowing	pedestrian remains near the robot’s blind or high-cost side
-queue_edge_case	pedestrian appears from behind a static obstacle or group
-
-These should be treated as development stress tests, not frozen benchmark cases until their solvability and plausibility are certified.
-
-Level C — learned multi-agent adversary
-
-Train one or more pedestrians against a frozen robot policy, then alternate:
-
-freeze robot policy
-train adversarial pedestrian(s)
-collect counterexamples
-retrain / tune robot policy
-freeze new robot policy
-retrain adversary
-
-The adversary reward should not simply reward collisions. It should reward plausible policy weakness:
-
-R_adv =
-  + failure_weight * robot_failure
-  + delay_weight * robot_delay
-  + near_miss_weight * near_miss_exposure
-  + deadlock_weight * deadlock_time
-  - implausibility_weight * deviation_from_human_motion_model
-  - effort_weight * pedestrian_control_effort
-  - illegality_weight * invalid_route_or_obstacle_overlap
-
-This prevents the adversary from becoming an unrealistic missile agent.
-
-5. Adaptive scenario definition
-
-Use a scenario grammar rather than only YAML enumeration. Scenic is the right conceptual model here: it is a probabilistic programming language for specifying distributions over scenes and dynamic-agent behaviors, with hard and soft constraints over scenario geometry and behavior.  ￼ Scenic also supports modeling stochastic multi-agent interactions with pedestrians, cyclists, and other traffic participants, and is an official scenario modeling language for CARLA.  ￼
-
-Robot-SF does not need to adopt Scenic immediately. It can implement a lightweight internal equivalent:
-
-scenario_template: crossing_ttc
-parameters:
-  robot_start: distribution
-  robot_goal: distribution
-  pedestrian_start: distribution
-  pedestrian_goal: distribution
-  spawn_time: distribution
-constraints:
-  - valid_robot_path_exists
-  - valid_pedestrian_path_exists
-  - min_static_clearance > 0.25
-  - initial_collision_free
-  - crossing_ttc in [1.0, 4.0]
-objectives:
-  - maximize near_miss
-  - maximize delay
-  - minimize pedestrian_implausibility
-
-Then implement:
-
-uv run python scripts/adversarial/search_scenarios.py \
-  --policy orca \
-  --scenario-template configs/scenarios/templates/crossing_ttc.yaml \
-  --search-space configs/adversarial/crossing_ttc_space.yaml \
-  --objective worst_case_snqi \
-  --out output/adversarial/strategy_2026_04_30/orca_crossing
-
-The output should be a counterexample bundle:
-
-scenario.yaml
-certificate.json
-episodes.jsonl
-trajectory.csv
-failure_attribution.json
-video.mp4
-
-6. Adversarial static scenario design: hard vs unsolvable
-
-The key problem is not generating harder static maps. It is certifying that they are solvable under the robot model.
-
-I would add robot_sf/scenario_certification/ with the following checks.
-
-Solvability taxonomy
-
-Label	Definition	Benchmark use
-invalid	start, goal, route, or obstacle geometry is malformed	validation fixture only
-geometrically_infeasible	no collision-free path exists after inflating obstacles by robot radius and safety margin	exclude from benchmark
-kinodynamically_infeasible	geometric path exists, but no path satisfies turning, acceleration, braking, or controller limits	exclude or mark separately
-dynamically_overconstrained	pedestrians can block all feasible paths indefinitely under allowed behavior	adversarial stress only
-knife_edge	oracle can solve only with near-zero clearance or timing margin	stress test, not headline benchmark
-hard_but_solvable	an oracle or high-budget planner solves with positive clearance and timing margin	valid benchmark candidate
-
-Certificate fields
-
-Each generated scenario should carry a machine-readable certificate:
-
-{
-  "schema": "robot_sf.scenario_cert.v1",
-  "scenario_id": "narrow_passage_generated_042",
-  "geometry": {
-    "inflated_path_exists": true,
-    "min_static_clearance_m": 0.32,
-    "shortest_path_length_m": 18.7,
-    "path_length_ratio": 1.42
-  },
-  "kinodynamics": {
-    "candidate_exists": true,
-    "min_turning_radius_ok": true,
-    "braking_margin_m_p05": 0.44
-  },
-  "dynamic_agents": {
-    "nominal_oracle_success_rate": 0.96,
-    "adversarial_success_rate": 0.71,
-    "oracle_min_distance_p05_m": 0.38
-  },
-  "baselines": {
-    "goal": "fail",
-    "orca": "pass",
-    "social_force": "fail",
-    "policy_stack_v1": "pass"
-  },
-  "difficulty": {
-    "consensus_rank": 0.82,
-    "seed_cv": 0.18,
-    "label": "hard_but_solvable"
-  }
-}
-
-The existing scenario-difficulty analysis already uses a consensus-outcome ranking and planner residual logic to distinguish “hard for everyone” from planner-specific mismatch. That should become a formal input into the certificate, not just a post-hoc report.  ￼
-
-7. Transfer to CARLA
-
-Robot-SF should transfer insights to CARLA only after the abstractions are simulator-independent. CARLA is appropriate for the next realism layer because it supports autonomous-driving simulation, flexible sensor suites, environmental conditions, open assets, and controlled scenarios of increasing difficulty.  ￼ CARLA also exposes control over static and dynamic actors, pedestrians, sensors, weather, maps, ScenarioRunner, and ROS integration.  ￼
-
-Transfer readiness criteria
-
-Move to CARLA when all six conditions are true:
-
-1. robot_sf has a stable scenario certificate format.
-2. The policy consumes simulator-independent observations: robot state, local grid, obstacle geometry, pedestrian tracks, prediction uncertainty, route.
-3. The policy outputs physical commands or local trajectories, not simulator-specific action IDs.
-4. Metrics are trajectory-based: success, collision, TTC, min distance, comfort, jerk, curvature, intervention rate, SNQI.
-5. Counterexamples are stable across seeds and not artifacts of SVG parsing, route handoff, or action projection.
-6. The policy passes:
-    * verified-simple subset,
-    * full atomic suite,
-    * classic + Francis 2023 scenario set,
-    * adversarial development set,
-    * frozen holdout seeds.
-
-Transfer stages
-
-Stage	Goal	Sensor model	Actor model
-T0	Export Robot-SF scenarios to neutral JSON	oracle	replay
-T1	CARLA 2D oracle parity	ground-truth tracks and map	scripted pedestrians
-T2	CARLA kinematic parity	ground truth	controlled robot dynamics
-T3	CARLA perception stress	LiDAR / camera / noisy tracks	scripted + Traffic Manager
-T4	CARLA policy validation	realistic perception stack	ScenarioRunner / Scenic-generated cases
-
-Do not start with CARLA training. Start with CARLA replay and parity. Otherwise, simulator complexity will hide whether a failure comes from policy logic, perception, dynamics, pedestrian behavior, or scenario translation.
-
-8. Roadmap
-
-Phase 1 — clean benchmark semantics
-
-Implement these first:
-
-1. Fix first-waypoint / spawn handoff: #730￼.
-2. Fix or fail-close invalid SVG obstacle conversion: #837￼.
-3. Unify SNQI semantics across training and benchmarking: #455￼.
-4. Add scenario_cert.v1.
-5. Produce a policy-by-scenario failure matrix.
-
-Recommended baseline command:
-
-uv run python scripts/tools/policy_analysis_run.py \
-  --scenario configs/scenarios/classic_interactions_francis2023.yaml \
-  --policy-sweep \
-  --seed-set eval \
-  --output output/benchmarks/strategy_2026_04_30/policy_sweep
-
-Phase 2 — adversarial development loop
-
-Add:
-
-1. black-box scenario-parameter search;
-2. scripted adversarial pedestrian families;
-3. counterexample replay suite;
-4. adversarial scorecards;
-5. separation of training_adversarial, dev_falsification, and frozen_eval.
-
-Phase 3 — layered policy stack
-
-Implement policy_stack_v1:
-
-1. route rebasing;
-2. obstacle-aware local subgoals;
-3. ORCA/HRVO/DWA/MPPI candidate generation;
-4. obstacle-conditioned pedestrian prediction;
-5. TTC / CVaR / comfort scoring;
-6. hard safety shield;
-7. unicycle / e-scooter controller.
-
-Phase 4 — CARLA bridge
-
-Create:
-
-robot_sf_carla_bridge/
-  scenario_export.py
-  carla_replay.py
-  observation_adapter.py
-  policy_adapter.py
-  metric_adapter.py
-
-First target: replay 10 certified Robot-SF scenarios in CARLA with oracle observations and scripted pedestrians. Only after parity should sensor-level perception be introduced.
-
-9. Concrete new issues to open
-
-1. feat: scenario certification v1
-    Add geometric, kinodynamic, dynamic, and oracle feasibility checks.
-2. feat: adversarial scenario search CLI
-    Add black-box seed/start/goal/timing search with CMA-ES, Bayesian optimization, or AST-style RL.
-3. feat: multi-pedestrian adversarial environment
-    Extend the adversarial-pedestrian environment to 1–N pedestrians with plausibility constraints.
-4. feat: obstacle-conditioned prediction baseline
-    Start with hand-engineered obstacle features, then move to graph + occupancy-grid fusion.
-5. feat: policy_stack_v1 portfolio planner
-    Combine ORCA/HRVO/DWA/learned proposals with risk scoring and a safety shield.
-6. feat: CARLA oracle replay bridge
-    Export certified Robot-SF scenarios into CARLA and compare trajectory-level metrics.
-
-Bottom line
-
-The strongest next step is a certified, adversarially tested, layered local-navigation stack. Better perception, scene understanding, prediction, decision making, and control all matter, but they should not be pursued independently. The immediate bottleneck is the lack of a closed loop that can say:
-
-this scenario is valid,
-this scenario is solvable,
-this policy failed for a known reason,
-this adversarial case is plausible,
-this improvement transfers beyond Robot-SF.
-
-Once that loop exists, Robot-SF becomes a fast falsification and policy-development platform. CARLA then becomes the higher-fidelity validation layer, not a premature replacement.
-
-References and visited links
-
-* robot_sf_ll7 repository￼ — Author: ll7; Publication: GitHub repository; Publication date: not applicable; Access date: 2026-04-30.
-
-<!-- Relevance: Primary repository inspected for current architecture, adversarial pedestrian support, environment factory, tests, release artifact, and project scope. -->
-
-* docs/README.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Documents current benchmark platform, SNQI, runner, metrics, and analysis capabilities. -->
-
-* docs/benchmark_spec.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Defines current scenario split, seed policy, baseline categories, metrics, and reproducible benchmark commands. -->
-
-* docs/context/issue_596_verified_simple_gate_proposal.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Provides existing atomic-scenario and verified-simple gate structure. -->
-
-* docs/context/issue_596_atomic_scenario_matrix.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Identifies scenario capabilities, target failure modes, and verified-simple membership. -->
-
-* docs/context/issue_692_scenario_difficulty_analysis.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Existing basis for scenario difficulty, consensus ranking, and planner residual analysis. -->
-
-* docs/benchmark_planner_family_coverage.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
-
-<!-- Relevance: Current planner-family coverage and readiness boundaries. -->
-
-* Issue #730: Fix brittle first-waypoint handoff￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
-
-<!-- Relevance: Shared route-handling failure can contaminate planner comparisons. -->
-
-* Issue #789: DreamerV3 multi-modal encoder￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
-
-<!-- Relevance: Supports the recommendation to preserve spatial occupancy-grid structure. -->
-
-* Issue #592: Hybrid graph + obstacle-context predictive model￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
-
-<!-- Relevance: Directly matches the proposed obstacle-conditioned prediction layer. -->
-
-* Issue #707: Improve ORCA performance on atomic failure scenarios￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
-
-<!-- Relevance: Shows known ORCA failure slices and the need for failure attribution. -->
-
-* Issue #768: Benchmark ORCA variants￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
-
-<!-- Relevance: Relevant to ORCA-DD / nonholonomic ORCA comparison. -->
-
-* Social robot navigation: a review and benchmarking of learning-based methods￼ — Author: Rashid Alyassi, Cesar Cadena, Robert Riener, Diego Paez-Granados; Publication: Frontiers in Robotics and AI; Publication date: 2025-12-11; Access date: 2026-04-30.
-
-<!-- Relevance: Current SOTA taxonomy for learning-based social-navigation methods. -->
-
-* Principles and Guidelines for Evaluating Social Robot Navigation Algorithms￼ — Author: Anthony Francis et al.; Publication: ACM Transactions on Human-Robot Interaction; Publication date: 2025-02-20; Access date: 2026-04-30.
-
-<!-- Relevance: Evaluation principles for social navigation: safety, comfort, legibility, politeness, social competency, agent understanding, proactivity, and responsiveness to context. -->
-
-* SocNavBench: A Grounded Simulation Testing Framework for Evaluating Social Navigation￼ — Author: Abhijat Biswas, Allan Wang, Gustavo Silvera, Aaron Steinfeld, Henny Admoni; Publication: ACM THRI / CMU Robotics Institute page; Publication date: 2021-08; Access date: 2026-04-30.
-
-<!-- Relevance: Benchmark design reference for social-navigation scenarios and metrics. -->
-
-* BARN Challenge￼ — Author: Xuesu Xiao et al.; Publication: ICRA 2022 Challenge page; Publication date: 2022; Access date: 2026-04-30.
-
-<!-- Relevance: Static-obstacle benchmark reference for difficulty-ranked, constrained navigation. -->
-
-* Optimal Reciprocal Collision Avoidance￼ — Author: Jur van den Berg, Stephen J. Guy, Jamie Snape, Ming C. Lin, Dinesh Manocha; Publication: ORCA project page; Publication date: related publications 2008–2011; Access date: 2026-04-30.
-
-<!-- Relevance: Classical reciprocal collision-avoidance baseline and proposal generator. -->
-
-* The Hybrid Reciprocal Velocity Obstacle￼ — Author: Jamie Snape, Jur van den Berg, Stephen J. Guy, Dinesh Manocha; Publication: IEEE Transactions on Robotics; Publication date: 2011-08; Access date: 2026-04-30.
-
-<!-- Relevance: HRVO baseline for oscillation-aware reciprocal avoidance. -->
-
-* The Dynamic Window Approach to Collision Avoidance￼ — Author: Dieter Fox, Wolfram Burgard, Sebastian Thrun; Publication: IEEE Robotics and Automation Magazine; Publication date: 1997-03; Access date: 2026-04-30.
-
-<!-- Relevance: Dynamics-aware local control baseline. -->
-
-* teb_local_planner ROS package￼ — Author: Christoph Rösmann et al.; Publication: ROS package index; Publication date: package page, rolling updates; Access date: 2026-04-30.
-
-<!-- Relevance: Kinodynamic local trajectory-optimization reference. -->
-
-* Adaptive stress testing: finding likely failure events with reinforcement learning￼ — Author: Ritchie Lee et al.; Publication: Journal of Artificial Intelligence Research / MIT Lincoln Laboratory page; Publication date: 2020-12-01; Access date: 2026-04-30.
-
-<!-- Relevance: Methodological basis for adversarial failure search. -->
-
-* Scenic: a language for scenario specification and data generation￼ — Author: Daniel J. Fremont et al.; Publication: Machine Learning; Publication date: 2022-02-02; Access date: 2026-04-30.
-
-<!-- Relevance: Scenario grammar, probabilistic scenario generation, and hard/soft constraints. -->
-
-* The Scenic Programming Language￼ — Author: Scenic project contributors; Publication: Project website; Publication date: site copyright 2019–2025; Access date: 2026-04-30.
-
-<!-- Relevance: Shows Scenic’s multi-agent, spatiotemporal, formal scenario-modeling capabilities and CARLA connection. -->
-
-* CARLA: An Open Urban Driving Simulator￼ — Author: Alexey Dosovitskiy, German Ros, Felipe Codevilla, Antonio Lopez, Vladlen Koltun; Publication: Proceedings of Machine Learning Research, CoRL 2017; Publication date: 2017; Access date: 2026-04-30.
-
-<!-- Relevance: CARLA transfer target and simulator baseline. -->
-
-* CARLA Simulator￼ — Author: CARLA Team; Publication: Project website; Publication date: current site, latest news through 2025; Access date: 2026-04-30.
-
-<!-- Relevance: Current CARLA capabilities: sensors, dynamic actors, ScenarioRunner, ROS bridge, maps. -->
-
-* SCOPE: Stochastic Cartographic Occupancy Prediction Engine for Uncertainty-Aware Dynamic Navigation￼ — Author: Zhanteng Xie, Philip Dames; Publication: GitHub repository / IEEE Transactions on Robotics 2025 paper; Publication date: 2025; Access date: 2026-04-30.
-
-<!-- Relevance: Modern occupancy-prediction reference for uncertainty-aware dynamic navigation. -->
-
-* Falcon: From Cognition to Precognition￼ — Author: Zeying Gong, Tianshuai Hu, Ronghe Qiu, Junwei Liang; Publication: GitHub repository / ICRA 2025 paper; Publication date: 2025; Access date: 2026-04-30.
-
-<!-- Relevance: Recent future-aware social-navigation example using trajectory prediction and future-path blocking penalties. -->
+```
+
+Start with a non-learning stack using route rebasing, obstacle-aware subgoals, ORCA/HRVO/DWA/MPPI
+proposal generation, TTC/distance/progress scoring, braking-distance checks, and a unicycle or
+e-scooter controller. Add learning in this order: prediction, risk scoring, proposal policy, then
+end-to-end policy as an ablation.
+
+### B4. CARLA transfer
+
+CARLA should be a higher-fidelity validation layer, not the starting point for training.
+
+Transfer readiness requires:
+
+- stable scenario certificates,
+- simulator-independent observations,
+- physical command or local-trajectory outputs,
+- trajectory-based metrics,
+- counterexamples that are stable across seeds and not parser or route artifacts,
+- validated Robot-SF performance on verified-simple, atomic, classic, adversarial-development, and
+  frozen evaluation sets.
+
+The first CARLA target should be oracle replay/parity for certified Robot-SF scenarios. Sensor-level
+perception and policy training inside CARLA should come after replay parity.
+
+## Shared proof spine
+
+The two horizons share one rule: no workstream promotes a claim until the evidence can be inspected,
+rerun, or traced to a durable artifact. This matters for paper delivery and for future research
+quality.
+
+Use these proof gates:
+
+- Paper benchmark claim: canonical benchmark run, SNQI diagnostics, bootstrap/seed evidence,
+  planner provenance, and durable artifact trail.
+- Planner readiness claim: current benchmark entrypoint, dependency availability, mode
+  classification, and non-fallback execution proof.
+- Metric or SNQI claim: contract diagnostics and reproducible input assets.
+- Research-roadmap promotion: executable proof in Robot-SF before any manuscript-facing claim.
+- CARLA transfer claim: parity evidence against certified Robot-SF scenarios before perception or
+  training claims.
+
+## Sequencing
+
+| Order | Work | Horizon | Why now |
+| --- | --- | --- | --- |
+| 1 | Claim-language cleanup and provenance audit | A | Prevents overclaiming before paper text and PRs reuse the result |
+| 2 | Camera-ready benchmark validation and SNQI diagnostics | A | Produces reviewer-auditable evidence |
+| 3 | Durable artifact and config provenance check | A | Makes the result recoverable outside this worktree |
+| 4 | Route, geometry, metric, and fallback blockers | A | Prevents invalid failure attribution |
+| 5 | Scenario certification v1 | B | Makes generated hard cases distinguishable from invalid cases |
+| 6 | Failure attribution and adversarial replay bundles | B | Turns failures into reusable development evidence |
+| 7 | Layered policy portfolio | B | Improves local navigation after the evaluation substrate is trustworthy |
+| 8 | CARLA oracle replay/parity | B | Tests transfer only after simulator-independent contracts exist |
+
+## Issue candidates
+
+### Paper-critical or paper-risk issues
+
+1. Audit issue-791 claim language against the narrow benchmark-set decision.
+2. Verify camera-ready PPO provenance, benchmark command, seed/bootstrap evidence, and SNQI
+   diagnostics.
+3. Audit baseline planner dependencies and native/adapter/fallback modes for the paper matrix.
+4. Verify durable artifact references for model, benchmark, SNQI, and release inputs.
+5. Resolve or caveat route handoff, invalid geometry, metric drift, and fallback/degraded execution
+   before using affected failures as policy evidence.
+
+### Research follow-up issues
+
+1. Add `scenario_cert.v1` for geometric, kinodynamic, dynamic-agent, and difficulty certification.
+2. Add adversarial scenario search with plausibility constraints and counterexample replay bundles.
+3. Extend adversarial pedestrians from single-agent templates to constrained multi-agent stress
+   tests.
+4. Add obstacle-conditioned prediction baselines and scene representations.
+5. Build `policy_stack_v1` as a portfolio planner with safety shielding and controller diagnostics.
+6. Add CARLA oracle replay/parity for certified Robot-SF scenarios.
+
+## Claim-boundary notes
+
+- PPO is currently the highest-yield paper-facing policy track, but the strongest result is
+  benchmark-set performance. Do not present it as OOD generalization, transfer, or performance on
+  unseen environments unless a separate held-out study is run.
+- DreamerV3 is historical context and a deprioritized research track for this paper cycle. A future
+  attempt needs a structurally different setup and fresh proof before it becomes a benchmark
+  competitor.
+- Fallback, degraded, skipped, or not-available planner execution can support diagnostics, but it
+  cannot count as benchmark success.
+- Worktree-local `output/` files are not durable evidence. Promote required artifacts or track a
+  manifest that identifies how to recover them.
+- CARLA is deferred until Robot-SF has simulator-independent scenario, observation, action, and
+  metric contracts. The first CARLA milestone is oracle replay/parity, not training.
+
+## Bottom line
+
+The strongest near-term step is to protect the paper claim: a strong policy and baseline set on the
+maintained scenario matrix, backed by provenance, SNQI diagnostics, uncertainty evidence, and
+fail-closed benchmark semantics.
+
+The strongest long-term step is to turn Robot-SF into a certified falsification loop. Scenario
+certification, adversarial replay, layered policy portfolios, richer prediction, and CARLA parity
+remain valuable, but they become claim-bearing only after the paper evidence spine is stable.

--- a/docs/plan/plan_big_picture_2026-04-30.md
+++ b/docs/plan/plan_big_picture_2026-04-30.md
@@ -1,0 +1,532 @@
+# Robot-SF improvement strategy — 2026-04-30
+
+Core recommendation
+
+The project should not optimize for “one best local policy” first. It should optimize for a layered, falsification-driven local-navigation stack whose failures are attributable to perception, prediction, decision, control, or scenario infeasibility.
+
+The current repository is already more than a simple simulator. It provides a Gymnasium-compatible training environment with Stable-Baselines3-oriented reinforcement-learning support, SocialForce pedestrian simulation, e-scooter kinematics, OSM-based maps, a refactored environment factory, a documented adversarial-pedestrian extension, a Zenodo-backed benchmark artifact, and a sizeable test suite.  ￼ The internal documentation also shows that the project already has a social-navigation benchmark platform, SNQI tooling, baseline runners, bootstrap aggregation, planner-readiness profiles, atomic scenario sets, and scenario-difficulty analysis infrastructure.  ￼  ￼  ￼
+
+The missing piece is therefore not “add another planner.” The missing piece is a policy-improvement loop:
+
+scenario generator
+  -> solvability certificate
+  -> policy sweep
+  -> failure attribution
+  -> adversarial search
+  -> counterexample replay set
+  -> training / planner update
+  -> frozen holdout evaluation
+
+1. What to improve for the best local policy
+
+Strategic target
+
+Build a portfolio local policy rather than a monolithic PPO, ORCA, SocialForce, or Dreamer policy. The best near-term architecture is:
+
+global route / topology
+  -> scene graph + local free-space representation
+  -> pedestrian / occupancy prediction
+  -> candidate trajectory generation
+  -> risk-aware trajectory scoring
+  -> safety shield
+  -> robot-specific controller
+
+This matches the broader social-navigation literature. A 2025 review classifies learning-based social-navigation methods into end-to-end, human-position-based, human-attention-based, human-prediction-based, and safety-aware methods, and notes that these methods function as local planners requiring global-planner integration for long-horizon navigation.  ￼ It also emphasizes that social navigation must go beyond obstacle avoidance to human-motion interpretation, social norms, realistic training environments, accurate anticipation of human motion, and evaluation methods that capture real-world complexity.  ￼
+
+Priority order
+
+Layer	Current risk	Improvement
+Shared route semantics	Local policies may fail because route handoff is ill-posed rather than because the planner is weak.	Fix first-waypoint / spawn / segment-progress handling before policy claims. This aligns with the known issue #730￼.
+Static geometry handling	Invalid SVG obstacle geometry or narrow-passage ambiguity can contaminate planner evaluation.	Add geometry-certification and parser-regression tests before adversarial static-scenario generation. See #837￼.
+Perception representation	Flattened occupancy grids or purely structured states lose spatial structure.	Use a two-branch observation model: structured state plus CNN-encoded local occupancy / semantic map. This is consistent with the direction in #789￼.
+Scene understanding	Current policies may see pedestrians as independent moving discs rather than agents with interaction context.	Build a scene graph with robot, pedestrians, groups, obstacle segments, bottlenecks, route topology, and right-of-way features.
+Prediction	Pedestrian prediction without obstacle context is weak near walls, corners, doors, queues, and bottlenecks.	Add obstacle-conditioned prediction: nearest-obstacle distance, obstacle normal, free-space sectors, then graph + occupancy-grid fusion. This is already aligned with #592￼.
+Decision making	Reactive methods solve many geometric cases but fail in deadlocks, timing traps, and bottlenecks.	Use candidate generation from ORCA/HRVO/DWA/TEB/MPPI/PPO proposals, then rank with risk, progress, comfort, and uncertainty.
+Control	Policy outputs may be feasible in abstract but not for e-scooter / differential-drive dynamics.	Track acceleration, jerk, braking distance, command projection, curvature, and actuator saturation as first-class metrics.
+Training objective	Optimizing a proxy metric can diverge from benchmark quality.	Unify SNQI between training and evaluation; #455￼ should be treated as a prerequisite for fair learned-policy comparison.
+
+2. State of the art and what it implies for Robot-SF
+
+Classical and optimization-based local planning
+
+ORCA remains a strong baseline because it gives reciprocal collision-avoidance guarantees under its assumptions, distributes pairwise avoidance responsibility, and reduces each agent’s action choice to a low-dimensional linear program.  ￼ HRVO extends reciprocal velocity-obstacle reasoning with explicit oscillation reduction for multi-agent navigation.  ￼ DWA remains relevant because it derives the admissible control set directly from robot dynamics, while TEB is relevant because it optimizes local trajectories for execution time, obstacle separation, and kinodynamic constraints.  ￼
+
+For Robot-SF, this means ORCA/HRVO/DWA/TEB should not be treated as outdated baselines. They should be used as trajectory proposal generators and diagnostic references inside a layered stack. The repository’s own planner-family coverage matrix already separates benchmark-ready planners from experimental and conceptually adjacent families; that distinction should remain strict.  ￼
+
+Learning-based social navigation
+
+The SOTA trend is not simply “bigger RL.” It is structured learning with prediction and safety. The 2025 Frontiers review explicitly identifies prediction-based and safety-aware families as central categories.  ￼ Recent methods such as SCOPE emphasize stochastic occupancy prediction conditioned on robot motion, dynamic-object motion, and static geometry, while future-aware social-navigation methods such as Falcon explicitly predict human trajectories and penalize actions that block future human paths.  ￼
+
+For Robot-SF, the practical SOTA-informed direction is:
+
+do not train policy(state) -> action only
+train / design policy(scene, route, prediction, uncertainty) -> short trajectory or command
+
+Benchmarking and evaluation
+
+The social-navigation evaluation literature warns that fair evaluation is hard because it includes static geometry, dynamic humans, and human perception of robot behavior. Francis et al. define social navigation in terms of safety, comfort, legibility, politeness, social competency, agent understanding, proactivity, and responsiveness to context.  ￼ SocNavBench addresses the same evaluation problem through photorealistic simulation, curated scenarios grounded in pedestrian data, and a metric suite for interpretable comparison.  ￼ BARN is a useful static-obstacle analogue: it shows that even metric ground navigation remains difficult in tightly constrained spaces, and it evaluates navigation using success, traversal time, and environment difficulty.  ￼
+
+Robot-SF should therefore keep a strict separation between:
+
+training scenarios
+development / adversarial scenarios
+frozen benchmark scenarios
+invalid or unsolvable fixtures
+
+The existing atomic scenario suite and verified-simple subset are a good foundation for this. The internal docs already define full runnable atomic scenarios, a verified-simple subset, validation-only fixtures, and scenario metadata such as purpose, expected behavior, pass criteria, failure modes, and primary capability.  ￼  ￼
+
+3. Proposed “best local policy” architecture
+
+I would implement policy_stack_v1 as a policy portfolio:
+
+Route layer:
+  visibility / Theta* / graph route
+  spawn-aware waypoint rebasing
+  local subgoal selection
+Scene layer:
+  robot state
+  pedestrian tracks
+  obstacle polygons / occupancy grid
+  bottleneck / corridor / doorway labels
+  local route topology
+Prediction layer:
+  constant-velocity baseline
+  SocialForce baseline
+  obstacle-conditioned graph predictor
+  stochastic occupancy-grid predictor
+Candidate layer:
+  ORCA / HRVO proposal
+  DWA / TEB / MPPI proposal
+  learned PPO / Dreamer proposal
+  stop / yield / backoff / commit maneuvers
+Risk layer:
+  collision probability
+  TTC
+  min-distance quantiles
+  comfort exposure
+  deadlock probability
+  route progress
+  uncertainty CVaR
+Safety layer:
+  hard clearance filter
+  braking-distance check
+  command feasibility check
+  emergency stop / yield policy
+Control layer:
+  unicycle / bicycle / e-scooter controller
+  acceleration and jerk limits
+  projection diagnostics
+
+The policy output should be a short trajectory or command sequence, not only an instantaneous (v, ω) action. Instantaneous commands are too weak for bottlenecks, head-on interactions, overtaking, and timing-sensitive pedestrian crossings.
+
+Minimal viable implementation
+
+Start with a non-learning stack:
+
+global path
+  + obstacle-aware local subgoal
+  + ORCA/HRVO/DWA candidate set
+  + TTC / distance / progress scoring
+  + braking-distance safety shield
+  + unicycle controller
+
+Then add learning only where it is most useful:
+
+1. learned pedestrian / occupancy prediction;
+2. learned risk scoring;
+3. learned proposal policy;
+4. end-to-end policy only as an ablation.
+
+This avoids a common failure mode: training an RL policy to compensate for missing route semantics, missing prediction, or invalid scenario geometry.
+
+4. Adversarial pedestrians
+
+The repository already contains the concept of a pedestrian as an adversarial agent that searches for weak points in the robot policy.  ￼ I would extend that into three levels.
+
+Level A — black-box parameter adversary
+
+Search over scenario parameters:
+
+robot_start: [x, y, theta]
+robot_goal: [x, y]
+ped_start: [x, y]
+ped_goal: [x, y]
+ped_spawn_time: t
+ped_speed: v
+ped_delay: dt
+ped_policy_seed: seed
+
+Objective:
+
+maximize:
+  robot_failure
+  + delay
+  + near_miss exposure
+  + comfort violation
+  + deadlock duration
+subject to:
+  pedestrian remains physically plausible
+  pedestrian has a valid route
+  pedestrian does not teleport
+  pedestrian does not intentionally collide from an impossible configuration
+
+This is close to adaptive stress testing. AST formulates failure search as a Markov decision process and uses reinforcement learning or MCTS-like methods to find likely failure trajectories in black-box simulators.  ￼
+
+Level B — scripted adversarial pedestrian families
+
+Implement reusable adversarial templates:
+
+Template	Failure mode
+ttc_crossing	pedestrian enters path at minimum time-to-collision margin
+doorway_blocker	pedestrian occupies the bottleneck exactly when robot commits
+head_on_mirror	pedestrian mirrors robot’s avoidance side, inducing oscillation
+group_squeeze	two pedestrians create a narrowing dynamic gap
+late_stop	pedestrian stops after the robot has committed
+overtake_cutoff	pedestrian moves parallel, then cuts across robot path
+shadowing	pedestrian remains near the robot’s blind or high-cost side
+queue_edge_case	pedestrian appears from behind a static obstacle or group
+
+These should be treated as development stress tests, not frozen benchmark cases until their solvability and plausibility are certified.
+
+Level C — learned multi-agent adversary
+
+Train one or more pedestrians against a frozen robot policy, then alternate:
+
+freeze robot policy
+train adversarial pedestrian(s)
+collect counterexamples
+retrain / tune robot policy
+freeze new robot policy
+retrain adversary
+
+The adversary reward should not simply reward collisions. It should reward plausible policy weakness:
+
+R_adv =
+  + failure_weight * robot_failure
+  + delay_weight * robot_delay
+  + near_miss_weight * near_miss_exposure
+  + deadlock_weight * deadlock_time
+  - implausibility_weight * deviation_from_human_motion_model
+  - effort_weight * pedestrian_control_effort
+  - illegality_weight * invalid_route_or_obstacle_overlap
+
+This prevents the adversary from becoming an unrealistic missile agent.
+
+5. Adaptive scenario definition
+
+Use a scenario grammar rather than only YAML enumeration. Scenic is the right conceptual model here: it is a probabilistic programming language for specifying distributions over scenes and dynamic-agent behaviors, with hard and soft constraints over scenario geometry and behavior.  ￼ Scenic also supports modeling stochastic multi-agent interactions with pedestrians, cyclists, and other traffic participants, and is an official scenario modeling language for CARLA.  ￼
+
+Robot-SF does not need to adopt Scenic immediately. It can implement a lightweight internal equivalent:
+
+scenario_template: crossing_ttc
+parameters:
+  robot_start: distribution
+  robot_goal: distribution
+  pedestrian_start: distribution
+  pedestrian_goal: distribution
+  spawn_time: distribution
+constraints:
+  - valid_robot_path_exists
+  - valid_pedestrian_path_exists
+  - min_static_clearance > 0.25
+  - initial_collision_free
+  - crossing_ttc in [1.0, 4.0]
+objectives:
+  - maximize near_miss
+  - maximize delay
+  - minimize pedestrian_implausibility
+
+Then implement:
+
+uv run python scripts/adversarial/search_scenarios.py \
+  --policy orca \
+  --scenario-template configs/scenarios/templates/crossing_ttc.yaml \
+  --search-space configs/adversarial/crossing_ttc_space.yaml \
+  --objective worst_case_snqi \
+  --out output/adversarial/strategy_2026_04_30/orca_crossing
+
+The output should be a counterexample bundle:
+
+scenario.yaml
+certificate.json
+episodes.jsonl
+trajectory.csv
+failure_attribution.json
+video.mp4
+
+6. Adversarial static scenario design: hard vs unsolvable
+
+The key problem is not generating harder static maps. It is certifying that they are solvable under the robot model.
+
+I would add robot_sf/scenario_certification/ with the following checks.
+
+Solvability taxonomy
+
+Label	Definition	Benchmark use
+invalid	start, goal, route, or obstacle geometry is malformed	validation fixture only
+geometrically_infeasible	no collision-free path exists after inflating obstacles by robot radius and safety margin	exclude from benchmark
+kinodynamically_infeasible	geometric path exists, but no path satisfies turning, acceleration, braking, or controller limits	exclude or mark separately
+dynamically_overconstrained	pedestrians can block all feasible paths indefinitely under allowed behavior	adversarial stress only
+knife_edge	oracle can solve only with near-zero clearance or timing margin	stress test, not headline benchmark
+hard_but_solvable	an oracle or high-budget planner solves with positive clearance and timing margin	valid benchmark candidate
+
+Certificate fields
+
+Each generated scenario should carry a machine-readable certificate:
+
+{
+  "schema": "robot_sf.scenario_cert.v1",
+  "scenario_id": "narrow_passage_generated_042",
+  "geometry": {
+    "inflated_path_exists": true,
+    "min_static_clearance_m": 0.32,
+    "shortest_path_length_m": 18.7,
+    "path_length_ratio": 1.42
+  },
+  "kinodynamics": {
+    "candidate_exists": true,
+    "min_turning_radius_ok": true,
+    "braking_margin_m_p05": 0.44
+  },
+  "dynamic_agents": {
+    "nominal_oracle_success_rate": 0.96,
+    "adversarial_success_rate": 0.71,
+    "oracle_min_distance_p05_m": 0.38
+  },
+  "baselines": {
+    "goal": "fail",
+    "orca": "pass",
+    "social_force": "fail",
+    "policy_stack_v1": "pass"
+  },
+  "difficulty": {
+    "consensus_rank": 0.82,
+    "seed_cv": 0.18,
+    "label": "hard_but_solvable"
+  }
+}
+
+The existing scenario-difficulty analysis already uses a consensus-outcome ranking and planner residual logic to distinguish “hard for everyone” from planner-specific mismatch. That should become a formal input into the certificate, not just a post-hoc report.  ￼
+
+7. Transfer to CARLA
+
+Robot-SF should transfer insights to CARLA only after the abstractions are simulator-independent. CARLA is appropriate for the next realism layer because it supports autonomous-driving simulation, flexible sensor suites, environmental conditions, open assets, and controlled scenarios of increasing difficulty.  ￼ CARLA also exposes control over static and dynamic actors, pedestrians, sensors, weather, maps, ScenarioRunner, and ROS integration.  ￼
+
+Transfer readiness criteria
+
+Move to CARLA when all six conditions are true:
+
+1. robot_sf has a stable scenario certificate format.
+2. The policy consumes simulator-independent observations: robot state, local grid, obstacle geometry, pedestrian tracks, prediction uncertainty, route.
+3. The policy outputs physical commands or local trajectories, not simulator-specific action IDs.
+4. Metrics are trajectory-based: success, collision, TTC, min distance, comfort, jerk, curvature, intervention rate, SNQI.
+5. Counterexamples are stable across seeds and not artifacts of SVG parsing, route handoff, or action projection.
+6. The policy passes:
+    * verified-simple subset,
+    * full atomic suite,
+    * classic + Francis 2023 scenario set,
+    * adversarial development set,
+    * frozen holdout seeds.
+
+Transfer stages
+
+Stage	Goal	Sensor model	Actor model
+T0	Export Robot-SF scenarios to neutral JSON	oracle	replay
+T1	CARLA 2D oracle parity	ground-truth tracks and map	scripted pedestrians
+T2	CARLA kinematic parity	ground truth	controlled robot dynamics
+T3	CARLA perception stress	LiDAR / camera / noisy tracks	scripted + Traffic Manager
+T4	CARLA policy validation	realistic perception stack	ScenarioRunner / Scenic-generated cases
+
+Do not start with CARLA training. Start with CARLA replay and parity. Otherwise, simulator complexity will hide whether a failure comes from policy logic, perception, dynamics, pedestrian behavior, or scenario translation.
+
+8. Roadmap
+
+Phase 1 — clean benchmark semantics
+
+Implement these first:
+
+1. Fix first-waypoint / spawn handoff: #730￼.
+2. Fix or fail-close invalid SVG obstacle conversion: #837￼.
+3. Unify SNQI semantics across training and benchmarking: #455￼.
+4. Add scenario_cert.v1.
+5. Produce a policy-by-scenario failure matrix.
+
+Recommended baseline command:
+
+uv run python scripts/tools/policy_analysis_run.py \
+  --scenario configs/scenarios/classic_interactions_francis2023.yaml \
+  --policy-sweep \
+  --seed-set eval \
+  --output output/benchmarks/strategy_2026_04_30/policy_sweep
+
+Phase 2 — adversarial development loop
+
+Add:
+
+1. black-box scenario-parameter search;
+2. scripted adversarial pedestrian families;
+3. counterexample replay suite;
+4. adversarial scorecards;
+5. separation of training_adversarial, dev_falsification, and frozen_eval.
+
+Phase 3 — layered policy stack
+
+Implement policy_stack_v1:
+
+1. route rebasing;
+2. obstacle-aware local subgoals;
+3. ORCA/HRVO/DWA/MPPI candidate generation;
+4. obstacle-conditioned pedestrian prediction;
+5. TTC / CVaR / comfort scoring;
+6. hard safety shield;
+7. unicycle / e-scooter controller.
+
+Phase 4 — CARLA bridge
+
+Create:
+
+robot_sf_carla_bridge/
+  scenario_export.py
+  carla_replay.py
+  observation_adapter.py
+  policy_adapter.py
+  metric_adapter.py
+
+First target: replay 10 certified Robot-SF scenarios in CARLA with oracle observations and scripted pedestrians. Only after parity should sensor-level perception be introduced.
+
+9. Concrete new issues to open
+
+1. feat: scenario certification v1
+    Add geometric, kinodynamic, dynamic, and oracle feasibility checks.
+2. feat: adversarial scenario search CLI
+    Add black-box seed/start/goal/timing search with CMA-ES, Bayesian optimization, or AST-style RL.
+3. feat: multi-pedestrian adversarial environment
+    Extend the adversarial-pedestrian environment to 1–N pedestrians with plausibility constraints.
+4. feat: obstacle-conditioned prediction baseline
+    Start with hand-engineered obstacle features, then move to graph + occupancy-grid fusion.
+5. feat: policy_stack_v1 portfolio planner
+    Combine ORCA/HRVO/DWA/learned proposals with risk scoring and a safety shield.
+6. feat: CARLA oracle replay bridge
+    Export certified Robot-SF scenarios into CARLA and compare trajectory-level metrics.
+
+Bottom line
+
+The strongest next step is a certified, adversarially tested, layered local-navigation stack. Better perception, scene understanding, prediction, decision making, and control all matter, but they should not be pursued independently. The immediate bottleneck is the lack of a closed loop that can say:
+
+this scenario is valid,
+this scenario is solvable,
+this policy failed for a known reason,
+this adversarial case is plausible,
+this improvement transfers beyond Robot-SF.
+
+Once that loop exists, Robot-SF becomes a fast falsification and policy-development platform. CARLA then becomes the higher-fidelity validation layer, not a premature replacement.
+
+References and visited links
+
+* robot_sf_ll7 repository￼ — Author: ll7; Publication: GitHub repository; Publication date: not applicable; Access date: 2026-04-30.
+
+<!-- Relevance: Primary repository inspected for current architecture, adversarial pedestrian support, environment factory, tests, release artifact, and project scope. -->
+
+* docs/README.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Documents current benchmark platform, SNQI, runner, metrics, and analysis capabilities. -->
+
+* docs/benchmark_spec.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Defines current scenario split, seed policy, baseline categories, metrics, and reproducible benchmark commands. -->
+
+* docs/context/issue_596_verified_simple_gate_proposal.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Provides existing atomic-scenario and verified-simple gate structure. -->
+
+* docs/context/issue_596_atomic_scenario_matrix.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Identifies scenario capabilities, target failure modes, and verified-simple membership. -->
+
+* docs/context/issue_692_scenario_difficulty_analysis.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Existing basis for scenario difficulty, consensus ranking, and planner residual analysis. -->
+
+* docs/benchmark_planner_family_coverage.md￼ — Author: ll7; Publication: GitHub repository documentation; Publication date: not visible; Access date: 2026-04-30.
+
+<!-- Relevance: Current planner-family coverage and readiness boundaries. -->
+
+* Issue #730: Fix brittle first-waypoint handoff￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
+
+<!-- Relevance: Shared route-handling failure can contaminate planner comparisons. -->
+
+* Issue #789: DreamerV3 multi-modal encoder￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
+
+<!-- Relevance: Supports the recommendation to preserve spatial occupancy-grid structure. -->
+
+* Issue #592: Hybrid graph + obstacle-context predictive model￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
+
+<!-- Relevance: Directly matches the proposed obstacle-conditioned prediction layer. -->
+
+* Issue #707: Improve ORCA performance on atomic failure scenarios￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
+
+<!-- Relevance: Shows known ORCA failure slices and the need for failure attribution. -->
+
+* Issue #768: Benchmark ORCA variants￼ — Author: ll7; Publication: GitHub issue; Publication date: not visible from connector; Access date: 2026-04-30.
+
+<!-- Relevance: Relevant to ORCA-DD / nonholonomic ORCA comparison. -->
+
+* Social robot navigation: a review and benchmarking of learning-based methods￼ — Author: Rashid Alyassi, Cesar Cadena, Robert Riener, Diego Paez-Granados; Publication: Frontiers in Robotics and AI; Publication date: 2025-12-11; Access date: 2026-04-30.
+
+<!-- Relevance: Current SOTA taxonomy for learning-based social-navigation methods. -->
+
+* Principles and Guidelines for Evaluating Social Robot Navigation Algorithms￼ — Author: Anthony Francis et al.; Publication: ACM Transactions on Human-Robot Interaction; Publication date: 2025-02-20; Access date: 2026-04-30.
+
+<!-- Relevance: Evaluation principles for social navigation: safety, comfort, legibility, politeness, social competency, agent understanding, proactivity, and responsiveness to context. -->
+
+* SocNavBench: A Grounded Simulation Testing Framework for Evaluating Social Navigation￼ — Author: Abhijat Biswas, Allan Wang, Gustavo Silvera, Aaron Steinfeld, Henny Admoni; Publication: ACM THRI / CMU Robotics Institute page; Publication date: 2021-08; Access date: 2026-04-30.
+
+<!-- Relevance: Benchmark design reference for social-navigation scenarios and metrics. -->
+
+* BARN Challenge￼ — Author: Xuesu Xiao et al.; Publication: ICRA 2022 Challenge page; Publication date: 2022; Access date: 2026-04-30.
+
+<!-- Relevance: Static-obstacle benchmark reference for difficulty-ranked, constrained navigation. -->
+
+* Optimal Reciprocal Collision Avoidance￼ — Author: Jur van den Berg, Stephen J. Guy, Jamie Snape, Ming C. Lin, Dinesh Manocha; Publication: ORCA project page; Publication date: related publications 2008–2011; Access date: 2026-04-30.
+
+<!-- Relevance: Classical reciprocal collision-avoidance baseline and proposal generator. -->
+
+* The Hybrid Reciprocal Velocity Obstacle￼ — Author: Jamie Snape, Jur van den Berg, Stephen J. Guy, Dinesh Manocha; Publication: IEEE Transactions on Robotics; Publication date: 2011-08; Access date: 2026-04-30.
+
+<!-- Relevance: HRVO baseline for oscillation-aware reciprocal avoidance. -->
+
+* The Dynamic Window Approach to Collision Avoidance￼ — Author: Dieter Fox, Wolfram Burgard, Sebastian Thrun; Publication: IEEE Robotics and Automation Magazine; Publication date: 1997-03; Access date: 2026-04-30.
+
+<!-- Relevance: Dynamics-aware local control baseline. -->
+
+* teb_local_planner ROS package￼ — Author: Christoph Rösmann et al.; Publication: ROS package index; Publication date: package page, rolling updates; Access date: 2026-04-30.
+
+<!-- Relevance: Kinodynamic local trajectory-optimization reference. -->
+
+* Adaptive stress testing: finding likely failure events with reinforcement learning￼ — Author: Ritchie Lee et al.; Publication: Journal of Artificial Intelligence Research / MIT Lincoln Laboratory page; Publication date: 2020-12-01; Access date: 2026-04-30.
+
+<!-- Relevance: Methodological basis for adversarial failure search. -->
+
+* Scenic: a language for scenario specification and data generation￼ — Author: Daniel J. Fremont et al.; Publication: Machine Learning; Publication date: 2022-02-02; Access date: 2026-04-30.
+
+<!-- Relevance: Scenario grammar, probabilistic scenario generation, and hard/soft constraints. -->
+
+* The Scenic Programming Language￼ — Author: Scenic project contributors; Publication: Project website; Publication date: site copyright 2019–2025; Access date: 2026-04-30.
+
+<!-- Relevance: Shows Scenic’s multi-agent, spatiotemporal, formal scenario-modeling capabilities and CARLA connection. -->
+
+* CARLA: An Open Urban Driving Simulator￼ — Author: Alexey Dosovitskiy, German Ros, Felipe Codevilla, Antonio Lopez, Vladlen Koltun; Publication: Proceedings of Machine Learning Research, CoRL 2017; Publication date: 2017; Access date: 2026-04-30.
+
+<!-- Relevance: CARLA transfer target and simulator baseline. -->
+
+* CARLA Simulator￼ — Author: CARLA Team; Publication: Project website; Publication date: current site, latest news through 2025; Access date: 2026-04-30.
+
+<!-- Relevance: Current CARLA capabilities: sensors, dynamic actors, ScenarioRunner, ROS bridge, maps. -->
+
+* SCOPE: Stochastic Cartographic Occupancy Prediction Engine for Uncertainty-Aware Dynamic Navigation￼ — Author: Zhanteng Xie, Philip Dames; Publication: GitHub repository / IEEE Transactions on Robotics 2025 paper; Publication date: 2025; Access date: 2026-04-30.
+
+<!-- Relevance: Modern occupancy-prediction reference for uncertainty-aware dynamic navigation. -->
+
+* Falcon: From Cognition to Precognition￼ — Author: Zeying Gong, Tianshuai Hu, Ronghe Qiu, Junwei Liang; Publication: GitHub repository / ICRA 2025 paper; Publication date: 2025; Access date: 2026-04-30.
+
+<!-- Relevance: Recent future-aware social-navigation example using trajectory prediction and future-path blocking penalties. -->

--- a/docs/plan/plan_big_picture_2026-04-30.md
+++ b/docs/plan/plan_big_picture_2026-04-30.md
@@ -212,13 +212,18 @@ Use these proof gates:
 
 ### Paper-critical or paper-risk issues
 
-1. Audit issue-791 claim language against the narrow benchmark-set decision.
+1. Audit issue-791 claim language against the narrow benchmark-set decision
+   (`memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md` and
+   `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md`).
 2. Verify camera-ready PPO provenance, benchmark command, seed/bootstrap evidence, and SNQI
-   diagnostics.
-3. Audit baseline planner dependencies and native/adapter/fallback modes for the paper matrix.
-4. Verify durable artifact references for model, benchmark, SNQI, and release inputs.
-5. Resolve or caveat route handoff, invalid geometry, metric drift, and fallback/degraded execution
-   before using affected failures as policy evidence.
+   diagnostics (`docs/benchmark_camera_ready.md` and release reproducibility docs).
+3. Audit baseline planner dependencies and native/adapter/fallback modes for the paper matrix using
+   `docs/benchmark_planner_family_coverage.md` and
+   `docs/context/issue_691_benchmark_fallback_policy.md`.
+4. Verify durable artifact references for model, benchmark, SNQI, and release inputs, following the
+   artifact durability rules in `AGENTS.md`.
+5. Resolve or caveat route handoff (`#730`), invalid SVG geometry (`#837`), SNQI semantics (`#455`),
+   metric drift, and fallback/degraded execution before using affected failures as policy evidence.
 
 ### Research follow-up issues
 

--- a/docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md
+++ b/docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md
@@ -1,0 +1,557 @@
+# Big-Picture Two-Horizon Plan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Revise `docs/plan/plan_big_picture_2026-04-30.md` into a two-horizon strategy that supports near-term paper delivery and long-term research roadmap quality.
+
+**Architecture:** This is a documentation-only change. The revised plan should keep useful strategic content, but reorganize it around Horizon A for camera-ready paper delivery, Horizon B for post-paper research, and a shared evidence/proof spine that prevents speculative roadmap work from becoming paper-facing claims.
+
+**Tech Stack:** Markdown documentation, repository context notes, benchmark documentation, `rg`, `sed`, `git diff`, and lightweight link/path validation.
+
+---
+
+## File Structure
+
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+  - Owns the final two-horizon strategy.
+  - Should become the source a future agent can read to understand immediate paper priorities and longer-term research sequence.
+- Reference only: `docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md`
+  - Approved design contract for this implementation plan.
+- Reference only: `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md`
+  - Evidence that PPO distribution alignment dominates the observed lift.
+- Reference only: `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md`
+  - Evidence that paper language must be benchmark-set scoped rather than OOD/generalization scoped.
+- Reference only: `docs/context/dreamerv3_program_close_out_2026_04_30.md`
+  - Evidence that DreamerV3 is deprioritized for camera-ready scope.
+- Reference only: `docs/benchmark_planner_family_coverage.md`
+  - Evidence for planner-family claim boundaries.
+- Reference only: `docs/benchmark_camera_ready.md`
+  - Evidence for camera-ready benchmark, SNQI, and artifact obligations.
+- Reference only: `docs/context/issue_691_benchmark_fallback_policy.md`
+  - Evidence that fallback/degraded execution is a limitation, not benchmark-strengthening proof.
+
+## Task 1: Confirm Source Context Before Editing
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md`
+- Read: `docs/plan/plan_big_picture_2026-04-30.md`
+- Read: `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md`
+- Read: `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md`
+- Read: `docs/context/dreamerv3_program_close_out_2026_04_30.md`
+- Read: `docs/benchmark_planner_family_coverage.md`
+
+- [ ] **Step 1: Read the approved design spec**
+
+Run:
+
+```bash
+sed -n '1,260p' docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md
+```
+
+Expected: the output includes `Horizon A: Paper Delivery Plan`, `Horizon B: Research Roadmap`, `Priority Order`, and `Validation Model`.
+
+- [ ] **Step 2: Read the current strategy document**
+
+Run:
+
+```bash
+sed -n '1,620p' docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: the output shows the current broad strategy, including policy-stack, adversarial, scenario-certification, CARLA, roadmap, and references sections.
+
+- [ ] **Step 3: Read the current PPO and claim-boundary evidence**
+
+Run:
+
+```bash
+sed -n '1,180p' memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md
+sed -n '1,180p' memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md
+```
+
+Expected: the first output states distribution alignment dominates the PPO lift; the second states the paper claim is a strong benchmark-set result, not OOD generalization.
+
+- [ ] **Step 4: Read the DreamerV3 and planner-family boundaries**
+
+Run:
+
+```bash
+sed -n '1,220p' docs/context/dreamerv3_program_close_out_2026_04_30.md
+sed -n '1,150p' docs/benchmark_planner_family_coverage.md
+```
+
+Expected: the DreamerV3 note says the track is closed/deprioritized for paper scope; the planner-family matrix distinguishes benchmarkable, experimental, conceptually adjacent, and missing planner families.
+
+- [ ] **Step 5: Inspect the working tree before edits**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only this implementation plan may be uncommitted if the plan has not yet been committed. Do not revert unrelated user changes.
+
+## Task 2: Replace the Top-Level Thesis and Evidence Summary
+
+**Files:**
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Replace the opening with the two-horizon thesis**
+
+Edit the beginning of `docs/plan/plan_big_picture_2026-04-30.md` so it starts with this structure:
+
+```markdown
+# Robot-SF two-horizon improvement strategy - 2026-04-30
+
+## Core recommendation
+
+Robot-SF should optimize for two linked horizons:
+
+1. **Near-term paper delivery:** protect a defensible camera-ready benchmark story with clear
+   provenance, SNQI contract evidence, baseline boundaries, and durable artifacts.
+2. **Long-term research roadmap:** build a certified, adversarially tested, layered local-navigation
+   stack after the benchmark claim is stable.
+
+The near-term target is not "one best local policy." It is a falsifiable benchmark claim:
+
+> A strong Robot-SF policy and baseline set evaluated on the maintained scenario matrix, with
+> clear planner provenance, seed/bootstrap uncertainty, SNQI diagnostics, and no fallback execution
+> counted as benchmark success.
+
+The long-term target is a policy-improvement loop:
+
+```text
+scenario generator
+  -> scenario certificate
+  -> policy sweep
+  -> failure attribution
+  -> adversarial search
+  -> counterexample replay set
+  -> training / planner update
+  -> frozen holdout evaluation
+```
+```
+
+Expected: the document no longer opens by implying that policy-stack construction is the immediate first priority.
+
+- [ ] **Step 2: Add a current-evidence section after the core recommendation**
+
+Insert this section immediately after the opening thesis:
+
+```markdown
+## Current evidence that changes the priority order
+
+- `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md` shows that
+  eval-aligned PPO training explains most of the observed lift to the current strong policy. Do not
+  credit architecture, curriculum, or foresight as the dominant driver without new evidence.
+- `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md` fixes the paper framing:
+  benchmark-set performance across the scenario matrix, not OOD generalization or transfer.
+- `docs/context/dreamerv3_program_close_out_2026_04_30.md` closes and deprioritizes the DreamerV3
+  track for camera-ready scope after repeated no-eval runs, NaNs, and OOM.
+- `docs/benchmark_planner_family_coverage.md` is the claim boundary for planner families. Only
+  implemented-and-benchmarkable rows should support current benchmark claims.
+- `docs/benchmark_camera_ready.md`, `docs/benchmark_release_protocol.md`, and
+  `docs/benchmark_release_reproducibility.md` define the paper-facing benchmark, SNQI, release,
+  and artifact obligations.
+- `docs/context/issue_691_benchmark_fallback_policy.md` is the fallback boundary: fallback or
+  degraded execution is a caveat or exclusion reason, not evidence of benchmark success.
+```
+
+Expected: the plan explicitly names the repository evidence that governs the rewrite.
+
+- [ ] **Step 3: Run a focused opening-section review**
+
+Run:
+
+```bash
+sed -n '1,120p' docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: the first 120 lines contain the two-horizon thesis and the current-evidence section.
+
+## Task 3: Build Horizon A for Paper Delivery
+
+**Files:**
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Add the Horizon A section**
+
+Create or replace the near-term roadmap area with this section:
+
+```markdown
+## Horizon A - near-term paper delivery
+
+The paper track is the first execution priority. It should produce a claim that a reviewer can
+audit from committed configs, benchmark artifacts, and context notes.
+
+### A1. Protect the claim language
+
+Use this public framing:
+
+- strong policy on a broad maintained scenario matrix,
+- comparison against baseline-ready planners under the same benchmark contract,
+- seed/bootstrap uncertainty and SNQI diagnostics reported with the result.
+
+Avoid this framing unless a separate study exists:
+
+- OOD generalization,
+- transfer to unseen environments,
+- architecture-driven lift beyond the eval-aligned PPO evidence,
+- DreamerV3 as a promoted benchmark competitor.
+
+### A2. Preserve benchmark and SNQI evidence
+
+Paper-facing benchmark evidence must include:
+
+- canonical benchmark command or release workflow,
+- planner list and kinematics mode,
+- SNQI weights, baseline assets, diagnostics, and sensitivity status,
+- bootstrap or seed-variance evidence,
+- artifact paths or durable artifact references,
+- explicit fallback/degraded/not-available status for planners that fail their contract.
+
+### A3. Keep planner-family claims conservative
+
+Use `docs/benchmark_planner_family_coverage.md` as the support boundary:
+
+- benchmarkable: current paper-facing support when provenance and dependencies are valid,
+- implemented but experimental: controlled experiments only,
+- conceptually adjacent: background or roadmap only,
+- missing: future work only.
+
+### A4. Treat semantic blockers as paper risks
+
+Resolve or caveat these before using failures as policy evidence:
+
+- route handoff or first-waypoint errors,
+- invalid SVG obstacle conversion,
+- SNQI or metric-contract drift,
+- missing optional planner dependencies,
+- fallback or degraded execution,
+- worktree-local artifacts that have not been promoted to durable evidence.
+```
+
+Expected: the paper track appears before adversarial, policy-stack, and CARLA roadmap sections.
+
+- [ ] **Step 2: Add Horizon A proof obligations**
+
+Append this subsection to Horizon A:
+
+```markdown
+### Horizon A proof obligations
+
+| Claim type | Required proof |
+| --- | --- |
+| PPO benchmark result | canonical config, model artifact provenance, benchmark run, seed/bootstrap evidence, SNQI diagnostics |
+| Baseline planner result | implemented benchmark entrypoint, dependency availability, native/adapter mode, non-fallback execution |
+| SNQI conclusion | versioned weights, baseline normalization assets, contract diagnostics, sensitivity or ablation status |
+| Release artifact | durable artifact reference or tracked manifest, plus enough metadata to recover the exact input |
+| Failure attribution | scenario validity, planner mode, route/geometry sanity, and reproducible episode or counterexample bundle |
+```
+
+Expected: the document defines what evidence must exist before a paper-facing claim is complete.
+
+## Task 4: Reframe Long-Term Research as Horizon B
+
+**Files:**
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Convert the existing policy-stack, adversarial, scenario, and CARLA content into Horizon B**
+
+Create a `## Horizon B - long-term research roadmap` section after Horizon A. Use this opening:
+
+```markdown
+## Horizon B - long-term research roadmap
+
+After the paper track is stable, Robot-SF should become a fast falsification and policy-development
+platform. The roadmap remains a layered local-navigation stack, but every promotion step must pass
+through executable Robot-SF evidence before it supports a manuscript or benchmark claim.
+```
+
+Expected: the long-term content is explicitly sequenced after the paper track.
+
+- [ ] **Step 2: Preserve scenario certification as the first Horizon B workstream**
+
+Include this subsection:
+
+```markdown
+### B1. Scenario certification
+
+Add a `scenario_cert.v1` concept before expanding adversarial scenario generation. The certificate
+should classify scenarios as invalid, geometrically infeasible, kinodynamically infeasible,
+dynamically overconstrained, knife-edge, or hard-but-solvable.
+
+The first useful certificate should cover:
+
+- inflated collision-free path existence,
+- minimum static clearance,
+- route validity for robot and pedestrians,
+- kinodynamic feasibility checks for turning, acceleration, and braking,
+- dynamic-agent plausibility,
+- oracle or high-budget baseline success evidence,
+- difficulty labels that distinguish universal hardness from planner-specific mismatch.
+```
+
+Expected: adversarial generation no longer precedes scenario validity.
+
+- [ ] **Step 3: Preserve adversarial falsification as the second Horizon B workstream**
+
+Include this subsection:
+
+```markdown
+### B2. Adversarial falsification
+
+Adversarial pedestrians and static scenarios should be development stress tools before they become
+frozen benchmark cases.
+
+Recommended sequence:
+
+1. black-box parameter search over starts, goals, timing, speed, and seeds;
+2. scripted adversarial families such as crossing, bottleneck blocker, mirror avoidance, group
+   squeeze, late stop, cutoff, and occluded emergence;
+3. counterexample replay bundles with scenario, certificate, episodes, trajectory, attribution, and
+   video;
+4. learned multi-agent adversaries only after plausibility constraints and replay evidence exist.
+```
+
+Expected: learned adversaries are not framed as immediate paper work.
+
+- [ ] **Step 4: Preserve policy-stack work as the third Horizon B workstream**
+
+Include this subsection:
+
+```markdown
+### B3. Layered policy portfolio
+
+The long-term local policy should be a portfolio stack rather than a monolithic policy:
+
+```text
+route / topology
+  -> scene graph + local free-space representation
+  -> pedestrian / occupancy prediction
+  -> candidate trajectory generation
+  -> risk-aware trajectory scoring
+  -> safety shield
+  -> robot-specific controller
+```
+
+Start with a non-learning stack using route rebasing, obstacle-aware subgoals, ORCA/HRVO/DWA/MPPI
+proposal generation, TTC/distance/progress scoring, braking-distance checks, and a unicycle or
+e-scooter controller. Add learning in this order: prediction, risk scoring, proposal policy, then
+end-to-end policy as an ablation.
+```
+
+Expected: the policy stack remains in the roadmap but is no longer the first near-term priority.
+
+- [ ] **Step 5: Preserve CARLA as a gated transfer track**
+
+Include this subsection:
+
+```markdown
+### B4. CARLA transfer
+
+CARLA should be a higher-fidelity validation layer, not the starting point for training.
+
+Transfer readiness requires:
+
+- stable scenario certificates,
+- simulator-independent observations,
+- physical command or local-trajectory outputs,
+- trajectory-based metrics,
+- counterexamples that are stable across seeds and not parser or route artifacts,
+- validated Robot-SF performance on verified-simple, atomic, classic, adversarial-development, and
+  frozen evaluation sets.
+
+The first CARLA target should be oracle replay/parity for certified Robot-SF scenarios. Sensor-level
+perception and CARLA training should come after replay parity.
+```
+
+Expected: CARLA work is useful but explicitly deferred behind Robot-SF contracts.
+
+## Task 5: Add Sequencing and Issue Candidate Tables
+
+**Files:**
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Add a sequencing table**
+
+Add this section after Horizon B:
+
+```markdown
+## Sequencing
+
+| Order | Work | Horizon | Why now |
+| --- | --- | --- | --- |
+| 1 | Claim-language cleanup and provenance audit | A | Prevents overclaiming before paper text and PRs reuse the result |
+| 2 | Camera-ready benchmark validation and SNQI diagnostics | A | Produces reviewer-auditable evidence |
+| 3 | Durable artifact and config provenance check | A | Makes the result recoverable outside this worktree |
+| 4 | Route, geometry, metric, and fallback blockers | A | Prevents invalid failure attribution |
+| 5 | Scenario certification v1 | B | Makes generated hard cases distinguishable from invalid cases |
+| 6 | Failure attribution and adversarial replay bundles | B | Turns failures into reusable development evidence |
+| 7 | Layered policy portfolio | B | Improves local navigation after the evaluation substrate is trustworthy |
+| 8 | CARLA oracle replay/parity | B | Tests transfer only after simulator-independent contracts exist |
+```
+
+Expected: a future agent can identify what to do now, next, and later.
+
+- [ ] **Step 2: Replace the issue candidate section with paper-risk and research-follow-up groups**
+
+Use this structure:
+
+```markdown
+## Issue candidates
+
+### Paper-critical or paper-risk issues
+
+1. Audit issue-791 claim language against the narrow benchmark-set decision.
+2. Verify camera-ready PPO provenance, benchmark command, seed/bootstrap evidence, and SNQI
+   diagnostics.
+3. Audit baseline planner dependencies and native/adapter/fallback modes for the paper matrix.
+4. Verify durable artifact references for model, benchmark, SNQI, and release inputs.
+5. Resolve or caveat route handoff, invalid geometry, metric drift, and fallback/degraded execution
+   before using affected failures as policy evidence.
+
+### Research follow-up issues
+
+1. Add `scenario_cert.v1` for geometric, kinodynamic, dynamic-agent, and difficulty certification.
+2. Add adversarial scenario search with plausibility constraints and counterexample replay bundles.
+3. Extend adversarial pedestrians from single-agent templates to constrained multi-agent stress
+   tests.
+4. Add obstacle-conditioned prediction baselines and scene representations.
+5. Build `policy_stack_v1` as a portfolio planner with safety shielding and controller diagnostics.
+6. Add CARLA oracle replay/parity for certified Robot-SF scenarios.
+```
+
+Expected: the issue list no longer mixes paper-critical work and exploratory research.
+
+## Task 6: Clean Up Conflicting or Stale Language
+
+**Files:**
+- Modify: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Search for public-claim risk words**
+
+Run:
+
+```bash
+rg -n "generaliz|transfer|unseen|OOD|DreamerV3|best local policy|CARLA training|fallback" docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: every match is either in a caveat, a long-term roadmap section, or a sentence that explicitly says the claim is out of near-term paper scope.
+
+- [ ] **Step 2: Rewrite risky phrases**
+
+Apply these replacements where the current wording makes near-term claims too broad:
+
+```text
+"best local policy" -> "defensible benchmark-set policy and long-term local-policy roadmap"
+"transfer to CARLA" -> "CARLA oracle replay/parity after Robot-SF contracts exist"
+"OOD generalization" -> "out-of-scope OOD generalization unless a separate study is run"
+"DreamerV3 challenger" -> "DreamerV3 historical/deprioritized track"
+"fallback success" -> "fallback/degraded caveat or exclusion"
+```
+
+Expected: the plan does not encourage public claims that conflict with current memory decisions.
+
+- [ ] **Step 3: Search for stale replacement targets**
+
+Run:
+
+```bash
+rg -n "best local policy|CARLA training|DreamerV3 challenger|fallback success" docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: no matches remain.
+
+## Task 7: Validate the Revised Document
+
+**Files:**
+- Validate: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Check referenced repository paths exist**
+
+Run:
+
+```bash
+while read -r path; do test -e "$path" || echo "missing: $path"; done <<'EOF'
+docs/plan/plan_big_picture_2026-04-30.md
+docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md
+memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md
+memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md
+docs/context/dreamerv3_program_close_out_2026_04_30.md
+docs/benchmark_planner_family_coverage.md
+docs/benchmark_camera_ready.md
+docs/benchmark_release_protocol.md
+docs/benchmark_release_reproducibility.md
+docs/context/issue_691_benchmark_fallback_policy.md
+EOF
+```
+
+Expected: no `missing:` lines.
+
+- [ ] **Step 2: Search for unfinished markers in the revised strategy**
+
+Run:
+
+```bash
+rg -n "T""BD|TO""DO|FIX""ME|place""holder|implement la""ter|fill in det""ails" docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Review the final diff**
+
+Run:
+
+```bash
+git diff -- docs/plan/plan_big_picture_2026-04-30.md
+```
+
+Expected: the diff shows a documentation-only rewrite that adds the two-horizon structure and removes or demotes stale near-term claims.
+
+- [ ] **Step 4: Run a lightweight docs sanity check**
+
+Run:
+
+```bash
+uv run ruff check .
+```
+
+Expected: PASS. If this command reports unrelated pre-existing failures, record the exact failures in the final handoff and do not fix unrelated files.
+
+## Task 8: Commit the Plan Revision
+
+**Files:**
+- Commit: `docs/plan/plan_big_picture_2026-04-30.md`
+
+- [ ] **Step 1: Inspect status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: `docs/plan/plan_big_picture_2026-04-30.md` is modified. This implementation plan may also be present if it has not been committed separately.
+
+- [ ] **Step 2: Commit only the intended documentation files**
+
+Run:
+
+```bash
+git add docs/plan/plan_big_picture_2026-04-30.md docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md
+git commit -m "docs: refine big-picture plan into two horizons"
+```
+
+Expected: commit succeeds. Pre-commit hooks may skip code-only checks for Markdown-only changes.
+
+- [ ] **Step 3: Capture final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes from this implementation remain.

--- a/docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md
+++ b/docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md
@@ -2,6 +2,10 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Status:** Implemented in commit `80a8ad7a` (`docs: refine big-picture plan into two horizons`).
+> This file is retained as the execution record and reference plan; unchecked boxes reflect the
+> original implementation checklist, not active unexecuted work.
+
 **Goal:** Revise `docs/plan/plan_big_picture_2026-04-30.md` into a two-horizon strategy that supports near-term paper delivery and long-term research roadmap quality.
 
 **Architecture:** This is a documentation-only change. The revised plan should keep useful strategic content, but reorganize it around Horizon A for camera-ready paper delivery, Horizon B for post-paper research, and a shared evidence/proof spine that prevents speculative roadmap work from becoming paper-facing claims.
@@ -101,7 +105,7 @@ Expected: only this implementation plan may be uncommitted if the plan has not y
 
 Edit the beginning of `docs/plan/plan_big_picture_2026-04-30.md` so it starts with this structure:
 
-```markdown
+````markdown
 # Robot-SF two-horizon improvement strategy - 2026-04-30
 
 ## Core recommendation
@@ -131,7 +135,7 @@ scenario generator
   -> training / planner update
   -> frozen holdout evaluation
 ```
-```
+````
 
 Expected: the document no longer opens by implying that policy-stack construction is the immediate first priority.
 
@@ -321,7 +325,7 @@ Expected: learned adversaries are not framed as immediate paper work.
 
 Include this subsection:
 
-```markdown
+````markdown
 ### B3. Layered policy portfolio
 
 The long-term local policy should be a portfolio stack rather than a monolithic policy:
@@ -340,7 +344,7 @@ Start with a non-learning stack using route rebasing, obstacle-aware subgoals, O
 proposal generation, TTC/distance/progress scoring, braking-distance checks, and a unicycle or
 e-scooter controller. Add learning in this order: prediction, risk scoring, proposal policy, then
 end-to-end policy as an ablation.
-```
+````
 
 Expected: the policy stack remains in the roadmap but is no longer the first near-term priority.
 

--- a/docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md
+++ b/docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md
@@ -1,0 +1,156 @@
+# Two-Horizon Big-Picture Plan Design
+
+Date: 2026-04-30
+Target document: `docs/plan/plan_big_picture_2026-04-30.md`
+Status: approved design draft for plan refinement
+
+## Goal
+
+Refine the current Robot-SF improvement strategy into a two-horizon plan that serves both
+near-term paper delivery and long-term research roadmap quality.
+
+The plan should keep the useful strategic ideas from the current document, but make the immediate
+priority unambiguous: defensible camera-ready benchmark evidence comes before new policy-stack,
+adversarial, DreamerV3, or CARLA expansion.
+
+## Boundaries
+
+In scope:
+
+- Restructure the big-picture plan into near-term and long-term horizons.
+- Preserve useful roadmap ideas while gating them behind evidence and sequencing.
+- Incorporate current repository evidence on PPO, DreamerV3, SNQI, planner readiness, and artifact
+  durability.
+- Make proof obligations explicit for paper-facing claims and research-roadmap promotions.
+
+Out of scope:
+
+- Implementing benchmark, planner, training, scenario-certification, adversarial, or CARLA code.
+- Opening or editing GitHub issues as part of this design.
+- Changing benchmark semantics, configs, metrics, or promoted policy artifacts directly.
+
+## Evidence Sources
+
+The refined plan should be anchored in these repository surfaces:
+
+- `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md`
+  - Distribution alignment explains most of the PPO lift to the current strong benchmark-set
+    result.
+- `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md`
+  - Paper framing is a strong policy on a broad scenario matrix, not OOD generalization.
+- `docs/context/dreamerv3_program_close_out_2026_04_30.md`
+  - DreamerV3 is closed and deprioritized for paper-facing scope after repeated no-eval runs,
+    NaNs, and OOM.
+- `docs/benchmark_planner_family_coverage.md`
+  - Planner-family claims must distinguish implemented benchmarkable planners from experimental or
+    conceptually adjacent families.
+- `docs/benchmark_camera_ready.md`, `docs/benchmark_release_protocol.md`, and
+  `docs/benchmark_release_reproducibility.md`
+  - Camera-ready benchmark, release, SNQI, and reproducibility obligations.
+- `docs/context/issue_691_benchmark_fallback_policy.md`
+  - Fallback or degraded execution is not benchmark-strengthening evidence.
+- `AGENTS.md` and `.agent/PLANS.md`
+  - Plans should be operational, evidence-backed, and validation-oriented.
+
+## Proposed Structure
+
+### Executive Recommendation
+
+The plan should lead with a two-horizon strategy:
+
+- Horizon A: camera-ready paper delivery.
+- Horizon B: post-paper research roadmap.
+- Shared evidence spine: every claim-promoting workstream needs named evidence and proof.
+
+This replaces the current implicit emphasis on building the "best local policy" first. The better
+near-term target is a defensible benchmark story with clean provenance and clear claim boundaries.
+
+### Current Evidence
+
+The plan should summarize the most decision-relevant evidence:
+
+- PPO is currently the highest-yield paper-facing policy track.
+- The strongest PPO result is benchmark-set performance and must not be framed as OOD transfer.
+- DreamerV3 is not part of the camera-ready scope.
+- Baseline-ready planner support is narrower than the roadmap planner list.
+- SNQI and camera-ready artifacts are claim-bearing surfaces, not incidental outputs.
+- Worktree-local `output/` files are not durable evidence unless promoted or represented by a
+  durable manifest.
+
+### Horizon A: Paper Delivery Plan
+
+Paper delivery should be the first execution track. It should include:
+
+- Protect the issue-791 claim language: benchmark-set performance across the scenario matrix.
+- Verify PPO and baseline provenance through canonical configs, artifacts, and benchmark commands.
+- Keep SNQI contract diagnostics and bootstrap/seed evidence visible in the validation story.
+- Use the planner-family coverage matrix to avoid overclaiming experimental planners.
+- Treat route handoff, invalid geometry, metric drift, fallback/degraded execution, and missing
+  durable artifacts as blockers or caveats before any public claim.
+- Record validation results in existing benchmark/context docs or a clearly linked context note.
+
+### Horizon B: Research Roadmap
+
+The long-term roadmap should remain ambitious but sequenced after the paper gate:
+
+- Scenario certification v1 for geometry, route, kinodynamics, dynamic-agent feasibility, and
+  difficulty labels.
+- Failure attribution and adversarial falsification loops built on certified scenarios.
+- Policy-stack portfolio work that uses classical, optimization, prediction, and learned proposals
+  as components rather than treating a single new policy as the immediate goal.
+- Obstacle-conditioned prediction and richer scene representations after semantic blockers are
+  controlled.
+- CARLA transfer only after simulator-independent scenario, observation, action, and metric
+  contracts exist; the first CARLA target should be oracle replay/parity, not training.
+
+DreamerV3 may remain as historical context or future optional research only if a structurally new
+setup is proposed. It should not appear as a near-term promoted baseline.
+
+## Priority Order
+
+The refined plan should order work as follows:
+
+1. Paper claim protection and wording boundaries.
+2. Benchmark readiness, SNQI contract, bootstrap/seed evidence, and durable artifacts.
+3. PPO and baseline provenance.
+4. Known semantic blockers that can corrupt attribution: route handoff, invalid SVG geometry,
+   metric drift, and fallback/degraded execution.
+5. Scenario certification and failure attribution.
+6. Adversarial scenario generation and counterexample replay.
+7. Portfolio policy stack and richer prediction/scene understanding.
+8. CARLA oracle replay/parity, then later sensor/perception stress.
+
+## Validation Model
+
+The plan should define proof obligations by claim type:
+
+- Paper benchmark claim: canonical benchmark run, SNQI diagnostics, bootstrap/seed evidence,
+  planner provenance, and durable artifact trail.
+- Planner readiness claim: current benchmark entrypoint, dependency availability, mode
+  classification, and non-fallback execution proof.
+- Metric or SNQI claim: contract diagnostics and reproducible input assets.
+- Research-roadmap promotion: executable proof in Robot-SF before any manuscript-facing claim.
+- CARLA transfer claim: parity evidence against certified Robot-SF scenarios before perception or
+  training claims.
+
+## Issue Candidate Handling
+
+The current issue list should be revised into two groups:
+
+- Paper-critical or paper-risk issues, such as claim protection, benchmark provenance, SNQI
+  contract, route handoff, geometry validity, and artifact durability.
+- Research follow-ups, such as scenario certification, adversarial search, portfolio policy stack,
+  obstacle-conditioned prediction, and CARLA oracle replay.
+
+This prevents exploratory roadmap work from appearing as immediate paper scope.
+
+## Acceptance Criteria
+
+The refined plan is acceptable when:
+
+- It clearly separates paper delivery from long-term research.
+- It reflects the current PPO, DreamerV3, planner-family, SNQI, and artifact evidence.
+- It names proof obligations before claim promotion.
+- It preserves useful long-term ideas without making them near-term blockers.
+- It can guide future agents without encouraging benchmark overclaims.
+

--- a/scripts/training/train_dreamerv3_rllib.py
+++ b/scripts/training/train_dreamerv3_rllib.py
@@ -853,6 +853,17 @@ def _json_safe_scalar(value: Any) -> Any:
     return value
 
 
+def _json_safe_value(value: Any) -> Any:
+    """Recursively convert nested payloads into strict-JSON-safe values."""
+    if isinstance(value, dict):
+        return {key: _json_safe_value(nested) for key, nested in value.items()}
+    if isinstance(value, list):
+        return [_json_safe_value(nested) for nested in value]
+    if isinstance(value, tuple):
+        return [_json_safe_value(nested) for nested in value]
+    return _json_safe_scalar(value)
+
+
 def _is_finite_scalar(value: Any) -> bool:
     """Return True when value is an int/float and finite."""
     return isinstance(value, int | float) and math.isfinite(float(value))
@@ -940,10 +951,10 @@ def _build_nonfinite_diagnostics(
     }
     return {
         "iteration": iteration,
-        "reward_mean": reward_mean,
-        "timesteps_total": timesteps_total,
+        "reward_mean": _json_safe_scalar(reward_mean),
+        "timesteps_total": _json_safe_scalar(timesteps_total),
         "top_level_keys": sorted(result.keys()),
-        "interesting_metrics": interesting_paths,
+        "interesting_metrics": _json_safe_value(interesting_paths),
         "nonfinite_scalars": _find_nonfinite_scalars(result),
     }
 


### PR DESCRIPTION
## Summary
Refines the 2026-04-30 Robot-SF big-picture strategy into a two-horizon plan: near-term
camera-ready paper delivery first, long-term research roadmap second.

## Linked Issues
- Relates to issue-791 benchmark-set claim framing.
- No issue closed by this PR.

## What Changed
- Added an approved design spec and implementation plan under `docs/superpowers/`.
- Rewrote `docs/plan/plan_big_picture_2026-04-30.md` around Horizon A paper delivery,
  Horizon B research roadmap, and explicit proof obligations.
- Added conservative anchors for PPO provenance, SNQI, planner-family boundaries, fallback policy,
  DreamerV3 close-out, durable artifacts, route handoff, and geometry validity.
- Fixed DreamerV3 non-finite diagnostics so `run_summary.json` no longer emits raw `NaN` literals.

## Why It Matters
- Added value: future agents get a paper-first strategy that does not overclaim OOD transfer,
  DreamerV3 readiness, fallback execution, or experimental planner support.
- Expected impact: clearer sequencing between camera-ready evidence work and longer-term policy,
  adversarial, certification, and CARLA roadmap work.
- Why this is worth merging now: the previous plan mixed immediate paper needs with roadmap-scale
  research; this makes the execution boundary explicit before follow-up work reuses the plan.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run pytest tests/training/test_train_dreamerv3_rllib_runtime.py::test_run_training_records_nonfinite_reward_diagnostics -vv`
  - `uv run pytest tests/training/test_train_dreamerv3_rllib_runtime.py -q`
  - `uv run ruff check scripts/training/train_dreamerv3_rllib.py tests/training/test_train_dreamerv3_rllib_runtime.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - PR readiness passed after syncing `origin/main`: `2991 passed, 17 skipped, 1 warning`.
  - Freshness stamp recorded for head `60ca0dca220444678ee1f0df2fcb77c723105644`.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; strategy/docs change plus a targeted DreamerV3 JSON-safety fix.

## Risks / Rollout
- Compatibility risks: low; primary change is documentation. The code fix only sanitizes
  non-finite values in DreamerV3 diagnostic summaries.
- Failure modes: future agents may still need to verify actual benchmark artifacts separately;
  these docs define proof boundaries but do not themselves prove benchmark outcomes.
- Rollback or fallback plan: revert the docs commits and the isolated DreamerV3 diagnostics fix if
  the strategy or JSON-safety behavior is not desired.

## Docs / Provenance
- Updated docs:
  - `docs/plan/plan_big_picture_2026-04-30.md`
  - `docs/superpowers/specs/2026-04-30-big-picture-two-horizon-plan-design.md`
  - `docs/superpowers/plans/2026-04-30-big-picture-two-horizon-plan.md`
- Relevant design or provenance notes:
  - `memory/experiments/2026-04-20_issue_791_distribution_alignment_dominates.md`
  - `memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md`
  - `docs/context/dreamerv3_program_close_out_2026_04_30.md`
  - `docs/benchmark_planner_family_coverage.md`
  - `docs/context/issue_691_benchmark_fallback_policy.md`
- Any assumptions that need to be preserved:
  - Paper-facing claims remain benchmark-set scoped unless a separate OOD/transfer study is run.
  - Fallback/degraded execution remains a caveat or exclusion reason, not success evidence.

## Follow-Up Issues
- Deferred work:
  - Create or update specific paper-risk and research-roadmap issues from the new issue-candidate
    split when maintainers choose the next execution batch.
- Issues opened for follow-up:
  - None in this PR.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - Claim wording in the revised strategy doc.
  - The small DreamerV3 diagnostics fix is intentionally scoped to strict JSON summary output.
- Any known limitations:
  - The full readiness gate produced ignored `output/coverage/` and
    `output/validation/pr_ready/` artifacts; these are validation outputs and are not committed.
