### PR TITLE
test: cover multi-ped adversarial policy-analysis smoke (#870)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -206,8 +206,9 @@ why a change was made rather than a full issue execution transcript.
   adds a template-merging manifest payload materializer for `adversarial-multi-ped.v1` configs, 
   stacked on the issue #936 override materializer.
 * [Issue #870 Multi-Ped Adversarial Runtime Slice](issue_870_multi_ped_adversarial_runtime.md)
-  adds a fail-closed config-to-`RobotSimulationConfig` runtime path with N>1 reset/step proof,
-  while keeping certification, policy-analysis smoke, and benchmark promotion out of scope.
+  adds a fail-closed config-to-`RobotSimulationConfig` runtime path with N>1 reset/step proof and
+  records the follow-up materialized policy-analysis smoke while keeping certification and benchmark
+  promotion out of scope.
 * [Issue #1015 Multi-Ped Adversarial Family Smoke](issue_1015_multi_ped_family_smoke.md)
   adds group-squeeze and doorway-blocker development smoke fixtures with deterministic reset/step
   proof and explicit non-benchmark-frozen episode metadata.

--- a/docs/context/issue_870_multi_ped_adversarial_runtime.md
+++ b/docs/context/issue_870_multi_ped_adversarial_runtime.md
@@ -41,10 +41,17 @@ scenario-loader `single_pedestrians` overrides, and `populate_single_pedestrians
 
 ## Scope Boundary
 
-This is a runtime smoke path, not the complete #870 epic. It does not yet add multiple scripted
-families, learned adversary training, policy-analysis smoke fixtures, scenario certification, replay
-certification, or benchmark-frozen case promotion. Treat generated scenarios as development stress
-tests until those later proof surfaces exist.
+This started as a runtime smoke path, not the complete #870 epic. Follow-up slices have now added
+two scripted development families and a policy-analysis smoke proof, but generated scenarios are
+still development stress tests unless a separate certification path promotes them.
+
+Still out of scope:
+
+- learned adversary training,
+- replay certification,
+- benchmark-frozen case promotion.
+
+Treat generated scenarios as development stress tests until those later proof surfaces exist.
 
 ## Validation
 
@@ -66,4 +73,42 @@ uv run ruff check robot_sf/adversarial/runtime.py robot_sf/adversarial/__init__.
   robot_sf/nav/map_config.py robot_sf/ped_npc/ped_population.py \
   robot_sf/training/scenario_loader.py tests/adversarial/test_adversarial_search.py
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+2026-05-06 update: a focused policy-analysis smoke now materializes a temporary multi-ped
+`group_squeeze` scenario against the existing `static_humans` map hooks (`h1`, `h2`), runs
+`scripts/tools/policy_analysis_run.py` through its Python `main(...)` entry point with the `goal`
+policy, and asserts that:
+
+- the produced episode is not an error-record fallback,
+- the episode has real rollout steps,
+- `scenario_params.metadata.adversarial_multi_ped_runtime` survives the policy-analysis record,
+- per-pedestrian attribution metadata survives the materialized `single_pedestrians` block.
+
+Validation command:
+
+```bash
+uv run pytest \
+  tests/tools/test_policy_analysis_run.py::test_policy_analysis_main_runs_materialized_multi_ped_adversarial_scenario -q
+```
+
+Observed result:
+
+```text
+1 passed in 40.39s
+```
+
+The runtime test coverage also now includes an explicit N=1 adversarial reset/step smoke for the
+same 1-N contract:
+
+```bash
+uv run pytest \
+  tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_runtime_config_resets_and_steps_single_pedestrian \
+  tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_runtime_config_resets_and_steps -q
+```
+
+Observed result:
+
+```text
+2 passed in 41.82s
 ```

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -599,6 +599,49 @@ def test_multi_ped_adversarial_runtime_config_resets_and_steps() -> None:
         env.close()
 
 
+def test_multi_ped_adversarial_runtime_config_resets_and_steps_single_pedestrian() -> None:
+    """The 1-N adversarial runtime contract should include N=1 reset/step coverage."""
+    config = MultiPedAdversarialConfig(
+        family="late_stop",
+        scenario_seed=43,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="stopper",
+                start=Pose2D(1.5, 2.0),
+                goal=Pose2D(6.5, 2.0),
+                spawn_time_s=0.1,
+                speed_mps=0.8,
+                metadata={"role": "single_blocker"},
+            )
+        ],
+    )
+    robot_config = build_multi_ped_adversarial_robot_config(
+        config,
+        _runtime_base_map(),
+        map_id="late_stop_runtime",
+        sim_time_in_secs=0.5,
+    )
+    runtime_map = robot_config.map_pool.get_map("late_stop_runtime")
+    assert [ped.id for ped in runtime_map.single_pedestrians] == ["stopper"]
+    assert runtime_map.single_pedestrians[0].metadata["pedestrian_metadata"] == {
+        "role": "single_blocker"
+    }
+
+    env = make_robot_env(config=robot_config, debug=True, seed=config.scenario_seed)
+    try:
+        action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
+        _obs, _info = env.reset(seed=config.scenario_seed)
+        first_positions = env.simulator.ped_pos.copy()
+
+        _obs, _reward, terminated, truncated, _info = env.step(action)
+        assert not (terminated and truncated)
+
+        env.reset(seed=config.scenario_seed)
+        np.testing.assert_allclose(env.simulator.ped_pos, first_positions)
+    finally:
+        env.close()
+
+
 @pytest.mark.parametrize(("fixture_path", "family", "expected_ids"), _MULTI_PED_FAMILY_FIXTURES)
 def test_multi_ped_adversarial_family_fixtures_reset_step_deterministically(
     fixture_path: Path,

--- a/tests/tools/test_policy_analysis_run.py
+++ b/tests/tools/test_policy_analysis_run.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+import yaml
 from gymnasium import spaces
 from loguru import logger
 
-from robot_sf.adversarial.config import MultiPedAdversarialConfig
+from robot_sf.adversarial.config import MultiPedAdversarialConfig, MultiPedCandidateSpec, Pose2D
 from robot_sf.adversarial.materialize import materialize_multi_ped_scenario_payload
 from robot_sf.planner.socnav import (
     HRVOPlannerAdapter,
@@ -642,6 +644,85 @@ def test_build_episode_record_preserves_multi_ped_adversarial_metadata(monkeypat
         record["scenario_params"]["single_pedestrians"][0]["metadata"]["adversarial_family"]
         == "doorway_blocker"
     )
+
+
+def test_policy_analysis_main_runs_materialized_multi_ped_adversarial_scenario(
+    tmp_path: Path,
+) -> None:
+    """A materialized multi-ped adversarial scenario should run through policy analysis."""
+
+    config = MultiPedAdversarialConfig(
+        family="group_squeeze",
+        scenario_seed=870,
+        pedestrians=[
+            MultiPedCandidateSpec(
+                id="h1",
+                start=Pose2D(14.0, 12.0),
+                goal=Pose2D(26.0, 12.0),
+                speed_mps=0.6,
+                metadata={"lane": "left"},
+            ),
+            MultiPedCandidateSpec(
+                id="h2",
+                start=Pose2D(26.0, 18.0),
+                goal=Pose2D(14.0, 18.0),
+                speed_mps=0.6,
+                metadata={"lane": "right"},
+            ),
+        ],
+    )
+    payload = materialize_multi_ped_scenario_payload(
+        config,
+        {
+            "scenarios": [
+                {
+                    "name": "issue_870_policy_analysis_smoke",
+                    "map_id": "static_humans",
+                    "simulation_config": {"max_episode_steps": 6, "ped_density": 0.0},
+                    "metadata": {"issue": 870, "evaluation_scope": "development_stress_test"},
+                }
+            ]
+        },
+    )
+    scenario = payload["scenarios"][0]
+    scenario_path = tmp_path / "multi_ped_policy_analysis_smoke.yaml"
+    output_dir = tmp_path / "policy_analysis"
+    scenario_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    exit_code = policy_analysis_run.main(
+        [
+            "--scenario",
+            str(scenario_path),
+            "--scenario-id",
+            scenario["name"],
+            "--policy",
+            "goal",
+            "--max-steps",
+            "3",
+            "--output",
+            str(output_dir),
+            "--no-record-forces",
+        ]
+    )
+
+    assert exit_code == 0
+    records = [
+        json.loads(line)
+        for line in (output_dir / "episodes.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record["steps"] > 0
+    assert record["termination_reason"] != "error"
+
+    scenario_params = record["scenario_params"]
+    runtime_status = scenario_params["metadata"]["adversarial_multi_ped_runtime"]
+    assert runtime_status["family"] == "group_squeeze"
+    assert runtime_status["pedestrian_ids"] == ["h1", "h2"]
+    assert runtime_status["benchmark_frozen"] is False
+    assert scenario_params["single_pedestrians"][0]["metadata"]["pedestrian_metadata"] == {
+        "lane": "left"
+    }
 
 
 def test_build_episode_record_metric_collision_overrides_route_complete(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Adds the final #870 validation coverage for the config-first multi-ped adversarial path: an explicit N=1 runtime reset/step smoke and a materialized policy-analysis smoke that runs through `policy_analysis_run.main(...)`. Updates the #870 context note and index so the remaining boundary is clear: these scenarios are development stress tests unless separately certified.

## Linked Issues
- Closes #870
- Relates to #1015

## What Changed
- Added N=1 reset/step coverage for `build_multi_ped_adversarial_robot_config(...)` in `tests/adversarial/test_adversarial_search.py`.
- Added a policy-analysis smoke in `tests/tools/test_policy_analysis_run.py` that materializes a temporary `group_squeeze` scenario onto the existing `static_humans` map hooks, runs the `goal` policy, and verifies real rollout steps plus preserved multi-ped metadata.
- Updated `docs/context/issue_870_multi_ped_adversarial_runtime.md` and `docs/context/README.md` with the new proof and certification boundary.

## Why It Matters
- Added value: completes the parent #870 proof checklist without promoting adversarial cases to benchmark-frozen status.
- Expected impact: future changes to materialization, scenario loading, episode records, or runtime config construction will fail tests if they break replay/policy-analysis compatibility.
- Why this is worth merging now: #870 already has the runtime path and family fixtures; this PR covers the remaining validation gap before closing the parent issue.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/tools/test_policy_analysis_run.py::test_policy_analysis_main_runs_materialized_multi_ped_adversarial_scenario -q` -> `1 passed in 40.39s`
  - `uv run pytest tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_runtime_config_resets_and_steps_single_pedestrian tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_runtime_config_resets_and_steps -q` -> `2 passed in 41.82s`
  - `uv run pytest tests/adversarial/test_adversarial_search.py tests/tools/test_policy_analysis_run.py -q` -> `68 passed in 40.80s`
  - `uv run ruff check tests/adversarial/test_adversarial_search.py tests/tools/test_policy_analysis_run.py` -> `All checks passed!`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `3223 passed, 14 skipped, 3 warnings in 403.94s`
- Evidence that the change works here: the policy-analysis smoke rejects error-record fallback by asserting `steps > 0` and `termination_reason != "error"`, then checks `adversarial_multi_ped_runtime` and per-pedestrian metadata in the produced episode record.
- Benchmarks or smoke tests, if applicable: no benchmark-frozen run; this remains a development stress-test path.

## Risks / Rollout
- Compatibility risks: low; this PR changes tests and context docs only.
- Failure modes: the policy-analysis smoke depends on the checked-in `static_humans` map retaining `h1`/`h2` single-pedestrian hooks.
- Rollback or fallback plan: revert this commit to remove the new smoke coverage; runtime behavior is unchanged.

## Docs / Provenance
- Updated docs: `docs/context/issue_870_multi_ped_adversarial_runtime.md`, `docs/context/README.md`.
- Relevant design or provenance notes: builds on the #870 runtime path plus #1015 family-smoke metadata note.
- Any assumptions that need to be preserved: generated adversarial scenarios are development stress tests and are not benchmark-frozen unless a separate certification path promotes them.
- Generated output artifacts inspected: `output/coverage` and `output/validation/pr_ready` are ignored disposable validation byproducts; no durable artifact dependency was introduced.

## Follow-Up Issues
- Deferred work: learned adversary training and benchmark-frozen promotion remain outside #870 scope; scenario certification is tracked separately from this development-smoke path.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the #870 checklist is now covered across the existing merged slices and this final validation PR.
- Any known limitations: the new PR does not certify these scenarios as benchmark cases and does not add learned adversary training.