### PR TITLE
feat: add hybrid portfolio diagnostics (#932)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -157,6 +157,9 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #592 Hybrid Obstacle-Context Predictor Design](./issue_592_hybrid_obstacle_predictor_design.md)
   scopes the obstacle-conditioned predictive-model idea into a feature-baseline-first experiment
   path with proof gates before any grid/CNN or obstacle-node graph prototype.
+- [Issue #932 Hybrid Portfolio Diagnostics](./issue_932_hybrid_portfolio_diagnostics.md)
+  records the first small policy-stack runtime diagnostics slice: selected-head counts, fallback
+  counts, and last-decision metadata on `HybridPortfolioAdapter`.
 - [Issue #589 Public Leaderboard MVP Boundary](./issue_589_public_leaderboard_mvp.md)
   records the no-implementation-now decision, future PR-based MVP boundary, and prerequisites for
   any public planner leaderboard work.

--- a/docs/context/issue_932_hybrid_portfolio_diagnostics.md
+++ b/docs/context/issue_932_hybrid_portfolio_diagnostics.md
@@ -1,0 +1,63 @@
+# Issue 932 Hybrid Portfolio Diagnostics
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/932>
+
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/871>
+
+## Goal
+
+Add a first small runtime diagnostics slice for the policy-stack workstream. The existing
+`HybridPortfolioAdapter` already switches between risk-DWA, ORCA, prediction, and optional MPPI
+planner heads, but it did not expose episode-local diagnostics for benchmark metadata.
+
+## Public Surface
+
+`HybridPortfolioAdapter.diagnostics()` now returns a JSON-safe payload with:
+
+- `steps`,
+- `active_head`,
+- `hold_remaining`,
+- `selected_head_counts`,
+- `fallback_count`,
+- `last_decision`.
+
+`last_decision` records the desired head, selected head, fallback flag, fallback source, error
+string when available, active head, and hysteresis hold count.
+
+## Scope Boundary
+
+This is not the full `policy_stack_v1` planner from #871. It does not add proposal normalization,
+risk scoring, safety shielding, route rebasing, or benchmark proof. It only gives the current
+hybrid portfolio a benchmark-consumable diagnostics hook that the existing map runner can snapshot
+through its generic `diagnostics()` path.
+
+Fallback-on-exception remains an explicit degraded behavior of `HybridPortfolioAdapter`; the
+diagnostics now make that visible through `fallback_count` and `last_decision`.
+
+## Validation
+
+Targeted TDD evidence:
+
+```bash
+uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py -q
+```
+
+The RED run failed with `AttributeError: 'HybridPortfolioAdapter' object has no attribute
+'diagnostics'` for the new selection and fallback tests. The GREEN run passed:
+
+```text
+24 passed in 9.78s
+```
+
+Before PR handoff, also run:
+
+```bash
+git diff --check
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Follow-Up Boundary
+
+Future #871 children should define the full `policy_stack_v1` proposal/risk/shield schema and then
+prove the planner through the normal benchmark or policy-analysis entry point. This diagnostics
+surface can be reused directly or superseded with an explicitly versioned policy-stack schema.

--- a/robot_sf/planner/hybrid_portfolio.py
+++ b/robot_sf/planner/hybrid_portfolio.py
@@ -58,6 +58,10 @@ class HybridPortfolioAdapter:
 
         self._active_head = "risk_dwa"
         self._hold_remaining = 0
+        self._selected_head_counts: dict[str, int] = {}
+        self._fallback_count = 0
+        self._steps = 0
+        self._last_decision: dict[str, Any] | None = None
 
     def _extract_ped_clearance(self, observation: dict[str, Any]) -> tuple[int, float]:
         """Return `(near_count, min_clearance)` around the robot."""
@@ -117,10 +121,41 @@ class HybridPortfolioAdapter:
             return self.prediction.plan(observation)
         return self.orca.plan(observation)
 
+    def _record_decision(
+        self,
+        *,
+        desired_head: str,
+        selected_head: str,
+        fallback: bool = False,
+        fallback_from: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Store JSON-safe diagnostics for one planner-head decision."""
+
+        self._steps += 1
+        self._selected_head_counts[selected_head] = (
+            self._selected_head_counts.get(selected_head, 0) + 1
+        )
+        if fallback:
+            self._fallback_count += 1
+        self._last_decision = {
+            "desired_head": desired_head,
+            "selected_head": selected_head,
+            "fallback": bool(fallback),
+            "fallback_from": fallback_from,
+            "error": error,
+            "active_head": self._active_head,
+            "hold_remaining": int(self._hold_remaining),
+        }
+
     def reset(self) -> None:
         """Clear portfolio hysteresis and reset any stateful child heads."""
         self._active_head = "risk_dwa"
         self._hold_remaining = 0
+        self._selected_head_counts.clear()
+        self._fallback_count = 0
+        self._steps = 0
+        self._last_decision = None
         for head in (self.risk_dwa, self.orca, self.prediction, self.mppi):
             reset = getattr(head, "reset", None)
             if callable(reset):
@@ -130,17 +165,44 @@ class HybridPortfolioAdapter:
         """Return command from selected planner head."""
         desired = self._desired_head(observation)
         self._switch_head(desired)
+        selected = self._active_head
         try:
-            return self._call_head(self._active_head, observation)
-        except Exception:
+            command = self._call_head(selected, observation)
+            self._record_decision(desired_head=desired, selected_head=selected)
+            return command
+        except Exception as exc:
             if not bool(self.config.fallback_on_exception):
                 raise
             logger.warning(
                 "Hybrid portfolio head '{}' failed; falling back to ORCA.",
-                self._active_head,
+                selected,
             )
             self._active_head = "orca"
-            return self.orca.plan(observation)
+            command = self.orca.plan(observation)
+            self._record_decision(
+                desired_head=desired,
+                selected_head="orca",
+                fallback=True,
+                fallback_from=selected,
+                error=str(exc),
+            )
+            return command
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return episode-local planner-head diagnostics.
+
+        Returns:
+            JSON-safe diagnostics for benchmark episode metadata.
+        """
+
+        return {
+            "steps": int(self._steps),
+            "active_head": self._active_head,
+            "hold_remaining": int(self._hold_remaining),
+            "selected_head_counts": dict(self._selected_head_counts),
+            "fallback_count": int(self._fallback_count),
+            "last_decision": dict(self._last_decision) if self._last_decision else None,
+        }
 
 
 @dataclass

--- a/robot_sf/planner/hybrid_portfolio.py
+++ b/robot_sf/planner/hybrid_portfolio.py
@@ -178,7 +178,6 @@ class HybridPortfolioAdapter:
                 selected,
             )
             self._active_head = "orca"
-            command = self.orca.plan(observation)
             self._record_decision(
                 desired_head=desired,
                 selected_head="orca",
@@ -186,7 +185,7 @@ class HybridPortfolioAdapter:
                 fallback_from=selected,
                 error=str(exc),
             )
-            return command
+            return self.orca.plan(observation)
 
     def diagnostics(self) -> dict[str, Any]:
         """Return episode-local planner-head diagnostics.

--- a/tests/planner/test_risk_dwa_mppi_hybrid.py
+++ b/tests/planner/test_risk_dwa_mppi_hybrid.py
@@ -430,6 +430,43 @@ def test_hybrid_portfolio_records_fallback_diagnostics() -> None:
     assert "boom" in diagnostics["last_decision"]["error"]
 
 
+def test_hybrid_portfolio_preserves_fallback_diagnostics_if_orca_raises() -> None:
+    """Fallback intent should still be recorded when the ORCA fallback raises."""
+
+    class _FailingHead(_DummyHead):
+        def plan(self, observation: dict) -> tuple[float, float]:
+            _ = observation
+            self.calls += 1
+            raise RuntimeError(f"{self.name} boom")
+
+    risk = _FailingHead("risk")
+    orca = _FailingHead("orca")
+    pred = _DummyHead("pred")
+    hybrid = HybridPortfolioAdapter(
+        hybrid_config=HybridPortfolioConfig(fallback_on_exception=True),
+        risk_dwa=risk,
+        orca=orca,
+        prediction=pred,
+        mppi=None,
+    )
+
+    with pytest.raises(RuntimeError, match="orca boom"):
+        hybrid.plan(_obs())
+
+    diagnostics = hybrid.diagnostics()
+
+    assert risk.calls == 1
+    assert orca.calls == 1
+    assert diagnostics["steps"] == 1
+    assert diagnostics["fallback_count"] == 1
+    assert diagnostics["selected_head_counts"] == {"orca": 1}
+    assert diagnostics["last_decision"]["desired_head"] == "risk_dwa"
+    assert diagnostics["last_decision"]["selected_head"] == "orca"
+    assert diagnostics["last_decision"]["fallback"] is True
+    assert diagnostics["last_decision"]["fallback_from"] == "risk_dwa"
+    assert diagnostics["last_decision"]["error"] == "risk boom"
+
+
 def test_hybrid_builder_applies_full_subhead_fields() -> None:
     """Hybrid build config should preserve full risk/mpii sub-config fields."""
     build = build_hybrid_portfolio_build_config(

--- a/tests/planner/test_risk_dwa_mppi_hybrid.py
+++ b/tests/planner/test_risk_dwa_mppi_hybrid.py
@@ -358,6 +358,78 @@ def test_hybrid_fallback_on_exception_and_config_defaults() -> None:
     assert isinstance(build.hybrid, HybridPortfolioConfig)
 
 
+def test_hybrid_portfolio_records_selection_diagnostics_and_reset() -> None:
+    """Hybrid diagnostics should expose selected heads and clear on episode reset."""
+    risk = _DummyHead("risk")
+    orca = _DummyHead("orca")
+    pred = _DummyHead("pred")
+    mppi = _DummyHead("mppi")
+    hybrid = HybridPortfolioAdapter(
+        hybrid_config=HybridPortfolioConfig(
+            emergency_clearance=0.4,
+            caution_clearance=1.0,
+            dense_ped_count=2,
+            hysteresis_steps=0,
+        ),
+        risk_dwa=risk,
+        orca=orca,
+        prediction=pred,
+        mppi=mppi,
+    )
+
+    hybrid.plan(_obs(ped_positions=[(0.8, 0.0), (0.9, 0.0)]))
+    hybrid.plan(_obs(ped_positions=[(5.0, 0.0)]))
+
+    diagnostics = hybrid.diagnostics()
+
+    assert diagnostics["steps"] == 2
+    assert diagnostics["selected_head_counts"] == {"prediction": 1, "mppi": 1}
+    assert diagnostics["fallback_count"] == 0
+    assert diagnostics["last_decision"]["desired_head"] == "mppi"
+    assert diagnostics["last_decision"]["selected_head"] == "mppi"
+    assert diagnostics["last_decision"]["fallback"] is False
+
+    diagnostics["selected_head_counts"]["mppi"] = 99
+    assert hybrid.diagnostics()["selected_head_counts"]["mppi"] == 1
+
+    hybrid.reset()
+    cleared = hybrid.diagnostics()
+    assert cleared["steps"] == 0
+    assert cleared["selected_head_counts"] == {}
+    assert cleared["last_decision"] is None
+
+
+def test_hybrid_portfolio_records_fallback_diagnostics() -> None:
+    """Fallback diagnostics should explain degraded ORCA selection after head failure."""
+
+    class _FailingHead(_DummyHead):
+        def plan(self, observation: dict) -> tuple[float, float]:
+            raise RuntimeError("boom")
+
+    risk = _FailingHead("risk")
+    orca = _DummyHead("orca")
+    pred = _DummyHead("pred")
+    hybrid = HybridPortfolioAdapter(
+        hybrid_config=HybridPortfolioConfig(fallback_on_exception=True),
+        risk_dwa=risk,
+        orca=orca,
+        prediction=pred,
+        mppi=None,
+    )
+
+    assert hybrid.plan(_obs()) == (0.5, 0.0)
+    diagnostics = hybrid.diagnostics()
+
+    assert diagnostics["steps"] == 1
+    assert diagnostics["fallback_count"] == 1
+    assert diagnostics["selected_head_counts"] == {"orca": 1}
+    assert diagnostics["last_decision"]["desired_head"] == "risk_dwa"
+    assert diagnostics["last_decision"]["selected_head"] == "orca"
+    assert diagnostics["last_decision"]["fallback"] is True
+    assert diagnostics["last_decision"]["fallback_from"] == "risk_dwa"
+    assert "boom" in diagnostics["last_decision"]["error"]
+
+
 def test_hybrid_builder_applies_full_subhead_fields() -> None:
     """Hybrid build config should preserve full risk/mpii sub-config fields."""
     build = build_hybrid_portfolio_build_config(


### PR DESCRIPTION
## Summary
Adds episode-local diagnostics to `HybridPortfolioAdapter`, covering selected planner-head counts, fallback count, active head state, and last-decision metadata.

## Linked Issues
- Closes #932
- Relates to #871

## What Changed
- Added `HybridPortfolioAdapter.diagnostics()` for JSON-safe benchmark metadata.
- Recorded normal planner-head selection and fallback-on-exception decisions.
- Reset episode-local diagnostics in `HybridPortfolioAdapter.reset()`.
- Added TDD coverage for selection diagnostics, fallback diagnostics, reset clearing, and defensive copy behavior.
- Added `docs/context/issue_932_hybrid_portfolio_diagnostics.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: gives the high-priority `policy_stack_v1` track a small runtime diagnostics slice without adding training or new proposal generators.
- Expected impact: benchmark episode metadata can now snapshot hybrid portfolio selected-head/fallback behavior through the existing generic planner `diagnostics()` hook.
- Why this is worth merging now: #871 requires diagnostic transparency before broader portfolio planner claims; this is a low-risk prerequisite.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py -q`
  - RED before implementation: `2 failed, 22 passed` with `AttributeError: HybridPortfolioAdapter object has no attribute diagnostics`.
  - GREEN after implementation: `24 passed in 9.78s`.
  - `scripts/dev/ruff_fix_format.sh`
  - `uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py tests/benchmark/test_map_runner_utils.py::test_run_map_episode_merges_planner_runtime_stats tests/benchmark/test_map_runner_utils.py::test_run_map_episode_snapshots_planner_runtime_before_close -q`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused planner + benchmark metadata tests: `26 passed in 17.36s`.
  - Full readiness gate: `3109 passed, 15 skipped, 3 warnings in 410.01s`.
  - Changed-file coverage warning: `robot_sf/planner/hybrid_portfolio.py` at `98.4%`; warning-only and above the 80% minimum.
- Benchmarks or smoke tests, if applicable: not applicable; this is a planner diagnostics slice, not a benchmark claim.

## Risks / Rollout
- Compatibility risks: low; existing `plan()` return behavior is unchanged.
- Failure modes: later `policy_stack_v1` diagnostics may need a stricter schema; this surface is intentionally generic and can be superseded.
- Rollback or fallback plan: revert the diagnostics state/method, tests, and context note.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_932_hybrid_portfolio_diagnostics.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - Parent #871.
- Any assumptions that need to be preserved:
  - Fallback-on-exception remains degraded behavior and should be visible in metadata, not treated as native portfolio success.

## Follow-Up Issues
- Deferred work: full `policy_stack_v1` proposal normalization, risk scoring, safety shield, route rebasing, and benchmark proof.
- Issues opened for follow-up: none; #871 remains the parent implementation track.

## Reviewer Notes
- Verify the diagnostics payload is JSON-safe and that returned dictionaries are copies.
- Verify fallback diagnostics do not hide the failed selected head.

## Artifact Persistence
- Validation generated ignored coverage files under `output/coverage` and reused pre-existing ignored `output/` artifacts. No PR behavior depends on those local files; they remain disposable.
