### PR TITLE
fix: force SA-CADRL CPU TensorFlow session

### DIFF
--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -8,6 +8,7 @@ observation emitted when `ObservationMode.SOCNAV_STRUCT` is enabled.
 """
 
 import os
+import re
 import sys
 import threading
 from collections.abc import Callable
@@ -3238,7 +3239,7 @@ def _sacadrl_session_config(tf_module: Any, *, device: str):
         "gpu_options": tf_module.GPUOptions(allow_growth=True),
     }
     normalized_device = device.lower().replace(" ", "")
-    if normalized_device.startswith("/cpu") or normalized_device.startswith("cpu"):
+    if re.search(r"(^|/)(device:)?cpu(?::|$)", normalized_device):
         kwargs["device_count"] = {"GPU": 0}
     return tf_module.ConfigProto(**kwargs)
 

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -3226,6 +3226,23 @@ def _sacadrl_actions() -> np.ndarray:
     return actions
 
 
+def _sacadrl_session_config(tf_module: Any, *, device: str):
+    """Build a TensorFlow session config for SA-CADRL inference.
+
+    Returns:
+        TensorFlow ConfigProto: Session configuration matching the requested device.
+    """
+    kwargs: dict[str, Any] = {
+        "allow_soft_placement": True,
+        "log_device_placement": False,
+        "gpu_options": tf_module.GPUOptions(allow_growth=True),
+    }
+    normalized_device = device.lower().replace(" ", "")
+    if normalized_device.startswith("/cpu") or normalized_device.startswith("cpu"):
+        kwargs["device_count"] = {"GPU": 0}
+    return tf_module.ConfigProto(**kwargs)
+
+
 class _SACADRLModel:
     """Tensorflow checkpoint wrapper for GA3C-CADRL policy inference."""
 
@@ -3241,11 +3258,7 @@ class _SACADRLModel:
             with self._tf.device(device):
                 self._sess = self._tf.Session(
                     graph=self._graph,
-                    config=self._tf.ConfigProto(
-                        allow_soft_placement=True,
-                        log_device_placement=False,
-                        gpu_options=self._tf.GPUOptions(allow_growth=True),
-                    ),
+                    config=_sacadrl_session_config(self._tf, device=device),
                 )
                 saver = self._tf.train.import_meta_graph(
                     f"{checkpoint_prefix}.meta", clear_devices=True

--- a/tests/test_socnav_planner_adapter.py
+++ b/tests/test_socnav_planner_adapter.py
@@ -17,6 +17,7 @@ from robot_sf.planner.socnav import (
     SocNavPlannerConfig,
     SocNavPlannerPolicy,
     TrivialReferencePlannerAdapter,
+    _sacadrl_session_config,
     make_hrvo_policy,
     make_orca_policy,
     make_prediction_policy,
@@ -492,6 +493,18 @@ def test_sacadrl_adapter_requires_model_when_fallback_disabled(monkeypatch):
     obs = _make_obs(goal=(2.0, 0.0), heading=0.0)
     with pytest.raises(RuntimeError, match="missing model"):
         adapter.plan(obs)
+
+
+def test_sacadrl_cpu_session_config_disables_gpu_devices():
+    """SA-CADRL CPU inference should not ask TensorFlow to initialize CUDA devices."""
+    from robot_sf.planner import socnav
+
+    if socnav.tf is None:
+        pytest.skip("TensorFlow not installed; skipping SA-CADRL TensorFlow config check.")
+
+    config = _sacadrl_session_config(socnav.tf, device="/cpu:0")
+    assert config.device_count["GPU"] == 0
+    assert config.allow_soft_placement is True
 
 
 def test_sacadrl_adapter_runs_model_when_available():

--- a/tests/test_socnav_planner_adapter.py
+++ b/tests/test_socnav_planner_adapter.py
@@ -506,6 +506,9 @@ def test_sacadrl_cpu_session_config_disables_gpu_devices():
     assert config.device_count["GPU"] == 0
     assert config.allow_soft_placement is True
 
+    device_config = _sacadrl_session_config(socnav.tf, device=" /device:CPU:0 ")
+    assert device_config.device_count["GPU"] == 0
+
 
 def test_sacadrl_adapter_runs_model_when_available():
     """SA-CADRL adapter should run inference when TensorFlow and checkpoint are available."""


### PR DESCRIPTION
## Summary
Force SA-CADRL TensorFlow sessions to disable GPU device initialization when the adapter explicitly requests CPU inference. This keeps the real-model inference path fail-closed while avoiding CUDA discovery crashes on machines with visible but unusable TensorFlow GPU runtime state.

## Linked Issues
- Relates to local validation failure observed while preparing the manual-control work; no dedicated issue exists for this small environment robustness fix.

## What Changed
- Added `_sacadrl_session_config(...)` to build the TensorFlow session config for SA-CADRL inference.
- Set `device_count={"GPU": 0}` when the SA-CADRL adapter is instantiated with a CPU device.
- Added a regression test asserting the CPU session config disables TensorFlow GPU devices.

## Why It Matters
- Added value: full PR readiness can run without requiring `CUDA_VISIBLE_DEVICES=-1` on this machine.
- Expected impact: CPU-only SA-CADRL inference remains real checkpoint-backed inference, not heuristic fallback.
- Why this is worth merging now: the failing test is already on `origin/main`; this avoids masking future PR validation with a local CUDA/TensorFlow environment failure.

## Validation / Proof
- Commands run:
  - `uv run pytest -n auto tests/test_socnav_planner_adapter.py -q`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - SocNav adapter suite: `47 passed`.
  - Full readiness: `3354 passed, 18 skipped, 5 warnings in 295.77s`.
  - Freshness stamp recorded for `10c486af7ce49ae41b38f9197538bd9326d2a9d5`.
- Benchmarks or smoke tests, if applicable:
  - Not a benchmark semantics change; this is TensorFlow runtime configuration for the existing SA-CADRL adapter path.

## Risks / Rollout
- Compatibility risks: low. The GPU-disabling behavior only applies when the adapter asks for a CPU device such as `/cpu:0`.
- Failure modes: if future SA-CADRL GPU inference is intentionally added, it should pass a GPU device and can retain GPU visibility.
- Rollback or fallback plan: revert this commit; local validation can still use `CUDA_VISIBLE_DEVICES=-1` as a workaround.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: preserves the existing fail-closed behavior for `allow_fallback=False`; no heuristic fallback was added.
- Any assumptions that need to be preserved: SA-CADRL model availability tests should continue to exercise real TensorFlow checkpoint inference when TensorFlow and the checkpoint are available.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that the no-fallback SA-CADRL inference test still exercises the model path rather than heuristic fallback.
- Known limitation: `robot_sf/planner/socnav.py` changed-file coverage is reported at `86.7%`, above the required threshold but below the aspirational 100% goal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved inference session setup to uniformly handle CPU vs GPU selection, including robust recognition of CPU device strings and disabling GPU usage when a CPU device is requested.

* **Tests**
  * Added a unit test verifying CPU-requested sessions disable GPU devices and allow soft placement for reliable execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1155)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->