### PR TITLE
feat: add multi-AMV episode extension (#1128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1128 multi-AMV episode extension surface: `multi_amv_episode_extension(...)`
+  now emits an additive namespaced `multi_amv` block for smoke outputs, requires explicit
+  planner status, omits optional planner notes when absent, and keeps invalid single-robot or
+  empty-metric inputs fail-closed through targeted regression coverage and the documented
+  multi-AMV smoke validation path.
+
 * Added the issue-857 horizon-alignment experiment surfaces: manifest-level `scenario_overrides`
   support in `robot_sf/training/scenario_loader.py`, the new
   `configs/scenarios/sets/ppo_full_maintained_eval_v1_horizon100.yaml` eval/training surface,

--- a/docs/README.md
+++ b/docs/README.md
@@ -198,6 +198,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Full Classic Interaction Benchmark](./benchmark_full_classic.md)** - Complete guide: episodes, aggregation, effect sizes, adaptive precision, plots, videos, scaling metrics
 * **[Benchmark Artifact Publication](./benchmark_artifact_publication.md)** - Public artifact policy, DOI-ready export bundles, release/Zenodo workflow
 * **[Multi-AMV Benchmark First Slice](./multi_amv_benchmark.md)** - Minimal multi-robot scenario surface, validation smoke, and inter-robot metric block
