### PR TITLE
feat: materialize multi-ped adversarial overrides (#936)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -172,6 +172,9 @@ why a change was made rather than a full issue execution transcript.
   scenario search API, bundle contract, certification boundary, and deferred optimizer scope.
 - [Issue #923 Multi-Ped Adversarial Candidate Schema](issue_923_multi_ped_adversarial_schema.md) -
   schema-only first slice under #870 for scripted multi-pedestrian adversarial candidates.
+- [Issue #936 Multi-Ped Adversarial Overrides](issue_936_multi_ped_adversarial_overrides.md)
+  records the pure-data materializer from `adversarial-multi-ped.v1` configs to scenario-loader
+  `single_pedestrians` override dictionaries, stacked on the issue #923 schema PR.
 - [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
   scope, public surfaces, validation path, and known limits.
 

--- a/docs/context/issue_936_multi_ped_adversarial_overrides.md
+++ b/docs/context/issue_936_multi_ped_adversarial_overrides.md
@@ -1,0 +1,64 @@
+# Issue 936 Multi-Ped Adversarial Overrides
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/936>
+
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/870>
+
+Depends on issue #923 / PR #924.
+
+## Goal
+
+Bridge the `adversarial-multi-ped.v1` schema toward existing Robot-SF scenario runtime surfaces
+without running environments or claiming benchmark readiness. The new materializer converts a
+validated `MultiPedAdversarialConfig` into deterministic `single_pedestrians` override dictionaries.
+
+## Public Surface
+
+- `robot_sf.adversarial.materialize.materialize_multi_ped_single_pedestrian_overrides(config)`
+- Re-exported from `robot_sf.adversarial`.
+
+Each materialized override records:
+
+- pedestrian `id`,
+- `start` and `goal` points,
+- `speed_m_s`,
+- `start_delay_s` as `spawn_time_s + delay_s`,
+- a human-readable adversarial note,
+- metadata with family, schema version, scenario seed, original per-ped metadata, spawn time, and
+  delay.
+
+## Scope Boundary
+
+This is pure data conversion. It does not mutate scenario manifests, load maps, apply overrides,
+step an environment, or certify generated adversarial cases. The output is a development stress-test
+bridge and must not be treated as frozen benchmark evidence without later scenario certification and
+runtime proof.
+
+## Validation
+
+Targeted TDD evidence:
+
+```bash
+uv run pytest tests/adversarial/test_adversarial_search.py -q
+```
+
+The RED run failed during collection with `ModuleNotFoundError: No module named
+'robot_sf.adversarial.materialize'`, proving the tests covered the missing public materializer
+surface. The GREEN run passed:
+
+```text
+26 passed in 22.90s
+```
+
+Before PR handoff, run the stacked readiness gate against the #923 branch:
+
+```bash
+git diff --check
+BASE_REF=origin/923-multi-ped-adversarial-schema scripts/dev/pr_ready_check.sh
+```
+
+## Follow-Up Boundary
+
+Future #870 children can wire these overrides into a scenario-loader or policy-analysis smoke path,
+then prove reset/step determinism. Learned adversaries and frozen benchmark promotion remain out of
+scope until certification and replay evidence exist.

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -10,6 +10,7 @@ from robot_sf.adversarial.config import (
     SearchRunResult,
     SearchSpaceConfig,
 )
+from robot_sf.adversarial.materialize import materialize_multi_ped_single_pedestrian_overrides
 from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
 from robot_sf.adversarial.search import run_adversarial_search
 
@@ -24,5 +25,6 @@ __all__ = [
     "SearchConfig",
     "SearchRunResult",
     "SearchSpaceConfig",
+    "materialize_multi_ped_single_pedestrian_overrides",
     "run_adversarial_search",
 ]

--- a/robot_sf/adversarial/materialize.py
+++ b/robot_sf/adversarial/materialize.py
@@ -7,12 +7,6 @@ from typing import Any
 from robot_sf.adversarial.config import MultiPedAdversarialConfig, MultiPedCandidateSpec
 
 
-def _point_payload(pose: Any) -> list[float]:
-    """Return a scenario-loader point payload from a pose-like object."""
-
-    return [float(pose.x), float(pose.y)]
-
-
 def _metadata_payload(
     config: MultiPedAdversarialConfig,
     pedestrian: MultiPedCandidateSpec,
@@ -46,8 +40,8 @@ def materialize_multi_ped_single_pedestrian_overrides(
         overrides.append(
             {
                 "id": pedestrian.id,
-                "start": _point_payload(pedestrian.start),
-                "goal": _point_payload(pedestrian.goal),
+                "start": pedestrian.start.as_waypoint(),
+                "goal": pedestrian.goal.as_waypoint(),
                 "speed_m_s": float(pedestrian.speed_mps),
                 "start_delay_s": float(pedestrian.spawn_time_s) + float(pedestrian.delay_s),
                 "note": (

--- a/robot_sf/adversarial/materialize.py
+++ b/robot_sf/adversarial/materialize.py
@@ -1,0 +1,60 @@
+"""Materializers for adversarial configs that feed existing scenario surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robot_sf.adversarial.config import MultiPedAdversarialConfig, MultiPedCandidateSpec
+
+
+def _point_payload(pose: Any) -> list[float]:
+    """Return a scenario-loader point payload from a pose-like object."""
+
+    return [float(pose.x), float(pose.y)]
+
+
+def _metadata_payload(
+    config: MultiPedAdversarialConfig,
+    pedestrian: MultiPedCandidateSpec,
+) -> dict[str, Any]:
+    """Return YAML-safe adversarial metadata for one materialized pedestrian."""
+
+    return {
+        "adversarial_family": config.family,
+        "adversarial_schema_version": config.schema_version,
+        "adversarial_scenario_seed": int(config.scenario_seed),
+        "pedestrian_metadata": dict(pedestrian.metadata),
+        "spawn_time_s": float(pedestrian.spawn_time_s),
+        "delay_s": float(pedestrian.delay_s),
+    }
+
+
+def materialize_multi_ped_single_pedestrian_overrides(
+    config: MultiPedAdversarialConfig,
+) -> list[dict[str, Any]]:
+    """Convert a multi-ped adversarial config into scenario-loader overrides.
+
+    The returned dictionaries are designed for the existing ``single_pedestrians`` scenario
+    override surface. This remains a pure-data bridge; it does not load maps or run environments.
+
+    Returns:
+        YAML/JSON-safe single-pedestrian override dictionaries.
+    """
+
+    overrides: list[dict[str, Any]] = []
+    for pedestrian in config.pedestrians:
+        overrides.append(
+            {
+                "id": pedestrian.id,
+                "start": _point_payload(pedestrian.start),
+                "goal": _point_payload(pedestrian.goal),
+                "speed_m_s": float(pedestrian.speed_mps),
+                "start_delay_s": float(pedestrian.spawn_time_s) + float(pedestrian.delay_s),
+                "note": (
+                    f"{config.schema_version} {config.family} "
+                    f"seed={int(config.scenario_seed)} ped={pedestrian.id}"
+                ),
+                "metadata": _metadata_payload(config, pedestrian),
+            }
+        )
+    return overrides

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -24,6 +24,9 @@ from robot_sf.adversarial.config import (
     SearchSpaceConfig,
 )
 from robot_sf.adversarial.io import read_first_jsonl_record
+from robot_sf.adversarial.materialize import (
+    materialize_multi_ped_single_pedestrian_overrides,
+)
 from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
 
 
@@ -285,6 +288,94 @@ def test_multi_ped_adversarial_example_config_is_valid() -> None:
     assert config.family == "group_squeeze"
     assert len(config.pedestrians) == 2
     assert config.validate() == []
+
+
+def test_multi_ped_config_materializes_single_pedestrian_overrides() -> None:
+    """Multi-ped adversarial configs should bridge to scenario-loader override entries."""
+    config = MultiPedAdversarialConfig(
+        family="group_squeeze",
+        scenario_seed=41,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="left_blocker",
+                start=Pose2D(1.0, 2.0, 0.1),
+                goal=Pose2D(5.0, 2.0),
+                spawn_time_s=0.5,
+                speed_mps=1.1,
+                delay_s=0.25,
+                metadata={"role": "left"},
+            ),
+            MultiPedCandidateSpec(
+                id="right_blocker",
+                start=Pose2D(1.0, 3.0),
+                goal=Pose2D(5.0, 3.0),
+                spawn_time_s=0.75,
+                speed_mps=1.2,
+            ),
+        ],
+    )
+
+    overrides = materialize_multi_ped_single_pedestrian_overrides(config)
+
+    assert overrides == [
+        {
+            "id": "left_blocker",
+            "start": [1.0, 2.0],
+            "goal": [5.0, 2.0],
+            "speed_m_s": 1.1,
+            "start_delay_s": 0.75,
+            "note": "adversarial-multi-ped.v1 group_squeeze seed=41 ped=left_blocker",
+            "metadata": {
+                "adversarial_family": "group_squeeze",
+                "adversarial_schema_version": "adversarial-multi-ped.v1",
+                "adversarial_scenario_seed": 41,
+                "pedestrian_metadata": {"role": "left"},
+                "spawn_time_s": 0.5,
+                "delay_s": 0.25,
+            },
+        },
+        {
+            "id": "right_blocker",
+            "start": [1.0, 3.0],
+            "goal": [5.0, 3.0],
+            "speed_m_s": 1.2,
+            "start_delay_s": 0.75,
+            "note": "adversarial-multi-ped.v1 group_squeeze seed=41 ped=right_blocker",
+            "metadata": {
+                "adversarial_family": "group_squeeze",
+                "adversarial_schema_version": "adversarial-multi-ped.v1",
+                "adversarial_scenario_seed": 41,
+                "pedestrian_metadata": {},
+                "spawn_time_s": 0.75,
+                "delay_s": 0.0,
+            },
+        },
+    ]
+
+
+def test_multi_ped_materialized_overrides_are_yaml_safe() -> None:
+    """Materialized overrides should serialize without custom YAML representers."""
+    config = MultiPedAdversarialConfig(
+        family="late_stop",
+        scenario_seed=7,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="stopper",
+                start=Pose2D(0.0, 0.0),
+                goal=Pose2D(1.0, 0.0),
+                speed_mps=0.8,
+            )
+        ],
+    )
+
+    dumped = yaml.safe_dump(
+        {"single_pedestrians": materialize_multi_ped_single_pedestrian_overrides(config)},
+        sort_keys=False,
+    )
+
+    loaded = yaml.safe_load(dumped)
+    assert loaded["single_pedestrians"][0]["id"] == "stopper"
+    assert loaded["single_pedestrians"][0]["start_delay_s"] == 0.0
 
 
 def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a pure-data materializer from validated `adversarial-multi-ped.v1` configs to scenario-loader `single_pedestrians` override dictionaries.

## Linked Issues
- Closes #936
- Relates to #870
- Depends on #923 / PR #924

## What Changed
- Added `robot_sf.adversarial.materialize.materialize_multi_ped_single_pedestrian_overrides(config)`.
- Re-exported the helper from `robot_sf.adversarial`.
- Preserved per-ped id, start, goal, speed, combined start delay, adversarial note, and metadata in YAML-safe output.
- Added tests for deterministic override materialization and YAML serialization.
- Added `docs/context/issue_936_multi_ped_adversarial_overrides.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: bridges PR #924’s multi-ped schema toward existing Robot-SF scenario override surfaces.
- Expected impact: future #870 runtime work can use these overrides as the first step toward reset/step and policy-analysis smoke tests.
- Why this is worth merging now: it is the next small, CARLA/training-free code slice under the high-priority multi-ped adversarial epic.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/adversarial/test_adversarial_search.py -q`
  - RED before implementation: collection failed with `ModuleNotFoundError: No module named robot_sf.adversarial.materialize`.
  - GREEN after implementation: `26 passed in 22.90s`.
  - `scripts/dev/ruff_fix_format.sh`
  - `git diff --check`
  - `uv run pytest tests/adversarial/test_adversarial_search.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q`
  - `BASE_REF=origin/923-multi-ped-adversarial-schema scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused stacked tests: `32 passed in 14.34s`.
  - Full stacked readiness gate: `3112 passed, 15 skipped, 3 warnings in 411.78s`.
  - Changed-file coverage: `robot_sf/adversarial/__init__.py` 100%, `robot_sf/adversarial/materialize.py` 100%.
- Benchmarks or smoke tests, if applicable: not applicable; this is pure data conversion, not runtime environment proof.

## Risks / Rollout
- Compatibility risks: low; additive helper stacked on the #923 schema branch.
- Failure modes: future scenario-loader integration may need a different metadata convention; this helper keeps metadata additive and YAML-safe.
- Rollback or fallback plan: revert the materializer, export, tests, and context note.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_936_multi_ped_adversarial_overrides.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - Parent #870.
  - Depends on #923 / PR #924.
- Any assumptions that need to be preserved:
  - Materialized overrides are development stress-test data, not frozen benchmark evidence.
  - `start_delay_s` is currently `spawn_time_s + delay_s` so both timing controls survive in one scenario-loader-compatible field while raw values remain in metadata.

## Follow-Up Issues
- Deferred work: wire these overrides into a scenario-loader or policy-analysis smoke path, then prove reset/step determinism.
- Issues opened for follow-up: none; #870 remains the parent implementation track.

## Reviewer Notes
- This PR is stacked on `923-multi-ped-adversarial-schema`; review after or alongside PR #924.
- Verify that output stays YAML-safe and does not claim runtime benchmark readiness.

## Artifact Persistence
- Validation generated ignored coverage files under `output/coverage` and reused pre-existing ignored `output/` artifacts. No PR behavior depends on those local files; they remain disposable.
