### PR TITLE
feat: add paired aggregate contrasts (#1078)

### DIFF
--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -222,6 +222,16 @@ records from `_run_map_episode`) includes:
 For aggregation, use the utilities in `robot_sf/benchmark/aggregate.py` or the CLI
 ( `robot_sf_bench aggregate` ) to compute mean/median/p95 and optional bootstrap CIs.
 Aggregation validates threshold-profile consistency and rejects mixed profiles.
+When bootstrap sampling is enabled, aggregate output also includes an additive
+`pairwise_contrasts` block when at least two planner groups share paired episode identities. The
+contrast pairing key is `(scenario_id, seed)` with `seed_index` as a fallback, the reported delta is
+`right_minus_left`, and each
+metric contrast includes the paired mean delta, percentile bootstrap interval, two-sided bootstrap
+sign p-value, Holm-adjusted p-value, and paired Cohen's dz effect size. Holm correction is applied
+within the current aggregate family (`family="all"`) separately for each metric; run aggregation on
+scenario-family-filtered inputs when family-specific correction is required. These contrasts are
+descriptive benchmark summaries and do not by themselves establish high-power inference for small
+or weakly paired evidence bases.
 
 For threshold studies, run `scripts/benchmark_threshold_sensitivity.py` to quantify
 distance/comfort threshold impacts across scenario families and to compare speed-aware

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1093,6 +1093,14 @@ Output format
 
 - For each group and metric, the aggregator returns mean, median, p95.
 - When CIs are enabled, additional keys are included: mean_ci, median_ci, p95_ci as [low, high].
+- When CIs are enabled and at least two groups share `(scenario_id, seed)` episode identities
+  (`seed_index` is accepted as a fallback), an additive top-level `pairwise_contrasts` block reports
+  paired bootstrap mean deltas, confidence intervals, two-sided bootstrap sign p-values,
+  Holm-adjusted p-values, and paired Cohen's dz effect sizes. Deltas are `right_minus_left` for
+  comparison keys like `A__vs__B`.
+- Holm correction is applied within the current aggregate family (`family="all"`) separately for
+  each metric. For scenario-family-specific correction, filter or split the input records by family
+  before aggregation.
 
 Programmatic usage
 

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -18,6 +18,7 @@ import csv
 import json
 import math
 from collections import defaultdict
