### PR TITLE
feat: add multi-ped adversarial schema (#923)

### DIFF
--- a/configs/adversarial/group_squeeze_multi_ped_example.yaml
+++ b/configs/adversarial/group_squeeze_multi_ped_example.yaml
@@ -1,0 +1,18 @@
+schema_version: adversarial-multi-ped.v1
+family: group_squeeze
+description: Schema-only example for issue 923; not a benchmark-ready runtime config.
+scenario_seed: 41
+constraints:
+  min_start_goal_distance_m: 1.0
+pedestrians:
+  - id: left_blocker
+    start: {x: 1.0, y: 2.0}
+    goal: {x: 5.0, y: 2.0}
+    spawn_time_s: 0.5
+    speed_mps: 1.1
+    delay_s: 0.25
+  - id: right_blocker
+    start: {x: 1.0, y: 3.0}
+    goal: {x: 5.0, y: 3.0}
+    spawn_time_s: 0.75
+    speed_mps: 1.2

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -170,6 +170,8 @@ why a change was made rather than a full issue execution transcript.
   evidence collection path for diagnosing low CPU utilization without launching new jobs.
 - [Issue #869 Adversarial Runner](issue_869_adversarial_runner.md) - programmable adversarial
   scenario search API, bundle contract, certification boundary, and deferred optimizer scope.
+- [Issue #923 Multi-Ped Adversarial Candidate Schema](issue_923_multi_ped_adversarial_schema.md) -
+  schema-only first slice under #870 for scripted multi-pedestrian adversarial candidates.
 - [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
   scope, public surfaces, validation path, and known limits.
 

--- a/docs/context/issue_923_multi_ped_adversarial_schema.md
+++ b/docs/context/issue_923_multi_ped_adversarial_schema.md
@@ -1,0 +1,47 @@
+# Issue #923: Multi-Ped Adversarial Candidate Schema
+
+## Goal
+
+Issue #923 is the first bounded implementation slice under the larger #870 multi-pedestrian
+adversarial environment epic. It adds a versioned schema for scripted multi-pedestrian adversarial
+candidates before any reset/step, learned-adversary, or benchmark-runner integration exists.
+
+## Scope Boundary
+
+This schema is a development contract only:
+
+- it can parse YAML into typed candidate entries,
+- it validates pedestrian IDs, poses, timing, speed, seed, and minimum route length,
+- it serializes to deterministic JSON-compatible dictionaries,
+- it does not create or certify benchmark scenarios,
+- it does not alter existing single-pedestrian adversarial search behavior.
+
+Runtime generation, plausibility checks against concrete maps, episode attribution, and replay
+integration remain future #870 work.
+
+## Current Surfaces
+
+- Schema code: `robot_sf/adversarial/config.py`
+- Example config: `configs/adversarial/group_squeeze_multi_ped_example.yaml`
+- Tests: `tests/adversarial/test_adversarial_search.py`
+
+## Validation Path
+
+Use targeted checks for this slice:
+
+```bash
+uv run pytest tests/adversarial/test_adversarial_search.py -q
+uv run ruff check robot_sf/adversarial/config.py tests/adversarial/test_adversarial_search.py
+```
+
+Before PR handoff, run the repository readiness gate:
+
+```bash
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Caveats
+
+Do not report this schema as multi-pedestrian adversarial benchmark support. The fail-closed
+benchmark policy still applies: until runtime execution and scenario certification are proven, these
+payloads are inputs for future development stress tooling only.

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -3,6 +3,8 @@
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
+    MultiPedAdversarialConfig,
+    MultiPedCandidateSpec,
     Pose2D,
     SearchConfig,
     SearchRunResult,
@@ -15,6 +17,8 @@ __all__ = [
     "CandidateEvaluation",
     "CandidateSpec",
     "CoordinateRefinementSampler",
+    "MultiPedAdversarialConfig",
+    "MultiPedCandidateSpec",
     "Pose2D",
     "RandomCandidateSampler",
     "SearchConfig",

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -80,7 +80,8 @@ class MultiPedCandidateSpec:
         """Build one multi-pedestrian entry from a YAML/JSON mapping."""
         if not isinstance(payload, dict):
             raise ValueError(f"pedestrians[{index}] must be a mapping")
-        pedestrian_id = str(payload.get("id", "")).strip()
+        raw_id = payload.get("id")
+        pedestrian_id = str(raw_id).strip() if raw_id is not None else ""
         if not pedestrian_id:
             raise ValueError(f"pedestrians[{index}].id must be non-empty")
         start = _pose_from_mapping(payload.get("start"), name=f"pedestrians[{index}].start")
@@ -90,13 +91,16 @@ class MultiPedCandidateSpec:
             raw_metadata = {}
         if not isinstance(raw_metadata, dict):
             raise ValueError(f"pedestrians[{index}].metadata must be a mapping")
+        spawn_time_raw = payload.get("spawn_time_s")
+        speed_raw = payload.get("speed_mps", payload.get("pedestrian_speed_mps"))
+        delay_raw = payload.get("delay_s", payload.get("pedestrian_delay_s"))
         return cls(
             id=pedestrian_id,
             start=start,
             goal=goal,
-            spawn_time_s=float(payload.get("spawn_time_s", 0.0)),
-            speed_mps=float(payload.get("speed_mps", payload.get("pedestrian_speed_mps", 1.0))),
-            delay_s=float(payload.get("delay_s", payload.get("pedestrian_delay_s", 0.0))),
+            spawn_time_s=float(spawn_time_raw) if spawn_time_raw is not None else 0.0,
+            speed_mps=float(speed_raw) if speed_raw is not None else 1.0,
+            delay_s=float(delay_raw) if delay_raw is not None else 0.0,
             metadata=dict(raw_metadata),
         )
 
@@ -182,14 +186,24 @@ class MultiPedAdversarialConfig:
             errors.append("min_start_goal_distance_m must be finite and >= 0")
         ids = [ped.id for ped in self.pedestrians]
         if len(ids) != len(set(ids)):
-            errors.append("pedestrians ids must be unique")
+            seen: set[str] = set()
+            duplicates: list[str] = []
+            for ped_id in ids:
+                if ped_id in seen and ped_id not in duplicates:
+                    duplicates.append(ped_id)
+                seen.add(ped_id)
+            errors.append(
+                f"pedestrians ids must be unique; duplicates: {', '.join(sorted(duplicates))}"
+            )
         for index, pedestrian in enumerate(self.pedestrians):
             errors.extend(_validate_multi_pedestrian_entry(pedestrian, index=index))
             dx = float(pedestrian.goal.x) - float(pedestrian.start.x)
             dy = float(pedestrian.goal.y) - float(pedestrian.start.y)
-            if math.hypot(dx, dy) < self.min_start_goal_distance_m:
+            distance = math.hypot(dx, dy)
+            if distance < self.min_start_goal_distance_m:
                 errors.append(
-                    f"pedestrians[{index}] start and goal are closer than min_start_goal_distance_m"
+                    f"pedestrians[{index}] start and goal distance ({distance:.3f}m) is less "
+                    f"than min_start_goal_distance_m ({self.min_start_goal_distance_m}m)"
                 )
         return errors
 
@@ -210,7 +224,9 @@ def _pose_from_mapping(payload: object, *, name: str) -> Pose2D:
         raise ValueError(f"{name} must be a mapping")
     if "x" not in payload or "y" not in payload:
         raise ValueError(f"{name} must define x and y")
-    return Pose2D(float(payload["x"]), float(payload["y"]), float(payload.get("theta", 0.0)))
+    theta_raw = payload.get("theta")
+    theta = float(theta_raw) if theta_raw is not None else 0.0
+    return Pose2D(float(payload["x"]), float(payload["y"]), theta)
 
 
 def _validate_multi_pedestrian_entry(

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -59,6 +59,191 @@ class CandidateSpec:
 
 
 @dataclass(frozen=True)
+class MultiPedCandidateSpec:
+    """One pedestrian in a scripted multi-pedestrian adversarial candidate."""
+
+    id: str
+    start: Pose2D
+    goal: Pose2D
+    spawn_time_s: float = 0.0
+    speed_mps: float = 1.0
+    delay_s: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        index: int,
+    ) -> MultiPedCandidateSpec:
+        """Build one multi-pedestrian entry from a YAML/JSON mapping."""
+        if not isinstance(payload, dict):
+            raise ValueError(f"pedestrians[{index}] must be a mapping")
+        pedestrian_id = str(payload.get("id", "")).strip()
+        if not pedestrian_id:
+            raise ValueError(f"pedestrians[{index}].id must be non-empty")
+        start = _pose_from_mapping(payload.get("start"), name=f"pedestrians[{index}].start")
+        goal = _pose_from_mapping(payload.get("goal"), name=f"pedestrians[{index}].goal")
+        raw_metadata = payload.get("metadata", {})
+        if raw_metadata is None:
+            raw_metadata = {}
+        if not isinstance(raw_metadata, dict):
+            raise ValueError(f"pedestrians[{index}].metadata must be a mapping")
+        return cls(
+            id=pedestrian_id,
+            start=start,
+            goal=goal,
+            spawn_time_s=float(payload.get("spawn_time_s", 0.0)),
+            speed_mps=float(payload.get("speed_mps", payload.get("pedestrian_speed_mps", 1.0))),
+            delay_s=float(payload.get("delay_s", payload.get("pedestrian_delay_s", 0.0))),
+            metadata=dict(raw_metadata),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-compatible payload for this pedestrian candidate."""
+        return {
+            "id": self.id,
+            "start": self.start.to_json(),
+            "goal": self.goal.to_json(),
+            "spawn_time_s": float(self.spawn_time_s),
+            "speed_mps": float(self.speed_mps),
+            "delay_s": float(self.delay_s),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class MultiPedAdversarialConfig:
+    """Validated schema for scripted multi-pedestrian adversarial candidates.
+
+    This contract is intentionally additive and schema-only. Runtime environment
+    integration remains a separate benchmark-sensitive step.
+    """
+
+    family: str
+    scenario_seed: int
+    pedestrians: list[MultiPedCandidateSpec]
+    schema_version: str = "adversarial-multi-ped.v1"
+    min_start_goal_distance_m: float = 0.25
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> MultiPedAdversarialConfig:
+        """Load and validate a multi-pedestrian adversarial config YAML file."""
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"Multi-ped adversarial config must be a mapping: {path}")
+        return cls.from_mapping(raw)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> MultiPedAdversarialConfig:
+        """Build a multi-pedestrian adversarial config from a mapping."""
+        pedestrians = payload.get("pedestrians")
+        if not isinstance(pedestrians, list) or not pedestrians:
+            raise ValueError("pedestrians must be a non-empty list")
+        constraints = payload.get("constraints", {})
+        if constraints is None:
+            constraints = {}
+        if not isinstance(constraints, dict):
+            raise ValueError("constraints must be a mapping")
+        config = cls(
+            schema_version=str(payload.get("schema_version", "adversarial-multi-ped.v1")),
+            family=str(payload.get("family", "")).strip(),
+            scenario_seed=int(payload.get("scenario_seed", 0)),
+            min_start_goal_distance_m=float(constraints.get("min_start_goal_distance_m", 0.25)),
+            pedestrians=[
+                MultiPedCandidateSpec.from_mapping(entry, index=index)
+                for index, entry in enumerate(pedestrians)
+            ],
+        )
+        if not config.family:
+            raise ValueError("family must be non-empty")
+        if config.schema_version != "adversarial-multi-ped.v1":
+            raise ValueError("schema_version must be adversarial-multi-ped.v1")
+        if (
+            not math.isfinite(config.min_start_goal_distance_m)
+            or config.min_start_goal_distance_m < 0.0
+        ):
+            raise ValueError("min_start_goal_distance_m must be finite and >= 0")
+        errors = config.validate()
+        if errors:
+            raise ValueError("; ".join(errors))
+        return config
+
+    def validate(self) -> list[str]:
+        """Return validation errors for the multi-pedestrian candidate contract."""
+        errors: list[str] = []
+        if self.scenario_seed < 0:
+            errors.append("scenario_seed must be non-negative")
+        if (
+            not math.isfinite(self.min_start_goal_distance_m)
+            or self.min_start_goal_distance_m < 0.0
+        ):
+            errors.append("min_start_goal_distance_m must be finite and >= 0")
+        ids = [ped.id for ped in self.pedestrians]
+        if len(ids) != len(set(ids)):
+            errors.append("pedestrians ids must be unique")
+        for index, pedestrian in enumerate(self.pedestrians):
+            errors.extend(_validate_multi_pedestrian_entry(pedestrian, index=index))
+            dx = float(pedestrian.goal.x) - float(pedestrian.start.x)
+            dy = float(pedestrian.goal.y) - float(pedestrian.start.y)
+            if math.hypot(dx, dy) < self.min_start_goal_distance_m:
+                errors.append(
+                    f"pedestrians[{index}] start and goal are closer than min_start_goal_distance_m"
+                )
+        return errors
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-compatible multi-pedestrian adversarial payload."""
+        return {
+            "schema_version": self.schema_version,
+            "family": self.family,
+            "scenario_seed": int(self.scenario_seed),
+            "constraints": {"min_start_goal_distance_m": self.min_start_goal_distance_m},
+            "pedestrians": [pedestrian.to_json() for pedestrian in self.pedestrians],
+        }
+
+
+def _pose_from_mapping(payload: object, *, name: str) -> Pose2D:
+    """Build a pose from a mapping with x/y and optional theta fields."""
+    if not isinstance(payload, dict):
+        raise ValueError(f"{name} must be a mapping")
+    if "x" not in payload or "y" not in payload:
+        raise ValueError(f"{name} must define x and y")
+    return Pose2D(float(payload["x"]), float(payload["y"]), float(payload.get("theta", 0.0)))
+
+
+def _validate_multi_pedestrian_entry(
+    pedestrian: MultiPedCandidateSpec,
+    *,
+    index: int,
+) -> list[str]:
+    """Return validation errors for one pedestrian entry."""
+    errors: list[str] = []
+    values = {
+        "start.x": pedestrian.start.x,
+        "start.y": pedestrian.start.y,
+        "start.theta": pedestrian.start.theta,
+        "goal.x": pedestrian.goal.x,
+        "goal.y": pedestrian.goal.y,
+        "goal.theta": pedestrian.goal.theta,
+        "spawn_time_s": pedestrian.spawn_time_s,
+        "speed_mps": pedestrian.speed_mps,
+        "delay_s": pedestrian.delay_s,
+    }
+    for name, value in values.items():
+        if not math.isfinite(float(value)):
+            errors.append(f"pedestrians[{index}].{name} must be finite")
+    if pedestrian.spawn_time_s < 0.0:
+        errors.append(f"pedestrians[{index}].spawn_time_s must be non-negative")
+    if pedestrian.speed_mps <= 0.0:
+        errors.append(f"pedestrians[{index}].speed_mps must be positive")
+    if pedestrian.delay_s < 0.0:
+        errors.append(f"pedestrians[{index}].delay_s must be non-negative")
+    return errors
+
+
+@dataclass(frozen=True)
 class CandidateEvaluation:
     """Evaluation result for one candidate."""
 

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -268,10 +268,11 @@ def test_multi_ped_adversarial_config_reports_validation_errors() -> None:
     errors = config.validate()
 
     assert "scenario_seed must be non-negative" in errors
-    assert "pedestrians ids must be unique" in errors
+    assert any("pedestrians ids must be unique" in err for err in errors)
+    assert any("duplicates: blocker" in err for err in errors)
     assert "pedestrians[0].spawn_time_s must be non-negative" in errors
     assert "pedestrians[0].speed_mps must be positive" in errors
-    assert "pedestrians[0] start and goal are closer than min_start_goal_distance_m" in errors
+    assert any(err.startswith("pedestrians[0] start and goal distance") for err in errors)
     assert "pedestrians[1].start.x must be finite" in errors
     assert "pedestrians[1].delay_s must be non-negative" in errors
 

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -17,6 +17,8 @@ from robot_sf.adversarial.certification import failed_status, not_available_stat
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
+    MultiPedAdversarialConfig,
+    MultiPedCandidateSpec,
     Pose2D,
     SearchConfig,
     SearchSpaceConfig,
@@ -168,6 +170,121 @@ def test_search_space_rejects_non_integral_seed_bounds() -> None:
 
     with pytest.raises(ValueError, match="scenario_seed bounds must be integers"):
         SearchSpaceConfig.from_mapping(payload)
+
+
+def test_multi_ped_adversarial_config_parses_and_serializes_yaml(tmp_path: Path) -> None:
+    """Multi-ped adversarial candidates should have a deterministic schema contract."""
+    path = tmp_path / "multi_ped.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "adversarial-multi-ped.v1",
+                "family": "group_squeeze",
+                "scenario_seed": 41,
+                "constraints": {"min_start_goal_distance_m": 1.0},
+                "pedestrians": [
+                    {
+                        "id": "left_blocker",
+                        "start": {"x": 1.0, "y": 2.0},
+                        "goal": {"x": 5.0, "y": 2.0},
+                        "spawn_time_s": 0.5,
+                        "speed_mps": 1.1,
+                        "delay_s": 0.25,
+                    },
+                    {
+                        "id": "right_blocker",
+                        "start": {"x": 1.0, "y": 3.0},
+                        "goal": {"x": 5.0, "y": 3.0},
+                        "spawn_time_s": 0.75,
+                        "speed_mps": 1.2,
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config = MultiPedAdversarialConfig.from_file(path)
+
+    assert config.schema_version == "adversarial-multi-ped.v1"
+    assert config.family == "group_squeeze"
+    assert config.scenario_seed == 41
+    assert config.validate() == []
+    assert [ped.id for ped in config.pedestrians] == ["left_blocker", "right_blocker"]
+    assert config.to_json() == {
+        "schema_version": "adversarial-multi-ped.v1",
+        "family": "group_squeeze",
+        "scenario_seed": 41,
+        "constraints": {"min_start_goal_distance_m": 1.0},
+        "pedestrians": [
+            {
+                "id": "left_blocker",
+                "start": {"x": 1.0, "y": 2.0, "theta": 0.0},
+                "goal": {"x": 5.0, "y": 2.0, "theta": 0.0},
+                "spawn_time_s": 0.5,
+                "speed_mps": 1.1,
+                "delay_s": 0.25,
+                "metadata": {},
+            },
+            {
+                "id": "right_blocker",
+                "start": {"x": 1.0, "y": 3.0, "theta": 0.0},
+                "goal": {"x": 5.0, "y": 3.0, "theta": 0.0},
+                "spawn_time_s": 0.75,
+                "speed_mps": 1.2,
+                "delay_s": 0.0,
+                "metadata": {},
+            },
+        ],
+    }
+
+
+def test_multi_ped_adversarial_config_reports_validation_errors() -> None:
+    """Invalid multi-ped contracts should fail before runtime integration."""
+    config = MultiPedAdversarialConfig(
+        family="group_squeeze",
+        scenario_seed=-1,
+        min_start_goal_distance_m=2.0,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="blocker",
+                start=Pose2D(1.0, 2.0),
+                goal=Pose2D(1.5, 2.0),
+                spawn_time_s=-0.1,
+                speed_mps=0.0,
+            ),
+            MultiPedCandidateSpec(
+                id="blocker",
+                start=Pose2D(float("nan"), 3.0),
+                goal=Pose2D(5.0, 3.0),
+                spawn_time_s=0.0,
+                speed_mps=1.0,
+                delay_s=-0.5,
+            ),
+        ],
+    )
+
+    errors = config.validate()
+
+    assert "scenario_seed must be non-negative" in errors
+    assert "pedestrians ids must be unique" in errors
+    assert "pedestrians[0].spawn_time_s must be non-negative" in errors
+    assert "pedestrians[0].speed_mps must be positive" in errors
+    assert "pedestrians[0] start and goal are closer than min_start_goal_distance_m" in errors
+    assert "pedestrians[1].start.x must be finite" in errors
+    assert "pedestrians[1].delay_s must be non-negative" in errors
+
+
+def test_multi_ped_adversarial_example_config_is_valid() -> None:
+    """The checked-in example should stay aligned with the schema parser."""
+    config = MultiPedAdversarialConfig.from_file(
+        Path("configs/adversarial/group_squeeze_multi_ped_example.yaml")
+    )
+
+    assert config.family == "group_squeeze"
+    assert len(config.pedestrians) == 2
+    assert config.validate() == []
 
 
 def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds an additive `adversarial-multi-ped.v1` schema for scripted multi-pedestrian adversarial candidates, with parser, validation, JSON serialization, an example config, and context docs. This is the first PR-sized slice under #870 and does not enable runtime multi-ped adversarial benchmark support.

## Linked Issues
- Closes #923
- Relates to #870

## What Changed
- Added `MultiPedCandidateSpec` and `MultiPedAdversarialConfig` in `robot_sf/adversarial/config.py`.
- Exported the new schema classes from `robot_sf/adversarial/__init__.py`.
- Added `configs/adversarial/group_squeeze_multi_ped_example.yaml` as a schema-only example.
- Added validation coverage for YAML parsing, duplicate IDs, invalid timing/speed/poses, short routes, and the checked-in example config.
- Added `docs/context/issue_923_multi_ped_adversarial_schema.md` and indexed it from `docs/context/README.md`.

## Why It Matters
- Added value: gives #870 a stable, tested contract before environment integration.
- Expected impact: future multi-ped adversarial runtime work can consume a typed payload instead of inventing schema during simulator plumbing.
- Why this is worth merging now: it de-risks a high-priority epic with a small additive contract and preserves fail-closed benchmark semantics.

## Validation / Proof
- RED before implementation: `uv run pytest tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_config_parses_and_serializes_yaml tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_config_reports_validation_errors -q` failed with missing imports for `MultiPedAdversarialConfig` / `MultiPedCandidateSpec`.
- `uv run pytest tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_config_parses_and_serializes_yaml tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_config_reports_validation_errors tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_example_config_is_valid -q` -> 3 passed.
- `uv run pytest tests/adversarial/test_adversarial_search.py -q` -> 24 passed.
- `uv run ruff check robot_sf/adversarial/config.py robot_sf/adversarial/__init__.py tests/adversarial/test_adversarial_search.py` -> passed.
- `uv run ruff format --check robot_sf/adversarial/config.py robot_sf/adversarial/__init__.py tests/adversarial/test_adversarial_search.py` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` via `rtk proxy bash -lc` -> 3110 passed, 15 skipped, 3 warnings.

## Risks / Rollout
- Compatibility risks: low; existing single-ped adversarial search APIs are unchanged.
- Failure modes: future runtime work may need additional map-specific plausibility checks beyond this schema.
- Rollback or fallback plan: revert the schema/classes, example config, tests, and context note.

## Docs / Provenance
- Updated docs: `docs/context/issue_923_multi_ped_adversarial_schema.md`, `docs/context/README.md`.
- Relevant design or provenance notes: #870 remains the environment/runtime epic; #923 is schema-only.
- Assumption preserved: these payloads are development inputs only and are not certified benchmark scenarios.

## Follow-Up Issues
- Deferred work: runtime reset/step integration, map-aware plausibility checks, per-ped episode attribution, and benchmark smoke remain under #870 or future child issues.
- Issues opened for follow-up: none in this PR.

## Reviewer Notes
- Verify that the new schema stays additive and does not imply benchmark support.
- The generated `output/coverage` files from test runs are ignored/disposable and are not required artifacts.
