### PR TITLE
fix: align adversarial certification adapter (#888)

### DIFF
--- a/robot_sf/adversarial/certification.py
+++ b/robot_sf/adversarial/certification.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -77,14 +78,18 @@ def certify_candidate(
     available, this function fails closed with a ``not_available`` status.
     """
     try:
-        from robot_sf.scenario_certification import certify_scenario  # type: ignore
+        scenario_certification = import_module("robot_sf.scenario_certification")
     except ImportError:
         if require_certification:
             return not_available_status("scenario_cert.v1 adapter is not available")
         return passed_status("scenario_cert.v1 adapter not available; advisory mode")
 
     try:
-        payload = certify_scenario(scenario_yaml_path, candidate=candidate)
+        payload = _run_scenario_certification_adapter(
+            scenario_certification,
+            candidate=candidate,
+            scenario_yaml_path=scenario_yaml_path,
+        )
     except Exception as exc:  # pragma: no cover - defensive against future adapter errors
         return failed_status(
             "scenario_cert.v1 raised during certification", details={"error": repr(exc)}
@@ -102,6 +107,45 @@ def certify_candidate(
     if status in {"not_available", "unavailable"}:
         return CertificationStatus("scenario_cert.v1", "not_available", reason, details)
     return CertificationStatus("scenario_cert.v1", "failed", reason, details)
+
+
+def _run_scenario_certification_adapter(
+    scenario_certification: Any,
+    *,
+    candidate: CandidateSpec,
+    scenario_yaml_path: Path,
+) -> dict[str, Any]:
+    """Run the available scenario certification API and normalize its payload."""
+    certify_scenario_file = getattr(scenario_certification, "certify_scenario_file", None)
+    certificate_to_dict = getattr(scenario_certification, "certificate_to_dict", None)
+    if callable(certify_scenario_file) and callable(certificate_to_dict):
+        certificates = certify_scenario_file(scenario_yaml_path)
+        payloads = [certificate_to_dict(certificate) for certificate in certificates]
+        if not payloads:
+            return {"status": "failed", "reason": "scenario_cert.v1 returned no certificates"}
+        worst = max(
+            payloads,
+            key=lambda payload: (
+                1 if str(payload.get("benchmark_eligibility", "")).lower() == "excluded" else 0
+            ),
+        )
+        status = (
+            "failed"
+            if str(worst.get("benchmark_eligibility", "")).lower() == "excluded"
+            else "passed"
+        )
+        reasons = worst.get("reasons", [])
+        reason = "; ".join(str(reason) for reason in reasons) if isinstance(reasons, list) else ""
+        return {
+            "status": status,
+            "reason": reason or str(worst.get("classification", status)),
+            "details": {"certificates": payloads},
+        }
+
+    certify_scenario = getattr(scenario_certification, "certify_scenario", None)
+    if callable(certify_scenario):
+        return certify_scenario(scenario_yaml_path, candidate=candidate)
+    return {"status": "not_available", "reason": "scenario_cert.v1 adapter is not available"}
 
 
 def candidate_allowed(status: CertificationStatus, *, require_certification: bool) -> bool:

--- a/robot_sf/adversarial/certification.py
+++ b/robot_sf/adversarial/certification.py
@@ -11,6 +11,22 @@ if TYPE_CHECKING:
     from robot_sf.adversarial.config import CandidateSpec
 
 
+_CLASSIFICATION_TO_ELIGIBILITY = {
+    "invalid": "excluded",
+    "geometrically_infeasible": "excluded",
+    "kinodynamically_infeasible": "excluded",
+    "dynamically_overconstrained": "excluded",
+    "knife_edge": "stress_only",
+    "hard_but_solvable": "eligible",
+    "valid": "eligible",
+}
+_ELIGIBILITY_SEVERITY = {
+    "eligible": 0,
+    "stress_only": 1,
+    "excluded": 2,
+}
+
+
 @dataclass(frozen=True)
 class CertificationStatus:
     """Certification outcome for a generated candidate."""
@@ -123,17 +139,9 @@ def _run_scenario_certification_adapter(
         payloads = [certificate_to_dict(certificate) for certificate in certificates]
         if not payloads:
             return {"status": "failed", "reason": "scenario_cert.v1 returned no certificates"}
-        worst = max(
-            payloads,
-            key=lambda payload: (
-                1 if str(payload.get("benchmark_eligibility", "")).lower() == "excluded" else 0
-            ),
-        )
-        status = (
-            "failed"
-            if str(worst.get("benchmark_eligibility", "")).lower() == "excluded"
-            else "passed"
-        )
+        worst = max(payloads, key=_certificate_payload_severity)
+        eligibility = _certificate_payload_eligibility(worst)
+        status = "failed" if eligibility in {"", "excluded"} else "passed"
         reasons = worst.get("reasons", [])
         reason = "; ".join(str(reason) for reason in reasons) if isinstance(reasons, list) else ""
         return {
@@ -146,6 +154,28 @@ def _run_scenario_certification_adapter(
     if callable(certify_scenario):
         return certify_scenario(scenario_yaml_path, candidate=candidate)
     return {"status": "not_available", "reason": "scenario_cert.v1 adapter is not available"}
+
+
+def _normalize_certificate_text(value: Any) -> str:
+    """Normalize optional certificate enum fields without stringifying null values."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def _certificate_payload_eligibility(payload: dict[str, Any]) -> str:
+    """Return benchmark eligibility, inferring it from classification when omitted."""
+    eligibility = _normalize_certificate_text(payload.get("benchmark_eligibility"))
+    if eligibility in _ELIGIBILITY_SEVERITY:
+        return eligibility
+    classification = _normalize_certificate_text(payload.get("classification"))
+    return _CLASSIFICATION_TO_ELIGIBILITY.get(classification, "")
+
+
+def _certificate_payload_severity(payload: dict[str, Any]) -> tuple[int, str]:
+    """Sort certificates by benchmark eligibility severity, failing closed on unknown values."""
+    eligibility = _certificate_payload_eligibility(payload)
+    return (_ELIGIBILITY_SEVERITY.get(eligibility, 3), eligibility)
 
 
 def candidate_allowed(status: CertificationStatus, *, require_certification: bool) -> bool:

--- a/scripts/wandb_ppo_training.py
+++ b/scripts/wandb_ppo_training.py
@@ -3,13 +3,13 @@ Train ppo robot and log to wandb
 Documentation can be found in `docs/wandb.md`
 """
 
+import wandb
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import CallbackList, CheckpointCallback
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import SubprocVecEnv
 from wandb.integration.sb3 import WandbCallback
 
-import wandb
 from robot_sf.feature_extractor import DynamicsExtractor
 from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv

--- a/scripts/wandb_ppo_training.py
+++ b/scripts/wandb_ppo_training.py
@@ -3,13 +3,13 @@ Train ppo robot and log to wandb
 Documentation can be found in `docs/wandb.md`
 """
 
-import wandb
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import CallbackList, CheckpointCallback
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import SubprocVecEnv
 from wandb.integration.sb3 import WandbCallback
 
+import wandb
 from robot_sf.feature_extractor import DynamicsExtractor
 from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -13,7 +13,7 @@ import yaml
 from robot_sf.adversarial import certification, objectives, search
 from robot_sf.adversarial.attribution import attribution_from_episode_record, attribution_from_error
 from robot_sf.adversarial.bundle import write_trajectory_csv
-from robot_sf.adversarial.certification import failed_status, passed_status
+from robot_sf.adversarial.certification import failed_status, not_available_status, passed_status
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
@@ -234,6 +234,9 @@ def test_required_certification_fails_closed_when_adapter_missing(tmp_path: Path
     result = search.run_adversarial_search(
         config,
         evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: not_available_status(
+            "scenario_cert.v1 adapter is not available"
+        ),
         sampler=_SequenceSampler([_candidate(7)]),
     )
 
@@ -318,7 +321,7 @@ def test_certification_adapter_handles_missing_and_mocked_backends(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Certification must fail closed when required and normalize adapter payloads."""
-    monkeypatch.delitem(sys.modules, "robot_sf.scenario_certification", raising=False)
+    monkeypatch.setitem(sys.modules, "robot_sf.scenario_certification", None)
 
     advisory = certification.certify_candidate(
         _candidate(1), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=False
@@ -358,6 +361,35 @@ def test_certification_adapter_handles_missing_and_mocked_backends(
     assert unavailable.status == "not_available"
     assert non_mapping.status == "failed"
     assert failed.reason == "outside map"
+
+
+def test_certification_adapter_uses_current_scenario_certification_file_api(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Adversarial certification should call the in-repo scenario-cert file API."""
+    fake_module = types.ModuleType("robot_sf.scenario_certification")
+
+    def fake_certify_scenario_file(*_args: object, **_kwargs: object) -> list[object]:
+        return [object()]
+
+    def fake_certificate_to_dict(_certificate: object) -> dict[str, object]:
+        return {
+            "classification": "valid",
+            "benchmark_eligibility": "eligible",
+            "reasons": ["ok"],
+        }
+
+    fake_module.certify_scenario_file = fake_certify_scenario_file
+    fake_module.certificate_to_dict = fake_certificate_to_dict
+    monkeypatch.setitem(sys.modules, "robot_sf.scenario_certification", fake_module)
+
+    status = certification.certify_candidate(
+        _candidate(6), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+
+    assert status.passed
+    assert status.reason == "ok"
+    assert status.details["certificates"][0]["classification"] == "valid"
 
 
 def test_objective_registry_and_fallback_scoring(

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -392,6 +392,48 @@ def test_certification_adapter_uses_current_scenario_certification_file_api(
     assert status.details["certificates"][0]["classification"] == "valid"
 
 
+def test_certification_adapter_preserves_worst_file_api_eligibility(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """File-API normalization should keep stress-only/excluded evidence visible."""
+    fake_module = types.ModuleType("robot_sf.scenario_certification")
+
+    def fake_certify_scenario_file(*_args: object, **_kwargs: object) -> list[object]:
+        return [object(), object(), object()]
+
+    payloads: list[dict[str, object]] = [
+        {
+            "classification": "valid",
+            "benchmark_eligibility": None,
+            "reasons": ["valid fallback"],
+        },
+        {
+            "classification": "knife_edge",
+            "benchmark_eligibility": "stress_only",
+            "reasons": ["knife-edge clearance"],
+        },
+        {
+            "classification": "valid",
+            "benchmark_eligibility": "eligible",
+            "reasons": ["eligible route"],
+        },
+    ]
+
+    def fake_certificate_to_dict(_certificate: object) -> dict[str, object]:
+        return payloads.pop(0)
+
+    fake_module.certify_scenario_file = fake_certify_scenario_file
+    fake_module.certificate_to_dict = fake_certificate_to_dict
+    monkeypatch.setitem(sys.modules, "robot_sf.scenario_certification", fake_module)
+
+    status = certification.certify_candidate(
+        _candidate(7), scenario_yaml_path=tmp_path / "scenario.yaml", require_certification=True
+    )
+
+    assert status.passed
+    assert status.reason == "knife-edge clearance"
+
+
 def test_objective_registry_and_fallback_scoring(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes the adversarial certification adapter so it works with the current in-repo `scenario_certification` file API and restores the standard PR readiness gate.

## Linked Issues
- Closes #888
- Relates to #889

## What Changed
- Updated `robot_sf/adversarial/certification.py` to load `robot_sf.scenario_certification` dynamically and normalize `certify_scenario_file()` certificate payloads into adversarial `CertificationStatus` values.
- Kept legacy mocked `certify_scenario()` normalization covered for compatibility with existing tests.
- Updated adversarial-search tests to explicitly simulate missing certification and cover the current file API.
- Included the import-order change in `scripts/wandb_ppo_training.py` made by the repo’s standard `ruff_fix_format.sh` gate.

## Why It Matters
- Added value: the fail-closed certification path is no longer broken by the repo’s newer scenario-certification API.
- Expected impact: adversarial search can use current certificate results and reject excluded scenarios before evaluation.
- Why this is worth merging now: this was blocking `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` during #380 validation.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/adversarial/test_adversarial_search.py::test_required_certification_fails_closed_when_adapter_missing -q` (failed before fix, passed after)
  - `uv run pytest tests/adversarial/test_adversarial_search.py -q`
  - `uv run ruff check robot_sf/adversarial/certification.py tests/adversarial/test_adversarial_search.py scripts/wandb_ppo_training.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: full gate passed with `3070 passed, 15 skipped, 3 warnings`.
- Benchmarks or smoke tests, if applicable: no training or benchmark run needed.

## Risks / Rollout
- Compatibility risks: low to medium; the adapter now maps scenario-cert `benchmark_eligibility == excluded` to adversarial certification failure and all other certificate outputs to pass.
- Failure modes: if multi-scenario files mix eligible and excluded certificates, the worst excluded result controls the candidate status.
- Rollback or fallback plan: revert this adapter change; adversarial strict certification would return to the previous failing behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: uses the public `robot_sf.scenario_certification` API exported in `__init__.py`.
- Any assumptions that need to be preserved: missing adapters remain `not_available`, and strict search still rejects that before evaluator execution.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the status mapping in `_run_scenario_certification_adapter()` closely, especially the `benchmark_eligibility == excluded` policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced certification adapter handling with improved flexibility for multiple certification APIs and normalized result structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->