### PR TITLE
fix: quiet PPO subproc worker startup logs (#803)

### DIFF
--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -28,6 +28,7 @@ import shutil
 import sys
 import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -264,6 +265,24 @@ def _preconfigure_loguru_level_from_argv() -> None:
 
 
 _preconfigure_loguru_level_from_argv()
+
+
+@contextmanager
+def _subproc_worker_log_environment(worker_mode: str):
+    """Temporarily quiet import-time info logs inherited by PPO subprocess workers."""
+    if worker_mode != "subproc":
+        yield
+        return
+
+    previous_level = os.environ.get("LOGURU_LEVEL")
+    os.environ["LOGURU_LEVEL"] = "WARNING"
+    try:
+        yield
+    finally:
+        if previous_level is None:
+            os.environ.pop("LOGURU_LEVEL", None)
+        else:
+            os.environ["LOGURU_LEVEL"] = previous_level
 
 
 class _TeeStream:
@@ -2241,7 +2260,8 @@ def _init_training_model(
         for seed in env_seeds
     ]
     if worker_mode == "subproc":
-        vec_env = SubprocVecEnv(env_fns)
+        with _subproc_worker_log_environment(worker_mode):
+            vec_env = SubprocVecEnv(env_fns)
     else:
         vec_env = DummyVecEnv(env_fns)
     policy_class, policy_kwargs, critic_profile = _resolve_policy_selection(config)

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -185,6 +185,93 @@ def test_log_startup_summary_reports_num_envs_resolution(monkeypatch, tmp_path: 
     assert "mode=auto_stable" in summary
 
 
+def test_subproc_worker_log_environment_is_warning_only_during_spawn(monkeypatch) -> None:
+    """PPO subproc workers should inherit a quiet startup log level without muting parent logs."""
+    monkeypatch.setenv("LOGURU_LEVEL", "INFO")
+
+    with train_ppo._subproc_worker_log_environment("subproc"):
+        assert train_ppo.os.environ["LOGURU_LEVEL"] == "WARNING"
+
+    assert train_ppo.os.environ["LOGURU_LEVEL"] == "INFO"
+
+
+def test_dummy_worker_log_environment_leaves_log_level_unchanged(monkeypatch) -> None:
+    """Non-subproc PPO runs should not alter log-level inheritance."""
+    monkeypatch.setenv("LOGURU_LEVEL", "INFO")
+
+    with train_ppo._subproc_worker_log_environment("dummy"):
+        assert train_ppo.os.environ["LOGURU_LEVEL"] == "INFO"
+
+    assert train_ppo.os.environ["LOGURU_LEVEL"] == "INFO"
+
+
+def test_init_training_model_quiets_loguru_while_spawning_subproc_workers(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Subproc worker creation should inherit WARNING while parent logging is restored."""
+    observed_levels: list[str | None] = []
+    monkeypatch.setenv("LOGURU_LEVEL", "INFO")
+    monkeypatch.setattr(train_ppo, "_resolve_num_envs", lambda _config: 2)
+    monkeypatch.setattr(train_ppo, "_resolve_worker_mode", lambda _config, _num_envs: "subproc")
+
+    def _fake_make_training_env(*args, **kwargs):
+        return object
+
+    monkeypatch.setattr(train_ppo, "_make_training_env", _fake_make_training_env)
+    monkeypatch.setattr(
+        train_ppo,
+        "_resolve_policy_selection",
+        lambda _config: ("MlpPolicy", {}, "mlp"),
+    )
+    monkeypatch.setattr(train_ppo, "_resolve_resume_checkpoint", lambda **kwargs: None)
+    monkeypatch.setattr(train_ppo, "_resolve_ppo_hyperparams", lambda _config: {})
+
+    class _FakeSubprocVecEnv:
+        def __init__(self, env_fns):
+            observed_levels.append(train_ppo.os.environ.get("LOGURU_LEVEL"))
+            self.env_fns = env_fns
+
+    class _FakePPO:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(train_ppo, "SubprocVecEnv", _FakeSubprocVecEnv)
+    monkeypatch.setattr(train_ppo, "PPO", _FakePPO)
+
+    config = ExpertTrainingConfig.from_raw(
+        scenario_config=tmp_path / "scenarios.yaml",
+        seeds=(123,),
+        total_timesteps=32_000,
+        policy_id="ppo_subproc_log_level_test",
+        convergence=ConvergenceCriteria(
+            success_rate=0.9,
+            collision_rate=0.05,
+            plateau_window=1000,
+        ),
+        evaluation=EvaluationSchedule(
+            frequency_episodes=0,
+            evaluation_episodes=4,
+            step_schedule=((None, 16_000),),
+            randomize_seeds=False,
+        ),
+        worker_mode="subproc",
+    )
+
+    train_ppo._init_training_model(
+        config=config,
+        scenario=None,
+        scenario_definitions=({"id": "scenario_a"},),
+        exclude_scenarios=(),
+        run_id="run",
+        tensorboard_log=None,
+        resume_from=None,
+    )
+
+    assert observed_levels == ["WARNING"]
+    assert train_ppo.os.environ["LOGURU_LEVEL"] == "INFO"
+
+
 def test_resolve_policy_selection_uses_asymmetric_grid_socnav_policy(tmp_path: Path) -> None:
     """Asymmetric critic config should select the dedicated policy class."""
     config = ExpertTrainingConfig.from_raw(


### PR DESCRIPTION
## Summary
Reduces PPO subprocess worker startup log spam by making subproc workers inherit `LOGURU_LEVEL=WARNING` only while worker processes are spawned, then restoring the parent log level.

## Linked Issues
- Closes #803
- Stacked on #890

## What Changed
- Added `_subproc_worker_log_environment()` in `scripts/training/train_ppo.py`.
- Wrapped `SubprocVecEnv(env_fns)` creation so worker import-time/info logs are quieted without muting parent startup summaries or warnings/errors.
- Added PPO contract tests covering subproc, dummy, restoration, and `_init_training_model()` usage.

## Why It Matters
- Added value: subproc PPO logs are easier to scan while retaining actionable diagnostics.
- Expected impact: no PPO behavior or training output change; only worker startup log-level inheritance changes.
- Why this is worth merging now: it resolves the low-risk residual logging cleanup from #803.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/training/test_train_expert_ppo_contract.py -q`
  - `uv run pytest tests/integration/test_train_expert_ppo.py::test_expert_training_dry_run -q`
  - `uv run ruff check scripts/training/train_ppo.py tests/training/test_train_expert_ppo_contract.py`
  - `BASE_REF=origin/888-fix-adversarial-cert-status scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: full stacked gate passed with `3073 passed, 15 skipped, 3 warnings`.
- Benchmarks or smoke tests, if applicable: no training run needed; dry-run integration smoke passed.

## Risks / Rollout
- Compatibility risks: low; parent `LOGURU_LEVEL` is restored immediately after worker spawn.
- Failure modes: if future worker diagnostics use `INFO`, they will be suppressed during import/startup in subproc mode; warnings/errors remain visible.
- Rollback or fallback plan: revert the context-manager wrapper and tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: stacked on #890 because `main` currently fails the standard gate on the adversarial certification issue fixed there.
- Any assumptions that need to be preserved: parent startup summary remains the authoritative INFO-level run summary.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review this PR against base branch `888-fix-adversarial-cert-status`; the issue-specific diff is limited to `scripts/training/train_ppo.py` and `tests/training/test_train_expert_ppo_contract.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced log verbosity during PPO training initialization with worker processes to provide cleaner console output. Parent process log settings are restored after worker spawning.

* **Tests**
  * Added contract tests verifying proper log level handling during training initialization, including behavior across different worker modes and parent process restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->