### PR TITLE
feat: add multi-ped adversarial family smoke fixtures (#1015)

### DIFF
--- a/configs/adversarial/doorway_blocker_multi_ped_example.yaml
+++ b/configs/adversarial/doorway_blocker_multi_ped_example.yaml
@@ -1,0 +1,25 @@
+schema_version: adversarial-multi-ped.v1
+family: doorway_blocker
+description: Development-smoke doorway blocker fixture for issue 1015; not benchmark-frozen.
+scenario_seed: 53
+constraints:
+  min_start_goal_distance_m: 1.0
+pedestrians:
+  - id: door_left
+    start: {x: 3.6, y: 1.5}
+    goal: {x: 3.6, y: 4.5}
+    spawn_time_s: 0.2
+    speed_mps: 0.8
+    delay_s: 0.0
+    metadata:
+      role: doorway_blocker
+      side: left
+  - id: door_right
+    start: {x: 4.4, y: 4.5}
+    goal: {x: 4.4, y: 1.5}
+    spawn_time_s: 0.4
+    speed_mps: 0.8
+    delay_s: 0.0
+    metadata:
+      role: doorway_blocker
+      side: right

--- a/configs/adversarial/group_squeeze_multi_ped_example.yaml
+++ b/configs/adversarial/group_squeeze_multi_ped_example.yaml
@@ -1,6 +1,6 @@
 schema_version: adversarial-multi-ped.v1
 family: group_squeeze
-description: Schema-only example for issue 923; not a benchmark-ready runtime config.
+description: Development-smoke group squeeze fixture for issue 1015; not benchmark-frozen.
 scenario_seed: 41
 constraints:
   min_start_goal_distance_m: 1.0
@@ -11,8 +11,14 @@ pedestrians:
     spawn_time_s: 0.5
     speed_mps: 1.1
     delay_s: 0.25
+    metadata:
+      role: squeeze_left
+      lane: left
   - id: right_blocker
     start: {x: 1.0, y: 3.0}
     goal: {x: 5.0, y: 3.0}
     spawn_time_s: 0.75
     speed_mps: 1.2
+    metadata:
+      role: squeeze_right
+      lane: right

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -208,6 +208,9 @@ why a change was made rather than a full issue execution transcript.
 * [Issue #870 Multi-Ped Adversarial Runtime Slice](issue_870_multi_ped_adversarial_runtime.md)
   adds a fail-closed config-to-`RobotSimulationConfig` runtime path with N>1 reset/step proof,
   while keeping certification, policy-analysis smoke, and benchmark promotion out of scope.
+* [Issue #1015 Multi-Ped Adversarial Family Smoke](issue_1015_multi_ped_family_smoke.md)
+  adds group-squeeze and doorway-blocker development smoke fixtures with deterministic reset/step
+  proof and explicit non-benchmark-frozen episode metadata.
 * [Issue 868 Scenario Certification](issue_868_scenario_certification.md) - `scenario_cert.v1`
   scope, public surfaces, validation path, and known limits.
 * [Issue #930 CARLA T0 Neutral Export Schema](issue_930_carla_t0_export_schema.md)

--- a/docs/context/issue_1015_multi_ped_family_smoke.md
+++ b/docs/context/issue_1015_multi_ped_family_smoke.md
@@ -1,0 +1,54 @@
+# Issue #1015 Multi-Ped Adversarial Family Smoke
+
+Related issues:
+
+- Parent: <https://github.com/ll7/robot_sf_ll7/issues/870>
+- Child: <https://github.com/ll7/robot_sf_ll7/issues/1015>
+
+## Goal
+
+This slice follows the #870 runtime path with concrete scripted family fixtures and metadata proof
+for development smoke use. It remains deliberately short of benchmark-frozen certification.
+
+## What Changed
+
+- `configs/adversarial/group_squeeze_multi_ped_example.yaml` is now documented as a development
+  smoke fixture and carries per-pedestrian role/lane metadata.
+- `configs/adversarial/doorway_blocker_multi_ped_example.yaml` adds a second concrete scripted
+  family fixture with deterministic seed 53.
+- `materialize_multi_ped_scenario_payload(...)` now adds
+  `metadata.adversarial_multi_ped_runtime`, including:
+  - family,
+  - schema version,
+  - scenario seed,
+  - pedestrian ids,
+  - `evaluation_scope: development_stress_test`,
+  - `certification_status: uncertified_development_smoke`,
+  - `benchmark_frozen: false`.
+- Policy-analysis episode records preserve this metadata through `scenario_params` because the
+  scenario payload is copied into the record.
+
+## Proof
+
+TDD red proof:
+
+```bash
+uv run pytest \
+  tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_family_fixtures_reset_step_deterministically \
+  tests/tools/test_policy_analysis_run.py::test_build_episode_record_preserves_multi_ped_adversarial_metadata -q
+```
+
+Before implementation, this failed because `adversarial_multi_ped_runtime` did not exist and the
+doorway blocker fixture was missing.
+
+After implementation, the same targeted command passed:
+
+```text
+3 passed in 36.58s
+```
+
+## Boundary
+
+These fixtures are development stress tests only. They are not benchmark-frozen cases and should
+not be used as benchmark evidence until they pass the repository scenario-certification and replay
+proof path.

--- a/robot_sf/adversarial/materialize.py
+++ b/robot_sf/adversarial/materialize.py
@@ -24,6 +24,20 @@ def _metadata_payload(
     }
 
 
+def _runtime_status_payload(config: MultiPedAdversarialConfig) -> dict[str, Any]:
+    """Return certification-boundary metadata for development adversarial smoke cases."""
+
+    return {
+        "schema_version": config.schema_version,
+        "family": config.family,
+        "scenario_seed": int(config.scenario_seed),
+        "pedestrian_ids": [pedestrian.id for pedestrian in config.pedestrians],
+        "evaluation_scope": "development_stress_test",
+        "certification_status": "uncertified_development_smoke",
+        "benchmark_frozen": False,
+    }
+
+
 def materialize_multi_ped_single_pedestrian_overrides(
     config: MultiPedAdversarialConfig,
 ) -> list[dict[str, Any]]:
@@ -84,6 +98,7 @@ def materialize_multi_ped_scenario_payload(
 
     metadata = dict(scenario.get("metadata") or {})
     metadata["adversarial_multi_ped"] = config.to_json()
+    metadata["adversarial_multi_ped_runtime"] = _runtime_status_payload(config)
     scenario["metadata"] = metadata
 
     scenario["single_pedestrians"] = _merge_single_pedestrian_entries(

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -7,6 +7,7 @@ import types
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 import yaml
 
@@ -38,6 +39,19 @@ from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.ped_npc.ped_population import populate_single_pedestrians
+
+_MULTI_PED_FAMILY_FIXTURES = (
+    (
+        Path("configs/adversarial/group_squeeze_multi_ped_example.yaml"),
+        "group_squeeze",
+        ("left_blocker", "right_blocker"),
+    ),
+    (
+        Path("configs/adversarial/doorway_blocker_multi_ped_example.yaml"),
+        "doorway_blocker",
+        ("door_left", "door_right"),
+    ),
+)
 
 
 def _write_template(path: Path) -> None:
@@ -581,6 +595,61 @@ def test_multi_ped_adversarial_runtime_config_resets_and_steps() -> None:
         env.reset(seed=config.scenario_seed)
         assert env.simulator.ped_pos.shape == first_reset_positions.shape
         assert (env.simulator.ped_pos == first_reset_positions).all()
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize(("fixture_path", "family", "expected_ids"), _MULTI_PED_FAMILY_FIXTURES)
+def test_multi_ped_adversarial_family_fixtures_reset_step_deterministically(
+    fixture_path: Path,
+    family: str,
+    expected_ids: tuple[str, ...],
+) -> None:
+    """Certified development fixtures should reset and step deterministically."""
+    config = MultiPedAdversarialConfig.from_file(fixture_path)
+    assert config.family == family
+
+    payload = materialize_multi_ped_scenario_payload(
+        config,
+        {"scenarios": [{"name": f"{family}_smoke", "map_id": "synthetic_runtime"}]},
+    )
+    scenario = payload["scenarios"][0]
+    status = scenario["metadata"]["adversarial_multi_ped_runtime"]
+    assert status["benchmark_frozen"] is False
+    assert status["certification_status"] == "uncertified_development_smoke"
+    assert tuple(status["pedestrian_ids"]) == expected_ids
+
+    robot_config = build_multi_ped_adversarial_robot_config(
+        config,
+        _runtime_base_map(),
+        map_id=f"{family}_runtime",
+        sim_time_in_secs=0.5,
+    )
+    runtime_map = robot_config.map_pool.get_map(f"{family}_runtime")
+    assert tuple(ped.id for ped in runtime_map.single_pedestrians) == expected_ids
+    assert all(
+        ped.metadata["adversarial_family"] == family for ped in runtime_map.single_pedestrians
+    )
+
+    env = make_robot_env(config=robot_config, debug=True, seed=config.scenario_seed)
+    try:
+        action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
+
+        def rollout_positions() -> list[np.ndarray]:
+            env.reset(seed=config.scenario_seed)
+            positions = [env.simulator.ped_pos.copy()]
+            for _ in range(2):
+                _obs, _reward, terminated, truncated, _info = env.step(action)
+                positions.append(env.simulator.ped_pos.copy())
+                if terminated or truncated:
+                    break
+            return positions
+
+        first = rollout_positions()
+        second = rollout_positions()
+        assert len(first) == len(second)
+        for left, right in zip(first, second, strict=True):
+            np.testing.assert_allclose(left, right)
     finally:
         env.close()
 

--- a/tests/tools/test_policy_analysis_run.py
+++ b/tests/tools/test_policy_analysis_run.py
@@ -12,6 +12,8 @@ import pytest
 from gymnasium import spaces
 from loguru import logger
 
+from robot_sf.adversarial.config import MultiPedAdversarialConfig
+from robot_sf.adversarial.materialize import materialize_multi_ped_scenario_payload
 from robot_sf.planner.socnav import (
     HRVOPlannerAdapter,
     ORCAPlannerAdapter,
@@ -573,6 +575,73 @@ def test_build_episode_record_route_complete_success_without_terminal_flags(monk
     assert record["termination_reason"] == "success"
     assert record["outcome"]["route_complete"] is True
     assert record["outcome"]["collision_event"] is False
+
+
+def test_build_episode_record_preserves_multi_ped_adversarial_metadata(monkeypatch) -> None:
+    """Episode records should preserve multi-ped family attribution metadata."""
+
+    monkeypatch.setattr(
+        policy_analysis_run,
+        "compute_all_metrics",
+        lambda *args, **kwargs: {"success": 1.0, "collisions": 0.0, "time_to_goal_norm": 0.2},
+    )
+    monkeypatch.setattr(
+        policy_analysis_run,
+        "post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+    monkeypatch.setattr(policy_analysis_run, "sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(policy_analysis_run, "compute_shortest_path_length", lambda *args: 1.0)
+
+    class _Map:
+        obstacles = []
+        bounds = ((0.0, 0.0), (1.0, 1.0))
+
+    config = MultiPedAdversarialConfig.from_file(
+        "configs/adversarial/doorway_blocker_multi_ped_example.yaml"
+    )
+    scenario = materialize_multi_ped_scenario_payload(
+        config,
+        {"scenarios": [{"name": "doorway_blocker_smoke", "map_id": "synthetic_runtime"}]},
+    )["scenarios"][0]
+    traj = policy_analysis_run.EpisodeTrajectory(
+        robot_positions=[np.array([0.0, 0.0], dtype=float), np.array([1.0, 0.0], dtype=float)],
+        ped_positions=[],
+        ped_forces=[],
+    )
+
+    record = policy_analysis_run._build_episode_record(
+        scenario,
+        seed=config.scenario_seed,
+        policy_name="goal",
+        map_def=_Map(),
+        goal_vec=np.array([1.0, 0.0], dtype=float),
+        trajectory=traj,
+        reached_goal_step=1,
+        wall_time=1.0,
+        max_steps=10,
+        dt=0.1,
+        robot_max_speed=1.0,
+        robot_radius=1.0,
+        ped_radius=0.4,
+        ts_start="2026-03-02T00:00:00+00:00",
+        video_path=None,
+        terminated=False,
+        truncated=False,
+        last_info={"meta": {"is_route_complete": True}},
+        reached_max_steps=False,
+    )
+
+    metadata = record["scenario_params"]["metadata"]
+    runtime_status = metadata["adversarial_multi_ped_runtime"]
+    assert runtime_status["family"] == "doorway_blocker"
+    assert runtime_status["benchmark_frozen"] is False
+    assert runtime_status["certification_status"] == "uncertified_development_smoke"
+    assert runtime_status["pedestrian_ids"] == ["door_left", "door_right"]
+    assert (
+        record["scenario_params"]["single_pedestrians"][0]["metadata"]["adversarial_family"]
+        == "doorway_blocker"
+    )
 
 
 def test_build_episode_record_metric_collision_overrides_route_complete(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Adds concrete group-squeeze and doorway-blocker multi-pedestrian adversarial development-smoke fixtures, plus metadata that keeps these generated stress tests explicitly non-benchmark-frozen.

## Linked Issues
- Closes #1015
- Relates to #870

## What Changed
- Added `configs/adversarial/doorway_blocker_multi_ped_example.yaml` as a second scripted family fixture.
- Updated `configs/adversarial/group_squeeze_multi_ped_example.yaml` from schema-only wording to a development-smoke fixture with per-pedestrian role metadata.
- Added `metadata.adversarial_multi_ped_runtime` to materialized scenario payloads with family, seed, pedestrian ids, `evaluation_scope: development_stress_test`, `certification_status: uncertified_development_smoke`, and `benchmark_frozen: false`.
- Added deterministic reset/step smoke coverage for both fixtures and policy-analysis episode-record metadata preservation coverage.
- Added `docs/context/issue_1015_multi_ped_family_smoke.md` and indexed it from `docs/context/README.md`.

## Why It Matters
- Added value: turns the #870 runtime slice into concrete reusable family fixtures instead of only a generic config path.
- Expected impact: makes multi-ped adversarial development smoke reproducible and auditable without implying benchmark certification.
- Why this is worth merging now: it closes the next child acceptance path under #870 while preserving the parent issue for benchmark-facing certification work.

## Validation / Proof
- Commands run:
  - RED: `rtk uv run pytest tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_family_fixtures_reset_step_deterministically tests/tools/test_policy_analysis_run.py::test_build_episode_record_preserves_multi_ped_adversarial_metadata -q` failed because `adversarial_multi_ped_runtime` was missing and the doorway fixture did not exist.
  - GREEN targeted: same command -> 3 passed in 36.58s.
  - `rtk uv run ruff check robot_sf/adversarial/materialize.py tests/adversarial/test_adversarial_search.py tests/tools/test_policy_analysis_run.py` -> All checks passed.
  - `rtk uv run pytest tests/adversarial/test_adversarial_search.py tests/tools/test_policy_analysis_run.py -q` -> 66 passed in 35.22s.
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` on final head `1c939a2026b8fd79f30875237ccc6a8eb1c8df1f` -> 3221 passed, 14 skipped, 3 warnings in 404.83s.
  - Changed-file coverage warning only: `robot_sf/adversarial/materialize.py` 97.7%; no TODO docstrings found in touched definitions.
  - `rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` -> passed stamp at `output/validation/pr_ready/1015-multi-ped-family-smoke.json`.
- Evidence that the change works here: both fixture configs load through `MultiPedAdversarialConfig`, materialize attribution/certification-boundary metadata, and execute deterministic reset/step smoke in Robot-SF.
- Benchmarks or smoke tests, if applicable: smoke only; fixtures are explicitly marked `benchmark_frozen: false` and `uncertified_development_smoke`.

## Risks / Rollout
- Compatibility risks: additive metadata fields may appear in scenario payloads; existing consumers should ignore unknown metadata.
- Failure modes: downstream tools must not treat these fixtures as benchmark-certified cases.
- Rollback or fallback plan: revert this commit to remove the second fixture and runtime metadata field.

## Docs / Provenance
- Updated docs: `docs/context/issue_1015_multi_ped_family_smoke.md`, `docs/context/README.md`.
- Relevant design or provenance notes: builds on `docs/context/issue_870_multi_ped_adversarial_runtime.md` and prior #923/#936/#944 schema/materialization notes.
- Any assumptions that need to be preserved: these fixtures are development stress tests only until the scenario-certification and replay proof path is completed.

## Follow-Up Issues
- Deferred work: parent #870 remains open for benchmark certification, replay proof, and broader adversarial environment completion.
- Issues opened for follow-up: none; #870 remains the active parent tracker.

## Reviewer Notes
- Verify that `adversarial_multi_ped_runtime` does not imply benchmark certification.
- Known limitation: this PR closes child #1015, not parent #870.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-pedestrian adversarial scenario configurations for doorway blocker and group squeeze scenarios with deterministic runtime behavior and metadata tracking.

* **Documentation**
  * Added comprehensive documentation for multi-pedestrian adversarial scenario fixtures and integration notes.

* **Tests**
  * Added tests for deterministic reset/step behavior in multi-pedestrian adversarial scenarios.
  * Added tests verifying metadata preservation across policy analysis records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->