### PR TITLE
refactor: clean pedestrian NPC docstrings

### DIFF
--- a/robot_sf/ped_npc/__init__.py
+++ b/robot_sf/ped_npc/__init__.py
@@ -1,1 +1,1 @@
-"""TODO docstring. Document this module."""
+"""Pedestrian NPC controllers, population helpers, grouping state, and force models."""

--- a/robot_sf/ped_npc/ped_behavior.py
+++ b/robot_sf/ped_npc/ped_behavior.py
@@ -1,8 +1,4 @@
-"""
-ped_behavior.py
-- Defines the behavior of pedestrian groups
-- Pedestrian groups can be assigned to follow a route or to move around a crowded zone
-"""
+"""Pedestrian behavior controllers for crowd zones, routes, and scripted actors."""
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,17 +18,14 @@ if TYPE_CHECKING:
 
 
 class PedestrianBehavior(Protocol):
-    """
-    !!! Not Implemented !!!
-    This class is used for type checking the pedestrian behaviors.
-    """
+    """Protocol implemented by pedestrian behavior controllers."""
 
     def step(self):
-        """TODO docstring. Document this function."""
+        """Advance behavior state for one simulation timestep."""
         raise NotImplementedError()
 
     def reset(self):
-        """TODO docstring. Document this function."""
+        """Reset behavior state at an episode boundary."""
         raise NotImplementedError()
 
 
@@ -51,7 +44,7 @@ class CrowdedZoneBehavior:
         The crowded zones.
     goal_proximity_threshold : float
         The distance threshold for proximity to a goal. Default is 1.
-        TODO: What is the unit of this distance?
+        Uses the same world-coordinate units as pedestrian positions and zones.
 
     Methods
     -------

--- a/robot_sf/ped_npc/ped_robot_force.py
+++ b/robot_sf/ped_npc/ped_robot_force.py
@@ -1,4 +1,10 @@
-"""TODO docstring. Document this module."""
+"""Robot-aware force model for pedestrian Social Force simulations.
+
+The module exposes a PySocialForce-compatible callable that applies an inverse-cubic
+potential field between the robot and each pedestrian inside a configurable activation
+radius. Positive multipliers repel pedestrians from the robot; negative multipliers can
+be used for adversarial attraction experiments.
+"""
 
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -13,7 +19,7 @@ from robot_sf.common.types import Vec2D
 
 @dataclass
 class PedRobotForceConfig:
-    """TODO docstring. Document this class."""
+    """Configuration for robot-to-pedestrian force computation."""
 
     is_active: bool = True
     robot_radius: float = 1.0
@@ -22,11 +28,12 @@ class PedRobotForceConfig:
 
 
 class PedRobotForce:
-    """This force represents a behavior that's making the pedestrians
-    aware of the robot such that they try to avoid it.
+    """PySocialForce-compatible robot interaction force for pedestrians.
 
-    If the force multiplier is parameterized with a negative factor,
-    this force can be used for adverserial trainings as well."""
+    The force reads pedestrian positions from ``peds`` at call time and obtains the
+    latest robot position through ``get_robot_pos``. The resulting force array has
+    shape ``(num_peds, 2)`` and is stored in ``last_forces`` for diagnostics.
+    """
 
     def __init__(
         self,
@@ -34,12 +41,12 @@ class PedRobotForce:
         peds: PedState,
         get_robot_pos: Callable[[], Vec2D],
     ):
-        """TODO docstring. Document this function.
+        """Create a robot-aware pedestrian force.
 
         Args:
-            config: TODO docstring.
-            peds: TODO docstring.
-            get_robot_pos: TODO docstring.
+            config: Force activation, geometry, and scaling parameters.
+            peds: PySocialForce pedestrian state backing the current simulation.
+            get_robot_pos: Callback returning the robot position in world coordinates.
         """
         self.config = config
         self.peds = peds
@@ -94,15 +101,19 @@ def ped_robot_force(
 @numba.njit(fastmath=True)
 def der_euclid_dist(p1: Vec2D, p2: Vec2D, distance: float) -> Vec2D:
     # info: distance is an expensive operation and therefore pre-computed
-    """TODO docstring. Document this function.
+    """Return the derivative of Euclidean distance with respect to ``p1``.
 
     Args:
-        p1: TODO docstring.
-        p2: TODO docstring.
-        distance: TODO docstring.
+        p1: Point whose distance derivative is being evaluated.
+        p2: Reference point for the distance calculation.
+        distance: Precomputed Euclidean distance between ``p1`` and ``p2``.
 
     Returns:
-        TODO docstring.
+        Unit vector pointing from ``p2`` toward ``p1``.
+
+    Notes:
+        ``distance`` must be positive; callers precompute it to avoid duplicate
+        square-root work inside the numba kernel.
     """
     dx1_dist = (p1[0] - p2[0]) / distance
     dy1_dist = (p1[1] - p2[1]) / distance
@@ -111,15 +122,15 @@ def der_euclid_dist(p1: Vec2D, p2: Vec2D, distance: float) -> Vec2D:
 
 @numba.njit(fastmath=True)
 def potential_field_force(dist: float, dx_dist: float, dy_dist: float) -> tuple[float, float]:
