### PR TITLE
feat: expose CARLA availability schema CLI (#980)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -225,6 +225,8 @@ why a change was made rather than a full issue execution transcript.
   adds a schema version to CARLA availability metadata for stable script consumption.
 - [Issue #978 CARLA Availability JSON Schema](issue_978_carla_availability_json_schema.md)
   adds a JSON Schema for validating CARLA availability metadata.
+- [Issue #980 CARLA Availability Schema CLI](issue_980_carla_availability_schema_cli.md)
+  exposes the CARLA availability JSON Schema through `robot-sf-check-carla --schema`.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_980_carla_availability_schema_cli.md
+++ b/docs/context/issue_980_carla_availability_schema_cli.md
@@ -1,0 +1,36 @@
+# Issue #980 CARLA Availability Schema CLI
+
+## Scope
+
+Issue #980 extends `robot-sf-check-carla` with `--schema`, which prints the
+`carla-availability.v1` JSON Schema as deterministic JSON. The command uses
+`load_availability_schema()` and returns `0` without probing for CARLA availability.
+
+Existing modes remain intact:
+
+- text status output,
+- `--json` status output,
+- `--require` fail-closed status checks.
+
+## Boundary
+
+This change only exposes the local metadata schema. It does not install CARLA, start CARLA, run
+replay, change dependency metadata, or compare simulator metrics.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_schema -q
+```
+
+Failed before implementation because `--schema` was not recognized.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_schema tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_require_fails_when_unavailable -q
+```
+
+Passed after adding schema mode: `3 passed`.

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -7,7 +7,7 @@ import json
 import sys
 from pathlib import Path
 
-from robot_sf_carla_bridge.availability import check_carla_availability
+from robot_sf_carla_bridge.availability import check_carla_availability, load_availability_schema
 from robot_sf_carla_bridge.export import (
     build_export_payloads_from_scenario_file,
     load_export_manifest_payloads,
@@ -100,12 +100,17 @@ def check_carla_availability_main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description="Check optional CARLA Python API availability.")
     parser.add_argument("--json", action="store_true", help="Print a machine-readable status.")
+    parser.add_argument("--schema", action="store_true", help="Print the JSON Schema contract.")
     parser.add_argument(
         "--require",
         action="store_true",
         help="Exit nonzero when the CARLA Python API is not available.",
     )
     args = parser.parse_args(argv)
+
+    if args.schema:
+        sys.stdout.write(f"{json.dumps(load_availability_schema(), sort_keys=True)}\n")
+        return 0
 
     status = check_carla_availability()
     exit_code = 0 if status["status"] == "available" or not args.require else 1

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -168,6 +168,17 @@ def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -
     }
 
 
+def test_check_carla_availability_main_prints_schema(capsys) -> None:
+    """CARLA availability CLI should expose its JSON Schema contract."""
+    from robot_sf_carla_bridge.availability import load_availability_schema
+    from robot_sf_carla_bridge.cli import check_carla_availability_main
+
+    exit_code = check_carla_availability_main(["--schema"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == load_availability_schema()
+
+
 def test_check_carla_availability_main_prints_text_status(monkeypatch, capsys) -> None:
     """CARLA availability CLI should keep a concise human-readable output."""
     import robot_sf_carla_bridge.cli as cli_module


### PR DESCRIPTION
## Summary
- add `robot-sf-check-carla --schema` to print the packaged CARLA availability JSON Schema deterministically
- cover the schema mode with a CLI regression test
- record the issue context note and README index entry

Closes #980.
Relates to #872.
Stacked on #979 / `978-carla-availability-json-schema`.

## Boundary
- only exposes the local schema contract
- does not install CARLA, start CARLA, run replay, or compare simulator metrics

## Validation
- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_schema -q` failed before implementation because `--schema` was not recognized
- GREEN: `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_schema tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_prints_json_status tests/carla_bridge/test_t0_export_cli.py::test_check_carla_availability_main_require_fails_when_unavailable -q` -> `3 passed in 12.66s`
- Focused: `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> `42 passed in 15.24s`
- Full gate: `rtk git diff --check origin/978-carla-availability-json-schema...HEAD && rtk proxy bash -lc 'BASE_REF=origin/978-carla-availability-json-schema scripts/dev/pr_ready_check.sh'` -> `3143 passed, 15 skipped, 3 warnings in 409.02s (0:06:49)`

## Artifact Persistence
- full gate regenerated ignored `output/coverage/*`
- `git status --ignored --short -uall output` also shows pre-existing ignored `output/ai/*` and `.uv_cache` artifacts; no generated output is required for this PR and nothing was promoted