### PR TITLE
feat: add CARLA availability schema version (#976)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -221,6 +221,8 @@ why a change was made rather than a full issue execution transcript.
   adds fail-closed availability checking for CARLA-dependent setup gates.
 - [Issue #974 CARLA Availability Boolean Field](issue_974_carla_availability_boolean_field.md)
   adds an explicit boolean to CARLA availability metadata and CLI JSON output.
+- [Issue #976 CARLA Availability Schema Version](issue_976_carla_availability_schema_version.md)
+  adds a schema version to CARLA availability metadata for stable script consumption.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_976_carla_availability_schema_version.md
+++ b/docs/context/issue_976_carla_availability_schema_version.md
@@ -1,0 +1,37 @@
+# Issue #976 CARLA Availability Schema Version
+
+## Scope
+
+Issue #976 adds `schema_version: "carla-availability.v1"` to CARLA bridge availability metadata.
+The field is emitted by `check_carla_availability()` in both available and not-available cases and
+therefore appears in `robot-sf-check-carla --json`.
+
+Existing fields remain intact:
+
+- `available`
+- `status`
+- `reason`
+- `dependency`
+
+## Boundary
+
+This change only versions the local availability metadata contract. It does not install CARLA,
+start CARLA, run replay, change dependency metadata, or compare simulator metrics.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q
+```
+
+Failed before implementation because `schema_version` was absent from helper and CLI JSON metadata.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q
+```
+
+Passed after adding the schema version field: `3 passed`.

--- a/robot_sf_carla_bridge/availability.py
+++ b/robot_sf_carla_bridge/availability.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+AVAILABILITY_SCHEMA_VERSION = "carla-availability.v1"
+
 
 class CarlaUnavailableError(RuntimeError):
     """Raised when a CARLA-dependent bridge path is used without CARLA installed."""
@@ -20,12 +22,14 @@ def check_carla_availability() -> dict[str, Any]:
 
     if importlib.util.find_spec("carla") is None:
         return {
+            "schema_version": AVAILABILITY_SCHEMA_VERSION,
             "status": "not-available",
             "available": False,
             "reason": "CARLA Python API package 'carla' is not importable",
             "dependency": "carla",
         }
     return {
+        "schema_version": AVAILABILITY_SCHEMA_VERSION,
         "status": "available",
         "available": True,
         "reason": "CARLA Python API package is importable",

--- a/tests/carla_bridge/test_t0_export.py
+++ b/tests/carla_bridge/test_t0_export.py
@@ -692,6 +692,7 @@ def test_missing_carla_reports_not_available(monkeypatch) -> None:
 
     assert status["status"] == "not-available"
     assert status["available"] is False
+    assert status["schema_version"] == "carla-availability.v1"
     assert "carla" in status["reason"].lower()
 
 
@@ -707,4 +708,5 @@ def test_importable_carla_reports_available(monkeypatch) -> None:
 
     assert status["status"] == "available"
     assert status["available"] is True
+    assert status["schema_version"] == "carla-availability.v1"
     assert status["dependency"] == "carla"

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -163,6 +163,7 @@ def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -
         "available": False,
         "dependency": "carla",
         "reason": "CARLA Python API package 'carla' is not importable",
+        "schema_version": "carla-availability.v1",
         "status": "not-available",
     }
 


### PR DESCRIPTION
## Summary

- add `schema_version: "carla-availability.v1"` to CARLA bridge availability metadata
- preserve existing `available`, `status`, `reason`, and `dependency` fields
- verify `robot-sf-check-carla --json` includes the schema version via the real helper path
- add tests and a context note for the versioned metadata contract

Closes #976. Relates #872. Stacked on #975 / branch `974-carla-availability-boolean`.

## Boundary

This only versions the local availability metadata contract. It does not install CARLA, start CARLA, run replay, change dependency metadata, upload artifacts, or claim simulator parity.

## Validation

- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available tests/carla_bridge/test_t0_export.py::test_importable_carla_reports_available tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status -q` failed before implementation because `schema_version` was absent.
- GREEN: same targeted command -> `3 passed in 13.08s`.
- `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> Ruff clean and `39 passed in 14.71s`.
- `rtk git diff --check origin/974-carla-availability-boolean...HEAD && rtk proxy bash -lc 'BASE_REF=origin/974-carla-availability-boolean scripts/dev/pr_ready_check.sh'` -> `3140 passed, 15 skipped, 3 warnings in 409.93s (0:06:49)`.

## Artifact Persistence

`git status --ignored --short -uall output` shows ignored worktree-local `output/*` entries including coverage and pre-existing experiment outputs. No generated output is required by this change or promoted as a durable artifact.