### PR TITLE
docs: mark mlp default promotion as pending (#834)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -153,8 +153,9 @@ knowledge, not every transient iteration detail.
 ## Feature Extractor Notes
 
 * [Issue #193 Feature Extractor Evaluation](./issue_193_feature_extractor_evaluation.md)
-  GPU throughput microbenchmark + 32 K PPO comparison of DynamicsExtractor vs MLP/CNN/Attention; 
-  recommends `mlp_small` as new default for fresh training runs.
+  GPU throughput microbenchmark + 32 K PPO comparison of DynamicsExtractor vs MLP/CNN/Attention;
+  preserves the historical `mlp_small` recommendation but marks default promotion as superseded
+  pending the later `dyn_large_med` safety blocker and #834 maintainer decision.
 * [Issue #193 Feature Extractor Optuna Study](./issue_193_feature_extractor_optuna_study.md)
   4 M-step SLURM sweep infrastructure, DB classification, and April 20 final pre-screen analysis; 
 `feat_sweep_4m_array.db` is the current evidence surface, with longer 10 M+ validation still

--- a/docs/context/issue_193_feature_extractor_evaluation.md
+++ b/docs/context/issue_193_feature_extractor_evaluation.md
@@ -179,7 +179,7 @@ blocker is resolved or a maintainer explicitly accepts an interim default.
 
 1. **Resolve #834 default-promotion decision** before changing PPO defaults. If maintainers accept
    `mlp_small` as an interim default, update the current `scripts/training/train_ppo.py` default
-   resolution path and canonical configs, not only the older `environment_factory.py` wording.
+   resolution path and canonical configs.
 2. **Investigate `lightweight_cnn` divergence** at ≥28 K steps (potential learning-rate or
    gradient-norm interaction with large feature dim).
 3. **Full multi-seed evaluation campaign** (3 seeds × 500 K steps) to validate `mlp_small`

--- a/docs/context/issue_193_feature_extractor_evaluation.md
+++ b/docs/context/issue_193_feature_extractor_evaluation.md
@@ -5,11 +5,17 @@
 **Date**: 2026-04-16
 
 > **Superseded recommendation, 2026-04-28:** the 32 K result below is useful historical
-> pre-screening evidence, but it is no longer the promotion recommendation.  The later Optuna and
+> pre-screening evidence, but it is no longer the promotion recommendation. The later Optuna and
 > 12 M fixed-candidate study in
 > `docs/context/issue_193_feature_extractor_optuna_study.md` selects `dyn_large_med` as the
 > preferred architecture candidate and rejects default promotion until collision failures are fixed
 > in follow-up issue #850.
+>
+> **Issue #834 status, 2026-05-10:** do not promote `mlp_small` as the new PPO default from this
+> note alone. The owner comment on #834 says the evidence is not sufficient for promotion, and the
+> current evidence trail has moved from `mlp_small` to the still-blocked `dyn_large_med` safety
+> follow-up. #834 should stay decision-required unless maintainers explicitly choose an interim
+> `mlp_small` default despite the newer evidence.
 **Machine**: imech156-u — AMD Ryzen 9 3950X, RTX 3070 8 GB, CUDA 12.8, Ubuntu 24.04
 
 ---
@@ -20,7 +26,7 @@ Four extractors were compared: the original `DynamicsExtractor` against `MLPFeat
 `LightweightCNNExtractor`, and `AttentionFeatureExtractor`. Both a static GPU throughput
 microbenchmark and a 32 000-step PPO training run (seed 42) were executed on the same machine.
 
-**Recommendation: replace the default with `mlp_small` for new PPO training runs.**
+**Historical recommendation: replace the default with `mlp_small` for new PPO training runs.**
 The original `DynamicsExtractor` remains the only safe choice when loading pre-trained checkpoints
 (the module path is hard-coded into SB3 policy files).
 
@@ -146,7 +152,7 @@ cuda_version = getattr(version_mod, "cuda", None) if version_mod is not None els
 
 ---
 
-## Recommendation
+## Historical Recommendation
 
 | Criterion                  | `dynamics_original` | `mlp_small`     |
 |----------------------------|---------------------|-----------------|
@@ -155,20 +161,25 @@ cuda_version = getattr(version_mod, "cuda", None) if version_mod is not None els
 | Training stability         | variable            | **improving**   |
 | Backward compat (checkpts) | **required**        | new runs only   |
 
-**Decision**:
-- **For new PPO training runs**: use `mlp_small` as the default feature extractor.
+**Historical decision at 32 K only**:
+- **For new PPO training runs**: the early-screen recommendation was to use `mlp_small` as the
+  default feature extractor.
 - **For loading existing checkpoints**: keep `DynamicsExtractor` as-is (module path is embedded in
   serialised policy files — changing it breaks loading).
 - **Defer** `lightweight_cnn` and `attention_small` promotion to dedicated follow-up issues with
   longer training campaigns and multi-seed comparisons.
 
+Current default-promotion status is superseded by the 2026-04-28 note at the top of this file:
+neither `mlp_small` nor `dyn_large_med` should be treated as promoted until the later safety
+blocker is resolved or a maintainer explicitly accepts an interim default.
+
 ---
 
 ## Follow-up Issues Needed
 
-1. **Promote `mlp_small` as the new default** in `environment_factory.py` and canonical PPO
-   configs — requires updating `policy_kwargs` defaults and verifying backward compat shims for
-   checkpoint loading.
+1. **Resolve #834 default-promotion decision** before changing PPO defaults. If maintainers accept
+   `mlp_small` as an interim default, update the current `scripts/training/train_ppo.py` default
+   resolution path and canonical configs, not only the older `environment_factory.py` wording.
 2. **Investigate `lightweight_cnn` divergence** at ≥28 K steps (potential learning-rate or
    gradient-norm interaction with large feature dim).
 3. **Full multi-seed evaluation campaign** (3 seeds × 500 K steps) to validate `mlp_small`


### PR DESCRIPTION
## Summary
Marks the old `mlp_small` PPO-default recommendation as historical/superseded and records that #834 needs a maintainer decision before defaults should change.

## Linked Issues
- Relates to #834
- Relates to #193
- Relates to #850

## What Changed
- Updated `docs/context/issue_193_feature_extractor_evaluation.md` so the 32 K `mlp_small` result is clearly historical, not an active default-promotion recommendation.
- Added the 2026-05-10 #834 status: do not promote `mlp_small` from this note alone; wait for an explicit maintainer decision or the newer safety blocker to resolve.
- Updated `docs/context/README.md` so the context index no longer says `mlp_small` is the current recommended fresh-training default.
- Added `decision-required` to #834 and posted an options/recommendation comment there.

## Why It Matters
- Added value: prevents accidental PPO default churn based on stale early-screen evidence.
- Expected impact: no runtime behavior change; this is documentation and issue-triage only.
- Why this is worth merging now: #834 currently conflicts with its own owner comment and the newer issue-193 evidence trail, so changing training defaults would be premature.

## Validation / Proof
- Commands run:
  - `gh issue view 834 --comments --json number,title,body,labels,milestone,state,url,comments`
  - `rg -n "feature_extractor|MLPFeatureExtractor|DynamicsExtractor|mlp_small|dyn_large_med|policy_kwargs" scripts/training/train_ppo.py tests/training/test_train_expert_ppo_contract.py tests/sb3_test.py robot_sf/feature_extractor.py configs/training/ppo docs/context/issue_193_feature_extractor_evaluation.md | head -240`
  - `rg -n "Issue #834 status|Historical recommendation|Historical Recommendation|Resolve #834|decision" docs/context/issue_193_feature_extractor_evaluation.md docs/context/README.md`
  - `git diff --check`
  - `gh issue view 834 --json number,title,state,labels,comments --jq '{number,title,state,labels:[.labels[].name],lastComment:(.comments[-1].body // "")}'`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
  - `rtk uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main && rtk uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here: #834 has `decision-required`; #834 has a structured options comment; the docs no longer present `mlp_small` promotion as current.
- Benchmarks or smoke tests, if applicable: full PR readiness gate passed with `3272 passed, 17 skipped, 3 warnings` on commit `84295db84e3452fe08708f4a050923ec6e176e38`.

## Risks / Rollout
- Compatibility risks: none; no code or training default behavior changes.
- Failure modes: a maintainer may still choose to promote `mlp_small` as an interim default; that should be a follow-up code PR after the decision.
- Rollback or fallback plan: revert the documentation edits and remove `decision-required` if maintainers decide #834 is ready for code implementation.

## Docs / Provenance
- Updated docs: `docs/context/issue_193_feature_extractor_evaluation.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_193_feature_extractor_optuna_study.md`, #850 safety blocker.
- Any assumptions that need to be preserved: current PPO defaults are intentionally unchanged until the promotion decision is made.

## Follow-Up Issues
- Deferred work: actual PPO default switch, if maintainers approve `mlp_small` as an interim default.
- Issues opened for follow-up: none; #834 itself now carries the decision point.

## Reviewer Notes
- Anything a reviewer should verify closely: whether #834 should remain open with `decision-required`, close behind #850, or proceed with an explicit interim `mlp_small` default.
- Any known limitations: this PR does not change `scripts/training/train_ppo.py`, configs, or checkpoint compatibility behavior.
