### PR TITLE
feat: expose CARLA schema catalog CLI (#996)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -243,6 +243,8 @@ why a change was made rather than a full issue execution transcript.
   `robot-sf-validate-carla-t0-batch --schema`.
 - [Issue #994 CARLA Bridge Schema Catalog API](issue_994_carla_schema_catalog_api.md)
   adds an import-safe catalog for CARLA bridge schema names, versions, and loader helpers.
+- [Issue #996 CARLA Bridge Schema Catalog CLI](issue_996_carla_schema_catalog_cli.md)
+  exposes the CARLA bridge schema catalog through `robot-sf-catalog-carla-schemas`.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_996_carla_schema_catalog_cli.md
+++ b/docs/context/issue_996_carla_schema_catalog_cli.md
@@ -1,0 +1,34 @@
+# Issue #996 CARLA Bridge Schema Catalog CLI
+
+## Scope
+
+Issue #996 adds `robot-sf-catalog-carla-schemas`, a no-argument CLI that prints the
+`list_carla_bridge_schema_catalog()` metadata as deterministic JSON. The command is packaged as a
+project script and remains import-safe without CARLA installed.
+
+Existing schema-specific CLIs remain unchanged.
+
+## Boundary
+
+This change only exposes schema catalog metadata through a command-line surface. It does not change
+schema catalog contents, change individual schema CLIs, install CARLA, start CARLA, run replay, or
+compare simulator metrics.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_catalog tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q
+```
+
+Failed before implementation because `catalog_carla_schemas_main` and the
+`robot-sf-catalog-carla-schemas` project script were missing.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_catalog tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q
+```
+
+Passed after adding the CLI and script entry: `2 passed in 20.85s`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -489,6 +489,7 @@ robot-sf-export-carla-t0 = "robot_sf_carla_bridge.cli:export_t0_scenarios_main"
 robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_manifest_main"
 robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"
 robot-sf-check-carla = "robot_sf_carla_bridge.cli:check_carla_availability_main"
+robot-sf-catalog-carla-schemas = "robot_sf_carla_bridge.cli:catalog_carla_schemas_main"
 robot-sf-migrate-artifacts = "scripts.tools.migrate_artifacts:main"
 
 # Note: uv-specific config removed to avoid duplicate-config warnings with uv.toml

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -18,6 +18,7 @@ from robot_sf_carla_bridge.export import (
     read_export_manifest,
     write_export_records,
 )
+from robot_sf_carla_bridge.schema_catalog import list_carla_bridge_schema_catalog
 
 
 def export_t0_scenarios_main(argv: list[str] | None = None) -> int:
@@ -156,6 +157,20 @@ def check_carla_availability_main(argv: list[str] | None = None) -> int:
 
     sys.stdout.write(f"{status['dependency']}: {status['status']} - {status['reason']}\n")
     return exit_code
+
+
+def catalog_carla_schemas_main(argv: list[str] | None = None) -> int:
+    """Print import-safe CARLA bridge schema catalog metadata.
+
+    Returns:
+        Process-style exit code.
+    """
+
+    parser = argparse.ArgumentParser(description="Print CARLA bridge schema catalog metadata.")
+    parser.parse_args(argv)
+
+    sys.stdout.write(f"{json.dumps(list_carla_bridge_schema_catalog(), sort_keys=True)}\n")
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -208,6 +208,17 @@ def test_validate_t0_export_batch_main_prints_schema(capsys) -> None:
     assert json.loads(capsys.readouterr().out) == load_batch_validation_summary_schema()
 
 
+def test_catalog_carla_schemas_main_prints_catalog(capsys) -> None:
+    """Schema catalog CLI should expose deterministic catalog metadata."""
+    from robot_sf_carla_bridge import list_carla_bridge_schema_catalog
+    from robot_sf_carla_bridge.cli import catalog_carla_schemas_main
+
+    exit_code = catalog_carla_schemas_main([])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == list_carla_bridge_schema_catalog()
+
+
 def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -> None:
     """CARLA availability CLI should expose deterministic machine-readable status."""
     from robot_sf_carla_bridge.cli import check_carla_availability_main
@@ -328,6 +339,9 @@ def test_export_t0_cli_is_packaged_as_project_script() -> None:
     )
     assert pyproject["project"]["scripts"]["robot-sf-check-carla"] == (
         "robot_sf_carla_bridge.cli:check_carla_availability_main"
+    )
+    assert pyproject["project"]["scripts"]["robot-sf-catalog-carla-schemas"] == (
+        "robot_sf_carla_bridge.cli:catalog_carla_schemas_main"
     )
     hatchling_packages = pyproject["tool"]["hatchling"]["build"]["targets"]["wheel"]["packages"]
     assert {"include": "robot_sf_carla_bridge"} in hatchling_packages


### PR DESCRIPTION
## Summary
- add `robot-sf-catalog-carla-schemas` CLI for deterministic schema catalog JSON
- package the project script entry point
- cover CLI output and script metadata, and record the context note

Closes #996.
Relates to #872.
Stacked on #995 / `994-carla-schema-catalog-api`.

## Boundary
- only exposes schema catalog metadata through a command-line surface
- does not change schema catalog contents, individual schema CLIs, install CARLA, start CARLA, run replay, or compare simulator metrics

## Validation
- RED: `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_catalog tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q` failed before implementation because `catalog_carla_schemas_main` and the `robot-sf-catalog-carla-schemas` project script were missing
- GREEN: same targeted command -> `2 passed in 20.85s`
- Focused: `rtk scripts/dev/ruff_fix_format.sh && rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py tests/test_ai_prompt_surfaces.py tests/test_issue_workflow_batching.py -q` -> `50 passed in 15.45s`
- Full gate: `rtk git diff --check origin/994-carla-schema-catalog-api...HEAD && rtk proxy bash -lc 'BASE_REF=origin/994-carla-schema-catalog-api scripts/dev/pr_ready_check.sh'` -> `3151 passed, 15 skipped, 3 warnings in 291.69s (0:04:51)`

## Artifact Persistence
- full gate regenerated ignored `output/coverage/*`
- `git status --ignored --short -uall output` also shows pre-existing ignored `output/ai/*` and `.uv_cache` artifacts; no generated output is required for this PR and nothing was promoted