### PR TITLE
docs: record durable paper evidence archive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -140,6 +140,8 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 * **[Issue #821 Paper Evidence Upgrade](./context/issue_821_paper_evidence_upgrade.md)** - Extended camera-ready matrix with guarded PPO, TEB, and SNQI ranking ablation evidence
 * **[Issue #750 Paper Results Handoff](./context/issue_750_paper_results_handoff.md)** - Deterministic paper-facing JSON/CSV handoff contract for frozen benchmark bundles with CI metadata and provenance fields
 * **[Benchmark Release 0.0.2 Execution Log](./context/benchmark_release_0_0_2_2026-04-13.md)** - All-planners release manifest/config decisions, tmux execution path, assumptions, and follow-up publish steps
+* **[Benchmark Release 0.0.2 Publication Snapshot](./experiments/publication/20260414_benchmark_release_0_0_2/summary.md)** - Durable scoped seven-planner release pointer with DOI, archive checksum, embedded manifest/checksum/SNQI paths, and fresh-checkout recovery command
+* **[Issue #1062 Paper Evidence Archive Pointer](./context/issue_1062_paper_evidence_archive.md)** - Paper evidence archive recovery note for the scoped `0.0.2` bundle without committing raw benchmark outputs
 * **[Issue #435 Map Coverage Flow](./context/issue_435_map_coverage_flow.md)** - Parent flow state for map coverage, SocNavBench import, and map-quality child issues
 * **[Issue #328 Real-World Map Parent Tracker](./context/issue_328_real_world_map_parent.md)** - Parent/child map-coverage split, child issue status, and shared validation contract for real-world benchmark maps
 * **[Issue #692 Scenario Difficulty Analysis](./context/issue_692_scenario_difficulty_analysis.md)** - Artifact-driven camera-ready workflow for consensus ranking, planner residuals, and verified-simple subset assessment

--- a/docs/benchmark_release_reproducibility.md
+++ b/docs/benchmark_release_reproducibility.md
@@ -135,6 +135,34 @@ Non-comparable:
 The benchmark release artifact is the publication bundle generated from the
 release workflow, not the raw source checkout alone.
 
+For the current scoped seven-planner paper release, use the tracked publication snapshot:
+
+- `docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md`
+- `docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json`
+
+Durable endpoints:
+
+- Release: `https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2`
+- DOI: `https://doi.org/10.5281/zenodo.19563812`
+- Archive:
+  `https://github.com/ll7/robot_sf_ll7/releases/download/0.0.2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
+
+Release `0.0.2` publishes the publication manifest, checksums, and SNQI diagnostics inside the
+archive rather than as separate release assets. A fresh checkout can recover them with:
+
+```bash
+mkdir -p output/benchmark_release_0_0_2
+gh release download 0.0.2 \
+  --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' \
+  --dir output/benchmark_release_0_0_2
+sha256sum output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz
+tar -tzf output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  | rg 'publication_manifest.json|checksums.sha256|snqi_diagnostics\.(json|md)'
+```
+
+The expected archive SHA-256 is:
+`64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`.
+
 Primary artifact locations:
 
 - `output/benchmarks/camera_ready/<campaign_id>/`

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -121,6 +121,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1053 Durable Artifact Reference Audit](issue_1053_durable_artifact_references.md)
   separates durable W&B/release/artifact-store pointers from local `output/` caches and records the
   publication-bundle archive blocker.
+* [Issue #1062 Paper Evidence Archive Pointer](issue_1062_paper_evidence_archive.md)
+  records the durable scoped `0.0.2` release archive, DOI, checksums, publication manifest, and SNQI
+  diagnostics recovery path without committing raw benchmark outputs.
 * [Issue #1054 Planner Readiness And Fallback Audit](issue_1054_planner_readiness_fallback_audit.md)
   records the paper-matrix planner readiness table, dependency status, and fail-closed treatment of
   fallback or degraded rows.

--- a/docs/context/issue_1051_camera_ready_evidence_provenance_audit.md
+++ b/docs/context/issue_1051_camera_ready_evidence_provenance_audit.md
@@ -15,6 +15,10 @@ documentation/provenance audit only; it does not rerun benchmarks or reinterpret
 
 ## Current Verdict
 
+> 2026-05-09 update: issue `#1062` records a durable publication archive pointer for scoped release
+> `0.0.2`. The May 4 all-planners compact evidence remains partial and should not be treated as the
+> publication archive.
+
 The release contract is mostly reconstructable from committed configs and docs, but the evidence
 trail is not yet publication-archive complete.
 
@@ -30,12 +34,13 @@ Gaps:
 * the current tracked May 4 evidence bundle is partial and explicitly not publication-ready;
 * `docs/context/evidence/camera_ready_all_planners_2026-05-04/` does not include
   `reports/snqi_diagnostics.json`;
-* several context notes still cite publication bundles only as local `output/` paths;
+* several historical context notes cite publication bundles only as local `output/` paths;
 * the canonical PPO registry entry still has `commit: null`, a local `local_path`, and one note
   pointing at a local `output/model_cache/.../best_summary.json` file.
 
-Use issue `#1053` to repair durable artifact references and archive pointers before treating this
-as a complete paper evidence trail.
+Use `docs/context/issue_1062_paper_evidence_archive.md` and
+`docs/experiments/publication/20260414_benchmark_release_0_0_2/` for the current scoped
+seven-planner archive pointer. Continue treating the May 4 all-planners compact evidence as partial.
 
 ## Evidence Checklist
 
@@ -55,7 +60,7 @@ as a complete paper evidence trail.
 | Publication bundle workflow | `docs/benchmark_camera_ready_release.md` | present | Defines GitHub release upload, checksums, and manifest validation. |
 | Tracked compact evidence | `docs/context/evidence/camera_ready_all_planners_2026-05-04/` | partial | Useful internal evidence, but `benchmark_success=false` and publication bundle was skipped. |
 | Tracked SNQI diagnostics for May 4 bundle | `docs/context/evidence/camera_ready_all_planners_2026-05-04/reports/snqi_diagnostics.json` | missing | The source run reported SNQI pass, but this compact bundle does not carry the diagnostics JSON required by the release manifest. |
-| Durable publication archive URL | release asset / DOI URL in current paper evidence | missing | Existing docs mostly cite local bundle paths or placeholders; #1053 should replace these with durable archive pointers. |
+| Durable publication archive URL | release asset / DOI URL in current paper evidence | present for scoped `0.0.2` | `#1062` records the GitHub release asset, DOI URL, archive checksum, embedded manifest, embedded checksums, and embedded SNQI diagnostics. |
 
 ## Hash Check
 
@@ -93,8 +98,7 @@ payload with weights, baseline, rank alignment, outcome separation, and dominanc
 
 ## Follow-Up Boundary
 
-No benchmark rerun is required by this audit alone. The next paper-critical action is issue `#1053`:
-replace or supplement local `output/` publication-bundle references with durable archive pointers,
-fold the `model/registry.yaml` `local_path` and `Best summary` note fields into the same
-durable-reference repair so the PPO checkpoint carries no worktree-local fallback, and include the
-required SNQI diagnostics payload when promoting any compact evidence bundle as paper support.
+No benchmark rerun is required by this audit alone. Issue `#1062` later recorded the durable scoped
+`0.0.2` archive pointer, embedded manifest, embedded checksums, and embedded SNQI diagnostics. The
+PPO registry provenance caveat and May 4 all-planners compact-evidence caveat remain separate from
+that scoped release archive.

--- a/docs/context/issue_1053_durable_artifact_references.md
+++ b/docs/context/issue_1053_durable_artifact_references.md
@@ -15,7 +15,12 @@ tree.
 
 ## Current Verdict
 
-The model side has a durable pointer; the publication-bundle side is still blocked.
+> 2026-05-09 update: issue `#1062` records a durable publication archive pointer for the scoped
+> seven-planner release `0.0.2`. Keep the original audit below as the May 7 state before that
+> pointer was verified.
+
+The model side has a durable pointer; the scoped `0.0.2` publication-bundle side now has a durable
+GitHub release and DOI pointer. The all-planners May 4 compact evidence remains partial.
 
 * The current paper-facing PPO checkpoint has a W&B artifact pointer in `model/registry.yaml`.
 * The benchmark release inputs are tracked and hash-pinned in
@@ -25,9 +30,10 @@ The model side has a durable pointer; the publication-bundle side is still block
   notes and should be treated as cache/history unless paired with a W&B artifact, release asset,
   DOI, or other durable manifest.
 * No bulky generated outputs were promoted during this audit.
-
-The missing paper-critical source is a durable publication bundle and diagnostics pointer. Issue
-`#1062` now tracks publishing or recording that archive, checksums, manifest, and SNQI diagnostics.
+* Issue `#1062` later recorded the durable scoped release archive, embedded manifest, embedded
+  checksums, and SNQI diagnostics in
+  `docs/context/issue_1062_paper_evidence_archive.md` and
+  `docs/experiments/publication/20260414_benchmark_release_0_0_2/`.
 
 ## Artifact Inventory
 
@@ -38,8 +44,8 @@ The missing paper-critical source is a durable publication bundle and diagnostic
 | Benchmark release config | `configs/benchmarks/paper_experiment_matrix_v1.yaml` | durable | tracked and hash-pinned by the release manifest. |
 | Scenario matrix | `configs/scenarios/classic_interactions_francis2023.yaml` | durable | tracked and hash-pinned by the release manifest. |
 | SNQI weights/baseline | `configs/benchmarks/snqi_weights_camera_ready_v3.json`, `configs/benchmarks/snqi_baseline_camera_ready_v3.json` | durable | tracked and hash-pinned by the release manifest. |
-| SNQI diagnostics | `reports/snqi_diagnostics.{json,md}` inside campaign/publication bundles | blocked for current paper archive | compact evidence bundles may include diagnostics, but the current paper bundle still needs a durable archive pointer. |
-| Publication bundle archive | `output/benchmarks/publication/<bundle_name>.tar.gz` | blocked | local path only unless uploaded; tracked by follow-up `#1062`. |
+| SNQI diagnostics | `reports/snqi_diagnostics.{json,md}` inside campaign/publication bundles | durable for scoped `0.0.2` | Recover from the `0.0.2` release archive; see `docs/context/issue_1062_paper_evidence_archive.md`. |
+| Publication bundle archive | `output/benchmarks/publication/<bundle_name>.tar.gz` | durable for scoped `0.0.2` | GitHub release asset plus DOI pointer recorded by `#1062`; local output paths remain cache/history. |
 | Compact evidence bundles | `docs/context/evidence/` | partial durable summaries | acceptable for small review evidence, not a replacement for the full publication bundle. |
 
 Date suffixes embedded in artifact identifiers and bundle names follow the `YYYYMMDD` format (for
@@ -69,7 +75,7 @@ This audit updates:
 
 ## Follow-Up Boundary
 
-Issue `#1062` is the blocker for archive publication. It should verify every new durable URL or
-artifact pointer and keep raw episode JSONL, videos, large logs, coverage, and model checkpoints out
-of git unless a maintainer explicitly chooses a small fixture.
-
+Issue `#1062` resolves the archive-publication blocker for the scoped seven-planner release `0.0.2`
+by verifying the durable release URL, DOI, archive checksum, embedded publication manifest,
+embedded checksums, and embedded SNQI diagnostics. The all-planners surface remains separate because
+`socnav_bench` still depends on external licensed assets.

--- a/docs/context/issue_1062_paper_evidence_archive.md
+++ b/docs/context/issue_1062_paper_evidence_archive.md
@@ -1,0 +1,86 @@
+# Issue 1062 Paper Evidence Archive Pointer
+
+Date: 2026-05-09
+
+Related issue: `ll7/robot_sf_ll7#1062`
+
+## Goal
+
+Make the paper-facing benchmark evidence recoverable from durable release pointers instead of from a
+single machine's local `output/` tree.
+
+## Current Source Of Truth
+
+The current durable benchmark archive is GitHub release `0.0.2`:
+
+- Release: `https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2`
+- DOI: `https://doi.org/10.5281/zenodo.19563812`
+- Archive:
+  `https://github.com/ll7/robot_sf_ll7/releases/download/0.0.2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
+- Archive SHA-256:
+  `64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`
+
+Release `0.0.2` is the scoped seven-planner release. It is not the blocked all-planners release
+with `socnav_bench`; that planner remains excluded until the licensed SocNavBench assets are
+available.
+
+## Embedded Required Artifacts
+
+The release publishes one tarball asset. The paper-critical files are durable through their paths
+inside that archive:
+
+| Artifact | Archive path | SHA-256 |
+|---|---|---|
+| Publication manifest | `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/publication_manifest.json` | `29af662569e83a201a3ff8b2316a7a1f60d66f1f7cff042cb412a6c9875a56bc` |
+| Checksums | `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/checksums.sha256` | `a7ba5f7b4405d6becd493963506563b80891a0fefa78675683a8959e22682904` |
+| SNQI diagnostics JSON | `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/payload/reports/snqi_diagnostics.json` | `aba8803dccde08fb86a86fbb34962928656a20ed4e1ac9dd8df181efa3220c6f` |
+| SNQI diagnostics Markdown | `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/payload/reports/snqi_diagnostics.md` | `dbb178d7240a52f79b7e4d8117b9344d728310b980c5aeefffd660376b5e0224` |
+
+The compact tracked metadata lives in
+`docs/experiments/publication/20260414_benchmark_release_0_0_2/`.
+
+## Recovery Path
+
+From a fresh checkout:
+
+```bash
+mkdir -p output/benchmark_release_0_0_2
+gh release download 0.0.2 \
+  --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' \
+  --dir output/benchmark_release_0_0_2
+sha256sum output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz
+tar -tzf output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  | rg 'publication_manifest.json|checksums.sha256|snqi_diagnostics\.(json|md)'
+```
+
+The SHA-256 should match
+`64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`.
+
+## Validation Performed
+
+On 2026-05-09:
+
+- `gh release view 0.0.2 --json tagName,name,url,isPrerelease,assets,body`
+  confirmed the release and asset URL.
+- `gh release download 0.0.2 --pattern ... --dir output/issue_1062_release_probe`
+  recovered the archive into ignored local output.
+- `sha256sum output/issue_1062_release_probe/*.tar.gz`
+  produced the archive checksum recorded above.
+- `tar -tzf ... | rg 'publication_manifest.json|checksums.sha256|snqi_diagnostics\.(json|md)'`
+  confirmed the required manifest, checksum, and SNQI diagnostic paths inside the archive.
+- `curl -I -L https://doi.org/10.5281/zenodo.19563812`
+  resolved through Zenodo to HTTP 200.
+
+No raw benchmark outputs, episode JSONL, videos, model caches, or publication tarballs were added
+to git.
+
+## Historical Notes Updated
+
+The older durable-artifact audits remain useful historical records, but their publication-bundle
+blocker is now resolved for the scoped `0.0.2` seven-planner release:
+
+- `docs/context/issue_1051_camera_ready_evidence_provenance_audit.md`
+- `docs/context/issue_1053_durable_artifact_references.md`
+
+The May 4 all-planners compact evidence remains partial and is still not a replacement for the
+publication archive.

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json
@@ -37,7 +37,7 @@
     "campaign_id": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316",
     "name": "paper_experiment_matrix_7planners_v1",
     "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
-    "scenario_matrix_hash": "6bfb216f1c48",
+    "scenario_matrix_hash": "d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5",
     "git_hash": "f7ebdcae2375d085e925213197a75a386e26a79c",
     "total_episodes": 987,
     "successful_runs": 7,

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "tracked-publication-snapshot.v1",
+  "snapshot_date": "2026-05-09",
+  "release": {
+    "tag": "0.0.2",
+    "url": "https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2",
+    "doi_url": "https://doi.org/10.5281/zenodo.19563812",
+    "prerelease": false,
+    "target_commit": "f7ebdcae2375d085e925213197a75a386e26a79c",
+    "source_branch": "release/v0.0.2-scoped-7-planners"
+  },
+  "assets": {
+    "bundle_archive": {
+      "name": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz",
+      "url": "https://github.com/ll7/robot_sf_ll7/releases/download/0.0.2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz",
+      "sha256": "64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90",
+      "size_bytes": 544734
+    },
+    "embedded_manifest": {
+      "path_in_archive": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/publication_manifest.json",
+      "sha256": "29af662569e83a201a3ff8b2316a7a1f60d66f1f7cff042cb412a6c9875a56bc"
+    },
+    "embedded_checksums": {
+      "path_in_archive": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/checksums.sha256",
+      "sha256": "a7ba5f7b4405d6becd493963506563b80891a0fefa78675683a8959e22682904"
+    },
+    "embedded_snqi_diagnostics_json": {
+      "path_in_archive": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/payload/reports/snqi_diagnostics.json",
+      "sha256": "aba8803dccde08fb86a86fbb34962928656a20ed4e1ac9dd8df181efa3220c6f"
+    },
+    "embedded_snqi_diagnostics_md": {
+      "path_in_archive": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle/payload/reports/snqi_diagnostics.md",
+      "sha256": "dbb178d7240a52f79b7e4d8117b9344d728310b980c5aeefffd660376b5e0224"
+    }
+  },
+  "campaign": {
+    "campaign_id": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316",
+    "name": "paper_experiment_matrix_7planners_v1",
+    "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+    "scenario_matrix_hash": "6bfb216f1c48",
+    "git_hash": "f7ebdcae2375d085e925213197a75a386e26a79c",
+    "total_episodes": 987,
+    "successful_runs": 7,
+    "total_runs": 7,
+    "runtime_sec": 681.3386159999936,
+    "episodes_per_second": 1.4486189052287757,
+    "paper_profile_version": "paper-matrix-v1",
+    "paper_interpretation_profile": "baseline-ready-core",
+    "amv_coverage_status": "warn",
+    "snqi_contract_status": "pass",
+    "snqi_contract_rank_alignment_spearman": 0.6428571428571429,
+    "snqi_contract_outcome_separation": 0.20799643544298344,
+    "snqi_contract_dominant_component": "time_penalty"
+  },
+  "seed_policy": {
+    "mode": "seed-set",
+    "seed_set": "eval",
+    "resolved_seeds": [
+      111,
+      112,
+      113
+    ],
+    "repeat_count_per_planner_seed": 47
+  },
+  "publication_bundle": {
+    "bundle_name": "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle",
+    "file_count": 49,
+    "total_bytes": 7458751,
+    "policy_profile": "public-paper-v1",
+    "embedded_artifact_policy": "The GitHub release publishes one tar.gz asset. The publication manifest, checksums, and SNQI diagnostics are durable through their paths inside that archive."
+  },
+  "scope": {
+    "planner_count": 7,
+    "included_planners": [
+      "goal",
+      "orca",
+      "ppo",
+      "prediction_planner",
+      "sacadrl",
+      "social_force",
+      "socnav_sampling"
+    ],
+    "excluded_planners": [
+      "socnav_bench"
+    ],
+    "exclusion_reason": "socnav_bench was excluded from the scoped 0.0.2 release because required licensed SocNavBench data assets were not staged."
+  }
+}

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
@@ -1,0 +1,85 @@
+# Benchmark Release 0.0.2 Publication Snapshot
+
+Date: 2026-05-09
+
+## Purpose
+
+This tracked snapshot records the durable publication pointer for benchmark release `0.0.2`
+without committing the raw publication bundle under `output/`.
+
+Release `0.0.2` is the scoped seven-planner benchmark release. It excludes `socnav_bench` because
+the licensed SocNavBench dataset assets were not staged for the release run. The scope decision is
+documented in
+[`docs/context/benchmark_release_0_0_2_scoped_rationale.md`](../../context/benchmark_release_0_0_2_scoped_rationale.md).
+
+## Public Endpoints
+
+- Release: `https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2`
+- DOI: `https://doi.org/10.5281/zenodo.19563812`
+- Bundle archive:
+  `https://github.com/ll7/robot_sf_ll7/releases/download/0.0.2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
+
+Unlike the older `camera-ready-v0.0.1a` prerelease, release `0.0.2` publishes a single durable
+bundle asset. The publication manifest, checksums, and SNQI diagnostics are inside that archive:
+
+- `publication_manifest.json`
+- `checksums.sha256`
+- `payload/reports/snqi_diagnostics.json`
+- `payload/reports/snqi_diagnostics.md`
+
+## Frozen Source
+
+- Campaign id:
+  `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316`
+- Repository commit:
+  `f7ebdcae2375d085e925213197a75a386e26a79c`
+- Release manifest:
+  `configs/benchmarks/releases/paper_experiment_matrix_7planners_v1_release_v0_0_2_scoped.yaml`
+- Canonical campaign config:
+  `configs/benchmarks/paper_experiment_matrix_7planners_v1.yaml`
+- Scenario matrix:
+  `configs/scenarios/classic_interactions_francis2023.yaml`
+- Seed policy:
+  `eval` seed set resolved to `111,112,113`
+- Episodes:
+  `987` total, `141` per planner
+- Runtime:
+  `681.34 s`
+- Benchmark success:
+  `true`
+- SNQI contract status:
+  `pass`
+
+## Archive Verification
+
+Verified on 2026-05-09 with:
+
+```bash
+gh release download 0.0.2 \
+  --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' \
+  --dir output/issue_1062_release_probe
+sha256sum output/issue_1062_release_probe/*.tar.gz
+tar -tzf output/issue_1062_release_probe/*.tar.gz \
+  | rg 'publication_manifest.json|checksums.sha256|snqi_diagnostics\.(json|md)'
+```
+
+The downloaded archive SHA-256 is:
+
+`64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`
+
+## Recovery Command
+
+A fresh checkout can recover the publication evidence with:
+
+```bash
+mkdir -p output/benchmark_release_0_0_2
+gh release download 0.0.2 \
+  --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' \
+  --dir output/benchmark_release_0_0_2
+tar -xzf output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  -C output/benchmark_release_0_0_2
+```
+
+## Tracked Companion Files
+
+- `release_metadata.json`: compact release, asset, campaign, and embedded-artifact metadata.

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
@@ -10,7 +10,7 @@ without committing the raw publication bundle under `output/`.
 Release `0.0.2` is the scoped seven-planner benchmark release. It excludes `socnav_bench` because
 the licensed SocNavBench dataset assets were not staged for the release run. The scope decision is
 documented in
-[`docs/context/benchmark_release_0_0_2_scoped_rationale.md`](../../context/benchmark_release_0_0_2_scoped_rationale.md).
+[`docs/context/benchmark_release_0_0_2_scoped_rationale.md`](../../../context/benchmark_release_0_0_2_scoped_rationale.md).
 
 ## Public Endpoints
 


### PR DESCRIPTION
## Summary

Closes #1062.

Records the durable paper evidence pointer for the scoped `0.0.2` seven-planner release without committing raw benchmark outputs. The PR adds a compact tracked publication snapshot, a context note with fresh-checkout recovery commands, and updates historical provenance notes so local `output/` paths are no longer treated as the paper archive.

Key boundaries:

- `0.0.2` is the scoped seven-planner release, excluding `socnav_bench` because licensed SocNavBench assets were not staged.
- The GitHub release publishes one durable tarball asset; `publication_manifest.json`, `checksums.sha256`, and `payload/reports/snqi_diagnostics.{json,md}` are recoverable from inside that archive.
- The May 4 all-planners compact evidence remains partial and is not promoted as the canonical archive.

## Validation

- `gh release view 0.0.2 --json tagName,name,url,isPrerelease,assets`
- `gh release download 0.0.2 --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' --dir output/issue_1062_release_probe`
- `sha256sum output/issue_1062_release_probe/*.tar.gz`
  - `64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`
- `tar -tzf output/issue_1062_release_probe/*.tar.gz | rg 'publication_manifest.json|checksums.sha256|snqi_diagnostics\.(json|md)'`
- `curl -I -L --max-time 30 https://doi.org/10.5281/zenodo.19563812`
- `jq . docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json >/dev/null`
- `rtk git diff --check`
- `rtk git status --ignored --short -uall output`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
  - `3273 passed, 16 skipped, 3 warnings in 250.90s`
- `BASE_REF=origin/main rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
  - recorded passed for `2caa2f3aa6ac0e7d8802fa1472a95ca96dd7d0b6`
