### PR TITLE
feat: add dynamic pedestrian occlusion filtering (#1124)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Benchmark Docker Reproduction Path](./benchmark_docker_repro.md)** - Build a pinned Docker image and run the canonical small benchmark artifact smoke with one command
 * **[Camera-ready Release Workflow](./benchmark_camera_ready_release.md)** - Guided release upload checklist for campaign publication bundles
 * **[Benchmark Observation Visibility](./benchmark_observation_visibility.md)** - Configurable planner-facing FOV, range, and static-occlusion filtering for partial-observability experiments
+* **[Issue #1124 Dynamic Pedestrian Occlusion Contract](./context/issue_1124_dynamic_pedestrian_occlusion_contract.md)** - Opt-in planner-facing pedestrian-to-pedestrian occlusion semantics, metadata behavior, and benchmark-reporting limits
 * **[Benchmark Planner-Family Coverage Matrix](./benchmark_planner_family_coverage.md)** - Benchmark-facing mapping from current planner/config support to Alyassi-style planner families, including readiness and overclaim guardrails
 * **[Benchmark: Experimental Planners](./benchmark_experimental_planners.md)** - Opt-in guardrails and usage notes for unfinished benchmark planner families
 * **[Planner Adapter Starter Template](./dev/planner_adapter_template.md)** - Copy-and-adapt path plus a diagnostic reference adapter for new local planner contributions

--- a/docs/context/issue_1124_dynamic_pedestrian_occlusion_contract.md
+++ b/docs/context/issue_1124_dynamic_pedestrian_occlusion_contract.md
@@ -1,0 +1,50 @@
+# Issue 1124 dynamic pedestrian occlusion contract
+
+Date: 2026-05-12
+
+## Scope
+
+This note records the first opt-in dynamic pedestrian occlusion contract for planner-facing SocNav observations.
+
+Implemented files:
+
+- `robot_sf/sensor/socnav_observation.py`
+- `robot_sf/gym_env/unified_config.py`
+- `robot_sf/training/scenario_loader.py`
+- `tests/test_socnav_dynamic_occlusion.py`
+- `tests/test_socnav_observation.py`
+- `tests/training/test_scenario_loader.py`
+
+## Contract
+
+Dynamic occlusion is disabled by default and enabled only through:
+
+```yaml
+observation_visibility:
+  enabled: true
+  dynamic_occlusion: true
+```
+
+The setting is exposed in benchmark metadata through `ObservationVisibilitySettings.to_metadata()` as `dynamic_occlusion`.
+
+Planner-facing visibility semantics:
+
+- Pedestrians are modeled as circular blockers with radius `SimulationSettings.ped_radius`.
+- The helper tests center-line visibility from robot center to target pedestrian center.
+- A target pedestrian is hidden when a nearer currently-visible pedestrian disk intersects that line segment.
+- Already-hidden pedestrians do not act as blockers for farther pedestrians.
+- Simulator ground-truth state, metrics, and raw pedestrian arrays are not mutated; filtering applies only to planner-facing SocNav observations.
+
+## Limits
+
+This is an abstraction, not a calibrated perception model.
+
+- It does not model partial body visibility.
+- It does not model detector probabilities, false positives, tracking delay, or sensor-specific angular resolution.
+- Results with `dynamic_occlusion=true` should not be compared against default observations without noting the opt-in visibility setting.
+
+## Remaining work
+
+- Run targeted tests and a visibility smoke before PR handoff.
+- Add scenario examples only if needed for a benchmark profile.
+- Keep reports explicit about `observation_visibility.dynamic_occlusion`.

--- a/robot_sf/gym_env/unified_config.py
+++ b/robot_sf/gym_env/unified_config.py
@@ -40,6 +40,7 @@ class ObservationVisibilitySettings:
     fov_degrees: float = 360.0
     max_range_m: float | None = None
     static_occlusion: bool = False
+    dynamic_occlusion: bool = False
 
     def to_metadata(self) -> dict[str, bool | float | None]:
         """Return JSON-safe visibility settings metadata."""
@@ -48,6 +49,7 @@ class ObservationVisibilitySettings:
             "fov_degrees": float(self.fov_degrees),
             "max_range_m": None if self.max_range_m is None else float(self.max_range_m),
             "static_occlusion": bool(self.static_occlusion),
+            "dynamic_occlusion": bool(self.dynamic_occlusion),
         }
 
 

--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -30,6 +30,83 @@ SOCNAV_POSITION_CAP_M = 50.0
 """Global cap for SocNav position-like observations to keep bounds consistent."""
 
 
+def dynamic_pedestrian_occlusion_mask(
+    ped_positions: np.ndarray,
+    *,
+    robot_pos: np.ndarray,
+    pedestrian_radius: float,
+    base_visible: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return planner-facing pedestrian visibility after dynamic body occlusion.
+
+    Contract for this first helper:
+    - pedestrians are circular blockers with radius ``pedestrian_radius``;
+    - only a target pedestrian's center-line visibility is tested;
+    - a nearer visible pedestrian blocks a farther target when the line segment from
+      robot center to target center passes through the nearer pedestrian disk;
+    - ground-truth simulator state is not modified.
+    """
+    ped_positions = np.asarray(ped_positions, dtype=float)
+    if ped_positions.size == 0:
+        return np.zeros((0,), dtype=bool)
+    if pedestrian_radius < 0:
+        raise ValueError("pedestrian_radius must be >= 0")
+
+    visible = (
+        np.ones((ped_positions.shape[0],), dtype=bool)
+        if base_visible is None
+        else np.asarray(base_visible, dtype=bool).copy()
+    )
+    robot = np.asarray(robot_pos, dtype=float)
+    rel = ped_positions - robot
+    dists = np.linalg.norm(rel, axis=1)
+    order = np.argsort(dists, kind="stable")
+
+    for target_idx in order:
+        if not visible[target_idx]:
+            continue
+        target_dist = float(dists[target_idx])
+        if target_dist <= 0.0:
+            continue
+        target_vec = rel[target_idx]
+        for blocker_idx in order:
+            if blocker_idx == target_idx or not visible[blocker_idx]:
+                continue
+            blocker_dist = float(dists[blocker_idx])
+            if blocker_dist >= target_dist:
+                break
+            if _point_blocks_segment(
+                point=ped_positions[blocker_idx],
+                segment_start=robot,
+                segment_end=ped_positions[target_idx],
+                radius=pedestrian_radius,
+                segment_vec=target_vec,
+                segment_len_sq=target_dist * target_dist,
+            ):
+                visible[target_idx] = False
+                break
+    return visible
+
+
+def _point_blocks_segment(
+    *,
+    point: np.ndarray,
+    segment_start: np.ndarray,
+    segment_end: np.ndarray,
+    radius: float,
+    segment_vec: np.ndarray,
+    segment_len_sq: float,
+) -> bool:
+    """Return whether a disk centered at ``point`` blocks a center-line segment."""
+    if segment_len_sq <= 0.0:
+        return False
+    projection = float(np.dot(point - segment_start, segment_vec) / segment_len_sq)
+    if projection <= 0.0 or projection >= 1.0:
+        return False
+    nearest = segment_start + projection * segment_vec
+    return float(np.linalg.norm(point - nearest)) <= radius
+
+
 def _map_position_cap(map_def: Any) -> np.ndarray:
     """Return per-axis position caps that preserve coordinates on larger maps."""
     width = float(getattr(map_def, "width", SOCNAV_POSITION_CAP_M) or SOCNAV_POSITION_CAP_M)
@@ -264,6 +341,13 @@ class SocNavObservationFusion:
             for idx, ped_pos in enumerate(ped_positions):
                 if visible[idx] and self._statically_occluded(robot_pos=robot_pos, ped_pos=ped_pos):
                     visible[idx] = False
+        if bool(getattr(settings, "dynamic_occlusion", False)):
+            visible = dynamic_pedestrian_occlusion_mask(
+                ped_positions,
+                robot_pos=robot_pos,
+                pedestrian_radius=float(getattr(self.env_config.sim_config, "ped_radius", 0.0)),
+                base_visible=visible,
+            )
         return visible
 
     def _statically_occluded(self, *, robot_pos: np.ndarray, ped_pos: np.ndarray) -> bool:

--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -52,11 +52,13 @@ def dynamic_pedestrian_occlusion_mask(
     if pedestrian_radius < 0:
         raise ValueError("pedestrian_radius must be >= 0")
 
-    visible = (
-        np.ones((ped_positions.shape[0],), dtype=bool)
-        if base_visible is None
-        else np.asarray(base_visible, dtype=bool).copy()
-    )
+    if base_visible is None:
+        visible = np.ones((ped_positions.shape[0],), dtype=bool)
+    else:
+        mask = np.asarray(base_visible, dtype=bool)
+        if mask.ndim != 1 or mask.shape[0] != ped_positions.shape[0]:
+            raise ValueError("base_visible must be a 1D mask matching ped_positions length")
+        visible = mask.copy()
     robot = np.asarray(robot_pos, dtype=float)
     rel = ped_positions - robot
     dists = np.linalg.norm(rel, axis=1)
@@ -68,31 +70,49 @@ def dynamic_pedestrian_occlusion_mask(
         target_dist = float(dists[target_idx])
         if target_dist <= 0.0:
             continue
-        target_vec = rel[target_idx]
-        for blocker_idx in order:
-            if blocker_idx == target_idx or not visible[blocker_idx]:
-                continue
-            blocker_dist = float(dists[blocker_idx])
-            if blocker_dist >= target_dist:
-                break
-            if _point_blocks_segment(
-                point=ped_positions[blocker_idx],
-                segment_start=robot,
-                segment_end=ped_positions[target_idx],
-                radius=pedestrian_radius,
-                segment_vec=target_vec,
-                segment_len_sq=target_dist * target_dist,
-            ):
-                visible[target_idx] = False
-                break
+        if _blocked_by_nearer_pedestrian(
+            target_idx=target_idx,
+            order=order,
+            visible=visible,
+            dists=dists,
+            rel=rel,
+            pedestrian_radius=pedestrian_radius,
+        ):
+            visible[target_idx] = False
     return visible
+
+
+def _blocked_by_nearer_pedestrian(
+    *,
+    target_idx: int,
+    order: np.ndarray,
+    visible: np.ndarray,
+    dists: np.ndarray,
+    rel: np.ndarray,
+    pedestrian_radius: float,
+) -> bool:
+    """Return whether a nearer visible pedestrian occludes the target pedestrian."""
+    target_dist = float(dists[target_idx])
+    target_vec = rel[target_idx]
+    for blocker_idx in order:
+        if blocker_idx == target_idx or not visible[blocker_idx]:
+            continue
+        blocker_dist = float(dists[blocker_idx])
+        if blocker_dist >= target_dist:
+            break
+        if _point_blocks_segment(
+            rel_point=rel[blocker_idx],
+            radius=pedestrian_radius,
+            segment_vec=target_vec,
+            segment_len_sq=target_dist * target_dist,
+        ):
+            return True
+    return False
 
 
 def _point_blocks_segment(
     *,
-    point: np.ndarray,
-    segment_start: np.ndarray,
-    segment_end: np.ndarray,
+    rel_point: np.ndarray,
     radius: float,
     segment_vec: np.ndarray,
     segment_len_sq: float,
@@ -100,11 +120,11 @@ def _point_blocks_segment(
     """Return whether a disk centered at ``point`` blocks a center-line segment."""
     if segment_len_sq <= 0.0:
         return False
-    projection = float(np.dot(point - segment_start, segment_vec) / segment_len_sq)
+    projection = float(np.dot(rel_point, segment_vec) / segment_len_sq)
     if projection <= 0.0 or projection >= 1.0:
         return False
-    nearest = segment_start + projection * segment_vec
-    return float(np.linalg.norm(point - nearest)) <= radius
+    dist_sq = float(np.dot(rel_point, rel_point) - (projection**2 * segment_len_sq))
+    return max(0.0, dist_sq) <= radius * radius
 
 
 def _map_position_cap(map_def: Any) -> np.ndarray:

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1137,7 +1137,7 @@ def _apply_observation_visibility_overrides(
         return
     if not isinstance(overrides, Mapping):
         raise ValueError("observation_visibility must be a mapping.")
-    allowed = {"enabled", "fov_degrees", "max_range_m", "static_occlusion"}
+    allowed = {"enabled", "fov_degrees", "max_range_m", "static_occlusion", "dynamic_occlusion"}
     unknown = sorted(set(overrides) - allowed)
     if unknown:
         raise ValueError(f"observation_visibility contains unknown keys: {', '.join(unknown)}.")
@@ -1171,11 +1171,20 @@ def _apply_observation_visibility_overrides(
         if "static_occlusion" in overrides
         else False
     )
+    dynamic_occlusion = (
+        _coerce_bool(
+            overrides["dynamic_occlusion"],
+            field_name="observation_visibility.dynamic_occlusion",
+        )
+        if "dynamic_occlusion" in overrides
+        else False
+    )
     config.observation_visibility = ObservationVisibilitySettings(
         enabled=enabled,
         fov_degrees=fov_degrees,
         max_range_m=max_range_m,
         static_occlusion=static_occlusion,
+        dynamic_occlusion=dynamic_occlusion,
     )
 
 

--- a/tests/test_socnav_dynamic_occlusion.py
+++ b/tests/test_socnav_dynamic_occlusion.py
@@ -1,0 +1,56 @@
+"""Tests for dynamic pedestrian occlusion semantics."""
+
+import numpy as np
+import pytest
+
+from robot_sf.sensor.socnav_observation import dynamic_pedestrian_occlusion_mask
+
+
+def test_dynamic_occlusion_hides_far_pedestrian_behind_near_body():
+    """A nearer pedestrian disk should hide a farther center-line target."""
+    ped_positions = np.asarray([[2.0, 0.0], [4.0, 0.0]], dtype=np.float32)
+
+    visible = dynamic_pedestrian_occlusion_mask(
+        ped_positions,
+        robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
+        pedestrian_radius=0.4,
+    )
+
+    assert visible.tolist() == [True, False]
+
+
+def test_dynamic_occlusion_keeps_adjacent_pedestrian_visible():
+    """A pedestrian outside the nearer body disk should remain visible."""
+    ped_positions = np.asarray([[2.0, 0.0], [4.0, 1.0]], dtype=np.float32)
+
+    visible = dynamic_pedestrian_occlusion_mask(
+        ped_positions,
+        robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
+        pedestrian_radius=0.4,
+    )
+
+    assert visible.tolist() == [True, True]
+
+
+def test_dynamic_occlusion_respects_existing_visibility_mask():
+    """Already-hidden pedestrians should not become visible or act as blockers."""
+    ped_positions = np.asarray([[2.0, 0.0], [4.0, 0.0]], dtype=np.float32)
+
+    visible = dynamic_pedestrian_occlusion_mask(
+        ped_positions,
+        robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
+        pedestrian_radius=0.4,
+        base_visible=np.asarray([False, True]),
+    )
+
+    assert visible.tolist() == [False, True]
+
+
+def test_dynamic_occlusion_rejects_negative_radius():
+    """Invalid body radius should fail closed."""
+    with pytest.raises(ValueError, match="pedestrian_radius"):
+        dynamic_pedestrian_occlusion_mask(
+            np.asarray([[2.0, 0.0]], dtype=np.float32),
+            robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
+            pedestrian_radius=-0.1,
+        )

--- a/tests/test_socnav_dynamic_occlusion.py
+++ b/tests/test_socnav_dynamic_occlusion.py
@@ -54,3 +54,14 @@ def test_dynamic_occlusion_rejects_negative_radius():
             robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
             pedestrian_radius=-0.1,
         )
+
+
+def test_dynamic_occlusion_rejects_malformed_base_visibility_mask():
+    """Malformed base visibility masks should fail with a clear contract error."""
+    with pytest.raises(ValueError, match="base_visible"):
+        dynamic_pedestrian_occlusion_mask(
+            np.asarray([[2.0, 0.0], [4.0, 0.0]], dtype=np.float32),
+            robot_pos=np.asarray([0.0, 0.0], dtype=np.float32),
+            pedestrian_radius=0.4,
+            base_visible=np.asarray([[True, False]]),
+        )

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -160,3 +160,37 @@ def test_socnav_observation_visibility_filters_static_occluded_pedestrian() -> N
         simulator.ped_pos,
         np.array([[3.0, 0.0], [0.0, 3.0]], dtype=np.float32),
     )
+
+
+def test_socnav_observation_visibility_filters_dynamic_occluded_pedestrian() -> None:
+    """Opt-in dynamic occlusion should hide pedestrians blocked by nearer pedestrians."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        dynamic_occlusion=True,
+    )
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[2.0, 0.0], [4.0, 0.0], [4.0, 1.0]], dtype=np.float32),
+        ped_vel=np.zeros((3, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+
+    obs = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    ).next_obs()
+
+    assert obs["pedestrians"]["count"][0] == pytest.approx(2.0)
+    assert obs["pedestrians"]["positions"][0].tolist() == pytest.approx([2.0, 0.0])
+    assert obs["pedestrians"]["positions"][1].tolist() == pytest.approx([4.0, 1.0])

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -67,6 +67,7 @@ def test_build_robot_config_parses_observation_visibility_settings(tmp_path: Pat
                 "fov_degrees": 120,
                 "max_range_m": 8.5,
                 "static_occlusion": True,
+                "dynamic_occlusion": True,
             },
         },
         scenario_path=tmp_path / "scenario.yaml",
