### PR TITLE
fix: add guarded static corridor transit (#884)

### DIFF
--- a/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+++ b/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
@@ -11,6 +11,11 @@ params:
   static_recenter_enabled: true
   static_recenter_weight: 0.7
   static_recenter_probe_speed: 0.3
+  static_corridor_transit_enabled: true
+  static_corridor_transit_initial_band: 0.08
+  static_corridor_transit_tolerance: 0.08
+  static_corridor_transit_min_progress_3s: 0.1
+  static_corridor_transit_weight: 0.5
 scenario_overrides:
   francis2023_perpendicular_traffic:
     very_slow_speed: 0.6

--- a/docs/context/issue_884_classic_merging_diagnostics.md
+++ b/docs/context/issue_884_classic_merging_diagnostics.md
@@ -10,9 +10,14 @@ Resolve the remaining `classic_merging_low` and `classic_merging_medium` failure
 `hybrid_rule_v3_fast_progress_static_escape` policy-search candidate without weakening the hard
 static-collision gate or counting fallback/degraded execution as success.
 
-This pass did not find a PR-safe merge-policy fix. It adds reusable decision diagnostics and records
-two rejected mechanisms so the next attempt can start from concrete trace evidence rather than
-repeat the same tuning loop.
+The first pass did not find a PR-safe merge-policy fix. It added reusable decision diagnostics and
+recorded two rejected mechanisms so the next attempt could start from concrete trace evidence
+rather than repeat the same tuning loop.
+
+A follow-up guarded static-corridor transit mechanism recovered one of the five named seeds and
+removed the low-density obstacle collision, while preserving the retained horizon-500 nominal and
+stress gates. It is still a partial improvement: four named classic-merging seeds remain timeouts,
+so #884 is not closed by this note.
 
 ## Diagnostic Change
 
@@ -52,6 +57,55 @@ clearance. The collision trace remains the unsafe side of the same corridor fami
 making progress until an obstacle collision.
 
 ## Rejected Mechanisms
+
+### Unguarded Static-Corridor Transit
+
+Probe output:
+`output/ai/autoresearch/issue_884_corridor_transit_probe/`
+
+Hypothesis: allow a slow command to pass through the conservative static-clearance band when the
+robot starts just outside the band, stays above an explicit minimum clearance, and makes local
+goal progress.
+
+Result:
+
+- `classic_merging_low` seed `113` recovered route completion.
+- `classic_merging_low` seed `111` converted from obstacle collision to timeout.
+- `classic_merging_medium` seeds `111` and `112` still timed out.
+- `classic_merging_medium` seed `113` regressed from timeout to obstacle collision after repeated
+  low-progress creep.
+
+Conclusion: reject the unguarded form. The mechanism needs a recent-progress guard so it can help
+through an active corridor passage without indefinitely creeping along the wall after progress has
+collapsed.
+
+### Guarded Static-Corridor Transit
+
+Probe output:
+`output/ai/autoresearch/issue_884_corridor_transit_guard_probe/`
+
+Hypothesis: keep the bounded static-corridor transit gate, but require recent 3 s progress before
+using it. This should preserve the `classic_merging_low` seed `113` corridor recovery and prevent
+the late `classic_merging_medium` seed `113` wall-creep collision.
+
+Result on the five named horizon-500 probes:
+
+| Scenario | Seed | Guarded outcome | Change from diagnostic baseline |
+|---|---:|---|---|
+| `classic_merging_low` | 111 | timeout | obstacle collision converted to timeout |
+| `classic_merging_low` | 113 | route-complete success at step `330` | timeout recovered |
+| `classic_merging_medium` | 111 | timeout | unchanged |
+| `classic_merging_medium` | 112 | timeout | unchanged |
+| `classic_merging_medium` | 113 | timeout | unchanged; unguarded collision avoided |
+
+Horizon-500 gate checks:
+
+- `nominal_sanity`: pass, `18/18` successes, `0` collisions, near-miss rate `0.2778`.
+- `stress_slice`: tracked, `24/24` successes, `0` collisions, near-miss rate `0.5000`.
+
+Conclusion: keep only the guarded form as a partial safety/progress improvement. It does not resolve
+#884 because three medium-density seeds and low seed `111` still fail to complete the route at
+horizon `500`.
 
 ### Static-Corridor Reorient Promotion
 
@@ -94,11 +148,13 @@ static band or still finds unsafe progress commands.
 
 ## Current Conclusion
 
-Issue #884 remains unresolved. The next credible implementation needs a route- or corridor-aware
-policy mechanism that preserves hard static-collision filtering while proving actual route
-completion on the five classic-merging seeds. The new diagnostics make that next mechanism easier
-to evaluate by showing which candidate sources are blocked by static clearance at each stalled
-step.
+Issue #884 remains unresolved. The guarded corridor-transit slice is safe enough to preserve because
+it removes one obstacle collision and recovers one route-complete seed without regressing the
+retained horizon-500 nominal/stress gates, but it is not a closing mechanism. The next credible
+implementation needs a route- or corridor-aware policy mechanism that proves actual route
+completion on the remaining four classic-merging seeds. The new diagnostics make that next
+mechanism easier to evaluate by showing which candidate sources are blocked by static clearance at
+each stalled step.
 
 Do not promote the rejected reorientation or sampling overrides as benchmark improvements. They are
 worktree-local failed experiments, not durable candidate configs.
@@ -133,3 +189,35 @@ The same command shape was run for:
 Sampling probes used the same five scenario/seed pairs with output roots
 `output/ai/autoresearch/issue_884_sampling_probe/` and
 `output/ai/autoresearch/issue_884_angular_sampling_probe/`.
+
+Guarded corridor-transit targeted probes used:
+
+```bash
+rtk env LOGURU_LEVEL=WARNING uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v3_fast_progress_static_escape \
+  --stage full_matrix \
+  --scenario-name classic_merging_low \
+  --seed 113 \
+  --horizon 500 \
+  --output-dir output/ai/autoresearch/issue_884_corridor_transit_guard_probe/classic_merging_low_113_h500
+```
+
+The same command shape was run for the five named scenario/seed pairs. Horizon-500 gate checks:
+
+```bash
+rtk env LOGURU_LEVEL=WARNING uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate hybrid_rule_v3_fast_progress_static_escape \
+  --stage nominal_sanity \
+  --horizon 500 \
+  --output-dir output/ai/autoresearch/issue_884_corridor_transit_guard_regression/nominal_sanity_h500 \
+  --docs-root output/ai/autoresearch/issue_884_corridor_transit_guard_regression/docs_h500 \
+  --workers 2
+
+rtk env LOGURU_LEVEL=WARNING uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate hybrid_rule_v3_fast_progress_static_escape \
+  --stage stress_slice \
+  --horizon 500 \
+  --output-dir output/ai/autoresearch/issue_884_corridor_transit_guard_regression/stress_slice_h500 \
+  --docs-root output/ai/autoresearch/issue_884_corridor_transit_guard_regression/docs_h500 \
+  --workers 2
+```

--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -181,6 +181,11 @@ class HybridRuleLocalPlannerConfig:
     static_recenter_enabled: bool = False
     static_recenter_weight: float = 0.0
     static_recenter_probe_speed: float = 0.3
+    static_corridor_transit_enabled: bool = False
+    static_corridor_transit_initial_band: float = 0.05
+    static_corridor_transit_tolerance: float = 0.05
+    static_corridor_transit_min_progress_3s: float = 0.0
+    static_corridor_transit_weight: float = 0.0
 
     # Ablation-only route-commitment bonus. It remains configurable for
     # diagnostics, but benchmark evidence rejected it due static collisions.
@@ -605,6 +610,81 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             return False
         return bool(current_min_clearance + tolerance >= initial_clearance)
 
+    def _static_corridor_transit_allowed(
+        self,
+        *,
+        candidate: HybridRuleCandidate,
+        initial_clearance: float,
+        current_min_clearance: float,
+        hard_static_clearance: float,
+        step_progress: float,
+        progress_windows: dict[str, float],
+    ) -> bool:
+        """Allow slow progress through a narrow conservative static-clearance band.
+
+        Returns:
+            bool: True when a candidate preserves occupied-cell collision rejection,
+            remains above an explicit minimum clearance, and only enters the hard
+            clearance band by a small configured tolerance while making progress.
+        """
+        if not bool(self.config.static_corridor_transit_enabled):
+            return False
+        if candidate.linear <= float(self.config.freezing_speed_threshold):
+            return False
+        if candidate.linear > float(self.config.static_clearance_escape_max_speed):
+            return False
+        if step_progress <= 0.0:
+            return False
+        min_recent_progress = max(float(self.config.static_corridor_transit_min_progress_3s), 0.0)
+        if float(progress_windows.get("3s", 0.0)) < min_recent_progress:
+            return False
+        if not np.isfinite(initial_clearance) or not np.isfinite(current_min_clearance):
+            return False
+        if initial_clearance <= hard_static_clearance:
+            return False
+        initial_band = max(float(self.config.static_corridor_transit_initial_band), 0.0)
+        if initial_clearance > hard_static_clearance + initial_band:
+            return False
+        min_transit_clearance = float(self.config.static_clearance_escape_min_clearance)
+        if current_min_clearance < min_transit_clearance:
+            return False
+        tolerance = max(float(self.config.static_corridor_transit_tolerance), 0.0)
+        return bool(current_min_clearance + tolerance >= hard_static_clearance)
+
+    def _static_clearance_violation_policy(
+        self,
+        *,
+        candidate: HybridRuleCandidate,
+        initial_clearance: float,
+        current_min_clearance: float,
+        hard_static_clearance: float,
+        step_progress: float,
+        progress_windows: dict[str, float],
+    ) -> str | None:
+        """Classify an allowed conservative static-clearance band exception.
+
+        Returns:
+            str | None: ``"escape"`` or ``"corridor_transit"`` when a guarded
+            exception applies, otherwise ``None``.
+        """
+        if self._static_clearance_escape_allowed(
+            candidate=candidate,
+            initial_clearance=initial_clearance,
+            current_min_clearance=current_min_clearance,
+            hard_static_clearance=hard_static_clearance,
+        ):
+            return "escape"
+        if self._static_corridor_transit_allowed(
+            candidate=candidate,
+            initial_clearance=initial_clearance,
+            current_min_clearance=current_min_clearance,
+            hard_static_clearance=hard_static_clearance,
+            step_progress=step_progress,
+            progress_windows=progress_windows,
+        ):
+            return "corridor_transit"
+        return None
+
     def _static_recenter_probe_score(
         self,
         *,
@@ -654,6 +734,47 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
                 return 0.0
         return 1.0
 
+    def _static_recenter_term(
+        self,
+        *,
+        candidate: HybridRuleCandidate,
+        observation: dict[str, Any],
+        state: dict[str, Any],
+        hard_static_clearance: float,
+        stalled_progress: bool,
+        start_dist: float,
+        nearest_ped: float,
+    ) -> float:
+        """Return the scored static-recenter term when stalled away from pedestrians."""
+        if not (
+            stalled_progress
+            and start_dist > float(self.config.goal_far_distance)
+            and nearest_ped >= float(self.config.slow_distance_human)
+        ):
+            return 0.0
+        return self._static_recenter_probe_score(
+            candidate=candidate,
+            observation=observation,
+            state=state,
+            hard_static_clearance=hard_static_clearance,
+        )
+
+    def _route_guide_commitment_term(
+        self,
+        *,
+        candidate: HybridRuleCandidate,
+        progress_windows: dict[str, float],
+        start_dist: float,
+    ) -> float:
+        """Return the route-guide commitment bonus term for stalled route candidates."""
+        if candidate.source != "route_guide":
+            return 0.0
+        if float(progress_windows.get("3s", 0.0)) > float(
+            self.config.route_guide_commitment_progress_threshold
+        ) or start_dist <= float(self.config.goal_far_distance):
+            return 0.0
+        return 1.0
+
     def _evaluate_candidate(
         self,
         *,
@@ -701,7 +822,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         initial_static_clearance = self._min_obstacle_clearance(robot_pos, observation)
         min_static_clearance = float("inf")
         min_dynamic_clearance = float("inf")
-        static_clearance_escape_used = False
+        static_clearance_exception_terms: set[str] = set()
 
         for step_idx in range(steps):
             t = (step_idx + 1) * dt
@@ -733,14 +854,15 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
                 self._min_obstacle_clearance(robot_pos, observation),
             )
             if min_static_clearance <= hard_static_clearance:
-                if self._static_clearance_escape_allowed(
+                static_violation_policy = self._static_clearance_violation_policy(
                     candidate=candidate,
                     initial_clearance=initial_static_clearance,
                     current_min_clearance=min_static_clearance,
                     hard_static_clearance=hard_static_clearance,
-                ):
-                    static_clearance_escape_used = True
-                else:
+                    step_progress=start_dist - float(np.linalg.norm(goal - robot_pos)),
+                    progress_windows=progress_windows,
+                )
+                if static_violation_policy is None:
                     return {
                         "accepted": False,
                         "reason": "static_clearance",
@@ -749,9 +871,10 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
                         "hard_static_clearance": float(hard_static_clearance),
                         "time": float(t),
                     }
+                static_clearance_exception_terms.add(static_violation_policy)
 
             if (
-                static_clearance_escape_used
+                "escape" in static_clearance_exception_terms
                 and initial_static_clearance <= hard_static_clearance
                 and min_static_clearance + float(self.config.static_clearance_escape_tolerance)
                 < initial_static_clearance
@@ -834,25 +957,19 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             and abs(candidate.angular) >= float(self.config.deadlock_rotation_threshold)
             else 0.0
         )
-        static_recenter = (
-            self._static_recenter_probe_score(
-                candidate=candidate,
-                observation=observation,
-                state=state,
-                hard_static_clearance=hard_static_clearance,
-            )
-            if stalled_progress
-            and start_dist > float(self.config.goal_far_distance)
-            and nearest_ped >= float(self.config.slow_distance_human)
-            else 0.0
+        static_recenter = self._static_recenter_term(
+            candidate=candidate,
+            observation=observation,
+            state=state,
+            hard_static_clearance=hard_static_clearance,
+            stalled_progress=stalled_progress,
+            start_dist=start_dist,
+            nearest_ped=nearest_ped,
         )
-        route_guide_commitment = (
-            1.0
-            if candidate.source == "route_guide"
-            and float(progress_windows.get("3s", 0.0))
-            <= float(self.config.route_guide_commitment_progress_threshold)
-            and start_dist > float(self.config.goal_far_distance)
-            else 0.0
+        route_guide_commitment = self._route_guide_commitment_term(
+            candidate=candidate,
+            progress_windows=progress_windows,
+            start_dist=start_dist,
         )
         terms = {
             "goal_progress": float(np.clip(progress / max_progress, -1.0, 1.0)),
@@ -880,7 +997,10 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             "oscillation_penalty": self._oscillation_penalty(candidate.angular),
             "deadlock_escape": deadlock_escape,
             "static_recenter": static_recenter,
-            "static_clearance_escape": 1.0 if static_clearance_escape_used else 0.0,
+            "static_clearance_escape": 1.0 if "escape" in static_clearance_exception_terms else 0.0,
+            "static_corridor_transit": 1.0
+            if "corridor_transit" in static_clearance_exception_terms
+            else 0.0,
             "route_guide_commitment": route_guide_commitment,
         }
         score = (
@@ -895,6 +1015,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             + float(self.config.control_effort_weight) * terms["control_effort"]
             + float(self.config.deadlock_escape_weight) * terms["deadlock_escape"]
             + float(self.config.static_recenter_weight) * terms["static_recenter"]
+            + float(self.config.static_corridor_transit_weight) * terms["static_corridor_transit"]
             + float(self.config.route_guide_commitment_weight) * terms["route_guide_commitment"]
             - float(self.config.freezing_weight) * terms["freezing_penalty"]
             - float(self.config.oscillation_weight) * terms["oscillation_penalty"]

--- a/tests/planner/test_hybrid_rule_local_planner.py
+++ b/tests/planner/test_hybrid_rule_local_planner.py
@@ -288,7 +288,7 @@ def test_hybrid_rule_static_clearance_escape_rejects_below_minimum(monkeypatch) 
 def test_hybrid_rule_static_clearance_escape_rejects_bounded_corridor_transit(
     monkeypatch,
 ) -> None:
-    """Static escape should not enter the hard band from a currently safe pose."""
+    """Static escape alone should not enter the hard band from a currently safe pose."""
     cfg = HybridRuleLocalPlannerConfig(
         linear_samples=2,
         angular_samples=3,
@@ -319,6 +319,92 @@ def test_hybrid_rule_static_clearance_escape_rejects_bounded_corridor_transit(
         speed_cap=cfg.max_linear_speed,
         nearest_ped=float("inf"),
         progress_windows={"3s": 1.0},
+    )
+
+    assert evaluation["accepted"] is False
+    assert evaluation["reason"] == "static_clearance"
+
+
+def test_hybrid_rule_static_corridor_transit_allows_slow_progress(
+    monkeypatch,
+) -> None:
+    """Corridor transit should permit bounded slow progress through the conservative band."""
+    cfg = HybridRuleLocalPlannerConfig(
+        linear_samples=2,
+        angular_samples=3,
+        max_linear_speed=0.4,
+        hard_safety_margin=0.1,
+        rollout_horizon=0.2,
+        static_clearance_escape_min_clearance=0.3,
+        static_clearance_escape_max_speed=0.3,
+        static_corridor_transit_enabled=True,
+        static_corridor_transit_initial_band=0.05,
+        static_corridor_transit_tolerance=0.05,
+        static_corridor_transit_min_progress_3s=0.1,
+    )
+    planner = HybridRuleLocalPlannerAdapter(cfg)
+    observation = _obs(speed=0.2, goal=(2.0, 0.0))
+    state = planner._extract_state(observation)
+    candidate = HybridRuleCandidate(0.2, 0.0, "test_corridor_transit")
+    clearances = iter([0.37, 0.33])
+
+    monkeypatch.setattr(planner, "_obstacle_grid_payload", lambda observation: None)
+    monkeypatch.setattr(
+        planner,
+        "_min_obstacle_clearance",
+        lambda point, observation: next(clearances),
+    )
+
+    evaluation = planner._evaluate_candidate(
+        candidate=candidate,
+        observation=observation,
+        state=state,
+        speed_cap=cfg.max_linear_speed,
+        nearest_ped=float("inf"),
+        progress_windows={"3s": 0.2},
+    )
+
+    assert evaluation["accepted"] is True
+    assert evaluation["terms"]["static_corridor_transit"] == 1.0
+
+
+def test_hybrid_rule_static_corridor_transit_requires_recent_progress(
+    monkeypatch,
+) -> None:
+    """Corridor transit should not keep creeping after recent progress has collapsed."""
+    cfg = HybridRuleLocalPlannerConfig(
+        linear_samples=2,
+        angular_samples=3,
+        max_linear_speed=0.4,
+        hard_safety_margin=0.1,
+        rollout_horizon=0.2,
+        static_clearance_escape_min_clearance=0.3,
+        static_clearance_escape_max_speed=0.3,
+        static_corridor_transit_enabled=True,
+        static_corridor_transit_initial_band=0.05,
+        static_corridor_transit_tolerance=0.05,
+        static_corridor_transit_min_progress_3s=0.1,
+    )
+    planner = HybridRuleLocalPlannerAdapter(cfg)
+    observation = _obs(speed=0.2, goal=(2.0, 0.0))
+    state = planner._extract_state(observation)
+    candidate = HybridRuleCandidate(0.2, 0.0, "test_corridor_transit")
+    clearances = iter([0.37, 0.33])
+
+    monkeypatch.setattr(planner, "_obstacle_grid_payload", lambda observation: None)
+    monkeypatch.setattr(
+        planner,
+        "_min_obstacle_clearance",
+        lambda point, observation: next(clearances),
+    )
+
+    evaluation = planner._evaluate_candidate(
+        candidate=candidate,
+        observation=observation,
+        state=state,
+        speed_cap=cfg.max_linear_speed,
+        nearest_ped=float("inf"),
+        progress_windows={"3s": 0.05},
     )
 
     assert evaluation["accepted"] is False


### PR DESCRIPTION
## Summary
- Adds a guarded `static_corridor_transit` exception for the hybrid-rule local planner so a near-corridor robot may make bounded progress through the static obstacle safety band only after recent route progress.
- Keeps the new behavior disabled by default and enables it only for `configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml`.
- Adds source-level diagnostics and regression tests for the allowed/progress-gated transit path, and updates `docs/context/issue_884_classic_merging_diagnostics.md` with accepted and rejected probe evidence.

## Scope
Relates to #884. This is a partial safety/progress improvement and should not close #884: several classic-merging seeds still time out, so route-completing recovery remains open.

## Validation
- TDD red proof: the new transit test initially failed with `TypeError: HybridRuleLocalPlannerConfig.__init__() got an unexpected keyword argument 'static_corridor_transit_enabled'` before implementation.
- `uv run pytest tests/planner/test_hybrid_rule_local_planner.py::test_hybrid_rule_static_corridor_transit_allows_slow_progress tests/planner/test_hybrid_rule_local_planner.py::test_hybrid_rule_static_corridor_transit_requires_recent_progress -q` -> 2 passed.
- `uv run pytest tests/planner/test_hybrid_rule_local_planner.py -q` -> 23 passed in 10.06s.
- `uv run ruff check robot_sf/planner/hybrid_rule_local_planner.py tests/planner/test_hybrid_rule_local_planner.py` -> All checks passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` on synced head `c1ebb7da9c4cae46aad146177d98b801cc20fa6b` -> 3216 passed, 14 skipped, 3 warnings in 404.24s; changed-file coverage warning only: `robot_sf/planner/hybrid_rule_local_planner.py` 85.6%; no TODO docstrings found.
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` -> passed stamp at `output/validation/pr_ready/884-classic-merging-route-recovery.json`.

## Scenario Evidence
- Guarded h500 probe in `output/ai/autoresearch/issue_884_corridor_transit_guard_probe/`: recovered `classic_merging_low` seed 113 to route-complete success at step 330; converted low seed 111 obstacle collision to timeout; preserved medium seeds 111/112/113 as non-colliding timeouts.
- h500 regression gates in `output/ai/autoresearch/issue_884_corridor_transit_guard_regression/`: nominal sanity 18/18 success, collision_rate 0.0; stress slice 24/24 success, collision_rate 0.0.
- Unguarded corridor-transit probe was rejected because it recovered one low seed but regressed medium seed 113 to obstacle collision; this is documented in `docs/context/issue_884_classic_merging_diagnostics.md`.

## Artifact Handling
Ignored validation outputs under `output/coverage`, `output/validation/pr_ready`, and `output/ai/autoresearch/issue_884_corridor_transit_guard_*` were inspected and left untracked as disposable local proof artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added corridor-transit mode enabling controlled slow progress through narrow clearance zones when configured.

* **Improvements**
  * Enhanced static-clearance policy evaluation with improved recenter and route-guide logic.

* **Documentation**
  * Updated diagnostics documentation with corridor-transit validation scenarios and probe outputs.

* **Tests**
  * Expanded test coverage for corridor-transit behavior under progress constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->