### PR TITLE
feat: add CARLA bridge schema catalog API (#994)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -241,6 +241,8 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #992 CARLA T0 Batch Summary Schema CLI](issue_992_carla_t0_batch_summary_schema_cli.md)
   exposes the CARLA T0 batch validation summary JSON Schema through
   `robot-sf-validate-carla-t0-batch --schema`.
+- [Issue #994 CARLA Bridge Schema Catalog API](issue_994_carla_schema_catalog_api.md)
+  adds an import-safe catalog for CARLA bridge schema names, versions, and loader helpers.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_994_carla_schema_catalog_api.md
+++ b/docs/context/issue_994_carla_schema_catalog_api.md
@@ -1,0 +1,39 @@
+# Issue #994 CARLA Bridge Schema Catalog API
+
+## Scope
+
+Issue #994 adds `list_carla_bridge_schema_catalog()`, an import-safe helper that returns
+deterministic JSON-safe metadata for CARLA bridge schemas. The catalog is versioned as
+`carla-bridge-schema-catalog.v1` and lists:
+
+- `availability`
+- `t0_export_payload`
+- `t0_export_manifest`
+- `t0_batch_validation_summary`
+
+Each entry reports the schema name, schema version, and public loader helper.
+
+## Boundary
+
+This change only reports schema metadata. It does not add a schema catalog CLI, change existing
+schema contents, change CLI outputs, install CARLA, start CARLA, run replay, or compare simulator
+metrics.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_schema_catalog_lists_all_carla_bridge_contracts -q
+```
+
+Failed before implementation because `list_carla_bridge_schema_catalog` was not exported by
+`robot_sf_carla_bridge`.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_schema_catalog_lists_all_carla_bridge_contracts tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available -q
+```
+
+Passed after adding the catalog helper: `2 passed in 13.08s`.

--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -36,12 +36,17 @@ from robot_sf_carla_bridge.export import (
     write_export_payload,
     write_export_records,
 )
+from robot_sf_carla_bridge.schema_catalog import (
+    SCHEMA_CATALOG_VERSION,
+    list_carla_bridge_schema_catalog,
+)
 
 __all__ = [
     "AVAILABILITY_SCHEMA_VERSION",
     "BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION",
     "EXPORT_MANIFEST_SCHEMA_VERSION",
     "EXPORT_SCHEMA_VERSION",
+    "SCHEMA_CATALOG_VERSION",
     "CarlaUnavailableError",
     "CertificateRef",
     "PedestrianReplaySpec",
@@ -54,6 +59,7 @@ __all__ = [
     "build_export_payload_from_scenario_entry",
     "build_export_payloads_from_scenario_file",
     "check_carla_availability",
+    "list_carla_bridge_schema_catalog",
     "load_availability_schema",
     "load_batch_validation_summary_schema",
     "load_export_manifest_payloads",

--- a/robot_sf_carla_bridge/schema_catalog.py
+++ b/robot_sf_carla_bridge/schema_catalog.py
@@ -1,0 +1,48 @@
+"""Schema catalog metadata for import-safe CARLA bridge automation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robot_sf_carla_bridge.availability import AVAILABILITY_SCHEMA_VERSION
+from robot_sf_carla_bridge.export import (
+    BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION,
+    EXPORT_MANIFEST_SCHEMA_VERSION,
+    EXPORT_SCHEMA_VERSION,
+)
+
+SCHEMA_CATALOG_VERSION = "carla-bridge-schema-catalog.v1"
+
+
+def list_carla_bridge_schema_catalog() -> dict[str, Any]:
+    """Return JSON-safe metadata for CARLA bridge schema contracts.
+
+    Returns:
+        Deterministic schema catalog metadata.
+    """
+
+    return {
+        "schema_version": SCHEMA_CATALOG_VERSION,
+        "schemas": [
+            {
+                "name": "availability",
+                "loader": "load_availability_schema",
+                "schema_version": AVAILABILITY_SCHEMA_VERSION,
+            },
+            {
+                "name": "t0_export_payload",
+                "loader": "load_export_schema",
+                "schema_version": EXPORT_SCHEMA_VERSION,
+            },
+            {
+                "name": "t0_export_manifest",
+                "loader": "load_export_manifest_schema",
+                "schema_version": EXPORT_MANIFEST_SCHEMA_VERSION,
+            },
+            {
+                "name": "t0_batch_validation_summary",
+                "loader": "load_batch_validation_summary_schema",
+                "schema_version": BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION,
+            },
+        ],
+    }

--- a/tests/carla_bridge/test_t0_export.py
+++ b/tests/carla_bridge/test_t0_export.py
@@ -736,6 +736,39 @@ def test_missing_carla_availability_validates_against_schema(monkeypatch) -> Non
     jsonschema.validate(check_carla_availability(), load_availability_schema())
 
 
+def test_schema_catalog_lists_all_carla_bridge_contracts() -> None:
+    """Schema catalog should expose every CARLA bridge schema contract."""
+    from robot_sf_carla_bridge import list_carla_bridge_schema_catalog
+
+    catalog = list_carla_bridge_schema_catalog()
+
+    assert catalog == {
+        "schema_version": "carla-bridge-schema-catalog.v1",
+        "schemas": [
+            {
+                "name": "availability",
+                "loader": "load_availability_schema",
+                "schema_version": "carla-availability.v1",
+            },
+            {
+                "name": "t0_export_payload",
+                "loader": "load_export_schema",
+                "schema_version": "carla-replay-export.v1",
+            },
+            {
+                "name": "t0_export_manifest",
+                "loader": "load_export_manifest_schema",
+                "schema_version": "carla-replay-export-manifest.v1",
+            },
+            {
+                "name": "t0_batch_validation_summary",
+                "loader": "load_batch_validation_summary_schema",
+                "schema_version": "carla-replay-export-batch-validation-summary.v1",
+            },
+        ],
+    }
+
+
 def test_importable_carla_reports_available(monkeypatch) -> None:
     """Importable CARLA should report a boolean available status."""
     from robot_sf_carla_bridge.availability import check_carla_availability


### PR DESCRIPTION
## Summary
- add import-safe `list_carla_bridge_schema_catalog()` metadata helper
- expose `SCHEMA_CATALOG_VERSION` and the catalog helper from `robot_sf_carla_bridge`
- cover deterministic catalog contents and record the context note

Closes #994.
Relates to #872.
Stacked on #993 / `992-carla-t0-batch-summary-schema-cli`.

## Boundary
- only reports schema metadata
- does not add a schema catalog CLI, change schema contents, change CLI outputs, install CARLA, start CARLA, run replay, or compare simulator metrics

## Validation
- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_schema_catalog_lists_all_carla_bridge_contracts -q` failed before implementation because `list_carla_bridge_schema_catalog` was not exported by `robot_sf_carla_bridge`
- GREEN: `rtk uv run pytest tests/carla_bridge/test_t0_export.py::test_schema_catalog_lists_all_carla_bridge_contracts tests/carla_bridge/test_t0_export.py::test_missing_carla_reports_not_available -q` -> `2 passed in 13.08s`
- Focused: `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> `49 passed in 14.91s`
- Full gate: `rtk git diff --check origin/992-carla-t0-batch-summary-schema-cli...HEAD && rtk proxy bash -lc 'BASE_REF=origin/992-carla-t0-batch-summary-schema-cli scripts/dev/pr_ready_check.sh'` -> `3151 passed, 14 skipped, 3 warnings in 300.67s (0:05:00)`

## Artifact Persistence
- full gate regenerated ignored `output/coverage/*`
- `git status --ignored --short -uall output` also shows pre-existing ignored `output/ai/*` and `.uv_cache` artifacts; no generated output is required for this PR and nothing was promoted