### PR TITLE
docs: define SocNavBench ETH import gate (#334)

### DIFF
--- a/configs/maps/socnavbench_import_batches.yaml
+++ b/configs/maps/socnavbench_import_batches.yaml
@@ -1,0 +1,57 @@
+version: 1
+source_family: socnavbench
+source_policy: license_safe_local_staging_required
+upstream:
+  repository: https://github.com/CMU-TBD/SocNavBench
+  checked_commit: 2724ea85ff22ca61a88ee95285dfc3fa056656c6
+  official_asset_source: https://drive.google.com/drive/folders/1LAySlmE9dwrTghnL3Y5gE62K5cDJkPm1
+  upstream_docs:
+    - output/repos/SocNavBench/docs/install.md
+    - output/repos/SocNavBench/docs/usage.md
+    - output/repos/SocNavBench/sd3dis/README.md
+notes:
+  - This manifest intentionally does not vendor SocNavBench/S3DIS map assets.
+  - Convert only maps whose official source files are staged locally and checksum-recorded.
+batches:
+  - batch_id: eth_first
+    status: blocked_pending_source_assets
+    issue: 334
+    description: First staged SocNavBench map import batch selected by maintainer decision.
+    maps:
+      - map_id: socnavbench_eth
+        upstream_map_name: ETH
+        upstream_episode_keys:
+          - t_ETH1
+          - t_ETH2
+          - t_eth_follow
+          - t_eth_against
+          - t_eth_dense_flow
+          - t_eth_dense_against
+        source_assets:
+          - key: eth_mesh_dir
+            description: Curated SocNavBench ETH mesh directory.
+            relative_path: sd3dis/stanford_building_parser_dataset/mesh/ETH
+            kind: directory
+            required_for_conversion: true
+            checksum_status: pending_official_asset_staging
+          - key: eth_traversible_pickle
+            description: Precomputed ETH traversible generated from the curated mesh.
+            relative_path: sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl
+            kind: file
+            required_for_conversion: true
+            checksum_status: pending_official_asset_staging
+          - key: eth_pedestrian_dataset
+            description: Upstream ETH pedestrian trajectory CSV used by SocNavBench episodes.
+            relative_path: agents/humans/datasets/eth/world_coordinate_inter_eth.csv
+            kind: file
+            required_for_conversion: false
+            checksum_status: upstream_git_tracked
+        planned_outputs:
+          map_svg: maps/svg_maps/socnavbench/socnavbench_eth.svg
+          scenario_config: configs/scenarios/single/socnavbench_eth_smoke.yaml
+          provenance_note: docs/context/issue_334_socnavbench_eth_import.md
+        acceptance_checks:
+          - SVG parser accepts the converted map.
+          - Route and zone semantics are explicit and non-overlapping.
+          - A representative smoke benchmark reaches the map loading path without fallback.
+          - Geometry scale and source checksums are documented before merge.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -260,6 +260,9 @@ knowledge, not every transient iteration detail.
 
 * [Issue #435 Map Coverage Flow](./issue_435_map_coverage_flow.md)
   parent flow state for real-world maps, SocNavBench import, and map-quality repair issues.
+* [Issue #334 SocNavBench ETH Import Batch](issue_334_socnavbench_eth_import.md)
+  records the first staged SocNavBench map-import batch, the fail-closed source-asset validator,
+  and the boundary before a converted ETH SVG can be committed.
 * [Issue #328 Real-World Map Parent Tracker](./issue_328_real_world_map_parent.md)
   parent/child split, current child issue state, and shared validation contract for real-world
   benchmark maps.

--- a/docs/context/issue_334_socnavbench_eth_import.md
+++ b/docs/context/issue_334_socnavbench_eth_import.md
@@ -1,0 +1,62 @@
+# Issue #334 SocNavBench ETH Import Batch
+
+Date: 2026-05-10
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/334>
+Follow-up issue: <https://github.com/ll7/robot_sf_ll7/issues/1134>
+
+## Decision
+
+The first SocNavBench map-import batch is `ETH`, matching the maintainer decision on issue #334.
+The batch is now represented in `configs/maps/socnavbench_import_batches.yaml`.
+
+## Current Status
+
+The repository still cannot commit a converted ETH map safely because the actual SocNavBench ETH
+map geometry and traversible files are not tracked in the upstream Git repository. Upstream Git
+contains ETH episode parameters and pedestrian trajectory CSVs, but the map geometry comes from the
+official SocNavBench/S3DIS asset distribution described by upstream `docs/install.md`.
+
+Required local source assets before conversion:
+
+- `third_party/socnavbench/sd3dis/stanford_building_parser_dataset/mesh/ETH/`
+- `third_party/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl`
+
+The validator is deliberately fail-closed:
+
+```bash
+uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first
+```
+
+On a machine without the official ETH source assets staged, it reports the missing required files
+and exits with status `2`. Once the assets are staged and checksummed, the same command becomes the
+pre-conversion gate.
+
+## Why This Shape
+
+Committing a hand-authored or inferred ETH-like SVG would look like a SocNavBench import while not
+being one. The manifest records the exact source contract and planned outputs without weakening the
+license-safe asset policy in `docs/socnav_assets_setup.md`.
+
+## Planned Outputs After Asset Staging
+
+- `maps/svg_maps/socnavbench/socnavbench_eth.svg`
+- `configs/scenarios/single/socnavbench_eth_smoke.yaml`
+- parser, route/zone, and smoke-benchmark validation evidence
+- source checksums for the official ETH mesh/traversible inputs
+
+Issue #1134 owns this conversion step after official source assets are staged.
+
+## Validation
+
+Focused checks for this first-batch manifest:
+
+```bash
+rtk uv run ruff check scripts/tools/validate_socnav_map_batch.py tests/tools/test_validate_socnav_map_batch.py
+rtk uv run pytest tests/tools/test_validate_socnav_map_batch.py -q
+rtk uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first \
+  --report-json output/maps/issue_334_eth_batch_missing_assets.json
+```
+
+The last command is expected to exit `2` on this machine because the official ETH source assets are
+not staged. It reported `eth_mesh_dir` and `eth_traversible_pickle` as missing required inputs.

--- a/docs/socnav_assets_setup.md
+++ b/docs/socnav_assets_setup.md
@@ -116,6 +116,19 @@ Expected behavior:
 - With complete assets, `socnav_bench` preflight does not fail due to missing data.
 - Without required assets, run fails fast with explicit missing path errors.
 
+## 6. SocNavBench Map Import Batches
+
+Issue #334 uses a staged map-import manifest instead of bulk asset ingestion:
+
+```bash
+uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first
+```
+
+The first batch is `ETH` and is defined in
+`configs/maps/socnavbench_import_batches.yaml`. This command validates that the exact source
+mesh/traversible inputs are staged locally before any converted Robot SF SVG or scenario wiring is
+accepted. Missing required source assets fail closed.
+
 ## Licensing and Repository Hygiene
 
 - Do not commit downloaded dataset assets.

--- a/scripts/tools/validate_socnav_map_batch.py
+++ b/scripts/tools/validate_socnav_map_batch.py
@@ -43,6 +43,18 @@ def _asset_exists(path: Path, kind: str) -> bool:
     raise ValueError(f"Unsupported asset kind: {kind}")
 
 
+def _validated_relative_asset_path(asset: dict[str, Any]) -> str:
+    """Return a safe non-empty relative path from one asset manifest entry."""
+    rel_val = asset.get("relative_path")
+    if not isinstance(rel_val, str) or not rel_val.strip():
+        raise ValueError(f"Asset '{asset.get('key')}' must have a non-empty relative path")
+    rel = rel_val.strip()
+    rel_path = Path(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        raise ValueError(f"Asset '{asset.get('key')}' must be a relative path within the root")
+    return rel
+
+
 def validate_batch(
     *,
     manifest_path: Path,
@@ -68,8 +80,8 @@ def validate_batch(
         for asset in assets:
             if not isinstance(asset, dict):
                 raise TypeError(f"Source asset in map '{map_entry.get('map_id')}' is invalid")
-            rel = str(asset.get("relative_path", "")).strip()
-            kind = str(asset.get("kind", "")).strip()
+            rel = _validated_relative_asset_path(asset)
+            kind = str(asset.get("kind") or "").strip()
             required = bool(asset.get("required_for_conversion", False))
             path = socnav_root / rel
             exists = _asset_exists(path, kind)

--- a/scripts/tools/validate_socnav_map_batch.py
+++ b/scripts/tools/validate_socnav_map_batch.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate staged SocNavBench map-import source assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = REPO_ROOT / "configs" / "maps" / "socnavbench_import_batches.yaml"
+DEFAULT_SOCNAV_ROOT = REPO_ROOT / "third_party" / "socnavbench"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML mapping from disk."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected YAML mapping: {path}")
+    return payload
+
+
+def _find_batch(manifest: dict[str, Any], batch_id: str) -> dict[str, Any]:
+    """Return one batch from the SocNav import manifest."""
+    batches = manifest.get("batches")
+    if not isinstance(batches, list):
+        raise TypeError("Manifest must contain a 'batches' list")
+    for batch in batches:
+        if isinstance(batch, dict) and str(batch.get("batch_id")) == batch_id:
+            return batch
+    raise KeyError(f"Unknown SocNavBench import batch: {batch_id}")
+
+
+def _asset_exists(path: Path, kind: str) -> bool:
+    """Check whether a staged source asset exists with the expected filesystem kind."""
+    if kind == "directory":
+        return path.is_dir()
+    if kind == "file":
+        return path.is_file()
+    raise ValueError(f"Unsupported asset kind: {kind}")
+
+
+def validate_batch(
+    *,
+    manifest_path: Path,
+    socnav_root: Path,
+    batch_id: str,
+) -> dict[str, Any]:
+    """Validate staged source assets for one SocNavBench map-import batch."""
+    manifest = _load_yaml(manifest_path)
+    batch = _find_batch(manifest, batch_id)
+    maps = batch.get("maps")
+    if not isinstance(maps, list) or not maps:
+        raise TypeError(f"Batch '{batch_id}' must contain at least one map")
+
+    map_reports: list[dict[str, Any]] = []
+    missing_required: list[dict[str, str]] = []
+    for map_entry in maps:
+        if not isinstance(map_entry, dict):
+            raise TypeError(f"Map entry in batch '{batch_id}' must be a mapping")
+        asset_reports: list[dict[str, Any]] = []
+        assets = map_entry.get("source_assets")
+        if not isinstance(assets, list) or not assets:
+            raise TypeError(f"Map '{map_entry.get('map_id')}' must declare source assets")
+        for asset in assets:
+            if not isinstance(asset, dict):
+                raise TypeError(f"Source asset in map '{map_entry.get('map_id')}' is invalid")
+            rel = str(asset.get("relative_path", "")).strip()
+            kind = str(asset.get("kind", "")).strip()
+            required = bool(asset.get("required_for_conversion", False))
+            path = socnav_root / rel
+            exists = _asset_exists(path, kind)
+            asset_report = {
+                "key": str(asset.get("key", "")),
+                "relative_path": rel,
+                "kind": kind,
+                "required_for_conversion": required,
+                "exists": exists,
+                "path": str(path),
+            }
+            asset_reports.append(asset_report)
+            if required and not exists:
+                missing_required.append(
+                    {
+                        "map_id": str(map_entry.get("map_id", "")),
+                        "asset_key": asset_report["key"],
+                        "relative_path": rel,
+                    }
+                )
+        map_reports.append(
+            {
+                "map_id": str(map_entry.get("map_id", "")),
+                "upstream_map_name": str(map_entry.get("upstream_map_name", "")),
+                "assets": asset_reports,
+                "planned_outputs": map_entry.get("planned_outputs", {}),
+            }
+        )
+
+    return {
+        "manifest": str(manifest_path),
+        "socnav_root": str(socnav_root),
+        "batch_id": batch_id,
+        "batch_status": str(batch.get("status", "unknown")),
+        "ok": not missing_required,
+        "missing_required": missing_required,
+        "maps": map_reports,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--socnav-root", type=Path, default=DEFAULT_SOCNAV_ROOT)
+    parser.add_argument("--batch-id", default="eth_first")
+    parser.add_argument("--report-json", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Validate one SocNavBench import batch and return a process exit code."""
+    args = parse_args()
+    report = validate_batch(
+        manifest_path=args.manifest.resolve(),
+        socnav_root=args.socnav_root.resolve(),
+        batch_id=str(args.batch_id),
+    )
+    if args.report_json is not None:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_validate_socnav_map_batch.py
+++ b/tests/tools/test_validate_socnav_map_batch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 import yaml
 
 from scripts.tools.validate_socnav_map_batch import validate_batch
@@ -90,3 +91,51 @@ def test_validate_batch_accepts_staged_eth_assets(tmp_path: Path) -> None:
     assert report["ok"] is True
     assert report["missing_required"] == []
     assert report["maps"][0]["map_id"] == "socnavbench_eth"
+
+
+def test_validate_batch_rejects_empty_relative_path(tmp_path: Path) -> None:
+    """Validator should fail fast when a source asset omits its relative path."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["batches"][0]["maps"][0]["source_assets"][0]["relative_path"] = ""
+    manifest.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="non-empty relative path"):
+        validate_batch(
+            manifest_path=manifest,
+            socnav_root=tmp_path / "socnavbench",
+            batch_id="eth_first",
+        )
+
+
+def test_validate_batch_rejects_parent_relative_path(tmp_path: Path) -> None:
+    """Validator should reject parent-relative source asset paths before resolution."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["batches"][0]["maps"][0]["source_assets"][0]["relative_path"] = "../secret"
+    manifest.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="relative path within the root"):
+        validate_batch(
+            manifest_path=manifest,
+            socnav_root=tmp_path / "socnavbench",
+            batch_id="eth_first",
+        )
+
+
+def test_validate_batch_rejects_absolute_relative_path(tmp_path: Path) -> None:
+    """Validator should reject absolute source asset paths before resolution."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["batches"][0]["maps"][0]["source_assets"][0]["relative_path"] = "/tmp/eth"
+    manifest.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="relative path within the root"):
+        validate_batch(
+            manifest_path=manifest,
+            socnav_root=tmp_path / "socnavbench",
+            batch_id="eth_first",
+        )

--- a/tests/tools/test_validate_socnav_map_batch.py
+++ b/tests/tools/test_validate_socnav_map_batch.py
@@ -1,0 +1,92 @@
+"""Tests for the SocNavBench map-import batch validator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools.validate_socnav_map_batch import validate_batch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_manifest(path: Path) -> None:
+    """Write a minimal SocNavBench import manifest fixture."""
+    payload = {
+        "version": 1,
+        "batches": [
+            {
+                "batch_id": "eth_first",
+                "status": "blocked_pending_source_assets",
+                "maps": [
+                    {
+                        "map_id": "socnavbench_eth",
+                        "upstream_map_name": "ETH",
+                        "source_assets": [
+                            {
+                                "key": "eth_mesh_dir",
+                                "relative_path": (
+                                    "sd3dis/stanford_building_parser_dataset/mesh/ETH"
+                                ),
+                                "kind": "directory",
+                                "required_for_conversion": True,
+                            },
+                            {
+                                "key": "eth_traversible_pickle",
+                                "relative_path": (
+                                    "sd3dis/stanford_building_parser_dataset/"
+                                    "traversibles/ETH/data.pkl"
+                                ),
+                                "kind": "file",
+                                "required_for_conversion": True,
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def test_validate_batch_reports_missing_required_assets(tmp_path: Path) -> None:
+    """Missing ETH source assets should fail closed before conversion."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+
+    report = validate_batch(
+        manifest_path=manifest,
+        socnav_root=tmp_path / "socnavbench",
+        batch_id="eth_first",
+    )
+
+    assert report["ok"] is False
+    assert {item["asset_key"] for item in report["missing_required"]} == {
+        "eth_mesh_dir",
+        "eth_traversible_pickle",
+    }
+
+
+def test_validate_batch_accepts_staged_eth_assets(tmp_path: Path) -> None:
+    """Validator should pass once the exact ETH source assets are staged."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    root = tmp_path / "socnavbench"
+    (root / "sd3dis" / "stanford_building_parser_dataset" / "mesh" / "ETH").mkdir(parents=True)
+    traversible = (
+        root / "sd3dis" / "stanford_building_parser_dataset" / "traversibles" / "ETH" / "data.pkl"
+    )
+    traversible.parent.mkdir(parents=True)
+    traversible.write_bytes(b"fixture")
+
+    report = validate_batch(
+        manifest_path=manifest,
+        socnav_root=root,
+        batch_id="eth_first",
+    )
+
+    assert report["ok"] is True
+    assert report["missing_required"] == []
+    assert report["maps"][0]["map_id"] == "socnavbench_eth"


### PR DESCRIPTION
## Summary
Defines the first SocNavBench map-import batch as ETH and adds a fail-closed validator for the source assets required before conversion.

## Linked Issues
- Relates to #334
- Follow-up: #1134

## What Changed
- Added `configs/maps/socnavbench_import_batches.yaml` with the selected `eth_first` batch, upstream provenance, required source assets, and planned Robot SF outputs.
- Added `scripts/tools/validate_socnav_map_batch.py` to validate staged SocNavBench map-import assets before conversion.
- Added focused tests for missing-source fail-closed behavior and successful staged-source validation.
- Updated `docs/socnav_assets_setup.md` and added `docs/context/issue_334_socnavbench_eth_import.md`.
- Linked the new note from `docs/context/README.md`.

## Why It Matters
- Added value: #334 no longer depends on historical comments to define the ETH first batch or the source-asset gate.
- Expected impact: reviewers can see exactly which official SocNavBench ETH inputs are required before a converted Robot SF SVG can be accepted.
- Why this is worth merging now: committing inferred ETH-like geometry would weaken provenance; this PR makes the import path executable and fail-closed until the official assets are staged.

## Validation / Proof
- Commands run:
  - `rtk uv run ruff format scripts/tools/validate_socnav_map_batch.py tests/tools/test_validate_socnav_map_batch.py`
  - `rtk uv run ruff check scripts/tools/validate_socnav_map_batch.py tests/tools/test_validate_socnav_map_batch.py`
  - `rtk uv run pytest tests/tools/test_validate_socnav_map_batch.py -q`
  - `rtk uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first --report-json output/maps/issue_334_eth_batch_missing_assets.json; test $? -eq 2`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
  - `rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main && rtk uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - Focused tests pass: `2 passed`.
  - The validator correctly exits `2` on this machine because `eth_mesh_dir` and `eth_traversible_pickle` are missing.
  - Full readiness passed: `3274 passed, 17 skipped, 3 warnings`.
  - Freshness stamp is fresh for `14877bfe0c48b0d94b3ab301bff3619f5664fa49` against `origin/main`.
- Benchmarks or smoke tests, if applicable: no smoke benchmark is possible until the official ETH mesh/traversible assets are staged; #1134 owns that conversion and smoke path.

## Risks / Rollout
- Compatibility risks: low; additive manifest, validator, tests, and docs only.
- Failure modes: if the official ETH asset layout differs, update `configs/maps/socnavbench_import_batches.yaml` before conversion.
- Rollback or fallback plan: remove the manifest/validator and continue using `docs/socnav_assets_setup.md` only; no runtime benchmark behavior changes.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_334_socnavbench_eth_import.md`
  - `docs/socnav_assets_setup.md`
  - `docs/context/README.md`
- Relevant design or provenance notes: upstream SocNavBench Git commit `2724ea85ff22ca61a88ee95285dfc3fa056656c6`; official asset folder recorded in the manifest.
- Any assumptions that need to be preserved: raw SocNavBench/S3DIS assets must remain local and untracked; converted/reviewable outputs need source checksums before merge.

## Follow-Up Issues
- Deferred work: actual ETH SVG conversion, scenario wiring, parser/route validation, and smoke benchmark after official source assets are staged.
- Issues opened for follow-up: #1134.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the expected ETH mesh/traversible paths match the official staged asset layout before #1134 starts.
- Any known limitations: this is a partial #334 implementation because the required official ETH source assets are not present in this worktree or upstream Git.
