### PR TITLE
fix: reject invalid policy stack proposals (#871)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -155,6 +155,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1004 Policy Stack V1 Runtime](issue_1004_policy_stack_v1_runtime.md)
   records the first runnable `policy_stack_v1` slice, its explicit proposal-status diagnostics, and
   the map-runner smoke limitation under parent #871.
+* [Issue #871 Policy Stack Proposal Normalization](issue_871_policy_stack_proposal_normalization.md)
+  hardens `policy_stack_v1` so malformed, non-finite, or command-bounds-violating child proposals
+  are rejected before risk scoring.
 
 ## Map Coverage Notes
 

--- a/docs/context/issue_871_policy_stack_proposal_normalization.md
+++ b/docs/context/issue_871_policy_stack_proposal_normalization.md
@@ -1,0 +1,51 @@
+# Issue #871 Policy Stack Proposal Normalization
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/871>
+
+Predecessor note:
+
+- [Issue #1004 Policy Stack V1 Runtime](issue_1004_policy_stack_v1_runtime.md)
+
+## Goal
+
+This slice tightens the `policy_stack_v1` proposal boundary after the first runnable runtime PR.
+Child proposal sources must now return finite two-value commands inside the configured linear and
+angular speed bounds before they can enter risk scoring.
+
+## Decision
+
+`PolicyStackV1Adapter` normalizes every command-producing proposal through a common helper:
+
+- malformed command shapes become `rejected`,
+- non-finite commands become `rejected`,
+- commands outside `max_linear_speed` or `max_angular_speed` become `rejected`,
+- rejected mandatory sources fail closed just like failed or unavailable mandatory sources.
+
+Rejected proposal diagnostics now contribute to both `proposal_status_counts["rejected"]` and the
+step-level `rejected_count`, so episode diagnostics reflect invalid proposals instead of silently
+scoring them.
+
+## Scope Boundary
+
+This is not the full #871 portfolio planner. It does not add new proposal families, route/subgoal
+rebasing, learned scorers, topology-heavy proof, or paper-facing benchmark promotion. It only
+hardens the existing minimal `goal` + `risk_dwa` runtime slice against invalid child commands.
+
+## Validation
+
+TDD evidence for this branch:
+
+```bash
+uv run pytest tests/planner/test_policy_stack_v1.py -q
+```
+
+The RED run failed because invalid Risk-DWA commands were still reported as `adapter` proposals.
+After implementation, the focused planner test file passed with `8 passed`.
+
+Focused lint:
+
+```bash
+uv run ruff check robot_sf/planner/policy_stack_v1.py tests/planner/test_policy_stack_v1.py
+```
+
+Result: `All checks passed!`

--- a/robot_sf/planner/policy_stack_v1.py
+++ b/robot_sf/planner/policy_stack_v1.py
@@ -155,10 +155,11 @@ class PolicyStackV1Adapter:
                 f"hard stop clearance below {float(self.config.hard_stop_clearance):.3f} m"
             )
 
-        rejected_count = max(len(candidates) - 1, 0)
+        additional_rejected_count = max(len(candidates) - 1, 0)
         if shield_intervened:
-            rejected_count += 1
-        step_status_counts["rejected"] += rejected_count
+            additional_rejected_count += 1
+        step_status_counts["rejected"] += additional_rejected_count
+        rejected_count = step_status_counts["rejected"]
 
         failed_count = step_status_counts["failed"]
         unavailable_count = step_status_counts["not_available"]
@@ -207,7 +208,7 @@ class PolicyStackV1Adapter:
             key = _normalize_source(source)
             proposal = self._proposal_from_source(key, observation)
             if (
-                proposal.status in {"failed", "not_available"}
+                proposal.status in {"failed", "not_available", "rejected"}
                 and key in self.config.mandatory_sources
             ):
                 reason = proposal.reason or proposal.status.replace("_", " ")
@@ -218,18 +219,51 @@ class PolicyStackV1Adapter:
     def _proposal_from_source(self, key: str, observation: dict[str, Any]) -> _Proposal:
         status = self._source_mode(key)
         if key == "goal":
-            return _Proposal(key=key, status=status, command=self._goal_command(observation))
+            return self._command_proposal(
+                key=key, status=status, command=self._goal_command(observation)
+            )
         if key == "risk_dwa":
             try:
                 command = self.risk_dwa.plan(observation)
             except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
                 return _Proposal(key=key, status="failed", reason=str(exc))
+            return self._command_proposal(key=key, status=status, command=command)
+        return _Proposal(key=key, status="not_available", reason="not available")
+
+    def _command_proposal(
+        self,
+        *,
+        key: str,
+        status: str,
+        command: object,
+    ) -> _Proposal:
+        """Return a proposal with a normalized command or a rejected diagnostic."""
+        try:
+            values = np.asarray(command, dtype=float).reshape(-1)
+        except (TypeError, ValueError) as exc:
+            return _Proposal(key=key, status="rejected", reason=f"invalid command: {exc}")
+        if values.size != 2:
             return _Proposal(
                 key=key,
-                status=status,
-                command=(float(command[0]), float(command[1])),
+                status="rejected",
+                reason=f"invalid command shape: expected 2 values, got {values.size}",
             )
-        return _Proposal(key=key, status="not_available", reason="not available")
+        linear, angular = float(values[0]), float(values[1])
+        if not np.isfinite([linear, angular]).all():
+            return _Proposal(key=key, status="rejected", reason="non-finite command")
+        if abs(linear) > float(self.config.max_linear_speed) or abs(angular) > float(
+            self.config.max_angular_speed
+        ):
+            return _Proposal(
+                key=key,
+                status="rejected",
+                reason=(
+                    "outside configured command bounds: "
+                    f"linear={linear:.3f} max={float(self.config.max_linear_speed):.3f}, "
+                    f"angular={angular:.3f} max={float(self.config.max_angular_speed):.3f}"
+                ),
+            )
+        return _Proposal(key=key, status=status, command=(linear, angular))
 
     def _source_mode(self, key: str) -> str:
         if key in self.config.fallback_sources:

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -98,6 +98,48 @@ def test_policy_stack_records_failed_and_not_available_without_fallback_success(
     assert "not available" in last["rejection_reasons"]["missing_optional"]
 
 
+def test_policy_stack_rejects_nonfinite_adapter_command_before_scoring() -> None:
+    """Non-finite adapter commands should be rejected instead of entering risk scoring."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(proposal_sources=("goal", "risk_dwa")),
+        risk_dwa=_DummyRiskDWA(command=(float("nan"), 0.0)),
+    )
+
+    command = stack.plan(_obs())
+    last = stack.diagnostics()["last_step"]
+
+    assert command[0] > 0.0
+    assert last["selected_proposal_key"] == "goal"
+    assert last["proposal_statuses"]["risk_dwa"] == "rejected"
+    assert last["proposal_status_counts"]["rejected"] == 1
+    assert last["rejected_count"] == 1
+    assert "non-finite command" in last["rejection_reasons"]["risk_dwa"]
+    assert set(last["risk_score_components"]) == {"goal"}
+    json.dumps(stack.diagnostics(), allow_nan=False)
+
+
+def test_policy_stack_rejects_adapter_command_outside_configured_bounds() -> None:
+    """Out-of-bounds adapter commands should fail closed at the proposal boundary."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal", "risk_dwa"),
+            max_linear_speed=0.8,
+            max_angular_speed=0.6,
+        ),
+        risk_dwa=_DummyRiskDWA(command=(1.5, 0.8)),
+    )
+
+    command = stack.plan(_obs())
+    last = stack.diagnostics()["last_step"]
+
+    assert command[0] > 0.0
+    assert last["proposal_statuses"]["risk_dwa"] == "rejected"
+    assert last["proposal_status_counts"]["rejected"] == 1
+    assert last["rejected_count"] == 1
+    assert "outside configured command bounds" in last["rejection_reasons"]["risk_dwa"]
+    assert set(last["risk_score_components"]) == {"goal"}
+
+
 def test_policy_stack_fail_closes_when_mandatory_source_is_unavailable() -> None:
     """Mandatory proposal source gaps should raise instead of becoming fallback success."""
     stack = PolicyStackV1Adapter(


### PR DESCRIPTION
## Summary
Hardens the existing `policy_stack_v1` runtime slice by rejecting malformed, non-finite, or command-bounds-violating child proposal commands before risk scoring.

## Linked Issues
- Relates to #871

## What Changed
- Added proposal command normalization in `PolicyStackV1Adapter`.
- Non-finite commands, malformed command shapes, and commands outside configured linear/angular bounds now become `rejected` proposals with explicit diagnostics.
- Rejected mandatory proposal sources now fail closed instead of being allowed to continue.
- Updated `rejected_count` so rejected proposal statuses contribute to step and episode diagnostics.
- Added tests and a context note for this #871 child slice.
- Synced the branch onto current `origin/main` after PRs #1014, #1016, and #1018; resolved the `docs/context/README.md` index conflict by preserving both issue-note entries.

## Why It Matters
- Added value: prevents invalid child planner output from contaminating policy-stack risk scores or JSON diagnostics.
- Expected impact: keeps the portfolio proposal interface stricter and more auditable before adding more planner families.
- Why this is worth merging now: #1004 made `policy_stack_v1` runnable; this closes a concrete proposal-normalization gap from the parent #871 contract.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/planner/test_policy_stack_v1.py -q` initially failed with two expected assertions because invalid Risk-DWA commands were still reported as `adapter` proposals.
  - `rtk uv run pytest tests/planner/test_policy_stack_v1.py -q` on refreshed head `464035d6c3011e4800364d13bca4982ded1b459f` -> 8 passed in 22.48s.
  - `rtk uv run ruff check robot_sf/planner/policy_stack_v1.py tests/planner/test_policy_stack_v1.py docs/context/README.md docs/context/issue_871_policy_stack_proposal_normalization.md` -> All checks passed.
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` on final head `405dbc274a94110273bfb06354c94b329f9d85d8` -> 3218 passed, 14 skipped, 3 warnings in 405.26s.
  - Changed-file coverage warning only: `robot_sf/planner/policy_stack_v1.py` 93.7%; no TODO docstrings found in touched definitions.
  - `rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` -> passed stamp at `output/validation/pr_ready/871-policy-stack-proposal-normalization.json` for head `405dbc274a94110273bfb06354c94b329f9d85d8`.
  - Hosted CI for `405dbc274a94110273bfb06354c94b329f9d85d8` completed successfully as run 25410480480.
- Evidence that the change works here: focused tests prove non-finite and out-of-bounds adapter commands are rejected before scoring and omitted from `risk_score_components`.
- Benchmarks or smoke tests, if applicable: this is a unit-level proposal-interface hardening slice, not a planner-quality benchmark run.

## Risks / Rollout
- Compatibility risks: stricter command validation can reject adapter outputs that previously made it to scoring; this is intended for invalid commands.
- Failure modes: a mandatory source returning an invalid command now raises as unavailable/rejected rather than silently falling through.
- Rollback or fallback plan: revert this commit to restore the prior permissive proposal behavior.

## Docs / Provenance
- Updated docs: `docs/context/issue_871_policy_stack_proposal_normalization.md`, `docs/context/README.md`.
- Relevant design or provenance notes: builds on `docs/context/issue_1004_policy_stack_v1_runtime.md` and the #926 contract note.
- Any assumptions that need to be preserved: `policy_stack_v1` remains experimental and not paper-facing until representative scenario proof exists.
- Artifact persistence: ignored `output/coverage/*` and `output/validation/pr_ready/871-policy-stack-proposal-normalization.json` are disposable local validation byproducts; no code or docs depend on them.

## Follow-Up Issues
- Deferred work: richer proposal families, route/subgoal handoff proof, topology-heavy smoke, and paper-facing promotion remain on parent #871.
- Issues opened for follow-up: none; the parent #871 remains the active tracker for the remaining portfolio-planner acceptance criteria.

## Reviewer Notes
- Verify that rejected proposal statuses are counted once and that only accepted commands enter `risk_score_components`.
- Known limitation: this PR does not close #871; it is a bounded hardening slice under the parent epic.