### PR TITLE
feat: add hybrid portfolio last decision (#938)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -160,6 +160,9 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #932 Hybrid Portfolio Diagnostics](./issue_932_hybrid_portfolio_diagnostics.md)
   records the first small policy-stack runtime diagnostics slice: selected-head counts, fallback
   counts, and last-decision metadata on `HybridPortfolioAdapter`.
+- [Issue #938 Hybrid Portfolio Last Decision](./issue_938_hybrid_portfolio_last_decision.md)
+  adds a step-level `HybridPortfolioAdapter.last_decision()` accessor consistent with nearby
+  planner diagnostics APIs.
 - [Issue #589 Public Leaderboard MVP Boundary](./issue_589_public_leaderboard_mvp.md)
   records the no-implementation-now decision, future PR-based MVP boundary, and prerequisites for
   any public planner leaderboard work.

--- a/docs/context/issue_938_hybrid_portfolio_last_decision.md
+++ b/docs/context/issue_938_hybrid_portfolio_last_decision.md
@@ -1,0 +1,42 @@
+# Issue 938 Hybrid Portfolio Last Decision
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/938>
+
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/871>
+
+Depends on issue #932 / PR #933.
+
+## Goal
+
+Align `HybridPortfolioAdapter` with existing planner step-level diagnostics conventions. The
+portfolio diagnostics added in #932 expose `last_decision` through `diagnostics()`, and this issue
+adds the direct `last_decision()` accessor already used by nearby planners.
+
+## Public Surface
+
+- `HybridPortfolioAdapter.last_decision() -> dict[str, Any] | None`
+
+The method returns a defensive copy of the latest selected-head decision, or `None` before the
+first planning step and after `reset()`.
+
+## Validation
+
+Targeted TDD evidence:
+
+```bash
+uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py -q
+```
+
+The RED run failed with `AttributeError: 'HybridPortfolioAdapter' object has no attribute
+'last_decision'`. The GREEN run passed:
+
+```text
+25 passed in 9.81s
+```
+
+Before PR handoff, run the stacked readiness gate against the #932 branch:
+
+```bash
+git diff --check
+BASE_REF=origin/932-hybrid-portfolio-diagnostics scripts/dev/pr_ready_check.sh
+```

--- a/robot_sf/planner/hybrid_portfolio.py
+++ b/robot_sf/planner/hybrid_portfolio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, fields
 from typing import Any
 
@@ -201,17 +202,21 @@ class HybridPortfolioAdapter:
             "hold_remaining": int(self._hold_remaining),
             "selected_head_counts": dict(self._selected_head_counts),
             "fallback_count": int(self._fallback_count),
-            "last_decision": dict(self._last_decision) if self._last_decision else None,
+            "last_decision": deepcopy(self._last_decision) if self._last_decision else None,
         }
 
     def last_decision(self) -> dict[str, Any] | None:
         """Return the latest planner-head decision for step-level tooling.
 
+        Returns a deep copy so callers can safely store, compare, or mutate the
+        payload without affecting the planner's internal state, even if future
+        decisions include nested structures (e.g. candidate score tables).
+
         Returns:
             Copy of the latest decision payload, or ``None`` before the first step/reset.
         """
 
-        return dict(self._last_decision) if self._last_decision else None
+        return deepcopy(self._last_decision) if self._last_decision else None
 
 
 @dataclass

--- a/robot_sf/planner/hybrid_portfolio.py
+++ b/robot_sf/planner/hybrid_portfolio.py
@@ -204,6 +204,15 @@ class HybridPortfolioAdapter:
             "last_decision": dict(self._last_decision) if self._last_decision else None,
         }
 
+    def last_decision(self) -> dict[str, Any] | None:
+        """Return the latest planner-head decision for step-level tooling.
+
+        Returns:
+            Copy of the latest decision payload, or ``None`` before the first step/reset.
+        """
+
+        return dict(self._last_decision) if self._last_decision else None
+
 
 @dataclass
 class HybridPortfolioBuildConfig:

--- a/tests/planner/test_risk_dwa_mppi_hybrid.py
+++ b/tests/planner/test_risk_dwa_mppi_hybrid.py
@@ -399,6 +399,34 @@ def test_hybrid_portfolio_records_selection_diagnostics_and_reset() -> None:
     assert cleared["last_decision"] is None
 
 
+def test_hybrid_portfolio_last_decision_returns_copy_and_resets() -> None:
+    """Step-level tooling should be able to read the latest hybrid decision safely."""
+    risk = _DummyHead("risk")
+    orca = _DummyHead("orca")
+    pred = _DummyHead("pred")
+    mppi = _DummyHead("mppi")
+    hybrid = HybridPortfolioAdapter(
+        hybrid_config=HybridPortfolioConfig(hysteresis_steps=0),
+        risk_dwa=risk,
+        orca=orca,
+        prediction=pred,
+        mppi=mppi,
+    )
+
+    assert hybrid.last_decision() is None
+
+    hybrid.plan(_obs(ped_positions=[(5.0, 0.0)]))
+    last = hybrid.last_decision()
+
+    assert last is not None
+    assert last["selected_head"] == "mppi"
+    last["selected_head"] = "mutated"
+    assert hybrid.last_decision()["selected_head"] == "mppi"
+
+    hybrid.reset()
+    assert hybrid.last_decision() is None
+
+
 def test_hybrid_portfolio_records_fallback_diagnostics() -> None:
     """Fallback diagnostics should explain degraded ORCA selection after head failure."""
 


### PR DESCRIPTION
## Summary
Adds `HybridPortfolioAdapter.last_decision()` so the hybrid portfolio matches nearby planner step-level diagnostics conventions.

## Linked Issues
- Closes #938
- Relates to #871
- Depends on #932 / PR #933

## What Changed
- Added `HybridPortfolioAdapter.last_decision()` returning a defensive copy of the latest decision payload or `None` before first step/reset.
- Added tests for populated, mutation-safe, and reset-cleared behavior.
- Added `docs/context/issue_938_hybrid_portfolio_last_decision.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: keeps the hybrid portfolio diagnostics API consistent with `hybrid_rule_local_planner` and `hybrid_orca_sampler`.
- Expected impact: future `policy_stack_v1` step-level tooling can read the latest selected-head decision without unpacking the full episode diagnostics payload.
- Why this is worth merging now: it is a small compatibility follow-up to PR #933 under the high-priority #871 track.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py -q`
  - RED before implementation: `1 failed, 24 passed` with `AttributeError: HybridPortfolioAdapter object has no attribute last_decision`.
  - GREEN after implementation: `25 passed in 9.81s`.
  - `scripts/dev/ruff_fix_format.sh`
  - `git diff --check`
  - `uv run pytest tests/planner/test_risk_dwa_mppi_hybrid.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q`
  - `BASE_REF=origin/932-hybrid-portfolio-diagnostics scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused stacked tests: `31 passed in 10.00s`.
  - Full stacked readiness gate: `3110 passed, 15 skipped, 3 warnings in 409.92s`.
  - Changed-file coverage warning: `robot_sf/planner/hybrid_portfolio.py` at `98.4%`; warning-only and above the 80% minimum.
- Benchmarks or smoke tests, if applicable: not applicable; this is a diagnostics API compatibility slice.

## Risks / Rollout
- Compatibility risks: low; additive method only.
- Failure modes: future policy-stack diagnostics may supersede this shape, but this follows existing planner convention.
- Rollback or fallback plan: revert the accessor, tests, and context note.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_938_hybrid_portfolio_last_decision.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - Parent #871.
  - Depends on #932 / PR #933.

## Follow-Up Issues
- Deferred work: full `policy_stack_v1` proposal normalization, risk scoring, safety shield, route rebasing, and benchmark proof.
- Issues opened for follow-up: none; #871 remains the parent implementation track.

## Reviewer Notes
- This PR is stacked on `932-hybrid-portfolio-diagnostics`; review after or alongside PR #933.
- Verify returned decision dictionaries are defensive copies.

## Artifact Persistence
- Validation generated ignored coverage files under `output/coverage` and reused pre-existing ignored `output/` artifacts. No PR behavior depends on those local files; they remain disposable.
