### PR TITLE
fix: repair negative route clearance geometry (#1130)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -78,6 +78,7 @@ knowledge, not every transient iteration detail.
 * Contributor workflow: [docs/dev_guide.md](../dev_guide.md)
 * Docs index entry: [docs/README.md](../README.md)
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
+* Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)
 * Note-maintenance skill:
   [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 

--- a/docs/context/issue_1130_negative_route_clearance_repair.md
+++ b/docs/context/issue_1130_negative_route_clearance_repair.md
@@ -1,0 +1,43 @@
+# Issue 1130 Negative Route-Clearance Repair
+
+Issue: [#1130](https://github.com/ll7/robot_sf_ll7/issues/1130)
+
+## Goal
+
+Repair the underlying route geometry for the negative-clearance scenarios identified during the
+route-clearance audit, without changing planner behavior or benchmark metrics.
+
+## Changes
+
+Two SVG maps were adjusted:
+
+* `maps/svg_maps/classic_merging.svg`
+  * rerouted `robot_route_0_0` through the open Y-merge corridor instead of across the central
+    stem obstacle,
+  * rerouted `ped_route_0_0` through the same obstacle-free merge corridor because SVG inspection
+    found it also crossed the central stem.
+* `maps/svg_maps/classic_station_platform.svg`
+  * rerouted `robot_route_0_0` through the clear passage left of the elevator core instead of
+    through the elevator obstacle.
+
+The edits keep the same spawn/goal zones and preserve the intended merging and station-platform
+interaction layouts. They change only route centerlines that previously crossed obstacle interiors.
+
+## Evidence
+
+`svg_inspect.py --strict error` reports no findings for both edited maps, and direct clearance
+checks show nonnegative robot footprint margins:
+
+* `classic_merging.svg`: robot route minimum center distance `1.563773 m`, margin `0.563773 m`
+* `classic_station_platform.svg`: robot route minimum center distance `3.5 m`, margin `2.5 m`
+
+The map regression test `tests/maps/test_route_clearance_maps.py` locks both conditions:
+
+* no robot or pedestrian route crosses obstacle interiors for the edited maps,
+* affected robot routes keep a nonnegative footprint margin.
+
+## Interpretation Boundary
+
+This repair addresses only the three negative route/obstacle overlaps from #1105/#1130. Other
+paper-matrix route-clearance warnings with zero or low positive margins remain stress-geometry
+caveats rather than map defects.

--- a/maps/svg_maps/classic_merging.svg
+++ b/maps/svg_maps/classic_merging.svg
@@ -141,20 +141,20 @@
      id="routes"
      inkscape:label="Routes">
     <path
-       d="M 9.461555,11.260392 15.030132,22.903815 22.088904,9.9556054 34.032522,31.133104"
+       d="M 9.461555,11.260392 12.5,22.8 18.0,22.8 18.0,10.8 25.6,10.8 25.6,18.8 31.5,18.8 34.032522,31.133104"
        stroke="#0300d5"
        stroke-width="1"
        fill="none"
        inkscape:label="robot_route_0_0"
        id="path11"
-       sodipodi:nodetypes="cccc" />
+       sodipodi:nodetypes="cccccccc" />
     <path
-       d="M 9.5739824,33.437863 17.898886,21.097983 21.897775,10.688809 28.896097,19.683472 36.168641,11.37282"
+       d="M 9.5739824,33.437863 18.0,24.0 18.0,10.8 25.6,10.8 25.6,18.8 31.5,18.8 36.168641,11.37282"
        stroke="#c40202"
        stroke-width="1"
        fill="none"
        inkscape:label="ped_route_0_0"
        id="path12"
-       sodipodi:nodetypes="ccccc" />
+       sodipodi:nodetypes="ccccccc" />
   </g>
 </svg>

--- a/maps/svg_maps/classic_station_platform.svg
+++ b/maps/svg_maps/classic_station_platform.svg
@@ -28,7 +28,7 @@
     <rect x="2" y="3" width="4" height="3" fill="#ffdf00" inkscape:label="robot_spawn_zone_0" />
     <rect x="77" y="21" width="4" height="3" fill="#ff6c00" inkscape:label="robot_goal_zone_0" />
     <path
-      d="M 6 4.5 L 20 4.5 L 34 4.5 L 42 4.5 L 46 5.5 L 48 8.0 L 47 11.0 L 44 13.5 L 41 16.5 L 39 20.0 L 38 22.5 L 55 22.5 L 68 22.5 L 77 22.5"
+      d="M 6 4.5 L 20 4.5 L 34 4.5 L 36 6.5 L 36 19.5 L 38 22.5 L 55 22.5 L 68 22.5 L 77 22.5"
       stroke="#0300d5"
       stroke-width="0.4"
       fill="none"

--- a/tests/maps/test_route_clearance_maps.py
+++ b/tests/maps/test_route_clearance_maps.py
@@ -1,0 +1,75 @@
+"""Regression checks for benchmark maps with repaired route-clearance geometry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from shapely.geometry import LineString, Polygon
+
+from robot_sf.nav.svg_map_parser import convert_map
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _obstacle_polygons(map_path: Path) -> list[Polygon]:
+    """Return obstacle polygons parsed from an SVG map.
+
+    Returns:
+        Non-empty obstacle polygons.
+    """
+    map_def = convert_map(str(map_path))
+    polygons: list[Polygon] = []
+    for obstacle in map_def.obstacles:
+        vertices = getattr(obstacle, "vertices", None)
+        if vertices:
+            polygon = Polygon(vertices)
+            if polygon.is_valid and not polygon.is_empty:
+                polygons.append(polygon)
+    return polygons
+
+
+def _route_lines(map_path: Path, *, kind: str) -> list[LineString]:
+    """Return parsed route centerlines for one route kind.
+
+    Returns:
+        Non-empty route lines.
+    """
+    map_def = convert_map(str(map_path))
+    routes = map_def.robot_routes if kind == "robot" else map_def.ped_routes
+    return [LineString(route.waypoints) for route in routes if len(route.waypoints) >= 2]
+
+
+def test_repaired_maps_do_not_route_through_obstacle_interiors() -> None:
+    """Classic merging and station-platform routes should avoid obstacle interiors."""
+    for rel_path in (
+        Path("maps/svg_maps/classic_merging.svg"),
+        Path("maps/svg_maps/classic_station_platform.svg"),
+    ):
+        map_path = REPO_ROOT / rel_path
+        obstacles = _obstacle_polygons(map_path)
+        assert obstacles, f"{rel_path} should parse obstacle geometry"
+
+        for kind in ("robot", "ped"):
+            for line in _route_lines(map_path, kind=kind):
+                assert not any(line.crosses(obstacle) for obstacle in obstacles), (
+                    f"{rel_path} {kind} route crosses obstacle interior"
+                )
+
+
+def test_repaired_robot_routes_keep_nonnegative_footprint_margin() -> None:
+    """Affected robot routes should no longer report negative route-clearance margin."""
+    expected_min_margin_m = {
+        "classic_merging.svg": 0.5,
+        "classic_station_platform.svg": 2.0,
+    }
+
+    for filename, min_expected_margin in expected_min_margin_m.items():
+        map_path = REPO_ROOT / "maps" / "svg_maps" / filename
+        obstacles = _obstacle_polygons(map_path)
+        route_margins = []
+        for line in _route_lines(map_path, kind="robot"):
+            min_center_distance = min(line.distance(obstacle) for obstacle in obstacles)
+            route_margins.append(min_center_distance - 1.0)
+
+        assert route_margins, f"{filename} should have at least one robot route"
+        assert min(route_margins) >= min_expected_margin

--- a/tests/maps/test_route_clearance_maps.py
+++ b/tests/maps/test_route_clearance_maps.py
@@ -9,6 +9,18 @@ from shapely.geometry import LineString, Polygon
 from robot_sf.nav.svg_map_parser import convert_map
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+ROBOT_RADIUS_M = 1.0
+
+
+def _resolve_map_path(map_path: Path) -> Path:
+    """Resolve map paths relative to the repository root used by this test module.
+
+    Returns:
+        Absolute repository-local map path.
+    """
+
+    assert map_path, "map_path must be provided"
+    return map_path if map_path.is_absolute() else (REPO_ROOT / map_path).resolve()
 
 
 def _obstacle_polygons(map_path: Path) -> list[Polygon]:
@@ -17,7 +29,9 @@ def _obstacle_polygons(map_path: Path) -> list[Polygon]:
     Returns:
         Non-empty obstacle polygons.
     """
-    map_def = convert_map(str(map_path))
+    resolved_map_path = _resolve_map_path(map_path)
+    map_def = convert_map(str(resolved_map_path))
+    assert map_def is not None, f"Failed to convert map: {resolved_map_path}"
     polygons: list[Polygon] = []
     for obstacle in map_def.obstacles:
         vertices = getattr(obstacle, "vertices", None)
@@ -34,7 +48,9 @@ def _route_lines(map_path: Path, *, kind: str) -> list[LineString]:
     Returns:
         Non-empty route lines.
     """
-    map_def = convert_map(str(map_path))
+    resolved_map_path = _resolve_map_path(map_path)
+    map_def = convert_map(str(resolved_map_path))
+    assert map_def is not None, f"Failed to convert map: {resolved_map_path}"
     routes = map_def.robot_routes if kind == "robot" else map_def.ped_routes
     return [LineString(route.waypoints) for route in routes if len(route.waypoints) >= 2]
 
@@ -45,15 +61,15 @@ def test_repaired_maps_do_not_route_through_obstacle_interiors() -> None:
         Path("maps/svg_maps/classic_merging.svg"),
         Path("maps/svg_maps/classic_station_platform.svg"),
     ):
-        map_path = REPO_ROOT / rel_path
+        map_path = rel_path
         obstacles = _obstacle_polygons(map_path)
         assert obstacles, f"{rel_path} should parse obstacle geometry"
 
         for kind in ("robot", "ped"):
             for line in _route_lines(map_path, kind=kind):
-                assert not any(line.crosses(obstacle) for obstacle in obstacles), (
-                    f"{rel_path} {kind} route crosses obstacle interior"
-                )
+                assert not any(
+                    line.crosses(obstacle) or line.within(obstacle) for obstacle in obstacles
+                ), f"{rel_path} {kind} route intersects an obstacle interior"
 
 
 def test_repaired_robot_routes_keep_nonnegative_footprint_margin() -> None:
@@ -64,12 +80,13 @@ def test_repaired_robot_routes_keep_nonnegative_footprint_margin() -> None:
     }
 
     for filename, min_expected_margin in expected_min_margin_m.items():
-        map_path = REPO_ROOT / "maps" / "svg_maps" / filename
+        map_path = Path("maps/svg_maps") / filename
         obstacles = _obstacle_polygons(map_path)
+        assert obstacles, f"{filename} should parse obstacle geometry"
         route_margins = []
         for line in _route_lines(map_path, kind="robot"):
             min_center_distance = min(line.distance(obstacle) for obstacle in obstacles)
-            route_margins.append(min_center_distance - 1.0)
+            route_margins.append(min_center_distance - ROBOT_RADIUS_M)
 
         assert route_margins, f"{filename} should have at least one robot route"
         assert min(route_margins) >= min_expected_margin


### PR DESCRIPTION
## Summary
Repairs the classic merging and station-platform route centerlines that produced negative route-clearance margins in the paper matrix and h500 preflights.

## Linked Issues
- Closes #1130
- Relates to #1105
- Relates to #1065

## What Changed
- Rerouted `maps/svg_maps/classic_merging.svg` robot and pedestrian routes through the open Y-merge corridor instead of across the central stem obstacle.
- Rerouted `maps/svg_maps/classic_station_platform.svg` robot route through the clear passage left of the elevator core instead of through the elevator obstacle.
- Added `tests/maps/test_route_clearance_maps.py` to lock obstacle-interior avoidance and nonnegative robot footprint margins.
- Added `docs/context/issue_1130_negative_route_clearance_repair.md` documenting the repair boundary.

## Why It Matters
- Added value: the three negative-clearance paper/h500 rows no longer appear in route-clearance warnings.
- Expected impact: `classic_merging_low`, `classic_merging_medium`, and `classic_station_platform_medium` are no longer blocked by route/obstacle overlap evidence.
- Why this is worth merging now: #1105 certified/excluded the rows for attribution; this PR fixes the underlying SVG route geometry.

## Validation / Proof
- Commands run:
  - `rtk uv run python scripts/validation/svg_inspect.py maps/svg_maps/classic_merging.svg --show-routes --strict error`
  - `rtk uv run python scripts/validation/svg_inspect.py maps/svg_maps/classic_station_platform.svg --show-routes --strict error`
  - `rtk uv run pytest tests/maps/test_route_clearance_maps.py tests/maps/test_station_platform_map.py -q`
  - `rtk uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1.yaml --mode preflight --campaign-id issue1130_paper_preflight --log-level WARNING`
  - `rtk uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml --mode preflight --campaign-id issue1130_h500_preflight --log-level WARNING`
  - `jq -e '.route_clearance_warning_count == 15 and ([.route_clearance_warnings[].scenario] | index("classic_merging_low") == null and index("classic_merging_medium") == null and index("classic_station_platform_medium") == null)' output/benchmarks/camera_ready/issue1130_paper_preflight/preflight/validate_config.json`
  - same `jq` check for `issue1130_h500_preflight`
  - `rtk uv run python scripts/validation/verify_maps.py --scope all --mode local` -> 70 passed, 0 failed, 0 warned
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> `3273 passed, 18 skipped, 3 warnings`
  - `rtk uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` -> fresh for `270dccb1cca9eb9b5ca97a3170f1402f0e39e252`
- Evidence that the change works here: both edited maps pass SVG inspection with no findings; paper and h500 preflight warning counts drop from 18 to 15 and omit all three affected scenario IDs.
- Benchmarks or smoke tests, if applicable: preflight-only; no episode execution changed.

## Risks / Rollout
- Compatibility risks: route centerlines changed for two existing maps, so exact route-following trajectories may shift in affected scenarios.
- Failure modes: remaining zero/low-positive route-clearance warnings are intentionally left as stress-geometry caveats, not map defects.
- Rollback or fallback plan: revert the SVG route edits to restore previous route geometry.

## Docs / Provenance
- Updated docs: `docs/context/issue_1130_negative_route_clearance_repair.md`, `docs/context/README.md`.
- Relevant design or provenance notes: #1105 certification PR and #1065 route-clearance audit.
- Any assumptions that need to be preserved: generated `output/benchmarks/camera_ready/issue1130_*_preflight/` and `output/coverage/` artifacts are reproducible local validation byproducts and remain ignored.

## Follow-Up Issues
- Deferred work: none for the three negative-clearance rows.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the rerouted merging path still matches the intended Y-merge interaction.
- Any known limitations: this PR does not attempt to eliminate the remaining 15 low-positive/tangent warnings.
