### PR TITLE
fix: apply small open-issue correctness fixes (#1142)

### DIFF
--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -104,7 +104,7 @@ def _empty_map_definition() -> MapDefinition:
 
 @dataclass
 class VisualizableAction:
-    """TODO docstring. Document this class."""
+    """Action payload rendered alongside an agent pose and goal."""
 
     pose: RobotPose
     action: DifferentialDriveAction | BicycleAction | UnicycleAction
@@ -218,7 +218,7 @@ class SimulationView:
     focus_on_ego_ped: bool = False
     record_video: bool = False
     video_path: str | None = None
-    video_fps: float = 10.0
+    video_fps: float | None = None
     frames: list[np.ndarray] = field(default_factory=list)
     clock: pygame.time.Clock = field(init=False)
 
@@ -550,15 +550,21 @@ class SimulationView:
 
     def _finalize_frame(self, target_fps: float):
         """Capture or display the completed frame."""
+        # Store the effective render cadence for video encoding and diagnostics.
+        self.current_target_fps = target_fps
         if self.record_video:
             self._capture_frame()
         else:
-            # Store the current target FPS for display
-            self.current_target_fps = target_fps
             if self._use_display:
                 pygame.display.update()
             # Control frame rate with pygame's clock
             self.clock.tick(target_fps)
+
+    def _effective_video_fps(self) -> float:
+        """Return the FPS used when encoding captured frames."""
+        if self.video_fps is not None:
+            return float(self.video_fps)
+        return float(self.current_target_fps)
 
     def _capture_frame(self):
         """Capture the current frame for video recording."""
@@ -587,11 +593,11 @@ class SimulationView:
 
     @property
     def _timestep_text_pos(self) -> Vec2D:
-        """TODO docstring. Document this function.
+        """Return the default screen position for timestep text.
 
 
         Returns:
-            tuple[int, int]: Default ray vector rendering size (16, 16) pixels.
+            Default ``(x, y)`` text position in screen pixels.
         """
         return (16, 16)
 
@@ -646,8 +652,7 @@ class SimulationView:
         self.is_abortion_requested = True
         if self.record_video and self.frames and MOVIEPY_AVAILABLE and self.video_path:
             logger.debug("Writing video file.")
-            # TODO: get the correct fps from the simulation
-            clip = ImageSequenceClip(self.frames, fps=self.video_fps)
+            clip = ImageSequenceClip(self.frames, fps=self._effective_video_fps())
             clip.write_videofile(self.video_path)
             self.frames = []
         elif self.record_video and self.frames and MOVIEPY_AVAILABLE and not self.video_path:

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -653,8 +653,9 @@ class SimulationView:
         self.is_abortion_requested = True
         if self.record_video and self.frames and MOVIEPY_AVAILABLE and self.video_path:
             logger.debug("Writing video file.")
-            clip = ImageSequenceClip(self.frames, fps=self._effective_video_fps())
-            clip.write_videofile(self.video_path)
+            resolved_fps = self._effective_video_fps()
+            clip = ImageSequenceClip(self.frames, fps=resolved_fps)
+            clip.write_videofile(self.video_path, fps=resolved_fps)
             self.frames = []
         elif self.record_video and self.frames and MOVIEPY_AVAILABLE and not self.video_path:
             logger.warning(

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -180,7 +180,8 @@ class SimulationView:
         focus_on_ego_ped (bool): Whether to focus the camera on the ego pedestrian.
         record_video (bool): Whether to record the simulation as a video.
         video_path (str): Path to save the recorded video.
-        video_fps (float): Frames per second for the recorded video.
+        video_fps (float | None): Explicit frames per second for the recorded video. When unset,
+            the latest render target FPS is used.
         frames (List[np.ndarray]): List of frames recorded for the video.
         clock (pygame.time.Clock): PyGame clock for controlling frame rate.
         screen (pygame.surface.Surface): PyGame surface for rendering.

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -8,8 +8,8 @@ from gymnasium import spaces
 
 from robot_sf.common.types import DifferentialDriveAction, PolarVec2D, RobotPose, Vec2D
 
-WheelSpeedState = tuple[float, float]  # tuple of (left, right) speeds
-# TODO: Is WheelSpeedState in translation or rotation units?
+WheelSpeedState = tuple[float, float]
+"""Left and right wheel angular velocities in radians per second."""
 
 
 @dataclass
@@ -64,7 +64,9 @@ class DifferentialDriveState:
     pose: RobotPose = ((0.0, 0.0), 0.0)
     velocity: PolarVec2D = (0.0, 0.0)
     last_wheel_speeds: WheelSpeedState = (0.0, 0.0)
+    """Previous left/right wheel angular velocities in radians per second."""
     wheel_speeds: WheelSpeedState = (0.0, 0.0)
+    """Current left/right wheel angular velocities in radians per second."""
 
 
 @dataclass

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -141,8 +141,8 @@ class DifferentialDriveMotion:
         Computes the distance covered by the robot over the time interval ``d_t``.
 
         Args:
-            last_wheel_speeds: The previous wheel speeds.
-            new_wheel_speeds: The updated wheel speeds.
+            last_wheel_speeds: The previous left/right wheel angular velocities in rad/s.
+            new_wheel_speeds: The updated left/right wheel angular velocities in rad/s.
             d_t: The time elapsed since last speeds measurement.
 
         Returns:
@@ -168,8 +168,8 @@ class DifferentialDriveMotion:
 
         Args:
             robot_orient: The prior orientation angle of the robot (radians).
-            last_wheel_speeds: The previous left and right wheel speeds.
-            wheel_speeds: The new left and right wheel speeds.
+            last_wheel_speeds: The previous left/right wheel angular velocities in rad/s.
+            wheel_speeds: The new left/right wheel angular velocities in rad/s.
             d_t: Time elapsed (seconds).
 
         Returns:

--- a/scripts/classic_benchmark_full.py
+++ b/scripts/classic_benchmark_full.py
@@ -15,17 +15,36 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 
+
+class FullBenchmarkUnavailableError(RuntimeError):
+    """Raised when the full classic benchmark backend cannot be imported."""
+
+
+def _full_benchmark_unavailable_message(exc: BaseException) -> str:
+    """Build an actionable fail-closed message for unavailable benchmark backend imports."""
+    return (
+        "Full Classic Interaction Benchmark is unavailable because "
+        "`robot_sf.benchmark.full_classic.orchestrator.run_full_benchmark` could not be imported. "
+        "Use the supported `robot_sf.benchmark.full_classic` package path in an initialized "
+        "checkout, or run `uv sync --all-extras` before invoking this legacy CLI wrapper. "
+        f"Import error: {exc}"
+    )
+
+
 try:
     from robot_sf.benchmark.full_classic.orchestrator import run_full_benchmark  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - during early scaffolding
+except (ImportError, ModuleNotFoundError) as _run_full_benchmark_import_error:
+    _run_full_benchmark_unavailable_message = _full_benchmark_unavailable_message(
+        _run_full_benchmark_import_error
+    )
 
     def run_full_benchmark(cfg):  # fallback placeholder
-        """TODO docstring. Document this function.
+        """Fail closed when the full-classic benchmark backend is unavailable.
 
         Args:
-            cfg: TODO docstring.
+            cfg: Parsed benchmark configuration, unused because execution cannot continue.
         """
-        raise NotImplementedError("Full benchmark not yet implemented. Follow tasks T022+.")
+        raise FullBenchmarkUnavailableError(_run_full_benchmark_unavailable_message)
 
 
 @dataclass
@@ -258,13 +277,13 @@ def _args_to_config(ns: argparse.Namespace) -> BenchmarkCLIConfig:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """TODO docstring. Document this function.
+    """Run the Full Classic Interaction Benchmark CLI.
 
     Args:
-        argv: TODO docstring.
+        argv: Optional CLI argument list. When ``None``, argparse reads ``sys.argv``.
 
     Returns:
-        TODO docstring.
+        Process exit code. Returns ``2`` when the backend import is unavailable.
     """
     parser = build_arg_parser()
     args = parser.parse_args(argv)
@@ -278,7 +297,11 @@ def main(argv: list[str] | None = None) -> int:
         pass
     cfg = _args_to_config(args)
     print("[classic_benchmark_full] Configuration:", cfg)
-    run_full_benchmark(cfg)
+    try:
+        run_full_benchmark(cfg)
+    except FullBenchmarkUnavailableError as exc:
+        print(f"[classic_benchmark_full] ERROR: {exc}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/tests/benchmark_full/test_classic_benchmark_full_cli.py
+++ b/tests/benchmark_full/test_classic_benchmark_full_cli.py
@@ -1,0 +1,31 @@
+"""CLI behavior tests for the classic full benchmark wrapper."""
+
+from __future__ import annotations
+
+from scripts import classic_benchmark_full
+
+
+def test_classic_benchmark_full_unavailable_backend_is_actionable(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    """Unavailable backend exits nonzero with an actionable error and no traceback."""
+
+    def unavailable_backend(_cfg):
+        raise classic_benchmark_full.FullBenchmarkUnavailableError("backend import missing")
+
+    monkeypatch.setattr(classic_benchmark_full, "run_full_benchmark", unavailable_backend)
+
+    exit_code = classic_benchmark_full.main(
+        [
+            "--output",
+            str(tmp_path / "classic-full"),
+            "--smoke",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "backend import missing" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/benchmark_full/test_classic_benchmark_full_cli.py
+++ b/tests/benchmark_full/test_classic_benchmark_full_cli.py
@@ -2,7 +2,50 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts import classic_benchmark_full
+
+
+def test_classic_benchmark_full_help_exits_before_backend_execution(monkeypatch, capsys) -> None:
+    """``--help`` should be usable without running benchmark logic."""
+
+    def fail_if_called(_cfg):
+        raise AssertionError("run_full_benchmark should not run for --help")
+
+    monkeypatch.setattr(classic_benchmark_full, "run_full_benchmark", fail_if_called)
+
+    with pytest.raises(SystemExit) as exc_info:
+        classic_benchmark_full.main(["--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "Full Classic Interaction Benchmark" in captured.out
+
+
+def test_classic_benchmark_full_delegates_to_backend(monkeypatch, tmp_path) -> None:
+    """Supported invocation should call the real benchmark backend contract."""
+    captured = {}
+
+    def fake_backend(cfg):
+        captured["cfg"] = cfg
+
+    monkeypatch.setattr(classic_benchmark_full, "run_full_benchmark", fake_backend)
+
+    exit_code = classic_benchmark_full.main(
+        [
+            "--output",
+            str(tmp_path / "classic-full"),
+            "--smoke",
+            "--workers",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["cfg"].output_root == str(tmp_path / "classic-full")
+    assert captured["cfg"].smoke is True
+    assert captured["cfg"].workers == 1
 
 
 def test_classic_benchmark_full_unavailable_backend_is_actionable(

--- a/tests/differential_drive_test.py
+++ b/tests/differential_drive_test.py
@@ -1,4 +1,4 @@
-"""TODO docstring. Document this module."""
+"""Tests for differential-drive kinematics and wheel-speed conventions."""
 
 from math import pi
 
@@ -10,13 +10,13 @@ from robot_sf.robot.differential_drive import (
 
 
 def norm_angle(angle: float) -> float:
-    """TODO docstring. Document this function.
+    """Normalize an angle to the ``[0, 2*pi)`` range.
 
     Args:
-        angle: TODO docstring.
+        angle: Angle in radians.
 
     Returns:
-        TODO docstring.
+        Equivalent non-negative angle in radians.
     """
     while angle < 0:
         angle += 2 * pi
@@ -26,7 +26,7 @@ def norm_angle(angle: float) -> float:
 
 
 def test_can_drive_right_curve():
-    """TODO docstring. Document this function."""
+    """A right-turn action should move and orient the robot into the fourth quadrant."""
     motion = DifferentialDriveMotion(DifferentialDriveSettings(1, 1, 1, 1))
     pose_before, vel_before, wheel_speeds = ((0, 0), 0), (1, 0), (1, 1)
     state = DifferentialDriveState(pose_before, vel_before, wheel_speeds, wheel_speeds)
@@ -38,7 +38,7 @@ def test_can_drive_right_curve():
 
 
 def test_can_drive_left_curve():
-    """TODO docstring. Document this function."""
+    """A left-turn action should move and orient the robot into the first quadrant."""
     motion = DifferentialDriveMotion(DifferentialDriveSettings(1, 1, 1, 1))
     pose_before, vel_before, wheel_speeds = ((0, 0), 0), (1, 0), (1, 1)
     state = DifferentialDriveState(pose_before, vel_before, wheel_speeds, wheel_speeds)
@@ -65,6 +65,23 @@ def test_straight_line_distance_matches_kinematics() -> None:
     pos_after, orient_after = state.pose
     assert pos_after == (1.0, 0.0)
     assert orient_after == 0.0
+
+
+def test_resulting_wheel_speeds_are_angular_rates() -> None:
+    """WheelSpeedState stores left/right wheel angular velocity in rad/s."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(
+            max_linear_speed=5.0,
+            max_angular_speed=5.0,
+            wheel_radius=0.5,
+            interaxis_length=1.0,
+        ),
+    )
+
+    left_wheel_rad_s, right_wheel_rad_s = motion._resulting_wheel_speeds((1.0, 2.0))
+
+    assert left_wheel_rad_s == 0.0
+    assert right_wheel_rad_s == 4.0
 
 
 def test_in_place_rotation_matches_kinematics() -> None:

--- a/tests/differential_drive_test.py
+++ b/tests/differential_drive_test.py
@@ -78,8 +78,11 @@ def test_resulting_wheel_speeds_are_angular_rates() -> None:
         ),
     )
 
+    straight_left_rad_s, straight_right_rad_s = motion._resulting_wheel_speeds((1.0, 0.0))
     left_wheel_rad_s, right_wheel_rad_s = motion._resulting_wheel_speeds((1.0, 2.0))
 
+    assert straight_left_rad_s == 2.0
+    assert straight_right_rad_s == 2.0
     assert left_wheel_rad_s == 0.0
     assert right_wheel_rad_s == 4.0
 

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -156,6 +156,40 @@ def test_sim_view_render_pipeline_and_helpers(monkeypatch) -> None:
     assert view.redraw_needed is True
 
 
+def test_sim_view_video_encoding_uses_render_target_when_fps_unset(monkeypatch, tmp_path) -> None:
+    """Encode recorded frames at the render cadence when no explicit video FPS is set."""
+    captured = {}
+
+    class DummyClip:
+        """Record the FPS passed to the encoder without writing a real video."""
+
+        def __init__(self, frames, *, fps):
+            self.frames = frames
+            captured["fps"] = fps
+
+        def write_videofile(self, path):
+            captured["path"] = path
+
+    monkeypatch.setattr(sim_view_mod, "MOVIEPY_AVAILABLE", True)
+    monkeypatch.setattr(sim_view_mod, "ImageSequenceClip", DummyClip)
+    monkeypatch.setattr(pygame.event, "get", lambda: [])
+
+    video_path = tmp_path / "render-cadence.mp4"
+    view = SimulationView(
+        width=64,
+        height=48,
+        map_def=_map_def_with_routes_and_obstacles(),
+        record_video=True,
+        video_path=str(video_path),
+        video_fps=None,
+    )
+    view.render(_make_state(), target_fps=24)
+    view._handle_quit()
+
+    assert captured["fps"] == 24.0
+    assert captured["path"] == str(video_path)
+
+
 def test_sim_view_occupancy_grid_error_and_rotation_paths(monkeypatch) -> None:
     """Exercise occupancy-grid render branches: runtime error, empty, and ego rotation."""
     view = SimulationView(

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -165,10 +165,11 @@ def test_sim_view_video_encoding_uses_render_target_when_fps_unset(monkeypatch, 
 
         def __init__(self, frames, *, fps):
             self.frames = frames
-            captured["fps"] = fps
+            captured["clip_fps"] = fps
 
-        def write_videofile(self, path):
+        def write_videofile(self, path, **kwargs):
             captured["path"] = path
+            captured["write_kwargs"] = kwargs
 
     monkeypatch.setattr(sim_view_mod, "MOVIEPY_AVAILABLE", True)
     monkeypatch.setattr(sim_view_mod, "ImageSequenceClip", DummyClip)
@@ -186,8 +187,9 @@ def test_sim_view_video_encoding_uses_render_target_when_fps_unset(monkeypatch, 
     view.render(_make_state(), target_fps=24)
     view._handle_quit()
 
-    assert captured["fps"] == 24.0
+    assert captured["clip_fps"] == 24.0
     assert captured["path"] == str(video_path)
+    assert captured["write_kwargs"]["fps"] == 24.0
 
 
 def test_sim_view_video_encoding_prefers_explicit_video_fps(monkeypatch, tmp_path) -> None:
@@ -199,10 +201,11 @@ def test_sim_view_video_encoding_prefers_explicit_video_fps(monkeypatch, tmp_pat
 
         def __init__(self, frames, *, fps):
             self.frames = frames
-            captured["fps"] = fps
+            captured["clip_fps"] = fps
 
-        def write_videofile(self, path):
+        def write_videofile(self, path, **kwargs):
             captured["path"] = path
+            captured["write_kwargs"] = kwargs
 
     monkeypatch.setattr(sim_view_mod, "MOVIEPY_AVAILABLE", True)
     monkeypatch.setattr(sim_view_mod, "ImageSequenceClip", DummyClip)
@@ -220,8 +223,9 @@ def test_sim_view_video_encoding_prefers_explicit_video_fps(monkeypatch, tmp_pat
     view.render(_make_state(), target_fps=24)
     view._handle_quit()
 
-    assert captured["fps"] == 12.0
+    assert captured["clip_fps"] == 12.0
     assert captured["path"] == str(video_path)
+    assert captured["write_kwargs"]["fps"] == 12.0
 
 
 def test_sim_view_occupancy_grid_error_and_rotation_paths(monkeypatch) -> None:

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -190,6 +190,40 @@ def test_sim_view_video_encoding_uses_render_target_when_fps_unset(monkeypatch, 
     assert captured["path"] == str(video_path)
 
 
+def test_sim_view_video_encoding_prefers_explicit_video_fps(monkeypatch, tmp_path) -> None:
+    """An explicit video FPS should override the latest render target FPS."""
+    captured = {}
+
+    class DummyClip:
+        """Record the FPS passed to the encoder without writing a real video."""
+
+        def __init__(self, frames, *, fps):
+            self.frames = frames
+            captured["fps"] = fps
+
+        def write_videofile(self, path):
+            captured["path"] = path
+
+    monkeypatch.setattr(sim_view_mod, "MOVIEPY_AVAILABLE", True)
+    monkeypatch.setattr(sim_view_mod, "ImageSequenceClip", DummyClip)
+    monkeypatch.setattr(pygame.event, "get", lambda: [])
+
+    video_path = tmp_path / "explicit-fps.mp4"
+    view = SimulationView(
+        width=64,
+        height=48,
+        map_def=_map_def_with_routes_and_obstacles(),
+        record_video=True,
+        video_path=str(video_path),
+        video_fps=12.0,
+    )
+    view.render(_make_state(), target_fps=24)
+    view._handle_quit()
+
+    assert captured["fps"] == 12.0
+    assert captured["path"] == str(video_path)
+
+
 def test_sim_view_occupancy_grid_error_and_rotation_paths(monkeypatch) -> None:
     """Exercise occupancy-grid render branches: runtime error, empty, and ego rotation."""
     view = SimulationView(


### PR DESCRIPTION
## Summary
Fixes three small open-issue correctness/documentation gaps: visualization video FPS now falls back to the effective render cadence, differential-drive wheel speed units are clarified as angular rates, and the legacy full-classic benchmark wrapper fails closed with an actionable error when its backend is unavailable.

## Linked Issues
- Closes #1142
- Closes #1144
- Closes #1147

## What Changed
- Updated `robot_sf/render/sim_view.py` so video encoding uses an explicit target FPS when configured, otherwise the active render cadence.
- Clarified `WheelSpeedState`/differential-drive wheel speeds as angular wheel rates in rad/s and added a regression assertion.
- Added `FullBenchmarkUnavailableError` handling in `scripts/classic_benchmark_full.py` so unavailable backend imports produce exit code 2 and no traceback.
- Added targeted regression tests for the video FPS fallback, wheel-speed units, and full-classic fail-closed behavior.

## Why It Matters
- Added value: removes misleading video timing, ambiguous drive-state units, and a brittle legacy CLI failure mode.
- Expected impact: low-risk correctness and maintainability improvement on existing public surfaces.
- Why this is worth merging now: the changes are small, tested, and unblock the broader open-issues split by landing independent fixes first.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/visuals/test_sim_view_coverage_paths.py tests/differential_drive_test.py tests/benchmark_full/test_classic_benchmark_full_cli.py -q`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Targeted tests: 17 passed in 13.60s.
  - PR readiness: 3356 passed, 18 skipped, 6 warnings in 252.68s.
  - Freshness stamp: `output/validation/pr_ready/issue-1142-1144-1147-small-fixes.json` for head `33d6f9c7dfce11c480a32ead6bd21f828d780b4b`.
- Benchmarks or smoke tests, if applicable: not applicable; no benchmark semantics are changed.

## Risks / Rollout
- Compatibility risks: low. The full-classic wrapper now exits cleanly when the backend is missing instead of failing with an import traceback.
- Failure modes: consumers relying on the previous traceback text would see the new actionable stderr and exit code 2.
- Rollback or fallback plan: revert this PR; affected surfaces are isolated to visualization FPS handling, drive docstrings/tests, and the legacy CLI wrapper.

## Docs / Provenance
- Updated docs: inline API/class docstrings only.
- Relevant design or provenance notes: split from the broad WIP snapshot documented in `docs/context/open_issues_pr_split_strategy_2026-05-13.md` on the handoff branch.
- Any assumptions that need to be preserved: generated coverage output and PR-readiness stamps under `output/` are local validation byproducts and should remain ignored, not promoted as durable artifacts.

## Follow-Up Issues
- Deferred work: none for these three issues.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: check `SimView._effective_video_fps()` and the full-classic unavailable-backend fallback path.
- Any known limitations: coverage for changed files has warning-only gaps (`sim_view.py` 86.4%, `differential_drive.py` 96.4%) but full PR readiness passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video recording now selects FPS per-frame, using an explicit video FPS when set or falling back to the render target FPS.

* **Bug Fixes**
  * Benchmark CLI now fails gracefully with an actionable error and distinct exit code when backend support is unavailable.

* **Documentation**
  * Clarified docstrings for wheel-speed semantics and simulation view properties.

* **Tests**
  * Added tests covering video FPS selection, benchmark CLI behavior, and differential-drive wheel-speed expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1156)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->