### PR TITLE
test: add hybrid rule rejection attribution

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -152,6 +152,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1004 Policy Stack V1 Runtime](issue_1004_policy_stack_v1_runtime.md)
   records the first runnable `policy_stack_v1` slice, its explicit proposal-status diagnostics, and
   the map-runner smoke limitation under parent #871.
+* [Issue #884 Classic Merging Diagnostics](issue_884_classic_merging_diagnostics.md)
+  records source-level hybrid-rule rejection diagnostics and two rejected classic-merging recovery
+  mechanisms; #884 remains unresolved until a route-completing corridor policy is proven.
 
 ## Map Coverage Notes
 

--- a/docs/context/issue_884_classic_merging_diagnostics.md
+++ b/docs/context/issue_884_classic_merging_diagnostics.md
@@ -1,0 +1,135 @@
+# Issue #884 Classic Merging Diagnostics
+
+Date: 2026-05-05
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/884>
+
+## Goal
+
+Resolve the remaining `classic_merging_low` and `classic_merging_medium` failures for the
+`hybrid_rule_v3_fast_progress_static_escape` policy-search candidate without weakening the hard
+static-collision gate or counting fallback/degraded execution as success.
+
+This pass did not find a PR-safe merge-policy fix. It adds reusable decision diagnostics and records
+two rejected mechanisms so the next attempt can start from concrete trace evidence rather than
+repeat the same tuning loop.
+
+## Diagnostic Change
+
+`HybridRuleLocalPlannerAdapter.last_decision()` now reports:
+
+- `moving_rejection_counts`: rejection reasons restricted to candidates with non-zero linear
+  commands,
+- `rejection_counts_by_source`: rejection reasons grouped by candidate source such as
+  `dynamic_window`, `creep`, `path_follow_0.5m`, or `route_guide`.
+
+The added source-level attribution explains whether a static-corridor stall is caused by every
+moving source entering the hard static-clearance band, rather than just reporting aggregate
+`static_clearance` counts.
+
+Fresh diagnostics with this change are under
+`output/ai/autoresearch/issue_884_diagnostics_after/`. The final step for the four timeout seeds
+reports `moving_rejection_counts={"static_clearance": 57}` with source attribution:
+`dynamic_window=54`, `creep=1`, `path_follow_0.5m=1`, and `route_guide=1`. The obstacle-collision
+seed `classic_merging_low` seed `111` reports `moving_rejection_counts={"static_clearance": 10}`
+from `dynamic_window`.
+
+## Baseline Evidence
+
+Existing baseline traces under `output/ai/autoresearch/issue_884_baseline/` reproduce the five
+classic-merging failures:
+
+| Scenario | Seed | Baseline outcome | Last dominant rejection |
+|---|---:|---|---|
+| `classic_merging_low` | 111 | obstacle collision at step `242` | `static_clearance` |
+| `classic_merging_low` | 113 | timeout at horizon `500` | `static_clearance` |
+| `classic_merging_medium` | 111 | timeout at horizon `500` | `static_clearance` |
+| `classic_merging_medium` | 112 | timeout at horizon `500` | `static_clearance` |
+| `classic_merging_medium` | 113 | timeout at horizon `500` | `static_clearance` |
+
+The timeout traces end with full-stop commands while moving candidates are rejected by hard static
+clearance. The collision trace remains the unsafe side of the same corridor family: it continues
+making progress until an obstacle collision.
+
+## Rejected Mechanisms
+
+### Static-Corridor Reorient Promotion
+
+Probe output:
+`output/ai/autoresearch/issue_884_static_corridor_reorient/`
+
+Hypothesis: when stalled, no pedestrian is near, the best accepted command is a full stop, and
+moving candidates are rejected by static clearance, promote an already accepted rotate-in-place
+candidate without relaxing hard safety filters.
+
+Result:
+
+- `classic_merging_low` seed `111` still hit an obstacle collision.
+- `classic_merging_low` seed `113` still timed out.
+- `classic_merging_medium` seeds `111` and `112` still timed out.
+- `classic_merging_medium` seed `113` regressed from timeout to obstacle collision.
+
+Conclusion: reject. Rotation promotion changes the terminal behavior but does not create a safe
+route-completing corridor policy.
+
+### Classic-Merging Sampling Overrides
+
+Probe outputs:
+
+- `output/ai/autoresearch/issue_884_sampling_probe/`
+- `output/ai/autoresearch/issue_884_angular_sampling_probe/`
+
+Hypothesis: the candidate lattice is too coarse to find a valid command through the narrow static
+corridor, so increasing samples might recover a safe command while preserving the hard static gate.
+
+Results:
+
+- `linear_samples: 11` plus `angular_samples: 17` avoided the low-seed obstacle collision but
+  converted the five probes into earlier or unchanged static deadlocks with zero successes.
+- `angular_samples: 17` alone still produced obstacle collisions on `classic_merging_low` seed
+  `111` and `classic_merging_medium` seed `112`, with the other three probes timing out.
+
+Conclusion: reject. Higher-resolution local sampling is not enough; it either stalls in the same
+static band or still finds unsafe progress commands.
+
+## Current Conclusion
+
+Issue #884 remains unresolved. The next credible implementation needs a route- or corridor-aware
+policy mechanism that preserves hard static-collision filtering while proving actual route
+completion on the five classic-merging seeds. The new diagnostics make that next mechanism easier
+to evaluate by showing which candidate sources are blocked by static clearance at each stalled
+step.
+
+Do not promote the rejected reorientation or sampling overrides as benchmark improvements. They are
+worktree-local failed experiments, not durable candidate configs.
+
+## Validation Commands
+
+Focused code validation:
+
+```bash
+rtk uv run ruff check robot_sf/planner/hybrid_rule_local_planner.py \
+  tests/planner/test_hybrid_rule_local_planner.py
+rtk uv run pytest tests/planner/test_hybrid_rule_local_planner.py -q
+```
+
+Rejected reorient probe shape:
+
+```bash
+LOGURU_LEVEL=WARNING rtk uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v3_fast_progress_static_escape \
+  --stage full_matrix \
+  --scenario-name classic_merging_low \
+  --seed 111 \
+  --horizon 500 \
+  --output-dir output/ai/autoresearch/issue_884_static_corridor_reorient/classic_merging_low_111_h500
+```
+
+The same command shape was run for:
+
+- `classic_merging_low` seeds `111`, `113`,
+- `classic_merging_medium` seeds `111`, `112`, `113`.
+
+Sampling probes used the same five scenario/seed pairs with output roots
+`output/ai/autoresearch/issue_884_sampling_probe/` and
+`output/ai/autoresearch/issue_884_angular_sampling_probe/`.

--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -944,6 +944,67 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
                 row[key] = float(value)
         return row
 
+    def _evaluate_candidates_for_plan(
+        self,
+        *,
+        candidates: list[HybridRuleCandidate],
+        observation: dict[str, Any],
+        state: dict[str, Any],
+        speed_cap: float,
+        nearest_ped: float,
+        progress_windows: dict[str, float],
+    ) -> tuple[
+        list[dict[str, Any]],
+        Counter[str],
+        Counter[str],
+        dict[str, dict[str, int]],
+        list[dict[str, Any]],
+    ]:
+        """Evaluate a candidate set and collect rejection diagnostics.
+
+        Returns:
+            tuple: Accepted evaluations, aggregate rejections, moving-command
+            rejections, source-level rejections, and compact examples.
+        """
+        accepted: list[dict[str, Any]] = []
+        rejection_counts: Counter[str] = Counter()
+        moving_rejection_counts: Counter[str] = Counter()
+        rejection_counts_by_source: dict[str, Counter[str]] = {}
+        rejected_examples: list[dict[str, Any]] = []
+
+        for candidate in candidates:
+            evaluation = self._evaluate_candidate(
+                candidate=candidate,
+                observation=observation,
+                state=state,
+                speed_cap=speed_cap,
+                nearest_ped=nearest_ped,
+                progress_windows=progress_windows,
+            )
+            if bool(evaluation.get("accepted")):
+                accepted.append(evaluation)
+                continue
+
+            reason = str(evaluation.get("reason", "unknown"))
+            rejection_counts[reason] += 1
+            source_counts = rejection_counts_by_source.setdefault(candidate.source, Counter())
+            source_counts[reason] += 1
+            if candidate.linear > float(self.config.freezing_speed_threshold):
+                moving_rejection_counts[reason] += 1
+            if len(rejected_examples) < max(int(self.config.top_k_diagnostics), 1):
+                rejected_examples.append(self._rejection_diagnostic(evaluation))
+
+        return (
+            accepted,
+            rejection_counts,
+            moving_rejection_counts,
+            {
+                source: dict(sorted(counts.items()))
+                for source, counts in sorted(rejection_counts_by_source.items())
+            },
+            rejected_examples,
+        )
+
     def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
         """Return the selected ``(linear, angular)`` command."""
         state = self._extract_state(observation)
@@ -974,25 +1035,20 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         speed_cap = self._human_speed_cap(nearest_ped)
         self._clearance_context = self._build_clearance_context(observation)
         candidates = self._generate_candidates(state, speed_cap)
-        accepted: list[dict[str, Any]] = []
-        rejection_counts: Counter[str] = Counter()
-        rejected_examples: list[dict[str, Any]] = []
-        for candidate in candidates:
-            evaluation = self._evaluate_candidate(
-                candidate=candidate,
-                observation=observation,
-                state=state,
-                speed_cap=speed_cap,
-                nearest_ped=nearest_ped,
-                progress_windows=progress_windows,
-            )
-            if bool(evaluation.get("accepted")):
-                accepted.append(evaluation)
-            else:
-                reason = str(evaluation.get("reason", "unknown"))
-                rejection_counts[reason] += 1
-                if len(rejected_examples) < max(int(self.config.top_k_diagnostics), 1):
-                    rejected_examples.append(self._rejection_diagnostic(evaluation))
+        (
+            accepted,
+            rejection_counts,
+            moving_rejection_counts,
+            rejection_counts_by_source,
+            rejected_examples,
+        ) = self._evaluate_candidates_for_plan(
+            candidates=candidates,
+            observation=observation,
+            state=state,
+            speed_cap=speed_cap,
+            nearest_ped=nearest_ped,
+            progress_windows=progress_windows,
+        )
 
         self._rejection_counts.update(rejection_counts)
         if accepted:
@@ -1051,6 +1107,8 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             predicted_ttc=predicted_ttc,
             progress_windows=progress_windows,
             rejected_examples=rejected_examples,
+            moving_rejection_counts=dict(moving_rejection_counts),
+            rejection_counts_by_source=rejection_counts_by_source,
         )
         return command
 
