### PR TITLE
feat: normalize success probability to accept percentage scale

### DIFF
--- a/scripts/tools/project_priority_score.py
+++ b/scripts/tools/project_priority_score.py
@@ -45,6 +45,7 @@ MIN_IMPROVEMENT = MIN_SCORE_MULTIPLIER
 MAX_IMPROVEMENT = MAX_SCORE_MULTIPLIER
 MIN_SUCCESS_PROBABILITY = 0.0
 MAX_SUCCESS_PROBABILITY = 1.0
+SUCCESS_PROBABILITY_PERCENT_SCALE = 100.0
 
 EFFORT_FIELD = "Expected Duration in Hours"
 PRIORITY_SCORE_FIELD = "Priority Score"
@@ -138,6 +139,16 @@ def field_value(item: dict[str, Any], name: str) -> object:
     return None
 
 
+def _normalize_success_probability(raw: float | None) -> float:
+    """Return a 0-1 probability, accepting whole-percent project-field inputs."""
+
+    if raw is None:
+        return DEFAULT_SUCCESS_PROBABILITY
+    if raw > MAX_SUCCESS_PROBABILITY:
+        return raw / SUCCESS_PROBABILITY_PERCENT_SCALE
+    return raw
+
+
 def normalize_inputs(item: dict[str, Any]) -> ScoreInputs:
     """Extract and clamp score inputs from a project item payload."""
 
@@ -154,13 +165,7 @@ def normalize_inputs(item: dict[str, Any]) -> ScoreInputs:
             upper=MAX_IMPROVEMENT,
         ),
         success_probability=clamp(
-            (
-                success_probability / 100.0
-                if success_probability is not None and success_probability > 10.0
-                else success_probability
-                if success_probability is not None
-                else DEFAULT_SUCCESS_PROBABILITY
-            ),
+            _normalize_success_probability(success_probability),
             lower=MIN_SUCCESS_PROBABILITY,
             upper=MAX_SUCCESS_PROBABILITY,
         ),
@@ -350,17 +355,16 @@ class GhProjectClient:
 
         number_literal = format(number, ".8g")
         self.run(
-            "api",
-            "graphql",
-            "-f",
-            (
-                "query=mutation{updateProjectV2ItemFieldValue(input:{"
-                f'projectId:"{project_id}",'
-                f'itemId:"{item_id}",'
-                f'fieldId:"{field_id}",'
-                f"value:{{number:{number_literal}}}"
-                "}){projectV2Item{id}}}"
-            ),
+            "project",
+            "item-edit",
+            "--id",
+            item_id,
+            "--project-id",
+            project_id,
+            "--field-id",
+            field_id,
+            "--number",
+            number_literal,
         )
 
 

--- a/scripts/tools/project_priority_score.py
+++ b/scripts/tools/project_priority_score.py
@@ -154,7 +154,13 @@ def normalize_inputs(item: dict[str, Any]) -> ScoreInputs:
             upper=MAX_IMPROVEMENT,
         ),
         success_probability=clamp(
-            success_probability if success_probability is not None else DEFAULT_SUCCESS_PROBABILITY,
+            (
+                success_probability / 100.0
+                if success_probability is not None and success_probability > 10.0
+                else success_probability
+                if success_probability is not None
+                else DEFAULT_SUCCESS_PROBABILITY
+            ),
             lower=MIN_SUCCESS_PROBABILITY,
             upper=MAX_SUCCESS_PROBABILITY,
         ),
@@ -342,17 +348,19 @@ class GhProjectClient:
     ) -> None:
         """Write a numeric field value back to the project item."""
 
+        number_literal = format(number, ".8g")
         self.run(
-            "project",
-            "item-edit",
-            "--id",
-            item_id,
-            "--project-id",
-            project_id,
-            "--field-id",
-            field_id,
-            "--number",
-            f"{number:.6f}",
+            "api",
+            "graphql",
+            "-f",
+            (
+                "query=mutation{updateProjectV2ItemFieldValue(input:{"
+                f'projectId:"{project_id}",'
+                f'itemId:"{item_id}",'
+                f'fieldId:"{field_id}",'
+                f"value:{{number:{number_literal}}}"
+                "}){projectV2Item{id}}}"
+            ),
         )
 
 

--- a/tests/tools/test_project_priority_score.py
+++ b/tests/tools/test_project_priority_score.py
@@ -134,6 +134,13 @@ def test_normalize_inputs_clamps_and_defaults() -> None:
     assert defaulted.effort_hours == 1.0
 
 
+def test_normalize_inputs_accepts_percent_scale_success_probability() -> None:
+    """GitHub percentage-style project fields should normalize to probability."""
+    inputs = normalize_inputs({"success probability": 60})
+
+    assert inputs.success_probability == 0.6
+
+
 def test_build_previews_skips_done_and_rounds_scores() -> None:
     """Verify preview generation respects project status and score rounding.
 

--- a/tests/tools/test_project_priority_score.py
+++ b/tests/tools/test_project_priority_score.py
@@ -113,7 +113,7 @@ def test_normalize_inputs_clamps_and_defaults() -> None:
 
     assert inputs == ScoreInputs(
         improvement=10.0,
-        success_probability=1.0,
+        success_probability=0.017,
         effort_hours=0.1,
         time_criticality=9.0,
         unlock_factor=0.1,
@@ -135,10 +135,17 @@ def test_normalize_inputs_clamps_and_defaults() -> None:
 
 
 def test_normalize_inputs_accepts_percent_scale_success_probability() -> None:
-    """GitHub percentage-style project fields should normalize to probability."""
-    inputs = normalize_inputs({"success probability": 60})
+    """Verify whole-percent inputs normalize without breaking 0-1 probabilities.
 
-    assert inputs.success_probability == 0.6
+    This matters because GitHub project number fields may be entered as either
+    fractional probabilities or whole percentages, and the scoring model needs
+    one consistent 0-1 representation before ranking work.
+    """
+
+    assert normalize_inputs({"success probability": 1.0}).success_probability == 1.0
+    assert normalize_inputs({"success probability": 1.7}).success_probability == 0.017
+    assert normalize_inputs({"success probability": 5}).success_probability == 0.05
+    assert normalize_inputs({"success probability": 60}).success_probability == 0.6
 
 
 def test_build_previews_skips_done_and_rounds_scores() -> None:


### PR DESCRIPTION
normalize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Success Probability field to properly interpret percentage-scale input values (e.g., 60 as 60%) and normalize them correctly.
  * Updated Priority Score synchronization with GitHub projects for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->