-    """TODO docstring. Document this function.
+    """Compute the inverse-cubic potential-field force for one pedestrian.
 
     Args:
-        dist: TODO docstring.
-        dx_dist: TODO docstring.
-        dy_dist: TODO docstring.
+        dist: Distance from the pedestrian to the robot.
+        dx_dist: X component of the distance derivative.
+        dy_dist: Y component of the distance derivative.
 
     Returns:
-        TODO docstring.
+        Force vector in world-coordinate units.
     """
     der_potential = 1 / pow(dist, 3)
     return der_potential * dx_dist, der_potential * dy_dist

--- a/tests/test_ped_npc_docstrings.py
+++ b/tests/test_ped_npc_docstrings.py
@@ -1,0 +1,41 @@
+"""Tests for pedestrian NPC documentation contracts."""
+
+import ast
+from pathlib import Path
+
+PED_NPC_ROOT = Path(__file__).resolve().parents[1] / "robot_sf" / "ped_npc"
+TARGET_MODULES = (
+    "__init__.py",
+    "ped_behavior.py",
+    "ped_robot_force.py",
+)
+PLACEHOLDER_MARKERS = ("TODO docstring", "TODO:")
+
+
+def _iter_docstrings(tree: ast.Module) -> list[tuple[str, str]]:
+    """Collect module, class, and function docstrings from an AST."""
+    docstrings: list[tuple[str, str]] = []
+    module_docstring = ast.get_docstring(tree)
+    if module_docstring:
+        docstrings.append(("<module>", module_docstring))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            docstring = ast.get_docstring(node)
+            if docstring:
+                docstrings.append((node.name, docstring))
+    return docstrings
+
+
+def test_targeted_ped_npc_docstrings_do_not_contain_todo_placeholders() -> None:
+    """Keep pedestrian NPC force and behavior docs free of TODO placeholders."""
+    offenders: list[str] = []
+    for module_name in TARGET_MODULES:
+        path = PED_NPC_ROOT / module_name
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for qualified_name, docstring in _iter_docstrings(tree):
+            if any(marker in docstring for marker in PLACEHOLDER_MARKERS):
+                first_line = docstring.splitlines()[0]
+                offenders.append(f"{module_name}:{qualified_name}: {first_line}")
+
+    assert offenders == []

--- a/tests/test_ped_robot_force_contract.py
+++ b/tests/test_ped_robot_force_contract.py
@@ -1,0 +1,35 @@
+"""Contract tests for robot-to-pedestrian force helpers."""
+
+import numpy as np
+
+from robot_sf.ped_npc.ped_robot_force import (
+    der_euclid_dist,
+    ped_robot_force,
+    potential_field_force,
+)
+
+
+def test_ped_robot_force_applies_inverse_cubic_force_inside_threshold() -> None:
+    """Apply forces only to pedestrians within the configured activation distance."""
+    out_forces = np.zeros((2, 2), dtype=float)
+    ped_positions = np.array(
+        [
+            [1.0, 0.0],
+            [3.0, 0.0],
+        ],
+        dtype=float,
+    )
+
+    ped_robot_force.py_func(out_forces, ped_positions, (0.0, 0.0), 2.0)
+
+    assert np.allclose(out_forces[0], [1.0, 0.0])
+    assert np.allclose(out_forces[1], [0.0, 0.0])
+
+
+def test_force_helper_math_contracts() -> None:
+    """Keep derivative and potential helpers aligned with the documented force field."""
+    dx_dist, dy_dist = der_euclid_dist.py_func((3.0, 4.0), (0.0, 0.0), 5.0)
+    force_x, force_y = potential_field_force.py_func(2.0, dx_dist, dy_dist)
+
+    assert np.allclose([dx_dist, dy_dist], [0.6, 0.8])
+    assert np.allclose([force_x, force_y], [0.075, 0.1])


### PR DESCRIPTION
## Summary

- Replaces TODO placeholder docstrings in pedestrian NPC package entrypoint, behavior protocol docs, crowded-zone threshold docs, and robot force helpers.
- Adds a focused docstring guard test for the targeted pedestrian NPC modules.
- Adds robot-force helper contract tests that exercise the Python implementations behind the numba dispatchers and keep changed-file coverage above the repository gate.

Closes #1005

## Validation

- RED: `rtk uv run pytest tests/test_ped_npc_docstrings.py -q` failed with 9 TODO placeholder offenders before the cleanup.
- `rtk uv run pytest tests/test_ped_npc_docstrings.py tests/test_single_pedestrian_behavior.py tests/test_robot_with_ped_obstacle_force.py tests/test_adversial_ped_force.py tests/test_force_flags.py -q` -> 20 passed.
- `rtk uv run pytest tests/test_ped_robot_force_contract.py tests/test_ped_npc_docstrings.py -q` -> 3 passed.
- `rtk uv run ruff check ...` and `rtk uv run ruff format --check ...` on touched files -> clean.
- `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after syncing latest `origin/main` -> 3199 passed, 15 skipped, 3 warnings in 359.45s; changed-file coverage accepted (`ped_robot_force.py` 100.0%, `ped_behavior.py` 81.2% warning only); no TODO docstrings found in touched definitions.

## Artifacts

- Full test runs produced ignored `output/coverage/*` reports only. These are disposable local validation outputs and are not durable dependencies.