### PR TITLE
feat: add scenario certification v1 (#868)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 ### Benchmarking & Metrics
 
 * **[Benchmark Spec (Classic Interactions)](./benchmark_spec.md)** - Scenario split + seeds, baseline categories, reproducible commands, and metric caveats
+* **[Scenario Certification](./scenario_certification.md)** - `scenario_cert.v1` schema, CLI, labels, and fail-closed benchmark eligibility rules
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
 * **[Issue #595 Seed-Variability Contract](./context/issue_595_seed_variability_contract.md)** - Frozen camera-ready artifact contract and pilot slice for paper-side seed variability analysis
 * **[Issue #832 Paper-Matrix Extended Seed Schedule](./context/issue_832_paper_matrix_extended_seed_schedule.md)** - Staged S5/S10/S20 seed extension policy, runtime estimates, tmux commands, and comparison artifact contract for the frozen paper matrix
@@ -293,6 +294,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * [**Single Pedestrians**](./single_pedestrians.md) - Define individual pedestrians with goals or trajectories in SVG/JSON/code
 * [**Multi-Pedestrian Example**](../examples/example_multi_pedestrian.py) - Demonstrates multiple single pedestrians (goal, trajectory, static) in one scenario
 * [**Scenario Specification Checklist**](./scenario_spec_checklist.md) - Authoring checklist for per-scenario/archetype/manifest files
+* [**Scenario Certification**](./scenario_certification.md) - Generate machine-readable validity, feasibility, stress-only, and hard-but-solvable certificates for scenario manifests
 * **Classic Interaction Scenario Pack** (configs/scenarios/classic_interactions.yaml) – Canonical crossing, head‑on, overtaking, bottleneck, doorway, merging, T‑intersection, and group crossing archetypes for benchmark coverage.
 * **[Francis 2023 Scenario Pack](../maps/svg_maps/francis2023/readme.md)** - SVG maps +
   scenario matrix in [configs/scenarios/francis2023.yaml](../configs/scenarios/francis2023.yaml).

--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -7,6 +7,10 @@ Canonical benchmark fallback policy:
 
 - `docs/context/issue_691_benchmark_fallback_policy.md`
 
+Scenario certification contract:
+
+- [`docs/scenario_certification.md`](./scenario_certification.md)
+
 Francis-guideline crosswalk for the current benchmark contract:
 
 - [Francis Guideline Mapping For Robot SF](./context/issue_759_francis_guideline_mapping.md)
@@ -66,6 +70,10 @@ Notes:
 * ORCA requires the rvo2 binding; install with `uv sync --extra orca`.
 * Fallback execution may still be used for explicit diagnostics, but it is not benchmark-success
   evidence and must fail closed in benchmark mode.
+* `scenario_cert.v1` certificates classify malformed, infeasible, stress-only, and
+  hard-but-solvable scenarios before benchmark interpretation. Treat `excluded` certificates as
+  non-benchmark evidence and `stress_only` certificates as caveated stress coverage unless a
+  separate benchmark issue promotes them.
 * `socnav_bench` requires SocNavBench prerequisites (including `skfmm`); install with
   `uv sync --extra socnav` for native upstream execution.
 * `socnav_sampling` uses the in-repo sampling adapter baseline, while `socnav_bench` is the

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -121,6 +121,8 @@ why a change was made rather than a full issue execution transcript.
 - [SLURM Multi-Worktree Branch Workflow](slurm_multi_worktree_branch_workflow.md) - branch-isolated
   SLURM submissions from a shared login node, including `local.machine.md` symlink guidance and
   virtualenv boundaries.
+- [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
+  scope, public surfaces, validation path, and known limits.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_868_scenario_certification.md
+++ b/docs/context/issue_868_scenario_certification.md
@@ -1,0 +1,63 @@
+# Issue 868 Scenario Certification
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/868>
+
+## Goal
+
+Add a first `scenario_cert.v1` surface that classifies scenarios before they are used for benchmark
+claims. The certificate must fail closed for malformed geometry and infeasible route contracts,
+while still representing stress-only and hard-but-solvable cases without flattening everything into
+pass/fail.
+
+## Scope Decision
+
+The v1 implementation is intentionally conservative:
+
+- it uses the existing scenario loader so map registry resolution and route overrides match
+  benchmark/training behavior,
+- it uses the classic A* global planner with obstacle inflation and no fallback to prove an
+  inflated path exists,
+- it treats scenario-difficulty and planner-residual analysis as optional diagnostic evidence only,
+- it excludes only dynamic cases that are clearly blocked by static single pedestrians on the
+  inflated robot route corridor.
+
+Out of scope for this issue: adversarial scenario generation, headline benchmark promotion, CARLA
+export, and treating campaign outcomes as proof of scenario validity.
+
+## Public Surfaces
+
+- Library API: `robot_sf.scenario_certification`
+- CLI: `scripts/tools/certify_scenarios.py`
+- JSON schema: `robot_sf/benchmark/schemas/scenario_cert.v1.json`
+- User docs: `docs/scenario_certification.md`
+
+## Validation Plan
+
+Targeted tests cover the label taxonomy and schema validation:
+
+```bash
+PYTEST_ADDOPTS=--no-cov uv run pytest tests/scenario_certification/test_scenario_certification_v1.py -q
+```
+
+Smoke generation should run on the atomic invalid fixture set without requiring durable artifacts:
+
+```bash
+uv run python scripts/tools/certify_scenarios.py \
+  configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml \
+  --output output/scenario_cert/issue868_atomic_validation.json
+```
+
+Before handoff, run the repository readiness gate after syncing with `origin/main`:
+
+```bash
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Known Limits
+
+- `scenario_cert.v1` is not a complete dynamic oracle. Moving pedestrians are hardness evidence
+  unless the scenario is obviously overconstrained by a static pedestrian blocking the route.
+- Bicycle kinodynamic checks use authored-route turn geometry. Differential and holonomic robots
+  are considered turn-feasible because current settings allow rotation in place.
+- Worktree-local outputs under `output/` remain disposable; the durable contract is the code,
+  schema, tests, and docs.

--- a/docs/scenario_certification.md
+++ b/docs/scenario_certification.md
@@ -1,0 +1,108 @@
+# Scenario Certification
+
+[← Back to Documentation Index](./README.md)
+
+`scenario_cert.v1` is the first machine-readable certification surface for generated and curated
+scenario manifests. It is intentionally conservative: malformed scenarios, missing inflated paths,
+kinodynamic violations, and clearly blocked dynamic setups are excluded before they can support
+benchmark claims.
+
+## Contract
+
+The public schema lives at
+[`robot_sf/benchmark/schemas/scenario_cert.v1.json`](../robot_sf/benchmark/schemas/scenario_cert.v1.json).
+Each certificate includes:
+
+- `schema_version`: always `scenario_cert.v1`.
+- `scenario_id` and `source`: the scenario name/id and manifest or programmatic source.
+- `classification`: one of `valid`, `invalid`, `geometrically_infeasible`,
+  `kinodynamically_infeasible`, `dynamically_overconstrained`, `knife_edge`, or
+  `hard_but_solvable`.
+- `benchmark_eligibility`: `eligible`, `stress_only`, or `excluded`.
+- `checks`: deterministic geometry, route, planner, kinodynamic, and dynamic checks.
+- `route_certificates`: per-route evidence for every applicable robot route.
+- `evidence`: optional scenario metadata and scenario-difficulty provenance.
+
+Benchmark inclusion policy:
+
+- `valid` and `hard_but_solvable` are benchmark-eligible.
+- `knife_edge` is stress-only and should not be promoted as headline benchmark evidence without
+  an explicit benchmark issue.
+- `invalid`, `geometrically_infeasible`, `kinodynamically_infeasible`, and
+  `dynamically_overconstrained` are excluded.
+
+## Checks
+
+The v1 certifier uses the repository scenario loader, so `map_id`, `map_file`, route overrides,
+single-pedestrian overrides, and robot config parsing follow the same path as training and
+benchmark tools.
+
+Geometry checks:
+
+- finite start and goal coordinates within map bounds,
+- start/goal not inside static obstacles,
+- inflated global path existence using the classic A* planner with no inflation fallback,
+- shortest inflated path length,
+- path length ratio against direct start-goal distance,
+- authored route static clearance against obstacles.
+
+Kinodynamic checks:
+
+- differential-drive and holonomic robots are considered command-feasible when their existing
+  settings validate, because they can rotate in place,
+- bicycle-drive routes are excluded when the authored route contains a turn tighter than the
+  configured `wheelbase / tan(max_steer)` limit.
+
+Dynamic checks:
+
+- moving single pedestrians are optional hardness evidence,
+- static single pedestrians whose start position blocks the inflated robot route corridor classify
+  the scenario as `dynamically_overconstrained`.
+
+Scenario difficulty and planner residual analysis from
+[`docs/context/issue_692_scenario_difficulty_analysis.md`](./context/issue_692_scenario_difficulty_analysis.md)
+is linked as diagnostic evidence only. It is not treated as a replacement for validity or
+feasibility checks.
+
+## CLI
+
+Generate a batch JSON document:
+
+```bash
+uv run python scripts/tools/certify_scenarios.py \
+  configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml \
+  --output output/scenario_cert/atomic_validation.json
+```
+
+Generate one JSON object per line:
+
+```bash
+uv run python scripts/tools/certify_scenarios.py \
+  configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml \
+  --jsonl
+```
+
+Use `--scenario-id <name>` to certify one scenario. Use `--fail-on-excluded` in gates that should
+exit non-zero when any scenario is excluded.
+
+## Library API
+
+```python
+from pathlib import Path
+
+from robot_sf.scenario_certification import certify_scenario_file, certificate_to_dict
+
+certificates = certify_scenario_file(
+    Path("configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml")
+)
+payload = [certificate_to_dict(certificate) for certificate in certificates]
+```
+
+Programmatic tests can call `certify_map_definition(...)` directly with a `MapDefinition`.
+
+## Limits
+
+`scenario_cert.v1` is a first-pass fail-closed contract, not a high-budget oracle planner. It does
+not generate adversarial scenarios, promote stress cases into headline benchmarks, or prove that a
+planner will solve a valid scenario. It only certifies that the scenario geometry and currently
+exposed robot/dynamic constraints are not malformed or impossible under the v1 checks.

--- a/robot_sf/benchmark/schemas/scenario_cert.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_cert.v1.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/scenario_cert.v1.json",
+  "title": "RobotSF Scenario Certificate (v1)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "source",
+    "classification",
+    "benchmark_eligibility",
+    "reasons",
+    "checks",
+    "route_certificates",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "scenario_cert.v1"
+    },
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string"
+    },
+    "classification": {
+      "$ref": "#/$defs/classification"
+    },
+    "benchmark_eligibility": {
+      "$ref": "#/$defs/eligibility"
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "checks": {
+      "type": "object"
+    },
+    "route_certificates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/route_certificate"
+      }
+    },
+    "evidence": {
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "classification": {
+      "type": "string",
+      "enum": [
+        "valid",
+        "invalid",
+        "geometrically_infeasible",
+        "kinodynamically_infeasible",
+        "dynamically_overconstrained",
+        "knife_edge",
+        "hard_but_solvable"
+      ]
+    },
+    "eligibility": {
+      "type": "string",
+      "enum": [
+        "eligible",
+        "stress_only",
+        "excluded"
+      ]
+    },
+    "route_certificate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "spawn_id",
+        "goal_id",
+        "classification",
+        "benchmark_eligibility",
+        "reasons",
+        "checks",
+        "evidence"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "spawn_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "goal_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "classification": {
+          "$ref": "#/$defs/classification"
+        },
+        "benchmark_eligibility": {
+          "$ref": "#/$defs/eligibility"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "checks": {
+          "type": "object"
+        },
+        "evidence": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/scenario_certification/__init__.py
+++ b/robot_sf/scenario_certification/__init__.py
@@ -1,0 +1,21 @@
+"""Scenario certification public API."""
+
+from robot_sf.scenario_certification.v1 import (
+    CERT_SCHEMA_VERSION,
+    CertificationSettings,
+    ScenarioCertificate,
+    certificate_to_dict,
+    certify_map_definition,
+    certify_scenario,
+    certify_scenario_file,
+)
+
+__all__ = [
+    "CERT_SCHEMA_VERSION",
+    "CertificationSettings",
+    "ScenarioCertificate",
+    "certificate_to_dict",
+    "certify_map_definition",
+    "certify_scenario",
+    "certify_scenario_file",
+]

--- a/robot_sf/scenario_certification/v1.py
+++ b/robot_sf/scenario_certification/v1.py
@@ -1,0 +1,793 @@
+"""Versioned scenario certification for benchmark-facing scenario manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+from shapely.geometry import GeometryCollection, LineString, Point, Polygon, box
+from shapely.ops import unary_union
+
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.nav.map_config import MapDefinitionPool
+from robot_sf.planner.classic_global_planner import (
+    ClassicGlobalPlanner,
+    ClassicPlannerConfig,
+    PlanningError,
+)
+from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from robot_sf.common.types import Vec2D
+    from robot_sf.nav.global_route import GlobalRoute
+    from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
+
+CERT_SCHEMA_VERSION = "scenario_cert.v1"
+
+VALID = "valid"
+INVALID = "invalid"
+GEOMETRICALLY_INFEASIBLE = "geometrically_infeasible"
+KINODYNAMICALLY_INFEASIBLE = "kinodynamically_infeasible"
+DYNAMICALLY_OVERCONSTRAINED = "dynamically_overconstrained"
+KNIFE_EDGE = "knife_edge"
+HARD_BUT_SOLVABLE = "hard_but_solvable"
+
+EXCLUDED_STATUSES = {
+    INVALID,
+    GEOMETRICALLY_INFEASIBLE,
+    KINODYNAMICALLY_INFEASIBLE,
+    DYNAMICALLY_OVERCONSTRAINED,
+}
+
+_STATUS_SEVERITY = {
+    INVALID: 60,
+    GEOMETRICALLY_INFEASIBLE: 50,
+    KINODYNAMICALLY_INFEASIBLE: 40,
+    DYNAMICALLY_OVERCONSTRAINED: 30,
+    KNIFE_EDGE: 20,
+    HARD_BUT_SOLVABLE: 10,
+    VALID: 0,
+}
+
+
+@dataclass(frozen=True)
+class CertificationSettings:
+    """Tunable thresholds for ``scenario_cert.v1`` classification."""
+
+    planner_cells_per_meter: float = 2.0
+    knife_edge_clearance_margin_m: float = 0.15
+    hard_clearance_margin_m: float = 0.35
+    hard_path_length_ratio: float = 1.5
+    knife_edge_path_length_ratio: float = 2.5
+    hard_turn_count: int = 3
+
+
+@dataclass(frozen=True)
+class RouteCertificate:
+    """Certificate evidence for one applicable robot route."""
+
+    route_id: str
+    spawn_id: int
+    goal_id: int
+    classification: str
+    benchmark_eligibility: str
+    reasons: list[str]
+    checks: dict[str, Any]
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ScenarioCertificate:
+    """Machine-readable scenario certificate for benchmark inclusion decisions."""
+
+    schema_version: str
+    scenario_id: str
+    source: str
+    classification: str
+    benchmark_eligibility: str
+    reasons: list[str]
+    checks: dict[str, Any]
+    route_certificates: list[RouteCertificate]
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+def certify_scenario_file(
+    scenario_path: Path,
+    *,
+    scenario_id: str | None = None,
+    settings: CertificationSettings | None = None,
+) -> list[ScenarioCertificate]:
+    """Certify all scenarios, or one selected scenario, from a scenario manifest.
+
+    Returns:
+        List of certificates in manifest order, or a single selected certificate.
+    """
+
+    scenarios = load_scenarios(scenario_path)
+    selected = [
+        scenario
+        for scenario in scenarios
+        if scenario_id is None or _scenario_id(scenario).lower() == scenario_id.lower()
+    ]
+    if scenario_id is not None and not selected:
+        raise ValueError(f"Scenario id '{scenario_id}' not found in {scenario_path}")
+    return [
+        certify_scenario(scenario, scenario_path=scenario_path, settings=settings)
+        for scenario in selected
+    ]
+
+
+def certify_scenario(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_path: Path,
+    settings: CertificationSettings | None = None,
+) -> ScenarioCertificate:
+    """Build a ``scenario_cert.v1`` certificate from a scenario-loader entry.
+
+    Returns:
+        Scenario certificate with fail-closed classification and evidence.
+    """
+
+    cert_settings = settings or CertificationSettings()
+    sid = _scenario_id(scenario)
+    try:
+        config = build_robot_config_from_scenario(scenario, scenario_path=scenario_path)
+    except Exception as exc:  # noqa: BLE001 - certificate must fail closed on loader errors.
+        return _invalid_scenario_certificate(
+            scenario,
+            scenario_id=sid,
+            source=scenario_path.as_posix(),
+            reason=f"scenario_loader_error: {exc}",
+        )
+
+    map_defs = list(config.map_pool.map_defs.items())
+    if not map_defs:
+        return _invalid_scenario_certificate(
+            scenario,
+            scenario_id=sid,
+            source=scenario_path.as_posix(),
+            reason="map_pool_empty",
+        )
+
+    route_certs: list[RouteCertificate] = []
+    for map_name, map_def in map_defs:
+        route_certs.extend(
+            _certify_routes_for_map(
+                map_def,
+                scenario=scenario,
+                map_name=map_name,
+                config=config,
+                settings=cert_settings,
+            )
+        )
+
+    if not route_certs:
+        return _invalid_scenario_certificate(
+            scenario,
+            scenario_id=sid,
+            source=scenario_path.as_posix(),
+            reason="no_applicable_robot_routes",
+        )
+    return _aggregate_scenario_certificate(
+        scenario,
+        scenario_id=sid,
+        source=scenario_path.as_posix(),
+        route_certs=route_certs,
+        settings=cert_settings,
+    )
+
+
+def certify_map_definition(
+    map_def: MapDefinition,
+    *,
+    scenario: Mapping[str, Any] | None = None,
+    source: str = "programmatic",
+    robot_config: DifferentialDriveSettings
+    | BicycleDriveSettings
+    | HolonomicDriveSettings
+    | None = None,
+    sim_config: Any | None = None,
+    settings: CertificationSettings | None = None,
+) -> ScenarioCertificate:
+    """Certify a programmatic map definition without loading a YAML scenario.
+
+    Returns:
+        Scenario certificate for the supplied map definition and optional scenario payload.
+    """
+
+    scenario_payload = scenario or {"name": "programmatic"}
+    config = RobotSimulationConfig(map_pool=MapDefinitionPool(map_defs={"programmatic": map_def}))
+    if robot_config is not None:
+        config.robot_config = robot_config
+    if sim_config is not None:
+        config.sim_config = sim_config
+    route_certs = _certify_routes_for_map(
+        map_def,
+        scenario=scenario_payload,
+        map_name="programmatic",
+        config=config,
+        settings=settings or CertificationSettings(),
+    )
+    if not route_certs:
+        return _invalid_scenario_certificate(
+            scenario_payload,
+            scenario_id=_scenario_id(scenario_payload),
+            source=source,
+            reason="no_applicable_robot_routes",
+        )
+    return _aggregate_scenario_certificate(
+        scenario_payload,
+        scenario_id=_scenario_id(scenario_payload),
+        source=source,
+        route_certs=route_certs,
+        settings=settings or CertificationSettings(),
+    )
+
+
+def certificate_to_dict(certificate: ScenarioCertificate) -> dict[str, Any]:
+    """Convert a certificate dataclass into JSON-safe primitives.
+
+    Returns:
+        JSON-serializable dictionary representation of the certificate.
+    """
+
+    return _sanitize_json_value(asdict(certificate))
+
+
+def _certify_routes_for_map(
+    map_def: MapDefinition,
+    *,
+    scenario: Mapping[str, Any],
+    map_name: str,
+    config: RobotSimulationConfig,
+    settings: CertificationSettings,
+) -> list[RouteCertificate]:
+    routes = _applicable_routes(map_def, scenario)
+    return [
+        _certify_route(
+            route,
+            map_def=map_def,
+            map_name=map_name,
+            config=config,
+            settings=settings,
+        )
+        for route in routes
+    ]
+
+
+def _certify_route(
+    route: GlobalRoute,
+    *,
+    map_def: MapDefinition,
+    map_name: str,
+    config: RobotSimulationConfig,
+    settings: CertificationSettings,
+) -> RouteCertificate:
+    route_id = route.source_label or f"robot_route_{route.spawn_id}_{route.goal_id}"
+    reasons: list[str] = []
+    checks: dict[str, Any] = {"map_name": map_name}
+    evidence: dict[str, Any] = {}
+    robot_radius = float(getattr(config.robot_config, "radius", 1.0))
+    ped_radius = float(getattr(config.sim_config, "ped_radius", 0.4))
+    start, goal = _route_start_goal(route)
+    route_line = _line_from_points(route.waypoints)
+    obstacle_union = _obstacle_union(map_def)
+    map_bounds = box(0.0, 0.0, float(map_def.width), float(map_def.height))
+
+    checks.update(
+        {
+            "robot_radius_m": robot_radius,
+            "ped_radius_m": ped_radius,
+            "start": list(start) if start else None,
+            "goal": list(goal) if goal else None,
+            "waypoint_count": len(route.waypoints),
+        }
+    )
+
+    invalid_reasons = _validate_route_shape(route, start, goal, map_bounds, obstacle_union)
+    if invalid_reasons:
+        reasons.extend(invalid_reasons)
+        return _route_certificate(
+            route,
+            route_id=route_id,
+            status=INVALID,
+            reasons=reasons,
+            checks=checks,
+            evidence=evidence,
+        )
+
+    assert start is not None
+    assert goal is not None
+    assert route_line is not None
+    direct_length = float(Point(start).distance(Point(goal)))
+    checks["direct_start_goal_distance_m"] = direct_length
+    checks["authored_route_length_m"] = _polyline_length(route.waypoints)
+    checks["minimum_static_clearance_m"] = _minimum_static_clearance(
+        route_line,
+        obstacle_union=obstacle_union,
+        robot_radius=robot_radius,
+    )
+
+    planned_path, planner_info, planner_error = _plan_inflated_shortest_path(
+        map_def,
+        start=start,
+        goal=goal,
+        robot_radius=robot_radius,
+        settings=settings,
+    )
+    if planned_path is None:
+        reasons.append(f"no_inflated_collision_free_path: {planner_error}")
+        checks["inflated_collision_free_path"] = False
+        return _route_certificate(
+            route,
+            route_id=route_id,
+            status=GEOMETRICALLY_INFEASIBLE,
+            reasons=reasons,
+            checks=checks,
+            evidence=evidence,
+        )
+
+    planned_line = _line_from_points(planned_path)
+    shortest_length = _polyline_length(planned_path)
+    path_length_ratio = _safe_ratio(shortest_length, direct_length)
+    checks.update(
+        {
+            "inflated_collision_free_path": True,
+            "shortest_path_length_m": shortest_length,
+            "path_length_ratio": path_length_ratio,
+            "planner": planner_info,
+            "planned_waypoint_count": len(planned_path),
+            "planned_turn_count": _turn_count(planned_path),
+        }
+    )
+
+    kinodynamic_reasons, kinodynamic_checks = _kinodynamic_checks(
+        route,
+        robot_config=config.robot_config,
+    )
+    checks["kinodynamic"] = kinodynamic_checks
+    if kinodynamic_reasons:
+        reasons.extend(kinodynamic_reasons)
+        return _route_certificate(
+            route,
+            route_id=route_id,
+            status=KINODYNAMICALLY_INFEASIBLE,
+            reasons=reasons,
+            checks=checks,
+            evidence=evidence,
+        )
+
+    dynamic_reasons, dynamic_checks = _dynamic_checks(
+        map_def,
+        planned_line=planned_line,
+        robot_radius=robot_radius,
+        ped_radius=ped_radius,
+    )
+    checks["dynamic"] = dynamic_checks
+    if dynamic_reasons:
+        reasons.extend(dynamic_reasons)
+        return _route_certificate(
+            route,
+            route_id=route_id,
+            status=DYNAMICALLY_OVERCONSTRAINED,
+            reasons=reasons,
+            checks=checks,
+            evidence=evidence,
+        )
+
+    route_status = _classify_solvable_route(checks, settings=settings)
+    reasons.extend(_solvable_reasons(route_status, checks, settings=settings))
+    evidence["difficulty_analysis"] = {
+        "source": "docs/context/issue_692_scenario_difficulty_analysis.md",
+        "role": "optional_diagnostic_evidence_only",
+    }
+    return _route_certificate(
+        route,
+        route_id=route_id,
+        status=route_status,
+        reasons=reasons,
+        checks=checks,
+        evidence=evidence,
+    )
+
+
+def _aggregate_scenario_certificate(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_id: str,
+    source: str,
+    route_certs: list[RouteCertificate],
+    settings: CertificationSettings,
+) -> ScenarioCertificate:
+    status = max(route_certs, key=lambda cert: _STATUS_SEVERITY[cert.classification]).classification
+    reasons = sorted({reason for cert in route_certs for reason in cert.reasons})
+    checks = {
+        "route_count": len(route_certs),
+        "settings": asdict(settings),
+        "all_routes_benchmark_eligible": all(
+            cert.benchmark_eligibility == "eligible" for cert in route_certs
+        ),
+    }
+    evidence = _scenario_evidence(scenario)
+    return ScenarioCertificate(
+        schema_version=CERT_SCHEMA_VERSION,
+        scenario_id=scenario_id,
+        source=source,
+        classification=status,
+        benchmark_eligibility=_benchmark_eligibility(status),
+        reasons=reasons,
+        checks=checks,
+        route_certificates=route_certs,
+        evidence=evidence,
+    )
+
+
+def _invalid_scenario_certificate(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_id: str,
+    source: str,
+    reason: str,
+) -> ScenarioCertificate:
+    return ScenarioCertificate(
+        schema_version=CERT_SCHEMA_VERSION,
+        scenario_id=scenario_id,
+        source=source,
+        classification=INVALID,
+        benchmark_eligibility="excluded",
+        reasons=[reason],
+        checks={"route_count": 0},
+        route_certificates=[],
+        evidence=_scenario_evidence(scenario),
+    )
+
+
+def _route_certificate(
+    route: GlobalRoute,
+    *,
+    route_id: str,
+    status: str,
+    reasons: list[str],
+    checks: dict[str, Any],
+    evidence: dict[str, Any],
+) -> RouteCertificate:
+    return RouteCertificate(
+        route_id=route_id,
+        spawn_id=int(route.spawn_id),
+        goal_id=int(route.goal_id),
+        classification=status,
+        benchmark_eligibility=_benchmark_eligibility(status),
+        reasons=reasons,
+        checks=checks,
+        evidence=evidence,
+    )
+
+
+def _benchmark_eligibility(status: str) -> str:
+    if status in EXCLUDED_STATUSES:
+        return "excluded"
+    if status == KNIFE_EDGE:
+        return "stress_only"
+    return "eligible"
+
+
+def _scenario_id(scenario: Mapping[str, Any]) -> str:
+    raw = scenario.get("name") or scenario.get("scenario_id") or scenario.get("id")
+    return str(raw or "unknown").strip() or "unknown"
+
+
+def _scenario_evidence(scenario: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = scenario.get("metadata")
+    evidence: dict[str, Any] = {"scenario_fingerprint": _fingerprint_mapping(scenario)}
+    if isinstance(metadata, Mapping):
+        plausibility = metadata.get("plausibility")
+        if isinstance(plausibility, Mapping):
+            evidence["plausibility"] = _sanitize_json_value(dict(plausibility))
+        for key in ("archetype", "primary_capability", "target_failure_mode", "determinism"):
+            if key in metadata:
+                evidence[key] = _sanitize_json_value(metadata[key])
+    evidence["difficulty_analysis"] = {
+        "source": "docs/context/issue_692_scenario_difficulty_analysis.md",
+        "role": "optional_diagnostic_evidence_only",
+    }
+    return evidence
+
+
+def _fingerprint_mapping(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(_sanitize_json_value(dict(payload)), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _applicable_routes(map_def: MapDefinition, scenario: Mapping[str, Any]) -> list[GlobalRoute]:
+    spawn_id = scenario.get("robot_spawn_id")
+    goal_id = scenario.get("robot_goal_id")
+    if isinstance(spawn_id, int) and isinstance(goal_id, int):
+        route = map_def.find_route(spawn_id, goal_id)
+        return [route] if route is not None else []
+    return list(map_def.robot_routes)
+
+
+def _route_start_goal(route: GlobalRoute) -> tuple[Vec2D | None, Vec2D | None]:
+    if len(route.waypoints) < 2:
+        return None, None
+    return tuple(route.waypoints[0]), tuple(route.waypoints[-1])
+
+
+def _validate_route_shape(
+    route: GlobalRoute,
+    start: Vec2D | None,
+    goal: Vec2D | None,
+    map_bounds: Polygon,
+    obstacle_union: Any,
+) -> list[str]:
+    reasons: list[str] = []
+    if start is None or goal is None:
+        return ["route_requires_at_least_two_waypoints"]
+    for label, point in (("start", start), ("goal", goal)):
+        if not _finite_point(point):
+            reasons.append(f"{label}_point_not_finite")
+            continue
+        if not map_bounds.covers(Point(point)):
+            reasons.append(f"{label}_outside_map_bounds")
+        if not obstacle_union.is_empty and obstacle_union.covers(Point(point)):
+            reasons.append(f"{label}_inside_static_obstacle")
+    for idx, waypoint in enumerate(route.waypoints):
+        if not _finite_point(waypoint):
+            reasons.append(f"waypoint_{idx}_not_finite")
+    return reasons
+
+
+def _finite_point(point: Vec2D) -> bool:
+    return len(point) == 2 and all(math.isfinite(float(coord)) for coord in point)
+
+
+def _obstacle_union(map_def: MapDefinition) -> Any:
+    polygons = []
+    for obstacle in map_def.obstacles:
+        polygons.extend(obstacle.iter_polygons())
+    if not polygons:
+        return GeometryCollection()
+    return unary_union(polygons)
+
+
+def _line_from_points(points: list[Vec2D]) -> LineString | None:
+    if len(points) < 2:
+        return None
+    line = LineString(points)
+    if line.is_empty or not line.is_valid:
+        return None
+    return line
+
+
+def _minimum_static_clearance(
+    line: LineString,
+    *,
+    obstacle_union: Any,
+    robot_radius: float,
+) -> float | None:
+    if obstacle_union.is_empty:
+        return None
+    return float(line.distance(obstacle_union) - robot_radius)
+
+
+def _plan_inflated_shortest_path(
+    map_def: MapDefinition,
+    *,
+    start: Vec2D,
+    goal: Vec2D,
+    robot_radius: float,
+    settings: CertificationSettings,
+) -> tuple[list[Vec2D] | None, dict[str, Any], str | None]:
+    planner_config = ClassicPlannerConfig(
+        cells_per_meter=settings.planner_cells_per_meter,
+        inflate_radius_meters=robot_radius,
+        algorithm="a_star",
+    )
+    planner = ClassicGlobalPlanner(map_def, planner_config)
+    try:
+        path, info = planner.plan(start, goal, algorithm="a_star", allow_inflation_fallback=False)
+    except (PlanningError, ValueError, RuntimeError) as exc:
+        return None, {"algorithm": "a_star", "inflation_fallback": False}, str(exc)
+    if not path:
+        return None, {"algorithm": "a_star", "inflation_fallback": False}, "empty_path"
+    planner_info = {
+        "algorithm": "a_star",
+        "cells_per_meter": settings.planner_cells_per_meter,
+        "inflation_radius_m": robot_radius,
+        "inflation_fallback": False,
+    }
+    if isinstance(info, Mapping):
+        planner_info["raw_info"] = _sanitize_json_value(dict(info))
+    return [(float(x), float(y)) for x, y in path], planner_info, None
+
+
+def _kinodynamic_checks(
+    route: GlobalRoute,
+    *,
+    robot_config: DifferentialDriveSettings | BicycleDriveSettings | HolonomicDriveSettings,
+) -> tuple[list[str], dict[str, Any]]:
+    checks: dict[str, Any] = {
+        "robot_model": type(robot_config).__name__,
+        "command_limits_valid": True,
+    }
+    reasons: list[str] = []
+    if isinstance(robot_config, BicycleDriveSettings):
+        max_steer = float(robot_config.max_steer)
+        if max_steer <= 0:
+            checks["command_limits_valid"] = False
+            return ["bicycle_max_steer_non_positive"], checks
+        min_turning_radius = float(robot_config.wheelbase / math.tan(max_steer))
+        route_min_radius = _minimum_route_turn_radius(route.waypoints)
+        checks.update(
+            {
+                "minimum_turning_radius_m": min_turning_radius,
+                "route_minimum_turn_radius_m": route_min_radius,
+            }
+        )
+        if route_min_radius is not None and route_min_radius < min_turning_radius:
+            reasons.append(
+                "route_turn_radius_below_bicycle_limit: "
+                f"{route_min_radius:.3f} < {min_turning_radius:.3f}"
+            )
+    elif isinstance(robot_config, DifferentialDriveSettings):
+        checks["minimum_turning_radius_m"] = 0.0
+        checks["controller_semantics"] = "can_rotate_in_place"
+    elif isinstance(robot_config, HolonomicDriveSettings):
+        checks["minimum_turning_radius_m"] = 0.0
+        checks["controller_semantics"] = robot_config.command_mode
+    else:
+        checks["command_limits_valid"] = False
+        reasons.append(f"unsupported_robot_config: {type(robot_config).__name__}")
+    return reasons, checks
+
+
+def _minimum_route_turn_radius(points: list[Vec2D]) -> float | None:
+    radii: list[float] = []
+    for p0, p1, p2 in zip(points[:-2], points[1:-1], points[2:], strict=False):
+        radius = _circumradius(p0, p1, p2)
+        if radius is not None:
+            radii.append(radius)
+    return min(radii) if radii else None
+
+
+def _circumradius(p0: Vec2D, p1: Vec2D, p2: Vec2D) -> float | None:
+    a = Point(p1).distance(Point(p2))
+    b = Point(p0).distance(Point(p2))
+    c = Point(p0).distance(Point(p1))
+    area2 = abs((p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]))
+    if a <= 1e-9 or b <= 1e-9 or c <= 1e-9 or area2 <= 1e-9:
+        return None
+    return float((a * b * c) / (2.0 * area2))
+
+
+def _dynamic_checks(
+    map_def: MapDefinition,
+    *,
+    planned_line: LineString | None,
+    robot_radius: float,
+    ped_radius: float,
+) -> tuple[list[str], dict[str, Any]]:
+    pedestrians = list(getattr(map_def, "single_pedestrians", []))
+    checks = {
+        "single_pedestrian_count": len(pedestrians),
+        "static_blocking_pedestrian_ids": [],
+    }
+    if planned_line is None or not pedestrians:
+        return [], checks
+    corridor = planned_line.buffer(robot_radius + ped_radius)
+    blocking: list[str] = []
+    dynamic_count = 0
+    for ped in pedestrians:
+        if _pedestrian_is_static(ped):
+            if corridor.covers(Point(ped.start)):
+                blocking.append(str(ped.id))
+        else:
+            dynamic_count += 1
+    checks["dynamic_interaction_count"] = dynamic_count
+    checks["static_blocking_pedestrian_ids"] = blocking
+    if blocking:
+        return [f"static_pedestrians_block_route: {', '.join(blocking)}"], checks
+    return [], checks
+
+
+def _pedestrian_is_static(pedestrian: SinglePedestrianDefinition) -> bool:
+    return (
+        pedestrian.goal is None
+        and pedestrian.trajectory is None
+        and getattr(pedestrian, "role", None) is None
+    )
+
+
+def _classify_solvable_route(checks: Mapping[str, Any], *, settings: CertificationSettings) -> str:
+    clearance = checks.get("minimum_static_clearance_m")
+    ratio = checks.get("path_length_ratio")
+    dynamic = checks.get("dynamic")
+    dynamic_count = (
+        int(dynamic.get("dynamic_interaction_count", 0)) if isinstance(dynamic, Mapping) else 0
+    )
+    turn_count = int(checks.get("planned_turn_count", 0))
+    if isinstance(clearance, (int, float)) and clearance <= settings.knife_edge_clearance_margin_m:
+        return KNIFE_EDGE
+    if isinstance(ratio, (int, float)) and ratio >= settings.knife_edge_path_length_ratio:
+        return KNIFE_EDGE
+    if isinstance(clearance, (int, float)) and clearance <= settings.hard_clearance_margin_m:
+        return HARD_BUT_SOLVABLE
+    if isinstance(ratio, (int, float)) and ratio >= settings.hard_path_length_ratio:
+        return HARD_BUT_SOLVABLE
+    if turn_count >= settings.hard_turn_count:
+        return HARD_BUT_SOLVABLE
+    if dynamic_count > 0:
+        return HARD_BUT_SOLVABLE
+    return VALID
+
+
+def _solvable_reasons(
+    status: str,
+    checks: Mapping[str, Any],
+    *,
+    settings: CertificationSettings,
+) -> list[str]:
+    if status == VALID:
+        return ["inflated_path_found_with_nominal_clearance"]
+    if status == KNIFE_EDGE:
+        return ["solvable_but_near_certification_threshold"]
+    reasons: list[str] = []
+    clearance = checks.get("minimum_static_clearance_m")
+    ratio = checks.get("path_length_ratio")
+    dynamic = checks.get("dynamic")
+    if isinstance(clearance, (int, float)) and clearance <= settings.hard_clearance_margin_m:
+        reasons.append("low_static_clearance_margin")
+    if isinstance(ratio, (int, float)) and ratio >= settings.hard_path_length_ratio:
+        reasons.append("long_detour_relative_to_direct_distance")
+    if isinstance(dynamic, Mapping) and int(dynamic.get("dynamic_interaction_count", 0)) > 0:
+        reasons.append("dynamic_interaction_present")
+    if not reasons:
+        reasons.append("solvable_with_hardness_caveat")
+    return reasons
+
+
+def _polyline_length(points: list[Vec2D]) -> float:
+    if len(points) < 2:
+        return 0.0
+    return float(sum(Point(a).distance(Point(b)) for a, b in pairwise(points)))
+
+
+def _turn_count(points: list[Vec2D]) -> int:
+    turns = 0
+    for p0, p1, p2 in zip(points[:-2], points[1:-1], points[2:], strict=False):
+        dx1 = p1[0] - p0[0]
+        dy1 = p1[1] - p0[1]
+        dx2 = p2[0] - p1[0]
+        dy2 = p2[1] - p1[1]
+        if abs(dx1 * dy2 - dy1 * dx2) > 1e-9:
+            turns += 1
+    return turns
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float | None:
+    if denominator <= 1e-9:
+        return None
+    return float(numerator / denominator)
+
+
+def _sanitize_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _sanitize_json_value(val) for key, val in value.items()}
+    if isinstance(value, list | tuple):
+        return [_sanitize_json_value(item) for item in value]
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if value is None or isinstance(value, bool | int | str):
+        return value
+    return str(value)

--- a/robot_sf/scenario_certification/v1.py
+++ b/robot_sf/scenario_certification/v1.py
@@ -662,9 +662,9 @@ def _minimum_route_turn_radius(points: list[Vec2D]) -> float | None:
 
 
 def _circumradius(p0: Vec2D, p1: Vec2D, p2: Vec2D) -> float | None:
-    a = Point(p1).distance(Point(p2))
-    b = Point(p0).distance(Point(p2))
-    c = Point(p0).distance(Point(p1))
+    a = math.dist(p1, p2)
+    b = math.dist(p0, p2)
+    c = math.dist(p0, p1)
     area2 = abs((p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]))
     if a <= 1e-9 or b <= 1e-9 or c <= 1e-9 or area2 <= 1e-9:
         return None
@@ -685,12 +685,12 @@ def _dynamic_checks(
     }
     if planned_line is None or not pedestrians:
         return [], checks
-    corridor = planned_line.buffer(robot_radius + ped_radius)
+    blocking_threshold = robot_radius + ped_radius
     blocking: list[str] = []
     dynamic_count = 0
     for ped in pedestrians:
         if _pedestrian_is_static(ped):
-            if corridor.covers(Point(ped.start)):
+            if planned_line.distance(Point(ped.start)) <= blocking_threshold:
                 blocking.append(str(ped.id))
         else:
             dynamic_count += 1
@@ -760,7 +760,7 @@ def _solvable_reasons(
 def _polyline_length(points: list[Vec2D]) -> float:
     if len(points) < 2:
         return 0.0
-    return float(sum(Point(a).distance(Point(b)) for a, b in pairwise(points)))
+    return float(sum(math.dist(a, b) for a, b in pairwise(points)))
 
 
 def _turn_count(points: list[Vec2D]) -> int:

--- a/scripts/tools/certify_scenarios.py
+++ b/scripts/tools/certify_scenarios.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Generate ``scenario_cert.v1`` certificates for scenario manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.scenario_certification import (
+    CERT_SCHEMA_VERSION,
+    certificate_to_dict,
+    certify_scenario_file,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario_config", type=Path, help="Scenario YAML manifest to certify.")
+    parser.add_argument("--scenario-id", help="Optional scenario id/name selector.")
+    parser.add_argument("--output", type=Path, help="Write JSON output to this path.")
+    parser.add_argument(
+        "--jsonl",
+        action="store_true",
+        help="Emit one certificate per JSONL line instead of a batch object.",
+    )
+    parser.add_argument(
+        "--fail-on-excluded",
+        action="store_true",
+        help="Exit non-zero when any certificate is benchmark-excluded.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the scenario certification CLI."""
+
+    args = _build_parser().parse_args()
+    certificates = certify_scenario_file(args.scenario_config, scenario_id=args.scenario_id)
+    payloads = [certificate_to_dict(certificate) for certificate in certificates]
+    if args.jsonl:
+        output = "\n".join(json.dumps(payload, sort_keys=True) for payload in payloads) + "\n"
+    else:
+        output = json.dumps(
+            {
+                "schema_version": f"{CERT_SCHEMA_VERSION}.batch",
+                "scenario_config": args.scenario_config.as_posix(),
+                "certificates": payloads,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        output += "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+    if args.fail_on_excluded and any(
+        payload.get("benchmark_eligibility") == "excluded" for payload in payloads
+    ):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scenario_certification/test_scenario_certification_v1.py
+++ b/tests/scenario_certification/test_scenario_certification_v1.py
@@ -1,0 +1,181 @@
+"""Tests for scenario_cert.v1 certification contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
+from robot_sf.nav.obstacle import Obstacle
+from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+from robot_sf.scenario_certification import certificate_to_dict, certify_map_definition
+from robot_sf.scenario_certification.v1 import (
+    DYNAMICALLY_OVERCONSTRAINED,
+    GEOMETRICALLY_INFEASIBLE,
+    HARD_BUT_SOLVABLE,
+    INVALID,
+    KINODYNAMICALLY_INFEASIBLE,
+    KNIFE_EDGE,
+    VALID,
+    CertificationSettings,
+)
+
+
+def _zone(
+    x: float, y: float
+) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    return ((x - 0.2, y - 0.2), (x + 0.2, y - 0.2), (x + 0.2, y + 0.2))
+
+
+def _bounds(width: float, height: float) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    return [
+        ((0.0, 0.0), (width, 0.0)),
+        ((width, 0.0), (width, height)),
+        ((width, height), (0.0, height)),
+        ((0.0, height), (0.0, 0.0)),
+    ]
+
+
+def _obstacle(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+) -> Obstacle:
+    return Obstacle([(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_x, max_y)])
+
+
+def _map(
+    route_points: list[tuple[float, float]],
+    *,
+    width: float = 12.0,
+    height: float = 8.0,
+    obstacles: list[Obstacle] | None = None,
+    pedestrians: list[SinglePedestrianDefinition] | None = None,
+) -> MapDefinition:
+    route = GlobalRoute(
+        spawn_id=0,
+        goal_id=0,
+        waypoints=route_points,
+        spawn_zone=_zone(*route_points[0]),
+        goal_zone=_zone(*route_points[-1]),
+    )
+    return MapDefinition(
+        width=width,
+        height=height,
+        obstacles=obstacles or [],
+        robot_spawn_zones=[route.spawn_zone],
+        ped_spawn_zones=[],
+        robot_goal_zones=[route.goal_zone],
+        bounds=_bounds(width, height),
+        robot_routes=[route],
+        ped_goal_zones=[],
+        ped_crowded_zones=[],
+        ped_routes=[],
+        single_pedestrians=pedestrians or [],
+    )
+
+
+def _classify(
+    map_def: MapDefinition,
+    *,
+    robot_config: object | None = None,
+) -> str:
+    certificate = certify_map_definition(
+        map_def,
+        robot_config=robot_config or DifferentialDriveSettings(radius=0.4),
+        settings=CertificationSettings(planner_cells_per_meter=2.0),
+    )
+    return certificate.classification
+
+
+def test_certificate_schema_validates_emitted_valid_certificate() -> None:
+    """Verify emitted certificates satisfy the versioned JSON schema used by tools."""
+
+    certificate = certify_map_definition(
+        _map([(2.0, 2.0), (10.0, 2.0)]),
+        robot_config=DifferentialDriveSettings(radius=0.4),
+    )
+    schema_path = Path("robot_sf/benchmark/schemas/scenario_cert.v1.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(certificate_to_dict(certificate), schema)
+    assert certificate.classification == VALID
+
+
+def test_invalid_route_fails_closed_when_start_is_outside_map() -> None:
+    """Invalid start coordinates are excluded before planner evidence is considered."""
+
+    assert _classify(_map([(-1.0, 2.0), (10.0, 2.0)])) == INVALID
+
+
+def test_geometrically_infeasible_when_inflated_path_is_blocked() -> None:
+    """A wall spanning the map separates start and goal with no inflated route."""
+
+    blocked = _map(
+        [(2.0, 4.0), (10.0, 4.0)],
+        obstacles=[_obstacle(5.0, 0.0, 7.0, 8.0)],
+    )
+    assert _classify(blocked) == GEOMETRICALLY_INFEASIBLE
+
+
+def test_kinodynamically_infeasible_for_tighter_turn_than_bicycle_limit() -> None:
+    """Bicycle routes with turns tighter than the configured limit are excluded."""
+
+    tight_turn = _map([(2.0, 2.0), (3.0, 2.0), (3.0, 3.0)])
+    robot = BicycleDriveSettings(radius=0.4, wheelbase=4.0, max_steer=0.5)
+    assert _classify(tight_turn, robot_config=robot) == KINODYNAMICALLY_INFEASIBLE
+
+
+def test_static_pedestrian_on_route_is_dynamically_overconstrained() -> None:
+    """Static pedestrians blocking the certified route are excluded as overconstrained."""
+
+    blocked = _map(
+        [(2.0, 2.0), (10.0, 2.0)],
+        pedestrians=[SinglePedestrianDefinition(id="p0", start=(5.0, 2.0))],
+    )
+    assert _classify(blocked) == DYNAMICALLY_OVERCONSTRAINED
+
+
+def test_low_clearance_solvable_route_is_knife_edge() -> None:
+    """Solvable paths close to a static obstacle are marked stress-only."""
+
+    narrow = _map(
+        [(2.0, 2.0), (10.0, 2.0)],
+        obstacles=[_obstacle(5.0, 2.55, 7.0, 4.0)],
+    )
+    assert _classify(narrow) == KNIFE_EDGE
+
+
+def test_dynamic_crossing_is_hard_but_solvable() -> None:
+    """Moving pedestrian interactions are represented without collapsing to pass/fail."""
+
+    crossing = _map(
+        [(2.0, 2.0), (10.0, 2.0)],
+        pedestrians=[SinglePedestrianDefinition(id="p0", start=(5.0, 0.5), goal=(5.0, 4.0))],
+    )
+    assert _classify(crossing) == HARD_BUT_SOLVABLE
+
+
+@pytest.mark.parametrize(
+    ("classification", "eligibility"),
+    [
+        (VALID, "eligible"),
+        (HARD_BUT_SOLVABLE, "eligible"),
+        (KNIFE_EDGE, "stress_only"),
+        (INVALID, "excluded"),
+        (GEOMETRICALLY_INFEASIBLE, "excluded"),
+        (KINODYNAMICALLY_INFEASIBLE, "excluded"),
+        (DYNAMICALLY_OVERCONSTRAINED, "excluded"),
+    ],
+)
+def test_schema_enum_documents_expected_statuses(classification: str, eligibility: str) -> None:
+    """The public schema keeps the status taxonomy explicit and machine-readable."""
+
+    schema = json.loads(Path("robot_sf/benchmark/schemas/scenario_cert.v1.json").read_text())
+    assert classification in schema["$defs"]["classification"]["enum"]
+    assert eligibility in schema["$defs"]["eligibility"]["enum"]


### PR DESCRIPTION
## Summary
Adds the first `scenario_cert.v1` certification surface for scenario manifests, including a library API, CLI, JSON schema, focused tests, and benchmark-facing docs.

## Linked Issues
- Closes #868

## What Changed
- Added `robot_sf.scenario_certification` with conservative v1 classifications: `valid`, `invalid`, `geometrically_infeasible`, `kinodynamically_infeasible`, `dynamically_overconstrained`, `knife_edge`, and `hard_but_solvable`.
- Added `scripts/tools/certify_scenarios.py` for batch JSON/JSONL certificate generation from scenario manifests.
- Added `robot_sf/benchmark/schemas/scenario_cert.v1.json` and tests covering schema validation plus every label class.
- Documented the certification contract in `docs/scenario_certification.md`, linked it from benchmark docs, and captured issue context in `docs/context/issue_868_scenario_certification.md`.

## Why It Matters
- Benchmark reports can now distinguish malformed or infeasible scenarios from planner weakness before using results as claims.
- Upstream generators and reviewers get machine-readable eligibility (`eligible`, `stress_only`, `excluded`) with concrete reasons and route-level evidence.
- This creates the prerequisite certificate contract for adversarial scenario search and benchmark inclusion policy without promoting any new benchmark scenarios.

## Validation / Proof
Fresh proof after merging latest `origin/main` into `868-scenario-certification`:

- `PYTEST_ADDOPTS=--no-cov uv run pytest tests/scenario_certification/test_scenario_certification_v1.py -q`
  - `14 passed in 1.23s`.
- `uv run python scripts/tools/certify_scenarios.py configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml --output output/scenario_cert/issue868_atomic_validation_post_merge.json`
  - emitted `goal_inside_obstacle_invalid invalid excluded` with reason `goal_inside_static_obstacle`.
- `PYTEST_NUM_WORKERS=4 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - ruff passed and formatting left `1090 files` unchanged.
  - pytest: `3005 passed, 18 skipped, 3 warnings in 240.13s`.
  - changed-files coverage: `robot_sf/scenario_certification/__init__.py` 100.0%; `robot_sf/scenario_certification/v1.py` 84.0% warning-only against an 80% minimum.
  - docstring TODO diff check passed.

Notes on validation environment:
- Default/12-worker full-suite attempts exposed unrelated local concurrency instability (`demo_social_nav_scenarios.py` timeout once; `robot_sf_bench snqi` subprocess returned 139 once). Both exact failing paths passed in isolation, and the 4-worker readiness gate passed cleanly.
- Smoke outputs and coverage artifacts were generated under ignored `output/`; they are disposable worktree-local proof, not durable dependencies.

## Risks / Rollout
- Compatibility risks: additive API/schema/CLI only; no existing benchmark schema or scenario loader contract is changed.
- Failure modes: v1 is conservative and may classify some ambiguous routes as stress-only or excluded until richer oracle evidence exists.
- Rollback or fallback plan: remove the additive package/CLI/docs if the v1 contract needs redesign before adoption.

## Docs / Provenance
- Updated docs:
  - `docs/scenario_certification.md`
  - `docs/benchmark_spec.md`
  - `docs/README.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - `docs/context/issue_868_scenario_certification.md`
  - `docs/context/issue_692_scenario_difficulty_analysis.md` remains linked as diagnostic evidence only.
- Assumptions preserved: fallback/degraded planner evidence is not certification success; scenario difficulty and residuals are optional evidence, not validity checks.

## Follow-Up Issues
- Deferred work: no follow-up issue opened in this PR.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please look closely at the classification thresholds and the v1 boundary between `knife_edge` and `hard_but_solvable`.
- Known limitation: dynamic feasibility is intentionally minimal in v1; moving pedestrians are hardness evidence unless a static pedestrian clearly blocks the route corridor.
- Project #5 update attempt remains blocked locally because the current `gh` token lacks `read:project` scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scenario certification capability to validate scenario manifests and classify their benchmark eligibility
  * New CLI tool for generating machine-readable scenario certificates in JSON/JSONL formats
  * Machine-readable certificate schema with eligibility classifications and validation rules

* **Documentation**
  * Added comprehensive guides covering scenario certification, certificate format, validation rules, and CLI usage

* **Tests**
  * Added test coverage for certification functionality including validation of edge cases and classification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->