@@ -76,6 +77,7 @@ def test_build_robot_config_parses_observation_visibility_settings(tmp_path: Pat
     assert config.observation_visibility.fov_degrees == pytest.approx(120.0)
     assert config.observation_visibility.max_range_m == pytest.approx(8.5)
     assert config.observation_visibility.static_occlusion is True
+    assert config.observation_visibility.dynamic_occlusion is True
 
 
 def test_build_robot_config_rejects_invalid_observation_visibility(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds opt-in dynamic pedestrian occlusion filtering for SocNav planner observations, including scenario-loader config support and a context note for the observation contract.

## Linked Issues
- Closes #1124

## What Changed
- Added dynamic pedestrian occlusion masking in `robot_sf/sensor/socnav_observation.py`.
- Added `ObservationVisibilitySettings.dynamic_occlusion` and scenario-loader parsing for `observation_visibility.dynamic_occlusion`.
- Added regression tests for direct mask behavior, SocNav observation filtering, and scenario config loading.
- Added `docs/context/issue_1124_dynamic_pedestrian_occlusion_contract.md` to document the opt-in contract and boundary.

## Why It Matters
- Added value: planner-facing observations can now model pedestrians occluding pedestrians, not only static obstacles.
- Expected impact: improves partial-observability realism while preserving existing default behavior.
- Why this is worth merging now: it is isolated behind an opt-in config flag and has explicit contract tests.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_socnav_dynamic_occlusion.py tests/test_socnav_observation.py tests/training/test_scenario_loader.py -q`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Targeted tests: 34 passed in 13.74s.
  - PR readiness: 3359 passed, 17 skipped, 6 warnings in 259.32s.
  - Freshness stamp: `output/validation/pr_ready/issue-1124-dynamic-ped-occlusion.json` for head `1b1d85ae8be83ace4422b1221ca9b2bc790f7eaa`.
- Benchmarks or smoke tests, if applicable: no benchmark result claim; this PR adds an opt-in observation filter and tests its geometry/config behavior.

## Risks / Rollout
- Compatibility risks: low. `dynamic_occlusion` defaults to disabled, so existing scenarios keep their previous visibility behavior.
- Failure modes: overly conservative pedestrian-body radius assumptions could hide actors in edge cases when the option is enabled.
- Rollback or fallback plan: disable `observation_visibility.dynamic_occlusion` or revert this PR.

## Docs / Provenance
- Updated docs: `docs/context/issue_1124_dynamic_pedestrian_occlusion_contract.md`.
- Relevant design or provenance notes: this preserves the ground-truth/observation separation and treats dynamic occlusion as planner-facing visibility only.
- Any assumptions that need to be preserved: generated coverage output and PR-readiness stamps under `output/` are local validation byproducts and should remain ignored, not promoted as durable artifacts.

## Follow-Up Issues
- Deferred work: none for this issue.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the line-of-sight geometry in `dynamic_pedestrian_occlusion_mask(...)` and that the default `dynamic_occlusion=False` keeps prior behavior.
- Any known limitations: changed-file coverage has warning-only gaps, but all changed files are above the hard 80% gate and full PR readiness passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in dynamic pedestrian occlusion for planner-facing observations: nearer pedestrians can block line-of-sight to farther ones when enabled.

* **Documentation**
  * Added a note describing the opt-in setting, semantics, limitations, and that the dynamic occlusion flag is exposed in observation metadata.

* **Tests**
  * Added comprehensive tests for occlusion behavior, validation, interaction with existing visibility masks, and configuration parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1159)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->