### PR TITLE
feat: expose CARLA schema catalog schema CLI

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -268,6 +268,9 @@ why a change was made rather than a full issue execution transcript.
   exposes the CARLA bridge schema catalog through `robot-sf-catalog-carla-schemas`.
 - [Issue #998 CARLA Bridge Schema Catalog Schema](issue_998_carla_schema_catalog_schema.md)
   adds a packaged JSON Schema for `carla-bridge-schema-catalog.v1` metadata.
+- [Issue #1000 CARLA Bridge Schema Catalog Schema CLI](issue_1000_carla_schema_catalog_schema_cli.md)
+  exposes the CARLA bridge schema catalog JSON Schema through
+  `robot-sf-catalog-carla-schemas --schema`.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_1000_carla_schema_catalog_schema_cli.md
+++ b/docs/context/issue_1000_carla_schema_catalog_schema_cli.md
@@ -1,0 +1,51 @@
+# Issue #1000 CARLA Bridge Schema Catalog Schema CLI
+
+## Scope
+
+Issue #1000 extends `robot-sf-catalog-carla-schemas` with `--schema`, which prints the
+`load_schema_catalog_schema()` JSON Schema as deterministic JSON. This keeps the schema catalog
+CLI paired with the import-safe loader added by issue #998.
+
+Existing no-argument catalog output remains unchanged and continues to print
+`list_carla_bridge_schema_catalog()` metadata.
+
+## Boundary
+
+This change only exposes the existing schema catalog schema through the CLI. It does not change the
+catalog metadata, schema contents, CARLA installation behavior, replay execution, scenario export,
+or simulator metric comparison.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_schema -q
+```
+
+Failed before implementation because `--schema` was rejected as an unrecognized argument by
+`catalog_carla_schemas_main`.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_schema tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_catalog -q
+```
+
+Passed after adding schema mode: `2 passed in 12.72s`.
+
+Broader local proof:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py::test_schema_catalog_validates_against_schema -q
+BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh
+```
+
+The targeted CARLA bridge command passed with `21 passed in 13.57s`. The full PR readiness gate
+passed with `3190 passed, 15 skipped, 3 warnings in 256.54s`.
+
+## Artifact Decision
+
+Validation refreshed ignored coverage output under `output/coverage/`. The CLI change does not
+depend on generated artifacts, model checkpoints, benchmark bundles, or local cache state, so those
+ignored files are disposable and are not promoted.

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -19,7 +19,10 @@ from robot_sf_carla_bridge.export import (
     resolve_export_manifest_payload_paths,
     write_export_records,
 )
-from robot_sf_carla_bridge.schema_catalog import list_carla_bridge_schema_catalog
+from robot_sf_carla_bridge.schema_catalog import (
+    list_carla_bridge_schema_catalog,
+    load_schema_catalog_schema,
+)
 
 
 def _has_parent_reference(path_value: str) -> bool:
@@ -223,8 +226,12 @@ def catalog_carla_schemas_main(argv: list[str] | None = None) -> int:
     """
 
     parser = argparse.ArgumentParser(description="Print CARLA bridge schema catalog metadata.")
-    parser.parse_args(argv)
+    parser.add_argument("--schema", action="store_true", help="Print the JSON Schema contract.")
+    args = parser.parse_args(argv)
 
+    if args.schema:
+        sys.stdout.write(f"{json.dumps(load_schema_catalog_schema(), sort_keys=True)}\n")
+        return 0
     sys.stdout.write(f"{json.dumps(list_carla_bridge_schema_catalog(), sort_keys=True)}\n")
     return 0
 

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -266,6 +266,17 @@ def test_catalog_carla_schemas_main_prints_catalog(capsys) -> None:
     assert json.loads(capsys.readouterr().out) == list_carla_bridge_schema_catalog()
 
 
+def test_catalog_carla_schemas_main_prints_schema(capsys) -> None:
+    """Schema catalog CLI should expose the catalog JSON Schema contract."""
+    from robot_sf_carla_bridge import load_schema_catalog_schema
+    from robot_sf_carla_bridge.cli import catalog_carla_schemas_main
+
+    exit_code = catalog_carla_schemas_main(["--schema"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == load_schema_catalog_schema()
+
+
 def test_check_carla_availability_main_prints_json_status(monkeypatch, capsys) -> None:
     """CARLA availability CLI should expose deterministic machine-readable status."""
     import importlib.util


### PR DESCRIPTION
## Summary
Adds `--schema` support to `robot-sf-catalog-carla-schemas` so scripts can discover the CARLA bridge schema catalog JSON Schema from the command line.

## Linked Issues
- Closes #1000
- Relates to #998

## What Changed
- Added `--schema` parsing to `robot_sf_carla_bridge.cli.catalog_carla_schemas_main`.
- Reused `load_schema_catalog_schema()` for deterministic sorted JSON output.
- Added CLI regression coverage for schema output while keeping the existing no-argument catalog output covered.
- Added `docs/context/issue_1000_carla_schema_catalog_schema_cli.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: CARLA bridge schema catalog metadata is now self-describing from the CLI, matching nearby schema CLI patterns.
- Expected impact: automation can validate catalog metadata without importing Python helpers directly.
- Why this is worth merging now: #998 is already on main, so this is a small additive closure of the remaining command-line discoverability gap.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_schema -q` (RED: failed before implementation because `--schema` was unrecognized)
  - `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_schema tests/carla_bridge/test_t0_export_cli.py::test_catalog_carla_schemas_main_prints_catalog -q` (`2 passed in 12.72s`)
  - `rtk uv run pytest tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_t0_export.py::test_schema_catalog_validates_against_schema -q` (`21 passed in 13.57s`)
  - `rtk uv run ruff check robot_sf_carla_bridge/cli.py tests/carla_bridge/test_t0_export_cli.py` (`All checks passed!`)
  - `rtk uv run python -c 'import json, subprocess; out = subprocess.check_output(["robot-sf-catalog-carla-schemas", "--schema"], text=True); data = json.loads(out); print(data["$id"]); print(data["title"])'`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after committing and syncing main (`3191 passed, 14 skipped, 3 warnings in 247.69s`; changed-file checks: no matching include-pattern coverage files, no touched-definition TODO docstrings)
- Evidence that the change works here: installed console script emits valid JSON with `$id` `https://robot-sf.local/schemas/carla_bridge_schema_catalog.v1.json` and title `Robot-SF CARLA Bridge Schema Catalog`.
- Benchmarks or smoke tests: no benchmark run needed; this is an import-safe CLI/schema discoverability change.

## Risks / Rollout
- Compatibility risks: low; no-argument output remains unchanged and tested.
- Failure modes: callers relying on invalid extra args still get argparse rejection except for the new supported `--schema` flag.
- Rollback or fallback plan: revert the additive CLI flag and test if needed.

## Docs / Provenance
- Updated docs: `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_1000_carla_schema_catalog_schema_cli.md`.
- Artifact persistence: validation refreshed ignored `output/coverage/`; no generated artifact is required by this change, so ignored output remains disposable and unpromoted.

## Follow-Up Issues
- Deferred work: none for this issue.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that broader CARLA replay/schema work remains out of scope here and under existing CARLA follow-up issues such as #872.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CARLA bridge schema catalog command now supports a `--schema` flag to output the JSON Schema definition.

* **Documentation**
  * Added documentation describing the schema flag behavior and related implementation details.
  * Updated the CARLA Bridge Schema Catalog reference guide.

* **Tests**
  * Added test coverage for the schema flag functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->