### PR TITLE
feat: add planner observation mode contracts

### DIFF
--- a/configs/benchmarks/observation_mode_goal_parity_smoke.yaml
+++ b/configs/benchmarks/observation_mode_goal_parity_smoke.yaml
@@ -1,0 +1,33 @@
+name: observation_mode_goal_parity_smoke
+paper_facing: false
+scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
+
+seed_policy:
+  mode: fixed-list
+  seeds: [1080]
+
+workers: 1
+horizon: 80
+dt: 0.1
+record_forces: false
+resume: true
+stop_on_failure: false
+bootstrap_samples: 50
+bootstrap_confidence: 0.95
+bootstrap_seed: 1080
+
+kinematics_matrix:
+  - differential_drive
+
+planners:
+  - key: goal_state_goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+    observation_mode: goal_state
+
+  - key: socnav_state_goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+    observation_mode: socnav_state

--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -91,6 +91,22 @@ CLI gating:
 * `--benchmark-profile experimental`: allows baseline-ready + experimental algorithms.
 * `--adapter-impact-eval` (optional): records adapter-impact metadata (native vs adapted step
   counts where measurable, currently most informative for PPO command conversion).
+* `--observation-mode <mode>` (optional): requests a declared planner observation contract for
+  controlled input-modality checks. Unsupported planner/mode combinations fail before episodes
+  are written.
+
+Observation-mode declarations are metadata contracts, not automatic environment rewrites. The
+current standard modes are:
+
+* `goal_state`: robot state plus route goal only.
+* `socnav_state`: structured robot, goal, and pedestrian state.
+* `headed_socnav_state`: structured social-navigation state with headed robot fields.
+* `sensor_fusion_state`: configured sensor-fusion stack used by learned checkpoint policies.
+* `lidar_human_state` / `gst_human_state`: upstream learned-wrapper input contracts.
+
+The built-in `goal` planner declares both `goal_state` and `socnav_state`, making it the initial
+two-mode demonstration path. Extra channels in `socnav_state` are ignored by that planner, so this
+is useful for input-contract parity checks but is not a claim of pure planner-logic attribution.
 
 Placeholder planners (`rvo`, `dwa`, `teb`) are hard-blocked for benchmark runs.
 
@@ -204,6 +220,8 @@ Each episode record is schema-validated against
 * `algorithm_metadata.planner_kinematics` including `execution_mode` (`native|adapter|mixed`) and
   adapter markers for compatibility interpretation. Contract now also includes
   `planner_command_space` (`unicycle_vw|holonomic_vxy`) for kinematics-aware interpretation.
+* `observation_mode` and `algorithm_metadata.observation_spec`, including the planner's default
+  mode, supported modes, active mode, and whether an override was applied.
 * `algorithm_metadata.kinematics_feasibility` with command-level intervention diagnostics:
   `commands_evaluated`, `infeasible_native_count`, `projected_count`,
   `projection_rate`, `infeasible_rate`, `mean/max abs delta` for linear and angular commands.

--- a/docs/context/issue_1080_observation_modes.md
+++ b/docs/context/issue_1080_observation_modes.md
@@ -1,0 +1,63 @@
+# Issue 1080 Observation-Mode Contracts
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1080>
+
+## Scope
+
+This change makes planner observation assumptions first-class benchmark metadata and adds a
+fail-closed observation-mode override for map-runner and camera-ready campaign paths.
+
+The override is a contract check, not a new observation builder. Existing environment observation
+construction remains unchanged; unsupported planner/mode combinations fail before benchmark
+episodes are written. This keeps parity experiments explicit without claiming that modality alone
+explains planner differences.
+
+## Modes
+
+- `goal_state`: robot state plus route goal only.
+- `socnav_state`: structured robot, goal, and pedestrian state.
+- `headed_socnav_state`: social-navigation state with headed robot fields.
+- `sensor_fusion_state`: configured sensor-fusion stack used by learned policies.
+- `lidar_human_state` / `gst_human_state`: upstream learned-wrapper contracts.
+
+The initial two-mode demonstration path is
+`configs/benchmarks/observation_mode_goal_parity_smoke.yaml`, which runs the built-in `goal`
+planner under both `goal_state` and `socnav_state` on a fixed planner-sanity scenario/seed.
+
+## Validation Notes
+
+Validated on 2026-05-09:
+
+- `uv run pytest tests/benchmark/test_algorithm_metadata_contract.py tests/test_algorithm_metadata.py
+  tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_resume_identity.py
+  tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_camera_ready_campaign.py
+  tests/contract/test_episode_schema.py -q` passed (`179 passed`).
+- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed (`3275 passed`, `18 skipped`,
+  `3 warnings`). The changed-files coverage gate reported warning-only coverage below the
+  aspirational goal for broad benchmark modules; no readiness failure was raised.
+- `uv run python scripts/tools/run_camera_ready_benchmark.py --config
+  configs/benchmarks/observation_mode_goal_parity_smoke.yaml --mode preflight --output-root
+  output/benchmarks/issue_1080 --campaign-id observation_mode_goal_parity_preflight`
+  generated validate/preview and matrix-summary artifacts with both goal-planner observation modes.
+- `uv run python scripts/tools/run_camera_ready_benchmark.py --config
+  configs/benchmarks/observation_mode_goal_parity_smoke.yaml --mode run --output-root
+  output/benchmarks/issue_1080 --campaign-id observation_mode_goal_parity_run
+  --skip-publication-bundle` completed successfully with two runs and two episodes.
+- Episode JSONL inspection confirmed top-level `observation_mode`,
+  `scenario_params.observation_mode`, and
+  `algorithm_metadata.observation_spec.active_mode` were `goal_state` for one run and
+  `socnav_state` for the other.
+- `uv run robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out
+  output/benchmarks/issue_1080/direct_goal_socnav/episodes.jsonl --schema
+  robot_sf/benchmark/schemas/episode.schema.v1.json --algo goal --benchmark-profile baseline-safe
+  --observation-mode socnav_state --horizon 5 --workers 1 --no-video --no-resume` completed
+  successfully with `total_jobs=3`, `written=3`, and `failed=0`.
+- `uv run robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out
+  output/benchmarks/issue_1080/unsupported_override/episodes.jsonl --schema
+  robot_sf/benchmark/schemas/episode.schema.v1.json --algo orca --benchmark-profile
+  baseline-safe --socnav-missing-prereq-policy fallback --observation-mode goal_state --horizon 1
+  --workers 1 --no-video --no-resume` exited with code `2`, confirming unsupported overrides
+  fail closed through the CLI path.
+
+The representative run emitted degenerate-baseline SNQI warnings because the smoke config has only
+two goal-planner episodes. Those warnings do not affect the observation-mode contract proof.

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -106,6 +106,111 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "nmpc_social": "nonlinear_model_predictive_local_planner",
 }
 
