### PR TITLE
feat: add programmable adversarial search runner (#869)

### DIFF
--- a/.opencode/tools/package.json
+++ b/.opencode/tools/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/configs/adversarial/crossing_ttc_space.yaml
+++ b/configs/adversarial/crossing_ttc_space.yaml
@@ -1,0 +1,29 @@
+schema_version: adversarial-search-space.v1
+description: Bounded v1 random-search space for crossing/TTC adversarial candidates.
+variables:
+  start_x:
+    min: 1.0
+    max: 3.0
+  start_y:
+    min: 2.0
+    max: 4.0
+  goal_x:
+    min: 7.0
+    max: 9.0
+  goal_y:
+    min: 2.0
+    max: 4.0
+  spawn_time_s:
+    min: 0.0
+    max: 2.0
+  pedestrian_speed_mps:
+    min: 0.8
+    max: 1.4
+  pedestrian_delay_s:
+    min: 0.0
+    max: 2.0
+  scenario_seed:
+    min: 100
+    max: 999
+constraints:
+  min_start_goal_distance_m: 2.0

--- a/configs/scenarios/templates/crossing_ttc.yaml
+++ b/configs/scenarios/templates/crossing_ttc.yaml
@@ -1,0 +1,16 @@
+scenarios:
+  - name: crossing_ttc_template
+    map_id: classic_cross_trap
+    simulation_config:
+      max_episode_steps: 120
+      ped_density: 0.02
+    robot_config: {}
+    metadata:
+      archetype: adversarial_crossing_ttc
+      flow: cross
+      behavior: generated_stress_test
+      purpose: Base template for programmable adversarial crossing/TTC search.
+      generated_cases_are_benchmark_evidence: false
+      promotion_note: Generated cases remain development stress tests until separately certified and promoted.
+    seeds:
+      - 123

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -121,6 +121,8 @@ why a change was made rather than a full issue execution transcript.
 - [SLURM Multi-Worktree Branch Workflow](slurm_multi_worktree_branch_workflow.md) - branch-isolated
   SLURM submissions from a shared login node, including `local.machine.md` symlink guidance and
   virtualenv boundaries.
+- [Issue #869 Adversarial Runner](issue_869_adversarial_runner.md) - programmable adversarial
+  scenario search API, bundle contract, certification boundary, and deferred optimizer scope.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_869_adversarial_runner.md
+++ b/docs/context/issue_869_adversarial_runner.md
@@ -72,6 +72,19 @@ PR handoff should still run:
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 ```
 
+Observed on 2026-05-01 after syncing with `origin/main`:
+
+- `uv run pytest tests/adversarial/test_adversarial_search.py` passed (`8 passed`).
+- The smoke search above produced
+  `output/adversarial/issue_869_smoke/goal_crossing/candidate_0000` with
+  `num_failed_evaluations=0` and `num_invalid_candidates=0`.
+- A direct replay of the emitted `candidate_0000/scenario.yaml` through `run_batch(...)` wrote one
+  episode to `episode_records_replay.jsonl` with zero failures.
+- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed after the coverage-focused tests were
+  added (`2998 passed, 19 skipped, 3 warnings`). Changed-file coverage was above the hard 80%
+  floor; `bundle.py`, `config.py`, `io.py`, and `search.py` remained below the aspirational 100%
+  goal as warning-only items.
+
 Observed on 2026-04-30: the focused tests and smoke path passed. The full readiness script passed
 Ruff, then failed in the broad parallel pytest phase due unrelated performance/worker issues
 (`tests/examples/test_examples_run.py` timeouts, `tests/test_ci_performance.py` runtime budget,

--- a/docs/context/issue_869_adversarial_runner.md
+++ b/docs/context/issue_869_adversarial_runner.md
@@ -1,0 +1,87 @@
+# Issue 869 Adversarial Runner
+
+Issue: https://github.com/ll7/robot_sf_ll7/issues/869
+
+## Goal
+
+Issue 869 adds a programmable adversarial scenario search runner under
+`robot_sf/adversarial/`. The implementation boundary is the Python API, not a CLI, so search
+programs, tests, notebooks, and future optimizer adapters can call the same core directly.
+
+## Current V1 Boundary
+
+- `SearchConfig.from_files(...)` loads a scenario template and search-space YAML.
+- `run_adversarial_search(...)` runs a bounded random-search loop by default.
+- Candidate generation is deterministic for a fixed seed.
+- Search-space validation rejects malformed candidates before policy evaluation.
+- `require_certification=True` fails closed when `scenario_cert.v1` is not available.
+- The default evaluator delegates to the existing benchmark `run_batch` path.
+- Tests can inject evaluator, certifier, and sampler callables to cover orchestration without
+  spawning a subprocess.
+
+## Artifact Contract
+
+Each valid candidate gets a bundle directory under the configured `output_dir`:
+
+- `scenario.yaml` for replay through the normal scenario loader,
+- `route_overrides.yaml` with generated robot route waypoints,
+- `episode_records.jsonl` from the benchmark runner when evaluation runs,
+- `trajectory.csv` as a replay index until the benchmark runner exposes dense per-step export,
+- `failure_attribution.json`,
+- top-level `manifest.json` summarizing all candidates and the best scored bundle.
+
+Generated bundles under `output/` are development stress-test artifacts. They are not durable
+benchmark evidence until separately certified, promoted, and published through the repository's
+normal artifact policy.
+
+## Validation Path
+
+Focused tests:
+
+```bash
+uv run pytest tests/adversarial/test_adversarial_search.py
+```
+
+Smoke proof against an existing policy path:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from robot_sf.adversarial.config import SearchConfig
+from robot_sf.adversarial.search import run_adversarial_search
+
+config = SearchConfig.from_files(
+    policy="goal",
+    scenario_template=Path("configs/scenarios/templates/crossing_ttc.yaml"),
+    search_space=Path("configs/adversarial/crossing_ttc_space.yaml"),
+    objective="worst_case_snqi",
+    output_dir=Path("output/adversarial/issue_869_smoke/goal_crossing"),
+    budget=1,
+    seed=123,
+    horizon=20,
+    require_certification=False,
+)
+result = run_adversarial_search(config)
+print(result.best_bundle_path, result.num_failed_evaluations)
+PY
+```
+
+PR handoff should still run:
+
+```bash
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+Observed on 2026-04-30: the focused tests and smoke path passed. The full readiness script passed
+Ruff, then failed in the broad parallel pytest phase due unrelated performance/worker issues
+(`tests/examples/test_examples_run.py` timeouts, `tests/test_ci_performance.py` runtime budget,
+`tests/research/test_performance_smoke.py` runtime budget, and one xdist worker crash in
+`tests/test_force_field_figure.py`). No adversarial tests failed in that run.
+
+## Deferred Follow-Ups
+
+- Add a real `scenario_cert.v1` adapter once the certification package lands.
+- Replace the `trajectory.csv` replay index with dense per-step trajectory export when the
+  benchmark runner exposes robot/pedestrian trajectories.
+- Add optimizer adapters such as CMA-ES or Bayesian optimization only after the scenario semantics
+  and bundle contract are stable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,11 @@ max-statements = 60
 "robot_sf/benchmark/**/*" = ["BLE001"]
 "robot_sf/benchmark/full_classic/visuals.py" = ["C901"]
 "robot_sf/benchmark/full_classic/render_sim_view.py" = ["C901"]
+"robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
+"robot_sf/adversarial/config.py" = ["C901", "PLR0913"]
+"robot_sf/adversarial/search.py" = ["BLE001"]
+"robot_sf/adversarial/certification.py" = ["BLE001", "PLC0415"]
+"tests/adversarial/**/*.py" = ["D100", "D103", "TC003"]
 
 # fast-pysf subtree: gradual adoption - complexity rules relaxed, allow prints in examples/benchmarks
 "fast-pysf/**/*.py" = [

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -1,0 +1,21 @@
+"""Programmable adversarial scenario search helpers."""
+
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    SearchConfig,
+    SearchRunResult,
+    SearchSpaceConfig,
+)
+from robot_sf.adversarial.search import run_adversarial_search
+
+__all__ = [
+    "CandidateEvaluation",
+    "CandidateSpec",
+    "Pose2D",
+    "SearchConfig",
+    "SearchRunResult",
+    "SearchSpaceConfig",
+    "run_adversarial_search",
+]

--- a/robot_sf/adversarial/attribution.py
+++ b/robot_sf/adversarial/attribution.py
@@ -31,10 +31,12 @@ def attribution_from_episode_record(record: dict[str, Any]) -> FailureAttributio
     termination = str(record.get("termination_reason", record.get("status", "unknown")))
     reasons: list[str] = []
     primary: str | None = None
-    if bool(outcome.get("collision")):
+    collision = bool(outcome.get("collision")) or bool(outcome.get("collision_event"))
+    timeout = bool(outcome.get("timeout")) or bool(outcome.get("timeout_event"))
+    if collision:
         primary = "collision"
         reasons.append("episode outcome reports a collision")
-    elif bool(outcome.get("timeout")):
+    elif timeout:
         primary = "timeout"
         reasons.append("episode timed out before route completion")
     elif not bool(outcome.get("route_complete")):

--- a/robot_sf/adversarial/attribution.py
+++ b/robot_sf/adversarial/attribution.py
@@ -1,0 +1,65 @@
+"""Failure-attribution helpers for adversarial search bundles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FailureAttribution:
+    """Small, replay-bundle-friendly failure attribution payload."""
+
+    status: str
+    primary_failure: str | None
+    reasons: list[str]
+    details: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable attribution payload."""
+        return {
+            "status": self.status,
+            "primary_failure": self.primary_failure,
+            "reasons": list(self.reasons),
+            "details": dict(self.details),
+        }
+
+
+def attribution_from_episode_record(record: dict[str, Any]) -> FailureAttribution:
+    """Build a conservative attribution summary from a benchmark episode record."""
+    outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+    termination = str(record.get("termination_reason", record.get("status", "unknown")))
+    reasons: list[str] = []
+    primary: str | None = None
+    if bool(outcome.get("collision")):
+        primary = "collision"
+        reasons.append("episode outcome reports a collision")
+    elif bool(outcome.get("timeout")):
+        primary = "timeout"
+        reasons.append("episode timed out before route completion")
+    elif not bool(outcome.get("route_complete")):
+        primary = "incomplete"
+        reasons.append("episode did not report route completion")
+    else:
+        primary = "success"
+        reasons.append("episode completed without an attributed failure")
+    return FailureAttribution(
+        status="attributed",
+        primary_failure=primary,
+        reasons=reasons,
+        details={
+            "termination_reason": termination,
+            "status": record.get("status"),
+            "outcome": outcome,
+        },
+    )
+
+
+def attribution_from_error(error: str) -> FailureAttribution:
+    """Build an attribution payload for an evaluation error."""
+    return FailureAttribution(
+        status="evaluation_failed",
+        primary_failure="evaluation_error",
+        reasons=[error],
+        details={"error": error},
+    )

--- a/robot_sf/adversarial/bundle.py
+++ b/robot_sf/adversarial/bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from copy import deepcopy
 from dataclasses import asdict, is_dataclass
@@ -143,10 +144,10 @@ def write_trajectory_csv(path: Path, record: dict[str, Any] | None) -> Path:
         str(record.get("steps", "")),
         str(record.get("termination_reason", "")),
     ]
-    path.write_text(
-        "episode_id,seed,status,steps,termination_reason\n" + ",".join(row) + "\n",
-        encoding="utf-8",
-    )
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(["episode_id", "seed", "status", "steps", "termination_reason"])
+        writer.writerow(row)
     return path
 
 

--- a/robot_sf/adversarial/bundle.py
+++ b/robot_sf/adversarial/bundle.py
@@ -1,0 +1,214 @@
+"""Counterexample bundle writing for adversarial search."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec, SearchConfig
+
+MANIFEST_SCHEMA_VERSION = "adversarial-search-manifest.v1"
+
+
+def _load_template(path: Path) -> dict[str, Any]:
+    """Load a scenario-template YAML file."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"Scenario template must be a mapping: {path}")
+    scenarios = payload.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError(f"Scenario template must contain a non-empty scenarios list: {path}")
+    if not isinstance(scenarios[0], dict):
+        raise ValueError("Scenario template first scenario must be a mapping")
+    return payload
+
+
+def _candidate_route_payload(candidate: CandidateSpec, *, index: int) -> dict[str, Any]:
+    """Build a route-overrides payload for the candidate start and goal."""
+    route_id = 100_000 + int(index)
+    return {
+        "robot_routes": [
+            {
+                "spawn_id": route_id,
+                "goal_id": route_id,
+                "waypoints": [candidate.start.as_waypoint(), candidate.goal.as_waypoint()],
+            }
+        ],
+        "ped_routes": [],
+    }
+
+
+def _apply_candidate_to_scenario(
+    scenario: dict[str, Any],
+    candidate: CandidateSpec,
+    *,
+    index: int,
+    route_file_name: str,
+    pedestrian_id: str | None,
+) -> dict[str, Any]:
+    """Return a scenario dictionary specialized for one candidate."""
+    updated = deepcopy(scenario)
+    base_name = str(updated.get("name") or updated.get("scenario_id") or "scenario")
+    updated["name"] = f"{base_name}_adversarial_{index:04d}"
+    updated["route_overrides_file"] = route_file_name
+    updated["seeds"] = [int(candidate.scenario_seed)]
+    sim_config = dict(updated.get("simulation_config") or {})
+    sim_config["route_spawn_seed"] = int(candidate.scenario_seed)
+    sim_config["peds_speed_mult"] = float(candidate.pedestrian_speed_mps)
+    updated["simulation_config"] = sim_config
+    metadata = dict(updated.get("metadata") or {})
+    metadata["adversarial_candidate"] = {
+        **candidate.to_json(),
+        "candidate_index": int(index),
+        "spawn_time_s_note": "stored for search provenance; route-spawn timing support is adapter-dependent",
+    }
+    updated["metadata"] = metadata
+
+    if pedestrian_id:
+        entries = list(updated.get("single_pedestrians") or [])
+        replacement = {
+            "id": pedestrian_id,
+            "speed_m_s": float(candidate.pedestrian_speed_mps),
+            "wait_at": [{"waypoint_index": 0, "wait_s": float(candidate.pedestrian_delay_s)}],
+        }
+        for entry_index, entry in enumerate(entries):
+            if isinstance(entry, dict) and entry.get("id") == pedestrian_id:
+                merged = dict(entry)
+                merged.update(replacement)
+                entries[entry_index] = merged
+                break
+        else:
+            entries.append(replacement)
+        updated["single_pedestrians"] = entries
+    return updated
+
+
+def write_candidate_inputs(
+    *,
+    config: SearchConfig,
+    candidate: CandidateSpec,
+    candidate_dir: Path,
+    index: int,
+) -> tuple[Path, Path]:
+    """Write replayable scenario and route-override files for a candidate."""
+    candidate_dir.mkdir(parents=True, exist_ok=True)
+    route_path = candidate_dir / "route_overrides.yaml"
+    scenario_path = candidate_dir / "scenario.yaml"
+    route_payload = _candidate_route_payload(candidate, index=index)
+    route_path.write_text(yaml.safe_dump(route_payload, sort_keys=False), encoding="utf-8")
+
+    template = _load_template(config.scenario_template)
+    scenario = _apply_candidate_to_scenario(
+        dict(template["scenarios"][0]),
+        candidate,
+        index=index,
+        route_file_name=route_path.name,
+        pedestrian_id=config.search_space.pedestrian_id,
+    )
+    scenario_payload = {"scenarios": [scenario]}
+    scenario_path.write_text(yaml.safe_dump(scenario_payload, sort_keys=False), encoding="utf-8")
+    return scenario_path, route_path
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> Path:
+    """Write a JSON payload with stable formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_json_safe(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def write_trajectory_csv(path: Path, record: dict[str, Any] | None) -> Path:
+    """Write a small CSV replay index for the evaluated candidate.
+
+    The current benchmark episode record does not expose full per-step
+    trajectories. This CSV therefore records replay-identifying fields and can
+    be replaced by a denser trajectory export once the runner exposes one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if record is None:
+        path.write_text("episode_id,seed,status,steps,termination_reason\n", encoding="utf-8")
+        return path
+    row = [
+        str(record.get("episode_id", "")),
+        str(record.get("seed", "")),
+        str(record.get("status", "")),
+        str(record.get("steps", "")),
+        str(record.get("termination_reason", "")),
+    ]
+    path.write_text(
+        "episode_id,seed,status,steps,termination_reason\n" + ",".join(row) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_search_manifest(
+    *,
+    config: SearchConfig,
+    manifest_path: Path,
+    evaluations: list[CandidateEvaluation],
+    best: CandidateEvaluation | None,
+    num_invalid_candidates: int,
+    num_failed_evaluations: int,
+) -> Path:
+    """Write the top-level search manifest."""
+    payload = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "created_at": datetime.now(UTC).isoformat(),
+        "config": config.to_json(),
+        "summary": {
+            "num_candidates": len(evaluations),
+            "num_valid_candidates": len(evaluations) - num_invalid_candidates,
+            "num_invalid_candidates": num_invalid_candidates,
+            "num_failed_evaluations": num_failed_evaluations,
+            "best_objective_value": best.objective_value if best else None,
+            "best_bundle_path": best.bundle_path.as_posix() if best and best.bundle_path else None,
+        },
+        "candidates": [_evaluation_to_json(item) for item in evaluations],
+    }
+    return write_json(manifest_path, payload)
+
+
+def _evaluation_to_json(evaluation: CandidateEvaluation) -> dict[str, Any]:
+    """Convert an evaluation dataclass into a manifest payload."""
+    attribution = (
+        evaluation.failure_attribution.to_json() if evaluation.failure_attribution else None
+    )
+    return {
+        "candidate": evaluation.candidate.to_json(),
+        "certification_status": evaluation.certification_status.to_json(),
+        "objective_value": evaluation.objective_value,
+        "failure_attribution": attribution,
+        "episode_record_path": evaluation.episode_record_path.as_posix()
+        if evaluation.episode_record_path
+        else None,
+        "trajectory_csv_path": evaluation.trajectory_csv_path.as_posix()
+        if evaluation.trajectory_csv_path
+        else None,
+        "scenario_yaml_path": evaluation.scenario_yaml_path.as_posix()
+        if evaluation.scenario_yaml_path
+        else None,
+        "bundle_path": evaluation.bundle_path.as_posix() if evaluation.bundle_path else None,
+        "error": evaluation.error,
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively convert common Python objects to JSON-safe values."""
+    if isinstance(value, Path):
+        return value.as_posix()
+    if is_dataclass(value):
+        return _json_safe(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _json_safe(nested) for key, nested in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe(nested) for nested in value]
+    return value

--- a/robot_sf/adversarial/certification.py
+++ b/robot_sf/adversarial/certification.py
@@ -1,0 +1,111 @@
+"""Scenario-certification adapter for adversarial candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from robot_sf.adversarial.config import CandidateSpec
+
+
+@dataclass(frozen=True)
+class CertificationStatus:
+    """Certification outcome for a generated candidate."""
+
+    schema_version: str
+    status: str
+    reason: str
+    details: dict[str, Any]
+
+    @property
+    def passed(self) -> bool:
+        """Return True when the candidate is certified valid."""
+        return self.status == "passed"
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable payload."""
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "reason": self.reason,
+            "details": dict(self.details),
+        }
+
+
+def passed_status(reason: str = "certification not required") -> CertificationStatus:
+    """Return a passing advisory status."""
+    return CertificationStatus(
+        schema_version="scenario_cert.v1",
+        status="passed",
+        reason=reason,
+        details={},
+    )
+
+
+def failed_status(reason: str, *, details: dict[str, Any] | None = None) -> CertificationStatus:
+    """Return a failed certification status."""
+    return CertificationStatus(
+        schema_version="scenario_cert.v1",
+        status="failed",
+        reason=reason,
+        details=details or {},
+    )
+
+
+def not_available_status(reason: str) -> CertificationStatus:
+    """Return a not-available certification status."""
+    return CertificationStatus(
+        schema_version="scenario_cert.v1",
+        status="not_available",
+        reason=reason,
+        details={},
+    )
+
+
+def certify_candidate(
+    candidate: CandidateSpec,
+    *,
+    scenario_yaml_path: Path,
+    require_certification: bool,
+) -> CertificationStatus:
+    """Certify a generated candidate using ``scenario_cert.v1`` when available.
+
+    The scenario-certification package is a planned prerequisite, not yet a
+    stable in-repo API. When strict certification is requested and no adapter is
+    available, this function fails closed with a ``not_available`` status.
+    """
+    try:
+        from robot_sf.scenario_certification import certify_scenario  # type: ignore
+    except ImportError:
+        if require_certification:
+            return not_available_status("scenario_cert.v1 adapter is not available")
+        return passed_status("scenario_cert.v1 adapter not available; advisory mode")
+
+    try:
+        payload = certify_scenario(scenario_yaml_path, candidate=candidate)
+    except Exception as exc:  # pragma: no cover - defensive against future adapter errors
+        return failed_status(
+            "scenario_cert.v1 raised during certification", details={"error": repr(exc)}
+        )
+
+    if not isinstance(payload, dict):
+        return failed_status("scenario_cert.v1 returned a non-mapping payload")
+    status = str(payload.get("status", "")).strip().lower()
+    reason = str(payload.get("reason", status or "unknown"))
+    details = payload.get("details", {})
+    if not isinstance(details, dict):
+        details = {"raw_details": details}
+    if status in {"passed", "valid", "ok"}:
+        return CertificationStatus("scenario_cert.v1", "passed", reason, details)
+    if status in {"not_available", "unavailable"}:
+        return CertificationStatus("scenario_cert.v1", "not_available", reason, details)
+    return CertificationStatus("scenario_cert.v1", "failed", reason, details)
+
+
+def candidate_allowed(status: CertificationStatus, *, require_certification: bool) -> bool:
+    """Return whether a candidate may proceed to policy evaluation."""
+    if status.passed:
+        return True
+    return not require_certification and status.status == "not_available"

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -184,7 +184,7 @@ class SearchSpaceConfig:
         if pedestrian_id is not None:
             pedestrian_id = str(pedestrian_id).strip() or None
 
-        return cls(
+        config = cls(
             start_x=_range("start_x"),
             start_y=_range("start_y"),
             goal_x=_range("goal_x"),
@@ -196,6 +196,12 @@ class SearchSpaceConfig:
             min_start_goal_distance_m=float(constraints.get("min_start_goal_distance_m", 0.25)),
             pedestrian_id=pedestrian_id,
         )
+        if (
+            not math.isfinite(config.min_start_goal_distance_m)
+            or config.min_start_goal_distance_m < 0.0
+        ):
+            raise ValueError("search-space min_start_goal_distance_m must be finite and >= 0")
+        return config
 
     def sample_candidate(self, rng: Random) -> CandidateSpec:
         """Sample a candidate deterministically from the provided RNG."""
@@ -231,6 +237,14 @@ class SearchSpaceConfig:
             errors.append("goal.x outside search space")
         if not self.goal_y.contains(candidate.goal.y):
             errors.append("goal.y outside search space")
+        if not self.spawn_time_s.contains(candidate.spawn_time_s):
+            errors.append("spawn_time_s outside search space")
+        if not self.pedestrian_speed_mps.contains(candidate.pedestrian_speed_mps):
+            errors.append("pedestrian_speed_mps outside search space")
+        if not self.pedestrian_delay_s.contains(candidate.pedestrian_delay_s):
+            errors.append("pedestrian_delay_s outside search space")
+        if not self.scenario_seed.contains(float(candidate.scenario_seed)):
+            errors.append("scenario_seed outside search space")
         if candidate.spawn_time_s < 0.0:
             errors.append("spawn_time_s must be non-negative")
         if candidate.pedestrian_speed_mps <= 0.0:

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -196,6 +196,8 @@ class SearchSpaceConfig:
             min_start_goal_distance_m=float(constraints.get("min_start_goal_distance_m", 0.25)),
             pedestrian_id=pedestrian_id,
         )
+        if not config.scenario_seed.min.is_integer() or not config.scenario_seed.max.is_integer():
+            raise ValueError("search-space scenario_seed bounds must be integers")
         if (
             not math.isfinite(config.min_start_goal_distance_m)
             or config.min_start_goal_distance_m < 0.0
@@ -211,7 +213,7 @@ class SearchSpaceConfig:
             spawn_time_s=self.spawn_time_s.sample(rng),
             pedestrian_speed_mps=self.pedestrian_speed_mps.sample(rng),
             pedestrian_delay_s=self.pedestrian_delay_s.sample(rng),
-            scenario_seed=round(self.scenario_seed.sample(rng)),
+            scenario_seed=rng.randint(int(self.scenario_seed.min), int(self.scenario_seed.max)),
         )
 
     def validate_candidate(self, candidate: CandidateSpec) -> list[str]:

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -1,0 +1,373 @@
+"""Configuration and public contracts for adversarial scenario search."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from random import Random
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from robot_sf.adversarial.attribution import FailureAttribution
+    from robot_sf.adversarial.certification import CertificationStatus
+
+
+@dataclass(frozen=True)
+class Pose2D:
+    """Planar pose used by the adversarial candidate contract."""
+
+    x: float
+    y: float
+    theta: float = 0.0
+
+    def as_waypoint(self) -> list[float]:
+        """Return the pose position as a route waypoint."""
+        return [float(self.x), float(self.y)]
+
+    def to_json(self) -> dict[str, float]:
+        """Return a JSON-serializable payload."""
+        return {"x": float(self.x), "y": float(self.y), "theta": float(self.theta)}
+
+
+@dataclass(frozen=True)
+class CandidateSpec:
+    """One sampled adversarial scenario candidate."""
+
+    start: Pose2D
+    goal: Pose2D
+    spawn_time_s: float
+    pedestrian_speed_mps: float
+    pedestrian_delay_s: float
+    scenario_seed: int
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable candidate payload."""
+        return {
+            "start": self.start.to_json(),
+            "goal": self.goal.to_json(),
+            "spawn_time_s": float(self.spawn_time_s),
+            "pedestrian_speed_mps": float(self.pedestrian_speed_mps),
+            "pedestrian_delay_s": float(self.pedestrian_delay_s),
+            "scenario_seed": int(self.scenario_seed),
+        }
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    """Evaluation result for one candidate."""
+
+    candidate: CandidateSpec
+    certification_status: CertificationStatus
+    objective_value: float | None
+    failure_attribution: FailureAttribution | None
+    episode_record_path: Path | None
+    trajectory_csv_path: Path | None
+    scenario_yaml_path: Path | None
+    bundle_path: Path | None = None
+    error: str | None = None
+
+    def with_objective(self, objective_value: float | None) -> CandidateEvaluation:
+        """Return a copy with an objective score attached."""
+        return replace(self, objective_value=objective_value)
+
+
+@dataclass(frozen=True)
+class SearchRunResult:
+    """Summary returned by :func:`run_adversarial_search`."""
+
+    manifest_path: Path
+    best_candidate: CandidateEvaluation | None
+    best_bundle_path: Path | None
+    num_candidates: int
+    num_valid_candidates: int
+    num_invalid_candidates: int
+    num_failed_evaluations: int
+
+    @property
+    def best_objective_value(self) -> float | None:
+        """Return the best objective value, if any candidate scored."""
+        if self.best_candidate is None:
+            return None
+        return self.best_candidate.objective_value
+
+
+@dataclass(frozen=True)
+class RangeConfig:
+    """Inclusive numeric sampling range."""
+
+    min: float
+    max: float
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any], *, name: str) -> RangeConfig:
+        """Build a range from YAML payload."""
+        if "min" not in payload or "max" not in payload:
+            raise ValueError(f"search_space.{name} must define min and max")
+        lo = float(payload["min"])
+        hi = float(payload["max"])
+        if not math.isfinite(lo) or not math.isfinite(hi):
+            raise ValueError(f"search_space.{name} bounds must be finite")
+        if lo > hi:
+            raise ValueError(f"search_space.{name}.min must be <= max")
+        return cls(min=lo, max=hi)
+
+    def sample(self, rng: Random) -> float:
+        """Sample a value from the range."""
+        return float(rng.uniform(self.min, self.max))
+
+    def contains(self, value: float) -> bool:
+        """Return whether a value falls inside the inclusive range."""
+        return self.min <= float(value) <= self.max
+
+    def to_json(self) -> dict[str, float]:
+        """Return a JSON-serializable range payload."""
+        return {"min": float(self.min), "max": float(self.max)}
+
+
+@dataclass(frozen=True)
+class SearchSpaceConfig:
+    """Validated candidate sampling space for adversarial search."""
+
+    start_x: RangeConfig
+    start_y: RangeConfig
+    goal_x: RangeConfig
+    goal_y: RangeConfig
+    spawn_time_s: RangeConfig = field(default_factory=lambda: RangeConfig(0.0, 0.0))
+    pedestrian_speed_mps: RangeConfig = field(default_factory=lambda: RangeConfig(1.0, 1.0))
+    pedestrian_delay_s: RangeConfig = field(default_factory=lambda: RangeConfig(0.0, 0.0))
+    scenario_seed: RangeConfig = field(default_factory=lambda: RangeConfig(1.0, 1.0))
+    min_start_goal_distance_m: float = 0.25
+    pedestrian_id: str | None = None
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> SearchSpaceConfig:
+        """Load and validate a search-space YAML file."""
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"Search-space config must be a mapping: {path}")
+        return cls.from_mapping(raw)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> SearchSpaceConfig:
+        """Build a search-space config from a mapping."""
+        variables = payload.get("variables", payload)
+        if not isinstance(variables, dict):
+            raise ValueError("search-space variables must be a mapping")
+
+        def _range(name: str, default: tuple[float, float] | None = None) -> RangeConfig:
+            raw_value = variables.get(name)
+            if raw_value is None:
+                if default is None:
+                    raise ValueError(f"search_space.{name} is required")
+                return RangeConfig(*default)
+            if not isinstance(raw_value, dict):
+                raise ValueError(f"search_space.{name} must be a mapping")
+            return RangeConfig.from_mapping(raw_value, name=name)
+
+        constraints = payload.get("constraints", {})
+        if constraints is None:
+            constraints = {}
+        if not isinstance(constraints, dict):
+            raise ValueError("search-space constraints must be a mapping")
+        pedestrian = payload.get("pedestrian", {})
+        if pedestrian is None:
+            pedestrian = {}
+        if not isinstance(pedestrian, dict):
+            raise ValueError("search-space pedestrian section must be a mapping")
+        pedestrian_id = pedestrian.get("id")
+        if pedestrian_id is not None:
+            pedestrian_id = str(pedestrian_id).strip() or None
+
+        return cls(
+            start_x=_range("start_x"),
+            start_y=_range("start_y"),
+            goal_x=_range("goal_x"),
+            goal_y=_range("goal_y"),
+            spawn_time_s=_range("spawn_time_s", (0.0, 0.0)),
+            pedestrian_speed_mps=_range("pedestrian_speed_mps", (1.0, 1.0)),
+            pedestrian_delay_s=_range("pedestrian_delay_s", (0.0, 0.0)),
+            scenario_seed=_range("scenario_seed", (1.0, 1.0)),
+            min_start_goal_distance_m=float(constraints.get("min_start_goal_distance_m", 0.25)),
+            pedestrian_id=pedestrian_id,
+        )
+
+    def sample_candidate(self, rng: Random) -> CandidateSpec:
+        """Sample a candidate deterministically from the provided RNG."""
+        return CandidateSpec(
+            start=Pose2D(self.start_x.sample(rng), self.start_y.sample(rng)),
+            goal=Pose2D(self.goal_x.sample(rng), self.goal_y.sample(rng)),
+            spawn_time_s=self.spawn_time_s.sample(rng),
+            pedestrian_speed_mps=self.pedestrian_speed_mps.sample(rng),
+            pedestrian_delay_s=self.pedestrian_delay_s.sample(rng),
+            scenario_seed=round(self.scenario_seed.sample(rng)),
+        )
+
+    def validate_candidate(self, candidate: CandidateSpec) -> list[str]:
+        """Return validation errors for a candidate; empty means valid."""
+        errors: list[str] = []
+        values = {
+            "start.x": candidate.start.x,
+            "start.y": candidate.start.y,
+            "goal.x": candidate.goal.x,
+            "goal.y": candidate.goal.y,
+            "spawn_time_s": candidate.spawn_time_s,
+            "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
+            "pedestrian_delay_s": candidate.pedestrian_delay_s,
+        }
+        for name, value in values.items():
+            if not math.isfinite(float(value)):
+                errors.append(f"{name} must be finite")
+        if not self.start_x.contains(candidate.start.x):
+            errors.append("start.x outside search space")
+        if not self.start_y.contains(candidate.start.y):
+            errors.append("start.y outside search space")
+        if not self.goal_x.contains(candidate.goal.x):
+            errors.append("goal.x outside search space")
+        if not self.goal_y.contains(candidate.goal.y):
+            errors.append("goal.y outside search space")
+        if candidate.spawn_time_s < 0.0:
+            errors.append("spawn_time_s must be non-negative")
+        if candidate.pedestrian_speed_mps <= 0.0:
+            errors.append("pedestrian_speed_mps must be positive")
+        if candidate.pedestrian_delay_s < 0.0:
+            errors.append("pedestrian_delay_s must be non-negative")
+        if candidate.scenario_seed < 0:
+            errors.append("scenario_seed must be non-negative")
+        dx = float(candidate.goal.x) - float(candidate.start.x)
+        dy = float(candidate.goal.y) - float(candidate.start.y)
+        if math.hypot(dx, dy) < self.min_start_goal_distance_m:
+            errors.append("start and goal are closer than min_start_goal_distance_m")
+        return errors
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable search-space payload."""
+        return {
+            "variables": {
+                "start_x": self.start_x.to_json(),
+                "start_y": self.start_y.to_json(),
+                "goal_x": self.goal_x.to_json(),
+                "goal_y": self.goal_y.to_json(),
+                "spawn_time_s": self.spawn_time_s.to_json(),
+                "pedestrian_speed_mps": self.pedestrian_speed_mps.to_json(),
+                "pedestrian_delay_s": self.pedestrian_delay_s.to_json(),
+                "scenario_seed": self.scenario_seed.to_json(),
+            },
+            "constraints": {"min_start_goal_distance_m": self.min_start_goal_distance_m},
+            "pedestrian": {"id": self.pedestrian_id} if self.pedestrian_id else {},
+        }
+
+
+@dataclass(frozen=True)
+class SearchConfig:
+    """Top-level adversarial-search run configuration."""
+
+    policy: str
+    scenario_template: Path
+    search_space_path: Path
+    search_space: SearchSpaceConfig
+    objective: str
+    output_dir: Path
+    budget: int = 64
+    seed: int = 0
+    algo_config_path: Path | None = None
+    horizon: int | None = None
+    dt: float | None = None
+    workers: int = 1
+    record_forces: bool = True
+    require_certification: bool = False
+    benchmark_profile: str = "baseline-safe"
+    snqi_weights_path: Path | None = None
+    snqi_baseline_path: Path | None = None
+
+    @classmethod
+    def from_files(
+        cls,
+        *,
+        policy: str,
+        scenario_template: Path,
+        search_space: Path,
+        objective: str,
+        output_dir: Path,
+        budget: int = 64,
+        seed: int = 0,
+        algo_config_path: Path | None = None,
+        horizon: int | None = None,
+        dt: float | None = None,
+        workers: int = 1,
+        record_forces: bool = True,
+        require_certification: bool = False,
+        benchmark_profile: str = "baseline-safe",
+        snqi_weights_path: Path | None = None,
+        snqi_baseline_path: Path | None = None,
+    ) -> SearchConfig:
+        """Create a search config by loading the search-space YAML."""
+        return cls(
+            policy=policy,
+            scenario_template=Path(scenario_template),
+            search_space_path=Path(search_space),
+            search_space=SearchSpaceConfig.from_file(search_space),
+            objective=objective,
+            output_dir=Path(output_dir),
+            budget=int(budget),
+            seed=int(seed),
+            algo_config_path=Path(algo_config_path) if algo_config_path else None,
+            horizon=horizon,
+            dt=dt,
+            workers=int(workers),
+            record_forces=bool(record_forces),
+            require_certification=bool(require_certification),
+            benchmark_profile=benchmark_profile,
+            snqi_weights_path=Path(snqi_weights_path) if snqi_weights_path else None,
+            snqi_baseline_path=Path(snqi_baseline_path) if snqi_baseline_path else None,
+        )
+
+    def validate(self) -> None:
+        """Validate top-level search settings."""
+        if not self.policy.strip():
+            raise ValueError("policy must be non-empty")
+        if self.budget < 1:
+            raise ValueError("budget must be >= 1")
+        if self.workers < 1:
+            raise ValueError("workers must be >= 1")
+        if not self.scenario_template.exists():
+            raise FileNotFoundError(f"Scenario template not found: {self.scenario_template}")
+        if self.algo_config_path is not None and not self.algo_config_path.exists():
+            raise FileNotFoundError(f"Algorithm config not found: {self.algo_config_path}")
+
+    def load_optional_json(self, path: Path | None) -> dict[str, Any] | None:
+        """Load an optional JSON config file."""
+        if path is None:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable config payload for manifests."""
+        return {
+            "policy": self.policy,
+            "scenario_template": self.scenario_template.as_posix(),
+            "search_space_path": self.search_space_path.as_posix(),
+            "search_space": self.search_space.to_json(),
+            "objective": self.objective,
+            "output_dir": self.output_dir.as_posix(),
+            "budget": int(self.budget),
+            "seed": int(self.seed),
+            "algo_config_path": self.algo_config_path.as_posix() if self.algo_config_path else None,
+            "horizon": self.horizon,
+            "dt": self.dt,
+            "workers": int(self.workers),
+            "record_forces": bool(self.record_forces),
+            "require_certification": bool(self.require_certification),
+            "benchmark_profile": self.benchmark_profile,
+            "snqi_weights_path": self.snqi_weights_path.as_posix()
+            if self.snqi_weights_path
+            else None,
+            "snqi_baseline_path": self.snqi_baseline_path.as_posix()
+            if self.snqi_baseline_path
+            else None,
+        }

--- a/robot_sf/adversarial/io.py
+++ b/robot_sf/adversarial/io.py
@@ -15,6 +15,9 @@ def read_first_jsonl_record(path: Path | None) -> dict[str, Any] | None:
         for line in handle:
             stripped = line.strip()
             if stripped:
-                payload = json.loads(stripped)
+                try:
+                    payload = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
                 return payload if isinstance(payload, dict) else None
     return None

--- a/robot_sf/adversarial/objectives.py
+++ b/robot_sf/adversarial/objectives.py
@@ -60,6 +60,11 @@ def register_objective(name: str, objective: ObjectiveFn) -> None:
     _OBJECTIVES[key] = objective
 
 
+def unregister_objective(name: str) -> None:
+    """Remove a registered objective function if present."""
+    _OBJECTIVES.pop(name.strip(), None)
+
+
 def get_objective(name: str) -> ObjectiveFn:
     """Return a registered objective function."""
     try:

--- a/robot_sf/adversarial/objectives.py
+++ b/robot_sf/adversarial/objectives.py
@@ -1,0 +1,86 @@
+"""Objective registry for adversarial scenario search."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from robot_sf.adversarial.config import CandidateEvaluation
+
+ObjectiveFn = Callable[["CandidateEvaluation"], float | None]
+
+
+def _read_first_episode(path: Path | None) -> dict[str, Any] | None:
+    """Read the first JSONL episode record from an evaluation artifact."""
+    if path is None or not path.exists():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped:
+            payload = json.loads(stripped)
+            return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _metric(metrics: dict[str, Any], key: str, default: float = 0.0) -> float:
+    """Read a finite metric scalar with a default."""
+    value = metrics.get(key, default)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def worst_case_snqi(evaluation: CandidateEvaluation) -> float | None:
+    """Score lower-SNQI or failure-like records higher for maximization.
+
+    If a benchmark record already contains ``metrics.snqi``, this returns
+    ``-snqi`` so the search maximizes worse social-navigation quality. Some
+    smoke paths do not compute calibrated SNQI; for those records, a conservative
+    fallback failure score keeps the runner usable without pretending the value
+    is camera-ready SNQI evidence.
+    """
+    record = _read_first_episode(evaluation.episode_record_path)
+    if record is None:
+        return None
+    metrics = record.get("metrics") if isinstance(record.get("metrics"), dict) else {}
+    if "snqi" in metrics:
+        return -_metric(metrics, "snqi")
+    outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+    collision = 1.0 if bool(outcome.get("collision")) else 0.0
+    timeout = 1.0 if bool(outcome.get("timeout")) else 0.0
+    success = _metric(metrics, "success", 1.0 if bool(outcome.get("route_complete")) else 0.0)
+    near = _metric(metrics, "near_misses", 0.0)
+    return float(collision * 10.0 + timeout * 3.0 + near - success)
+
+
+_OBJECTIVES: dict[str, ObjectiveFn] = {
+    "worst_case_snqi": worst_case_snqi,
+}
+
+
+def register_objective(name: str, objective: ObjectiveFn) -> None:
+    """Register an objective function by name."""
+    key = name.strip()
+    if not key:
+        raise ValueError("objective name must be non-empty")
+    _OBJECTIVES[key] = objective
+
+
+def get_objective(name: str) -> ObjectiveFn:
+    """Return a registered objective function."""
+    try:
+        return _OBJECTIVES[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(_OBJECTIVES))
+        raise ValueError(f"Unknown adversarial objective '{name}'. Available: {available}") from exc
+
+
+def list_objectives() -> tuple[str, ...]:
+    """Return registered objective names."""
+    return tuple(sorted(_OBJECTIVES))

--- a/robot_sf/adversarial/objectives.py
+++ b/robot_sf/adversarial/objectives.py
@@ -40,8 +40,8 @@ def worst_case_snqi(evaluation: CandidateEvaluation) -> float | None:
     if "snqi" in metrics:
         return -_metric(metrics, "snqi")
     outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
-    collision = 1.0 if bool(outcome.get("collision")) else 0.0
-    timeout = 1.0 if bool(outcome.get("timeout")) else 0.0
+    collision = 1.0 if bool(outcome.get("collision") or outcome.get("collision_event")) else 0.0
+    timeout = 1.0 if bool(outcome.get("timeout") or outcome.get("timeout_event")) else 0.0
     success = _metric(metrics, "success", 1.0 if bool(outcome.get("route_complete")) else 0.0)
     near = _metric(metrics, "near_misses", 0.0)
     return float(collision * 10.0 + timeout * 3.0 + near - success)

--- a/robot_sf/adversarial/samplers.py
+++ b/robot_sf/adversarial/samplers.py
@@ -1,0 +1,28 @@
+"""Candidate samplers for adversarial search."""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Protocol
+
+from robot_sf.adversarial.config import CandidateSpec, SearchSpaceConfig
+
+
+class CandidateSampler(Protocol):
+    """Protocol for optimizer-backed candidate samplers."""
+
+    def sample(self) -> CandidateSpec:
+        """Return the next candidate."""
+
+
+class RandomCandidateSampler:
+    """Dependency-light random-search sampler."""
+
+    def __init__(self, search_space: SearchSpaceConfig, *, seed: int) -> None:
+        """Initialize the sampler with a search space and deterministic seed."""
+        self._search_space = search_space
+        self._rng = Random(seed)
+
+    def sample(self) -> CandidateSpec:
+        """Return the next random candidate."""
+        return self._search_space.sample_candidate(self._rng)

--- a/robot_sf/adversarial/search.py
+++ b/robot_sf/adversarial/search.py
@@ -1,0 +1,262 @@
+"""Programmable adversarial scenario search runner."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+from robot_sf.adversarial.attribution import (
+    FailureAttribution,
+    attribution_from_episode_record,
+    attribution_from_error,
+)
+from robot_sf.adversarial.bundle import (
+    write_candidate_inputs,
+    write_json,
+    write_search_manifest,
+    write_trajectory_csv,
+)
+from robot_sf.adversarial.certification import (
+    CertificationStatus,
+    candidate_allowed,
+    certify_candidate,
+    failed_status,
+)
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    SearchConfig,
+    SearchRunResult,
+)
+from robot_sf.adversarial.objectives import get_objective
+from robot_sf.adversarial.samplers import CandidateSampler, RandomCandidateSampler
+from robot_sf.benchmark.runner import run_batch
+
+CandidateEvaluator = Callable[[SearchConfig, CandidateSpec, Path, Path], CandidateEvaluation]
+CandidateCertifier = Callable[[CandidateSpec, Path, bool], CertificationStatus]
+
+DEFAULT_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
+
+
+def _read_first_episode(path: Path) -> dict | None:
+    """Read the first JSONL record from a benchmark output."""
+    if not path.exists():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped:
+            payload = json.loads(stripped)
+            return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _default_evaluator(
+    config: SearchConfig,
+    candidate: CandidateSpec,
+    scenario_yaml_path: Path,
+    candidate_dir: Path,
+) -> CandidateEvaluation:
+    """Evaluate one candidate through the existing benchmark batch runner."""
+    episode_path = candidate_dir / "episode_records.jsonl"
+    snqi_weights = config.load_optional_json(config.snqi_weights_path)
+    snqi_baseline = config.load_optional_json(config.snqi_baseline_path)
+    summary = run_batch(
+        scenario_yaml_path,
+        out_path=episode_path,
+        schema_path=DEFAULT_SCHEMA_PATH,
+        horizon=config.horizon or 100,
+        dt=config.dt or 0.1,
+        record_forces=config.record_forces,
+        snqi_weights=snqi_weights,
+        snqi_baseline=snqi_baseline,
+        algo=config.policy,
+        algo_config_path=str(config.algo_config_path) if config.algo_config_path else None,
+        benchmark_profile=config.benchmark_profile,
+        workers=config.workers,
+        resume=False,
+    )
+    if int(summary.get("failed_jobs", 0)) > 0:
+        raise RuntimeError(f"candidate evaluation failed: {summary.get('failures')}")
+    record = _read_first_episode(episode_path)
+    trajectory_path = write_trajectory_csv(candidate_dir / "trajectory.csv", record)
+    attribution = attribution_from_episode_record(record or {})
+    write_json(candidate_dir / "failure_attribution.json", attribution.to_json())
+    return CandidateEvaluation(
+        candidate=candidate,
+        certification_status=failed_status("certification not assigned by evaluator"),
+        objective_value=None,
+        failure_attribution=attribution,
+        episode_record_path=episode_path,
+        trajectory_csv_path=trajectory_path,
+        scenario_yaml_path=scenario_yaml_path,
+        bundle_path=candidate_dir,
+    )
+
+
+def _default_certifier(
+    candidate: CandidateSpec,
+    scenario_yaml_path: Path,
+    require_certification: bool,
+) -> CertificationStatus:
+    """Default scenario-certification adapter."""
+    return certify_candidate(
+        candidate,
+        scenario_yaml_path=scenario_yaml_path,
+        require_certification=require_certification,
+    )
+
+
+def _invalid_evaluation(
+    *,
+    candidate: CandidateSpec,
+    certification_status: CertificationStatus,
+    scenario_yaml_path: Path | None,
+    bundle_path: Path | None,
+    reason: str,
+) -> CandidateEvaluation:
+    """Build an evaluation payload for a rejected candidate."""
+    return CandidateEvaluation(
+        candidate=candidate,
+        certification_status=certification_status,
+        objective_value=None,
+        failure_attribution=FailureAttribution(
+            status="not_evaluated",
+            primary_failure="invalid_candidate",
+            reasons=[reason],
+            details={},
+        ),
+        episode_record_path=None,
+        trajectory_csv_path=None,
+        scenario_yaml_path=scenario_yaml_path,
+        bundle_path=bundle_path,
+        error=reason,
+    )
+
+
+def run_adversarial_search(
+    config: SearchConfig,
+    *,
+    evaluator: CandidateEvaluator | None = None,
+    certifier: CandidateCertifier | None = None,
+    sampler: CandidateSampler | None = None,
+) -> SearchRunResult:
+    """Run a bounded adversarial scenario search.
+
+    Args:
+        config: Search configuration and contracts.
+        evaluator: Optional injected evaluator for tests or experiment harnesses.
+        certifier: Optional injected certification adapter.
+        sampler: Optional injected sampler or optimizer adapter.
+
+    Returns:
+        SearchRunResult containing the manifest path and best candidate.
+    """
+    config.validate()
+    objective = get_objective(config.objective)
+    active_evaluator = evaluator or _default_evaluator
+    active_certifier = certifier or _default_certifier
+    active_sampler = sampler or RandomCandidateSampler(config.search_space, seed=config.seed)
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    evaluations: list[CandidateEvaluation] = []
+    num_invalid = 0
+    num_failed = 0
+    best: CandidateEvaluation | None = None
+
+    for index in range(config.budget):
+        candidate = active_sampler.sample()
+        candidate_dir = config.output_dir / f"candidate_{index:04d}"
+        validation_errors = config.search_space.validate_candidate(candidate)
+        if validation_errors:
+            num_invalid += 1
+            evaluations.append(
+                _invalid_evaluation(
+                    candidate=candidate,
+                    certification_status=failed_status(
+                        "search-space validation failed",
+                        details={"errors": validation_errors},
+                    ),
+                    scenario_yaml_path=None,
+                    bundle_path=None,
+                    reason="; ".join(validation_errors),
+                )
+            )
+            continue
+
+        scenario_yaml_path, _route_path = write_candidate_inputs(
+            config=config,
+            candidate=candidate,
+            candidate_dir=candidate_dir,
+            index=index,
+        )
+        certification_status = active_certifier(
+            candidate,
+            scenario_yaml_path,
+            config.require_certification,
+        )
+        if not candidate_allowed(
+            certification_status,
+            require_certification=config.require_certification,
+        ):
+            num_invalid += 1
+            evaluation = _invalid_evaluation(
+                candidate=candidate,
+                certification_status=certification_status,
+                scenario_yaml_path=scenario_yaml_path,
+                bundle_path=candidate_dir,
+                reason=certification_status.reason,
+            )
+            write_json(
+                candidate_dir / "failure_attribution.json", evaluation.failure_attribution.to_json()
+            )
+            evaluations.append(evaluation)
+            continue
+
+        try:
+            evaluation = active_evaluator(config, candidate, scenario_yaml_path, candidate_dir)
+            evaluation = replace(evaluation, certification_status=certification_status)
+            score = objective(evaluation)
+            evaluation = evaluation.with_objective(score)
+        except Exception as exc:
+            num_failed += 1
+            error = repr(exc)
+            attribution = attribution_from_error(error)
+            write_json(candidate_dir / "failure_attribution.json", attribution.to_json())
+            evaluation = CandidateEvaluation(
+                candidate=candidate,
+                certification_status=certification_status,
+                objective_value=None,
+                failure_attribution=attribution,
+                episode_record_path=candidate_dir / "episode_records.jsonl",
+                trajectory_csv_path=None,
+                scenario_yaml_path=scenario_yaml_path,
+                bundle_path=candidate_dir,
+                error=error,
+            )
+        evaluations.append(evaluation)
+        if evaluation.objective_value is not None and (
+            best is None
+            or best.objective_value is None
+            or evaluation.objective_value > best.objective_value
+        ):
+            best = evaluation
+
+    manifest_path = write_search_manifest(
+        config=config,
+        manifest_path=config.output_dir / "manifest.json",
+        evaluations=evaluations,
+        best=best,
+        num_invalid_candidates=num_invalid,
+        num_failed_evaluations=num_failed,
+    )
+    return SearchRunResult(
+        manifest_path=manifest_path,
+        best_candidate=best,
+        best_bundle_path=best.bundle_path if best else None,
+        num_candidates=len(evaluations),
+        num_valid_candidates=len(evaluations) - num_invalid,
+        num_invalid_candidates=num_invalid,
+        num_failed_evaluations=num_failed,
+    )

--- a/scripts/training/train_dreamerv3_rllib.py
+++ b/scripts/training/train_dreamerv3_rllib.py
@@ -1239,7 +1239,13 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
     """Write JSON payload with stable formatting."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
-        json.dump(_json_safe_value(payload), handle, allow_nan=False, indent=2, sort_keys=True)
+        json.dump(
+            _json_safe_value(copy.deepcopy(payload)),
+            handle,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
         handle.write("\n")
 
 

--- a/scripts/validation/package.json
+++ b/scripts/validation/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -389,8 +389,11 @@ def test_objective_registry_and_fallback_scoring(
     assert objectives.worst_case_snqi(scored_eval) == 15.0
 
     objectives.register_objective("unit_test_constant", lambda _evaluation: 42.0)
-    assert objectives.get_objective("unit_test_constant")(scored_eval) == 42.0
-    assert "unit_test_constant" in objectives.list_objectives()
+    try:
+        assert objectives.get_objective("unit_test_constant")(scored_eval) == 42.0
+        assert "unit_test_constant" in objectives.list_objectives()
+    finally:
+        objectives.unregister_objective("unit_test_constant")
     with pytest.raises(ValueError, match="objective name"):
         objectives.register_objective("", lambda _evaluation: 0.0)
     with pytest.raises(ValueError, match="Unknown adversarial objective"):

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.adversarial.attribution import attribution_from_episode_record
+from robot_sf.adversarial.bundle import write_trajectory_csv
+from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec, Pose2D, SearchConfig
+from robot_sf.adversarial.search import run_adversarial_search
+
+
+def _write_template(path: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "template",
+                        "map_id": "classic_cross_trap",
+                        "simulation_config": {"max_episode_steps": 30, "ped_density": 0.0},
+                        "robot_config": {},
+                        "metadata": {"archetype": "test"},
+                        "seeds": [1],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_space(path: Path, *, min_distance: float = 0.5) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "variables": {
+                    "start_x": {"min": 1.0, "max": 1.0},
+                    "start_y": {"min": 2.0, "max": 2.0},
+                    "goal_x": {"min": 5.0, "max": 5.0},
+                    "goal_y": {"min": 2.0, "max": 2.0},
+                    "spawn_time_s": {"min": 0.0, "max": 0.0},
+                    "pedestrian_speed_mps": {"min": 1.0, "max": 1.0},
+                    "pedestrian_delay_s": {"min": 0.0, "max": 0.0},
+                    "scenario_seed": {"min": 7, "max": 7},
+                },
+                "constraints": {"min_start_goal_distance_m": min_distance},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _config(tmp_path: Path, *, require_certification: bool = False) -> SearchConfig:
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    return SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+        budget=2,
+        seed=123,
+        require_certification=require_certification,
+    )
+
+
+class _SequenceSampler:
+    def __init__(self, candidates: list[CandidateSpec]) -> None:
+        self._candidates = list(candidates)
+
+    def sample(self) -> CandidateSpec:
+        return self._candidates.pop(0)
+
+
+def _candidate(seed: int, *, goal_x: float = 5.0) -> CandidateSpec:
+    return CandidateSpec(
+        start=Pose2D(1.0, 2.0),
+        goal=Pose2D(goal_x, 2.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=seed,
+    )
+
+
+def test_search_config_from_files_validates_candidate(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    candidate = config.search_space.sample_candidate(__import__("random").Random(1))
+
+    assert config.search_space.validate_candidate(candidate) == []
+    assert candidate.scenario_seed == 7
+
+
+def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    scores = [0.8, 0.2]
+
+    def evaluator(
+        _config: SearchConfig,
+        candidate: CandidateSpec,
+        scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        snqi = scores.pop(0)
+        record: dict[str, Any] = {
+            "episode_id": f"episode-{candidate.scenario_seed}",
+            "seed": candidate.scenario_seed,
+            "status": "success",
+            "steps": 3,
+            "termination_reason": "success",
+            "outcome": {"route_complete": True, "collision": False, "timeout": False},
+            "metrics": {"snqi": snqi, "success": 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        trajectory_path = write_trajectory_csv(candidate_dir / "trajectory.csv", record)
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status(),
+            objective_value=None,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=trajectory_path,
+            scenario_yaml_path=scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    result = run_adversarial_search(
+        config,
+        evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: passed_status("test certifier"),
+        sampler=_SequenceSampler([_candidate(1), _candidate(2)]),
+    )
+
+    assert result.num_candidates == 2
+    assert result.num_invalid_candidates == 0
+    assert result.best_objective_value == -0.2
+    assert result.best_bundle_path == config.output_dir / "candidate_0001"
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["summary"]["best_bundle_path"].endswith("candidate_0001")
+    assert (config.output_dir / "candidate_0001" / "scenario.yaml").exists()
+    assert (config.output_dir / "candidate_0001" / "route_overrides.yaml").exists()
+
+
+def test_required_certification_fails_closed_when_adapter_missing(tmp_path: Path) -> None:
+    config = _config(tmp_path, require_certification=True)
+    config = SearchConfig.from_files(
+        policy=config.policy,
+        scenario_template=config.scenario_template,
+        search_space=config.search_space_path,
+        objective=config.objective,
+        output_dir=config.output_dir,
+        budget=1,
+        seed=config.seed,
+        require_certification=True,
+    )
+
+    def evaluator(*_args: object, **_kwargs: object) -> CandidateEvaluation:
+        raise AssertionError("strict certification should reject before evaluation")
+
+    result = run_adversarial_search(
+        config,
+        evaluator=evaluator,
+        sampler=_SequenceSampler([_candidate(1)]),
+    )
+
+    assert result.best_candidate is None
+    assert result.num_invalid_candidates == 1
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["candidates"][0]["certification_status"]["status"] == "not_available"
+    assert manifest["candidates"][0]["error"] == "scenario_cert.v1 adapter is not available"

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -148,6 +148,22 @@ def test_search_space_rejects_invalid_min_start_goal_distance() -> None:
         SearchSpaceConfig.from_mapping(payload)
 
 
+def test_search_space_rejects_non_integral_seed_bounds() -> None:
+    """Scenario seed ranges must describe a discrete integer sampling space."""
+    payload = {
+        "variables": {
+            "start_x": {"min": 0, "max": 1},
+            "start_y": {"min": 0, "max": 1},
+            "goal_x": {"min": 2, "max": 3},
+            "goal_y": {"min": 2, "max": 3},
+            "scenario_seed": {"min": 1.5, "max": 2.5},
+        }
+    }
+
+    with pytest.raises(ValueError, match="scenario_seed bounds must be integers"):
+        SearchSpaceConfig.from_mapping(payload)
+
+
 def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:
     config = _config(tmp_path)
     scores = [0.8, 0.2]
@@ -406,6 +422,9 @@ def test_random_sampler_is_deterministic(tmp_path: Path) -> None:
     space_path = tmp_path / "space.yaml"
     _write_template(template_path)
     _write_space(space_path)
+    payload = yaml.safe_load(space_path.read_text(encoding="utf-8"))
+    payload["variables"]["scenario_seed"] = {"min": 7, "max": 9}
+    space_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     space = SearchConfig.from_files(
         policy="goal",
         scenario_template=template_path,
@@ -417,3 +436,5 @@ def test_random_sampler_is_deterministic(tmp_path: Path) -> None:
     right = RandomCandidateSampler(space, seed=7).sample()
 
     assert left == right
+    assert isinstance(left.scenario_seed, int)
+    assert 7 <= left.scenario_seed <= 9

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-from robot_sf.adversarial import search
-from robot_sf.adversarial.attribution import attribution_from_episode_record
+from robot_sf.adversarial import certification, objectives, search
+from robot_sf.adversarial.attribution import attribution_from_episode_record, attribution_from_error
 from robot_sf.adversarial.bundle import write_trajectory_csv
-from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.certification import failed_status, passed_status
 from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec, Pose2D, SearchConfig
+from robot_sf.adversarial.samplers import RandomCandidateSampler
 
 
 def _write_template(path: Path) -> None:
@@ -200,3 +203,135 @@ def test_default_evaluator_treats_failures_as_failed_jobs(
             tmp_path / "scenario.yaml",
             tmp_path / "candidate",
         )
+
+
+def test_failure_attribution_covers_primary_outcomes() -> None:
+    """Failure attribution must distinguish collision, timeout, incomplete, and errors."""
+    collision = attribution_from_episode_record(
+        {"status": "done", "outcome": {"collision": True, "route_complete": False}}
+    )
+    timeout = attribution_from_episode_record(
+        {"status": "done", "outcome": {"timeout": True, "route_complete": False}}
+    )
+    incomplete = attribution_from_episode_record(
+        {"status": "done", "outcome": {"route_complete": False}}
+    )
+    error = attribution_from_error("boom")
+
+    assert collision.primary_failure == "collision"
+    assert timeout.primary_failure == "timeout"
+    assert incomplete.primary_failure == "incomplete"
+    assert error.to_json()["status"] == "evaluation_failed"
+
+
+def test_certification_adapter_handles_missing_and_mocked_backends(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Certification must fail closed when required and normalize adapter payloads."""
+    monkeypatch.delitem(sys.modules, "robot_sf.scenario_certification", raising=False)
+
+    advisory = certification.certify_candidate(
+        _candidate(1), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=False
+    )
+    assert advisory.passed
+    assert failed_status("bad", details={"why": "test"}).to_json()["details"] == {"why": "test"}
+
+    fake_module = types.ModuleType("robot_sf.scenario_certification")
+    responses: list[object] = [
+        {"status": "valid", "reason": "ok", "details": ["raw"]},
+        {"status": "unavailable", "reason": "backend absent"},
+        "not a mapping",
+        {"status": "invalid", "reason": "outside map", "details": {"field": "start"}},
+    ]
+
+    def fake_certify_scenario(*_args: object, **_kwargs: object) -> object:
+        return responses.pop(0)
+
+    fake_module.certify_scenario = fake_certify_scenario
+    monkeypatch.setitem(sys.modules, "robot_sf.scenario_certification", fake_module)
+
+    passed = certification.certify_candidate(
+        _candidate(2), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+    unavailable = certification.certify_candidate(
+        _candidate(3), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+    non_mapping = certification.certify_candidate(
+        _candidate(4), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+    failed = certification.certify_candidate(
+        _candidate(5), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+
+    assert passed.passed
+    assert passed.details == {"raw_details": ["raw"]}
+    assert unavailable.status == "not_available"
+    assert non_mapping.status == "failed"
+    assert failed.reason == "outside map"
+
+
+def test_objective_registry_and_fallback_scoring(tmp_path: Path) -> None:
+    """Objectives should score SNQI records, fallback failures, and registry errors."""
+    episode_path = tmp_path / "episode.jsonl"
+    episode_path.write_text(
+        json.dumps({"metrics": {"snqi": "nan"}, "outcome": {"route_complete": True}}) + "\n",
+        encoding="utf-8",
+    )
+    empty_eval = CandidateEvaluation(
+        candidate=_candidate(1),
+        certification_status=passed_status(),
+        objective_value=None,
+        failure_attribution=None,
+        episode_record_path=None,
+        trajectory_csv_path=None,
+        scenario_yaml_path=None,
+    )
+    scored_eval = CandidateEvaluation(
+        candidate=_candidate(2),
+        certification_status=passed_status(),
+        objective_value=None,
+        failure_attribution=None,
+        episode_record_path=episode_path,
+        trajectory_csv_path=None,
+        scenario_yaml_path=None,
+    )
+
+    assert objectives.worst_case_snqi(empty_eval) is None
+    assert objectives.worst_case_snqi(scored_eval) == -0.0
+
+    episode_path.write_text(
+        json.dumps(
+            {
+                "metrics": {"success": "bad", "near_misses": 2},
+                "outcome": {"collision": True, "timeout": True, "route_complete": False},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert objectives.worst_case_snqi(scored_eval) == 15.0
+
+    objectives.register_objective("unit_test_constant", lambda _evaluation: 42.0)
+    assert objectives.get_objective("unit_test_constant")(scored_eval) == 42.0
+    assert "unit_test_constant" in objectives.list_objectives()
+    with pytest.raises(ValueError, match="objective name"):
+        objectives.register_objective("", lambda _evaluation: 0.0)
+    with pytest.raises(ValueError, match="Unknown adversarial objective"):
+        objectives.get_objective("missing")
+
+
+def test_random_sampler_is_deterministic(tmp_path: Path) -> None:
+    """Random search must be repeatable for the same seed and search space."""
+    space_path = tmp_path / "space.yaml"
+    _write_space(space_path)
+    space = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=tmp_path / "template.yaml",
+        search_space=space_path,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+    ).search_space
+    left = RandomCandidateSampler(space, seed=7).sample()
+    right = RandomCandidateSampler(space, seed=7).sample()
+
+    assert left == right

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 import sys
 import types
@@ -13,7 +14,14 @@ from robot_sf.adversarial import certification, objectives, search
 from robot_sf.adversarial.attribution import attribution_from_episode_record, attribution_from_error
 from robot_sf.adversarial.bundle import write_trajectory_csv
 from robot_sf.adversarial.certification import failed_status, passed_status
-from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec, Pose2D, SearchConfig
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    SearchConfig,
+    SearchSpaceConfig,
+)
+from robot_sf.adversarial.io import read_first_jsonl_record
 from robot_sf.adversarial.samplers import RandomCandidateSampler
 
 
@@ -105,6 +113,41 @@ def test_search_config_from_files_validates_candidate(tmp_path: Path) -> None:
     assert candidate.scenario_seed == 7
 
 
+def test_search_space_validates_all_configured_candidate_ranges(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    errors = config.search_space.validate_candidate(
+        CandidateSpec(
+            start=Pose2D(1.0, 2.0),
+            goal=Pose2D(5.0, 2.0),
+            spawn_time_s=1.0,
+            pedestrian_speed_mps=2.0,
+            pedestrian_delay_s=1.0,
+            scenario_seed=8,
+        )
+    )
+
+    assert "spawn_time_s outside search space" in errors
+    assert "pedestrian_speed_mps outside search space" in errors
+    assert "pedestrian_delay_s outside search space" in errors
+    assert "scenario_seed outside search space" in errors
+
+
+def test_search_space_rejects_invalid_min_start_goal_distance() -> None:
+    payload = {
+        "variables": {
+            "start_x": {"min": 0, "max": 1},
+            "start_y": {"min": 0, "max": 1},
+            "goal_x": {"min": 2, "max": 3},
+            "goal_y": {"min": 2, "max": 3},
+        },
+        "constraints": {"min_start_goal_distance_m": -1.0},
+    }
+
+    with pytest.raises(ValueError, match="min_start_goal_distance_m"):
+        SearchSpaceConfig.from_mapping(payload)
+
+
 def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:
     config = _config(tmp_path)
     scores = [0.8, 0.2]
@@ -143,7 +186,7 @@ def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path
         config,
         evaluator=evaluator,
         certifier=lambda _candidate, _path, _required: passed_status("test certifier"),
-        sampler=_SequenceSampler([_candidate(1), _candidate(2)]),
+        sampler=_SequenceSampler([_candidate(7), _candidate(7)]),
     )
 
     assert result.num_candidates == 2
@@ -175,7 +218,7 @@ def test_required_certification_fails_closed_when_adapter_missing(tmp_path: Path
     result = search.run_adversarial_search(
         config,
         evaluator=evaluator,
-        sampler=_SequenceSampler([_candidate(1)]),
+        sampler=_SequenceSampler([_candidate(7)]),
     )
 
     assert result.best_candidate is None
@@ -210,8 +253,11 @@ def test_failure_attribution_covers_primary_outcomes() -> None:
     collision = attribution_from_episode_record(
         {"status": "done", "outcome": {"collision": True, "route_complete": False}}
     )
+    legacy_collision = attribution_from_episode_record(
+        {"status": "done", "outcome": {"collision_event": True, "route_complete": False}}
+    )
     timeout = attribution_from_episode_record(
-        {"status": "done", "outcome": {"timeout": True, "route_complete": False}}
+        {"status": "done", "outcome": {"timeout_event": True, "route_complete": False}}
     )
     incomplete = attribution_from_episode_record(
         {"status": "done", "outcome": {"route_complete": False}}
@@ -219,9 +265,37 @@ def test_failure_attribution_covers_primary_outcomes() -> None:
     error = attribution_from_error("boom")
 
     assert collision.primary_failure == "collision"
+    assert legacy_collision.primary_failure == "collision"
     assert timeout.primary_failure == "timeout"
     assert incomplete.primary_failure == "incomplete"
     assert error.to_json()["status"] == "evaluation_failed"
+
+
+def test_read_first_jsonl_record_skips_malformed_lines(tmp_path: Path) -> None:
+    """JSONL helper should fail soft for malformed records and keep scanning."""
+    path = tmp_path / "episode.jsonl"
+    path.write_text("{bad json}\n\n" + json.dumps({"episode_id": "ok"}) + "\n", encoding="utf-8")
+
+    assert read_first_jsonl_record(path) == {"episode_id": "ok"}
+
+
+def test_write_trajectory_csv_escapes_fields(tmp_path: Path) -> None:
+    """Trajectory index rows should remain valid CSV when fields contain punctuation."""
+    path = write_trajectory_csv(
+        tmp_path / "trajectory.csv",
+        {
+            "episode_id": "episode,1",
+            "seed": 7,
+            "status": "done",
+            "steps": 3,
+            "termination_reason": 'quote "and" comma, here',
+        },
+    )
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.reader(handle))
+
+    assert rows[1] == ["episode,1", "7", "done", "3", 'quote "and" comma, here']
 
 
 def test_certification_adapter_handles_missing_and_mocked_backends(

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -344,8 +344,11 @@ def test_certification_adapter_handles_missing_and_mocked_backends(
     assert failed.reason == "outside map"
 
 
-def test_objective_registry_and_fallback_scoring(tmp_path: Path) -> None:
+def test_objective_registry_and_fallback_scoring(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Objectives should score SNQI records, fallback failures, and registry errors."""
+    monkeypatch.setattr(objectives, "_OBJECTIVES", dict(objectives._OBJECTIVES))
     episode_path = tmp_path / "episode.jsonl"
     episode_path.write_text(
         json.dumps({"metrics": {"snqi": "nan"}, "outcome": {"route_complete": True}}) + "\n",
@@ -396,11 +399,13 @@ def test_objective_registry_and_fallback_scoring(tmp_path: Path) -> None:
 
 def test_random_sampler_is_deterministic(tmp_path: Path) -> None:
     """Random search must be repeatable for the same seed and search space."""
+    template_path = tmp_path / "template.yaml"
     space_path = tmp_path / "space.yaml"
+    _write_template(template_path)
     _write_space(space_path)
     space = SearchConfig.from_files(
         policy="goal",
-        scenario_template=tmp_path / "template.yaml",
+        scenario_template=template_path,
         search_space=space_path,
         objective="worst_case_snqi",
         output_dir=tmp_path / "out",

--- a/tests/training/test_train_dreamerv3_rllib_runtime.py
+++ b/tests/training/test_train_dreamerv3_rllib_runtime.py
@@ -611,6 +611,17 @@ def test_json_safe_value_handles_numpy_paths_and_deep_payloads() -> None:
     assert cursor["value"] == "-inf"
 
 
+def test_write_json_does_not_mutate_payload(tmp_path: Path) -> None:
+    """Strict JSON writing should not alter objects the caller may reuse."""
+    write_json = _dreamer_callable("_write_json")
+    payload = {"nested": {"value": np.float64(np.nan)}, "path": Path("output/run")}
+
+    write_json(tmp_path / "payload.json", payload)
+
+    assert isinstance(payload["nested"]["value"], np.float64)
+    assert isinstance(payload["path"], Path)
+
+
 def test_run_training_cleans_up_ray_and_algo_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
Adds a reusable `robot_sf.adversarial` Python package for programmable adversarial scenario search, with random-search v1, search-space validation, objective scoring, certification gating, and replay-bundle writing.

## Linked Issues
- Closes #869

## What Changed
- Added `SearchConfig`, `SearchSpaceConfig`, `CandidateSpec`, `CandidateEvaluation`, and `SearchRunResult` contracts.
- Added `run_adversarial_search(...)` with injectable sampler, certifier, and evaluator hooks for Python search programs and tests.
- Added random sampling, `worst_case_snqi` objective registry, scenario-certification adapter, failure attribution helpers, and bundle manifest writing.
- Added first config-first surfaces: `configs/scenarios/templates/crossing_ttc.yaml` and `configs/adversarial/crossing_ttc_space.yaml`.
- Expanded focused tests for attribution, certification adapter normalization, objective fallback scoring, deterministic sampling, and changed-file coverage.
- Updated `docs/context/issue_869_adversarial_runner.md` with v1 boundaries, smoke proof, replay proof, and readiness evidence.

## Why It Matters
- Added value: turns issue #869 into a reusable programmatic falsification runner instead of a one-off command script.
- Expected impact: search orchestration, objective tests, certification fail-closed behavior, and bundle generation can be tested without subprocess-only workflows.
- Why this is worth merging now: it establishes the library boundary future optimizers and Python experiment harnesses can build on.

## Validation / Proof
- `git fetch origin main && git merge --ff-only origin/main`: already up to date before PR handoff.
- `scripts/dev/ruff_fix_format.sh`: passed.
- `uv run pytest tests/adversarial/test_adversarial_search.py`: passed, `8 passed`.
- Programmatic smoke against existing `goal` policy path passed with `budget=1`, writing ignored local bundle `output/adversarial/issue_869_smoke/goal_crossing/candidate_0000`; `num_invalid_candidates=0`, `num_failed_evaluations=0`.
- Direct replay of emitted `candidate_0000/scenario.yaml` through `run_batch(...)`: wrote one episode to `episode_records_replay.jsonl` with zero failures.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`: passed, `2998 passed, 19 skipped, 3 warnings`. Changed-file coverage is above the hard 80% floor; `bundle.py`, `config.py`, `io.py`, and `search.py` remain below the aspirational 100% goal as warning-only items.

## Risks / Rollout
- Compatibility risks: low; the package is new and opt-in.
- Failure modes: strict certification rejects all candidates until `scenario_cert.v1` is available; this is intentional fail-closed behavior when `require_certification=True`.
- Rollback or fallback plan: remove the new `robot_sf/adversarial` package and configs; existing benchmark paths are not changed.

## Docs / Provenance
- Updated docs: `docs/context/issue_869_adversarial_runner.md`, linked from `docs/context/README.md`.
- Relevant design or provenance notes: generated bundles under `output/` are development stress-test artifacts, not durable benchmark evidence.
- Assumption preserved: CLI work is out of scope for #869; the primary interface is the Python API.

## Follow-Up Issues
- #879: real `scenario_cert.v1` adapter for adversarial search.
- #880: dense per-step adversarial bundle trajectory export.
- #881: optimizer adapters such as CMA-ES or Bayesian optimization after semantics stabilize.
- Project routing note: Project #5 metadata could not be updated from this machine because the current `gh` token lacks `read:project` / project scopes.

## Reviewer Notes
- Please review the API shape in `robot_sf/adversarial/config.py` and `robot_sf/adversarial/search.py` closely.
- `trajectory.csv` is currently a replay index because the existing benchmark runner does not expose dense per-step trajectories to callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adversarial scenario search: deterministic candidate sampling, objective scoring, certification gating, and generation of candidate bundles/manifests and per-candidate artifacts for crossing/TTC stress tests.
  * New crossing/TTC scenario template and search-space configuration.

* **Documentation**
  * Added workflow and design notes with usage examples for the adversarial runner.

* **Tests**
  * Comprehensive tests covering sampling, evaluation, certification behavior, objectives, and artifact/manifest outputs.

* **Bug Fixes**
  * Strict JSON serialization to avoid non-finite values and preserve caller payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->