@@ -1085,6 +1143,8 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         predicted_ttc: float,
         progress_windows: dict[str, float],
         rejected_examples: list[dict[str, Any]] | None = None,
+        moving_rejection_counts: dict[str, int] | None = None,
+        rejection_counts_by_source: dict[str, dict[str, int]] | None = None,
     ) -> None:
         """Persist selected-command diagnostics and update state."""
         self._last_command = (float(command[0]), float(command[1]))
@@ -1104,6 +1164,8 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             },
             "top_k": top_k,
             "rejection_counts": dict(sorted(rejection_counts.items())),
+            "moving_rejection_counts": dict(sorted((moving_rejection_counts or {}).items())),
+            "rejection_counts_by_source": rejection_counts_by_source or {},
             "rejected_examples": rejected_examples or [],
             "nearest_pedestrian_distance": _finite_or_none(nearest_ped),
             "nearest_static_obstacle_distance": _finite_or_none(nearest_static),

--- a/tests/planner/test_hybrid_rule_local_planner.py
+++ b/tests/planner/test_hybrid_rule_local_planner.py
@@ -453,6 +453,81 @@ def test_hybrid_rule_static_recenter_probe_prefers_safe_rotation(monkeypatch) ->
     assert last["selected_terms"]["static_recenter"] == pytest.approx(1.0)
 
 