+_DEFAULT_OBSERVATION_SPEC: dict[str, Any] = {
+    "default_mode": "socnav_state",
+    "supported_modes": ("socnav_state",),
+    "inputs": ("robot_state", "goal", "pedestrians"),
+    "notes": (
+        "Structured Robot SF social-navigation state: robot pose/velocity, route goal, "
+        "and pedestrian state when present."
+    ),
+}
+
+_OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
+    "goal": {
+        "default_mode": "goal_state",
+        "supported_modes": ("goal_state", "socnav_state"),
+        "inputs": ("robot_state", "goal"),
+        "notes": (
+            "Goal baseline consumes robot and goal state only; it can run under socnav_state "
+            "as a parity control because extra pedestrian channels are ignored."
+        ),
+    },
+    "social_force": _DEFAULT_OBSERVATION_SPEC,
+    "orca": _DEFAULT_OBSERVATION_SPEC,
+    "hrvo": _DEFAULT_OBSERVATION_SPEC,
+    "socnav_orca_nonholonomic": _DEFAULT_OBSERVATION_SPEC,
+    "socnav_orca_dd": _DEFAULT_OBSERVATION_SPEC,
+    "socnav_orca_relaxed": _DEFAULT_OBSERVATION_SPEC,
+    "socnav_hrvo": _DEFAULT_OBSERVATION_SPEC,
+    "social_navigation_pyenvs_orca": _DEFAULT_OBSERVATION_SPEC,
+    "social_navigation_pyenvs_socialforce": _DEFAULT_OBSERVATION_SPEC,
+    "social_navigation_pyenvs_sfm_helbing": _DEFAULT_OBSERVATION_SPEC,
+    "social_navigation_pyenvs_hsfm_new_guo": {
+        "default_mode": "headed_socnav_state",
+        "supported_modes": ("headed_socnav_state",),
+        "inputs": ("robot_state", "robot_heading", "goal", "pedestrians"),
+        "notes": "Structured headed social-navigation state for HSFM-style adapters.",
+    },
+    "stream_gap": _DEFAULT_OBSERVATION_SPEC,
+    "gap_prediction": _DEFAULT_OBSERVATION_SPEC,
+    "risk_dwa": _DEFAULT_OBSERVATION_SPEC,
+    "mppi_social": _DEFAULT_OBSERVATION_SPEC,
+    "hybrid_portfolio": _DEFAULT_OBSERVATION_SPEC,
+    "hybrid_orca_sampler": _DEFAULT_OBSERVATION_SPEC,
+    "policy_stack_v1": _DEFAULT_OBSERVATION_SPEC,
+    "prediction_planner": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "pedestrians", "history"),
+        "notes": "Predictive planner consumes structured SocNav state plus short history features.",
+    },
+    "predictive_mppi": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "pedestrians", "prediction_model"),
+        "notes": "Predictive MPPI consumes SocNav state and learned prediction features.",
+    },
+    "ppo": {
+        "default_mode": "sensor_fusion_state",
+        "supported_modes": ("sensor_fusion_state",),
+        "inputs": ("robot_state", "goal", "lidar_rays", "history"),
+        "notes": "PPO checkpoint inference uses the configured sensor-fusion observation stack.",
+    },
+    "guarded_ppo": {
+        "default_mode": "sensor_fusion_state",
+        "supported_modes": ("sensor_fusion_state",),
+        "inputs": ("robot_state", "goal", "lidar_rays", "history", "safety_guard"),
+        "notes": "Guarded PPO uses sensor-fusion policy inputs plus a local safety guard.",
+    },
+    "crowdnav_height": {
+        "default_mode": "lidar_human_state",
+        "supported_modes": ("lidar_human_state",),
+        "inputs": ("robot_state", "goal", "lidar_rays", "humans"),
+        "notes": "CrowdNav HEIGHT wrapper reconstructs the upstream lidar-plus-human dict input.",
+    },
+    "sonic_crowdnav": {
+        "default_mode": "gst_human_state",
+        "supported_modes": ("gst_human_state",),
+        "inputs": ("robot_state", "goal", "humans"),
+        "notes": "SoNIC/GenSafeNav-style GST checkpoint input contract.",
+    },
+    "gensafenav_ours_gst": {
+        "default_mode": "gst_human_state",
+        "supported_modes": ("gst_human_state",),
+        "inputs": ("robot_state", "goal", "humans"),
+        "notes": "GenSafeNav Ours_GST checkpoint input contract.",
+    },
+    "gensafenav_ours_gst_guarded": {
+        "default_mode": "gst_human_state",
+        "supported_modes": ("gst_human_state",),
+        "inputs": ("robot_state", "goal", "humans", "safety_guard"),
+        "notes": "Guarded GenSafeNav Ours_GST checkpoint input contract.",
+    },
+    "gensafenav_gst_predictor_rand": {
+        "default_mode": "gst_human_state",
+        "supported_modes": ("gst_human_state",),
+        "inputs": ("robot_state", "goal", "humans"),
+        "notes": "GenSafeNav GST_predictor_rand checkpoint input contract.",
+    },
+    "gensafenav_gst_predictor_rand_guarded": {
+        "default_mode": "gst_human_state",
+        "supported_modes": ("gst_human_state",),
+        "inputs": ("robot_state", "goal", "humans", "safety_guard"),
+        "notes": "Guarded GenSafeNav GST_predictor_rand checkpoint input contract.",
+    },
+}
+
 _UPSTREAM_REFERENCE_BY_CANONICAL: dict[str, dict[str, Any]] = {
     "orca": {
         "repo_url": "https://github.com/mit-acl/Python-RVO2",
@@ -750,6 +855,49 @@ def canonical_algorithm_name(algo: str) -> str:
     return readiness.canonical_name if readiness is not None else alias
 
 
+def observation_spec_for_algorithm(algo: str) -> dict[str, Any]:
+    """Return the declared observation contract for an algorithm.
+
+    Returns:
+        dict[str, Any]: Stable observation-spec payload with default and supported modes.
+    """
+    canonical = canonical_algorithm_name(algo)
+    spec = _OBSERVATION_SPEC_BY_CANONICAL.get(canonical, _DEFAULT_OBSERVATION_SPEC)
+    return {
+        "default_mode": str(spec["default_mode"]),
+        "supported_modes": [str(mode) for mode in spec["supported_modes"]],
+        "inputs": [str(value) for value in spec.get("inputs", ())],
+        "notes": str(spec.get("notes", "")),
+    }
+
+
+def resolve_observation_mode(algo: str, requested_mode: str | None = None) -> str:
+    """Resolve and validate the active observation mode for an algorithm.
+
+    Args:
+        algo: Algorithm label or alias.
+        requested_mode: Optional explicit observation mode override.
+
+    Returns:
+        The active observation mode.
+
+    Raises:
+        ValueError: If ``requested_mode`` is unsupported for ``algo``.
+    """
+    spec = observation_spec_for_algorithm(algo)
+    default_mode = str(spec["default_mode"])
+    requested = str(requested_mode).strip() if requested_mode is not None else ""
+    active_mode = requested or default_mode
+    supported = tuple(str(mode) for mode in spec["supported_modes"])
+    if active_mode not in supported:
+        supported_text = ", ".join(supported)
+        raise ValueError(
+            f"Observation mode '{active_mode}' is not supported by algorithm "
+            f"'{canonical_algorithm_name(algo)}'. Supported modes: {supported_text}."
+        )
+    return active_mode
+
+
 def _base_kinematics_metadata(
     canonical_algo: str,
     *,
@@ -793,6 +941,7 @@ def enrich_algorithm_metadata(
     adapter_name: str | None = None,
     robot_kinematics: str | None = None,
     adapter_impact_requested: bool | None = None,
+    observation_mode: str | None = None,
 ) -> dict[str, Any]:
     """Return metadata enriched with baseline category and compatibility fields.
 
@@ -803,6 +952,7 @@ def enrich_algorithm_metadata(
         adapter_name: Optional runtime adapter override.
         robot_kinematics: Optional robot kinematics tag for this episode/run.
         adapter_impact_requested: Optional marker that adapter-impact probing was requested.
+        observation_mode: Optional runtime observation-mode override.
 
     Returns:
         A metadata dictionary with stable benchmark contract keys.
@@ -825,6 +975,16 @@ def enrich_algorithm_metadata(
     upstream_reference = _UPSTREAM_REFERENCE_BY_CANONICAL.get(canonical)
     if upstream_reference is not None:
         enriched.setdefault("upstream_reference", dict(upstream_reference))
+
+    active_observation_mode = resolve_observation_mode(canonical, observation_mode)
+    observation_spec = observation_spec_for_algorithm(canonical)
+    observation_spec["active_mode"] = active_observation_mode
+    observation_spec["override_applied"] = bool(
+        observation_mode is not None
+        and str(observation_mode).strip()
+        and active_observation_mode != observation_spec["default_mode"]
+    )
+    enriched["observation_spec"] = observation_spec
 
     current_kinematics = enriched.get("planner_kinematics")
     base_kinematics = _base_kinematics_metadata(
@@ -881,4 +1041,6 @@ __all__ = [
     "canonical_algorithm_name",
     "enrich_algorithm_metadata",
     "infer_execution_mode_from_counts",
+    "observation_spec_for_algorithm",
+    "resolve_observation_mode",
 ]

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -134,6 +134,7 @@ class PlannerSpec:
     algo_config_path: Path | None = None
     socnav_missing_prereq_policy: str = "fail-fast"
     adapter_impact_eval: bool = False
+    observation_mode: str | None = None
     workers_override: int | None = None
     horizon_override: int | None = None
     dt_override: float | None = None
@@ -188,6 +189,7 @@ class CampaignConfig:
     preview_scenario_limit: int = 100
     kinematics_matrix: tuple[str, ...] = ("differential_drive",)
     holonomic_command_mode: str = "vx_vy"
+    observation_mode: str | None = None
     paper_facing: bool = False
     paper_profile_version: str | None = None
     amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
@@ -1065,6 +1067,11 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912
                     entry.get("socnav_missing_prereq_policy", "fail-fast"),
                 ),
                 adapter_impact_eval=bool(entry.get("adapter_impact_eval", False)),
+                observation_mode=(
+                    str(entry.get("observation_mode")).strip()
+                    if entry.get("observation_mode") is not None
+                    else None
+                ),
                 workers_override=(
                     int(entry["workers"]) if entry.get("workers") is not None else None
                 ),
@@ -1174,6 +1181,11 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912
             if str(value).strip()
         ),
         holonomic_command_mode=str(payload.get("holonomic_command_mode", "vx_vy")).strip(),
+        observation_mode=(
+            str(payload.get("observation_mode")).strip()
+            if payload.get("observation_mode") is not None
+            else None
+        ),
         paper_facing=bool(payload.get("paper_facing", False)),
         paper_profile_version=(
             str(payload.get("paper_profile_version")).strip()
@@ -1298,6 +1310,7 @@ def _build_matrix_summary_rows(
     for planner in cfg.planners:
         if not planner.enabled:
             continue
+        active_observation_mode = planner.observation_mode or cfg.observation_mode
         for kinematics in normalized_kinematics:
             rows.append(
                 {
@@ -1308,6 +1321,7 @@ def _build_matrix_summary_rows(
                     "algo": planner.algo,
                     "planner_group": planner.planner_group,
                     "benchmark_profile": planner.benchmark_profile,
+                    "observation_mode": active_observation_mode,
                     "kinematics": kinematics,
                     "seed_policy.mode": cfg.seed_policy.mode,
                     "seed_policy.seed_set": cfg.seed_policy.seed_set,
@@ -2231,12 +2245,14 @@ def prepare_campaign_preflight(
                     if planner.algo_config_path is not None
                     else None
                 ),
+                "observation_mode": planner.observation_mode,
                 "enabled": planner.enabled,
             }
             for planner in cfg.planners
         ],
         "kinematics_matrix": list(cfg.kinematics_matrix),
         "holonomic_command_mode": cfg.holonomic_command_mode,
+        "observation_mode": cfg.observation_mode,
         "repository_url": cfg.repository_url,
         "release_tag": cfg.release_tag,
         "doi": cfg.doi,
@@ -2897,6 +2913,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     for planner in cfg.planners:
         if not planner.enabled:
             continue
+        active_observation_mode = planner.observation_mode or cfg.observation_mode
         for kinematics in kinematics_matrix:
             planner_run_key = f"{_sanitize_name(planner.key)}__{_sanitize_name(kinematics)}"
             planner_dir = runs_dir / planner_run_key
@@ -2948,6 +2965,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                     benchmark_profile=planner.benchmark_profile,
                     socnav_missing_prereq_policy=planner.socnav_missing_prereq_policy,
                     adapter_impact_eval=planner.adapter_impact_eval,
+                    observation_mode=active_observation_mode,
                     workers=effective_workers,
                     resume=cfg.resume,
                 )
@@ -3043,6 +3061,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                         ),
                         "socnav_missing_prereq_policy": planner.socnav_missing_prereq_policy,
                         "adapter_impact_eval": planner.adapter_impact_eval,
+                        "observation_mode": active_observation_mode,
                         "workers": effective_workers,
                         "horizon": effective_horizon,
                         "dt": effective_dt,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -102,6 +102,16 @@ _SNQI_CONTRACT_ENFORCEMENT = {"warn", "error"}
 _ROUTE_CLEARANCE_WARN_THRESHOLD_M = 0.5
 
 
+def _normalize_observation_mode(raw: Any, *, label: str) -> str | None:
+    """Return a normalized observation-mode override, rejecting blank strings."""
+    if raw is None:
+        return None
+    normalized = str(raw).strip()
+    if not normalized:
+        raise ValueError(f"{label} cannot be empty when provided")
+    return normalized
+
+
 @dataclass(frozen=True)
 class AmvProfileConfig:
     """AMV paper-profile scope contract settings."""
@@ -1067,10 +1077,9 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912
                     entry.get("socnav_missing_prereq_policy", "fail-fast"),
                 ),
                 adapter_impact_eval=bool(entry.get("adapter_impact_eval", False)),
-                observation_mode=(
-                    str(entry.get("observation_mode")).strip()
-                    if entry.get("observation_mode") is not None
-                    else None
+                observation_mode=_normalize_observation_mode(
+                    entry.get("observation_mode"),
+                    label="Planner entry 'observation_mode'",
                 ),
                 workers_override=(
                     int(entry["workers"]) if entry.get("workers") is not None else None
@@ -1181,10 +1190,9 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912
             if str(value).strip()
         ),
         holonomic_command_mode=str(payload.get("holonomic_command_mode", "vx_vy")).strip(),
-        observation_mode=(
-            str(payload.get("observation_mode")).strip()
-            if payload.get("observation_mode") is not None
-            else None
+        observation_mode=_normalize_observation_mode(
+            payload.get("observation_mode"),
+            label="Campaign 'observation_mode'",
         ),
         paper_facing=bool(payload.get("paper_facing", False)),
         paper_profile_version=(

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -267,6 +267,7 @@ def _handle_run(args) -> int:
             benchmark_profile=args.benchmark_profile,
             socnav_missing_prereq_policy=args.socnav_missing_prereq_policy,
             adapter_impact_eval=bool(getattr(args, "adapter_impact_eval", False)),
+            observation_mode=getattr(args, "observation_mode", None),
             snqi_weights=snqi_weights,
             snqi_baseline=snqi_baseline,
             workers=args.workers,
@@ -1230,6 +1231,14 @@ def _add_run_subparser(
         help=(
             "Enable adapter-impact metadata probing. "
             "For mixed-command planners (e.g., PPO), records native vs adapted step usage."
+        ),
+    )
+    p.add_argument(
+        "--observation-mode",
+        default=None,
+        help=(
+            "Optional planner observation-mode override. Unsupported planner/mode "
+            "combinations fail before episodes are written."
         ),
     )
     p.add_argument(

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -25,6 +25,7 @@ from robot_sf.benchmark import planner_command_contract as planner_commands
 from robot_sf.benchmark.algorithm_metadata import (
     enrich_algorithm_metadata,
     infer_execution_mode_from_counts,
+    resolve_observation_mode,
 )
 from robot_sf.benchmark.algorithm_readiness import (
     BenchmarkProfile,
@@ -2288,6 +2289,7 @@ def _scenario_identity_payload(
     horizon: int | None,
     dt: float | None,
     record_forces: bool,
+    observation_mode: str | None = None,
 ) -> dict[str, Any]:
     """Build the canonical scenario payload used for episode identity.
 
@@ -2305,6 +2307,8 @@ def _scenario_identity_payload(
     payload["algo"] = str(algo)
     payload["algo_config_hash"] = _config_hash(algo_config)
     payload["record_forces"] = bool(record_forces)
+    if observation_mode is not None:
+        payload["observation_mode"] = str(observation_mode)
     if horizon is not None and int(horizon) > 0:
         payload["run_horizon"] = int(horizon)
     if dt is not None and float(dt) > 0.0:
@@ -2596,6 +2600,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     algo_config: dict[str, Any] | None = None,
     algo_config_path: str | None = None,
     adapter_impact_eval: bool = False,
+    observation_mode: str | None = None,
 ) -> dict[str, Any]:
     """Run one scenario/seed episode and return a benchmark JSONL record.
 
@@ -2626,12 +2631,19 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         algo_config=raw_policy_cfg,
         scenario=scenario,
     )
+    active_observation_mode = resolve_observation_mode(algo, observation_mode)
     policy_fn, algo_meta = _build_policy(
         algo,
         policy_cfg,
         robot_kinematics=robot_kinematics,
         robot_command_mode=robot_command_mode,
         adapter_impact_eval=adapter_impact_eval,
+    )
+    algo_meta = enrich_algorithm_metadata(
+        algo=algo,
+        metadata=algo_meta,
+        robot_kinematics=robot_kinematics,
+        observation_mode=active_observation_mode,
     )
     planner_close = getattr(policy_fn, "_planner_close", None)
     planner_reset = getattr(policy_fn, "_planner_reset", None)
@@ -2795,6 +2807,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 metadata=algo_meta,
                 execution_mode=execution_mode,
                 robot_kinematics=robot_kinematics,
+                observation_mode=active_observation_mode,
             )
         else:
             impact["status"] = "not_applicable"
@@ -2819,6 +2832,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         horizon=horizon,
         dt=dt,
         record_forces=record_forces,
+        observation_mode=active_observation_mode,
     )
     steps_taken = int(robot_pos_arr.shape[0])
     wall_time = float(max(1e-9, time.time() - start_time))
@@ -2850,6 +2864,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "metrics": metrics,
         "algorithm_metadata": algo_meta,
         "algo": algo,
+        "observation_mode": active_observation_mode,
         "config_hash": _config_hash(scenario_params),
         "git_hash": _git_hash_fallback(),
         "timestamps": {"start": ts_start, "end": ts_end},
@@ -2916,6 +2931,7 @@ def _run_map_job_worker(
         algo_config_path=params.get("algo_config_path"),
         scenario_path=Path(params.get("scenario_path")),
         adapter_impact_eval=bool(params.get("adapter_impact_eval", False)),
+        observation_mode=params.get("observation_mode"),
     )
 
 
@@ -3047,6 +3063,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     benchmark_profile: BenchmarkProfile = "baseline-safe",
     socnav_missing_prereq_policy: str = "fail-fast",
     adapter_impact_eval: bool = False,
+    observation_mode: str | None = None,
     workers: int = 1,
     resume: bool = True,
 ) -> dict[str, Any]:
@@ -3096,7 +3113,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         metadata={},
         robot_kinematics=kinematics_tag,
         adapter_impact_requested=adapter_impact_eval,
+        observation_mode=observation_mode,
     )
+    active_observation_mode = str(algo_contract["observation_spec"]["active_mode"])
     planner_meta = algo_contract.get("planner_kinematics")
     if isinstance(planner_meta, dict):
         planner_meta["scenario_kinematics"] = scenario_kinematics
@@ -3191,6 +3210,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     horizon=horizon,
                     dt=dt,
                     record_forces=record_forces,
+                    observation_mode=active_observation_mode,
                 )
                 if _compute_map_episode_id(identity_payload, seed) not in existing:
                     filtered_jobs.append((sc, seed))
@@ -3207,6 +3227,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "algo_config_path": algo_config_path,
         "scenario_path": str(scenario_path),
         "adapter_impact_eval": bool(adapter_impact_eval),
+        "observation_mode": active_observation_mode,
     }
 
     total_jobs = len(jobs)
@@ -3317,6 +3338,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 metadata=algo_contract,
                 execution_mode=execution_mode,
                 robot_kinematics=kinematics_tag,
+                observation_mode=active_observation_mode,
             )
         else:
             impact_contract["status"] = "not_applicable"

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3108,12 +3108,13 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         kinematics_tag = scenario_kinematics[0]
     else:
         kinematics_tag = "mixed"
+    batch_observation_mode = str(observation_mode).strip() if observation_mode is not None else None
     algo_contract = enrich_algorithm_metadata(
         algo=algo,
         metadata={},
         robot_kinematics=kinematics_tag,
         adapter_impact_requested=adapter_impact_eval,
-        observation_mode=observation_mode,
+        observation_mode=batch_observation_mode,
     )
     active_observation_mode = str(algo_contract["observation_spec"]["active_mode"])
     planner_meta = algo_contract.get("planner_kinematics")
@@ -3203,6 +3204,10 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     algo_config=raw_policy_cfg,
                     scenario=sc,
                 )
+                identity_observation_mode = resolve_observation_mode(
+                    identity_algo,
+                    batch_observation_mode,
+                )
                 identity_payload = _scenario_identity_payload(
                     sc,
                     algo=identity_algo,
@@ -3210,7 +3215,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     horizon=horizon,
                     dt=dt,
                     record_forces=record_forces,
-                    observation_mode=active_observation_mode,
+                    observation_mode=identity_observation_mode,
                 )
                 if _compute_map_episode_id(identity_payload, seed) not in existing:
                     filtered_jobs.append((sc, seed))
@@ -3227,7 +3232,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "algo_config_path": algo_config_path,
         "scenario_path": str(scenario_path),
         "adapter_impact_eval": bool(adapter_impact_eval),
-        "observation_mode": active_observation_mode,
+        "observation_mode": batch_observation_mode,
     }
 
     total_jobs = len(jobs)

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1453,6 +1453,7 @@ def run_batch(  # noqa: PLR0913
     benchmark_profile: str = "baseline-safe",
     socnav_missing_prereq_policy: str = "fail-fast",
     adapter_impact_eval: bool = False,
+    observation_mode: str | None = None,
     workers: int = 1,
     resume: bool = True,
 ) -> dict[str, Any]:
@@ -1488,6 +1489,7 @@ def run_batch(  # noqa: PLR0913
             benchmark_profile=benchmark_profile,
             socnav_missing_prereq_policy=socnav_missing_prereq_policy,
             adapter_impact_eval=adapter_impact_eval,
+            observation_mode=observation_mode,
             workers=workers,
             resume=resume,
         )

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -39,6 +39,10 @@
         "algo": {
             "type": "string"
         },
+        "observation_mode": {
+            "type": "string",
+            "description": "Active planner observation-mode contract for this episode."
+        },
         "algorithm_metadata": {
             "type": "object",
             "description": "Metadata about the algorithm/policy used (name, config, status).",
@@ -72,6 +76,36 @@
                 },
                 "policy_semantics": {
                     "type": "string"
+                },
+                "observation_spec": {
+                    "type": "object",
+                    "properties": {
+                        "default_mode": {
+                            "type": "string"
+                        },
+                        "active_mode": {
+                            "type": "string"
+                        },
+                        "supported_modes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "inputs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "override_applied": {
+                            "type": "boolean"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": true
                 },
                 "config": {
                     "type": "object"

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from robot_sf.benchmark.algorithm_metadata import (
     canonical_algorithm_name,
     enrich_algorithm_metadata,
     infer_execution_mode_from_counts,
+    observation_spec_for_algorithm,
+    resolve_observation_mode,
 )
 
 
@@ -14,6 +18,25 @@ def test_canonical_algorithm_name_resolves_aliases() -> None:
     assert canonical_algorithm_name("simple_policy") == "goal"
     assert canonical_algorithm_name("sf") == "social_force"
     assert canonical_algorithm_name("unknown_algo") == "unknown_algo"
+
+
+def test_observation_spec_declares_supported_modes_and_rejects_invalid_override() -> None:
+    """Planner observation contracts should be inspectable and fail closed."""
+    goal_spec = observation_spec_for_algorithm("goal")
+    assert goal_spec["default_mode"] == "goal_state"
+    assert goal_spec["supported_modes"] == ["goal_state", "socnav_state"]
+    assert resolve_observation_mode("goal", "socnav_state") == "socnav_state"
+
+    meta = enrich_algorithm_metadata(algo="goal", observation_mode="socnav_state")
+    assert meta["observation_spec"]["active_mode"] == "socnav_state"
+    assert meta["observation_spec"]["override_applied"] is True
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_observation_mode("orca", "goal_state")
+    assert "Observation mode 'goal_state' is not supported by algorithm 'orca'" in str(
+        excinfo.value
+    )
+    assert "socnav_state" in str(excinfo.value)
 
 
 def test_random_baseline_metadata_marks_stochastic_reference() -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -116,6 +116,60 @@ def test_load_campaign_config_parses_observation_mode_overrides(tmp_path: Path) 
     assert cfg.planners[1].observation_mode == "goal_state"
 
 
+def test_load_campaign_config_rejects_blank_planner_observation_mode(tmp_path: Path) -> None:
+    """Blank planner-level observation-mode overrides should be rejected."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: observation_blank_planner",
+                f"scenario_matrix: {scenario_path.name}",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    observation_mode: '   '",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Planner entry 'observation_mode' cannot be empty"):
+        load_campaign_config(config_path)
+
+
+def test_load_campaign_config_rejects_blank_global_observation_mode(tmp_path: Path) -> None:
+    """Blank campaign-level observation-mode overrides should be rejected."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: observation_blank_global",
+                f"scenario_matrix: {scenario_path.name}",
+                "observation_mode: '   '",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Campaign 'observation_mode' cannot be empty"):
+        load_campaign_config(config_path)
+
+
 def test_scenario_horizon_schedule_applies_to_loaded_campaign_scenarios(
     tmp_path: Path,
 ) -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -81,6 +81,41 @@ def test_load_campaign_config_resolves_relative_paths(tmp_path: Path):
     assert list(cfg.seed_policy.seeds) == [101]
 
 
+def test_load_campaign_config_parses_observation_mode_overrides(tmp_path: Path) -> None:
+    """Campaign configs should support global and per-planner observation-mode overrides."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: observation_override_campaign",
+                f"scenario_matrix: {scenario_path.name}",
+                "observation_mode: socnav_state",
+                "planners:",
+                "  - key: goal_default_override",
+                "    algo: goal",
+                "    benchmark_profile: baseline-safe",
+                "  - key: goal_explicit_override",
+                "    algo: goal",
+                "    benchmark_profile: baseline-safe",
+                "    observation_mode: goal_state",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+
+    assert cfg.observation_mode == "socnav_state"
+    assert cfg.planners[0].observation_mode is None
+    assert cfg.planners[1].observation_mode == "goal_state"
+
+
 def test_scenario_horizon_schedule_applies_to_loaded_campaign_scenarios(
     tmp_path: Path,
 ) -> None:
@@ -649,6 +684,7 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
                 "  - key: goal",
                 "    algo: goal",
                 "    benchmark_profile: baseline-safe",
+                "    observation_mode: socnav_state",
                 "  - key: ppo",
                 "    algo: ppo",
                 "    benchmark_profile: experimental",
@@ -660,6 +696,7 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
 
     cfg = load_campaign_config(config_path)
     assert cfg.scenario_matrix_path == scenario_abs
+    run_batch_calls: list[dict[str, object]] = []
 
     def _fake_run_batch(
         scenarios_or_path,
@@ -673,7 +710,7 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
         """Write one episode record and return readiness/preflight metadata."""
         scenarios = list(scenarios_or_path) if isinstance(scenarios_or_path, list) else []
         _ = schema_path
-        _ = kwargs
+        run_batch_calls.append({"algo": algo, **kwargs})
         if scenarios:
             map_file = scenarios[0].get("map_file")
             if isinstance(map_file, str):
@@ -800,6 +837,7 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     )
 
     result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="test")
+    assert run_batch_calls[0]["observation_mode"] == "socnav_state"
 
     campaign_root = Path(result["campaign_root"])
     assert campaign_root.exists()
@@ -2374,6 +2412,7 @@ def test_prepare_campaign_preflight_writes_matrix_summary(tmp_path: Path) -> Non
                 "paper_facing: true",
                 "paper_profile_version: paper-matrix-v1",
                 "kinematics_matrix: [differential_drive]",
+                "observation_mode: socnav_state",
                 "comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml",
                 "seed_policy:",
                 "  mode: fixed-list",
@@ -2401,6 +2440,7 @@ def test_prepare_campaign_preflight_writes_matrix_summary(tmp_path: Path) -> Non
     first = matrix_payload["rows"][0]
     assert first["planner_group"] == "core"
     assert first["kinematics"] == "differential_drive"
+    assert first["observation_mode"] == "socnav_state"
 
 
 def test_prepare_campaign_preflight_accepts_fixed_campaign_id(tmp_path: Path) -> None:

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -81,6 +81,74 @@ def test_resume_identity_is_algorithm_aware(
     assert second["written"] == 1
 
 
+def test_resume_identity_uses_identity_algo_observation_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Resume skipping should resolve observation mode per resolved scenario algorithm."""
+    scenarios = [
+        {"name": "goal", "metadata": {"supported": True}, "simulation_config": {}},
+        {"name": "ppo", "metadata": {"supported": True}, "simulation_config": {}},
+    ]
+    runs: list[dict[str, object]] = []
+
+    monkeypatch.setattr(map_runner, "validate_scenario_list", lambda _scenarios: [])
+    monkeypatch.setattr(map_runner, "load_schema", lambda _path: {})
+    monkeypatch.setattr(
+        map_runner,
+        "_select_seeds",
+        lambda _scenario, suite_seeds=None, suite_key=None: [1],
+    )
+    monkeypatch.setattr(
+        map_runner,
+        "_compute_map_episode_id",
+        lambda payload, seed: (
+            f"{payload.get('id')}--{payload.get('algo')}--{payload.get('observation_mode')}"
+        ),
+    )
+
+    def fake_resolve(
+        default_algo: str, algo_config_path: str | None, algo_config: dict, scenario: dict
+    ):
+        if scenario.get("name") == "goal":
+            return "goal", {}
+        return "ppo", {}
+
+    monkeypatch.setattr(
+        map_runner,
+        "_resolve_policy_search_candidate_runtime",
+        fake_resolve,
+    )
+    monkeypatch.setattr(
+        map_runner,
+        "_run_map_job_worker",
+        lambda job: runs.append(job) or {"algorithm_metadata": {}},
+    )
+    monkeypatch.setattr(map_runner, "_write_validated", lambda *args, **kwargs: None)
+
+    monkeypatch.setattr(
+        map_runner,
+        "index_existing",
+        lambda _path: {
+            "goal--goal--goal_state",
+            "ppo--ppo--sensor_fusion_state",
+        },
+    )
+
+    out_path = tmp_path / "episodes.jsonl"
+    out_path.write_text("", encoding="utf-8")
+
+    result = map_runner.run_map_batch(
+        scenarios,
+        out_path,
+        schema_path=tmp_path / "schema.json",
+        resume=True,
+    )
+
+    assert result["written"] == 0
+    assert runs == []
+
+
 def test_resume_identity_includes_algo_config_hash(
     tmp_path: Path,
     monkeypatch,

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -46,6 +46,7 @@ def test_resume_identity_is_algorithm_aware(
             horizon=params.get("horizon"),
             dt=params.get("dt"),
             record_forces=bool(params.get("record_forces", True)),
+            observation_mode=params.get("observation_mode"),
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
@@ -100,6 +101,7 @@ def test_resume_identity_includes_algo_config_hash(
             horizon=params.get("horizon"),
             dt=params.get("dt"),
             record_forces=bool(params.get("record_forces", True)),
+            observation_mode=params.get("observation_mode"),
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
@@ -166,3 +168,30 @@ def test_scenario_identity_ignores_seed_schedule_fields() -> None:
     episode_a = map_runner._compute_map_episode_id(payload_a, seed=1)
     episode_b = map_runner._compute_map_episode_id(payload_b, seed=1)
     assert episode_a == episode_b
+
+
+def test_scenario_identity_includes_observation_mode() -> None:
+    """Observation-mode parity runs should not collide in resume identity."""
+    scenario = _minimal_map_scenario()
+    goal_state_payload = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        observation_mode="goal_state",
+    )
+    socnav_state_payload = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        observation_mode="socnav_state",
+    )
+
+    assert map_runner._compute_map_episode_id(goal_state_payload, seed=1) != (
+        map_runner._compute_map_episode_id(socnav_state_payload, seed=1)
+    )

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2637,6 +2637,7 @@ def test_run_map_batch_rejects_unsupported_observation_override(
 ) -> None:
     """Unsupported planner observation-mode overrides should fail before writing episodes."""
     scenario = {"name": "s1", "metadata": {"supported": True}}
+    out_path = tmp_path / "episodes.jsonl"
     monkeypatch.setattr(
         "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
     )
@@ -2644,13 +2645,14 @@ def test_run_map_batch_rejects_unsupported_observation_override(
     with pytest.raises(ValueError, match="Observation mode 'goal_state' is not supported"):
         run_map_batch(
             [scenario],
-            tmp_path / "episodes.jsonl",
+            out_path,
             schema_path=tmp_path / "schema.json",
             algo="orca",
             observation_mode="goal_state",
             workers=1,
             resume=False,
         )
+    assert not out_path.exists()
 
 
 def test_run_map_batch_parallel_writes_results_in_job_order(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -1994,6 +1994,9 @@ def test_run_map_episode_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
     assert record["metrics"]["success"] == 0.0
     algo_md = record["algorithm_metadata"]
     assert algo_md["baseline_category"] == "classical"
+    assert record["observation_mode"] == "goal_state"
+    assert record["scenario_params"]["observation_mode"] == "goal_state"
+    assert algo_md["observation_spec"]["active_mode"] == "goal_state"
     assert algo_md["planner_kinematics"]["robot_kinematics"] in {"unknown", "differential_drive"}
     feasibility = algo_md.get("kinematics_feasibility")
     assert isinstance(feasibility, dict)
@@ -2576,9 +2579,17 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
         "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
     )
     monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+    captured_params: list[dict[str, object]] = []
+
+    def _fake_run_map_job_worker(job):
+        """Capture fixed params propagated to map workers."""
+        _scenario, _seed, params = job
+        captured_params.append(dict(params))
+        return {"episode_id": "ep1"}
+
     monkeypatch.setattr(
         "robot_sf.benchmark.map_runner._run_map_job_worker",
-        lambda job: {"episode_id": "ep1"},
+        _fake_run_map_job_worker,
     )
     monkeypatch.setattr(
         "robot_sf.benchmark.map_runner._write_validated",
@@ -2590,10 +2601,15 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
         [scenario],
         out_path,
         schema_path=tmp_path / "schema.json",
+        observation_mode="socnav_state",
         workers=1,
         resume=False,
     )
     assert result["written"] == 1
+    assert captured_params[0]["observation_mode"] == "socnav_state"
+    assert result["algorithm_metadata_contract"]["observation_spec"]["active_mode"] == (
+        "socnav_state"
+    )
     assert result["algorithm_metadata_contract"]["baseline_category"] == "classical"
     assert result["algorithm_metadata_contract"]["planner_kinematics"]["robot_kinematics"] in {
         "unknown",
@@ -2614,6 +2630,27 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
         resume=True,
     )
     assert result["written"] == 0
+
+
+def test_run_map_batch_rejects_unsupported_observation_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsupported planner observation-mode overrides should fail before writing episodes."""
+    scenario = {"name": "s1", "metadata": {"supported": True}}
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+
+    with pytest.raises(ValueError, match="Observation mode 'goal_state' is not supported"):
+        run_map_batch(
+            [scenario],
+            tmp_path / "episodes.jsonl",
+            schema_path=tmp_path / "schema.json",
+            algo="orca",
+            observation_mode="goal_state",
+            workers=1,
+            resume=False,
+        )
 
 
 def test_run_map_batch_parallel_writes_results_in_job_order(


### PR DESCRIPTION
## Summary
Adds planner observation-mode contracts and a fail-closed override path for benchmark map runs and camera-ready campaigns.

## Linked Issues
- Closes #1080

## What Changed
- Added `algorithm_metadata.observation_spec` with default/supported/active modes and explicit override markers.
- Added `--observation-mode` to `robot_sf_bench run`, plus campaign-level and per-planner `observation_mode` config support.
- Records active `observation_mode` in episode JSONL and episode identity so resume state cannot collide across parity runs.
- Added `configs/benchmarks/observation_mode_goal_parity_smoke.yaml` as the two-mode goal-planner demonstration path.
- Updated episode schema, benchmark docs, context notes, and focused tests.

## Why It Matters
- Added value: benchmark users can inspect planner-input assumptions directly in outputs.
- Expected impact: controlled observation-mode parity checks can run through the normal benchmark surface.
- Why this is worth merging now: it makes a known interpretation boundary explicit without changing planner behavior or claiming full fairness attribution.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_algorithm_metadata_contract.py tests/test_algorithm_metadata.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_camera_ready_campaign.py tests/contract/test_episode_schema.py -q`
  - `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/observation_mode_goal_parity_smoke.yaml --mode preflight --output-root output/benchmarks/issue_1080 --campaign-id observation_mode_goal_parity_preflight`
  - `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/observation_mode_goal_parity_smoke.yaml --mode run --output-root output/benchmarks/issue_1080 --campaign-id observation_mode_goal_parity_run --skip-publication-bundle`
  - `uv run robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out output/benchmarks/issue_1080/direct_goal_socnav/episodes.jsonl --schema robot_sf/benchmark/schemas/episode.schema.v1.json --algo goal --benchmark-profile baseline-safe --observation-mode socnav_state --horizon 5 --workers 1 --no-video --no-resume`
  - `uv run robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out output/benchmarks/issue_1080/unsupported_override/episodes.jsonl --schema robot_sf/benchmark/schemas/episode.schema.v1.json --algo orca --benchmark-profile baseline-safe --socnav-missing-prereq-policy fallback --observation-mode goal_state --horizon 1 --workers 1 --no-video --no-resume`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - targeted suite passed: `179 passed`
  - campaign demo run completed: `total_runs=2`, `successful_runs=2`, `total_episodes=2`
  - direct CLI compatible override completed: `total_jobs=3`, `written=3`, `failed=0`
  - JSONL inspection confirmed `goal_state` and `socnav_state` are recorded in top-level `observation_mode`, `scenario_params.observation_mode`, and `algorithm_metadata.observation_spec.active_mode`
  - unsupported ORCA/`goal_state` override exited with code `2`
  - final readiness passed: `3276 passed, 17 skipped, 3 warnings`
- Benchmarks or smoke tests, if applicable: observation-mode goal parity smoke only; no paper-facing benchmark claim.

## Risks / Rollout
- Compatibility risks: additive metadata/config/schema fields; existing runs without overrides use each planner default mode.
- Failure modes: this is a contract check, not automatic environment observation reconstruction. Unsupported overrides fail closed.
- Rollback or fallback plan: remove the override plumbing and demo config; existing benchmark modes remain unaffected.

## Docs / Provenance
- Updated docs: `docs/benchmark_spec.md`, `docs/context/issue_1080_observation_modes.md`
- Relevant design or provenance notes: the initial two-mode demonstration uses `goal` because it can ignore extra `socnav_state` channels while preserving deterministic behavior.
- Any assumptions that need to be preserved: observation-mode parity is input-contract evidence, not proof of pure planner-logic attribution.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the observation-spec names and whether any planner should be assigned a stricter explicit mode instead of the default `socnav_state` contract.
- Generated validation artifacts and coverage output were inspected as ignored `output/` files and intentionally not committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observation-mode override support for benchmark planners via CLI and campaign configuration.
  * Observation modes are now resolved and validated against planner capabilities, with early failure for unsupported combinations.

* **Documentation**
  * Updated benchmark specification with observation-mode metadata contracts and schema requirements.
  * Added documentation page detailing observation-mode contracts and validation results.

* **Tests**
  * Added tests for observation-mode resolution, validation, campaign parsing, resume identity sensitivity, and rejection of unsupported overrides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1098)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->