+* **[Issue #1128 Multi-AMV Episode Extension](./context/issue_1128_multi_amv_episode_extension.md)** - Additive episode-output block for multi-AMV smoke runs, explicit planner-status contract, and fail-closed validation notes
 * **[Real-World Trajectory Import](./real_world_trajectory_import.md)** - Narrow Stanford Drone Dataset annotation importer, normalization contract, and provenance workflow
 * **[Benchmark Visual Artifacts](./benchmark_visuals.md)** - SimulationView & synthetic video pipeline, performance metrics
 * **[Metrics Specification](./dev/issues/social-navigation-benchmark/metrics_spec.md)** - Formal definitions of benchmark metrics (includes per-pedestrian force quantiles)

--- a/docs/context/issue_1128_multi_amv_episode_extension.md
+++ b/docs/context/issue_1128_multi_amv_episode_extension.md
@@ -1,0 +1,52 @@
+# Issue 1128 multi-AMV episode extension
+
+Date: 2026-05-12
+
+## Scope implemented so far
+
+This branch adds a namespaced, additive multi-AMV episode extension block and updates the existing multi-AMV smoke runner to emit it.
+
+Implemented files:
+
+- `robot_sf/benchmark/multi_amv.py`
+- `scripts/validation/run_multi_amv_smoke.py`
+- `tests/benchmark/test_multi_amv.py`
+
+## Record shape
+
+`multi_amv_episode_extension(...)` returns:
+
+```json
+{
+  "multi_amv": {
+    "enabled": true,
+    "num_robots": 2,
+    "near_miss_distance_m": 1.0,
+    "collision_distance_m": 0.4,
+    "deadlock_speed_mps": 0.05,
+    "deadlock_window_steps": 10,
+    "planner_status": "goal_controller_smoke",
+    "planner_note": "...",
+    "metrics": {
+      "inter_robot": {}
+    }
+  }
+}
+```
+
+The block is intentionally namespaced so existing single-robot episode consumers can ignore it without schema migration.
+
+## Fail-closed behavior
+
+The helper raises `ValueError` when called with fewer than two robots or empty inter-robot metrics.
+
+## Remaining work
+
+- Integrate multi-AMV execution into the primary benchmark command path or document the equivalent primary subcommand.
+- Carry the `multi_amv.metrics.inter_robot` block into aggregate reports.
+- Document planner support beyond the current goal-controller smoke path, or emit explicit unavailable/fail-closed statuses.
+- Add schema/report regression tests covering coexistence with single-robot outputs.
+
+## Validation status
+
+No validation commands have been run for this partial implementation in this pass.

--- a/docs/context/issue_1128_multi_amv_episode_extension.md
+++ b/docs/context/issue_1128_multi_amv_episode_extension.md
@@ -26,7 +26,6 @@ Implemented files:
     "deadlock_speed_mps": 0.05,
     "deadlock_window_steps": 10,
     "planner_status": "goal_controller_smoke",
-    "planner_note": "...",
     "metrics": {
       "inter_robot": {}
     }
@@ -35,6 +34,8 @@ Implemented files:
 ```
 
 The block is intentionally namespaced so existing single-robot episode consumers can ignore it without schema migration.
+`planner_status` is required so callers keep the planner mode explicit, and the optional
+`planner_note` field is omitted when no note is provided.
 
 ## Fail-closed behavior
 
@@ -49,4 +50,10 @@ The helper raises `ValueError` when called with fewer than two robots or empty i
 
 ## Validation status
 
-No validation commands have been run for this partial implementation in this pass.
+Validation has been run for this implementation slice:
+
+- `UV_NO_CONFIG=1 python -m pytest tests/benchmark/test_multi_amv.py -q`
+- `UV_NO_CONFIG=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+
+These checks cover the additive namespaced record shape, fail-closed single-robot and
+empty-metrics paths, and the branch-wide readiness gate for the main-based PR branch.

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -141,6 +141,42 @@ def inter_robot_metrics(
     }
 
 
+def multi_amv_episode_extension(
+    *,
+    settings: MultiAmvSettings,
+    inter_robot: dict[str, float | bool],
+    planner_status: str = "goal_controller_smoke",
+    planner_note: str | None = None,
+) -> dict[str, Any]:
+    """Build an additive episode-record block for multi-AMV benchmark outputs.
+
+    The block is intentionally namespaced under ``multi_amv`` so single-robot
+    episode consumers can ignore it without schema migration.
+
+    Returns
+    -------
+    dict[str, Any]
+        Namespaced episode extension containing settings, planner status, and inter-robot metrics.
+    """
+    if settings.num_robots < 2:
+        raise ValueError("multi-AMV episode extension requires at least two robots")
+    if not inter_robot:
+        raise ValueError("inter_robot metrics must be non-empty")
+    return {
+        "multi_amv": {
+            "enabled": True,
+            "num_robots": int(settings.num_robots),
+            "near_miss_distance_m": float(settings.near_miss_distance_m),
+            "collision_distance_m": float(settings.collision_distance_m),
+            "deadlock_speed_mps": float(settings.deadlock_speed_mps),
+            "deadlock_window_steps": int(settings.deadlock_window_steps),
+            "planner_status": str(planner_status),
+            "planner_note": planner_note,
+            "metrics": {"inter_robot": dict(inter_robot)},
+        }
+    }
+
+
 def _count_true_runs(values: np.ndarray) -> int:
     """Count contiguous true runs in a boolean sequence.
 

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -145,7 +145,7 @@ def multi_amv_episode_extension(
     *,
     settings: MultiAmvSettings,
     inter_robot: dict[str, float | bool],
-    planner_status: str = "goal_controller_smoke",
+    planner_status: str,
     planner_note: str | None = None,
 ) -> dict[str, Any]:
     """Build an additive episode-record block for multi-AMV benchmark outputs.
@@ -162,7 +162,7 @@ def multi_amv_episode_extension(
         raise ValueError("multi-AMV episode extension requires at least two robots")
     if not inter_robot:
         raise ValueError("inter_robot metrics must be non-empty")
-    return {
+    payload: dict[str, Any] = {
         "multi_amv": {
             "enabled": True,
             "num_robots": int(settings.num_robots),
@@ -171,10 +171,12 @@ def multi_amv_episode_extension(
             "deadlock_speed_mps": float(settings.deadlock_speed_mps),
             "deadlock_window_steps": int(settings.deadlock_window_steps),
             "planner_status": str(planner_status),
-            "planner_note": planner_note,
             "metrics": {"inter_robot": dict(inter_robot)},
         }
     }
+    if planner_note is not None:
+        payload["multi_amv"]["planner_note"] = planner_note
+    return payload
 
 
 def _count_true_runs(values: np.ndarray) -> int:

--- a/scripts/validation/run_multi_amv_smoke.py
+++ b/scripts/validation/run_multi_amv_smoke.py
@@ -11,7 +11,11 @@ from typing import Any
 
 import numpy as np
 
-from robot_sf.benchmark.multi_amv import inter_robot_metrics, multi_amv_settings_from_scenario
+from robot_sf.benchmark.multi_amv import (
+    inter_robot_metrics,
+    multi_amv_episode_extension,
+    multi_amv_settings_from_scenario,
+)
 from robot_sf.gym_env.environment_factory import make_multi_robot_env
 from robot_sf.gym_env.unified_config import MultiRobotConfig
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
@@ -88,14 +92,12 @@ def run_smoke(*, scenario_path: Path, horizon: int) -> dict[str, Any]:
         "scenario_id": scenario.get("name") or scenario.get("scenario_id") or scenario.get("id"),
         "horizon": horizon,
         "steps_recorded": int(robot_positions.shape[0]),
-        "multi_amv": {
-            "num_robots": settings.num_robots,
-            "near_miss_distance_m": settings.near_miss_distance_m,
-            "collision_distance_m": settings.collision_distance_m,
-            "deadlock_speed_mps": settings.deadlock_speed_mps,
-            "deadlock_window_steps": settings.deadlock_window_steps,
-        },
-        "metrics": {"inter_robot": metrics},
+        **multi_amv_episode_extension(
+            settings=settings,
+            inter_robot=metrics,
+            planner_status="goal_controller_smoke",
+            planner_note="Minimal multi-AMV smoke runner uses internal goal-directed actions.",
+        ),
     }
 
 

--- a/tests/benchmark/test_multi_amv.py
+++ b/tests/benchmark/test_multi_amv.py
@@ -10,6 +10,7 @@ import pytest
 from robot_sf.benchmark.multi_amv import (
     MultiAmvSettings,
     inter_robot_metrics,
+    multi_amv_episode_extension,
     multi_amv_settings_from_scenario,
 )
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
@@ -88,6 +89,34 @@ def test_inter_robot_metrics_handles_empty_trajectory() -> None:
     assert metrics["inter_robot_collision_events"] == pytest.approx(0.0)
     assert metrics["inter_robot_near_miss_events"] == pytest.approx(0.0)
     assert metrics["deadlock_detected"] is False
+
+
+def test_multi_amv_episode_extension_is_additive_and_namespaced() -> None:
+    """Multi-AMV episode data should live in a namespaced optional block."""
+    settings = MultiAmvSettings(num_robots=2)
+    metrics = {"robot_count": 2.0, "pair_count": 1.0, "deadlock_detected": False}
+
+    block = multi_amv_episode_extension(
+        settings=settings,
+        inter_robot=metrics,
+        planner_status="goal_controller_smoke",
+        planner_note="first-slice smoke planner",
+    )
+
+    assert set(block) == {"multi_amv"}
+    assert block["multi_amv"]["enabled"] is True
+    assert block["multi_amv"]["num_robots"] == 2
+    assert block["multi_amv"]["planner_status"] == "goal_controller_smoke"
+    assert block["multi_amv"]["metrics"]["inter_robot"] == metrics
+
+
+def test_multi_amv_episode_extension_requires_multi_robot_metrics() -> None:
+    """The extension should fail closed when called outside multi-robot scope."""
+    with pytest.raises(ValueError, match="at least two robots"):
+        multi_amv_episode_extension(
+            settings=MultiAmvSettings(num_robots=1),
+            inter_robot={"robot_count": 1.0},
+        )
 
 
 def test_multi_amv_smoke_scenario_passes_schema() -> None:

--- a/tests/benchmark/test_multi_amv.py
+++ b/tests/benchmark/test_multi_amv.py
@@ -116,7 +116,30 @@ def test_multi_amv_episode_extension_requires_multi_robot_metrics() -> None:
         multi_amv_episode_extension(
             settings=MultiAmvSettings(num_robots=1),
             inter_robot={"robot_count": 1.0},
+            planner_status="test",
         )
+
+
+def test_multi_amv_episode_extension_requires_non_empty_metrics() -> None:
+    """The extension should fail closed when called with empty metrics."""
+    with pytest.raises(ValueError, match="metrics must be non-empty"):
+        multi_amv_episode_extension(
+            settings=MultiAmvSettings(num_robots=2),
+            inter_robot={},
+            planner_status="test",
+        )
+
+
+def test_multi_amv_episode_extension_omits_optional_planner_note() -> None:
+    """Planner note should stay absent when callers do not provide one."""
+    block = multi_amv_episode_extension(
+        settings=MultiAmvSettings(num_robots=2),
+        inter_robot={"robot_count": 2.0, "pair_count": 1.0},
+        planner_status="explicit-status",
+    )
+
+    assert block["multi_amv"]["planner_status"] == "explicit-status"
+    assert "planner_note" not in block["multi_amv"]
 
 
 def test_multi_amv_smoke_scenario_passes_schema() -> None:


### PR DESCRIPTION
## Summary
Adds a namespaced `multi_amv` episode extension for primary benchmark outputs and updates the multi-AMV smoke runner to emit the same additive block.

## Linked Issues
- Relates to #1128
- Partial slice only; #1128 remains open for primary benchmark command, aggregate/report, and single-robot compatibility acceptance criteria.

## What Changed
- Added `multi_amv_episode_extension(...)` in `robot_sf/benchmark/multi_amv.py`.
- Updated `scripts/validation/run_multi_amv_smoke.py` to include the additive `multi_amv` block with planner status and inter-robot metrics.
- Added regression tests for fail-closed single-robot/empty-metric behavior and additive namespacing.
- Added `docs/context/issue_1128_multi_amv_episode_extension.md` documenting the first-slice output contract.

## Why It Matters
- Added value: multi-AMV runs can carry explicit multi-robot metrics without changing single-robot episode consumers.
- Expected impact: creates a reviewable first slice for benchmark output integration while keeping planner status/degraded mode visible.
- Why this is worth merging now: it is additive, namespaced, and validated independently from broader fleet benchmark work.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_multi_amv.py -q`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Targeted tests: 7 passed in 7.78s after docstring cleanup.
  - PR readiness: 3355 passed, 18 skipped, 6 warnings in 260.12s.
  - Freshness stamp: `output/validation/pr_ready/issue-1128-multi-amv-episode-extension.json` for head `81e15dfca26fc4a863c04078204ff2914fd1d01e`.
- Benchmarks or smoke tests, if applicable: no benchmark result claim; this PR updates the smoke-output schema path and validates it with unit tests.

## Risks / Rollout
- Compatibility risks: low. The new block is namespaced under `multi_amv`, so existing single-robot consumers can ignore it.
- Failure modes: the helper intentionally fails closed for single-robot settings or empty inter-robot metrics.
- Rollback or fallback plan: revert this PR; existing smoke output behavior returns to the prior non-extension shape.

## Docs / Provenance
- Updated docs: `docs/context/issue_1128_multi_amv_episode_extension.md`.
- Relevant design or provenance notes: planner status remains explicit so smoke/degraded planner modes are not presented as benchmark-strength evidence.
- Any assumptions that need to be preserved: generated coverage output and PR-readiness stamps under `output/` are local validation byproducts and should remain ignored, not promoted as durable artifacts.

## Follow-Up Issues
- Deferred work: full multi-AMV benchmark promotion remains outside this additive episode-extension PR.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: fail-closed behavior in `multi_amv_episode_extension(...)` and namespacing under `multi_amv`.
- Any known limitations: changed-file coverage has a warning-only gap at 85.0%; full PR readiness passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi‑AMV episode extension for benchmark outputs with validation enforcing minimum robot count and non‑empty inter‑robot metrics.

* **Documentation**
  * Added Issue 1128 docs describing the multi‑AMV record format, fail‑closed behavior, and current validation status.

* **Tests**
  * Added unit tests covering extension output, omission of optional planner note, and error cases.

* **Changelog**
  * Recorded the multi‑AMV episode extension in Unreleased.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1161)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
