### PR TITLE
fix: enforce canonical collision episode schema (#1077)

### DIFF
--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -151,7 +151,11 @@ Full details live in
 * `time_to_goal_norm_success_only`: same normalization, but only valid for successful episodes.
 * `time_to_goal_ideal_ratio`: success-only ratio of achieved time to ideal time
   (`shortest_path_len / robot_max_speed`).
-* `collisions`,  `near_misses`: counts based on distance thresholds.
+* `outcome.collision_event`: canonical per-episode collision event flag for new episode outputs.
+* `metrics.collisions`: collision count metric based on distance thresholds. For schema v1 episode
+  outputs it must agree with `outcome.collision_event`: positive when the canonical event is true
+  and zero when the canonical event is false.
+* `near_misses`: count based on distance thresholds.
 * `min_distance`,  `path_efficiency`: closest approach and shortest/actual path ratio.
 
 **Force/comfort**
@@ -210,6 +214,12 @@ Each episode record is schema-validated against
 * `metric_parameters.threshold_profile` + `metric_parameters.threshold_signature`
   for threshold provenance and reproducibility
 * Git/config hashes for reproducibility
+
+Collision compatibility: schema v1 consumers should read `outcome.collision_event` for the
+canonical per-episode collision status and treat `metrics.collisions` as the agreeing count metric.
+Older bundles that only carry legacy `status`, `collision_rate`, or inconsistent collision counts
+should be migrated with `scripts/tools/migrate_episode_schema_v1.py`; new bundles fail validation
+when `outcome.collision_event` and `metrics.collisions` disagree.
 
 Batch/campaign-level metadata returned by `run_map_batch` (not individual
 records from `_run_map_episode`) includes:

--- a/robot_sf/benchmark/schema_validator.py
+++ b/robot_sf/benchmark/schema_validator.py
@@ -37,7 +37,6 @@ def validate_episode(record: dict[str, Any], schema: dict[str, Any]) -> None:
 
     Raises:
         jsonschema.ValidationError: If the record violates the JSON schema.
-        ValueError: If schema-valid fields contradict the canonical outcome contract.
     """
     jsonschema.validate(instance=record, schema=schema)
     contradictions = outcome_contradictions(
@@ -47,4 +46,4 @@ def validate_episode(record: dict[str, Any], schema: dict[str, Any]) -> None:
     )
     if contradictions:
         joined = "; ".join(contradictions)
-        raise ValueError(f"episode semantic validation failed: {joined}")
+        raise jsonschema.ValidationError(f"episode semantic validation failed: {joined}")

--- a/robot_sf/benchmark/schema_validator.py
+++ b/robot_sf/benchmark/schema_validator.py
@@ -13,6 +13,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from robot_sf.benchmark.termination_reason import outcome_contradictions
+
 try:
     import jsonschema
 except ImportError as e:  # pragma: no cover
@@ -33,6 +35,16 @@ def load_schema(path: str | Path) -> dict[str, Any]:
 def validate_episode(record: dict[str, Any], schema: dict[str, Any]) -> None:
     """Validate a single episode record.
 
-    Raises jsonschema.ValidationError if invalid.
+    Raises:
+        jsonschema.ValidationError: If the record violates the JSON schema.
+        ValueError: If schema-valid fields contradict the canonical outcome contract.
     """
     jsonschema.validate(instance=record, schema=schema)
+    contradictions = outcome_contradictions(
+        termination_reason=str(record.get("termination_reason", "")),
+        outcome=record.get("outcome", {}),
+        metrics=record.get("metrics"),
+    )
+    if contradictions:
+        joined = "; ".join(contradictions)
+        raise ValueError(f"episode semantic validation failed: {joined}")

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -36,9 +36,6 @@
             "then": {
                 "properties": {
                     "metrics": {
-                        "required": [
-                            "collisions"
-                        ],
                         "properties": {
                             "collisions": {
                                 "type": [

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -14,6 +14,79 @@
         "outcome",
         "integrity"
     ],
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "outcome": {
+                        "properties": {
+                            "collision_event": {
+                                "const": true
+                            }
+                        },
+                        "required": [
+                            "collision_event"
+                        ]
+                    }
+                },
+                "required": [
+                    "outcome"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "metrics": {
+                        "required": [
+                            "collisions"
+                        ],
+                        "properties": {
+                            "collisions": {
+                                "type": [
+                                    "number",
+                                    "integer"
+                                ],
+                                "exclusiveMinimum": 0
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "outcome": {
+                        "properties": {
+                            "collision_event": {
+                                "const": false
+                            }
+                        },
+                        "required": [
+                            "collision_event"
+                        ]
+                    }
+                },
+                "required": [
+                    "outcome"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "metrics": {
+                        "properties": {
+                            "collisions": {
+                                "type": [
+                                    "number",
+                                    "integer"
+                                ],
+                                "maximum": 0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ],
     "properties": {
         "version": {
             "const": "v1"
@@ -246,6 +319,22 @@
         "metrics": {
             "type": "object",
             "minProperties": 1,
+            "properties": {
+                "collisions": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "collision_rate": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                }
+            },
             "additionalProperties": {
                 "type": [
                     "number",

--- a/robot_sf/benchmark/termination_reason.py
+++ b/robot_sf/benchmark/termination_reason.py
@@ -90,6 +90,39 @@ def _metric_scalar(metrics: Mapping[str, Any], *keys: str) -> float:
     return metric_scalar(metrics, *keys, default=0.0)
 
 
+def _collision_metric_value(metrics: Mapping[str, Any]) -> float:
+    """Return the strongest collision signal from canonical and legacy metric keys."""
+    return max(
+        _metric_scalar(metrics, "collisions"),
+        _metric_scalar(metrics, "collision_rate"),
+    )
+
+
+def _metric_outcome_contradictions(
+    *,
+    route_complete: bool,
+    collision: bool,
+    metrics: Mapping[str, Any],
+) -> list[str]:
+    """Return contradictions between outcome flags and metric values."""
+    contradictions: list[str] = []
+    success_metric = _metric_scalar(metrics, "success", "success_rate")
+    collision_metric = _collision_metric_value(metrics)
+    if collision and success_metric > 0.0:
+        contradictions.append("collision outcome but metrics.success > 0")
+    if collision and collision_metric <= 0.0:
+        contradictions.append("outcome.collision_event=true but metrics.collisions <= 0")
+    if (not collision) and collision_metric > 0.0:
+        contradictions.append("outcome.collision_event=false but metrics.collisions > 0")
+    if route_complete and collision_metric > 0.0:
+        contradictions.append("route_complete outcome but metrics.collisions > 0")
+    if route_complete and success_metric <= 0.0:
+        contradictions.append("outcome.route_complete=true but metrics.success <= 0")
+    if (not route_complete) and success_metric > 0.0:
+        contradictions.append("outcome.route_complete=false but metrics.success > 0")
+    return contradictions
+
+
 def outcome_contradictions(
     *,
     termination_reason: str,
@@ -111,16 +144,13 @@ def outcome_contradictions(
         contradictions.append("termination_reason=success but outcome.collision_event=true")
 
     if metrics is not None:
-        success_metric = _metric_scalar(metrics, "success", "success_rate")
-        collision_metric = _metric_scalar(metrics, "collisions", "collision_rate")
-        if collision and success_metric > 0.0:
-            contradictions.append("collision outcome but metrics.success > 0")
-        if route_complete and collision_metric > 0.0:
-            contradictions.append("route_complete outcome but metrics.collisions > 0")
-        if route_complete and success_metric <= 0.0:
-            contradictions.append("outcome.route_complete=true but metrics.success <= 0")
-        if (not route_complete) and success_metric > 0.0:
-            contradictions.append("outcome.route_complete=false but metrics.success > 0")
+        contradictions.extend(
+            _metric_outcome_contradictions(
+                route_complete=route_complete,
+                collision=collision,
+                metrics=metrics,
+            )
+        )
     return contradictions
 
 

--- a/robot_sf/benchmark/termination_reason.py
+++ b/robot_sf/benchmark/termination_reason.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -12,6 +13,12 @@ TERMINATION_REASONS: tuple[str, ...] = (
     "truncated",
     "max_steps",
     "error",
+)
+
+_COLLISION_COMPONENT_KEYS: tuple[str, ...] = (
+    "ped_collision_count",
+    "obstacle_collision_count",
+    "agent_collision_count",
 )
 
 
@@ -59,6 +66,54 @@ def build_outcome_payload(
     }
 
 
+def _resolved_total_collision_count(metrics: Mapping[str, Any]) -> float:
+    """Return the best available collision count from an episode metrics payload."""
+    explicit_total = metric_scalar(metrics, "total_collision_count", default=float("nan"))
+    if math.isfinite(explicit_total):
+        return max(0.0, explicit_total)
+
+    component_total = 0.0
+    saw_component = False
+    for key in _COLLISION_COMPONENT_KEYS:
+        if key not in metrics:
+            continue
+        saw_component = True
+        component_value = metric_scalar(metrics, key, default=0.0)
+        if not math.isfinite(component_value):
+            continue
+        component_total += max(0.0, component_value)
+    if saw_component:
+        return component_total if math.isfinite(component_total) else 0.0
+
+    fallback = metric_scalar(metrics, "collisions", default=0.0)
+    return max(0.0, fallback) if math.isfinite(fallback) else 0.0
+
+
+def canonicalize_collision_metrics(
+    metrics: Mapping[str, Any] | None,
+    *,
+    collision: bool,
+) -> dict[str, Any]:
+    """Return metrics with canonical episode-level collision encoding.
+
+    New episode outputs use ``metrics.collisions`` as the authoritative 0/1
+    event flag that mirrors ``outcome.collision_event``. Any count-style signal
+    remains available under ``total_collision_count`` and the component count
+    fields.
+    """
+    normalized = dict(metrics.items()) if isinstance(metrics, Mapping) else {}
+    if isinstance(metrics, Mapping) and (
+        "total_collision_count" not in normalized
+        and (
+            "collisions" in normalized
+            or any(key in normalized for key in _COLLISION_COMPONENT_KEYS)
+        )
+    ):
+        normalized["total_collision_count"] = int(_resolved_total_collision_count(metrics))
+    normalized["collisions"] = int(bool(collision))
+    return normalized
+
+
 def metric_scalar(
     metrics: Mapping[str, Any] | None,
     *keys: str,
@@ -90,60 +145,34 @@ def _metric_scalar(metrics: Mapping[str, Any], *keys: str) -> float:
     return metric_scalar(metrics, *keys, default=0.0)
 
 
-<<<<<<< HEAD
-def _collision_metric_value(metrics: Mapping[str, Any]) -> float:
-    """Return the strongest collision signal from canonical and legacy metric keys."""
-    return max(
-        _metric_scalar(metrics, "collisions"),
-        _metric_scalar(metrics, "collision_rate"),
-    )
-
-
-=======
->>>>>>> 7171dbea (fix: preserve collision aliases in migration)
 def _metric_outcome_contradictions(
     *,
     route_complete: bool,
     collision: bool,
     metrics: Mapping[str, Any],
 ) -> list[str]:
-<<<<<<< HEAD
-    """Return contradictions between outcome flags and metric values."""
-    contradictions: list[str] = []
-    success_metric = _metric_scalar(metrics, "success", "success_rate")
-    collision_metric = _collision_metric_value(metrics)
-    if collision and success_metric > 0.0:
-        contradictions.append("collision outcome but metrics.success > 0")
-    if collision and collision_metric <= 0.0:
-        contradictions.append("outcome.collision_event=true but metrics.collisions <= 0")
-    if (not collision) and collision_metric > 0.0:
-        contradictions.append("outcome.collision_event=false but metrics.collisions > 0")
-    if route_complete and collision_metric > 0.0:
-        contradictions.append("route_complete outcome but metrics.collisions > 0")
-    if route_complete and success_metric <= 0.0:
-        contradictions.append("outcome.route_complete=true but metrics.success <= 0")
-    if (not route_complete) and success_metric > 0.0:
-        contradictions.append("outcome.route_complete=false but metrics.success > 0")
-=======
     """Return contradiction messages involving metric aliases and outcome flags."""
     contradictions: list[str] = []
     success_metric = max(
-        _metric_scalar(metrics, "success"), _metric_scalar(metrics, "success_rate")
+        _metric_scalar(metrics, "success"),
+        _metric_scalar(metrics, "success_rate"),
     )
-    collision_metric = _metric_scalar(metrics, "collisions", "collision_rate")
-    if collision and success_metric > 0.0:
-        contradictions.append("collision outcome but success metrics > 0")
+    collision_metric = max(
+        _metric_scalar(metrics, "collisions"),
+        _metric_scalar(metrics, "collision_rate"),
+    )
     if collision and collision_metric <= 0.0:
         contradictions.append("outcome.collision_event=true but collision metrics <= 0")
     if (not collision) and collision_metric > 0.0:
         contradictions.append("outcome.collision_event=false but collision metrics > 0")
+    if collision and success_metric > 0.0:
+        contradictions.append("collision outcome but success metrics > 0")
     if route_complete and collision_metric > 0.0:
         contradictions.append("route_complete outcome but collision metrics > 0")
     if route_complete and success_metric <= 0.0:
         contradictions.append("outcome.route_complete=true but success metrics <= 0")
     if (not route_complete) and success_metric > 0.0:
         contradictions.append("outcome.route_complete=false but success metrics > 0")
->>>>>>> 7171dbea (fix: preserve collision aliases in migration)
     return contradictions
 
 
@@ -209,7 +238,6 @@ def resolve_termination_reason(
         return "truncated"
     if reached_max_steps:
         return "max_steps"
-    # Defensive fallback for callers that only provide info flags.
     if collision:
         return "collision"
     if success:
@@ -223,9 +251,8 @@ def status_from_termination_reason(reason: str) -> str:
     Returns:
         str: ``"success"``, ``"collision"``, or ``"failure"``.
     """
-    term = str(reason).strip()
-    if term == "success":
+    if reason == "success":
         return "success"
-    if term == "collision":
+    if reason == "collision":
         return "collision"
     return "failure"

--- a/robot_sf/benchmark/termination_reason.py
+++ b/robot_sf/benchmark/termination_reason.py
@@ -90,6 +90,7 @@ def _metric_scalar(metrics: Mapping[str, Any], *keys: str) -> float:
     return metric_scalar(metrics, *keys, default=0.0)
 
 
+<<<<<<< HEAD
 def _collision_metric_value(metrics: Mapping[str, Any]) -> float:
     """Return the strongest collision signal from canonical and legacy metric keys."""
     return max(
@@ -98,12 +99,15 @@ def _collision_metric_value(metrics: Mapping[str, Any]) -> float:
     )
 
 
+=======
+>>>>>>> 7171dbea (fix: preserve collision aliases in migration)
 def _metric_outcome_contradictions(
     *,
     route_complete: bool,
     collision: bool,
     metrics: Mapping[str, Any],
 ) -> list[str]:
+<<<<<<< HEAD
     """Return contradictions between outcome flags and metric values."""
     contradictions: list[str] = []
     success_metric = _metric_scalar(metrics, "success", "success_rate")
@@ -120,6 +124,26 @@ def _metric_outcome_contradictions(
         contradictions.append("outcome.route_complete=true but metrics.success <= 0")
     if (not route_complete) and success_metric > 0.0:
         contradictions.append("outcome.route_complete=false but metrics.success > 0")
+=======
+    """Return contradiction messages involving metric aliases and outcome flags."""
+    contradictions: list[str] = []
+    success_metric = max(
+        _metric_scalar(metrics, "success"), _metric_scalar(metrics, "success_rate")
+    )
+    collision_metric = _metric_scalar(metrics, "collisions", "collision_rate")
+    if collision and success_metric > 0.0:
+        contradictions.append("collision outcome but success metrics > 0")
+    if collision and collision_metric <= 0.0:
+        contradictions.append("outcome.collision_event=true but collision metrics <= 0")
+    if (not collision) and collision_metric > 0.0:
+        contradictions.append("outcome.collision_event=false but collision metrics > 0")
+    if route_complete and collision_metric > 0.0:
+        contradictions.append("route_complete outcome but collision metrics > 0")
+    if route_complete and success_metric <= 0.0:
+        contradictions.append("outcome.route_complete=true but success metrics <= 0")
+    if (not route_complete) and success_metric > 0.0:
+        contradictions.append("outcome.route_complete=false but success metrics > 0")
+>>>>>>> 7171dbea (fix: preserve collision aliases in migration)
     return contradictions
 
 
@@ -199,8 +223,9 @@ def status_from_termination_reason(reason: str) -> str:
     Returns:
         str: ``"success"``, ``"collision"``, or ``"failure"``.
     """
-    if reason == "success":
+    term = str(reason).strip()
+    if term == "success":
         return "success"
-    if reason == "collision":
+    if term == "collision":
         return "collision"
     return "failure"

--- a/robot_sf/benchmark/termination_reason.py
+++ b/robot_sf/benchmark/termination_reason.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -13,12 +12,6 @@ TERMINATION_REASONS: tuple[str, ...] = (
     "truncated",
     "max_steps",
     "error",
-)
-
-_COLLISION_COMPONENT_KEYS: tuple[str, ...] = (
-    "ped_collision_count",
-    "obstacle_collision_count",
-    "agent_collision_count",
 )
 
 
@@ -64,54 +57,6 @@ def build_outcome_payload(
         "collision_event": bool(collision),
         "timeout_event": bool(timeout),
     }
-
-
-def _resolved_total_collision_count(metrics: Mapping[str, Any]) -> float:
-    """Return the best available collision count from an episode metrics payload."""
-    explicit_total = metric_scalar(metrics, "total_collision_count", default=float("nan"))
-    if math.isfinite(explicit_total):
-        return max(0.0, explicit_total)
-
-    component_total = 0.0
-    saw_component = False
-    for key in _COLLISION_COMPONENT_KEYS:
-        if key not in metrics:
-            continue
-        saw_component = True
-        component_value = metric_scalar(metrics, key, default=0.0)
-        if not math.isfinite(component_value):
-            continue
-        component_total += max(0.0, component_value)
-    if saw_component:
-        return component_total if math.isfinite(component_total) else 0.0
-
-    fallback = metric_scalar(metrics, "collisions", default=0.0)
-    return max(0.0, fallback) if math.isfinite(fallback) else 0.0
-
-
-def canonicalize_collision_metrics(
-    metrics: Mapping[str, Any] | None,
-    *,
-    collision: bool,
-) -> dict[str, Any]:
-    """Return metrics with canonical episode-level collision encoding.
-
-    New episode outputs use ``metrics.collisions`` as the authoritative 0/1
-    event flag that mirrors ``outcome.collision_event``. Any count-style signal
-    remains available under ``total_collision_count`` and the component count
-    fields.
-    """
-    normalized = dict(metrics.items()) if isinstance(metrics, Mapping) else {}
-    if isinstance(metrics, Mapping) and (
-        "total_collision_count" not in normalized
-        and (
-            "collisions" in normalized
-            or any(key in normalized for key in _COLLISION_COMPONENT_KEYS)
-        )
-    ):
-        normalized["total_collision_count"] = int(_resolved_total_collision_count(metrics))
-    normalized["collisions"] = int(bool(collision))
-    return normalized
 
 
 def metric_scalar(

--- a/scripts/tools/migrate_episode_schema_v1.py
+++ b/scripts/tools/migrate_episode_schema_v1.py
@@ -209,6 +209,8 @@ def _migrate_record(record: dict[str, Any]) -> dict[str, Any]:
     _canonicalize_collision_metrics(metrics, outcome)
     updated["termination_reason"] = termination_reason
     updated["outcome"] = outcome
+    if outcome["collision_event"] and _metric_scalar(metrics, "collisions", default=0.0) <= 0.0:
+        metrics["collisions"] = max(1.0, _metric_scalar(metrics, "collision_rate", default=0.0))
     integrity = updated.get("integrity")
     if isinstance(integrity, dict) and isinstance(integrity.get("contradictions"), list):
         updated["integrity"] = integrity

--- a/scripts/tools/migrate_episode_schema_v1.py
+++ b/scripts/tools/migrate_episode_schema_v1.py
@@ -105,11 +105,9 @@ def _infer_outcome(record: dict[str, Any], termination_reason: str) -> dict[str,
 
     metrics = record.get("metrics")
     collision_metric = (
-        _metric_scalar(
-            metrics,
-            "collisions",
-            "collision_rate",
-            default=0.0,
+        max(
+            _metric_scalar(metrics, "collisions", default=0.0),
+            _metric_scalar(metrics, "collision_rate", default=0.0),
         )
         > 0.0
     )
@@ -165,6 +163,23 @@ def _infer_termination_reason(record: dict[str, Any], outcome: dict[str, bool]) 
     )
 
 
+def _collision_metric_value(metrics: dict[str, Any]) -> float:
+    """Return the strongest collision signal from canonical and legacy metric keys."""
+    return max(
+        _metric_scalar(metrics, "collisions", default=0.0),
+        _metric_scalar(metrics, "collision_rate", default=0.0),
+    )
+
+
+def _canonicalize_collision_metrics(metrics: dict[str, Any], outcome: dict[str, bool]) -> None:
+    """Backfill the canonical collision count required by schema v1."""
+    collision_metric = _collision_metric_value(metrics)
+    if outcome["collision_event"] and collision_metric <= 0.0:
+        metrics["collisions"] = 1.0
+    elif (not outcome["collision_event"]) and "collisions" not in metrics:
+        metrics["collisions"] = 0.0
+
+
 def _migrate_record(record: dict[str, Any]) -> dict[str, Any]:
     """Migrate one episode record to schema v1 fields.
 
@@ -191,6 +206,7 @@ def _migrate_record(record: dict[str, Any]) -> dict[str, Any]:
     outcome = _infer_outcome(updated, termination_reason="")
     termination_reason = _infer_termination_reason(updated, outcome)
     outcome = _infer_outcome(updated, termination_reason=termination_reason)
+    _canonicalize_collision_metrics(metrics, outcome)
     updated["termination_reason"] = termination_reason
     updated["outcome"] = outcome
     integrity = updated.get("integrity")

--- a/tests/benchmark/test_termination_reason.py
+++ b/tests/benchmark/test_termination_reason.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from robot_sf.benchmark.termination_reason import (
+    canonicalize_collision_metrics,
     collision_event,
     outcome_contradictions,
     resolve_termination_reason,
@@ -138,17 +139,54 @@ def test_collision_event_reads_info_and_meta_flags() -> None:
     assert collision_event({"meta": {"is_route_complete": True}}) is False
 
 
+def test_canonicalize_collision_metrics_preserves_explicit_counts() -> None:
+    """Canonical collision flag should keep richer count metrics on a separate key."""
+    metrics = canonicalize_collision_metrics(
+        {
+            "collisions": 3,
+            "ped_collision_count": 2,
+            "obstacle_collision_count": 1,
+        },
+        collision=True,
+    )
+
+    assert metrics["collisions"] == 1
+    assert metrics["total_collision_count"] == 3
+    assert metrics["ped_collision_count"] == 2
+    assert metrics["obstacle_collision_count"] == 1
+
+
+def test_canonicalize_collision_metrics_coerces_non_finite_counts_to_zero() -> None:
+    """Canonical collision encoding should fail closed on non-finite count payloads."""
+    fallback_metrics = canonicalize_collision_metrics(
+        {"collisions": float("inf")},
+        collision=False,
+    )
+    component_metrics = canonicalize_collision_metrics(
+        {"ped_collision_count": float("inf")},
+        collision=False,
+    )
+
+    assert fallback_metrics["total_collision_count"] == 0
+    assert fallback_metrics["collisions"] == 0
+    assert component_metrics["total_collision_count"] == 0
+    assert component_metrics["collisions"] == 0
+
+
 def test_outcome_contradictions_detect_success_mismatch() -> None:
     """Outcome integrity checks should flag success/outcome mismatches."""
     contradictions = outcome_contradictions(
         termination_reason="max_steps",
-        outcome={"route_complete": False, "collision_event": False, "timeout_event": True},
+        outcome={
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
         metrics={"success": 1.0, "collisions": 0.0},
     )
     assert contradictions
 
 
-<<<<<<< HEAD
 def test_outcome_contradictions_detect_collision_metric_drift() -> None:
     """Collision event outcome and collision count metric should agree."""
     missing_collision_metric = outcome_contradictions(
@@ -156,15 +194,16 @@ def test_outcome_contradictions_detect_collision_metric_drift() -> None:
         outcome={"route_complete": False, "collision_event": True, "timeout_event": False},
         metrics={"success": 0.0, "collisions": 0.0},
     )
-    assert "outcome.collision_event=true but metrics.collisions <= 0" in missing_collision_metric
+    assert "outcome.collision_event=true but collision metrics <= 0" in missing_collision_metric
 
     stale_collision_metric = outcome_contradictions(
         termination_reason="max_steps",
         outcome={"route_complete": False, "collision_event": False, "timeout_event": True},
         metrics={"success": 0.0, "collisions": 1.0},
     )
-    assert "outcome.collision_event=false but metrics.collisions > 0" in stale_collision_metric
-=======
+    assert "outcome.collision_event=false but collision metrics > 0" in stale_collision_metric
+
+
 def test_outcome_contradictions_uses_success_rate_alias_and_generic_messages() -> None:
     """Outcome contradictions should honor success aliases and generic metric wording."""
     contradictions = outcome_contradictions(
@@ -175,4 +214,3 @@ def test_outcome_contradictions_uses_success_rate_alias_and_generic_messages() -
 
     assert "collision outcome but success metrics > 0" in contradictions
     assert "outcome.collision_event=true but collision metrics <= 0" in contradictions
->>>>>>> 7171dbea (fix: preserve collision aliases in migration)

--- a/tests/benchmark/test_termination_reason.py
+++ b/tests/benchmark/test_termination_reason.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from robot_sf.benchmark.termination_reason import (
-    canonicalize_collision_metrics,
     collision_event,
     outcome_contradictions,
     resolve_termination_reason,
@@ -139,40 +138,6 @@ def test_collision_event_reads_info_and_meta_flags() -> None:
     assert collision_event({"meta": {"is_route_complete": True}}) is False
 
 
-def test_canonicalize_collision_metrics_preserves_explicit_counts() -> None:
-    """Canonical collision flag should keep richer count metrics on a separate key."""
-    metrics = canonicalize_collision_metrics(
-        {
-            "collisions": 3,
-            "ped_collision_count": 2,
-            "obstacle_collision_count": 1,
-        },
-        collision=True,
-    )
-
-    assert metrics["collisions"] == 1
-    assert metrics["total_collision_count"] == 3
-    assert metrics["ped_collision_count"] == 2
-    assert metrics["obstacle_collision_count"] == 1
-
-
-def test_canonicalize_collision_metrics_coerces_non_finite_counts_to_zero() -> None:
-    """Canonical collision encoding should fail closed on non-finite count payloads."""
-    fallback_metrics = canonicalize_collision_metrics(
-        {"collisions": float("inf")},
-        collision=False,
-    )
-    component_metrics = canonicalize_collision_metrics(
-        {"ped_collision_count": float("inf")},
-        collision=False,
-    )
-
-    assert fallback_metrics["total_collision_count"] == 0
-    assert fallback_metrics["collisions"] == 0
-    assert component_metrics["total_collision_count"] == 0
-    assert component_metrics["collisions"] == 0
-
-
 def test_outcome_contradictions_detect_success_mismatch() -> None:
     """Outcome integrity checks should flag success/outcome mismatches."""
     contradictions = outcome_contradictions(
@@ -191,14 +156,22 @@ def test_outcome_contradictions_detect_collision_metric_drift() -> None:
     """Collision event outcome and collision count metric should agree."""
     missing_collision_metric = outcome_contradictions(
         termination_reason="collision",
-        outcome={"route_complete": False, "collision_event": True, "timeout_event": False},
+        outcome={
+            "route_complete": False,
+            "collision_event": True,
+            "timeout_event": False,
+        },
         metrics={"success": 0.0, "collisions": 0.0},
     )
     assert "outcome.collision_event=true but collision metrics <= 0" in missing_collision_metric
 
     stale_collision_metric = outcome_contradictions(
         termination_reason="max_steps",
-        outcome={"route_complete": False, "collision_event": False, "timeout_event": True},
+        outcome={
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
         metrics={"success": 0.0, "collisions": 1.0},
     )
     assert "outcome.collision_event=false but collision metrics > 0" in stale_collision_metric
@@ -208,7 +181,11 @@ def test_outcome_contradictions_uses_success_rate_alias_and_generic_messages() -
     """Outcome contradictions should honor success aliases and generic metric wording."""
     contradictions = outcome_contradictions(
         termination_reason="collision",
-        outcome={"route_complete": False, "collision_event": True, "timeout_event": False},
+        outcome={
+            "route_complete": False,
+            "collision_event": True,
+            "timeout_event": False,
+        },
         metrics={"success": 0.0, "success_rate": 1.0, "collisions": 0.0},
     )
 

--- a/tests/benchmark/test_termination_reason.py
+++ b/tests/benchmark/test_termination_reason.py
@@ -148,6 +148,7 @@ def test_outcome_contradictions_detect_success_mismatch() -> None:
     assert contradictions
 
 
+<<<<<<< HEAD
 def test_outcome_contradictions_detect_collision_metric_drift() -> None:
     """Collision event outcome and collision count metric should agree."""
     missing_collision_metric = outcome_contradictions(
@@ -163,3 +164,15 @@ def test_outcome_contradictions_detect_collision_metric_drift() -> None:
         metrics={"success": 0.0, "collisions": 1.0},
     )
     assert "outcome.collision_event=false but metrics.collisions > 0" in stale_collision_metric
+=======
+def test_outcome_contradictions_uses_success_rate_alias_and_generic_messages() -> None:
+    """Outcome contradictions should honor success aliases and generic metric wording."""
+    contradictions = outcome_contradictions(
+        termination_reason="collision",
+        outcome={"route_complete": False, "collision_event": True, "timeout_event": False},
+        metrics={"success": 0.0, "success_rate": 1.0, "collisions": 0.0},
+    )
+
+    assert "collision outcome but success metrics > 0" in contradictions
+    assert "outcome.collision_event=true but collision metrics <= 0" in contradictions
+>>>>>>> 7171dbea (fix: preserve collision aliases in migration)

--- a/tests/benchmark/test_termination_reason.py
+++ b/tests/benchmark/test_termination_reason.py
@@ -146,3 +146,20 @@ def test_outcome_contradictions_detect_success_mismatch() -> None:
         metrics={"success": 1.0, "collisions": 0.0},
     )
     assert contradictions
+
+
+def test_outcome_contradictions_detect_collision_metric_drift() -> None:
+    """Collision event outcome and collision count metric should agree."""
+    missing_collision_metric = outcome_contradictions(
+        termination_reason="collision",
+        outcome={"route_complete": False, "collision_event": True, "timeout_event": False},
+        metrics={"success": 0.0, "collisions": 0.0},
+    )
+    assert "outcome.collision_event=true but metrics.collisions <= 0" in missing_collision_metric
+
+    stale_collision_metric = outcome_contradictions(
+        termination_reason="max_steps",
+        outcome={"route_complete": False, "collision_event": False, "timeout_event": True},
+        metrics={"success": 0.0, "collisions": 1.0},
+    )
+    assert "outcome.collision_event=false but metrics.collisions > 0" in stale_collision_metric

--- a/tests/contract/test_episode_schema.py
+++ b/tests/contract/test_episode_schema.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from robot_sf.benchmark.schema_validator import validate_episode
+
 try:
     import jsonschema  # type: ignore
 except Exception as e:  # pragma: no cover
@@ -83,3 +85,66 @@ def test_episode_schema_minimal_valid_passes_when_ready():
     except jsonschema.ValidationError:
         # Accept validation failure until full field set + required list decided
         pytest.xfail("Episode schema structure incomplete (expected during red phase)")
+
+
+def test_episode_schema_rejects_collision_event_without_collision_metric() -> None:
+    """New v1 records should not report collision_event=true with zero collision count."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_collision",
+        "version": "v1",
+        "scenario_id": "sc_collision",
+        "seed": 123,
+        "metrics": {"success": 0.0, "collisions": 0.0},
+        "termination_reason": "collision",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": True,
+            "timeout_event": False,
+        },
+        "integrity": {"contradictions": []},
+    }
+    with pytest.raises(jsonschema.ValidationError, match="collisions"):
+        jsonschema.validate(instance=record, schema=schema)
+
+
+def test_episode_schema_rejects_collision_metric_without_collision_event() -> None:
+    """New v1 records should not carry a positive collision count for non-collision episodes."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_stale_collision",
+        "version": "v1",
+        "scenario_id": "sc_collision",
+        "seed": 124,
+        "metrics": {"success": 0.0, "collisions": 1.0},
+        "termination_reason": "max_steps",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+    }
+    with pytest.raises(jsonschema.ValidationError, match="collisions"):
+        jsonschema.validate(instance=record, schema=schema)
+
+
+def test_episode_validator_rejects_legacy_collision_alias_drift() -> None:
+    """Semantic validation should also catch legacy collision aliases in schema-valid records."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_alias_collision",
+        "version": "v1",
+        "scenario_id": "sc_collision",
+        "seed": 125,
+        "metrics": {"success": 0.0, "collisions": 0.0, "collision_rate": 1.0},
+        "termination_reason": "max_steps",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+    }
+    with pytest.raises(ValueError, match="collision_event=false"):
+        validate_episode(record, schema)

--- a/tests/contract/test_episode_schema.py
+++ b/tests/contract/test_episode_schema.py
@@ -146,5 +146,5 @@ def test_episode_validator_rejects_legacy_collision_alias_drift() -> None:
         },
         "integrity": {"contradictions": []},
     }
-    with pytest.raises(ValueError, match="collision_event=false"):
+    with pytest.raises(jsonschema.ValidationError, match="collision_event=false"):
         validate_episode(record, schema)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -417,17 +417,18 @@ def test_episode_schema_accepts_ped_force_metrics():
     ep = _make_episode(T=3, K=1)
     ep.ped_forces[..., 0] = 2.0  # ensure finite force data
     metrics = compute_all_metrics(ep, horizon=5)
+    collision = metrics.get("collisions", 0.0) > 0.0
     record = {
         "version": "v1",
         "episode_id": "demo-1",
         "scenario_id": "sc-demo",
         "seed": 123,
         "metrics": metrics,
-        "termination_reason": "max_steps",
+        "termination_reason": "collision" if collision else "max_steps",
         "outcome": {
             "route_complete": False,
-            "collision_event": False,
-            "timeout_event": True,
+            "collision_event": collision,
+            "timeout_event": not collision,
         },
         "integrity": {"contradictions": []},
         "timing": {"steps_per_second": 1.0},

--- a/tests/tools/test_migrate_episode_schema_v1.py
+++ b/tests/tools/test_migrate_episode_schema_v1.py
@@ -76,3 +76,18 @@ def test_migrate_record_normalizes_existing_termination_reason_token() -> None:
     }
     migrated = migrate_episode_schema_v1._migrate_record(record)
     assert migrated["termination_reason"] == "collision"
+
+
+def test_migrate_record_backfills_collision_count_for_legacy_collision_status() -> None:
+    """Legacy collision-only records should migrate to the canonical collision contract."""
+    record = {
+        "scenario_id": "s4",
+        "seed": 10,
+        "metrics": {"success": 0.0},
+        "status": "collision",
+    }
+    migrated = migrate_episode_schema_v1._migrate_record(record)
+    assert migrated["termination_reason"] == "collision"
+    assert migrated["outcome"]["collision_event"] is True
+    assert migrated["metrics"]["collisions"] == 1.0
+    assert migrated["integrity"]["contradictions"] == []

--- a/tests/tools/test_migrate_episode_schema_v1.py
+++ b/tests/tools/test_migrate_episode_schema_v1.py
@@ -28,6 +28,21 @@ def test_migrate_record_backfills_new_required_v1_fields() -> None:
     assert "timestamps" in migrated
 
 
+def test_migrate_record_backfills_missing_collision_flag_from_collision_rate() -> None:
+    """Legacy collision-rate-only records should gain schema-v1 collisions when outcome collides."""
+    record = {
+        "scenario_id": "s4",
+        "seed": 4,
+        "status": "collision",
+        "metrics": {"collision_rate": 0.25},
+    }
+
+    migrated = migrate_episode_schema_v1._migrate_record(record)
+
+    assert migrated["outcome"]["collision_event"] is True
+    assert migrated["metrics"]["collisions"] == 1.0
+
+
 def test_migrate_record_preserves_existing_contract_fields() -> None:
     """Records that already satisfy the new contract should keep their explicit values."""
     record = {


### PR DESCRIPTION
## Summary
Canonicalizes episode collision reporting by making `outcome.collision_event` the documented per-episode event flag and requiring `metrics.collisions` to agree for schema v1 outputs.

## Linked Issues
- Closes #1077
- Relates to #1076

## What Changed
- Added JSON Schema v1 conditionals so new records with `collision_event=true` require positive `metrics.collisions`, and records with `collision_event=false` cannot carry a positive canonical collision count.
- Added semantic validation through `schema_validator.validate_episode(...)` so legacy collision aliases such as `collision_rate` are also caught when they contradict the canonical outcome.
- Updated the legacy migration helper to backfill canonical `metrics.collisions` for collision-only legacy records.
- Documented the canonical collision path and compatibility story in `docs/benchmark_spec.md`.
- Added conformance and migration coverage for collision drift, plus fixed an existing schema fixture that had an inconsistent collision count/outcome pair.

## Why It Matters
- Added value: downstream consumers can read one documented collision event path without bundle-specific caveats.
- Expected impact: new benchmark outputs fail validation when collision status and collision count drift apart.
- Why this is worth merging now: #1077 identifies a paper-facing benchmark credibility risk where `metrics.collisions` could be zero while the authoritative event lived elsewhere.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_termination_reason.py tests/contract/test_episode_schema.py tests/tools/test_migrate_episode_schema_v1.py -q` (first run failed before implementation, proving the new tests covered the missing invariant)
  - `uv run pytest tests/contract/test_episode_schema.py tests/benchmark/test_termination_reason.py tests/tools/test_migrate_episode_schema_v1.py -q`
  - `uv run pytest tests/unit/benchmark/test_utils_episode_helpers.py tests/benchmark/test_map_runner_utils.py tests/test_runner_smoke.py tests/tools/test_policy_analysis_run.py -q`
  - `uv run ruff format ...` on touched Python files
  - `uv run ruff check robot_sf/benchmark/termination_reason.py robot_sf/benchmark/schema_validator.py scripts/tools/migrate_episode_schema_v1.py tests/benchmark/test_termination_reason.py tests/contract/test_episode_schema.py tests/tools/test_migrate_episode_schema_v1.py`
  - `jq empty robot_sf/benchmark/schemas/episode.schema.v1.json`
  - `git diff --check`
  - `env BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
  - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - Focused conformance tests now reject both `collision_event=true` with zero `metrics.collisions` and `collision_event=false` with positive collision metrics.
  - Legacy migration now turns a `status=collision` record without `metrics.collisions` into a schema-conformant record with `metrics.collisions == 1.0`.
  - Broader benchmark writer/reader smoke tests passed after the stricter invariant.
  - Full PR readiness passed: `3276 passed, 18 skipped, 3 warnings`.
- Benchmarks or smoke tests, if applicable:
  - `tests/test_runner_smoke.py` and `tests/benchmark/test_map_runner_utils.py` passed inside the targeted and full readiness runs.

## Risks / Rollout
- Compatibility risks: older un-migrated bundles with inconsistent collision fields will now fail validation by design.
- Failure modes: consumers that used `metrics.collisions` as the event source should switch to `outcome.collision_event`; `metrics.collisions` remains the agreeing count metric.
- Rollback or fallback plan: use `scripts/tools/migrate_episode_schema_v1.py` for legacy bundles, or revert the schema/semantic validation changes if the contract proves too strict.

## Docs / Provenance
- Updated docs: `docs/benchmark_spec.md` documents `outcome.collision_event` as the canonical event flag and describes the legacy migration path.
- Relevant design or provenance notes: issue #1077 scope and #1076 parent tracker.
- Any assumptions that need to be preserved: schema v1 episode records are per-episode outputs, so a positive canonical collision count means the canonical event flag should be true.

## Follow-Up Issues
- Deferred work: none for #1077 scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the JSON Schema `allOf` conditionals and semantic alias check are intentionally stricter than previous behavior.
- Any known limitations: `output/coverage` and `output/validation/pr_ready/...` are disposable local validation byproducts; preexisting ignored `output/` benchmark/model artifacts were not used as durable evidence for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter validation to ensure collision event flags consistently match collision metric values across episode data.

* **Documentation**
  * Clarified collision metric definitions and schema compatibility guidelines for episode records.

* **Bug Fixes**
  * Improved legacy data migration to correctly backfill missing collision metrics from older data formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1095)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->