### PR TITLE
docs: define CARLA oracle replay contract (#928)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -172,6 +172,9 @@ why a change was made rather than a full issue execution transcript.
   scenario search API, bundle contract, certification boundary, and deferred optimizer scope.
 - [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
   scope, public surfaces, validation path, and known limits.
+- [Issue #928 CARLA T0/T1 Oracle Replay Contract](issue_928_carla_t0_t1_replay_contract.md)
+  documents the first CARLA transfer boundary: neutral export first, optional oracle replay later,
+  and fail-closed `not-available` / `failed` statuses instead of fallback parity claims.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_928_carla_t0_t1_replay_contract.md
+++ b/docs/context/issue_928_carla_t0_t1_replay_contract.md
@@ -30,7 +30,7 @@ minimum fields needed to reconstruct the Robot-SF scenario and compare trajector
 - scenario identity, source config, map identity, and certificate reference,
 - robot start, goal, footprint, kinematic profile, and command/action interpretation,
 - pedestrian initial states, scripted route or behavior metadata, and timing parameters,
-- static obstacle and route/topology references or a durable exported geometry representation,
+- static obstacle and route/topology references (in a right-handed, metric world frame; route/topology IDs may be simulator-specific) or a durable exported geometry representation in that frame,
 - time step, horizon, termination conditions, and metric configuration,
 - provenance fields that identify the Robot-SF commit, config, and certificate generator version.
 
@@ -46,7 +46,7 @@ itself; treating a fallback or partial replay as successful parity would be the 
 - Scenario export must require a valid scenario certificate before it is used for transfer claims.
 - CARLA replay outputs must identify mode as `oracle-replay`, `failed`, or `not-available`.
 - Metric comparison should use trajectory-level fields first: success, collision, minimum distance,
-  TTC where available, comfort, jerk, curvature, intervention rate, and SNQI-compatible fields when
+  TTC where available, comfort, jerk, curvature, intervention rate, and SNQI (Social Navigation Quality Index)-compatible fields when
   the input data supports them.
 - Reports must clearly distinguish Robot-SF evidence from CARLA replay evidence.
 

--- a/docs/context/issue_928_carla_t0_t1_replay_contract.md
+++ b/docs/context/issue_928_carla_t0_t1_replay_contract.md
@@ -1,0 +1,94 @@
+# Issue 928 CARLA T0/T1 Oracle Replay Contract
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/928>
+
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/872>
+
+Canonical roadmap: [docs/plan/plan_big_picture_2026-04-30.md](../plan/plan_big_picture_2026-04-30.md)
+
+Scenario-certification predecessor:
+[docs/context/issue_868_scenario_certification.md](issue_868_scenario_certification.md)
+
+## Goal
+
+Define the first CARLA transfer contract before adding optional simulator code. The first useful
+milestone is oracle replay and parity for certified Robot-SF scenarios, not CARLA training,
+perception stress, ROS integration, or paper-facing simulator-transfer claims.
+
+This note scopes the parent issue into two early stages:
+
+- T0: export certified Robot-SF scenario definitions to a neutral replay description without
+  importing CARLA or requiring CARLA assets.
+- T1: replay that neutral description in CARLA with oracle state, scripted pedestrians, and
+  trajectory-level metrics when a CARLA runtime is explicitly available.
+
+## Contract
+
+T0 neutral export should be treated as a simulator-independent data contract. It should include the
+minimum fields needed to reconstruct the Robot-SF scenario and compare trajectories later:
+
+- scenario identity, source config, map identity, and certificate reference,
+- robot start, goal, footprint, kinematic profile, and command/action interpretation,
+- pedestrian initial states, scripted route or behavior metadata, and timing parameters,
+- static obstacle and route/topology references or a durable exported geometry representation,
+- time step, horizon, termination conditions, and metric configuration,
+- provenance fields that identify the Robot-SF commit, config, and certificate generator version.
+
+T1 replay should remain an optional integration path. It may import the CARLA Python API only behind
+explicit dependency checks, and it should report `not available` when CARLA, a requested CARLA map,
+or a certified scenario input is missing. Missing runtime support is not a benchmark failure by
+itself; treating a fallback or partial replay as successful parity would be the failure.
+
+## Required Behavior
+
+- Normal Robot-SF installation, tests, training, and benchmark commands must not require CARLA.
+- Bridge imports must fail closed with actionable errors when optional dependencies are missing.
+- Scenario export must require a valid scenario certificate before it is used for transfer claims.
+- CARLA replay outputs must identify mode as `oracle-replay`, `failed`, or `not-available`.
+- Metric comparison should use trajectory-level fields first: success, collision, minimum distance,
+  TTC where available, comfort, jerk, curvature, intervention rate, and SNQI-compatible fields when
+  the input data supports them.
+- Reports must clearly distinguish Robot-SF evidence from CARLA replay evidence.
+
+## Out Of Scope
+
+- CARLA policy training.
+- Sensor-level perception stress tests.
+- ROS or autonomous-driving stack integration.
+- Claiming transfer or simulator parity from exported JSON alone.
+- Counting degraded, fallback, or hand-authored partial replay as benchmark-strengthening evidence.
+- Selecting the final first-ten certified scenario set before `scenario_cert.v1` coverage and
+  counterexample replay bundles are stable enough to justify that selection.
+
+## Fail-Closed Semantics
+
+Future bridge commands should prefer explicit statuses over silent fallback:
+
+- `not-available`: CARLA runtime, CARLA assets, optional Python package, or certified scenario input
+  is unavailable.
+- `failed`: replay was attempted but violated the contract, crashed, exceeded a timeout, or produced
+  invalid/incomplete outputs.
+- `oracle-replay`: CARLA replay ran with ground-truth state and scripted agents; this is parity
+  evidence only when paired with comparable Robot-SF trajectory metrics.
+
+Any `not-available` or `failed` status is valid diagnostic output, but it must not be reported as a
+successful benchmark outcome.
+
+## Validation Path
+
+This issue is docs-only. Validation for the contract PR should prove discoverability and avoid
+claiming runtime behavior:
+
+```bash
+git diff --check
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+Future implementation children should add CARLA-free tests for the neutral export schema and
+dependency-guard tests for missing CARLA before requiring a CARLA-capable smoke environment.
+
+## Follow-Up Boundary
+
+The next implementation issue under #872 should add the T0 neutral export schema and a dependency
+guard without importing CARLA in normal test collection. A later T1 issue can add a CARLA runtime
+smoke command once a CARLA-capable machine and first certified scenario set are identified.


### PR DESCRIPTION
## Summary
Defines the CARLA T0/T1 oracle replay contract before adding optional simulator bridge code.

## Linked Issues
- Closes #928
- Relates to #872

## What Changed
- Added `docs/context/issue_928_carla_t0_t1_replay_contract.md` with the neutral export, optional oracle replay, fail-closed status, and out-of-scope boundaries for the first CARLA transfer milestone.
- Linked the new note from `docs/context/README.md`.

## Why It Matters
- Added value: gives the large CARLA bridge epic a small, reviewable contract before implementation starts.
- Expected impact: future CARLA export/replay work has a clear fail-closed target and avoids optional dependency drift into normal Robot-SF workflows.
- Why this is worth merging now: #872 is too broad to implement safely in one PR, and the first split should pin down benchmark claim limits before code exists.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `uv run pytest tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted docs/discoverability tests: `6 passed in 17.87s`.
  - Full readiness gate: `3107 passed, 15 skipped, 3 warnings in 409.12s`.
- Benchmarks or smoke tests, if applicable: not applicable; this is a docs-only contract PR and intentionally does not claim CARLA runtime behavior.

## Risks / Rollout
- Compatibility risks: low; docs-only change.
- Failure modes: future bridge code could drift from this contract unless implementation PRs cite and update the note when needed.
- Rollback or fallback plan: revert the docs note and README link.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_928_carla_t0_t1_replay_contract.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - Parent issue #872.
  - `docs/plan/plan_big_picture_2026-04-30.md`.
  - `docs/context/issue_868_scenario_certification.md`.
- Any assumptions that need to be preserved:
  - CARLA remains optional and unavailable in normal CI unless explicitly configured.
  - Exported JSON alone is not simulator-transfer evidence.
  - `not-available` and `failed` are diagnostic statuses, not benchmark successes.

## Follow-Up Issues
- Deferred work: T0 neutral export schema and missing-CARLA dependency guard under #872.
- Issues opened for follow-up: none; #872 already tracks the parent implementation track.

## Reviewer Notes
- Verify the contract does not overclaim CARLA parity or imply CARLA is now required.
- Known limitation: first certified scenario set and CARLA coordinate mapping remain intentionally deferred.

## Artifact Persistence
- The readiness gate generated ignored coverage files under `output/coverage` and reused pre-existing ignored `output/` artifacts. No PR behavior depends on those local files; they remain disposable.
