### PR TITLE
docs: record leaderboard backlog next step (#589)

### DIFF
--- a/docs/context/issue_589_public_leaderboard_mvp.md
+++ b/docs/context/issue_589_public_leaderboard_mvp.md
@@ -6,6 +6,16 @@ Decide whether Robot SF should pursue a public social-navigation planner leaderb
 the smallest credible MVP boundary if it becomes valuable later.
 
 Related issue: <https://github.com/ll7/robot_sf_ll7/issues/589>
+Next actionable follow-up: <https://github.com/ll7/robot_sf_ll7/issues/1136>
+
+## 2026-05-10 Backlog Status
+
+Issue #589 was reopened as a future planned idea after the original MVP-boundary PR merged. Keep it
+as a parent/backlog concept, not a direct implementation request.
+
+The next actionable slice is #1136: draft the external planner submission manifest schema and
+validator. That issue is intentionally narrower than a leaderboard website, public upload endpoint,
+or arbitrary-code execution service.
 
 ## Current Decision
 
@@ -79,3 +89,5 @@ one maintainer-reviewed smoke path.
 
 Only after that schema exists should a separate issue consider a static leaderboard page generated
 from accepted release bundles.
+
+As of 2026-05-10, that narrower schema issue is #1136.

--- a/docs/context/issue_589_public_leaderboard_mvp.md
+++ b/docs/context/issue_589_public_leaderboard_mvp.md
@@ -13,9 +13,9 @@ Next actionable follow-up: <https://github.com/ll7/robot_sf_ll7/issues/1136>
 Issue #589 was reopened as a future planned idea after the original MVP-boundary PR merged. Keep it
 as a parent/backlog concept, not a direct implementation request.
 
-The next actionable slice is #1136: draft the external planner submission manifest schema and
-validator. That issue is intentionally narrower than a leaderboard website, public upload endpoint,
-or arbitrary-code execution service.
+The next actionable slice is #1136: draft the external planner submission manifest schema,
+validator, and maintainer-reviewed smoke path. That issue is intentionally narrower than a
+leaderboard website, public upload endpoint, or execution of arbitrary user code.
 
 ## Current Decision
 


### PR DESCRIPTION
## Summary
Records the reopened #589 state as a low-priority backlog parent and points the next actionable work to the narrower external planner submission manifest schema issue.

## Linked Issues
- Relates to #589
- Follow-up: #1136

## What Changed
- Updated `docs/context/issue_589_public_leaderboard_mvp.md` with the 2026-05-10 backlog status.
- Documented that #589 should remain a parent/future idea rather than a direct leaderboard implementation request.
- Created #1136 for the first concrete next step: drafting the external planner submission manifest schema and validator.

## Why It Matters
- Added value: avoids reinterpreting #589 as a website/upload implementation task after it was reopened.
- Expected impact: future work starts with the schema/provenance contract instead of public execution or deployment infrastructure.
- Why this is worth merging now: it gives the reopened issue a current PR and a concrete follow-up without expanding scope.

## Validation / Proof
- Commands run:
  - `test -f docs/context/issue_589_public_leaderboard_mvp.md && rg -n "1136|Backlog Status|leaderboard" docs/context/issue_589_public_leaderboard_mvp.md docs/README.md docs/context/README.md`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
  - `rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main && rtk uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - The note now links #1136 and states that #589 remains a parent/backlog concept.
  - Full readiness passed: `3273 passed, 16 skipped, 3 warnings`.
  - Freshness stamp is fresh for `89e1b127f354252deb9c8d07d2a49f246becde50` against `origin/main`.
- Benchmarks or smoke tests, if applicable: not applicable; docs-only backlog clarification.

## Risks / Rollout
- Compatibility risks: none; docs-only.
- Failure modes: future work could still over-expand #1136 into execution infrastructure; the note explicitly blocks that.
- Rollback or fallback plan: revert the context-note update and close #1136 if the team does not want a submission manifest prerequisite.

## Docs / Provenance
- Updated docs: `docs/context/issue_589_public_leaderboard_mvp.md`.
- Relevant design or provenance notes: prior merged PR #903 and issue #589 reopening comment.
- Any assumptions that need to be preserved: no public upload endpoint, website, or arbitrary-code execution belongs in #589.

## Follow-Up Issues
- Deferred work: external planner submission manifest schema and validator.
- Issues opened for follow-up: #1136.

## Reviewer Notes
- Anything a reviewer should verify closely: whether #1136 is the right next actionable slice or should remain lower priority.
- Any known limitations: this PR does not implement the manifest schema; it only records the reopened backlog state and routes the next step.
