### PR TITLE
feat: add CARLA availability boolean field (#974)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -219,6 +219,8 @@ why a change was made rather than a full issue execution transcript.
   exposes CARLA bridge availability metadata through a CARLA-free project script.
 - [Issue #972 CARLA Availability CLI Require Mode](issue_972_carla_availability_cli_require_mode.md)
   adds fail-closed availability checking for CARLA-dependent setup gates.
+- [Issue #974 CARLA Availability Boolean Field](issue_974_carla_availability_boolean_field.md)
+  adds an explicit boolean to CARLA availability metadata and CLI JSON output.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_974_carla_availability_boolean_field.md
+++ b/docs/context/issue_974_carla_availability_boolean_field.md
@@ -1,0 +1,35 @@
+# Issue #974 CARLA Availability Boolean Field
+
+## Scope
+
+Issue #974 adds `available: bool` to CARLA bridge availability metadata. The existing
+`status`, `reason`, and `dependency` fields remain intact for backwards-compatible text and script
+consumers.
+
+The field is emitted by `check_carla_availability()` and therefore also appears in
+`robot-sf-check-carla --json` output. It lets setup scripts branch on a boolean instead of parsing
+`status` strings.
+
+## Boundary
+
+This change only extends local availability metadata. It does not install CARLA, start CARLA, run
+replay, change dependency metadata, or compare simulator metrics.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q
+```
+
+Failed before implementation because the `available` key was absent from helper and CLI JSON
+metadata.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q
+```
+
+Passed after adding the boolean field: `3 passed`.

--- a/robot_sf_carla_bridge/availability.py
+++ b/robot_sf_carla_bridge/availability.py
@@ -21,11 +21,13 @@ def check_carla_availability() -> dict[str, Any]:
     if importlib.util.find_spec("carla") is None:
         return {
             "status": "not-available",
+            "available": False,
             "reason": "CARLA Python API package 'carla' is not importable",
             "dependency": "carla",
         }
     return {
         "status": "available",
+        "available": True,
         "reason": "CARLA Python API package is importable",
         "dependency": "carla",
     }

--- a/tests/carla_bridge/test_t0_export.py
+++ b/tests/carla_bridge/test_t0_export.py
@@ -682,10 +682,16 @@ def test_builder_invalid_radius_fails_schema_validation() -> None:
 
 def test_missing_carla_reports_not_available(monkeypatch) -> None:
     """Missing CARLA should be a status object, not an import-time crash."""
+    import importlib.util
+
     from robot_sf_carla_bridge.availability import check_carla_availability
 
+    real_find_spec = importlib.util.find_spec
     monkeypatch.setattr(
-        "importlib.util.find_spec", lambda name: None if name == "carla" else object()
+        "importlib.util.find_spec",
+        lambda name, *args, **kwargs: (
+            None if name == "carla" else real_find_spec(name, *args, **kwargs)
+        ),
     )
 
     status = check_carla_availability()
@@ -697,10 +703,16 @@ def test_missing_carla_reports_not_available(monkeypatch) -> None:
 
 def test_importable_carla_reports_available(monkeypatch) -> None:
     """Importable CARLA should report a boolean available status."""
+    import importlib.util
+
     from robot_sf_carla_bridge.availability import check_carla_availability
 
+    real_find_spec = importlib.util.find_spec
     monkeypatch.setattr(
-        "importlib.util.find_spec", lambda name: object() if name == "carla" else None
+        "importlib.util.find_spec",
+        lambda name, *args, **kwargs: (
+            object() if name == "carla" else real_find_spec(name, *args, **kwargs)
+        ),
     )
 
     status = check_carla_availability()

--- a/tests/carla_bridge/test_t0_export.py
+++ b/tests/carla_bridge/test_t0_export.py
@@ -691,4 +691,20 @@ def test_missing_carla_reports_not_available(monkeypatch) -> None:
     status = check_carla_availability()
 
     assert status["status"] == "not-available"
+    assert status["available"] is False
     assert "carla" in status["reason"].lower()
+
+
+def test_importable_carla_reports_available(monkeypatch) -> None:
+    """Importable CARLA should report a boolean available status."""
+    from robot_sf_carla_bridge.availability import check_carla_availability
+
+    monkeypatch.setattr(
+        "importlib.util.find_spec", lambda name: object() if name == "carla" else None
+    )
+
+    status = check_carla_availability()
+
+    assert status["status"] == "available"
+    assert status["available"] is True
+    assert status["dependency"] == "carla"

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -149,11 +149,16 @@ def test_validate_t0_export_batch_main_prints_json_summary(
 
 def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -> None:
     """CARLA availability CLI should expose deterministic machine-readable status."""
+    import importlib.util
+
     from robot_sf_carla_bridge.cli import check_carla_availability_main
 
+    real_find_spec = importlib.util.find_spec
     monkeypatch.setattr(
         "importlib.util.find_spec",
-        lambda name: None if name == "carla" else object(),
+        lambda name, *args, **kwargs: (
+            None if name == "carla" else real_find_spec(name, *args, **kwargs)
+        ),
     )
 
     exit_code = check_carla_availability_main(["--json"])

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -149,23 +149,18 @@ def test_validate_t0_export_batch_main_prints_json_summary(
 
 def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -> None:
     """CARLA availability CLI should expose deterministic machine-readable status."""
-    import robot_sf_carla_bridge.cli as cli_module
     from robot_sf_carla_bridge.cli import check_carla_availability_main
 
     monkeypatch.setattr(
-        cli_module,
-        "check_carla_availability",
-        lambda: {
-            "status": "not-available",
-            "reason": "CARLA Python API package 'carla' is not importable",
-            "dependency": "carla",
-        },
+        "importlib.util.find_spec",
+        lambda name: None if name == "carla" else object(),
     )
 
     exit_code = check_carla_availability_main(["--json"])
 
     assert exit_code == 0
     assert json.loads(capsys.readouterr().out) == {
+        "available": False,
         "dependency": "carla",
         "reason": "CARLA Python API package 'carla' is not importable",
         "status": "not-available",


### PR DESCRIPTION
## Summary

- add `available: bool` to CARLA bridge availability metadata
- preserve existing `status`, `reason`, and `dependency` fields
- ensure `robot-sf-check-carla --json` includes the boolean via the real helper path
- add helper/CLI tests and a context note

Closes #974. Relates #872. Stacked on #973 / branch `972-carla-availability-cli-require`.

## Boundary

This only extends local availability metadata. It does not install CARLA, start CARLA, run replay, change dependency metadata, upload artifacts, or claim simulator parity.

## Validation

- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q` failed before implementation because the `available` key was absent.
- GREEN: same targeted command -> `3 passed in 13.04s`.
- `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> Ruff clean and `39 passed in 14.78s`.
- `rtk git diff --check origin/972-carla-availability-cli-require...HEAD && rtk proxy bash -lc 'BASE_REF=origin/972-carla-availability-cli-require scripts/dev/pr_ready_check.sh'` -> `3140 passed, 15 skipped, 3 warnings in 397.84s (0:06:37)`.

## Artifact Persistence

`git status --ignored --short -uall output` shows ignored worktree-local `output/*` entries including coverage and pre-existing experiment outputs. No generated output is required by this change or promoted as a durable artifact.