### PR TITLE
fix: document sensor history ordering (#1143)

### DIFF
--- a/robot_sf/sensor/history_stack.py
+++ b/robot_sf/sensor/history_stack.py
@@ -1,0 +1,31 @@
+"""Shared helpers for oldest-to-newest temporal sensor stacks."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def fill_history_stack(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
+    """Return a stack prefilled with ``current_state`` in every temporal row."""
+    return np.repeat(current_state[np.newaxis, :], stacked_state.shape[0], axis=0).astype(
+        stacked_state.dtype, copy=False
+    )
+
+
+def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
+    """Append ``current_state`` as the newest row in an oldest-to-newest stack.
+
+    Returns
+    -------
+    np.ndarray
+        Updated stack with previous rows shifted toward index ``0`` and the current state at
+        index ``-1``.
+    """
+    stacked_state[:-1] = stacked_state[1:]
+    stacked_state[-1] = current_state
+    return stacked_state
+
+
+def reset_history_stack(stacked_state: np.ndarray) -> np.ndarray:
+    """Return a zero-filled stack preserving the existing shape and dtype."""
+    return np.zeros_like(stacked_state)

--- a/robot_sf/sensor/image_sensor_fusion.py
+++ b/robot_sf/sensor/image_sensor_fusion.py
@@ -11,7 +11,12 @@ from gymnasium import spaces
 
 from robot_sf.common.types import PolarVec2D
 from robot_sf.sensor.image_sensor import ImageSensor
-from robot_sf.sensor.sensor_fusion import OBS_DRIVE_STATE, OBS_IMAGE, OBS_RAYS
+from robot_sf.sensor.sensor_fusion import (
+    OBS_DRIVE_STATE,
+    OBS_IMAGE,
+    OBS_RAYS,
+    append_history_row,
+)
 
 
 @dataclass
@@ -120,10 +125,12 @@ class ImageSensorFusion:
 
     def _update_stacked_states(self, sensor_data: dict):
         """Update stacked states with current sensor data."""
-        self.stacked_drive_state = np.roll(self.stacked_drive_state, -1, axis=0)
-        self.stacked_drive_state[-1] = sensor_data["drive_state"]
-        self.stacked_lidar_state = np.roll(self.stacked_lidar_state, -1, axis=0)
-        self.stacked_lidar_state[-1] = sensor_data["lidar_state"]
+        self.stacked_drive_state = append_history_row(
+            self.stacked_drive_state, sensor_data["drive_state"]
+        )
+        self.stacked_lidar_state = append_history_row(
+            self.stacked_lidar_state, sensor_data["lidar_state"]
+        )
 
     def _build_observation(self, sensor_data: dict) -> dict[str, np.ndarray]:
         """Build the final observation dictionary.

--- a/robot_sf/sensor/image_sensor_fusion.py
+++ b/robot_sf/sensor/image_sensor_fusion.py
@@ -10,12 +10,16 @@ import numpy as np
 from gymnasium import spaces
 
 from robot_sf.common.types import PolarVec2D
+from robot_sf.sensor.history_stack import (
+    append_history_row,
+    fill_history_stack,
+    reset_history_stack,
+)
 from robot_sf.sensor.image_sensor import ImageSensor
 from robot_sf.sensor.sensor_fusion import (
     OBS_DRIVE_STATE,
     OBS_IMAGE,
     OBS_RAYS,
-    append_history_row,
 )
 
 
@@ -117,12 +121,12 @@ class ImageSensorFusion:
                 self.lidar_state_cache.append(sensor_data["lidar_state"])
                 if self.use_image_obs and sensor_data["image_state"] is not None:
                     self.image_state_cache.append(sensor_data["image_state"])
-            self.stacked_drive_state = np.repeat(
-                sensor_data["drive_state"][np.newaxis, :], self.cache_steps, axis=0
-            ).astype(self.stacked_drive_state.dtype, copy=False)
-            self.stacked_lidar_state = np.repeat(
-                sensor_data["lidar_state"][np.newaxis, :], self.cache_steps, axis=0
-            ).astype(self.stacked_lidar_state.dtype, copy=False)
+            self.stacked_drive_state = fill_history_stack(
+                self.stacked_drive_state, sensor_data["drive_state"]
+            )
+            self.stacked_lidar_state = fill_history_stack(
+                self.stacked_lidar_state, sensor_data["lidar_state"]
+            )
 
     def _update_sensor_caches(self, sensor_data: dict):
         """Update sensor caches with current data."""
@@ -197,5 +201,5 @@ class ImageSensorFusion:
             self.image_state_cache.clear()
 
         # Reset stacked states to zeros
-        self.stacked_drive_state = np.zeros_like(self.stacked_drive_state)
-        self.stacked_lidar_state = np.zeros_like(self.stacked_lidar_state)
+        self.stacked_drive_state = reset_history_stack(self.stacked_drive_state)
+        self.stacked_lidar_state = reset_history_stack(self.stacked_lidar_state)

--- a/robot_sf/sensor/image_sensor_fusion.py
+++ b/robot_sf/sensor/image_sensor_fusion.py
@@ -117,6 +117,12 @@ class ImageSensorFusion:
                 self.lidar_state_cache.append(sensor_data["lidar_state"])
                 if self.use_image_obs and sensor_data["image_state"] is not None:
                     self.image_state_cache.append(sensor_data["image_state"])
+            self.stacked_drive_state = np.repeat(
+                sensor_data["drive_state"][np.newaxis, :], self.cache_steps, axis=0
+            ).astype(self.stacked_drive_state.dtype, copy=False)
+            self.stacked_lidar_state = np.repeat(
+                sensor_data["lidar_state"][np.newaxis, :], self.cache_steps, axis=0
+            ).astype(self.stacked_lidar_state.dtype, copy=False)
 
     def _update_sensor_caches(self, sensor_data: dict):
         """Update sensor caches with current data."""

--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -26,9 +26,9 @@ def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> 
         Updated stack with previous rows shifted toward index ``0`` and the current state at
         index ``-1``.
     """
-    updated = np.roll(stacked_state, -1, axis=0)
-    updated[-1] = current_state
-    return updated
+    stacked_state[:-1] = stacked_state[1:]
+    stacked_state[-1] = current_state
+    return stacked_state
 
 
 def fused_sensor_space(
@@ -255,3 +255,5 @@ class SensorFusion:
         """
         self.drive_state_cache.clear()
         self.lidar_state_cache.clear()
+        self.stacked_drive_state = np.zeros_like(self.stacked_drive_state)
+        self.stacked_lidar_state = np.zeros_like(self.stacked_lidar_state)

--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -17,6 +17,20 @@ OBS_RAYS = "rays"
 OBS_IMAGE = "image"
 
 
+def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
+    """Append ``current_state`` as the newest row in an oldest-to-newest stack.
+
+    Returns
+    -------
+    np.ndarray
+        Updated stack with previous rows shifted toward index ``0`` and the current state at
+        index ``-1``.
+    """
+    updated = np.roll(stacked_state, -1, axis=0)
+    updated[-1] = current_state
+    return updated
+
+
 def fused_sensor_space(
     timesteps: int,
     robot_obs: spaces.Box,
@@ -188,10 +202,11 @@ class SensorFusion:
         -------
         Dict[str, np.ndarray]
             The next observation, consisting of the drive state and LiDAR state.
+            Stacked rows are ordered oldest-to-newest, with the current sample
+            stored at index ``-1``.
         """
         # Get the current LiDAR state
         lidar_state = self.lidar_sensor()
-        # TODO: append beginning at the end for conv feature extractor
 
         # Get the current robot speed
         speed_x, speed_rot = self.robot_speed_sensor()
@@ -220,13 +235,11 @@ class SensorFusion:
                 lidar_state[np.newaxis, :], self.cache_steps, axis=0
             )
         else:
-            # Add the current states to the caches and remove the oldest states
+            # Add current states as the newest row so temporal stacks are oldest-to-newest.
             self.drive_state_cache.append(drive_state)
             self.lidar_state_cache.append(lidar_state)
-            self.stacked_drive_state = np.roll(self.stacked_drive_state, -1, axis=0)
-            self.stacked_drive_state[-1] = drive_state
-            self.stacked_lidar_state = np.roll(self.stacked_lidar_state, -1, axis=0)
-            self.stacked_lidar_state[-1] = lidar_state
+            self.stacked_drive_state = append_history_row(self.stacked_drive_state, drive_state)
+            self.stacked_lidar_state = append_history_row(self.stacked_lidar_state, lidar_state)
 
         # Normalize the stacked states by the maximum values in the observation space
         max_drive = self.unnormed_obs_space[OBS_DRIVE_STATE].high

--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -11,24 +11,15 @@ import numpy as np
 from gymnasium import spaces
 
 from robot_sf.common.types import PolarVec2D
+from robot_sf.sensor.history_stack import (
+    append_history_row,
+    fill_history_stack,
+    reset_history_stack,
+)
 
 OBS_DRIVE_STATE = "drive_state"
 OBS_RAYS = "rays"
 OBS_IMAGE = "image"
-
-
-def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
-    """Append ``current_state`` as the newest row in an oldest-to-newest stack.
-
-    Returns
-    -------
-    np.ndarray
-        Updated stack with previous rows shifted toward index ``0`` and the current state at
-        index ``-1``.
-    """
-    stacked_state[:-1] = stacked_state[1:]
-    stacked_state[-1] = current_state
-    return stacked_state
 
 
 def fused_sensor_space(
@@ -228,12 +219,8 @@ class SensorFusion:
             for _ in range(self.cache_steps):
                 self.drive_state_cache.append(drive_state)
                 self.lidar_state_cache.append(lidar_state)
-            self.stacked_drive_state = np.repeat(
-                drive_state[np.newaxis, :], self.cache_steps, axis=0
-            )
-            self.stacked_lidar_state = np.repeat(
-                lidar_state[np.newaxis, :], self.cache_steps, axis=0
-            )
+            self.stacked_drive_state = fill_history_stack(self.stacked_drive_state, drive_state)
+            self.stacked_lidar_state = fill_history_stack(self.stacked_lidar_state, lidar_state)
         else:
             # Add current states as the newest row so temporal stacks are oldest-to-newest.
             self.drive_state_cache.append(drive_state)
@@ -255,5 +242,5 @@ class SensorFusion:
         """
         self.drive_state_cache.clear()
         self.lidar_state_cache.clear()
-        self.stacked_drive_state = np.zeros_like(self.stacked_drive_state)
-        self.stacked_lidar_state = np.zeros_like(self.stacked_lidar_state)
+        self.stacked_drive_state = reset_history_stack(self.stacked_drive_state)
+        self.stacked_lidar_state = reset_history_stack(self.stacked_lidar_state)

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 from gymnasium import spaces
 
+from robot_sf.sensor.image_sensor_fusion import ImageSensorFusion
 from robot_sf.sensor.sensor_fusion import (
     OBS_DRIVE_STATE,
     OBS_RAYS,
@@ -88,5 +89,36 @@ def test_sensor_fusion_history_is_oldest_to_newest() -> None:
             [0.1, 0.0, 0.1, 0.0, 0.0],
             [0.1, 0.0, 0.1, 0.0, 0.0],
             [0.2, 0.0, 0.2, 0.0, 0.0],
+        ],
+    )
+
+
+def test_image_sensor_fusion_first_observation_prefills_history() -> None:
+    """ImageSensorFusion should prefill temporal history on the first observation."""
+    robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
+    target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+    lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
+    timesteps = 3
+
+    _norm_space, orig_space = fused_sensor_space(timesteps, robot_obs, target_obs, lidar_obs)
+    fusion = ImageSensorFusion(
+        lidar_sensor=lambda: np.array([1.0, 1.0], dtype=np.float32),
+        robot_speed_sensor=lambda: (2.0, 0.0),
+        target_sensor=lambda: (3.0, 0.0, 0.0),
+        image_sensor=None,
+        unnormed_obs_space=orig_space,
+        use_next_goal=True,
+        use_image_obs=False,
+    )
+
+    obs = fusion.next_obs()
+
+    assert np.allclose(obs[OBS_RAYS], [[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]])
+    assert np.allclose(
+        obs[OBS_DRIVE_STATE],
+        [
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
         ],
     )

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -51,3 +51,42 @@ def test_sensor_fusion_stacks_history() -> None:
     expected_row = drive_state / orig_space[OBS_DRIVE_STATE].high[0]
     for row in obs[OBS_DRIVE_STATE]:
         assert np.allclose(row, expected_row)
+
+
+def test_sensor_fusion_history_is_oldest_to_newest() -> None:
+    """Keep current observations at the last temporal index for conv extractors."""
+    robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
+    target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+    lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
+    timesteps = 3
+
+    _norm_space, orig_space = fused_sensor_space(timesteps, robot_obs, target_obs, lidar_obs)
+    lidar_samples = iter(
+        [
+            np.array([0.0, 0.0], dtype=np.float32),
+            np.array([1.0, 1.0], dtype=np.float32),
+            np.array([2.0, 2.0], dtype=np.float32),
+        ]
+    )
+    speed_samples = iter([(1.0, 0.0), (2.0, 0.0)])
+    target_samples = iter([(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)])
+    fusion = SensorFusion(
+        lidar_sensor=lambda: next(lidar_samples),
+        robot_speed_sensor=lambda: next(speed_samples),
+        target_sensor=lambda: next(target_samples),
+        unnormed_obs_space=orig_space,
+        use_next_goal=True,
+    )
+
+    fusion.next_obs()
+    obs = fusion.next_obs()
+
+    assert np.allclose(obs[OBS_RAYS], [[0.1, 0.1], [0.1, 0.1], [0.2, 0.2]])
+    assert np.allclose(
+        obs[OBS_DRIVE_STATE],
+        [
+            [0.1, 0.0, 0.1, 0.0, 0.0],
+            [0.1, 0.0, 0.1, 0.0, 0.0],
+            [0.2, 0.0, 0.2, 0.0, 0.0],
+        ],
+    )

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -122,3 +122,51 @@ def test_image_sensor_fusion_first_observation_prefills_history() -> None:
             [0.2, 0.0, 0.3, 0.0, 0.0],
         ],
     )
