### PR TITLE
feat: add CARLA runtime availability guard (#968)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -213,6 +213,8 @@ why a change was made rather than a full issue execution transcript.
   script.
 - [Issue #966 CARLA T0 Batch Validation JSON Summary](issue_966_carla_t0_batch_validation_json_summary.md)
   adds deterministic machine-readable output to the CARLA-free batch validation CLI.
+- [Issue #968 CARLA Runtime Availability Guard](issue_968_carla_runtime_availability_guard.md)
+  adds a strict optional-CARLA import guard for future replay entry points.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_968_carla_runtime_availability_guard.md
+++ b/docs/context/issue_968_carla_runtime_availability_guard.md
@@ -1,0 +1,36 @@
+# Issue #968 CARLA Runtime Availability Guard
+
+## Scope
+
+Issue #968 extends the CARLA bridge availability surface with `require_carla()`, a strict guard for
+future replay entry points that need the optional CARLA Python API. Normal imports of
+`robot_sf_carla_bridge` remain CARLA-free; callers opt into the strict guard only when they are
+about to use CARLA-dependent runtime code.
+
+The guard raises `CarlaUnavailableError` with an actionable message when the `carla` module is not
+importable. If `carla` is importable, the helper returns the imported module so replay code can
+avoid duplicating optional import handling.
+
+## Boundary
+
+This change does not start a CARLA simulator, run replay, install CARLA, change dependency
+metadata, or compare simulator metrics. It only establishes the fail-clear import boundary needed by
+later replay entry points.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_runtime.py -q
+```
+
+Failed before implementation because `CarlaUnavailableError` and `require_carla` were absent.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_runtime.py -q
+```
+
+Passed after adding the strict guard: `2 passed`.

--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -4,7 +4,11 @@ The package must remain usable without CARLA installed. Runtime replay integrati
 the availability helpers before importing or invoking CARLA-specific APIs.
 """
 
-from robot_sf_carla_bridge.availability import check_carla_availability
+from robot_sf_carla_bridge.availability import (
+    CarlaUnavailableError,
+    check_carla_availability,
+    require_carla,
+)
 from robot_sf_carla_bridge.export import (
     EXPORT_MANIFEST_SCHEMA_VERSION,
     EXPORT_SCHEMA_VERSION,
@@ -31,6 +35,7 @@ from robot_sf_carla_bridge.export import (
 __all__ = [
     "EXPORT_MANIFEST_SCHEMA_VERSION",
     "EXPORT_SCHEMA_VERSION",
+    "CarlaUnavailableError",
     "CertificateRef",
     "PedestrianReplaySpec",
     "Pose2D",
@@ -46,6 +51,7 @@ __all__ = [
     "load_export_schema",
     "read_export_manifest",
     "read_export_payload",
+    "require_carla",
     "resolve_export_manifest_payload_paths",
     "validate_export_payload",
     "write_export_payload",

--- a/robot_sf_carla_bridge/availability.py
+++ b/robot_sf_carla_bridge/availability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from typing import Any
 
 

--- a/robot_sf_carla_bridge/availability.py
+++ b/robot_sf_carla_bridge/availability.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-import importlib.util
+import importlib
 from typing import Any
+
+
+class CarlaUnavailableError(RuntimeError):
+    """Raised when a CARLA-dependent bridge path is used without CARLA installed."""
 
 
 def check_carla_availability() -> dict[str, Any]:
@@ -25,3 +29,24 @@ def check_carla_availability() -> dict[str, Any]:
         "reason": "CARLA Python API package is importable",
         "dependency": "carla",
     }
+
+
+def require_carla() -> Any:
+    """Import and return the optional CARLA Python API or raise a clear bridge error.
+
+    Returns:
+        Imported ``carla`` module for CARLA-dependent replay entry points.
+
+    Raises:
+        CarlaUnavailableError: When the CARLA Python API cannot be imported.
+    """
+
+    try:
+        return importlib.import_module("carla")
+    except ModuleNotFoundError as exc:
+        if exc.name != "carla":
+            raise
+        raise CarlaUnavailableError(
+            "CARLA Python API package 'carla' is not importable. Install CARLA and ensure its "
+            "Python API is on PYTHONPATH before using CARLA replay entry points."
+        ) from exc

--- a/tests/carla_bridge/test_runtime.py
+++ b/tests/carla_bridge/test_runtime.py
@@ -1,0 +1,38 @@
+"""CARLA-free tests for optional CARLA runtime guards."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+
+def test_require_carla_raises_clear_error_when_api_is_missing(monkeypatch) -> None:
+    """Strict replay guards should fail clearly when CARLA is not importable."""
+    from robot_sf_carla_bridge.availability import CarlaUnavailableError, require_carla
+
+    def fake_import_module(name):
+        if name == "carla":
+            raise ModuleNotFoundError("No module named 'carla'", name="carla")
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("importlib.import_module", fake_import_module)
+
+    with pytest.raises(CarlaUnavailableError, match="CARLA Python API package 'carla'"):
+        require_carla()
+
+
+def test_require_carla_returns_imported_api_module(monkeypatch) -> None:
+    """Strict replay guards should return the importable CARLA API module."""
+    from robot_sf_carla_bridge.availability import require_carla
+
+    fake_carla = ModuleType("carla")
+
+    def fake_import_module(name):
+        if name == "carla":
+            return fake_carla
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr("importlib.import_module", fake_import_module)
+
+    assert require_carla() is fake_carla


### PR DESCRIPTION
## Summary

- add `CarlaUnavailableError` and `require_carla()` for strict optional-CARLA import handling
- keep normal bridge imports CARLA-free while giving future replay entry points an actionable failure path
- add CARLA-free tests for missing and present CARLA API cases
- add a context note for the runtime availability boundary

Closes #968. Relates #872. Stacked on #967 / branch `966-carla-t0-batch-validation-json`.

## Boundary

This only adds the optional import guard. It does not start CARLA, run replay, install CARLA, change dependency metadata, upload artifacts, or claim simulator parity.

## Validation

- RED: `rtk uv run pytest tests/carla_bridge/test_runtime.py -q` failed before implementation because `CarlaUnavailableError` and `require_carla` were absent.
- GREEN: `rtk uv run pytest tests/carla_bridge/test_runtime.py -q` -> `2 passed in 12.67s`.
- `rtk scripts/dev/ruff_fix_format.sh` initially reported style issues after implementation; after switching to `importlib.import_module`, rerun with focused tests passed.
- `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> Ruff clean and `34 passed in 14.53s`.
- `rtk git diff --check origin/966-carla-t0-batch-validation-json...HEAD && rtk proxy bash -lc 'BASE_REF=origin/966-carla-t0-batch-validation-json scripts/dev/pr_ready_check.sh'` -> `3135 passed, 15 skipped, 3 warnings in 407.54s (0:06:47)`.

## Artifact Persistence

`git status --ignored --short -uall output` shows ignored worktree-local `output/*` entries including coverage and pre-existing experiment outputs. No generated output is required by this change or promoted as a durable artifact.