+from itertools import combinations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -440,6 +441,166 @@ def _attach_ci_for_group(
         dst_group[metric_name]["p95_ci"] = [float(lo_hi_p95[0]), float(lo_hi_p95[1])]
 
 
+def _pair_identity(row: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the shared episode identity used for paired planner contrasts."""
+    scenario_id = row.get("scenario_id")
+    seed = row.get("seed", row.get("seed_index"))
+    if scenario_id is None or seed is None:
+        return None
+    return (str(scenario_id), str(seed))
+
+
+def _paired_metric_differences(
+    left_rows: list[dict[str, Any]],
+    right_rows: list[dict[str, Any]],
+) -> dict[str, np.ndarray]:
+    """Return paired ``right - left`` metric differences keyed by metric name."""
+    left_by_id = {
+        identity: _numeric_items(row)
+        for row in left_rows
+        if (identity := _pair_identity(row)) is not None
+    }
+    right_by_id = {
+        identity: _numeric_items(row)
+        for row in right_rows
+        if (identity := _pair_identity(row)) is not None
+    }
+    paired_ids = sorted(set(left_by_id) & set(right_by_id))
+    diffs: dict[str, list[float]] = defaultdict(list)
+    for identity in paired_ids:
+        left_metrics = left_by_id[identity]
+        right_metrics = right_by_id[identity]
+        for metric_name in sorted(set(left_metrics) & set(right_metrics)):
+            diffs[metric_name].append(right_metrics[metric_name] - left_metrics[metric_name])
+    return {name: np.asarray(values, dtype=float) for name, values in diffs.items()}
+
+
+def _bootstrap_delta_stats(
+    differences: np.ndarray,
+    *,
+    bootstrap_samples: int,
+    bootstrap_confidence: float,
+    bootstrap_seed: int | None,
+) -> dict[str, Any]:
+    """Summarize paired differences with percentile bootstrap and effect size metadata.
+
+    Returns:
+        Pairwise contrast statistics, or an empty mapping when no pairs are available.
+    """
+    clean = np.asarray(differences, dtype=float)
+    clean = clean[~np.isnan(clean)]
+    n_pairs = int(clean.size)
+    if n_pairs == 0:
+        return {}
+
+    delta_mean = float(np.mean(clean))
+    delta_median = float(np.median(clean))
+    sd = float(np.std(clean, ddof=1)) if n_pairs > 1 else float("nan")
+    effect_size = delta_mean / sd if sd > 0.0 and math.isfinite(sd) else None
+    rng = np.random.default_rng(bootstrap_seed)
+    boot_means = np.empty(int(bootstrap_samples), dtype=float)
+    for i in range(int(bootstrap_samples)):
+        idx = rng.integers(0, n_pairs, size=n_pairs)
+        boot_means[i] = float(np.mean(clean[idx]))
+
+    alpha = (1.0 - bootstrap_confidence) / 2.0
+    ci = [
+        float(np.percentile(boot_means, 100.0 * alpha)),
+        float(np.percentile(boot_means, 100.0 * (1.0 - alpha))),
+    ]
+    p_lower = float(np.mean(boot_means <= 0.0))
+    p_upper = float(np.mean(boot_means >= 0.0))
+    p_value = float(min(1.0, 2.0 * min(p_lower, p_upper)))
+    return {
+        "n_pairs": n_pairs,
+        "delta_mean": delta_mean,
+        "delta_median": delta_median,
+        "delta_ci": ci,
+        "p_value": p_value,
+        "effect_size": {
+            "type": "paired_cohens_dz",
+            "value": None if effect_size is None else float(effect_size),
+        },
+    }
+
+
+def _holm_adjust(p_values: list[tuple[str, str, float]]) -> dict[tuple[str, str], float]:
+    """Return Holm-adjusted p-values keyed by ``(comparison_key, metric_name)``."""
+    adjusted: dict[tuple[str, str], float] = {}
+    m = len(p_values)
+    running_max = 0.0
+    for rank, (comparison_key, metric_name, p_value) in enumerate(
+        sorted(p_values, key=lambda item: item[2]),
+        start=1,
+    ):
+        raw_adjusted = min(1.0, (m - rank + 1) * p_value)
+        running_max = max(running_max, raw_adjusted)
+        adjusted[(comparison_key, metric_name)] = running_max
+    return adjusted
+
+
+def _compute_pairwise_contrasts(
+    groups: dict[str, list[dict[str, Any]]],
+    *,
+    bootstrap_samples: int,
+    bootstrap_confidence: float,
+    bootstrap_seed: int | None,
+) -> dict[str, Any]:
+    """Compute paired planner contrasts for every group pair and metric.
+
+    Returns:
+        Additive ``pairwise_contrasts`` payload, or an empty mapping when unavailable.
+    """
+    if bootstrap_samples <= 0 or len(groups) < 2:
+        return {}
+
+    contrasts: dict[str, Any] = {
+        "_meta": {
+            "method": "paired_bootstrap_mean_delta",
+            "delta": "right_minus_left",
+            "pairing_keys": ["scenario_id", "seed_or_seed_index"],
+            "bootstrap_samples": int(bootstrap_samples),
+            "bootstrap_confidence": float(bootstrap_confidence),
+            "bootstrap_seed": bootstrap_seed,
+            "p_value_method": "two_sided_bootstrap_sign",
+            "p_value_correction": "holm",
+            "correction_family": ["family", "metric"],
+            "family": "all",
+        }
+    }
+    p_values_by_metric: dict[str, list[tuple[str, str, float]]] = defaultdict(list)
+
+    for left_name, right_name in combinations(sorted(groups), 2):
+        comparison_key = f"{left_name}__vs__{right_name}"
+        metric_diffs = _paired_metric_differences(groups[left_name], groups[right_name])
+        metric_stats: dict[str, dict[str, Any]] = {}
+        for metric_name, differences in metric_diffs.items():
+            stats = _bootstrap_delta_stats(
+                differences,
+                bootstrap_samples=bootstrap_samples,
+                bootstrap_confidence=bootstrap_confidence,
+                bootstrap_seed=bootstrap_seed,
+            )
+            if not stats:
+                continue
+            metric_stats[metric_name] = stats
+            p_values_by_metric[metric_name].append((comparison_key, metric_name, stats["p_value"]))
+        if metric_stats:
+            contrasts[comparison_key] = {
+                "left": left_name,
+                "right": right_name,
+                "metrics": metric_stats,
+            }
+
+    for metric_name, p_values in p_values_by_metric.items():
+        adjusted = _holm_adjust(p_values)
+        for comparison_key, _, _ in p_values:
+            contrasts[comparison_key]["metrics"][metric_name]["p_value_holm"] = adjusted[
+                (comparison_key, metric_name)
+            ]
+    return contrasts if len(contrasts) > 1 else {}
+
+
 def compute_aggregates_with_ci(  # noqa: PLR0913
     records: list[dict[str, Any]],
     *,
@@ -481,6 +642,12 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
     for rec in records:
         _ensure_snqi(rec, snqi_weights, snqi_baseline)
     groups = _group_flattened(records, group_by=group_by, fallback_group_by=fallback_group_by)
+    pairwise_contrasts = _compute_pairwise_contrasts(
+        groups,
+        bootstrap_samples=bootstrap_samples,
+        bootstrap_confidence=bootstrap_confidence,
+        bootstrap_seed=bootstrap_seed,
+    )
 
     out: dict[str, dict[str, dict[str, Any]]] = {
         k: dict(v) for k, v in base.items() if k != "_meta"
@@ -501,6 +668,8 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
             bootstrap_confidence=bootstrap_confidence,
             bootstrap_seed=bootstrap_seed,
         )
+    if pairwise_contrasts:
+        out["pairwise_contrasts"] = pairwise_contrasts  # type: ignore[assignment]
     return out
 
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -153,3 +153,63 @@ def test_compute_aggregates_with_ci_shape_and_determinism(tmp_path: Path):
         bootstrap_seed=123,
     )
     assert summary_ci == summary_ci_2
+
+
+def _paired_contrast_records() -> list[dict]:
+    """Build synthetic records with a planted paired effect for group B over group A."""
+    values_a = [1.0, 2.0, 3.0, 4.0, 5.0]
+    deltas = [1.0, 2.0, 3.0, 1.0, 2.0]
+    records = []
+    for seed, (value_a, delta) in enumerate(zip(values_a, deltas, strict=True), start=1):
+        for algo, score in (("A", value_a), ("B", value_a + delta)):
+            records.append(
+                {
+                    "episode_id": f"{algo}-{seed}",
+                    "scenario_id": "paired-scenario",
+                    "seed": seed,
+                    "scenario_params": {"algo": algo},
+                    "metrics": {"score": score},
+                }
+            )
+    return records
+
+
+def test_compute_aggregates_with_ci_emits_pairwise_contrasts_for_planted_effect() -> None:
+    """Pairwise contrast block should recover a planted paired group difference."""
+    summary_ci = compute_aggregates_with_ci(
+        _paired_contrast_records(),
+        group_by="scenario_params.algo",
+        bootstrap_samples=500,
+        bootstrap_confidence=0.90,
+        bootstrap_seed=123,
+    )
+
+    contrasts = summary_ci["pairwise_contrasts"]
+    assert contrasts["_meta"]["pairing_keys"] == ["scenario_id", "seed_or_seed_index"]
+    assert contrasts["_meta"]["p_value_correction"] == "holm"
+    score = contrasts["A__vs__B"]["metrics"]["score"]
+    assert score["n_pairs"] == 5
+    assert score["delta_mean"] == 1.8
+    assert score["delta_ci"][0] > 0.0
+    assert score["p_value_holm"] >= score["p_value"]
+    assert score["effect_size"]["type"] == "paired_cohens_dz"
+    assert score["effect_size"]["value"] > 0.0
+
+
+def test_compute_aggregates_with_ci_pairwise_contrasts_are_seed_deterministic() -> None:
+    """Pairwise bootstrap output should be reproducible for identical inputs and seeds."""
+    first = compute_aggregates_with_ci(
+        _paired_contrast_records(),
+        group_by="scenario_params.algo",
+        bootstrap_samples=250,
+        bootstrap_confidence=0.90,
+        bootstrap_seed=456,
+    )
+    second = compute_aggregates_with_ci(
+        _paired_contrast_records(),
+        group_by="scenario_params.algo",
+        bootstrap_samples=250,
+        bootstrap_confidence=0.90,
+        bootstrap_seed=456,
+    )
+    assert first["pairwise_contrasts"] == second["pairwise_contrasts"]

--- a/tests/test_cli_aggregate.py
+++ b/tests/test_cli_aggregate.py
@@ -162,3 +162,49 @@ def test_cli_aggregate_with_ci_and_seed(tmp_path: Path, capsys):
 
     # Determinism check: summaries should be identical with same seed
     assert d1 == d2
+
+
+def test_cli_aggregate_with_ci_writes_pairwise_contrasts(tmp_path: Path, capsys) -> None:
+    """Aggregate CLI should write additive pairwise contrasts for paired planner inputs."""
+    episodes = tmp_path / "paired_episodes.jsonl"
+    with episodes.open("w", encoding="utf-8") as f:
+        for seed, value_a in enumerate([1.0, 2.0, 3.0, 4.0], start=1):
+            for algo, score in (("A", value_a), ("B", value_a + 2.0)):
+                f.write(
+                    json.dumps(
+                        {
+                            "episode_id": f"{algo}-{seed}",
+                            "scenario_id": "paired-cli",
+                            "seed": seed,
+                            "scenario_params": {"algo": algo},
+                            "metrics": {"score": score},
+                        }
+                    )
+                    + "\n"
+                )
+
+    out_json = tmp_path / "summary_ci.json"
+    rc = cli_main(
+        [
+            "aggregate",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--bootstrap-samples",
+            "200",
+            "--bootstrap-confidence",
+            "0.9",
+            "--bootstrap-seed",
+            "123",
+        ]
+    )
+    cap = capsys.readouterr()
+    assert rc == 0, f"aggregate ci failed: {cap.err}"
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+    score = data["pairwise_contrasts"]["A__vs__B"]["metrics"]["score"]
+    assert score["n_pairs"] == 4
+    assert score["delta_mean"] == 2.0
+    assert score["delta_ci"] == [2.0, 2.0]
+    assert data["pairwise_contrasts"]["_meta"]["correction_family"] == ["family", "metric"]


### PR DESCRIPTION
## Summary
Adds an additive `pairwise_contrasts` block to aggregate outputs when bootstrap CI sampling is enabled, covering paired planner deltas, effect-size metadata, and Holm-adjusted p-values.

## Linked Issues
- Closes #1078
- Relates to #1076

## What Changed
- Added paired contrast computation in `robot_sf/benchmark/aggregate.py` using shared episode identity `(scenario_id, seed)` with `seed_index` as a fallback.
- Emits per-comparison metric blocks with `right_minus_left` paired mean/median delta, percentile bootstrap interval, two-sided bootstrap sign p-value, Holm-adjusted p-value, and paired Cohen's dz metadata.
- Keeps the output additive: existing aggregate group metric keys remain unchanged, and `pairwise_contrasts` appears only when bootstrap sampling is enabled and paired groups exist.
- Added synthetic planted-effect unit coverage and CLI coverage for the emitted contrast block.
- Documented pairing assumptions, correction family, and interpretation limits in `docs/benchmark_spec.md` and `docs/dev_guide.md`.

## Why It Matters
- Added value: consumers can compare two planners directly from aggregate output instead of writing bespoke post-processing scripts.
- Expected impact: benchmark aggregate JSON now carries reproducible pairwise deltas and conservative multiple-comparison metadata.
- Why this is worth merging now: #1078 is a paper-facing comparison gap and this centralizes the contrast logic in the benchmark aggregation surface.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_aggregate.py -q`
  - `uv run pytest tests/test_aggregate.py tests/test_cli_aggregate.py -q`
  - `uv run pytest tests/test_aggregate.py tests/test_cli_aggregate.py tests/test_aggregate_threshold_meta.py -q`
  - `uv run pytest tests/test_aggregate.py tests/test_cli_aggregate.py tests/test_aggregate_threshold_meta.py tests/benchmark/test_aggregation_algorithms.py tests/contract/test_aggregate_schema.py -q`
  - `uv run ruff format robot_sf/benchmark/aggregate.py tests/test_aggregate.py tests/test_cli_aggregate.py`
  - `uv run ruff check robot_sf/benchmark/aggregate.py tests/test_aggregate.py tests/test_cli_aggregate.py`
  - `git diff --check`
  - `env BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
  - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - Synthetic planted-effect test recovers positive paired delta and positive bootstrap interval for `A__vs__B`.
  - CLI test writes `pairwise_contrasts` into aggregate JSON and verifies `n_pairs`, `delta_mean`, interval shape, and correction metadata.
  - Existing aggregate CI determinism, threshold metadata, missing-algorithm warnings, and contract tests continue to pass.
  - Full PR readiness passed: `3274 passed, 18 skipped, 3 warnings`.
- Benchmarks or smoke tests, if applicable:
  - Aggregate CLI smoke path exercised with a synthetic paired JSONL bundle.

## Risks / Rollout
- Compatibility risks: low; the new block is additive and existing group metric keys are unchanged.
- Failure modes: pairwise contrasts are omitted when groups do not share `(scenario_id, seed)` / `seed_index` identities or when bootstrap sampling is disabled.
- Rollback or fallback plan: remove the additive `pairwise_contrasts` block generation while retaining existing aggregate mean/median/p95 and CI behavior.

## Docs / Provenance
- Updated docs: `docs/benchmark_spec.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: issue #1078 and parent tracker #1076.
- Any assumptions that need to be preserved: Holm correction is applied within the current aggregate family (`family="all"`) separately per metric. For scenario-family-specific correction, aggregate filtered/split inputs by family.

## Follow-Up Issues
- Deferred work: none for #1078 scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: p-value semantics are descriptive bootstrap sign p-values, not a claim of high-power inference.
- Any known limitations: `output/coverage` and `output/validation/pr_ready/...` are disposable local validation byproducts; preexisting ignored benchmark/checkpoint outputs were not used as durable evidence for this PR.