+
+
+def test_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
+    """Reset should clear both cache metadata and concrete temporal stack arrays."""
+    robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
+    target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+    lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
+    _norm_space, orig_space = fused_sensor_space(3, robot_obs, target_obs, lidar_obs)
+    fusion = SensorFusion(
+        lidar_sensor=lambda: np.array([1.0, 1.0], dtype=np.float32),
+        robot_speed_sensor=lambda: (2.0, 0.0),
+        target_sensor=lambda: (3.0, 0.0, 0.0),
+        unnormed_obs_space=orig_space,
+        use_next_goal=True,
+    )
+
+    fusion.next_obs()
+    fusion.reset_cache()
+
+    assert len(fusion.drive_state_cache) == 0
+    assert len(fusion.lidar_state_cache) == 0
+    assert np.allclose(fusion.stacked_drive_state, 0.0)
+    assert np.allclose(fusion.stacked_lidar_state, 0.0)
+
+
+def test_image_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
+    """ImageSensorFusion reset should use the same temporal stack reset semantics."""
+    robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
+    target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+    lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
+    _norm_space, orig_space = fused_sensor_space(3, robot_obs, target_obs, lidar_obs)
+    fusion = ImageSensorFusion(
+        lidar_sensor=lambda: np.array([1.0, 1.0], dtype=np.float32),
+        robot_speed_sensor=lambda: (2.0, 0.0),
+        target_sensor=lambda: (3.0, 0.0, 0.0),
+        image_sensor=None,
+        unnormed_obs_space=orig_space,
+        use_next_goal=True,
+        use_image_obs=False,
+    )
+
+    fusion.next_obs()
+    fusion.reset_cache()
+
+    assert len(fusion.drive_state_cache) == 0
+    assert len(fusion.lidar_state_cache) == 0
+    assert np.allclose(fusion.stacked_drive_state, 0.0)
+    assert np.allclose(fusion.stacked_lidar_state, 0.0)