+def test_hybrid_rule_rejection_diagnostics_include_moving_and_source_counts(monkeypatch) -> None:
+    """Decision diagnostics should attribute static rejection sources for trace analysis."""
+    cfg = HybridRuleLocalPlannerConfig(
+        linear_samples=2,
+        angular_samples=3,
+    )
+    planner = HybridRuleLocalPlannerAdapter(cfg)
+    planner._progress_history.extend([(0.0, 4.0), (1.0, 4.0), (2.0, 4.0)])
+    stop = HybridRuleCandidate(0.0, 0.0, "stop")
+    rotate = HybridRuleCandidate(0.0, 0.45, "rotate_left")
+    blocked_forward = HybridRuleCandidate(0.3, 0.0, "dynamic_window")
+
+    monkeypatch.setattr(
+        planner,
+        "_generate_candidates",
+        lambda state, speed_cap: [stop, rotate, blocked_forward],
+    )
+
+    def evaluate_candidate(
+        *,
+        candidate,
+        observation,
+        state,
+        speed_cap,
+        nearest_ped,
+        progress_windows,
+    ):
+        if candidate == blocked_forward:
+            return {
+                "accepted": False,
+                "reason": "static_clearance",
+                "candidate": candidate,
+                "min_static_clearance": 1.0,
+                "hard_static_clearance": 1.05,
+            }
+        terms = {
+            "goal_progress": 0.0,
+            "path_alignment": 0.9 if candidate == rotate else 0.8,
+            "speed_preference": 0.0,
+            "static_clearance": 1.0,
+            "dynamic_clearance": 1.0,
+            "time_to_collision_margin": 1.0,
+            "heading_smoothness": 0.8 if candidate == rotate else 1.0,
+            "velocity_smoothness": 1.0,
+            "control_effort": 0.8 if candidate == rotate else 1.0,
+            "freezing_penalty": 1.0,
+            "oscillation_penalty": 0.0,
+            "deadlock_escape": 0.0,
+            "static_recenter": 0.0,
+            "static_clearance_escape": 0.0,
+            "route_guide_commitment": 0.0,
+        }
+        return {
+            "accepted": True,
+            "candidate": candidate,
+            "score": 5.0 if candidate == stop else 4.8,
+            "terms": terms,
+            "min_static_clearance": 1.2,
+            "min_dynamic_clearance": float("inf"),
+            "predicted_ttc": float("inf"),
+        }
+
+    monkeypatch.setattr(planner, "_evaluate_candidate", evaluate_candidate)
+
+    command = planner.plan(_obs(goal=(4.0, 0.0)))
+
+    assert command == (0.0, 0.0)
+    last = planner.last_decision()
+    assert last is not None
+    assert last["planner_mode"] == "NORMAL"
+    assert last["selected_source"] == "stop"
+    assert last["moving_rejection_counts"] == {"static_clearance": 1}
+    assert last["rejection_counts_by_source"] == {"dynamic_window": {"static_clearance": 1}}
+
+
 def test_hybrid_rule_static_recovery_blocks_near_pedestrian() -> None:
     """Recovery should not rotate aggressively when a pedestrian is very close."""
     cfg = HybridRuleLocalPlannerConfig(recovery_enabled=True)


