### PR TITLE
feat: expose CARLA availability check CLI (#970)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -215,6 +215,8 @@ why a change was made rather than a full issue execution transcript.
   adds deterministic machine-readable output to the CARLA-free batch validation CLI.
 - [Issue #968 CARLA Runtime Availability Guard](issue_968_carla_runtime_availability_guard.md)
   adds a strict optional-CARLA import guard for future replay entry points.
+- [Issue #970 CARLA Availability Check CLI](issue_970_carla_availability_check_cli.md)
+  exposes CARLA bridge availability metadata through a CARLA-free project script.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_970_carla_availability_check_cli.md
+++ b/docs/context/issue_970_carla_availability_check_cli.md
@@ -1,0 +1,34 @@
+# Issue #970 CARLA Availability Check CLI
+
+## Scope
+
+Issue #970 exposes the CARLA bridge availability metadata through
+`robot-sf-check-carla`. The CLI calls `check_carla_availability()` and reports the dependency,
+status, and reason in either text or deterministic JSON form.
+
+The command is intentionally CARLA-free: it reports whether the optional CARLA Python API is
+importable without starting a simulator or importing replay code.
+
+## Boundary
+
+This change does not install CARLA, start CARLA, run replay, change dependency metadata, or compare
+Robot-SF/CARLA metrics. It only provides a setup-check surface for future replay workflows.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_text_status tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q
+```
+
+Failed before implementation because `check_carla_availability_main` and the
+`robot-sf-check-carla` project script were absent.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_text_status tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q
+```
+
+Passed after adding the CLI and script metadata: `3 passed`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -488,6 +488,7 @@ robot_sf_bench = "robot_sf.benchmark.cli:main"
 robot-sf-export-carla-t0 = "robot_sf_carla_bridge.cli:export_t0_scenarios_main"
 robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_manifest_main"
 robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"
+robot-sf-check-carla = "robot_sf_carla_bridge.cli:check_carla_availability_main"
 robot-sf-migrate-artifacts = "scripts.tools.migrate_artifacts:main"
 
 # Note: uv-specific config removed to avoid duplicate-config warnings with uv.toml

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -7,6 +7,7 @@ import json
 import sys
 from pathlib import Path
 
+from robot_sf_carla_bridge.availability import check_carla_availability
 from robot_sf_carla_bridge.export import (
     build_export_payloads_from_scenario_file,
     load_export_manifest_payloads,
@@ -87,6 +88,26 @@ def validate_t0_export_batch_main(argv: list[str] | None = None) -> int:
 
     noun = "payload" if payload_count == 1 else "payloads"
     sys.stdout.write(f"{manifest_path.as_posix()}: {payload_count} {noun}\n")
+    return 0
+
+
+def check_carla_availability_main(argv: list[str] | None = None) -> int:
+    """Report whether the optional CARLA Python API is importable.
+
+    Returns:
+        Process-style exit code.
+    """
+
+    parser = argparse.ArgumentParser(description="Check optional CARLA Python API availability.")
+    parser.add_argument("--json", action="store_true", help="Print a machine-readable status.")
+    args = parser.parse_args(argv)
+
+    status = check_carla_availability()
+    if args.json:
+        sys.stdout.write(f"{json.dumps(status, sort_keys=True)}\n")
+        return 0
+
+    sys.stdout.write(f"{status['dependency']}: {status['status']} - {status['reason']}\n")
     return 0
 
 

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -94,8 +94,15 @@ def validate_t0_export_batch_main(argv: list[str] | None = None) -> int:
 def check_carla_availability_main(argv: list[str] | None = None) -> int:
     """Report whether the optional CARLA Python API is importable.
 
+    The default mode is informational and always exits 0. A follow-up CLI flag
+    (``--require``) is layered on top in a separate change to gate scripts on
+    availability.
+
+    Args:
+        argv: Command-line arguments to parse; ``None`` reads from ``sys.argv``.
+
     Returns:
-        Process-style exit code.
+        Process-style exit code (always 0 in this informational mode).
     """
 
     parser = argparse.ArgumentParser(description="Check optional CARLA Python API availability.")

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -147,6 +147,52 @@ def test_validate_t0_export_batch_main_prints_json_summary(
     }
 
 
+def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -> None:
+    """CARLA availability CLI should expose deterministic machine-readable status."""
+    import robot_sf_carla_bridge.cli as cli_module
+    from robot_sf_carla_bridge.cli import check_carla_availability_main
+
+    monkeypatch.setattr(
+        cli_module,
+        "check_carla_availability",
+        lambda: {
+            "status": "not-available",
+            "reason": "CARLA Python API package 'carla' is not importable",
+            "dependency": "carla",
+        },
+    )
+
+    exit_code = check_carla_availability_main(["--json"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "dependency": "carla",
+        "reason": "CARLA Python API package 'carla' is not importable",
+        "status": "not-available",
+    }
+
+
+def test_check_carla_availability_main_prints_text_status(monkeypatch, capsys) -> None:
+    """CARLA availability CLI should keep a concise human-readable output."""
+    import robot_sf_carla_bridge.cli as cli_module
+    from robot_sf_carla_bridge.cli import check_carla_availability_main
+
+    monkeypatch.setattr(
+        cli_module,
+        "check_carla_availability",
+        lambda: {
+            "status": "available",
+            "reason": "CARLA Python API package is importable",
+            "dependency": "carla",
+        },
+    )
+
+    exit_code = check_carla_availability_main([])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == "carla: available - CARLA Python API package is importable\n"
+
+
 def test_export_t0_cli_is_packaged_as_project_script() -> None:
     """Project metadata should expose the CLI and include the bridge package."""
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -159,6 +205,9 @@ def test_export_t0_cli_is_packaged_as_project_script() -> None:
     )
     assert pyproject["project"]["scripts"]["robot-sf-validate-carla-t0-batch"] == (
         "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"
+    )
+    assert pyproject["project"]["scripts"]["robot-sf-check-carla"] == (
+        "robot_sf_carla_bridge.cli:check_carla_availability_main"
     )
     hatchling_packages = pyproject["tool"]["hatchling"]["build"]["targets"]["wheel"]["packages"]
     assert {"include": "robot_sf_carla_bridge"} in hatchling_packages


### PR DESCRIPTION
## Summary

- add `check_carla_availability_main` as a CARLA-free CLI surface for availability metadata
- expose `robot-sf-check-carla` as a project script
- support deterministic `--json` output and concise text output
- add CLI/package tests and a context note for the setup-check boundary

Closes #970. Relates #872. Stacked on #969 / branch `968-carla-runtime-availability-guard`.

## Boundary

This only reports optional CARLA Python API availability. It does not install CARLA, start CARLA, run replay, change dependency metadata, upload artifacts, or claim simulator parity.

## Validation

- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_text_status tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q` failed before implementation because `check_carla_availability_main` and `robot-sf-check-carla` were absent.
- GREEN: same targeted command -> `3 passed in 20.83s`.
- `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> Ruff clean and `36 passed in 15.01s`.
- `rtk git diff --check origin/968-carla-runtime-availability-guard...HEAD && rtk proxy bash -lc 'BASE_REF=origin/968-carla-runtime-availability-guard scripts/dev/pr_ready_check.sh'` -> `3137 passed, 15 skipped, 3 warnings in 398.72s (0:06:38)`.

## Artifact Persistence

`git status --ignored --short -uall output` shows ignored worktree-local `output/*` entries including coverage and pre-existing experiment outputs. No generated output is required by this change or promoted as a durable artifact.