### PR TITLE
feat: add CI timing summary

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -110,6 +110,8 @@ knowledge, not every transient iteration detail.
 * [Issue #1002 Complexity and Test Runtime Baseline](./issue_1002_complexity_runtime_baseline.md)
   adds a lightweight `scripts/dev/complexity_runtime_baseline.py` command and records the first
   2026-05-05 refactor-prioritization snapshot.
+* [Issue #1006 GitHub CI Runtime Drift Diagnosis](./issue_1006_ci_runtime_drift.md)
+  adds `scripts/dev/ci_timing_summary.py` and records timing evidence from PRs #1007 and #1008.
 * [Issue #513 High-Density Perf Gate Calibration](./issue_513_high_density_perf_gate.md)
   keeps `classic_cross_trap_high` advisory because no stable local trend-history window was
   available; documents the rerun evidence and non-blocking policy.

--- a/docs/context/issue_1006_ci_runtime_drift.md
+++ b/docs/context/issue_1006_ci_runtime_drift.md
@@ -1,0 +1,90 @@
+# Issue #1006 GitHub CI Runtime Drift Diagnosis
+
+## Scope
+
+Issue #1006 diagnoses why GitHub CI takes much longer than local PR readiness on recent small PRs.
+This slice adds `scripts/dev/ci_timing_summary.py`, a lightweight reporting command that turns
+`gh run view --json ...` output into a compact timing summary for issue comments and PR triage.
+
+No CI cache, shard, or test-selection policy is changed in this PR. The evidence below supports a
+reporting-first fix because the slow phase is observable but not yet isolated to one test subset or
+cache key.
+
+## Command
+
+For a completed GitHub Actions run:
+
+```bash
+rtk uv run python scripts/dev/ci_timing_summary.py --run-id <run-id> --top 10
+```
+
+For saved JSON from `gh run view`:
+
+```bash
+rtk gh run view <run-id> --json databaseId,displayTitle,headBranch,status,conclusion,createdAt,updatedAt,jobs > output/tmp/ci_run.json
+rtk uv run python scripts/dev/ci_timing_summary.py --run-json output/tmp/ci_run.json --top 10
+```
+
+The saved JSON/log path is disposable input. Do not promote it unless a later diagnosis needs a
+durable artifact.
+
+## Evidence
+
+Sampled completed PR CI runs:
+
+| PR | run | local proof | CI total | queue | slowest CI steps |
+| --- | --- | --- | --- | --- | --- |
+| #1007 | `25373308385` | `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` completed with `3191 passed, 14 skipped, 3 warnings in 247.69s` | 1477s | 3s | Unit tests 714s; System packages 489s; Validation smoke 125s |
+| #1008 | `25374732844` | post-main-merge readiness completed with `3194 passed, 14 skipped, 3 warnings in 296.02s` | 1042s | 34s | Unit tests 710s; Validation smoke 127s; Cache `.venv` 44s |
+
+Interpretation:
+
+- Queue time is not the bottleneck for these runs.
+- The repeatable dominant cost is the CI `Unit tests` step at about 11m50s, versus roughly 4-5m
+  local full readiness on the 16-worker Linux workstation.
+- `Validation smoke tests` consistently adds about 2m05s.
+- #1007 had an additional setup outlier: `System packages for headless` took 8m09s; #1008 reduced
+  that same step to 20s, so this appears intermittent mirror/package pressure rather than the main
+  repeatable drift.
+
+## Recommended Next Actions
+
+Use the new timing command before changing CI structure. The next evidence-bearing issue should:
+
+- compare `Unit tests` logs with the local slow-test report from `BASE_REF=origin/main
+  scripts/dev/pr_ready_check.sh`,
+- decide whether example/image integration tests need a separate CI phase or summary,
+- avoid cache-key changes unless multiple runs show setup/cache phases are the repeatable
+  bottleneck.
+
+This slice does not recommend test removal. Constitution Principle XIII still applies: optimize or
+split high-value tests only after verifying their contract value.
+
+## Validation
+
+RED proof:
+
+```bash
+rtk uv run pytest tests/dev/test_ci_timing_summary.py -q
+```
+
+Failed before implementation with `ModuleNotFoundError` because `scripts.dev.ci_timing_summary`
+did not exist.
+
+GREEN proof:
+
+```bash
+rtk uv run pytest tests/dev/test_ci_timing_summary.py -q
+rtk uv run ruff check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py
+rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25373308385 --top 6
+rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25374732844 --top 6
+rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25374732844 --top 3 --json
+```
+
+The targeted tests passed with `3 passed in 17.96s`; Ruff passed on the touched Python files.
+
+## Artifact Decision
+
+The timing command writes no files unless the caller chooses to save `gh run view` JSON separately.
+Targeted pytest refreshed ignored coverage output under `output/coverage/`; those files are
+disposable validation artifacts and are not promoted.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -161,6 +161,7 @@ scripts/dev/run_ci_local.sh
 scripts/dev/sbatch_use_max_time.sh SLURM/Auxme/auxme_gpu.sl
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
+uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run-id> --top 10
 scripts/dev/gh_comment.sh pr --current <<'EOF'
 Summary line
 - bullet 1
@@ -186,6 +187,9 @@ opening the PR.
 Use `uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests`
 before/after substantial refactor PRs when you need a quick, repeatable snapshot of largest modules,
 longest functions, and optional pytest duration rows from a captured `--pytest-log`.
+Use `uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run-id> --top 10`
+when GitHub CI wall time drifts from local readiness and you need queue, job, and slowest-step
+timings from `gh run view` data.
 
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 

--- a/scripts/dev/ci_timing_summary.py
+++ b/scripts/dev/ci_timing_summary.py
@@ -1,0 +1,185 @@
+"""Summarize GitHub Actions CI run timing from ``gh run view`` JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_GH_RUN_FIELDS = "databaseId,displayTitle,headBranch,status,conclusion,createdAt,updatedAt,jobs"
+
+
+@dataclass(frozen=True, slots=True)
+class StepTiming:
+    """Duration for one GitHub Actions job step."""
+
+    name: str
+    duration_seconds: float
+    started_at: str
+    completed_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RunTimingSummary:
+    """Compact timing summary for one GitHub Actions workflow run."""
+
+    run_id: int
+    title: str
+    queue_seconds: float
+    job_seconds: float
+    total_seconds: float
+    slowest_steps: list[StepTiming]
+
+    def to_json(self) -> str:
+        """Serialize the summary as deterministic JSON."""
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    """Parse a GitHub timestamp, treating missing or zero timestamps as absent."""
+    if not value or value.startswith("0001-01-01"):
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _duration_seconds(start: str | None, end: str | None) -> float | None:
+    """Return elapsed seconds for a timestamp pair, or ``None`` if incomplete."""
+    started = _parse_timestamp(start)
+    completed = _parse_timestamp(end)
+    if started is None or completed is None:
+        return None
+    return max((completed - started).total_seconds(), 0.0)
+
+
+def _completed_step_timings(payload: dict[str, Any]) -> list[StepTiming]:
+    """Extract completed step durations from all jobs in a run payload."""
+    timings: list[StepTiming] = []
+    for job in payload.get("jobs", []):
+        for step in job.get("steps", []):
+            duration = _duration_seconds(step.get("startedAt"), step.get("completedAt"))
+            if duration is None:
+                continue
+            timings.append(
+                StepTiming(
+                    name=str(step.get("name", "")),
+                    duration_seconds=duration,
+                    started_at=str(step.get("startedAt", "")),
+                    completed_at=str(step.get("completedAt", "")),
+                ),
+            )
+    return timings
+
+
+def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary:
+    """Summarize queue, job, total, and slowest-step durations from a run payload."""
+    jobs = list(payload.get("jobs", []))
+    created = _parse_timestamp(payload.get("createdAt"))
+    updated = _parse_timestamp(payload.get("updatedAt"))
+    job_starts = [
+        parsed for job in jobs if (parsed := _parse_timestamp(job.get("startedAt"))) is not None
+    ]
+    job_completions = [
+        parsed for job in jobs if (parsed := _parse_timestamp(job.get("completedAt"))) is not None
+    ]
+
+    queue_seconds = 0.0
+    if created is not None and job_starts:
+        queue_seconds = max((min(job_starts) - created).total_seconds(), 0.0)
+
+    job_seconds = 0.0
+    if job_starts and job_completions:
+        job_seconds = max((max(job_completions) - min(job_starts)).total_seconds(), 0.0)
+
+    total_seconds = 0.0
+    if created is not None and updated is not None:
+        total_seconds = max((updated - created).total_seconds(), 0.0)
+
+    slowest_steps = sorted(
+        _completed_step_timings(payload),
+        key=lambda step: (-step.duration_seconds, step.name),
+    )[:top]
+
+    return RunTimingSummary(
+        run_id=int(payload.get("databaseId") or 0),
+        title=str(payload.get("displayTitle") or ""),
+        queue_seconds=queue_seconds,
+        job_seconds=job_seconds,
+        total_seconds=total_seconds,
+        slowest_steps=slowest_steps,
+    )
+
+
+def _format_seconds(seconds: float) -> str:
+    """Format seconds with one decimal place for compact tables."""
+    return f"{seconds:.1f}s"
+
+
+def format_markdown(summary: RunTimingSummary) -> str:
+    """Format a timing summary as Markdown for issues and PR comments."""
+    lines = [
+        f"# CI Timing Summary: Run {summary.run_id}",
+        "",
+        f"Title: {summary.title}",
+        "",
+        "| metric | duration |",
+        "| --- | --- |",
+        f"| queue | {_format_seconds(summary.queue_seconds)} |",
+        f"| job | {_format_seconds(summary.job_seconds)} |",
+        f"| total | {_format_seconds(summary.total_seconds)} |",
+        "",
+        "## Slowest steps",
+        "| step | duration | started | completed |",
+        "| --- | --- | --- | --- |",
+    ]
+    for step in summary.slowest_steps:
+        lines.append(
+            "| "
+            f"{step.name} | {_format_seconds(step.duration_seconds)} | "
+            f"{step.started_at} | {step.completed_at} |",
+        )
+    return "\n".join(lines)
+
+
+def _load_payload_from_gh(run_id: str) -> dict[str, Any]:
+    """Fetch a workflow run payload through the GitHub CLI."""
+    output = subprocess.check_output(
+        ["gh", "run", "view", run_id, "--json", _GH_RUN_FIELDS],
+        text=True,
+    )
+    return json.loads(output)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments for the timing summary tool."""
+    parser = argparse.ArgumentParser(description="Summarize GitHub Actions CI timing.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--run-id", help="GitHub Actions run id to fetch through gh.")
+    source.add_argument("--run-json", type=Path, help="Saved gh run view JSON payload.")
+    parser.add_argument("--top", type=int, default=10, help="Number of slowest steps to report.")
+    parser.add_argument("--json", action="store_true", help="Print deterministic JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for CI timing summaries."""
+    args = _parse_args(argv)
+    if args.top <= 0:
+        raise SystemExit("--top must be a positive integer")
+    payload = (
+        json.loads(args.run_json.read_text(encoding="utf-8"))
+        if args.run_json is not None
+        else _load_payload_from_gh(args.run_id)
+    )
+    summary = summarize_run(payload, top=args.top)
+    sys.stdout.write(summary.to_json() if args.json else format_markdown(summary))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/dev/test_ci_timing_summary.py
+++ b/tests/dev/test_ci_timing_summary.py
@@ -1,0 +1,80 @@
+"""Tests for GitHub Actions CI timing summary helpers."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.dev.ci_timing_summary import format_markdown, main, summarize_run
+
+
+def _sample_run_payload() -> dict[str, object]:
+    return {
+        "databaseId": 123,
+        "displayTitle": "sample",
+        "createdAt": "2026-05-05T11:00:00Z",
+        "updatedAt": "2026-05-05T11:03:00Z",
+        "jobs": [
+            {
+                "name": "ci",
+                "startedAt": "2026-05-05T11:00:10Z",
+                "completedAt": "2026-05-05T11:03:00Z",
+                "steps": [
+                    {
+                        "name": "Set up job",
+                        "startedAt": "2026-05-05T11:00:10Z",
+                        "completedAt": "2026-05-05T11:00:20Z",
+                    },
+                    {
+                        "name": "Unit tests",
+                        "startedAt": "2026-05-05T11:00:30Z",
+                        "completedAt": "2026-05-05T11:02:30Z",
+                    },
+                    {
+                        "name": "Validation smoke tests",
+                        "startedAt": "2026-05-05T11:02:30Z",
+                        "completedAt": "2026-05-05T11:03:00Z",
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_summarize_run_reports_queue_job_and_slowest_steps() -> None:
+    """Timing summary should separate queue, job, and step-level durations."""
+    summary = summarize_run(_sample_run_payload(), top=2)
+
+    assert summary.run_id == 123
+    assert summary.queue_seconds == 10.0
+    assert summary.job_seconds == 170.0
+    assert [step.name for step in summary.slowest_steps] == [
+        "Unit tests",
+        "Validation smoke tests",
+    ]
+    assert summary.slowest_steps[0].duration_seconds == 120.0
+
+
+def test_format_markdown_includes_phase_totals() -> None:
+    """Markdown output should be compact enough for issues and PR comments."""
+    summary = summarize_run(_sample_run_payload(), top=2)
+
+    markdown = format_markdown(summary)
+
+    assert "Run 123" in markdown
+    assert "| queue | 10.0s |" in markdown
+    assert "| Unit tests | 120.0s |" in markdown
+    assert "| Validation smoke tests | 30.0s |" in markdown
+
+
+def test_main_reads_run_json_and_prints_markdown(tmp_path, capsys) -> None:
+    """CLI should summarize saved `gh run view --json ...` output."""
+    run_json = tmp_path / "run.json"
+    run_json.write_text(json.dumps(_sample_run_payload()), encoding="utf-8")
+
+    exit_code = main(["--run-json", str(run_json), "--top", "1"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "sample" in output
+    assert "Unit tests" in output
+    assert "Validation smoke tests" not in output


### PR DESCRIPTION
## Summary
Adds a small CI timing summary command so GitHub Actions run timing can be compared against local readiness without manually reading every workflow step.

## Linked Issues
- Closes #1006
- Relates to #1002

## What Changed
- Added `scripts/dev/ci_timing_summary.py` to summarize queue time, job duration, total duration, and slowest steps from `gh run view --json` payloads.
- Added tests for queue/job/step duration parsing, Markdown output, and CLI input from saved JSON.
- Added `docs/context/issue_1006_ci_runtime_drift.md` with timing evidence from PRs #1007 and #1008.
- Linked the new command from `docs/dev_guide.md` and `docs/context/README.md`.

## Why It Matters
- Added value: CI drift can now be diagnosed from stable run metadata instead of ad hoc UI inspection.
- Expected impact: future CI optimization work can distinguish queue/setup/test/smoke pressure before changing cache keys or sharding.
- Why this is worth merging now: today’s #1007 and #1008 runs showed the drift clearly and provided live evidence for the reporting command.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_ci_timing_summary.py -q` (RED: failed before implementation with `ModuleNotFoundError`)
  - `rtk uv run pytest tests/dev/test_ci_timing_summary.py -q` (`3 passed in 9.67s` targeted after implementation; later covered again by full gate)
  - `rtk uv run ruff check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py` (`All checks passed!`)
  - `rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25373308385 --top 6`
  - `rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25374732844 --top 6`
  - `rtk uv run python scripts/dev/ci_timing_summary.py --run-id 25374732844 --top 3 --json`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after commit/amend and latest-main sync (`3197 passed, 14 skipped, 3 warnings in 353.33s`; changed-file checks: no matching include-pattern coverage files, no touched-definition TODO docstrings)
- Evidence from sampled runs:
  - #1007 / run `25373308385`: queue 3s, job 1473s; slowest steps were Unit tests 714s, System packages 489s, Validation smoke 125s.
  - #1008 / run `25374732844`: queue 34s, job 1007s; slowest steps were Unit tests 710s, Validation smoke 127s, Cache `.venv` 44s.
- Root-cause boundary: queueing is not the bottleneck in these samples; repeatable pressure is unit tests and smoke runtime, with one setup-package outlier.

## Risks / Rollout
- Compatibility risks: low; additive dev script and docs only.
- Failure modes: the command depends on GitHub CLI JSON shape for `gh run view`; tests cover the local parser on saved payloads.
- Rollback or fallback plan: revert the script/docs if the reporting surface is not useful.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_1006_ci_runtime_drift.md`.
- Artifact persistence: the timing command writes no files by default. Validation refreshed ignored `output/coverage/`; those files are disposable and unpromoted.

## Follow-Up Issues
- Deferred work: no new issue needed from this slice.
- Existing next work: use #1006’s evidence from this PR to decide later whether example/image integration tests need a separate CI phase or summary.

## Reviewer Notes
- This intentionally does not tune caches, split tests, or change `.github/workflows/ci.yml`; the sampled evidence does not yet justify a structural CI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI tool to analyze GitHub Actions CI run timing metrics, including queue duration, job duration, and slowest steps ranking.

* **Documentation**
  * New guide for diagnosing CI runtime drift and comparing local development readiness.
  * Updated development guide with CI timing analysis workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->