### PR TITLE
docs: define environment reward benchmark boundary (#1039 #1040 #1041)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * **[Holonomic Action Contract](./dev/holonomic_action_contract.md)** - Exact holonomic action-space semantics, heading behavior, and benchmark bridge rules
 * **[Training Protocol Template](./dev/training_protocol_template.md)** - Fill-in template for documenting training/evaluation runs
 * **[Canonical PPO Training Workflow](./training/ppo_training_workflow.md)** - Config-driven PPO entrypoint, evaluation cadence semantics, and startup provenance logging.
+* **[Robot SF Environment Contract And Training Provenance](./training/environment_contract.md)** - Factory entrypoints, rollout ownership, reward-versus-benchmark boundary, and PPO run-record checklist.
 * **[Issue #1037 RL Environment Patterns](./context/issue_1037_rl_environment_patterns.md)** -
   Design note mapping May 2026 LLM-era RL environment patterns to Robot SF training, reward,
   rollout, benchmark, scaling, and provenance boundaries.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -12,6 +12,12 @@ The RobotSF benchmark system uses a consolidated schema management approach to e
 
 **See also**: [SNQI Weight Tools](./snqi-weight-tools/README.md) for weight recomputation and optimization, and [Distribution Plots](./distribution_plots.md) for visualization guidance.
 
+Benchmark outcomes are separate from dense training rewards. Benchmark claims must rely on
+schema-checked episode records, deterministic metrics, termination/outcome fields, and explicit
+runtime/readiness metadata; training reward totals are not benchmark-success evidence. See
+[Robot SF Environment Contract And Training Provenance](./training/environment_contract.md) and the
+[benchmark fallback policy](./context/issue_691_benchmark_fallback_policy.md).
+
 ### Canonical Schema Location
 
 **Single source of truth**: `robot_sf/benchmark/schemas/`

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -277,6 +277,10 @@ env = make_image_robot_env(debug=True)
 env = make_pedestrian_env(robot_model=model, debug=True)
 ```
 
+The compact reviewer contract for environment creation, rollout ownership, reward ownership,
+benchmark verifier boundaries, and PPO run-record provenance is
+`docs/training/environment_contract.md`.
+
 ### Key architectural layers
 
 - **`robot_sf/gym_env/`**: Gymnasium environment implementations with factory pattern

--- a/docs/training/environment_contract.md
+++ b/docs/training/environment_contract.md
@@ -1,0 +1,124 @@
+# Robot SF Environment Contract And Training Provenance
+
+This note is the reviewer-facing contract for Robot SF training and benchmark work. It summarizes
+where environment behavior belongs, who owns rollouts, how training rewards differ from benchmark
+outcomes, and which run-record fields must be preserved for PPO/RL provenance.
+
+Design source: [Issue #1037 RL Environment Patterns](../context/issue_1037_rl_environment_patterns.md).
+
+## Public Environment Contract
+
+Create environments through `robot_sf/gym_env/environment_factory.py`:
+
+- `make_robot_env(...)` for standard robot navigation observations,
+- `make_image_robot_env(...)` for image observations,
+- `make_pedestrian_env(...)` for pedestrian-policy training against a robot model.
+
+Do not instantiate concrete environment classes directly in training, benchmark, examples, or new
+workflow code. The factory layer owns:
+
+- config normalization and legacy-kwargs compatibility,
+- deterministic seeding when `seed` is provided,
+- reward profile/curriculum construction from `reward_name`, `reward_func`, and
+  `reward_curriculum`,
+- recording and render option precedence,
+- public metadata such as suite, scenario, algorithm, and recording seed.
+
+Environment `reset()` and `step()` follow Gymnasium semantics:
+
+- `reset()` initializes one scenario instance and returns the observation plus info metadata.
+- `step(action)` advances physics and returns `(observation, reward, terminated, truncated, info)`.
+- `terminated` is for environment outcomes such as route completion or collision.
+- `truncated` is for horizon or externally imposed cutoff.
+- `info` should carry diagnostic metadata needed by trainers, wrappers, and benchmark harnesses
+  without changing the observation contract.
+
+Environment code should contain simulation state transitions, observation construction, termination
+state, and dense training reward calculation. Trainer code should contain optimization, checkpoint
+cadence, vectorization, and trainer-specific logging. Benchmark code should contain evaluation
+episode ownership, schema validation, planner runtime metadata, and benchmark metric aggregation.
+
+## Rollout Ownership
+
+Robot SF has two different rollout owners:
+
+| Workflow | Rollout owner | Primary path | Output contract |
+|---|---|---|---|
+| PPO/SB3 training | Stable-Baselines3 through vectorized envs | `scripts/training/train_ppo.py` | checkpoints, eval timelines, training run manifests |
+| RLlib training | RLlib algorithm workers | `scripts/training/train_dreamerv3_rllib.py` | RLlib checkpoints and run diagnostics |
+| Benchmark evaluation | Robot SF benchmark harness | `robot_sf/benchmark/runner.py`, `robot_sf/benchmark/cli.py` | schema-checked episode JSONL and aggregate reports |
+
+Training loops may use dense rewards from `robot_sf/gym_env/reward.py`. Benchmark runs must use
+benchmark metrics and outcome fields from the benchmark episode schema. A high training reward is
+not benchmark success evidence.
+
+## Reward Versus Benchmark Outcome
+
+Training reward is an optimization signal. It may be dense, curriculum-driven, shaped, or tuned for
+sample efficiency. In PPO runs it is resolved from `env_factory_kwargs` by
+`scripts/training/train_ppo.py`; the default profile is `route_completion_v2` unless a reward name,
+custom callable, or curriculum is supplied.
+
+Benchmark success is an evaluation contract. Benchmark claims must rely on:
+
+- schema-checked episode records,
+- explicit termination and outcome fields,
+- component metrics such as success, collisions, near misses, time, comfort, force, and jerk,
+- SNQI only as a versioned composite with fixed weights/baselines,
+- execution mode and readiness metadata (`native`, `adapter`, `fallback`, `degraded`, etc.).
+
+Fallback or degraded execution is not successful benchmark evidence. Use the canonical
+[benchmark fallback policy](../context/issue_691_benchmark_fallback_policy.md) when deciding whether
+a planner row can support a benchmark claim.
+
+Do not use LLM-as-judge, subjective text scoring, or training reward totals as benchmark-success
+criteria. Those signals can be useful diagnostics in separate research workflows, but they do not
+replace deterministic schema-backed benchmark outcomes.
+
+## PPO Run-Record Checklist
+
+For every reviewer-facing PPO/RL training record, preserve the fields below. Required fields should
+be present in the config, startup summary, manifest, PR text, or context note. Optional local notes
+help debugging but are not durable provenance unless promoted to a tracked note or manifest.
+
+| Field | Required? | Where to check | Why it matters |
+|---|---|---|---|
+| Training command and config path | required | `uv run python scripts/training/train_ppo.py --config ...` | Replays the same workflow |
+| `policy_id` | required | training YAML, startup summary, expert manifest | Identifies checkpoints and registry entries |
+| Training scenario config | required | `scenario_config`, `input_artefacts` | Defines the task source |
+| Evaluation scenario config | required | `evaluation.scenario_config` or fallback to `scenario_config` | Separates train and hold-out surfaces |
+| Seed policy | required | `seeds`, `randomize_seeds`, `evaluation.randomize_seeds` | Bounds reproducibility and variance |
+| Reward profile or curriculum | required | `env_factory_kwargs.reward_name`, `reward_func`, `reward_curriculum` | Explains the optimization signal |
+| Environment factory kwargs | required | training YAML, startup summary when summarized | Captures public env behavior toggles |
+| Vectorization mode and env count | required | `num_envs`, resolved worker mode startup log | Affects throughput and stochastic exposure |
+| Evaluation cadence | required | `evaluation.step_schedule` | Defines checkpoint/eval timing |
+| Git/config hashes or copied config manifest | required | training manifest, checkpoint config copy, PR/context note | Makes artifacts auditable |
+| Checkpoint path and config manifest | required | expert manifest | Rehydrates the trained policy |
+| Episode log, eval timeline, per-scenario eval, perf summary | required when generated | training run manifest | Supports metric review beyond headline reward |
+| Artifact destination and durability decision | required for handoff | PR body or context note | Prevents hidden `output/` dependencies |
+| Local machine/resource notes | optional | `local.machine.md`, context note | Explains local throughput constraints |
+| W&B or external artifact pointer | optional unless relied on | model registry or PR/context note | Makes non-local artifacts recoverable |
+
+If a required field is absent, do not silently infer it from chat history. Add it to the run note,
+manifest, or follow-up issue before using the run as evidence.
+
+## Validation Commands
+
+Use these lightweight checks when updating this contract or reviewing referenced paths:
+
+```bash
+test -f robot_sf/gym_env/environment_factory.py
+test -f robot_sf/gym_env/reward.py
+test -f scripts/training/train_ppo.py
+test -f robot_sf/benchmark/schemas/episode.schema.v1.json
+test -f docs/context/issue_691_benchmark_fallback_policy.md
+```
+
+For a runnable PPO provenance smoke path:
+
+```bash
+uv run python scripts/training/train_ppo.py \
+  --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml \
+  --dry-run \
+  --log-level WARNING
+```

--- a/docs/training/ppo_training_workflow.md
+++ b/docs/training/ppo_training_workflow.md
@@ -20,6 +20,10 @@ uv run python scripts/training/train_ppo.py \
 `scripts/training_ppo.py` entrypoint fails closed with a migration command so old notes or shell
 history cannot silently launch an unsupported run.
 
+For the environment boundary, reward ownership, benchmark-outcome distinction, and reviewer
+run-record checklist, see
+[Robot SF Environment Contract And Training Provenance](environment_contract.md).
+
 ## Evaluation Cadence
 
 PPO training YAML files loaded through `load_expert_training_config()` must define


### PR DESCRIPTION
## Summary
Adds a compact reviewer-facing contract for Robot SF environment creation, rollout ownership, training reward provenance, and benchmark verifier boundaries.

## Linked Issues
- Closes #1039
- Closes #1040
- Closes #1041
- Relates to #1037

## What Changed
- Added `docs/training/environment_contract.md` covering factory entrypoints, Gymnasium reset/step semantics, info metadata expectations, rollout ownership, reward-vs-benchmark boundaries, and the PPO run-record checklist.
- Linked the contract from `docs/training/ppo_training_workflow.md`, `docs/dev_guide.md`, `docs/benchmark.md`, and `docs/README.md`.
- Clarified that dense training rewards, LLM-as-judge style scoring, fallback execution, and degraded execution are not benchmark-success evidence.

## Why It Matters
- Added value: reviewers get one discoverable place to check environment, reward, rollout, and provenance expectations before training or benchmark changes.
- Expected impact: reduces ambiguity between training optimization signals and benchmark outcome claims.
- Why this is worth merging now: #1037 split this follow-up docs work before larger training and benchmark changes diverge further.

## Validation / Proof
- Commands run:
  - `test -f robot_sf/gym_env/environment_factory.py && test -f robot_sf/gym_env/reward.py && test -f scripts/training/train_ppo.py && test -f robot_sf/benchmark/schemas/episode.schema.v1.json && test -f docs/context/issue_691_benchmark_fallback_policy.md && test -f docs/context/issue_1037_rl_environment_patterns.md`
  - `uv run python scripts/training/train_ppo.py --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml --dry-run --log-level WARNING`
  - `uv run pytest tests/training/test_train_expert_ppo_contract.py tests/docs/test_helper_catalog.py -q`
  - `git diff --check`
  - `git fetch origin main && git merge --ff-only origin/main`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Referenced local paths exist.
  - PPO dry-run exited 0.
  - Targeted tests: `18 passed in 10.72s`.
  - PR readiness: Ruff passed, full suite `3269 passed, 17 skipped, 3 warnings in 254.15s`.

## Implementation Verification
| Issue | Claim | Evidence surface | Validation | Result | Residual risk |
|---|---|---|---|---|---|
| #1039 | Environment contract and rollout ownership are discoverable | `docs/training/environment_contract.md`, `docs/dev_guide.md`, `docs/README.md` | path checks, targeted tests, full readiness | Documented factory entrypoints, reset/step semantics, info metadata, and SB3/RLlib/benchmark rollout owners | Docs only; no runtime contract change |
| #1040 | PPO reward/environment provenance checklist exists and is linked | `docs/training/environment_contract.md`, `docs/training/ppo_training_workflow.md` | PPO dry-run, targeted training tests | Checklist distinguishes required fields from optional local notes and names scenario configs, env kwargs, rewards, seeds, vectorization, hashes/manifests, and artifact destinations | Existing manifests may not contain every checklist field in structured form; checklist tells reviewers where PR/context notes must fill gaps |
| #1041 | Training reward versus benchmark verifier boundary is clear | `docs/training/environment_contract.md`, `docs/benchmark.md` | path checks and full readiness | Docs rule out training reward totals, fallback/degraded execution, and LLM-as-judge scoring as benchmark-success evidence | This is a docs guardrail, not a new benchmark validator |

## Risks / Rollout
- Compatibility risks: docs-only change; no code behavior changes.
- Failure modes: reviewers may still need to add PR/context-note provenance when older manifests lack structured fields.
- Rollback or fallback plan: revert the docs page and links.

## Docs / Provenance
- Updated docs:
  - `docs/training/environment_contract.md`
  - `docs/training/ppo_training_workflow.md`
  - `docs/dev_guide.md`
  - `docs/benchmark.md`
  - `docs/README.md`
- Relevant design or provenance notes:
  - `docs/context/issue_1037_rl_environment_patterns.md`
  - `docs/context/issue_691_benchmark_fallback_policy.md`
- Local artifact persistence decision:
  - PPO dry-run artifacts under `output/benchmarks/expert_policies/ppo_expert_br06_v3_15m_all_maps_randomized*` and `output/benchmarks/ppo_imitation/*20260507T065254*` are disposable validation byproducts.
  - `output/coverage/` is disposable coverage output from validation.
  - No generated artifact is required by this docs change.

## Follow-Up Issues
- Deferred work: none for #1039-#1041.
- Issues opened for follow-up: none.

## Reviewer Notes
- This intentionally keeps missing-manifest-field remediation out of scope unless a future training run needs a structured manifest extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new comprehensive documentation covering environment contract, training provenance requirements, and validation procedures
  * Clarified how benchmark outcomes differ from training rewards and specified required validation criteria
  * Added cross-references between training workflow and environment documentation for improved navigation
  * Updated documentation index with new training environment reference materials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->