### PR TITLE
test: add policy stack topology smoke (#871)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -158,6 +158,9 @@ knowledge, not every transient iteration detail.
 * [Issue #871 Policy Stack Proposal Normalization](issue_871_policy_stack_proposal_normalization.md)
   hardens `policy_stack_v1` so malformed, non-finite, or command-bounds-violating child proposals
   are rejected before risk scoring.
+* [Issue #871 Policy Stack Topology Smoke](issue_871_policy_stack_topology_smoke.md)
+  records the `corridor_following` atomic topology smoke that proves `policy_stack_v1` can reach a
+  topology-heavy goal through the normal map-runner path with proposal diagnostics intact.
 * [Issue #884 Classic Merging Diagnostics](issue_884_classic_merging_diagnostics.md)
   records source-level hybrid-rule rejection diagnostics and two rejected classic-merging recovery
   mechanisms; #884 remains unresolved until a route-completing corridor policy is proven.

--- a/docs/context/issue_871_policy_stack_topology_smoke.md
+++ b/docs/context/issue_871_policy_stack_topology_smoke.md
@@ -1,0 +1,78 @@
+# Issue #871 Policy Stack Topology Smoke
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/871>
+
+Predecessor notes:
+
+- [Issue #926 Policy Stack V1 Contract](issue_926_policy_stack_v1_contract.md)
+- [Issue #1004 Policy Stack V1 Runtime](issue_1004_policy_stack_v1_runtime.md)
+- [Issue #871 Policy Stack Proposal Normalization](issue_871_policy_stack_proposal_normalization.md)
+
+## Goal
+
+This slice adds representative topology proof for the existing `policy_stack_v1` runtime. The first
+runtime PR proved normal map-runner construction on `planner_sanity_simple`, but that smoke ended at
+`max_steps` and did not exercise an issue-596-style topology case.
+
+## What Changed
+
+`tests/planner/test_policy_stack_v1.py` now runs `policy_stack_v1` through `run_map_batch(...)` on
+the `corridor_following` scenario from `configs/scenarios/sets/atomic_navigation_minimal_full_v1.yaml`.
+The test pins seed `59621`, resolves the scenario map path for inline map-runner use, and asserts:
+
+- one benchmark job is written without failures,
+- the episode terminates as `success`,
+- `algorithm_metadata.policy_semantics` is `policy_stack_v1_portfolio`,
+- planner kinematics report adapter execution,
+- kinematics feasibility counts match the number of executed steps,
+- planner-runtime diagnostics include native and adapter proposal counts.
+
+## Boundary
+
+This is still experimental portfolio-planner evidence. It does not promote `policy_stack_v1` to a
+paper-facing planner, add learned proposals, or prove the full issue-596 matrix. It does close the
+previous evidence gap that `policy_stack_v1` lacked a topology-heavy atomic success through the
+normal benchmark runner.
+
+## Validation
+
+Targeted smoke:
+
+```bash
+uv run pytest \
+  tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner -q
+```
+
+Observed result:
+
+```text
+1 passed in 38.93s
+```
+
+Focused lint:
+
+```bash
+uv run ruff check tests/planner/test_policy_stack_v1.py
+```
+
+Observed result:
+
+```text
+All checks passed!
+```
+
+Focused planner file:
+
+```bash
+uv run pytest tests/planner/test_policy_stack_v1.py -q
+```
+
+Observed result:
+
+```text
+9 passed in 39.27s
+```
+
+The topology smoke is a real simulator/map-runner check and currently appears in the repository's
+soft slow-test report. It is intentionally retained as the representative #871 proof rather than
+being replaced with a mocked runner assertion.

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -25,6 +26,26 @@ def _obs(
         "goal": {"current": list(goal)},
         "pedestrians": {"positions": [list(p) for p in (peds or [])]},
     }
+
+
+def _load_atomic_topology_smoke_scenario(name: str) -> dict[str, object]:
+    """Load one atomic topology scenario with absolute map paths for inline map-runner use."""
+    from robot_sf.training.scenario_loader import load_scenarios
+
+    scenario_path = Path("configs/scenarios/sets/atomic_navigation_minimal_full_v1.yaml")
+    scenario_root = scenario_path.parent.resolve()
+    for scenario in load_scenarios(scenario_path, base_dir=scenario_path):
+        if scenario.get("name") != name:
+            continue
+        selected = dict(scenario)
+        selected["seeds"] = [59621]
+        map_file = selected.get("map_file")
+        if isinstance(map_file, str) and map_file.strip():
+            map_path = Path(map_file)
+            if not map_path.is_absolute():
+                selected["map_file"] = str((scenario_root / map_path).resolve())
+        return selected
+    raise AssertionError(f"Scenario not found: {name}")
 
 
 class _DummyRiskDWA:
@@ -237,3 +258,47 @@ def test_policy_stack_map_runner_registration(monkeypatch: pytest.MonkeyPatch) -
     assert meta["baseline_category"] == "classical"
     assert meta["policy_semantics"] == "policy_stack_v1_portfolio"
     assert meta["planner_kinematics"]["execution_mode"] == "adapter"
+
+
+def test_policy_stack_runs_atomic_topology_smoke_through_map_runner(tmp_path: Path) -> None:
+    """The stack should execute a topology-heavy atomic scenario through the benchmark runner."""
+    from robot_sf.benchmark.map_runner import run_map_batch
+
+    out_path = tmp_path / "episodes.jsonl"
+    summary = run_map_batch(
+        [_load_atomic_topology_smoke_scenario("corridor_following")],
+        out_path,
+        schema_path=Path("robot_sf/benchmark/schemas/episode.schema.v1.json"),
+        algo="policy_stack_v1",
+        algo_config_path="configs/algos/policy_stack_v1.yaml",
+        horizon=180,
+        dt=0.1,
+        record_forces=False,
+        workers=1,
+        resume=False,
+        benchmark_profile="experimental",
+    )
+    rows = [json.loads(line) for line in out_path.read_text(encoding="utf-8").splitlines()]
+
+    assert summary["total_jobs"] == 1
+    assert summary["successful_jobs"] == 1
+    assert summary["failed_jobs"] == 0
+    assert summary["benchmark_availability"]["benchmark_success"] is True
+    assert len(rows) == 1
+
+    record = rows[0]
+    assert record["scenario_id"] == "corridor_following"
+    assert record["status"] == "success"
+    assert record["termination_reason"] == "success"
+    assert record["steps"] > 0
+
+    metadata = record["algorithm_metadata"]
+    assert metadata["policy_semantics"] == "policy_stack_v1_portfolio"
+    assert metadata["planner_kinematics"]["execution_mode"] == "adapter"
+    assert metadata["kinematics_feasibility"]["commands_evaluated"] == record["steps"]
+
+    runtime = metadata["planner_runtime"]
+    assert runtime["steps"] == record["steps"]
+    assert runtime["proposal_status_counts"]["native"] > 0
+    assert runtime["proposal_status_counts"]["adapter"] > 0
+    assert runtime["last_step"]["selected_proposal_key"] in {"goal", "risk_dwa", "shield_stop"}


### PR DESCRIPTION
## Summary
- add a map-runner smoke test that executes `policy_stack_v1` on the atomic `corridor_following` topology scenario with real scenario config and simulator plumbing
- assert successful episode completion plus policy-stack metadata, adapter kinematics mode, feasibility counts, and planner runtime proposal/selection signals
- record #871 validation context and the remaining boundary in `docs/context/issue_871_policy_stack_topology_smoke.md`

## Validation
- `uv run pytest tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner -q` -> `1 passed in 38.93s`
- `uv run ruff check tests/planner/test_policy_stack_v1.py` -> all passed
- `uv run pytest tests/planner/test_policy_stack_v1.py -q` -> `9 passed in 39.27s`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `3224 passed, 14 skipped, 3 warnings in 405.03s` at `77b3e3fbd2787ffcb4cfe205b3ffa209144a6ed6`

## Artifact Handling
- inspected ignored `output/coverage`, `output/validation/pr_ready`, and `output/benchmarks/issue_871_policy_stack_topology_probe`; these are disposable local validation outputs and are not committed

## Boundary
Relates to #871. This proves the experimental policy-stack adapter can complete one atomic topology scenario through the real map-runner path. It does not close #871 yet: broader route/subgoal/full-matrix proof remains open, and `planner_sanity_simple` still needs follow-up before claiming the parent issue complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added topology smoke test for policy_stack_v1 to validate execution through the map-runner integration path.

* **Documentation**
  * Added documentation detailing topology smoke validation, including test goals, validation results, and observations about simulator checks.
  * Updated performance notes referencing the topology smoke test addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->