### PR TITLE
Document adversarial search concurrency model

### DIFF
--- a/docs/context/issue_869_adversarial_runner.md
+++ b/docs/context/issue_869_adversarial_runner.md
@@ -19,6 +19,19 @@ programs, tests, notebooks, and future optimizer adapters can call the same core
 - Tests can inject evaluator, certifier, and sampler callables to cover orchestration without
   spawning a subprocess.
 
+## Concurrency Model
+
+`run_adversarial_search(...)` evaluates candidates sequentially in sampler order. Candidate
+sampling, certification, bundle paths such as `candidate_0000`, objective scoring, and manifest
+rows all follow that deterministic order. This is the intended v1 behavior because optimizer
+adapters and replay bundles depend on stable candidate ordering.
+
+`SearchConfig.workers` is still honored, but only inside each single-candidate benchmark
+evaluation: the value is forwarded to `run_batch(..., workers=config.workers)` for the candidate
+currently being evaluated. It does not launch multiple adversarial candidates concurrently. Any
+future candidate-level parallelism must preserve deterministic manifest ordering or explicitly
+document the ordering change before it can be used as benchmark evidence.
+
 ## Artifact Contract
 
 Each valid candidate gets a bundle directory under the configured `output_dir`:

--- a/robot_sf/adversarial/search.py
+++ b/robot_sf/adversarial/search.py
@@ -134,6 +134,11 @@ def run_adversarial_search(
 ) -> SearchRunResult:
     """Run a bounded adversarial scenario search.
 
+    Candidate sampling, certification, evaluation, and manifest ordering are intentionally
+    sequential so a fixed sampler seed produces stable candidate directories and replayable
+    manifests. ``SearchConfig.workers`` is forwarded to the benchmark runner for each individual
+    candidate evaluation; it is not candidate-level parallelism.
+
     Args:
         config: Search configuration and contracts.
         evaluator: Optional injected evaluator for tests or experiment harnesses.

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -68,7 +68,12 @@ def _write_space(path: Path, *, min_distance: float = 0.5) -> None:
     )
 
 
-def _config(tmp_path: Path, *, require_certification: bool = False) -> SearchConfig:
+def _config(
+    tmp_path: Path,
+    *,
+    require_certification: bool = False,
+    workers: int = 1,
+) -> SearchConfig:
     template = tmp_path / "template.yaml"
     search_space = tmp_path / "space.yaml"
     _write_template(template)
@@ -81,6 +86,7 @@ def _config(tmp_path: Path, *, require_certification: bool = False) -> SearchCon
         output_dir=tmp_path / "out",
         budget=2,
         seed=123,
+        workers=workers,
         require_certification=require_certification,
     )
 
@@ -213,6 +219,49 @@ def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path
     assert manifest["summary"]["best_bundle_path"].endswith("candidate_0001")
     assert (config.output_dir / "candidate_0001" / "scenario.yaml").exists()
     assert (config.output_dir / "candidate_0001" / "route_overrides.yaml").exists()
+
+
+def test_default_search_keeps_candidate_evaluation_sequential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Candidate search order is deterministic; workers are scoped to each benchmark call."""
+    config = _config(tmp_path, workers=4)
+    call_order: list[tuple[Path, int]] = []
+
+    def fake_run_batch(
+        _scenario_yaml_path: Path,
+        *,
+        out_path: Path,
+        workers: int,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        call_order.append((out_path.parent, workers))
+        record: dict[str, Any] = {
+            "episode_id": out_path.parent.name,
+            "seed": len(call_order),
+            "status": "success",
+            "steps": 3,
+            "termination_reason": "success",
+            "outcome": {"route_complete": True, "collision": False, "timeout": False},
+            "metrics": {"snqi": 0.5, "success": 1.0},
+        }
+        out_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        return {"failures": []}
+
+    monkeypatch.setattr(search, "run_batch", fake_run_batch)
+
+    result = search.run_adversarial_search(
+        config,
+        certifier=lambda _candidate, _path, _required: passed_status("test certifier"),
+        sampler=_SequenceSampler([_candidate(7), _candidate(7)]),
+    )
+
+    assert result.num_candidates == 2
+    assert call_order == [
+        (config.output_dir / "candidate_0000", 4),
+        (config.output_dir / "candidate_0001", 4),
+    ]
 
 
 def test_required_certification_fails_closed_when_adapter_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Document that `run_adversarial_search(...)` intentionally evaluates candidates sequentially in sampler order.
- Clarify that `SearchConfig.workers` is scoped to each single-candidate `run_batch` call, not candidate-level parallelism.
- Add regression coverage proving deterministic candidate evaluation order while preserving per-candidate worker forwarding.

## Validation
- `uv run pytest tests/adversarial/test_adversarial_search.py -q`
- `scripts/dev/ruff_fix_format.sh`
- `BASE_REF=origin/888-fix-adversarial-cert-status scripts/dev/pr_ready_check.sh` (`3071 passed, 15 skipped, 3 warnings`)

## Notes
- This PR is stacked on #890 / `888-fix-adversarial-cert-status` so it only contains the issue #882 layer.
- Refreshed `output/coverage/...` files were inspected and left ignored as disposable local artifacts.

Closes #882