### PR DESCRIPTION
## Summary
Add source-level hybrid-rule rejection diagnostics so #884 traces can distinguish moving-command static-clearance blocks by candidate source. This is a diagnostic/blocker update, not a policy-resolution PR.

## Linked Issues
- Relates to #884

## What Changed
- Extracted candidate evaluation bookkeeping in `robot_sf/planner/hybrid_rule_local_planner.py` so each `last_decision()` includes `moving_rejection_counts` and `rejection_counts_by_source`.
- Added focused planner coverage for moving-command and per-source rejection attribution.
- Added `docs/context/issue_884_classic_merging_diagnostics.md` with the five-seed evidence and rejected recovery probes, and linked it from `docs/context/README.md`.

## Why It Matters
- Added value: future #884 work can see whether `dynamic_window`, `creep`, route-following, or `route_guide` candidates are blocked by static clearance instead of only seeing aggregate rejection counts.
- Expected impact: diagnostic clarity only; benchmark outcomes are intentionally unchanged.
- Why this is worth merging now: two plausible recovery mechanisms were tested and rejected, so the durable improvement is better attribution before the next corridor-aware policy attempt.

## Validation / Proof
- Commands run:
  - `rtk uv run ruff check robot_sf/planner/hybrid_rule_local_planner.py tests/planner/test_hybrid_rule_local_planner.py` -> `All checks passed!`.
  - `rtk uv run pytest tests/planner/test_hybrid_rule_local_planner.py -q` -> `21 passed`.
  - Five restored-config diagnostics under `output/ai/autoresearch/issue_884_diagnostics_after/` for `classic_merging_low` seeds `111`, `113` and `classic_merging_medium` seeds `111`, `112`, `113`.
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after merging latest `origin/main` -> `3210 passed, 14 skipped, 3 warnings`; changed-file coverage warning only for `robot_sf/planner/hybrid_rule_local_planner.py` at `85.7%`.
- Evidence that the change works here: final-step diagnostics now report `moving_rejection_counts` and `rejection_counts_by_source`; the four timeout seeds show moving static-clearance blocks split across `dynamic_window`, `creep`, `path_follow_0.5m`, and `route_guide`.
- Benchmarks or smoke tests, if applicable: rejected probes are documented in the context note and left under ignored local `output/` only.

## Risks / Rollout
- Compatibility risks: low; diagnostics are additive fields in the planner decision payload.
- Failure modes: consumers that assume an exact decision-key set could need to tolerate additional keys.
- Rollback or fallback plan: revert the diagnostic commit; no candidate config or benchmark policy change is required.

## Docs / Provenance
- Updated docs: `docs/context/issue_884_classic_merging_diagnostics.md`, `docs/context/README.md`.
- Relevant design or provenance notes: this PR explicitly rejects the static-corridor reorient and sampling overrides as benchmark improvements.
- Any assumptions that need to be preserved: fallback/degraded behavior and failed local probes are not success evidence.

## Follow-Up Issues
- Deferred work: #884 remains open for an actual route-completing classic-merging corridor policy.
- Issues opened for follow-up: none; #884 is the active follow-up scope.

## Reviewer Notes
- Verify closely that this PR does not modify `configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml` or promote the failed probes.
- Known limitation: this does not resolve the five classic-merging failures; it gives the next implementation the missing attribution needed to avoid repeating failed knobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive diagnostic documentation for Issue #884 detailing classic-merging behavior and rejection analysis.

* **Features**
  * Planner now captures rejection counts by source and moving rejection metrics in diagnostic output.

* **Tests**
  * Added test coverage for enhanced diagnostic fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->