### PR TITLE
feat: add multi-ped adversarial runtime slice (#870)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -199,6 +199,9 @@ why a change was made rather than a full issue execution transcript.
 * [Issue #944 Multi-Ped Adversarial Scenario Payload](issue_944_multi_ped_adversarial_scenario_payload.md)
   adds a template-merging manifest payload materializer for `adversarial-multi-ped.v1` configs, 
   stacked on the issue #936 override materializer.
+* [Issue #870 Multi-Ped Adversarial Runtime Slice](issue_870_multi_ped_adversarial_runtime.md)
+  adds a fail-closed config-to-`RobotSimulationConfig` runtime path with N>1 reset/step proof,
+  while keeping certification, policy-analysis smoke, and benchmark promotion out of scope.
 * [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
   scope, public surfaces, validation path, and known limits.
 * [Issue #930 CARLA T0 Neutral Export Schema](issue_930_carla_t0_export_schema.md)

--- a/docs/context/issue_870_multi_ped_adversarial_runtime.md
+++ b/docs/context/issue_870_multi_ped_adversarial_runtime.md
@@ -1,0 +1,69 @@
+# Issue #870 Multi-Ped Adversarial Runtime Slice
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/870>
+
+Predecessor notes:
+
+- [Issue #923 Multi-Ped Adversarial Candidate Schema](issue_923_multi_ped_adversarial_schema.md)
+- [Issue #936 Multi-Ped Adversarial Overrides](issue_936_multi_ped_adversarial_overrides.md)
+- [Issue #944 Multi-Ped Adversarial Scenario Payload](issue_944_multi_ped_adversarial_scenario_payload.md)
+
+## Goal
+
+This slice turns the existing `adversarial-multi-ped.v1` pure-data contract into a first runtime
+path that can build a `RobotSimulationConfig`, reset the Robot-SF environment, and step with N>1
+scripted adversarial pedestrians.
+
+## Public Surface
+
+- `robot_sf.adversarial.runtime.multi_ped_config_to_single_pedestrian_definitions(config)`
+- `robot_sf.adversarial.runtime.validate_multi_ped_runtime_plausibility(config, base_map, ...)`
+- `robot_sf.adversarial.runtime.build_multi_ped_adversarial_robot_config(config, base_map, ...)`
+- The same helpers are re-exported from `robot_sf.adversarial`.
+
+The runtime builder deep-copies the supplied base `MapDefinition`, replaces its
+`single_pedestrians` with the generated adversarial pedestrians, sets zero background pedestrian
+density, fixes the route-spawn seed to the adversarial scenario seed, and selects the generated map
+via `RobotSimulationConfig.map_id`.
+
+## Runtime Guardrails
+
+The new runtime check fails closed before environment construction when:
+
+- the schema-level config is invalid,
+- a scripted pedestrian speed exceeds the conservative runtime cap,
+- start or goal coordinates are outside the base map bounds,
+- start or goal coordinates are inside an obstacle or below the configured obstacle clearance,
+- two scripted pedestrians start closer than the configured start-separation threshold.
+
+Per-pedestrian adversarial metadata is now carried through `SinglePedestrianDefinition.metadata`,
+scenario-loader `single_pedestrians` overrides, and `populate_single_pedestrians(...)` metadata.
+
+## Scope Boundary
+
+This is a runtime smoke path, not the complete #870 epic. It does not yet add multiple scripted
+families, learned adversary training, policy-analysis smoke fixtures, scenario certification, replay
+certification, or benchmark-frozen case promotion. Treat generated scenarios as development stress
+tests until those later proof surfaces exist.
+
+## Validation
+
+TDD evidence for this branch:
+
+```bash
+uv run pytest tests/adversarial/test_adversarial_search.py -q
+```
+
+The RED run failed during collection with `ModuleNotFoundError: No module named
+'robot_sf.adversarial.runtime'`. After implementation, the same focused file passed with
+`32 passed`; the reset/step runtime smoke was the slowest case at about 19 seconds.
+
+Before PR handoff, run the broader targeted and readiness checks:
+
+```bash
+uv run pytest tests/adversarial/test_adversarial_search.py tests/test_multi_pedestrian.py -q
+uv run ruff check robot_sf/adversarial/runtime.py robot_sf/adversarial/__init__.py \
+  robot_sf/nav/map_config.py robot_sf/ped_npc/ped_population.py \
+  robot_sf/training/scenario_loader.py tests/adversarial/test_adversarial_search.py
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -14,6 +14,11 @@ from robot_sf.adversarial.materialize import (
     materialize_multi_ped_scenario_payload,
     materialize_multi_ped_single_pedestrian_overrides,
 )
+from robot_sf.adversarial.runtime import (
+    build_multi_ped_adversarial_robot_config,
+    multi_ped_config_to_single_pedestrian_definitions,
+    validate_multi_ped_runtime_plausibility,
+)
 from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
 from robot_sf.adversarial.search import run_adversarial_search
 
@@ -28,7 +33,10 @@ __all__ = [
     "SearchConfig",
     "SearchRunResult",
     "SearchSpaceConfig",
+    "build_multi_ped_adversarial_robot_config",
     "materialize_multi_ped_scenario_payload",
     "materialize_multi_ped_single_pedestrian_overrides",
+    "multi_ped_config_to_single_pedestrian_definitions",
     "run_adversarial_search",
+    "validate_multi_ped_runtime_plausibility",
 ]

--- a/robot_sf/adversarial/runtime.py
+++ b/robot_sf/adversarial/runtime.py
@@ -1,0 +1,234 @@
+"""Runtime adapters for scripted multi-pedestrian adversarial configs."""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from itertools import combinations
+from math import dist
+
+from shapely.geometry import Point
+
+from robot_sf.adversarial.config import MultiPedAdversarialConfig
+from robot_sf.adversarial.materialize import materialize_multi_ped_single_pedestrian_overrides
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool, SinglePedestrianDefinition
+from robot_sf.sim.sim_config import SimulationSettings
+
+DEFAULT_MIN_START_SEPARATION_M = 0.8
+DEFAULT_MIN_OBSTACLE_CLEARANCE_M = 0.05
+DEFAULT_MAX_SCRIPTED_SPEED_MPS = 2.5
+
+
+def multi_ped_config_to_single_pedestrian_definitions(
+    config: MultiPedAdversarialConfig,
+) -> list[SinglePedestrianDefinition]:
+    """Convert a multi-ped adversarial config into runtime single-pedestrian definitions.
+
+    Raises:
+        ValueError: If the config-level candidate contract is invalid.
+    """
+    errors = config.validate()
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    definitions: list[SinglePedestrianDefinition] = []
+    for entry in materialize_multi_ped_single_pedestrian_overrides(config):
+        definitions.append(
+            SinglePedestrianDefinition(
+                id=str(entry["id"]),
+                start=_tuple_point(entry["start"]),
+                goal=_tuple_point(entry["goal"]),
+                speed_m_s=float(entry["speed_m_s"]),
+                start_delay_s=float(entry["start_delay_s"]),
+                note=str(entry["note"]) if entry.get("note") is not None else None,
+                metadata=dict(entry.get("metadata") or {}),
+            )
+        )
+    return definitions
+
+
+def validate_multi_ped_runtime_plausibility(
+    config: MultiPedAdversarialConfig,
+    base_map: MapDefinition,
+    *,
+    min_start_separation_m: float = DEFAULT_MIN_START_SEPARATION_M,
+    min_obstacle_clearance_m: float = DEFAULT_MIN_OBSTACLE_CLEARANCE_M,
+    max_speed_mps: float = DEFAULT_MAX_SCRIPTED_SPEED_MPS,
+) -> list[str]:
+    """Return fail-closed runtime plausibility errors for a scripted multi-ped config."""
+    errors = config.validate()
+    if min_start_separation_m < 0.0:
+        errors.append("min_start_separation_m must be >= 0")
+    if min_obstacle_clearance_m < 0.0:
+        errors.append("min_obstacle_clearance_m must be >= 0")
+    if max_speed_mps <= 0.0:
+        errors.append("max_speed_mps must be > 0")
+    if errors:
+        return errors
+
+    for index, pedestrian in enumerate(config.pedestrians):
+        if pedestrian.speed_mps > max_speed_mps:
+            errors.append(
+                f"pedestrians[{index}] speed_mps ({pedestrian.speed_mps:.3f}) exceeds "
+                f"max_speed_mps ({max_speed_mps:.3f})"
+            )
+        start = pedestrian.start.x, pedestrian.start.y
+        goal = pedestrian.goal.x, pedestrian.goal.y
+        errors.extend(
+            _point_runtime_errors(
+                start,
+                label=f"pedestrians[{index}].start",
+                base_map=base_map,
+                min_obstacle_clearance_m=min_obstacle_clearance_m,
+            )
+        )
+        errors.extend(
+            _point_runtime_errors(
+                goal,
+                label=f"pedestrians[{index}].goal",
+                base_map=base_map,
+                min_obstacle_clearance_m=min_obstacle_clearance_m,
+            )
+        )
+
+    for left, right in combinations(config.pedestrians, 2):
+        separation = dist((left.start.x, left.start.y), (right.start.x, right.start.y))
+        if separation < min_start_separation_m:
+            errors.append(
+                f"pedestrians '{left.id}' and '{right.id}' start separation "
+                f"({separation:.3f}m) is less than min_start_separation_m "
+                f"({min_start_separation_m:.3f}m)"
+            )
+    return errors
+
+
+def build_multi_ped_adversarial_robot_config(
+    config: MultiPedAdversarialConfig,
+    base_map: MapDefinition,
+    *,
+    map_id: str | None = None,
+    min_start_separation_m: float = DEFAULT_MIN_START_SEPARATION_M,
+    min_obstacle_clearance_m: float = DEFAULT_MIN_OBSTACLE_CLEARANCE_M,
+    max_speed_mps: float = DEFAULT_MAX_SCRIPTED_SPEED_MPS,
+    sim_time_in_secs: float = 30.0,
+    time_per_step_in_secs: float = 0.1,
+) -> RobotSimulationConfig:
+    """Build a robot environment config for a scripted multi-ped adversarial scenario.
+
+    The returned config uses a deep-copied map with the generated adversarial
+    ``single_pedestrians`` and zero background pedestrian density. This helper proves the
+    environment reset/step path; it does not certify the scenario as benchmark-frozen.
+
+    Raises:
+        ValueError: If config or runtime plausibility checks fail.
+    """
+    errors = validate_multi_ped_runtime_plausibility(
+        config,
+        base_map,
+        min_start_separation_m=min_start_separation_m,
+        min_obstacle_clearance_m=min_obstacle_clearance_m,
+        max_speed_mps=max_speed_mps,
+    )
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    runtime_map_id = map_id or _default_map_id(config)
+    runtime_map = _copy_map_with_single_pedestrians(
+        base_map,
+        multi_ped_config_to_single_pedestrian_definitions(config),
+    )
+    sim_config = SimulationSettings(
+        sim_time_in_secs=sim_time_in_secs,
+        time_per_step_in_secs=time_per_step_in_secs,
+        ped_density_by_difficulty=[0.0],
+        difficulty=0,
+        route_spawn_seed=int(config.scenario_seed),
+        max_total_pedestrians=len(config.pedestrians),
+    )
+    return RobotSimulationConfig(
+        sim_config=sim_config,
+        map_pool=MapDefinitionPool(map_defs={runtime_map_id: runtime_map}),
+        map_id=runtime_map_id,
+    )
+
+
+def _copy_map_with_single_pedestrians(
+    base_map: MapDefinition,
+    single_pedestrians: list[SinglePedestrianDefinition],
+) -> MapDefinition:
+    """Return a validated deep copy of a map with explicit single pedestrians replaced."""
+    return MapDefinition(
+        width=base_map.width,
+        height=base_map.height,
+        obstacles=deepcopy(base_map.obstacles),
+        robot_spawn_zones=deepcopy(base_map.robot_spawn_zones),
+        ped_spawn_zones=deepcopy(base_map.ped_spawn_zones),
+        robot_goal_zones=deepcopy(base_map.robot_goal_zones),
+        bounds=deepcopy(base_map.bounds),
+        robot_routes=deepcopy(base_map.robot_routes),
+        ped_goal_zones=deepcopy(base_map.ped_goal_zones),
+        ped_crowded_zones=deepcopy(base_map.ped_crowded_zones),
+        ped_routes=deepcopy(base_map.ped_routes),
+        single_pedestrians=single_pedestrians,
+        poi_positions=deepcopy(base_map.poi_positions),
+        poi_labels=deepcopy(base_map.poi_labels),
+        allowed_areas=deepcopy(base_map.allowed_areas),
+    )
+
+
+def _point_runtime_errors(
+    point: tuple[float, float],
+    *,
+    label: str,
+    base_map: MapDefinition,
+    min_obstacle_clearance_m: float,
+) -> list[str]:
+    """Return runtime errors for one candidate point."""
+    errors: list[str] = []
+    x, y = point
+    if not (0.0 <= x <= base_map.width and 0.0 <= y <= base_map.height):
+        errors.append(
+            f"{label} ({x:.3f}, {y:.3f}) is outside map bounds "
+            f"(0, 0) to ({base_map.width:.3f}, {base_map.height:.3f})"
+        )
+        return errors
+
+    shapely_point = Point(point)
+    for obstacle_index, obstacle in enumerate(base_map.obstacles):
+        if obstacle.contains_point(point):
+            errors.append(f"{label} ({x:.3f}, {y:.3f}) is inside obstacle {obstacle_index}")
+            continue
+        geometry = getattr(obstacle, "geometry", None)
+        if geometry is None or min_obstacle_clearance_m <= 0.0:
+            continue
+        clearance = float(geometry.distance(shapely_point))
+        if clearance < min_obstacle_clearance_m:
+            errors.append(
+                f"{label} ({x:.3f}, {y:.3f}) obstacle clearance ({clearance:.3f}m) is less "
+                f"than min_obstacle_clearance_m ({min_obstacle_clearance_m:.3f}m)"
+            )
+    return errors
+
+
+def _tuple_point(value: object) -> tuple[float, float]:
+    """Coerce a materialized point into a runtime tuple."""
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"point must be a 2-item list or tuple, got: {value!r}")
+    return (float(value[0]), float(value[1]))
+
+
+def _default_map_id(config: MultiPedAdversarialConfig) -> str:
+    """Return a stable map id for an adversarial runtime map."""
+    family = re.sub(r"[^A-Za-z0-9_]+", "_", config.family).strip("_") or "multi_ped"
+    return f"{family}_multi_ped_adversarial_{int(config.scenario_seed):04d}"
+
+
+__all__ = [
+    "DEFAULT_MAX_SCRIPTED_SPEED_MPS",
+    "DEFAULT_MIN_OBSTACLE_CLEARANCE_M",
+    "DEFAULT_MIN_START_SEPARATION_M",
+    "build_multi_ped_adversarial_robot_config",
+    "multi_ped_config_to_single_pedestrian_definitions",
+    "validate_multi_ped_runtime_plausibility",
+]

--- a/robot_sf/nav/map_config.py
+++ b/robot_sf/nav/map_config.py
@@ -6,6 +6,7 @@ import os
 import random
 from dataclasses import dataclass, field
 from math import sqrt
+from typing import Any
 
 import matplotlib.axes
 import matplotlib.patches as mpl_patches
@@ -59,6 +60,7 @@ class SinglePedestrianDefinition:
         role (str | None): Optional runtime behavior role (wait, follow, lead, accompany, join, leave).
         role_target_id (str | None): Optional target identifier for role behaviors (e.g., "robot:0").
         role_offset (Vec2D | None): Optional (forward, lateral) offset for follow/lead/accompany roles.
+        metadata (dict[str, Any]): Optional JSON/YAML-safe attribution metadata.
     """
 
     id: str
@@ -72,6 +74,7 @@ class SinglePedestrianDefinition:
     role: str | None = None
     role_target_id: str | None = None
     role_offset: Vec2D | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         """
@@ -93,6 +96,7 @@ class SinglePedestrianDefinition:
         self._validate_role()
         self._validate_role_target()
         self._validate_role_offset()
+        self._validate_metadata()
         self._warn_if_static()
 
     def _validate_id(self):
@@ -258,6 +262,14 @@ class SinglePedestrianDefinition:
                 f"got {self.role_offset!r}"
             )
         self.role_offset = (float(self.role_offset[0]), float(self.role_offset[1]))
+
+    def _validate_metadata(self) -> None:
+        """Validate and copy optional per-pedestrian metadata."""
+        if not isinstance(self.metadata, dict):
+            raise ValueError(
+                f"Pedestrian '{self.id}': metadata must be a mapping, got {self.metadata!r}"
+            )
+        self.metadata = dict(self.metadata)
 
 
 @dataclass
@@ -979,6 +991,13 @@ def _parse_single_pedestrians(
         role = ped_def.get("role")
         role_target_id = ped_def.get("role_target_id")
         role_offset = ped_def.get("role_offset")
+        metadata = ped_def.get("metadata", {})
+        if metadata is None:
+            metadata = {}
+        if not isinstance(metadata, dict):
+            raise ValueError(
+                f"single_pedestrians metadata for '{ped_id}' must be a mapping, got: {metadata!r}"
+            )
         role_target_value = str(role_target_id) if role_target_id is not None else None
         role_offset_tuple = None
         if role_offset is not None:
@@ -1001,6 +1020,7 @@ def _parse_single_pedestrians(
                 role=str(role) if role is not None else None,
                 role_target_id=role_target_value,
                 role_offset=role_offset_tuple,
+                metadata=dict(metadata),
             )
         )
     return single_pedestrians

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -647,6 +647,7 @@ def populate_single_pedestrians(
                 "role": ped.role,
                 "role_target_id": ped.role_target_id,
                 "role_offset": ped.role_offset,
+                "metadata": dict(getattr(ped, "metadata", {}) or {}),
             }
         )
 

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1502,6 +1502,27 @@ def _resolve_role_overrides(
     return role, role_target_id, role_offset
 
 
+def _resolve_metadata_override(
+    ped: SinglePedestrianDefinition,
+    entry: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve additive per-pedestrian metadata from a scenario override.
+
+    Returns:
+        dict[str, Any]: Existing metadata merged with override metadata when present.
+    """
+    if "metadata" not in entry:
+        return dict(ped.metadata)
+    raw_metadata = entry.get("metadata")
+    if raw_metadata is None:
+        return {}
+    if not isinstance(raw_metadata, Mapping):
+        raise ValueError(f"single_pedestrians '{ped.id}' metadata must be a mapping")
+    metadata = dict(ped.metadata)
+    metadata.update(dict(raw_metadata))
+    return metadata
+
+
 def _apply_single_pedestrian_override(
     ped: SinglePedestrianDefinition,
     entry: Mapping[str, Any],
@@ -1523,6 +1544,7 @@ def _apply_single_pedestrian_override(
     start_delay_s = _resolve_start_delay_override(ped, entry)
     note = _resolve_note_override(ped, entry)
     role, role_target_id, role_offset = _resolve_role_overrides(ped, entry)
+    metadata = _resolve_metadata_override(ped, entry)
 
     return SinglePedestrianDefinition(
         id=ped.id,
@@ -1536,6 +1558,7 @@ def _apply_single_pedestrian_override(
         role=role,
         role_target_id=role_target_id,
         role_offset=role_offset,
+        metadata=metadata,
     )
 
 

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -28,7 +28,16 @@ from robot_sf.adversarial.materialize import (
     materialize_multi_ped_scenario_payload,
     materialize_multi_ped_single_pedestrian_overrides,
 )
+from robot_sf.adversarial.runtime import (
+    build_multi_ped_adversarial_robot_config,
+    multi_ped_config_to_single_pedestrian_definitions,
+)
 from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
+from robot_sf.gym_env.environment_factory import make_robot_env
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition
+from robot_sf.nav.obstacle import Obstacle
+from robot_sf.ped_npc.ped_population import populate_single_pedestrians
 
 
 def _write_template(path: Path) -> None:
@@ -113,6 +122,70 @@ def _candidate(seed: int, *, goal_x: float = 5.0) -> CandidateSpec:
         pedestrian_speed_mps=1.0,
         pedestrian_delay_s=0.0,
         scenario_seed=seed,
+    )
+
+
+def _runtime_base_map(*, obstacles: list[Obstacle] | None = None) -> MapDefinition:
+    width, height = 8.0, 6.0
+    robot_spawn_zones = [((0.5, 0.5), (1.0, 0.5), (1.0, 1.0))]
+    robot_goal_zones = [((7.0, 5.0), (7.5, 5.0), (7.5, 5.5))]
+    robot_routes = [
+        GlobalRoute(
+            spawn_id=0,
+            goal_id=0,
+            waypoints=[(0.75, 0.75), (4.0, 3.0), (7.25, 5.25)],
+            spawn_zone=robot_spawn_zones[0],
+            goal_zone=robot_goal_zones[0],
+        )
+    ]
+    return MapDefinition(
+        width=width,
+        height=height,
+        obstacles=obstacles or [],
+        robot_spawn_zones=robot_spawn_zones,
+        ped_spawn_zones=[],
+        robot_goal_zones=robot_goal_zones,
+        bounds=[
+            (0.0, width, 0.0, 0.0),
+            (0.0, width, height, height),
+            (0.0, 0.0, 0.0, height),
+            (width, width, 0.0, height),
+        ],
+        robot_routes=robot_routes,
+        ped_goal_zones=[],
+        ped_crowded_zones=[],
+        ped_routes=[],
+        single_pedestrians=[],
+    )
+
+
+def _runtime_multi_ped_config(
+    *,
+    second_start_y: float = 3.2,
+    first_start: Pose2D | None = None,
+) -> MultiPedAdversarialConfig:
+    return MultiPedAdversarialConfig(
+        family="group_squeeze",
+        scenario_seed=41,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="left_blocker",
+                start=first_start or Pose2D(1.5, 2.0),
+                goal=Pose2D(6.5, 2.0),
+                spawn_time_s=0.2,
+                speed_mps=1.1,
+                delay_s=0.1,
+                metadata={"lane": "left"},
+            ),
+            MultiPedCandidateSpec(
+                id="right_blocker",
+                start=Pose2D(1.5, second_start_y),
+                goal=Pose2D(6.5, second_start_y),
+                spawn_time_s=0.4,
+                speed_mps=1.2,
+                metadata={"lane": "right"},
+            ),
+        ],
     )
 
 
@@ -459,6 +532,74 @@ def test_multi_ped_materialized_scenario_payload_is_yaml_safe() -> None:
     assert loaded["scenarios"][0]["metadata"]["adversarial_multi_ped"]["schema_version"] == (
         "adversarial-multi-ped.v1"
     )
+
+
+def test_multi_ped_config_converts_to_runtime_single_pedestrians_with_metadata() -> None:
+    """Runtime definitions should preserve adversarial attribution metadata per pedestrian."""
+    config = _runtime_multi_ped_config()
+
+    ped_defs = multi_ped_config_to_single_pedestrian_definitions(config)
+    _ped_states, population_metadata = populate_single_pedestrians(ped_defs)
+
+    assert [ped.id for ped in ped_defs] == ["left_blocker", "right_blocker"]
+    assert ped_defs[0].start == (1.5, 2.0)
+    assert ped_defs[0].goal == (6.5, 2.0)
+    assert ped_defs[0].speed_m_s == pytest.approx(1.1)
+    assert ped_defs[0].start_delay_s == pytest.approx(0.3)
+    assert ped_defs[0].metadata["adversarial_family"] == "group_squeeze"
+    assert ped_defs[0].metadata["pedestrian_metadata"] == {"lane": "left"}
+    assert population_metadata[0]["metadata"]["adversarial_scenario_seed"] == 41
+
+
+def test_multi_ped_adversarial_runtime_config_resets_and_steps() -> None:
+    """A validated N>1 multi-ped config should run through the robot env reset/step path."""
+    config = _runtime_multi_ped_config()
+    base_map = _runtime_base_map()
+    robot_config = build_multi_ped_adversarial_robot_config(
+        config,
+        base_map,
+        map_id="issue_870_runtime",
+        sim_time_in_secs=1.0,
+    )
+
+    assert base_map.single_pedestrians == []
+    runtime_map = robot_config.map_pool.get_map("issue_870_runtime")
+    assert len(runtime_map.single_pedestrians) == 2
+    assert runtime_map.single_pedestrians[1].metadata["pedestrian_metadata"] == {"lane": "right"}
+
+    env = make_robot_env(config=robot_config, debug=True, seed=config.scenario_seed)
+    try:
+        _obs, _info = env.reset(seed=config.scenario_seed)
+        first_reset_positions = env.simulator.ped_pos.copy()
+
+        assert env.simulator.ped_pos.shape[0] >= 2
+        for _ in range(3):
+            _obs, _reward, terminated, truncated, _info = env.step(env.action_space.sample())
+            if terminated or truncated:
+                break
+
+        env.reset(seed=config.scenario_seed)
+        assert env.simulator.ped_pos.shape == first_reset_positions.shape
+        assert (env.simulator.ped_pos == first_reset_positions).all()
+    finally:
+        env.close()
+
+
+def test_multi_ped_adversarial_runtime_rejects_impossible_initial_collision() -> None:
+    """Runtime plausibility checks should fail closed on overlapping starts."""
+    config = _runtime_multi_ped_config(second_start_y=2.1)
+
+    with pytest.raises(ValueError, match="start separation"):
+        build_multi_ped_adversarial_robot_config(config, _runtime_base_map())
+
+
+def test_multi_ped_adversarial_runtime_rejects_obstacle_intersection() -> None:
+    """Runtime plausibility checks should fail closed when a pedestrian starts in an obstacle."""
+    obstacle = Obstacle([(1.0, 1.5), (2.0, 1.5), (2.0, 2.5), (1.0, 2.5)])
+    config = _runtime_multi_ped_config(first_start=Pose2D(1.5, 2.0))
+
+    with pytest.raises(ValueError, match="inside obstacle"):
+        build_multi_ped_adversarial_robot_config(config, _runtime_base_map(obstacles=[obstacle]))
 
 
 def test_programmatic_search_scores_candidates_without_subprocess(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds the first runtime slice for #870: validated `adversarial-multi-ped.v1` configs can now build a `RobotSimulationConfig`, reset the robot environment, and step with N>1 scripted adversarial pedestrians.

## Linked Issues
- Relates to #870
- Follow-up #1015

## What Changed
- Added `robot_sf.adversarial.runtime` with config-to-`SinglePedestrianDefinition` conversion, fail-closed runtime plausibility checks, and a config-to-`RobotSimulationConfig` builder.
- Added additive per-pedestrian metadata plumbing through `SinglePedestrianDefinition`, SVG/map parsing, scenario-loader single-ped overrides, and `populate_single_pedestrians(...)`.
- Added focused tests for metadata preservation, N>1 reset/step, deterministic reset positions, overlapping-start rejection, and obstacle-intersection rejection.
- Added `docs/context/issue_870_multi_ped_adversarial_runtime.md` and indexed it from `docs/context/README.md`.

## Why It Matters
- Added value: turns the prior schema/pure-data work under #870 into an executable Robot-SF runtime path.
- Expected impact: future scripted adversarial family runners can reuse a single fail-closed adapter instead of duplicating map mutation and plausibility checks.
- Why this is worth merging now: it proves reset/step behavior before adding benchmark-facing family suites or certification logic.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/adversarial/test_adversarial_search.py -q` initially failed during collection with `ModuleNotFoundError: No module named 'robot_sf.adversarial.runtime'`.
  - `rtk uv run pytest tests/adversarial/test_adversarial_search.py -q` passed with `32 passed`.
  - `rtk uv run ruff check robot_sf/adversarial/runtime.py robot_sf/adversarial/__init__.py robot_sf/nav/map_config.py robot_sf/ped_npc/ped_population.py robot_sf/training/scenario_loader.py tests/adversarial/test_adversarial_search.py` passed.
  - `rtk uv run pytest tests/adversarial/test_adversarial_search.py tests/test_multi_pedestrian.py -q` passed with `34 passed`.
  - `rtk uv run pytest tests/test_single_pedestrian.py tests/training/test_scenario_loader.py -q` passed with `42 passed`.
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` passed after merging latest `origin/main` on commit `ba82f3b04965bf046158f4821f253c8c1f773c6e` with `3214 passed, 14 skipped, 3 warnings in 406.25s`.
  - `rtk uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` reports `fresh: true`.
- Evidence that the change works here: the new runtime smoke resets and steps a generated N=2 adversarial pedestrian map, then verifies seeded reset positions are stable.
- Benchmarks or smoke tests, if applicable: this is a development stress-test runtime smoke, not a benchmark certification run.

## Risks / Rollout
- Compatibility risks: `SinglePedestrianDefinition.metadata` is additive and defaults to `{}`; existing callers do not need to set it.
- Failure modes: the runtime builder intentionally raises `ValueError` for invalid config, out-of-bounds points, obstacle intersections/clearance, excessive speed, or overlapping starts.
- Rollback or fallback plan: revert this commit to remove the new runtime helper and metadata propagation; existing pure-data materializers remain conceptually separate.

## Docs / Provenance
- Updated docs: `docs/context/issue_870_multi_ped_adversarial_runtime.md`, `docs/context/README.md`.
- Relevant design or provenance notes: predecessor #923/#936/#944 notes remain the schema and pure-data bridge history.
- Any assumptions that need to be preserved: generated multi-ped scenarios are development stress tests until separately certified and replay-proven.
- Artifact persistence: ignored `output/coverage/*` and `output/validation/pr_ready/870-multi-ped-adversarial-runtime.json` are disposable local validation byproducts; no code or docs depend on them.

## Follow-Up Issues
- Deferred work: multiple scripted families, policy-analysis smoke, episode-record attribution proof, and certification/replay promotion boundaries.
- Issues opened for follow-up: #1015.

## Reviewer Notes
- Verify the runtime builder's fail-closed boundary in `robot_sf/adversarial/runtime.py`.
- Check that metadata propagation is additive and does not change existing single-pedestrian behavior.
- Known limitation: this PR does not close #870; it is a bounded runtime slice under the parent epic.