### PR DESCRIPTION
## Summary
Defines and tests the SensorFusion temporal stacking contract as oldest-to-newest, with the current sample at index `-1`, and reuses the same append helper from image sensor fusion.

## Linked Issues
- Closes #1143
- Closes #1149

## What Changed
- Added `append_history_row(...)` in `robot_sf/sensor/sensor_fusion.py` as the shared oldest-to-newest stack update helper.
- Documented the SensorFusion temporal ordering contract in the observation path.
- Updated `robot_sf/sensor/image_sensor_fusion.py` to use the same history append semantics.
- Added a regression test proving that the current observation is kept at the last temporal index.

## Why It Matters
- Added value: downstream convolutional extractors get an explicit and tested temporal contract.
- Expected impact: reduces duplicated stack-update logic and removes ambiguity around time-axis order.
- Why this is worth merging now: it is an isolated refactor/test PR that can land before larger environment and observation changes.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_sensor_fusion_stack.py -q`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Targeted tests: 3 passed in 5.67s after fixing the fixture sample count.
  - PR readiness: 3354 passed, 18 skipped, 6 warnings in 262.51s.
  - Freshness stamp: `output/validation/pr_ready/issue-1143-1149-sensor-history-contract.json` for head `83e92b54e53edf4770433e27982c76eb4302c3bc`.
- Benchmarks or smoke tests, if applicable: not applicable; no benchmark semantics are changed.

## Risks / Rollout
- Compatibility risks: low. The helper preserves the current oldest-to-newest behavior and makes it explicit.
- Failure modes: learned policies depending on the opposite temporal interpretation would remain unsupported; this PR documents and tests the existing intended contract.
- Rollback or fallback plan: revert the PR to restore the previous duplicated stack-update code.

## Docs / Provenance
- Updated docs: code docstrings in the sensor fusion path.
- Relevant design or provenance notes: split from the broad WIP snapshot documented in `docs/context/open_issues_pr_split_strategy_2026-05-13.md` on the handoff branch.
- Any assumptions that need to be preserved: generated coverage output and PR-readiness stamps under `output/` are local validation byproducts and should remain ignored, not promoted as durable artifacts.

## Follow-Up Issues
- Deferred work: none for these two issues.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the temporal order expected by current conv extractors is oldest-to-newest with the current observation at index `-1`.
- Any known limitations: changed-file coverage has a warning-only gap on `robot_sf/sensor/image_sensor_fusion.py` at 93.5%; full PR readiness passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sensor-fusion history handling using shared utilities so stacked histories initialize consistently, preserve dtype, and advance reliably.

* **Bug Fixes**
  * Ensured stacked drive and LiDAR histories maintain correct oldest→newest ordering and are fully reinitialized on cache reset.

* **Tests**
  * Added a test that verifies sensor-history stacks are ordered oldest-to-newest.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1157)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->