### PR TITLE
feat: add CARLA T1 oracle replay smoke runner

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -392,6 +392,9 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #1000 CARLA Bridge Schema Catalog Schema CLI](issue_1000_carla_schema_catalog_schema_cli.md)
   exposes the CARLA bridge schema catalog JSON Schema through
   `robot-sf-catalog-carla-schemas --schema`.
+- [Issue #1003 CARLA T1 Oracle Replay Smoke](issue_1003_carla_t1_oracle_smoke.md)
+  adds a setup-only T1 oracle replay smoke command for one T0 export manifest payload, with
+  schema-catalog validation and fail-closed `not-available` behavior when CARLA is absent.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_1003_carla_t1_oracle_smoke.md
+++ b/docs/context/issue_1003_carla_t1_oracle_smoke.md
@@ -1,0 +1,93 @@
+# Issue #1003 CARLA T1 Oracle Replay Smoke
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1003>
+
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/872>
+
+Contract predecessor: [Issue #928 CARLA T0/T1 Oracle Replay Contract](issue_928_carla_t0_t1_replay_contract.md)
+
+## Scope
+
+Issue #1003 adds a narrow T1 oracle replay smoke setup boundary for one certified T0 export
+manifest payload. The implementation is intentionally setup-only:
+
+- it consumes one existing T0 export manifest/payload,
+- validates the CARLA bridge schema catalog and selected T0 payload before replay setup,
+- then requires the optional CARLA Python API before reporting an `oracle-replay` setup summary,
+- and fails closed with `not-available` when CARLA is not importable.
+
+This is not a CARLA benchmark result. Full metrics parity, multi-map replay, perception integration,
+and long-running CARLA campaigns remain out of scope for this issue.
+
+## Implementation
+
+- `robot_sf_carla_bridge.replay_smoke.build_t1_oracle_replay_smoke_setup(...)` selects one payload
+  from a T0 export manifest, validates the catalog/payload contract, and returns a JSON-safe
+  setup-only summary when CARLA is available.
+- `robot_sf_carla_bridge.replay_smoke.validate_t1_replay_catalog_payload(...)` validates the current
+  schema catalog against `carla-bridge-schema-catalog.v1`, then requires the selected payload
+  `schema_version` to match the catalog's `t0_export_payload` entry.
+- `robot-sf-carla-t1-oracle-smoke --manifest <path> [--scenario-id <id>] [--json]` exposes the
+  setup boundary as a project script.
+
+## Validation
+
+Focused unit and packaging coverage:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_t1_replay_smoke.py \
+  tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q
+```
+
+Result: `5 passed in 12.10s`.
+
+The tests cover:
+
+- no-CARLA fail-closed CLI behavior,
+- setup-only positive path with a fake importable `carla` module,
+- schema-catalog payload version mismatch rejection,
+- selecting a requested scenario from a multi-payload manifest,
+- project-script registration.
+
+Local CARLA availability:
+
+```bash
+rtk uv run robot-sf-check-carla --json
+```
+
+Result:
+
+```json
+{"available": false, "dependency": "carla", "reason": "CARLA Python API package 'carla' is not importable", "schema_version": "carla-availability.v1", "status": "not-available"}
+```
+
+Real T0 export and no-CARLA T1 smoke:
+
+```bash
+rtk uv run robot-sf-export-carla-t0 \
+  --scenario-file configs/scenarios/single/planner_sanity_simple.yaml \
+  --output-dir output/carla/issue_1003/t0 \
+  --robot-sf-commit "$(rtk git rev-parse HEAD)"
+
+rtk uv run robot-sf-validate-carla-t0-batch \
+  --manifest output/carla/issue_1003/t0/manifest.json --json
+
+rtk uv run robot-sf-carla-t1-oracle-smoke \
+  --manifest output/carla/issue_1003/t0/manifest.json --json
+```
+
+The batch validation reported one payload:
+
+```json
+{"manifest": "output/carla/issue_1003/t0/manifest.json", "payload_count": 1, "scenario_ids": ["planner_sanity_simple"], "schema_version": "carla-replay-export-batch-validation-summary.v1"}
+```
+
+The T1 smoke command exited nonzero and failed closed because CARLA is not installed:
+
+```json
+{"action": "Install CARLA and ensure its Python API is on PYTHONPATH before using CARLA replay entry points.", "dependency": "carla", "manifest": "output/carla/issue_1003/t0/manifest.json", "mode": "not-available", "reason": "CARLA Python API package 'carla' is not importable. Install CARLA and ensure its Python API is on PYTHONPATH before using CARLA replay entry points.", "schema_version": "carla-t1-oracle-replay-smoke.v1", "status": "not-available"}
+```
+
+No live CARLA replay setup was run on this machine because `carla` is not importable. The fake-CARLA
+unit test covers the positive setup-summary branch without making benchmark or runtime parity
+claims.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,6 +490,7 @@ robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_man
 robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"
 robot-sf-check-carla = "robot_sf_carla_bridge.cli:check_carla_availability_main"
 robot-sf-catalog-carla-schemas = "robot_sf_carla_bridge.cli:catalog_carla_schemas_main"
+robot-sf-carla-t1-oracle-smoke = "robot_sf_carla_bridge.cli:replay_t1_oracle_smoke_main"
 robot-sf-migrate-artifacts = "scripts.tools.migrate_artifacts:main"
 
 # Note: uv-specific config removed to avoid duplicate-config warnings with uv.toml

--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -37,6 +37,12 @@ from robot_sf_carla_bridge.export import (
     write_export_payload,
     write_export_records,
 )
+from robot_sf_carla_bridge.replay_smoke import (
+    T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION,
+    build_t1_oracle_replay_smoke_setup,
+    select_t0_export_payload,
+    validate_t1_replay_catalog_payload,
+)
 from robot_sf_carla_bridge.schema_catalog import (
     SCHEMA_CATALOG_VERSION,
     list_carla_bridge_schema_catalog,
@@ -49,6 +55,7 @@ __all__ = [
     "EXPORT_MANIFEST_SCHEMA_VERSION",
     "EXPORT_SCHEMA_VERSION",
     "SCHEMA_CATALOG_VERSION",
+    "T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION",
     "CarlaUnavailableError",
     "CertificateRef",
     "PedestrianReplaySpec",
@@ -61,6 +68,7 @@ __all__ = [
     "build_export_payload_from_map_definition",
     "build_export_payload_from_scenario_entry",
     "build_export_payloads_from_scenario_file",
+    "build_t1_oracle_replay_smoke_setup",
     "check_carla_availability",
     "list_carla_bridge_schema_catalog",
     "load_availability_schema",
@@ -73,7 +81,9 @@ __all__ = [
     "read_export_payload",
     "require_carla",
     "resolve_export_manifest_payload_paths",
+    "select_t0_export_payload",
     "validate_export_payload",
+    "validate_t1_replay_catalog_payload",
     "write_export_payload",
     "write_export_records",
 ]

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -1,4 +1,4 @@
-"""Command-line wrappers for CARLA-free T0 export helpers."""
+"""Command-line wrappers for CARLA bridge helpers."""
 
 from __future__ import annotations
 
@@ -7,7 +7,13 @@ import json
 import sys
 from pathlib import Path
 
-from robot_sf_carla_bridge.availability import check_carla_availability, load_availability_schema
+import jsonschema
+
+from robot_sf_carla_bridge.availability import (
+    CarlaUnavailableError,
+    check_carla_availability,
+    load_availability_schema,
+)
 from robot_sf_carla_bridge.export import (
     BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION,
     build_export_payloads_from_scenario_file,
@@ -18,6 +24,10 @@ from robot_sf_carla_bridge.export import (
     read_export_payload,
     resolve_export_manifest_payload_paths,
     write_export_records,
+)
+from robot_sf_carla_bridge.replay_smoke import (
+    T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION,
+    build_t1_oracle_replay_smoke_setup,
 )
 from robot_sf_carla_bridge.schema_catalog import (
     list_carla_bridge_schema_catalog,
@@ -233,6 +243,66 @@ def catalog_carla_schemas_main(argv: list[str] | None = None) -> int:
         sys.stdout.write(f"{json.dumps(load_schema_catalog_schema(), sort_keys=True)}\n")
         return 0
     sys.stdout.write(f"{json.dumps(list_carla_bridge_schema_catalog(), sort_keys=True)}\n")
+    return 0
+
+
+def replay_t1_oracle_smoke_main(argv: list[str] | None = None) -> int:
+    """Validate one T0 export and prepare a setup-only CARLA T1 oracle replay smoke.
+
+    Returns:
+        Process-style exit code.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Prepare one CARLA T1 oracle replay smoke from a T0 export manifest."
+    )
+    parser.add_argument("--manifest", help="Path to a T0 export manifest JSON.")
+    parser.add_argument(
+        "--scenario-id",
+        help="Optional scenario id to select from the manifest; defaults to the first payload.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print a machine-readable summary.")
+    args = parser.parse_args(argv)
+
+    if args.manifest is None or not str(args.manifest).strip():
+        parser.error("the following arguments are required: --manifest")
+
+    manifest_path = Path(args.manifest)
+    try:
+        summary = build_t1_oracle_replay_smoke_setup(
+            manifest_path,
+            scenario_id=args.scenario_id,
+        )
+    except CarlaUnavailableError as exc:
+        status = {
+            "schema_version": T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION,
+            "status": "not-available",
+            "mode": "not-available",
+            "manifest": manifest_path.as_posix(),
+            "dependency": "carla",
+            "reason": str(exc),
+            "action": (
+                "Install CARLA and ensure its Python API is on PYTHONPATH before using "
+                "CARLA replay entry points."
+            ),
+        }
+        if args.json:
+            sys.stdout.write(f"{json.dumps(status, sort_keys=True)}\n")
+        else:
+            sys.stderr.write(f"Error: {status['reason']} {status['action']}\n")
+        return 1
+    except (ValueError, OSError, json.JSONDecodeError, jsonschema.ValidationError) as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return 1
+
+    if args.json:
+        sys.stdout.write(f"{json.dumps(summary, sort_keys=True)}\n")
+        return 0
+
+    sys.stdout.write(
+        f"{manifest_path.as_posix()}: scenario "
+        f"{summary['selected_payload']['scenario_id']} ready for CARLA T1 oracle replay setup\n"
+    )
     return 0
 
 

--- a/robot_sf_carla_bridge/replay_smoke.py
+++ b/robot_sf_carla_bridge/replay_smoke.py
@@ -8,7 +8,11 @@ from typing import Any, cast
 import jsonschema
 
 from robot_sf_carla_bridge.availability import require_carla
-from robot_sf_carla_bridge.export import load_export_manifest_payloads, validate_export_payload
+from robot_sf_carla_bridge.export import (
+    read_export_payload,
+    resolve_export_manifest_payload_paths,
+    validate_export_payload,
+)
 from robot_sf_carla_bridge.schema_catalog import (
     list_carla_bridge_schema_catalog,
     load_schema_catalog_schema,
@@ -75,8 +79,8 @@ def select_t0_export_payload(
         ValueError: if the manifest has no payloads or the requested scenario is absent.
     """
 
-    records = load_export_manifest_payloads(manifest_path)
-    if not records:
+    entries = resolve_export_manifest_payload_paths(manifest_path)
+    if not entries:
         raise ValueError("T0 export manifest contains no payloads to replay")
 
     selected_index = 0
@@ -84,25 +88,25 @@ def select_t0_export_payload(
         selected_index = next(
             (
                 index
-                for index, record in enumerate(records)
-                if record.get("scenario_id") == scenario_id
+                for index, entry in enumerate(entries)
+                if entry.get("scenario_id") == scenario_id
             ),
             -1,
         )
         if selected_index < 0:
-            available = ", ".join(str(record.get("scenario_id")) for record in records)
+            available = ", ".join(str(entry.get("scenario_id")) for entry in entries)
             raise ValueError(
                 f"T0 export manifest does not contain scenario_id {scenario_id!r}; "
                 f"available: {available}"
             )
 
-    selected = dict(records[selected_index])
-    payload = selected.get("payload")
-    if not isinstance(payload, dict):
-        raise ValueError("selected T0 export payload must be a JSON object")
-    selected["payload"] = cast("dict[str, Any]", payload)
-    selected["payload_index"] = selected_index
-    return selected
+    selected = entries[selected_index]
+    return {
+        "scenario_id": selected["scenario_id"],
+        "path": selected["path"],
+        "payload": read_export_payload(selected["path"]),
+        "payload_index": selected_index,
+    }
 
 
 def build_t1_oracle_replay_smoke_setup(

--- a/robot_sf_carla_bridge/replay_smoke.py
+++ b/robot_sf_carla_bridge/replay_smoke.py
@@ -1,0 +1,176 @@
+"""T1 oracle replay smoke setup for one CARLA T0 export payload."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import jsonschema
+
+from robot_sf_carla_bridge.availability import require_carla
+from robot_sf_carla_bridge.export import load_export_manifest_payloads, validate_export_payload
+from robot_sf_carla_bridge.schema_catalog import (
+    list_carla_bridge_schema_catalog,
+    load_schema_catalog_schema,
+)
+
+T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION = "carla-t1-oracle-replay-smoke.v1"
+_CATALOG_T0_EXPORT_PAYLOAD_NAME = "t0_export_payload"
+
+
+def _catalog_schema_versions(catalog: dict[str, Any]) -> dict[str, str]:
+    """Return schema versions keyed by catalog entry name."""
+
+    versions: dict[str, str] = {}
+    for entry in catalog.get("schemas", []):
+        if isinstance(entry, dict):
+            versions[str(entry.get("name"))] = str(entry.get("schema_version"))
+    return versions
+
+
+def validate_t1_replay_catalog_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a T0 payload against the current CARLA bridge schema catalog.
+
+    Returns:
+        JSON-safe validation metadata for the selected payload.
+
+    Raises:
+        ValueError: if the catalog does not expose the T0 export payload schema contract or the
+            payload version does not match it.
+        jsonschema.ValidationError: if the catalog or payload does not satisfy its JSON Schema.
+    """
+
+    catalog = list_carla_bridge_schema_catalog()
+    jsonschema.validate(instance=catalog, schema=load_schema_catalog_schema())
+    versions = _catalog_schema_versions(catalog)
+    expected_payload_version = versions.get(_CATALOG_T0_EXPORT_PAYLOAD_NAME)
+    if expected_payload_version is None:
+        raise ValueError("CARLA schema catalog missing t0_export_payload contract")
+
+    validate_export_payload(payload)
+    payload_version = payload.get("schema_version")
+    if payload_version != expected_payload_version:
+        raise ValueError(
+            "T0 export payload schema_version "
+            f"{payload_version!r} does not match catalog version {expected_payload_version!r}"
+        )
+
+    return {
+        "schema_version": catalog["schema_version"],
+        "t0_export_payload_schema_version": expected_payload_version,
+    }
+
+
+def select_t0_export_payload(
+    manifest_path: str | Path,
+    *,
+    scenario_id: str | None = None,
+) -> dict[str, Any]:
+    """Select one validated T0 export payload from a manifest.
+
+    Returns:
+        Record with ``scenario_id``, resolved ``path``, ``payload_index``, and ``payload``.
+
+    Raises:
+        ValueError: if the manifest has no payloads or the requested scenario is absent.
+    """
+
+    records = load_export_manifest_payloads(manifest_path)
+    if not records:
+        raise ValueError("T0 export manifest contains no payloads to replay")
+
+    selected_index = 0
+    if scenario_id is not None:
+        selected_index = next(
+            (
+                index
+                for index, record in enumerate(records)
+                if record.get("scenario_id") == scenario_id
+            ),
+            -1,
+        )
+        if selected_index < 0:
+            available = ", ".join(str(record.get("scenario_id")) for record in records)
+            raise ValueError(
+                f"T0 export manifest does not contain scenario_id {scenario_id!r}; "
+                f"available: {available}"
+            )
+
+    selected = dict(records[selected_index])
+    payload = selected.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("selected T0 export payload must be a JSON object")
+    selected["payload"] = cast("dict[str, Any]", payload)
+    selected["payload_index"] = selected_index
+    return selected
+
+
+def build_t1_oracle_replay_smoke_setup(
+    manifest_path: str | Path,
+    *,
+    scenario_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a setup-only T1 oracle replay smoke summary for one T0 export.
+
+    The function intentionally stops before live CARLA replay or metric comparison. It proves that
+    one schema-valid T0 payload can reach a CARLA-facing setup boundary when the optional CARLA
+    Python API is available.
+
+    Returns:
+        JSON-safe setup summary.
+    """
+
+    manifest = Path(manifest_path)
+    record = select_t0_export_payload(manifest, scenario_id=scenario_id)
+    payload = cast("dict[str, Any]", record["payload"])
+    catalog_metadata = validate_t1_replay_catalog_payload(payload)
+    carla_module = require_carla()
+
+    scenario = cast("dict[str, Any]", payload["scenario"])
+    robot = cast("dict[str, Any]", payload["robot"])
+    static_geometry = cast("dict[str, Any]", payload["static_geometry"])
+    simulation = cast("dict[str, Any]", payload["simulation"])
+    pedestrians = cast("list[dict[str, Any]]", payload["pedestrians"])
+
+    return {
+        "schema_version": T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION,
+        "status": "oracle-replay",
+        "mode": "oracle-replay",
+        "stage": "setup-only",
+        "manifest": manifest.as_posix(),
+        "selected_payload": {
+            "scenario_id": str(record["scenario_id"]),
+            "path": Path(record["path"]).as_posix(),
+            "payload_index": int(record["payload_index"]),
+        },
+        "catalog": catalog_metadata,
+        "scenario": {
+            "id": scenario["id"],
+            "map_id": scenario["map_id"],
+            "source_config": scenario["source_config"],
+            "certificate_status": scenario["certificate"]["status"],
+        },
+        "robot": {
+            "start": robot["start"],
+            "goal": robot["goal"],
+            "footprint": robot["footprint"],
+        },
+        "pedestrian_count": len(pedestrians),
+        "static_obstacle_count": len(static_geometry.get("obstacles", [])),
+        "simulation": {
+            "dt_s": simulation["dt_s"],
+            "horizon_s": simulation["horizon_s"],
+            "termination": simulation["termination"],
+        },
+        "carla": {
+            "dependency": "carla",
+            "module": getattr(carla_module, "__name__", "carla"),
+            "available": True,
+        },
+        "boundary": {
+            "full_metrics_parity": False,
+            "multi_map_replay": False,
+            "long_running_benchmark": False,
+            "note": "setup-only smoke; no CARLA benchmark readiness or parity claim",
+        },
+    }

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -414,6 +414,9 @@ def test_export_t0_cli_is_packaged_as_project_script() -> None:
     assert pyproject["project"]["scripts"]["robot-sf-catalog-carla-schemas"] == (
         "robot_sf_carla_bridge.cli:catalog_carla_schemas_main"
     )
+    assert pyproject["project"]["scripts"]["robot-sf-carla-t1-oracle-smoke"] == (
+        "robot_sf_carla_bridge.cli:replay_t1_oracle_smoke_main"
+    )
     hatchling_packages = pyproject["tool"]["hatchling"]["build"]["targets"]["wheel"]["packages"]
     assert {"include": "robot_sf_carla_bridge"} in hatchling_packages
     assert (

--- a/tests/carla_bridge/test_t1_replay_smoke.py
+++ b/tests/carla_bridge/test_t1_replay_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import ModuleType
 
 import pytest
@@ -152,6 +153,34 @@ def test_t1_oracle_replay_smoke_selects_requested_scenario(tmp_path, monkeypatch
     assert summary["selected_payload"]["scenario_id"] == "second"
     assert summary["selected_payload"]["payload_index"] == 1
     assert summary["scenario"]["id"] == "second"
+
+
+def test_select_t0_export_payload_reads_only_selected_payload(tmp_path, monkeypatch) -> None:
+    """Selecting one scenario should not deserialize every payload in the manifest."""
+
+    import robot_sf_carla_bridge.replay_smoke as replay_module
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        [
+            {"scenario_id": "first", "payload": _minimal_t0_payload("first")},
+            {"scenario_id": "second", "payload": _minimal_t0_payload("second")},
+        ],
+    )
+
+    loaded_paths: list[Path] = []
+    real_read_export_payload = replay_module.read_export_payload
+
+    def _counting_read_export_payload(path: str | Path) -> dict:
+        loaded_paths.append(Path(path))
+        return real_read_export_payload(path)
+
+    monkeypatch.setattr(replay_module, "read_export_payload", _counting_read_export_payload)
+
+    record = replay_module.select_t0_export_payload(manifest_path, scenario_id="second")
+
+    assert record["scenario_id"] == "second"
+    assert loaded_paths == [Path(record["path"])]
 
 
 def test_t1_oracle_replay_smoke_rejects_catalog_payload_version_mismatch(

--- a/tests/carla_bridge/test_t1_replay_smoke.py
+++ b/tests/carla_bridge/test_t1_replay_smoke.py
@@ -1,0 +1,181 @@
+"""CARLA T1 oracle replay smoke tests."""
+
+from __future__ import annotations
+
+import json
+from types import ModuleType
+
+import pytest
+
+
+def _minimal_t0_payload(scenario_id: str = "unit_crossing") -> dict:
+    """Return a schema-valid minimal T0 export payload."""
+
+    from robot_sf_carla_bridge import (
+        CertificateRef,
+        PedestrianReplaySpec,
+        Pose2D,
+        RobotReplaySpec,
+        ScenarioReplayRef,
+        SimulationSpec,
+        Waypoint2D,
+        build_export_payload,
+    )
+
+    return build_export_payload(
+        scenario=ScenarioReplayRef(
+            scenario_id=scenario_id,
+            source_config="configs/scenarios/unit_crossing.yaml",
+            map_id="unit_map",
+            certificate=CertificateRef(status="passed", source="output/cert.json"),
+        ),
+        robot=RobotReplaySpec(
+            start=Pose2D(0.0, 0.0, 0.0),
+            goal=Pose2D(4.0, 0.0, 0.0),
+            radius_m=0.3,
+            kinematics={"model": "unicycle", "max_speed_mps": 1.0},
+        ),
+        pedestrians=[
+            PedestrianReplaySpec(
+                ped_id="ped_0",
+                start=Pose2D(2.0, -1.0, 1.57),
+                route=[Waypoint2D(2.0, 1.0)],
+                timing={"start_delay_s": 0.0},
+            )
+        ],
+        static_geometry={"obstacles": [], "route_topology_ref": "maps/svg_maps/unit_map.svg"},
+        simulation=SimulationSpec(dt_s=0.1, horizon_s=10.0),
+        trajectory_fields=["success", "collision", "min_distance"],
+        provenance={
+            "robot_sf_commit": "abc123",
+            "created_by": "unit-test",
+            "certificate_generator": "scenario_cert.v1",
+        },
+    )
+
+
+def _write_manifest(tmp_path, records: list[dict]) -> str:
+    """Write T0 export records and return the manifest path."""
+
+    from robot_sf_carla_bridge import write_export_records
+
+    output_dir = tmp_path / "exports"
+    write_export_records(records, output_dir)
+    return (output_dir / "manifest.json").as_posix()
+
+
+def test_replay_t1_oracle_smoke_main_fails_closed_without_carla(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """T1 smoke CLI should validate inputs, then fail closed when CARLA is unavailable."""
+
+    import robot_sf_carla_bridge.replay_smoke as replay_module
+    from robot_sf_carla_bridge.availability import CarlaUnavailableError
+    from robot_sf_carla_bridge.cli import replay_t1_oracle_smoke_main
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        [{"scenario_id": "unit_crossing", "payload": _minimal_t0_payload()}],
+    )
+
+    monkeypatch.setattr(
+        replay_module,
+        "require_carla",
+        lambda: (_ for _ in ()).throw(
+            CarlaUnavailableError(
+                "CARLA Python API package 'carla' is not importable. Install CARLA and ensure "
+                "its Python API is on PYTHONPATH before using CARLA replay entry points."
+            )
+        ),
+    )
+
+    exit_code = replay_t1_oracle_smoke_main(["--manifest", manifest_path, "--json"])
+
+    assert exit_code == 1
+    status = json.loads(capsys.readouterr().out)
+    assert status["status"] == "not-available"
+    assert status["dependency"] == "carla"
+    assert "CARLA Python API package 'carla' is not importable" in status["reason"]
+    assert "PYTHONPATH" in status["action"]
+
+
+def test_build_t1_oracle_replay_smoke_setup_reports_setup_only_summary(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """With a CARLA module available, the runner should emit a setup-only oracle summary."""
+
+    import robot_sf_carla_bridge.replay_smoke as replay_module
+    from robot_sf_carla_bridge import build_t1_oracle_replay_smoke_setup
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        [{"scenario_id": "unit_crossing", "payload": _minimal_t0_payload()}],
+    )
+    monkeypatch.setattr(replay_module, "require_carla", lambda: ModuleType("carla"))
+
+    summary = build_t1_oracle_replay_smoke_setup(manifest_path)
+
+    assert summary["status"] == "oracle-replay"
+    assert summary["stage"] == "setup-only"
+    assert summary["selected_payload"]["scenario_id"] == "unit_crossing"
+    assert summary["catalog"]["t0_export_payload_schema_version"] == "carla-replay-export.v1"
+    assert summary["scenario"]["certificate_status"] == "passed"
+    assert summary["pedestrian_count"] == 1
+    assert summary["boundary"] == {
+        "full_metrics_parity": False,
+        "multi_map_replay": False,
+        "long_running_benchmark": False,
+        "note": "setup-only smoke; no CARLA benchmark readiness or parity claim",
+    }
+
+
+def test_t1_oracle_replay_smoke_selects_requested_scenario(tmp_path, monkeypatch) -> None:
+    """Scenario selection should allow one manifest to hold multiple T0 exports."""
+
+    import robot_sf_carla_bridge.replay_smoke as replay_module
+    from robot_sf_carla_bridge import build_t1_oracle_replay_smoke_setup
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        [
+            {"scenario_id": "first", "payload": _minimal_t0_payload("first")},
+            {"scenario_id": "second", "payload": _minimal_t0_payload("second")},
+        ],
+    )
+    monkeypatch.setattr(replay_module, "require_carla", lambda: ModuleType("carla"))
+
+    summary = build_t1_oracle_replay_smoke_setup(manifest_path, scenario_id="second")
+
+    assert summary["selected_payload"]["scenario_id"] == "second"
+    assert summary["selected_payload"]["payload_index"] == 1
+    assert summary["scenario"]["id"] == "second"
+
+
+def test_t1_oracle_replay_smoke_rejects_catalog_payload_version_mismatch(
+    monkeypatch,
+) -> None:
+    """Payload validation should be tied to the current schema catalog contract."""
+
+    import robot_sf_carla_bridge.replay_smoke as replay_module
+    from robot_sf_carla_bridge import validate_t1_replay_catalog_payload
+
+    monkeypatch.setattr(
+        replay_module,
+        "list_carla_bridge_schema_catalog",
+        lambda: {
+            "schema_version": "carla-bridge-schema-catalog.v1",
+            "schemas": [
+                {
+                    "name": "t0_export_payload",
+                    "loader": "load_export_schema",
+                    "schema_version": "carla-replay-export.v999",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not match catalog version"):
+        validate_t1_replay_catalog_payload(_minimal_t0_payload())


### PR DESCRIPTION
## Summary
Adds a setup-only CARLA T1 oracle replay smoke runner for one T0 export manifest payload. The runner validates the CARLA bridge schema catalog and selected T0 payload before requiring CARLA, then fails closed with an actionable `not-available` status when the optional runtime is absent.

## Linked Issues
- Closes #1003
- Relates to #872

## What Changed
- Added `robot_sf_carla_bridge.replay_smoke` with payload selection, catalog/payload validation, and setup-only oracle replay summary construction.
- Added `robot-sf-carla-t1-oracle-smoke` CLI wiring and package exports.
- Added CARLA bridge tests for no-CARLA fail-closed behavior, fake-CARLA setup summary, schema-catalog mismatch rejection, scenario selection, and project script packaging.
- Documented validation proof and limitations in `docs/context/issue_1003_carla_t1_oracle_smoke.md`.

## Why It Matters
- Added value: moves the CARLA bridge from T0 schema/export-only toward an executable T1 setup boundary.
- Expected impact: optional CARLA dependencies remain isolated from normal Robot-SF workflows while T1 replay setup gains a reproducible entry point.
- Why this is worth merging now: #872 needs a small runtime-facing proof surface before broader CARLA parity work can be claimed safely.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/carla_bridge/test_t1_replay_smoke.py tests/carla_bridge/test_t0_export_cli.py::test_export_t0_cli_is_packaged_as_project_script -q` -> `5 passed in 12.10s`
  - `rtk uv run pytest tests/carla_bridge/test_t1_replay_smoke.py tests/carla_bridge/test_t0_export_cli.py tests/carla_bridge/test_runtime.py -q` -> `26 passed in 7.49s`
  - `rtk uv run robot-sf-check-carla --json` -> `status: not-available`
  - `rtk uv run robot-sf-export-carla-t0 --scenario-file configs/scenarios/single/planner_sanity_simple.yaml --output-dir output/carla/issue_1003/t0 --robot-sf-commit "$(rtk git rev-parse HEAD)"`
  - `rtk uv run robot-sf-validate-carla-t0-batch --manifest output/carla/issue_1003/t0/manifest.json --json` -> one `planner_sanity_simple` payload
  - `rtk uv run robot-sf-carla-t1-oracle-smoke --manifest output/carla/issue_1003/t0/manifest.json --json` -> nonzero fail-closed `not-available`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> `3276 passed, 17 skipped, 3 warnings`
- Freshness marker: `output/validation/pr_ready/issue-1003-carla-t1-replay-smoke.json`, head `4dea2fbba24897a204a0bf6c4e75eba0bf80afda`, fresh against `origin/main`.
- Ignored outputs inspected: `output/carla/issue_1003/t0/*`, `output/coverage/*`, and the PR readiness marker remain disposable ignored validation artifacts.

## Risks / Rollout
- Compatibility risks: low; normal bridge imports remain CARLA-free and the new runner imports CARLA only via the existing strict guard.
- Failure modes: invalid catalog/payload errors fail before setup; missing CARLA exits nonzero with `not-available`; live CARLA runtime behavior is not proven on this machine.
- Rollback or fallback plan: remove the project script and `replay_smoke` module if the T1 boundary needs redesign.

## Docs / Provenance
- Updated docs: `docs/context/issue_1003_carla_t1_oracle_smoke.md`, `docs/context/README.md`.
- Relevant design or provenance notes: follows the #928 T0/T1 contract and preserves fail-closed semantics.
- Assumption: setup-only smoke is intentionally not metrics parity, multi-map replay, perception integration, or a long-running CARLA benchmark claim.

## Follow-Up Issues
- Deferred work: live CARLA replay setup and metrics parity remain under #872 or later scoped issues.
- Issues opened for follow-up: none; live CARLA was already explicitly conditional in #1003 and unavailable locally.

## Reviewer Notes
- Verify the ordering in `build_t1_oracle_replay_smoke_setup`: manifest/payload and catalog validation happen before the CARLA availability guard.
- Known limitation: no live CARLA positive smoke was run because `carla` is not importable on this machine.