### PR TITLE
feat: add complexity runtime baseline

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -107,6 +107,9 @@ knowledge, not every transient iteration detail.
 
 ## Performance Notes
 
+* [Issue #1002 Complexity and Test Runtime Baseline](./issue_1002_complexity_runtime_baseline.md)
+  adds a lightweight `scripts/dev/complexity_runtime_baseline.py` command and records the first
+  2026-05-05 refactor-prioritization snapshot.
 * [Issue #513 High-Density Perf Gate Calibration](./issue_513_high_density_perf_gate.md)
   keeps `classic_cross_trap_high` advisory because no stable local trend-history window was
   available; documents the rerun evidence and non-blocking policy.

--- a/docs/context/issue_1002_complexity_runtime_baseline.md
+++ b/docs/context/issue_1002_complexity_runtime_baseline.md
@@ -1,0 +1,111 @@
+# Issue #1002 Complexity and Test Runtime Baseline
+
+## Scope
+
+Issue #1002 adds `scripts/dev/complexity_runtime_baseline.py`, a lightweight stdlib-only command
+for repeatable refactor triage. The command reports:
+
+- largest Python modules by simple non-comment source lines,
+- longest functions or methods by AST line span,
+- optional pytest `--durations` rows when a captured pytest log is supplied with `--pytest-log`.
+
+The command is intentionally not a dashboard. It prints text by default, supports deterministic
+JSON with `--json`, and does not create durable generated outputs.
+
+## Baseline Command
+
+```bash
+rtk uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
+```
+
+To include slow-test rows, pass a captured pytest output log:
+
+```bash
+rtk uv run python scripts/dev/complexity_runtime_baseline.py \
+  --top 10 \
+  --pytest-log output/tmp/pr_ready_pytest.log \
+  robot_sf scripts tests
+```
+
+The log path is an input only. Do not promote pytest logs as durable artifacts unless a later issue
+explicitly needs them.
+
+## First Snapshot
+
+Top module-size hotspots from the initial run:
+
+| path | code_lines | total_lines |
+| --- | --- | --- |
+| `robot_sf/planner/socnav.py` | 4379 | 4896 |
+| `robot_sf/benchmark/camera_ready_campaign.py` | 3357 | 3645 |
+| `robot_sf/benchmark/map_runner.py` | 2858 | 3131 |
+| `scripts/training/train_ppo.py` | 2740 | 3072 |
+| `tests/benchmark/test_map_runner_utils.py` | 2503 | 2959 |
+
+Top function-size hotspots:
+
+| path | function | lines |
+| --- | --- | --- |
+| `robot_sf/benchmark/camera_ready_campaign.py` | `run_campaign` | 1003 |
+| `robot_sf/benchmark/map_runner.py` | `_build_policy` | 979 |
+| `scripts/training/run_predictive_training_pipeline.py` | `main` | 501 |
+| `robot_sf/benchmark/scenario_difficulty.py` | `build_scenario_difficulty_analysis` | 453 |
+| `scripts/training/train_predictive_planner.py` | `main` | 433 |
+
+Runtime indicators were sampled from the committed PR readiness pytest duration output:
+
+| duration_seconds | phase | nodeid |
+| --- | --- | --- |
+| 27.40 | call | `tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/03_image_observations.py]` |
+| 24.01 | call | `tests/examples/test_examples_run.py::test_example_runs_without_error[occupancy_reward_shaping.py]` |
+| 23.77 | call | `tests/examples/test_examples_run.py::test_example_runs_without_error[quickstart/01_basic_robot.py]` |
+| 23.05 | call | `tests/test_load_states_and_record_video.py::test_load_states_and_record_video` |
+| 22.70 | call | `tests/test_image_system_integration.py::test_image_system_integration` |
+
+## Interpretation
+
+- Benchmark orchestration is the dominant refactor target: `camera_ready_campaign.py` and
+  `map_runner.py` appear in both module-size and function-size lists.
+- `robot_sf/planner/socnav.py` is the largest file, but this baseline alone does not prove it is
+  the first risk-reduction target; pair it with planner-specific behavior tests before splitting.
+- The slowest test pressure is concentrated in example/image integration paths, matching the need
+  for CI runtime diagnosis rather than broad test removal.
+- Training entry points remain large but are less urgent for benchmark correctness than the
+  benchmark runner/campaign hotspots.
+
+## Ticket Recommendations
+
+The 2026-05-05 scan already opened enough follow-up containers for this baseline:
+
+- #1001 should consume the benchmark/planner/training complexity evidence before broad refactors.
+- #1006 should consume the slow-test duration evidence before changing CI sharding or summaries.
+- #1005 remains a bounded maintenance ticket, but this baseline does not rank pedestrian NPC code
+  as a top-size hotspot; keep it behind benchmark orchestration and CI-runtime work.
+
+No additional follow-up issue is needed from this slice.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/dev/test_complexity_runtime_baseline.py -q
+```
+
+Failed before implementation with `ModuleNotFoundError` because
+`scripts.dev.complexity_runtime_baseline` did not exist.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/dev/test_complexity_runtime_baseline.py -q
+rtk uv run ruff check scripts/dev/complexity_runtime_baseline.py tests/dev/test_complexity_runtime_baseline.py
+rtk uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
+```
+
+The targeted test passed with `3 passed in 9.75s`; Ruff passed on the touched Python files.
+
+## Artifact Decision
+
+The baseline command writes no files. Targeted pytest refreshed ignored coverage output under
+`output/coverage/`; those files are disposable validation artifacts and are not promoted.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -160,6 +160,7 @@ scripts/dev/run_tests_parallel.sh
 scripts/dev/run_ci_local.sh
 scripts/dev/sbatch_use_max_time.sh SLURM/Auxme/auxme_gpu.sl
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
 scripts/dev/gh_comment.sh pr --current <<'EOF'
 Summary line
 - bullet 1
@@ -181,6 +182,10 @@ feature branch by itself, so validation from before the latest-main sync is stal
 Do not wait until PR creation to pick up `main` branch improvements on long-lived feature branches;
 merge latest `origin/main` into the current branch when active work starts, then sync again before
 opening the PR.
+
+Use `uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests`
+before/after substantial refactor PRs when you need a quick, repeatable snapshot of largest modules,
+longest functions, and optional pytest duration rows from a captured `--pytest-log`.
 
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 

--- a/scripts/dev/complexity_runtime_baseline.py
+++ b/scripts/dev/complexity_runtime_baseline.py
@@ -1,0 +1,279 @@
+"""Report lightweight complexity and pytest runtime baseline indicators."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_DURATION_RE = re.compile(
+    r"^\s*(?P<seconds>\d+(?:\.\d+)?)s\s+(?P<phase>\w+)\s+(?P<nodeid>\S.*)$",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleMetric:
+    """Simple physical-size metric for one Python source file."""
+
+    path: Path
+    code_lines: int
+    total_lines: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return {
+            "path": self.path.as_posix(),
+            "code_lines": self.code_lines,
+            "total_lines": self.total_lines,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionMetric:
+    """Line-span metric for one function or method."""
+
+    path: Path
+    qualified_name: str
+    length_lines: int
+    lineno: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return {
+            "path": self.path.as_posix(),
+            "qualified_name": self.qualified_name,
+            "length_lines": self.length_lines,
+            "lineno": self.lineno,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PytestDurationSample:
+    """One row from pytest's ``--durations`` report."""
+
+    nodeid: str
+    duration_seconds: float
+    phase: str
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineReport:
+    """Combined complexity and runtime-pressure baseline."""
+
+    modules: list[ModuleMetric]
+    functions: list[FunctionMetric]
+    pytest_durations: list[PytestDurationSample]
+
+    def to_json(self) -> str:
+        """Serialize the baseline as deterministic JSON."""
+        payload = {
+            "modules": [metric.to_dict() for metric in self.modules],
+            "functions": [metric.to_dict() for metric in self.functions],
+            "pytest_durations": [asdict(sample) for sample in self.pytest_durations],
+        }
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+
+class _FunctionVisitor(ast.NodeVisitor):
+    """Collect function spans while preserving class/function qualification."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.stack: list[str] = []
+        self.functions: list[FunctionMetric] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._record_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._record_function(node)
+
+    def _record_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        qualified_name = ".".join([*self.stack, node.name])
+        length_lines = int((node.end_lineno or node.lineno) - node.lineno + 1)
+        self.functions.append(
+            FunctionMetric(
+                path=self.path,
+                qualified_name=qualified_name,
+                length_lines=length_lines,
+                lineno=int(node.lineno),
+            ),
+        )
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+
+def _iter_python_files(roots: list[Path]) -> list[Path]:
+    """Return Python files under roots, skipping hidden and generated directories."""
+    files: list[Path] = []
+    skip_parts = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".venv", "output"}
+    for root in roots:
+        if root.is_file() and root.suffix == ".py":
+            files.append(root)
+            continue
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if any(part in skip_parts for part in path.parts):
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _module_metric(path: Path) -> ModuleMetric:
+    """Count total and simple non-comment source lines for a Python file."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    code_lines = sum(1 for line in lines if line.strip() and not line.lstrip().startswith("#"))
+    return ModuleMetric(path=path, code_lines=code_lines, total_lines=len(lines))
+
+
+def _function_metrics(path: Path) -> list[FunctionMetric]:
+    """Parse function spans from a Python file, returning no metrics on syntax errors."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=path.as_posix())
+    except SyntaxError:
+        return []
+    visitor = _FunctionVisitor(path)
+    visitor.visit(tree)
+    return visitor.functions
+
+
+def parse_pytest_durations(text: str) -> list[PytestDurationSample]:
+    """Parse pytest ``--durations`` rows from captured output."""
+    samples: list[PytestDurationSample] = []
+    for line in text.splitlines():
+        match = _DURATION_RE.match(line)
+        if match is None:
+            continue
+        samples.append(
+            PytestDurationSample(
+                nodeid=match.group("nodeid").strip(),
+                duration_seconds=float(match.group("seconds")),
+                phase=match.group("phase"),
+            ),
+        )
+    return sorted(samples, key=lambda sample: sample.duration_seconds, reverse=True)
+
+
+def build_baseline(
+    roots: list[Path],
+    *,
+    top: int = 10,
+    pytest_log: Path | None = None,
+) -> BaselineReport:
+    """Build a bounded baseline from source roots and an optional pytest output log."""
+    files = _iter_python_files(roots)
+    modules = sorted(
+        (_module_metric(path) for path in files),
+        key=lambda metric: (-metric.code_lines, -metric.total_lines, metric.path.as_posix()),
+    )[:top]
+    functions = sorted(
+        (metric for path in files for metric in _function_metrics(path)),
+        key=lambda metric: (-metric.length_lines, metric.path.as_posix(), metric.lineno),
+    )[:top]
+    pytest_durations: list[PytestDurationSample] = []
+    if pytest_log is not None:
+        pytest_durations = parse_pytest_durations(pytest_log.read_text(encoding="utf-8"))[:top]
+    return BaselineReport(
+        modules=modules,
+        functions=functions,
+        pytest_durations=pytest_durations,
+    )
+
+
+def _format_table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> list[str]:
+    """Format compact Markdown-style table rows for terminal and docs reuse."""
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    lines.extend("| " + " | ".join(str(value) for value in row) + " |" for row in rows)
+    return lines
+
+
+def format_text_report(report: BaselineReport) -> str:
+    """Format a human-readable baseline report."""
+    lines: list[str] = ["# Complexity and Test Runtime Baseline", ""]
+    lines.append("## Largest modules")
+    lines.extend(
+        _format_table(
+            ("path", "code_lines", "total_lines"),
+            [
+                (metric.path.as_posix(), metric.code_lines, metric.total_lines)
+                for metric in report.modules
+            ],
+        ),
+    )
+    lines.extend(["", "## Longest functions"])
+    lines.extend(
+        _format_table(
+            ("path", "qualified_name", "length_lines", "lineno"),
+            [
+                (
+                    metric.path.as_posix(),
+                    metric.qualified_name,
+                    metric.length_lines,
+                    metric.lineno,
+                )
+                for metric in report.functions
+            ],
+        ),
+    )
+    lines.extend(["", "## Test runtime indicators"])
+    if report.pytest_durations:
+        lines.extend(
+            _format_table(
+                ("duration_seconds", "phase", "nodeid"),
+                [
+                    (f"{sample.duration_seconds:.2f}", sample.phase, sample.nodeid)
+                    for sample in report.pytest_durations
+                ],
+            ),
+        )
+    else:
+        lines.append(
+            "No pytest duration log supplied; pass `--pytest-log <path>` with captured pytest "
+            "output to include slow-test indicators.",
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments for the baseline reporter."""
+    parser = argparse.ArgumentParser(
+        description="Report lightweight complexity and pytest runtime baseline indicators.",
+    )
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=["robot_sf", "scripts", "tests"],
+        help="Python files or directories to scan.",
+    )
+    parser.add_argument("--top", type=int, default=10, help="Number of rows per section.")
+    parser.add_argument("--pytest-log", type=Path, help="Captured pytest output to parse.")
+    parser.add_argument("--json", action="store_true", help="Print deterministic JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the baseline reporter."""
+    args = _parse_args(argv)
+    if args.top <= 0:
+        raise SystemExit("--top must be a positive integer")
+    roots = [Path(root) for root in args.roots]
+    report = build_baseline(roots, top=args.top, pytest_log=args.pytest_log)
+    sys.stdout.write(report.to_json() if args.json else format_text_report(report))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/dev/test_complexity_runtime_baseline.py
+++ b/tests/dev/test_complexity_runtime_baseline.py
@@ -1,0 +1,77 @@
+"""Tests for the lightweight complexity and runtime baseline command."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.dev.complexity_runtime_baseline import (
+    build_baseline,
+    format_text_report,
+    parse_pytest_durations,
+)
+
+
+def test_build_baseline_ranks_modules_and_functions(tmp_path) -> None:
+    """Baseline scan should rank source files and functions by simple size metrics."""
+    source_root = tmp_path / "src"
+    source_root.mkdir()
+    (source_root / "small.py").write_text(
+        "def tiny():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (source_root / "large.py").write_text(
+        "class Example:\n"
+        "    def long_method(self):\n"
+        "        value = 0\n"
+        "        value += 1\n"
+        "        value += 2\n"
+        "        return value\n",
+        encoding="utf-8",
+    )
+
+    baseline = build_baseline([source_root], top=2)
+
+    assert [module.path.name for module in baseline.modules] == ["large.py", "small.py"]
+    assert baseline.functions[0].qualified_name == "Example.long_method"
+    assert baseline.functions[0].length_lines == 5
+
+
+def test_parse_pytest_durations_extracts_runtime_samples() -> None:
+    """Pytest duration parsing should preserve phase, node id, and rank by wall time."""
+    samples = parse_pytest_durations(
+        "============================= slowest 10 durations =============================\n"
+        "27.40s call     tests/examples/test_examples_run.py::test_image\n"
+        "1.61s setup    tests/carla_bridge/test_t0_export_cli.py::test_schema\n"
+    )
+
+    assert [sample.nodeid for sample in samples] == [
+        "tests/examples/test_examples_run.py::test_image",
+        "tests/carla_bridge/test_t0_export_cli.py::test_schema",
+    ]
+    assert samples[0].duration_seconds == 27.40
+    assert samples[0].phase == "call"
+
+
+def test_format_text_report_includes_complexity_and_runtime_sections(tmp_path) -> None:
+    """Text output should be useful as a copyable context-note summary."""
+    source_root = tmp_path / "src"
+    source_root.mkdir()
+    (source_root / "sample.py").write_text(
+        "def example():\n    return 'ok'\n",
+        encoding="utf-8",
+    )
+    pytest_log = tmp_path / "pytest.log"
+    pytest_log.write_text(
+        "3.25s call     tests/test_sample.py::test_example\n",
+        encoding="utf-8",
+    )
+
+    baseline = build_baseline([source_root], top=1, pytest_log=pytest_log)
+    report = format_text_report(baseline)
+
+    assert "Largest modules" in report
+    assert "Longest functions" in report
+    assert "Test runtime indicators" in report
+    assert "sample.py" in report
+    assert "tests/test_sample.py::test_example" in report
+    assert json.loads(baseline.to_json())["pytest_durations"][0]["phase"] == "call"


### PR DESCRIPTION
## Summary
Adds a small stdlib-only refactor baseline command that reports largest modules, longest functions, and optional pytest duration rows for repeatable pre/post refactor triage.

## Linked Issues
- Closes #1002
- Relates to #1001
- Relates to #1006

## What Changed
- Added `scripts/dev/complexity_runtime_baseline.py` with text and deterministic JSON output.
- Added tests for module/function ranking, pytest duration parsing, formatted report output, and JSON serialization.
- Added the first baseline interpretation in `docs/context/issue_1002_complexity_runtime_baseline.md` and linked it from `docs/context/README.md`.
- Added the command to `docs/dev_guide.md` under reusable dev scripts.

## Why It Matters
- Added value: refactor discussions now have a repeatable, lightweight evidence source instead of ad hoc inspection.
- Expected impact: benchmark/planner/training hotspot triage can compare before/after snapshots without adding a dashboard or durable generated artifacts.
- Why this is worth merging now: the 2026-05-05 issue scan already opened refactor/runtime follow-ups, and this baseline gives those tickets a concrete evidence anchor.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_complexity_runtime_baseline.py -q` (RED: failed before implementation with `ModuleNotFoundError`)
  - `rtk uv run pytest tests/dev/test_complexity_runtime_baseline.py -q` (`3 passed in 9.84s` targeted after implementation; later covered again by full gate)
  - `rtk uv run ruff check scripts/dev/complexity_runtime_baseline.py tests/dev/test_complexity_runtime_baseline.py` (`All checks passed!`)
  - `rtk uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests`
  - `rtk uv run python scripts/dev/complexity_runtime_baseline.py --top 3 --json robot_sf scripts tests`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` before #1007 landed (`3193 passed, 14 skipped, 3 warnings in 290.67s`)
  - Merged latest `origin/main` after #1007, then reran `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` (`3194 passed, 14 skipped, 3 warnings in 296.02s`; changed-file checks: no matching include-pattern coverage files, no touched-definition TODO docstrings)
- Evidence that the change works here: the baseline reports `robot_sf/planner/socnav.py`, `robot_sf/benchmark/camera_ready_campaign.py`, and `robot_sf/benchmark/map_runner.py` as the top module-size hotspots, and `run_campaign` / `_build_policy` as the top function-size hotspots.
- Benchmarks or smoke tests: no benchmark run needed; this is a developer tooling and context-note change.

## Risks / Rollout
- Compatibility risks: low; additive script and docs only.
- Failure modes: simple physical line counts are triage signals, not architectural verdicts; the context note calls out that behavior/provenance tests still govern refactor decisions.
- Rollback or fallback plan: revert the script/tests/docs if the baseline proves too noisy.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_1002_complexity_runtime_baseline.md`.
- Artifact persistence: the baseline command writes no files. Validation refreshed ignored `output/coverage/`; those files are disposable and unpromoted.

## Follow-Up Issues
- Deferred work: no new issue needed from this slice.
- Existing follow-up containers confirmed:
  - #1001 should consume benchmark/planner/training complexity evidence.
  - #1006 should consume slow-test duration evidence before CI sharding/reporting changes.
  - #1005 remains a lower-priority maintenance ticket; this baseline does not rank pedestrian NPC code as a top-size hotspot.

## Reviewer Notes
- Please treat the metrics as triage hints only; they are intentionally simple and should not replace code review or behavior-preserving tests for actual refactors.