### PR TITLE
feat: add manual control foundations (#1151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1151 manual-control MVP foundation surface: append-only JSONL recording,
+  fail-closed mode/session helpers, baseline comparison primitives, and BC export utilities now
+  reject invalid mode values, non-finite speed multipliers, negative tolerances, and malformed
+  record payloads while keeping NumPy-backed observations serializable for recorder/export flows.
+
 * Added the issue-857 horizon-alignment experiment surfaces: manifest-level `scenario_overrides`
   support in `robot_sf/training/scenario_loader.py`, the new
   `configs/scenarios/sets/ppo_full_maintained_eval_v1_horizon100.yaml` eval/training surface,

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,8 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Awesome Copilot Adaptation](./ai/awesome_copilot_adaptation.md)** - Selective adaptation plan for Codex skills, including `autoresearch`,   `auto-improvement`, context-discovery, quality, and doc-sync skills
 * **[AI Retrieval Deferral Note](./ai/retrieval_deferral.md)** - Why MCP/retrieval layers stay out of scope until a real context boundary appears
 * **[Agent Memory Index](../memory/MEMORY.md)** - Repo-local Markdown memory taxonomy for durable agent context, with linked architecture, decision, experiment, failure, and benchmark notes
+* **[Issue #1151 Manual-Control MVP Foundation](./context/issue_1151_manual_control_mvp_foundation.md)** - Pygame manual-control benchmark recorder foundations: input mapping, session controller, recording module, and test suite
+* **[Issue #1154 Web-Game Data Collection Path](./context/issue_1154_web_game_data_collection_path.md)** - Deferred web-game data collection follow-up; rationale for keeping schema parity with the local recorder and sequenced implementation order
 * **[Observation Contract](./dev/observation_contract.md)** - Observation schemas, shapes, and normalization conventions
 * **[Holonomic Action Contract](./dev/holonomic_action_contract.md)** - Exact holonomic action-space semantics, heading behavior, and benchmark bridge rules
 * **[Training Protocol Template](./dev/training_protocol_template.md)** - Fill-in template for documenting training/evaluation runs

--- a/docs/context/issue_1151_manual_control_mvp_foundation.md
+++ b/docs/context/issue_1151_manual_control_mvp_foundation.md
@@ -89,7 +89,13 @@ Pause/countdown/retry events can be recorded with `training_sample=false`; behav
 
 ## Validation status
 
-No validation commands have been run for this partial implementation in this pass.
+Validation has been run for this implementation slice:
+
+- `UV_NO_CONFIG=1 python -m pytest tests/test_manual_control_*.py -q`
+- `UV_NO_CONFIG=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+
+These checks cover the manual-control foundation helpers, BC export CLI path, and the
+branch-wide readiness gate for the main-based PR branch.
 
 ## Additional foundation: baseline comparison
 

--- a/docs/context/issue_1151_manual_control_mvp_foundation.md
+++ b/docs/context/issue_1151_manual_control_mvp_foundation.md
@@ -1,0 +1,243 @@
+# Issue 1151 manual-control MVP foundation
+
+Date: 2026-05-12
+
+## Scope implemented so far
+
+This branch adds the first pure, testable foundations for the Pygame manual-control benchmark recorder epic. It does not yet implement the interactive Pygame runner, renderer integration, baseline loader, or full benchmark comparison loop.
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/input_mapping.py`
+  - `ManualKeyState`
+  - `DifferentialDriveKeyboardMapper`
+  - `manual_keyboard_diff_drive_hold_v1` metadata
+- `robot_sf/manual_control/session.py`
+  - `ManualSessionController`
+  - `ManualSessionState`
+  - `AttemptKey` / `AttemptProgress`
+- `robot_sf/manual_control/recording.py`
+  - `ManualSessionMetadata`
+  - `ManualControlRecord`
+  - `ManualJsonlRecorder`
+- Tests:
+  - `tests/test_manual_control_input_mapping.py`
+  - `tests/test_manual_control_session.py`
+  - `tests/test_manual_control_recording.py`
+
+## Design decisions
+
+### Input mapping
+
+The initial MVP mapper is differential-drive only and uses hold-to-command keyboard semantics. Held keys define target robot velocities; the emitted action is the delta from the current differential-drive velocity to that target.
+
+This matches the current differential-drive action model, where actions are applied as velocity deltas rather than absolute target velocities.
+
+Default key groups:
+
+- Forward: `w`, `up`
+- Backward: `s`, `down`
+- Left: `a`, `left`
+- Right: `d`, `right`
+- Brake: `space`, `brake`, `stop`
+
+When no movement key is held, the mapper emits a delta back to zero velocity. Reverse motion is only targeted when `DifferentialDriveSettings.allow_backwards=True`.
+
+### Session lifecycle
+
+The session controller is intentionally pure and renderer-independent. It owns:
+
+- countdown before stepping,
+- pause/resume state,
+- positive speed multiplier validation,
+- terminal attempt bookkeeping,
+- retry count,
+- completed attempts,
+- unresolved scenario/seed attempts where the human did not beat the baseline.
+
+The future Pygame runner should use `controller.should_step` as the gate before calling `env.step(...)`.
+
+### Recording contract
+
+Manual-control JSONL records use `record_schema=manual_control_v1` and include:
+
+- session metadata,
+- scenario id,
+- seed,
+- attempt id,
+- step index,
+- event type,
+- input keys,
+- mapped action,
+- optional observation payload,
+- metrics,
+- `training_sample` flag,
+- policy-to-beat id/source metadata.
+
+Pause/countdown/retry events can be recorded with `training_sample=false`; behavior-cloning extraction should use only records explicitly marked `training_sample=true` unless a future exporter applies additional filtering.
+
+## Remaining MVP work
+
+- Add an interactive runner under `robot_sf/manual_control/` or `scripts/manual_control/`.
+- Wire Pygame events into `ManualKeyState` and `ManualSessionController`.
+- Step `RobotEnv` with `DifferentialDriveKeyboardMapper.map_action(...)`.
+- Add overlays for goal, current steering/action state, countdown, pause, speed multiplier, episode status, and terminal/failure reason.
+- Record simulator state and per-step metrics into `ManualControlRecord` rows.
+- Load and freeze policy-to-beat metadata at session start.
+- Add baseline comparison logic and session manifest summaries.
+- Add a documented smoke command and targeted tests for runner orchestration.
+
+## Validation status
+
+No validation commands have been run for this partial implementation in this pass.
+
+## Additional foundation: baseline comparison
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/baseline.py`
+  - `MetricDirection`
+  - `BaselineMetric`
+  - `PolicyBaseline`
+  - `BaselineComparison`
+- Tests:
+  - `tests/test_manual_control_baseline.py`
+
+Design:
+
+- The policy-to-beat is represented as a frozen `PolicyBaseline` with a source string that should identify the config/artifact/registry entry used for the session.
+- The baseline has one primary metric that decides `beat_baseline`.
+- Metrics declare whether higher or lower values are better.
+- Optional tolerance prevents tiny numeric differences from counting as a meaningful win.
+- Missing primary candidate metrics fail closed with `KeyError` instead of silently treating the attempt as comparable.
+
+Remaining integration work:
+
+- Load a real `PolicyBaseline` from a config, registry entry, or command-line manifest selected at runner startup.
+- Store `PolicyBaseline.to_manifest_dict()` in the session manifest.
+- Use `PolicyBaseline.compare(...)` when an attempt reaches terminal state and feed the result into `ManualSessionController.mark_terminal(...)`.
+
+## Additional foundation: demonstration export
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/export.py`
+  - `DemonstrationSample`
+  - `export_demonstration_samples`
+- Tests:
+  - `tests/test_manual_control_export.py`
+
+Design:
+
+- Only records with `training_sample=true` are exported into BC samples.
+- Non-training events such as pause, countdown, retry, and metadata-only records remain in the JSONL stream but are filtered from BC samples.
+- Training-marked records must include both `observation` and `mapped_action`; missing alignment fails closed with `ValueError`.
+- Exported samples use `sample_schema=manual_control_bc_v1` and preserve session, scenario, seed, attempt, step, observation, action, and input keys.
+
+## Additional foundation: mapper dispatch
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/input_mapping.py::mapper_for_robot_config`
+
+Design:
+
+- The MVP supports `DifferentialDriveSettings` through `DifferentialDriveKeyboardMapper`.
+- Other action spaces intentionally fail closed with `NotImplementedError` until explicit mapper versions are added.
+- This gives follow-up steering/view-mode work a single dispatch point for holonomic, bicycle, mouse, cruise, or ego-view-specific mapper variants.
+
+## Additional foundation: JSONL loading
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/recording.py::ManualControlRecord.from_json_dict`
+- `robot_sf/manual_control/recording.py::load_manual_jsonl_records`
+
+Design:
+
+- Manual-control JSONL streams can be loaded back into typed `ManualControlRecord` instances.
+- Loading fails closed on unsupported `record_schema`, malformed JSON, non-object lines, or missing session metadata.
+- This is the read-side prerequisite for future replay and behavior-cloning export commands.
+
+## Additional foundation: JSONL-to-BC export
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/export.py::export_demonstration_samples_from_jsonl`
+
+Design:
+
+- The convenience exporter loads schema-validated manual-control JSONL records and extracts only `training_sample=true` rows.
+- This provides the compact BC extraction path required before a CLI/export command is added.
+
+## Additional foundation: compact BC sample writing
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/export.py::write_demonstration_samples_jsonl`
+
+Design:
+
+- Extracted `DemonstrationSample` instances can be written as sorted-key JSONL using `sample_schema=manual_control_bc_v1`.
+- This provides the derived dataset write path for future CLI/export commands.
+
+## Additional foundation: replay grouping
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/replay.py::group_records_by_attempt`
+- `robot_sf/manual_control/replay.py::ManualAttemptReplay`
+
+Design:
+
+- Manual-control records can be grouped by scenario id, seed, and attempt id.
+- Records inside each replay group are ordered by `step_idx`.
+- This is a data-ordering prerequisite for future visual replay and rewind work; it does not restore simulator state or render playback by itself.
+
+## Additional foundation: session manifest
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/manifest.py::ManualSessionManifest`
+- `robot_sf/manual_control/manifest.py::write_manual_session_manifest`
+
+Design:
+
+- The manifest uses `manifest_schema=manual_control_session_manifest_v1`.
+- It records session metadata, optional frozen policy baseline metadata, completed attempts, unresolved attempts, artifact paths, and notes.
+- This is the JSON manifest surface the future runner should write at session end.
+
+## Additional foundation: BC export CLI
+
+Implemented artifacts:
+
+- `scripts/manual_control/export_bc_samples.py`
+- `tests/test_manual_control_export_cli.py`
+
+Design:
+
+- The CLI reads a manual-control session JSONL through the schema-validating loader.
+- It writes compact `manual_control_bc_v1` samples to a destination JSONL.
+- Only records marked `training_sample=true` are exported.
+
+Usage sketch:
+
+```bash
+uv run python scripts/manual_control/export_bc_samples.py \
+  --input output/manual_control/session.jsonl \
+  --output output/manual_control/bc_samples.jsonl
+```
+
+## Additional foundation: mode identifiers
+
+Implemented artifacts:
+
+- `robot_sf/manual_control/modes.py`
+- `tests/test_manual_control_modes.py`
+
+Design:
+
+- `ManualControlMode` defines `keyboard_hold`, `keyboard_cruise`, and `mouse_target` identifiers.
+- `ManualViewMode` defines `fixed_map`, `ego_up`, and `robot_static` identifiers.
+- The current MVP supports only `keyboard_hold` + `fixed_map`.
+- `ensure_supported_mvp_mode(...)` fails closed for stretch modes until they are actually implemented.

--- a/docs/context/issue_1154_web_game_data_collection_path.md
+++ b/docs/context/issue_1154_web_game_data_collection_path.md
@@ -1,0 +1,117 @@
+# Issue 1154: Web-game manual-control data collection path
+
+Date: 2026-05-12
+Issue: #1154
+Parent: #1151
+
+## Decision
+
+A browser/web-game data collection path is worth keeping as a follow-up direction, but it should
+not be implemented before the local Pygame manual-control recorder has a stable session and attempt
+schema.
+
+The web path should start as a small compatibility prototype rather than a separate product stack.
+Its first success condition is schema parity with the local recorder, not polished gameplay or broad
+public deployment.
+
+## Rationale
+
+A web game could collect more human demonstrations than a local Pygame tool, but it introduces
+product and data-governance risks that are not present in local debugging:
+
+- consent and retention rules for external user trajectories,
+- hosted scenario and asset versioning,
+- data-quality checks for incomplete, noisy, or adversarial inputs,
+- browser input latency and frame-rate variability,
+- compatibility with the local manual-control behavior-cloning export path.
+
+Those risks are manageable only after #1151 defines the local recording contract: scenario ID, seed,
+attempt ID, input mapping version, view mode, user input events, mapped actions, simulator states,
+training-sample markers, terminal reason, and baseline-to-beat metadata.
+
+## Recommended sequence
+
+1. Finish the #1151 local Pygame MVP recorder first.
+2. Freeze a minimal local session/attempt schema version.
+3. Define a tiny hosted scenario subset with deterministic assets and seeds.
+4. Write consent, privacy, retention, and deletion rules before collecting external data.
+5. Build a browser prototype that exports the same session/attempt manifest fields or a lossless
+   converter into the local schema.
+6. Add data-quality checks before accepting trajectories for behavior-cloning experiments.
+
+## Minimal hosted scenario subset
+
+The first web prototype should use a deliberately small set:
+
+- one or two short scenarios,
+- fixed seeds,
+- short horizons,
+- no private model checkpoints in the client,
+- explicit scenario version metadata,
+- lightweight assets that can be reproduced or regenerated from tracked definitions.
+
+The goal is to validate data collection and schema compatibility, not benchmark breadth.
+
+## Consent and retention requirements
+
+Before collecting any external user data, the implementation must define:
+
+- what input and trajectory data is collected,
+- whether any browser/device metadata is collected,
+- where data is stored,
+- how long data is retained,
+- how a user can request deletion when identifiable data is present,
+- whether data may be used for behavior-cloning training,
+- whether data may be published as an anonymized aggregate or artifact.
+
+Until this policy exists, web collection should remain local-only or synthetic-test-only.
+
+## Schema compatibility requirements
+
+The web path must preserve or convert into the local #1151 schema fields:
+
+- `schema_version`,
+- `scenario_id`,
+- `scenario_version`,
+- `seed`,
+- `attempt_id`,
+- `retry_index`,
+- `input_mapping_version`,
+- `view_mode`,
+- input events,
+- mapped actions,
+- simulator timestamps/step indexes,
+- dynamic state observations,
+- `training_sample` markers,
+- terminal status and failure reason,
+- optional baseline-to-beat metadata.
+
+If the browser implementation cannot produce a field exactly, it should record an explicit
+`unavailable_reason` rather than silently changing semantics.
+
+## Data-quality checks
+
+A web trajectory should be flagged or rejected when:
+
+- it is incomplete or terminates before minimum usable duration,
+- it contains no meaningful control input,
+- client timing is too irregular for action/state alignment,
+- scenario version metadata is missing,
+- input mapping metadata is missing,
+- terminal status is missing,
+- the attempt is dominated by pause/countdown/non-training frames.
+
+These checks should run before a trajectory is used for behavior-cloning training.
+
+## Acceptance mapping for #1154
+
+- A written feasibility decision exists: this note.
+- The web schema maps to the local manual-control schema: required fields are listed above.
+- Consent/privacy/retention requirements are documented: see the consent section above.
+- A future implementation can start from a narrow prototype: recommended sequence and hosted subset
+  are defined above.
+
+## Open dependency
+
+This issue remains implementation-blocked on #1151's local recorder schema. Once #1151 lands, the
+next web task should be a narrow prototype/export converter, not broad web deployment.

--- a/robot_sf/manual_control/__init__.py
+++ b/robot_sf/manual_control/__init__.py
@@ -1,0 +1,70 @@
+"""Manual-control helpers for human-driven Robot SF sessions."""
+
+from robot_sf.manual_control.baseline import (
+    BaselineComparison,
+    BaselineMetric,
+    MetricDirection,
+    PolicyBaseline,
+)
+from robot_sf.manual_control.export import (
+    DemonstrationSample,
+    export_demonstration_samples,
+    export_demonstration_samples_from_jsonl,
+    write_demonstration_samples_jsonl,
+)
+from robot_sf.manual_control.input_mapping import (
+    DifferentialDriveKeyboardMapper,
+    ManualKeyState,
+    mapper_for_robot_config,
+)
+from robot_sf.manual_control.manifest import (
+    ManualSessionManifest,
+    write_manual_session_manifest,
+)
+from robot_sf.manual_control.modes import (
+    ManualControlMode,
+    ManualViewMode,
+    ensure_supported_mvp_mode,
+)
+from robot_sf.manual_control.recording import (
+    ManualControlRecord,
+    ManualJsonlRecorder,
+    ManualSessionMetadata,
+    load_manual_jsonl_records,
+)
+from robot_sf.manual_control.replay import ManualAttemptReplay, group_records_by_attempt
+from robot_sf.manual_control.session import (
+    AttemptKey,
+    AttemptProgress,
+    ManualSessionController,
+    ManualSessionState,
+)
+
+__all__ = [
+    "AttemptKey",
+    "AttemptProgress",
+    "BaselineComparison",
+    "BaselineMetric",
+    "DemonstrationSample",
+    "DifferentialDriveKeyboardMapper",
+    "ManualAttemptReplay",
+    "ManualControlMode",
+    "ManualControlRecord",
+    "ManualJsonlRecorder",
+    "ManualKeyState",
+    "ManualSessionController",
+    "ManualSessionManifest",
+    "ManualSessionMetadata",
+    "ManualSessionState",
+    "ManualViewMode",
+    "MetricDirection",
+    "PolicyBaseline",
+    "ensure_supported_mvp_mode",
+    "export_demonstration_samples",
+    "export_demonstration_samples_from_jsonl",
+    "group_records_by_attempt",
+    "load_manual_jsonl_records",
+    "mapper_for_robot_config",
+    "write_demonstration_samples_jsonl",
+    "write_manual_session_manifest",
+]

--- a/robot_sf/manual_control/baseline.py
+++ b/robot_sf/manual_control/baseline.py
@@ -23,6 +23,11 @@ class BaselineMetric:
     direction: MetricDirection
     tolerance: float = 0.0
 
+    def __post_init__(self) -> None:
+        """Reject invalid tolerance values that would invert comparison semantics."""
+        if self.tolerance < 0.0:
+            raise ValueError(f"tolerance must be non-negative, got {self.tolerance}")
+
     def is_beaten_by(self, candidate_value: float) -> bool:
         """Return whether ``candidate_value`` beats this baseline metric."""
         if self.direction == MetricDirection.HIGHER_IS_BETTER:

--- a/robot_sf/manual_control/baseline.py
+++ b/robot_sf/manual_control/baseline.py
@@ -1,0 +1,117 @@
+"""Baseline comparison helpers for manual-control sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class MetricDirection(StrEnum):
+    """Optimization direction for a baseline comparison metric."""
+
+    HIGHER_IS_BETTER = "higher_is_better"
+    LOWER_IS_BETTER = "lower_is_better"
+
+
+@dataclass(frozen=True)
+class BaselineMetric:
+    """Frozen policy-to-beat value for one comparable metric."""
+
+    name: str
+    value: float
+    direction: MetricDirection
+    tolerance: float = 0.0
+
+    def is_beaten_by(self, candidate_value: float) -> bool:
+        """Return whether ``candidate_value`` beats this baseline metric."""
+        if self.direction == MetricDirection.HIGHER_IS_BETTER:
+            return candidate_value > self.value + self.tolerance
+        return candidate_value < self.value - self.tolerance
+
+
+@dataclass(frozen=True)
+class PolicyBaseline:
+    """Frozen policy-to-beat metadata for a manual-control session."""
+
+    policy_id: str
+    source: str
+    primary_metric: str
+    metrics: dict[str, BaselineMetric]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def compare(self, candidate_metrics: dict[str, float]) -> BaselineComparison:
+        """Compare human/manual metrics against the frozen baseline.
+
+        Returns
+        -------
+        BaselineComparison
+            Per-metric and primary-metric comparison result.
+        """
+        if self.primary_metric not in self.metrics:
+            raise KeyError(f"primary metric {self.primary_metric!r} is missing from baseline")
+        if self.primary_metric not in candidate_metrics:
+            raise KeyError(f"candidate metric {self.primary_metric!r} is missing")
+
+        metric_results: dict[str, bool] = {}
+        for name, baseline_metric in self.metrics.items():
+            if name in candidate_metrics:
+                metric_results[name] = baseline_metric.is_beaten_by(candidate_metrics[name])
+
+        return BaselineComparison(
+            policy_id=self.policy_id,
+            source=self.source,
+            primary_metric=self.primary_metric,
+            beat_baseline=metric_results[self.primary_metric],
+            metric_results=metric_results,
+        )
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible baseline metadata for session manifests.
+
+        Returns
+        -------
+        dict[str, Any]
+            Serializable baseline metadata.
+        """
+        return {
+            "policy_id": self.policy_id,
+            "source": self.source,
+            "primary_metric": self.primary_metric,
+            "metrics": {
+                name: {
+                    "value": metric.value,
+                    "direction": metric.direction.value,
+                    "tolerance": metric.tolerance,
+                }
+                for name, metric in self.metrics.items()
+            },
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class BaselineComparison:
+    """Result of comparing manual-control metrics against a policy baseline."""
+
+    policy_id: str
+    source: str
+    primary_metric: str
+    beat_baseline: bool
+    metric_results: dict[str, bool]
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible comparison metadata for attempt summaries.
+
+        Returns
+        -------
+        dict[str, Any]
+            Serializable baseline-comparison metadata.
+        """
+        return {
+            "policy_id": self.policy_id,
+            "source": self.source,
+            "primary_metric": self.primary_metric,
+            "beat_baseline": self.beat_baseline,
+            "metric_results": self.metric_results,
+        }

--- a/robot_sf/manual_control/export.py
+++ b/robot_sf/manual_control/export.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from robot_sf.manual_control.recording import load_manual_jsonl_records
+from robot_sf.manual_control.recording import _json_compatible, load_manual_jsonl_records
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -36,17 +36,19 @@ class DemonstrationSample:
         dict[str, Any]
             Serializable behavior-cloning sample.
         """
-        return {
-            "sample_schema": "manual_control_bc_v1",
-            "session_id": self.session_id,
-            "scenario_id": self.scenario_id,
-            "seed": self.seed,
-            "attempt_id": self.attempt_id,
-            "step_idx": self.step_idx,
-            "observation": self.observation,
-            "action": list(self.action),
-            "input_keys": list(self.input_keys),
-        }
+        return _json_compatible(
+            {
+                "sample_schema": "manual_control_bc_v1",
+                "session_id": self.session_id,
+                "scenario_id": self.scenario_id,
+                "seed": self.seed,
+                "attempt_id": self.attempt_id,
+                "step_idx": self.step_idx,
+                "observation": self.observation,
+                "action": list(self.action),
+                "input_keys": list(self.input_keys),
+            }
+        )
 
 
 def export_demonstration_samples(

--- a/robot_sf/manual_control/export.py
+++ b/robot_sf/manual_control/export.py
@@ -1,0 +1,112 @@
+"""Demonstration export helpers for manual-control recordings."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.manual_control.recording import load_manual_jsonl_records
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from robot_sf.manual_control.recording import ManualControlRecord
+
+
+@dataclass(frozen=True)
+class DemonstrationSample:
+    """Compact behavior-cloning sample extracted from a manual-control record."""
+
+    session_id: str
+    scenario_id: str
+    seed: int
+    attempt_id: int
+    step_idx: int
+    observation: dict[str, Any]
+    action: tuple[float, ...]
+    input_keys: tuple[str, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible demonstration sample.
+
+        Returns
+        -------
+        dict[str, Any]
+            Serializable behavior-cloning sample.
+        """
+        return {
+            "sample_schema": "manual_control_bc_v1",
+            "session_id": self.session_id,
+            "scenario_id": self.scenario_id,
+            "seed": self.seed,
+            "attempt_id": self.attempt_id,
+            "step_idx": self.step_idx,
+            "observation": self.observation,
+            "action": list(self.action),
+            "input_keys": list(self.input_keys),
+        }
+
+
+def export_demonstration_samples(
+    records: Iterable[ManualControlRecord],
+) -> list[DemonstrationSample]:
+    """Extract behavior-cloning samples from training-marked manual records.
+
+    Returns
+    -------
+    list[DemonstrationSample]
+        Extracted demonstration samples in record order.
+    """
+    samples: list[DemonstrationSample] = []
+    for record in records:
+        if not record.training_sample:
+            continue
+        if record.observation is None or record.mapped_action is None:
+            raise ValueError(
+                "training_sample records must include both observation and mapped_action"
+            )
+        samples.append(
+            DemonstrationSample(
+                session_id=record.session.session_id,
+                scenario_id=record.scenario_id,
+                seed=record.seed,
+                attempt_id=record.attempt_id,
+                step_idx=record.step_idx,
+                observation=record.observation,
+                action=tuple(record.mapped_action),
+                input_keys=tuple(record.input_keys),
+            )
+        )
+    return samples
+
+
+def export_demonstration_samples_from_jsonl(path: str | Path) -> list[DemonstrationSample]:
+    """Load a manual-control JSONL stream and extract BC samples.
+
+    Returns
+    -------
+    list[DemonstrationSample]
+        Extracted demonstration samples from the JSONL recording.
+    """
+    return export_demonstration_samples(load_manual_jsonl_records(path))
+
+
+def write_demonstration_samples_jsonl(
+    samples: Iterable[DemonstrationSample],
+    path: str | Path,
+) -> Path:
+    """Write compact behavior-cloning samples as JSONL.
+
+    Returns
+    -------
+    Path
+        Output JSONL path.
+    """
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        for sample in samples:
+            handle.write(json.dumps(sample.to_json_dict(), sort_keys=True) + "\n")
+    return output_path

--- a/robot_sf/manual_control/input_mapping.py
+++ b/robot_sf/manual_control/input_mapping.py
@@ -1,0 +1,177 @@
+"""Pure input mappers for manual-control sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from robot_sf.manual_control.modes import ManualControlMode
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from robot_sf.common.types import DifferentialDriveAction
+    from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+    from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
+
+FORWARD_KEYS = frozenset({"w", "up"})
+BACKWARD_KEYS = frozenset({"s", "down"})
+LEFT_KEYS = frozenset({"a", "left"})
+RIGHT_KEYS = frozenset({"d", "right"})
+BRAKE_KEYS = frozenset({"space", "brake", "stop"})
+
+
+@dataclass(frozen=True)
+class ManualKeyState:
+    """Normalized keyboard state for one manual-control step."""
+
+    pressed: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_keys(cls, keys: Iterable[str]) -> ManualKeyState:
+        """Normalize raw key labels into lowercase symbolic key names.
+
+        Returns
+        -------
+        ManualKeyState
+            Normalized immutable key state.
+        """
+        return cls(frozenset(str(key).strip().lower() for key in keys if str(key).strip()))
+
+    def any_pressed(self, candidates: frozenset[str]) -> bool:
+        """Return whether any candidate key is currently pressed.
+
+        Returns
+        -------
+        bool
+            True when any candidate is present in the current key set.
+        """
+        return bool(self.pressed & candidates)
+
+
+@dataclass(frozen=True)
+class DifferentialDriveKeyboardMapper:
+    """Map keyboard hold controls into differential-drive velocity deltas.
+
+    The repository's differential-drive action is a ``(delta_linear, delta_angular)``
+    command applied to the current robot velocity. This mapper therefore treats
+    keyboard input as a target velocity and emits the delta needed to move from the
+    current velocity to that target for the next environment step.
+    """
+
+    settings: DifferentialDriveSettings = field(default_factory=DifferentialDriveSettings)
+    input_mapping_version: str = "manual_keyboard_diff_drive_hold_v1"
+
+    def map_action(
+        self,
+        keys: ManualKeyState | Iterable[str],
+        *,
+        current_velocity: tuple[float, float] = (0.0, 0.0),
+    ) -> DifferentialDriveAction:
+        """Return the action delta for the current key state.
+
+        Args:
+            keys: Normalized key state or raw key labels.
+            current_velocity: Current ``(linear, angular)`` robot velocity.
+
+        Returns:
+            Differential-drive action ``(delta_linear, delta_angular)``.
+        """
+        key_state = keys if isinstance(keys, ManualKeyState) else ManualKeyState.from_keys(keys)
+        target_linear, target_angular = self._target_velocity(key_state)
+        current_linear, current_angular = current_velocity
+        return (
+            float(target_linear - current_linear),
+            float(target_angular - current_angular),
+        )
+
+    def metadata(self) -> dict[str, object]:
+        """Return manifest metadata for recorded manual-control sessions.
+
+        Returns
+        -------
+        dict[str, object]
+            JSON-compatible input-mapping metadata.
+        """
+        return {
+            "input_mapping_version": self.input_mapping_version,
+            "control_mode": ManualControlMode.KEYBOARD_HOLD.value,
+            "robot_action_space": "differential_drive",
+            "forward_keys": sorted(FORWARD_KEYS),
+            "backward_keys": sorted(BACKWARD_KEYS),
+            "left_keys": sorted(LEFT_KEYS),
+            "right_keys": sorted(RIGHT_KEYS),
+            "brake_keys": sorted(BRAKE_KEYS),
+        }
+
+    def _target_velocity(self, keys: ManualKeyState) -> tuple[float, float]:
+        """Compute target velocity from held keys.
+
+        Returns
+        -------
+        tuple[float, float]
+            Target ``(linear, angular)`` velocity.
+        """
+        if keys.any_pressed(BRAKE_KEYS):
+            return 0.0, 0.0
+
+        target_linear = self._target_linear_velocity(keys)
+        target_angular = self._target_angular_velocity(keys)
+        return target_linear, target_angular
+
+    def _target_linear_velocity(self, keys: ManualKeyState) -> float:
+        """Compute target linear velocity from forward/backward keys.
+
+        Returns
+        -------
+        float
+            Target linear velocity in meters per second.
+        """
+        forward = keys.any_pressed(FORWARD_KEYS)
+        backward = keys.any_pressed(BACKWARD_KEYS)
+        if forward == backward:
+            return 0.0
+        if forward:
+            return float(self.settings.max_linear_speed)
+        if self.settings.allow_backwards:
+            return float(self.settings.min_linear_speed)
+        return 0.0
+
+    def _target_angular_velocity(self, keys: ManualKeyState) -> float:
+        """Compute target angular velocity from left/right keys.
+
+        Returns
+        -------
+        float
+            Target angular velocity in radians per second.
+        """
+        left = keys.any_pressed(LEFT_KEYS)
+        right = keys.any_pressed(RIGHT_KEYS)
+        if left == right:
+            return 0.0
+        angular = self.settings.max_angular_speed
+        return float(np.clip(angular if left else -angular, -angular, angular))
+
+
+def mapper_for_robot_config(
+    robot_config: DifferentialDriveSettings | BicycleDriveSettings | HolonomicDriveSettings,
+) -> DifferentialDriveKeyboardMapper:
+    """Return the supported manual-control mapper for a robot configuration.
+
+    The MVP supports differential-drive keyboard hold controls only. Other
+    action spaces fail closed until their explicit mapper versions are added.
+
+    Returns
+    -------
+    DifferentialDriveKeyboardMapper
+        Keyboard-hold mapper for differential-drive robots.
+    """
+    if isinstance(robot_config, DifferentialDriveSettings):
+        return DifferentialDriveKeyboardMapper(robot_config)
+    raise NotImplementedError(
+        "Manual control mapper is not available for "
+        f"{type(robot_config).__name__}; supported action space: differential_drive"
+    )

--- a/robot_sf/manual_control/manifest.py
+++ b/robot_sf/manual_control/manifest.py
@@ -1,0 +1,89 @@
+"""Session manifest helpers for manual-control benchmark runs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from robot_sf.manual_control.baseline import PolicyBaseline
+    from robot_sf.manual_control.recording import ManualSessionMetadata
+    from robot_sf.manual_control.session import AttemptProgress
+
+
+@dataclass(frozen=True)
+class ManualSessionManifest:
+    """JSON-safe manifest summarizing one manual-control session."""
+
+    session: ManualSessionMetadata
+    baseline: PolicyBaseline | None = None
+    completed_attempts: tuple[AttemptProgress, ...] = ()
+    unresolved_attempts: tuple[AttemptProgress, ...] = ()
+    artifacts: dict[str, str] = field(default_factory=dict)
+    notes: tuple[str, ...] = ()
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return the manifest as a JSON-compatible dictionary.
+
+        Returns
+        -------
+        dict[str, Any]
+            Serializable session manifest.
+        """
+        return {
+            "manifest_schema": "manual_control_session_manifest_v1",
+            "session": {
+                "session_id": self.session.session_id,
+                "input_mapping_version": self.session.input_mapping_version,
+                "view_mode": self.session.view_mode,
+                "policy_to_beat": self.session.policy_to_beat,
+                "policy_to_beat_source": self.session.policy_to_beat_source,
+                "extra": self.session.extra,
+            },
+            "baseline": self.baseline.to_manifest_dict() if self.baseline else None,
+            "completed_attempts": [
+                _attempt_progress_to_json(attempt) for attempt in self.completed_attempts
+            ],
+            "unresolved_attempts": [
+                _attempt_progress_to_json(attempt) for attempt in self.unresolved_attempts
+            ],
+            "artifacts": dict(self.artifacts),
+            "notes": list(self.notes),
+        }
+
+
+def write_manual_session_manifest(manifest: ManualSessionManifest, path: str | Path) -> Path:
+    """Write a manual-control session manifest as sorted JSON.
+
+    Returns
+    -------
+    Path
+        Output manifest path.
+    """
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(manifest.to_json_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def _attempt_progress_to_json(attempt: AttemptProgress) -> dict[str, Any]:
+    """Return JSON-compatible attempt progress metadata.
+
+    Returns
+    -------
+    dict[str, Any]
+        Serializable attempt progress metadata.
+    """
+    return {
+        "scenario_id": attempt.key.scenario_id,
+        "seed": attempt.key.seed,
+        "retry_count": attempt.retry_count,
+        "beat_baseline": attempt.beat_baseline,
+        "success": attempt.success,
+        "failure_reason": attempt.failure_reason,
+    }

--- a/robot_sf/manual_control/modes.py
+++ b/robot_sf/manual_control/modes.py
@@ -30,11 +30,33 @@ SUPPORTED_MVP_VIEW_MODES = (ManualViewMode.FIXED_MAP,)
 
 def ensure_supported_mvp_mode(
     *,
-    control_mode: ManualControlMode,
-    view_mode: ManualViewMode,
+    control_mode: ManualControlMode | str,
+    view_mode: ManualViewMode | str,
 ) -> None:
     """Fail closed when a requested manual-control mode is not implemented yet."""
-    if control_mode not in SUPPORTED_MVP_CONTROL_MODES:
-        raise NotImplementedError(f"manual control mode is not implemented: {control_mode.value}")
-    if view_mode not in SUPPORTED_MVP_VIEW_MODES:
-        raise NotImplementedError(f"manual view mode is not implemented: {view_mode.value}")
+    try:
+        normalized_control_mode = (
+            control_mode
+            if isinstance(control_mode, ManualControlMode)
+            else ManualControlMode(control_mode)
+        )
+    except ValueError as exc:
+        raise NotImplementedError(
+            f"manual control mode is not implemented: {control_mode}"
+        ) from exc
+
+    try:
+        normalized_view_mode = (
+            view_mode if isinstance(view_mode, ManualViewMode) else ManualViewMode(view_mode)
+        )
+    except ValueError as exc:
+        raise NotImplementedError(f"manual view mode is not implemented: {view_mode}") from exc
+
+    if normalized_control_mode not in SUPPORTED_MVP_CONTROL_MODES:
+        raise NotImplementedError(
+            f"manual control mode is not implemented: {normalized_control_mode.value}"
+        )
+    if normalized_view_mode not in SUPPORTED_MVP_VIEW_MODES:
+        raise NotImplementedError(
+            f"manual view mode is not implemented: {normalized_view_mode.value}"
+        )

--- a/robot_sf/manual_control/modes.py
+++ b/robot_sf/manual_control/modes.py
@@ -1,0 +1,40 @@
+"""Stable mode identifiers for manual-control runners and manifests."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ManualControlMode(StrEnum):
+    """Supported manual-control input mapping modes."""
+
+    KEYBOARD_HOLD = "keyboard_hold"
+    KEYBOARD_CRUISE = "keyboard_cruise"
+    MOUSE_TARGET = "mouse_target"
+
+
+class ManualViewMode(StrEnum):
+    """Supported manual-control camera/view modes."""
+
+    FIXED_MAP = "fixed_map"
+    EGO_UP = "ego_up"
+    ROBOT_STATIC = "robot_static"
+
+
+SUPPORTED_MVP_CONTROL_MODES = (ManualControlMode.KEYBOARD_HOLD,)
+"""Control modes implemented in the current MVP foundation."""
+
+SUPPORTED_MVP_VIEW_MODES = (ManualViewMode.FIXED_MAP,)
+"""View modes implemented in the current MVP foundation."""
+
+
+def ensure_supported_mvp_mode(
+    *,
+    control_mode: ManualControlMode,
+    view_mode: ManualViewMode,
+) -> None:
+    """Fail closed when a requested manual-control mode is not implemented yet."""
+    if control_mode not in SUPPORTED_MVP_CONTROL_MODES:
+        raise NotImplementedError(f"manual control mode is not implemented: {control_mode.value}")
+    if view_mode not in SUPPORTED_MVP_VIEW_MODES:
+        raise NotImplementedError(f"manual view mode is not implemented: {view_mode.value}")

--- a/robot_sf/manual_control/recording.py
+++ b/robot_sf/manual_control/recording.py
@@ -85,7 +85,7 @@ class ManualControlRecord:
         dict[str, Any]
             Serializable manual-control record.
         """
-        payload = asdict(self)
+        payload = _json_compatible(asdict(self))
         payload["record_schema"] = "manual_control_v1"
         return payload
 
@@ -104,6 +104,13 @@ class ManualControlRecord:
         session_payload = payload.get("session")
         if not isinstance(session_payload, dict):
             raise ValueError("manual-control record is missing session metadata")
+        view_mode = str(session_payload.get("view_mode", ManualViewMode.FIXED_MAP.value))
+        allowed_view_modes = {mode.value for mode in ManualViewMode}
+        if view_mode not in allowed_view_modes:
+            raise ValueError(f"unsupported manual-control view mode: {view_mode!r}")
+        training_sample = payload.get("training_sample", False)
+        if not isinstance(training_sample, bool):
+            raise ValueError("training_sample must be a boolean")
         return cls(
             event=str(payload["event"]),
             scenario_id=str(payload["scenario_id"]),
@@ -113,7 +120,7 @@ class ManualControlRecord:
             session=ManualSessionMetadata(
                 session_id=str(session_payload["session_id"]),
                 input_mapping_version=str(session_payload["input_mapping_version"]),
-                view_mode=str(session_payload.get("view_mode", "fixed_map")),
+                view_mode=view_mode,
                 policy_to_beat=session_payload.get("policy_to_beat"),
                 policy_to_beat_source=session_payload.get("policy_to_beat_source"),
                 extra=dict(session_payload.get("extra") or {}),
@@ -126,7 +133,7 @@ class ManualControlRecord:
             ),
             observation=payload.get("observation"),
             metrics=dict(payload.get("metrics") or {}),
-            training_sample=bool(payload.get("training_sample", False)),
+            training_sample=training_sample,
         )
 
 
@@ -172,16 +179,50 @@ def load_manual_jsonl_records(path: str | Path) -> list[ManualControlRecord]:
         Parsed records in file order.
     """
     records: list[ManualControlRecord] = []
-    for line_number, line in enumerate(
-        Path(path).read_text(encoding="utf-8").splitlines(), start=1
-    ):
-        if not line.strip():
-            continue
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"invalid JSON on manual-control line {line_number}") from exc
-        if not isinstance(payload, dict):
-            raise ValueError(f"manual-control line {line_number} is not a JSON object")
-        records.append(ManualControlRecord.from_json_dict(payload))
+    with Path(path).open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+                if not isinstance(payload, dict):
+                    raise ValueError("line is not a JSON object")
+                records.append(ManualControlRecord.from_json_dict(payload))
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"invalid record on manual-control line {line_number}: {exc}"
+                ) from exc
     return records
+
+
+def _json_compatible(value: Any) -> Any:
+    """Convert manual-control payload values into JSON-compatible builtins.
+
+    Returns
+    -------
+    Any
+        Equivalent builtin container or scalar value that `json.dumps` can serialize.
+    """
+    if isinstance(value, dict):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_compatible(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        converted = tolist()
+        if converted is not value:
+            return _json_compatible(converted)
+
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            converted = item()
+        except (TypeError, ValueError):
+            converted = value
+        if converted is not value:
+            return _json_compatible(converted)
+
+    return value

--- a/robot_sf/manual_control/recording.py
+++ b/robot_sf/manual_control/recording.py
@@ -1,0 +1,187 @@
+"""Append-only recording primitives for manual-control sessions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.manual_control.modes import ManualViewMode
+
+if TYPE_CHECKING:
+    from robot_sf.manual_control.session import AttemptKey
+
+
+@dataclass(frozen=True)
+class ManualSessionMetadata:
+    """Static metadata written into every manual-control session record."""
+
+    session_id: str
+    input_mapping_version: str
+    view_mode: str = ManualViewMode.FIXED_MAP.value
+    policy_to_beat: str | None = None
+    policy_to_beat_source: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ManualControlRecord:
+    """One append-only manual-control event or training sample."""
+
+    event: str
+    scenario_id: str
+    seed: int
+    attempt_id: int
+    step_idx: int
+    session: ManualSessionMetadata
+    input_keys: list[str] = field(default_factory=list)
+    mapped_action: tuple[float, ...] | None = None
+    observation: dict[str, Any] | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+    training_sample: bool = False
+
+    @classmethod
+    def for_attempt(  # noqa: PLR0913
+        cls,
+        *,
+        event: str,
+        attempt_key: AttemptKey,
+        attempt_id: int,
+        step_idx: int,
+        session: ManualSessionMetadata,
+        input_keys: list[str] | None = None,
+        mapped_action: tuple[float, ...] | None = None,
+        observation: dict[str, Any] | None = None,
+        metrics: dict[str, Any] | None = None,
+        training_sample: bool = False,
+    ) -> ManualControlRecord:
+        """Build a record tied to one scenario/seed attempt.
+
+        Returns
+        -------
+        ManualControlRecord
+            Record populated from the attempt key and supplied event data.
+        """
+        return cls(
+            event=event,
+            scenario_id=attempt_key.scenario_id,
+            seed=attempt_key.seed,
+            attempt_id=attempt_id,
+            step_idx=step_idx,
+            session=session,
+            input_keys=input_keys or [],
+            mapped_action=mapped_action,
+            observation=observation,
+            metrics=metrics or {},
+            training_sample=training_sample,
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary.
+
+        Returns
+        -------
+        dict[str, Any]
+            Serializable manual-control record.
+        """
+        payload = asdict(self)
+        payload["record_schema"] = "manual_control_v1"
+        return payload
+
+    @classmethod
+    def from_json_dict(cls, payload: dict[str, Any]) -> ManualControlRecord:
+        """Reconstruct a record from a JSONL payload.
+
+        Returns
+        -------
+        ManualControlRecord
+            Parsed manual-control record.
+        """
+        schema = payload.get("record_schema")
+        if schema != "manual_control_v1":
+            raise ValueError(f"unsupported manual-control record schema: {schema!r}")
+        session_payload = payload.get("session")
+        if not isinstance(session_payload, dict):
+            raise ValueError("manual-control record is missing session metadata")
+        return cls(
+            event=str(payload["event"]),
+            scenario_id=str(payload["scenario_id"]),
+            seed=int(payload["seed"]),
+            attempt_id=int(payload["attempt_id"]),
+            step_idx=int(payload["step_idx"]),
+            session=ManualSessionMetadata(
+                session_id=str(session_payload["session_id"]),
+                input_mapping_version=str(session_payload["input_mapping_version"]),
+                view_mode=str(session_payload.get("view_mode", "fixed_map")),
+                policy_to_beat=session_payload.get("policy_to_beat"),
+                policy_to_beat_source=session_payload.get("policy_to_beat_source"),
+                extra=dict(session_payload.get("extra") or {}),
+            ),
+            input_keys=list(payload.get("input_keys") or []),
+            mapped_action=(
+                tuple(float(value) for value in payload["mapped_action"])
+                if payload.get("mapped_action") is not None
+                else None
+            ),
+            observation=payload.get("observation"),
+            metrics=dict(payload.get("metrics") or {}),
+            training_sample=bool(payload.get("training_sample", False)),
+        )
+
+
+class ManualJsonlRecorder:
+    """Append-only JSONL recorder for manual-control sessions."""
+
+    def __init__(self, path: str | Path):
+        """Open a manual-control JSONL stream."""
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.path.open("a", encoding="utf-8")
+
+    def write(self, record: ManualControlRecord) -> None:
+        """Append one sorted-key JSON object and flush it."""
+        self._file.write(json.dumps(record.to_json_dict(), sort_keys=True) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        """Close the underlying JSONL file."""
+        self._file.close()
+
+    def __enter__(self) -> ManualJsonlRecorder:
+        """Return the recorder for context-manager use.
+
+        Returns
+        -------
+        ManualJsonlRecorder
+            Active recorder instance.
+        """
+        return self
+
+    def __exit__(self, *_exc_info) -> None:
+        """Close the recorder at context-manager exit."""
+        self.close()
+
+
+def load_manual_jsonl_records(path: str | Path) -> list[ManualControlRecord]:
+    """Load manual-control records from a JSONL file.
+
+    Returns
+    -------
+    list[ManualControlRecord]
+        Parsed records in file order.
+    """
+    records: list[ManualControlRecord] = []
+    for line_number, line in enumerate(
+        Path(path).read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON on manual-control line {line_number}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"manual-control line {line_number} is not a JSON object")
+        records.append(ManualControlRecord.from_json_dict(payload))
+    return records

--- a/robot_sf/manual_control/replay.py
+++ b/robot_sf/manual_control/replay.py
@@ -1,0 +1,48 @@
+"""Replay organization helpers for manual-control recordings."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from robot_sf.manual_control.session import AttemptKey
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from robot_sf.manual_control.recording import ManualControlRecord
+
+
+@dataclass(frozen=True)
+class ManualAttemptReplay:
+    """Ordered records for one manual-control scenario/seed attempt."""
+
+    key: AttemptKey
+    attempt_id: int
+    records: tuple[ManualControlRecord, ...]
+
+
+def group_records_by_attempt(records: Iterable[ManualControlRecord]) -> list[ManualAttemptReplay]:
+    """Group manual-control records by scenario, seed, and attempt id.
+
+    Returns
+    -------
+    list[ManualAttemptReplay]
+        Attempt replays sorted by scenario, seed, and attempt id.
+    """
+    grouped: dict[tuple[str, int, int], list[ManualControlRecord]] = defaultdict(list)
+    for record in records:
+        grouped[(record.scenario_id, record.seed, record.attempt_id)].append(record)
+
+    replays: list[ManualAttemptReplay] = []
+    for (scenario_id, seed, attempt_id), attempt_records in sorted(grouped.items()):
+        ordered = tuple(sorted(attempt_records, key=lambda record: record.step_idx))
+        replays.append(
+            ManualAttemptReplay(
+                key=AttemptKey(scenario_id=scenario_id, seed=seed),
+                attempt_id=attempt_id,
+                records=ordered,
+            )
+        )
+    return replays

--- a/robot_sf/manual_control/session.py
+++ b/robot_sf/manual_control/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import StrEnum
 
@@ -107,9 +108,10 @@ class ManualSessionController:
 
     def set_speed_multiplier(self, value: float) -> None:
         """Set the simulation speed multiplier used by the interactive runner."""
-        if value <= 0:
+        numeric_value = float(value)
+        if not math.isfinite(numeric_value) or numeric_value <= 0:
             raise ValueError("speed multiplier must be positive")
-        self.speed_multiplier = float(value)
+        self.speed_multiplier = numeric_value
 
     def mark_terminal(
         self,

--- a/robot_sf/manual_control/session.py
+++ b/robot_sf/manual_control/session.py
@@ -1,0 +1,173 @@
+"""Manual-control session state machine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ManualSessionState(StrEnum):
+    """High-level state for a manual-control attempt."""
+
+    IDLE = "idle"
+    COUNTDOWN = "countdown"
+    RUNNING = "running"
+    PAUSED = "paused"
+    TERMINAL = "terminal"
+
+
+@dataclass(frozen=True)
+class AttemptKey:
+    """Stable identifier for one scenario/seed attempt target."""
+
+    scenario_id: str
+    seed: int
+
+
+@dataclass
+class AttemptProgress:
+    """Progress metadata for the active manual-control attempt."""
+
+    key: AttemptKey
+    retry_count: int = 0
+    beat_baseline: bool = False
+    success: bool = False
+    failure_reason: str | None = None
+
+
+@dataclass
+class ManualSessionController:
+    """Pure controller for manual-control attempt lifecycle state."""
+
+    countdown_steps: int = 3
+    stop_between_episodes: bool = True
+    speed_multiplier: float = 1.0
+    state: ManualSessionState = ManualSessionState.IDLE
+    countdown_remaining: int = 0
+    active_attempt: AttemptProgress | None = None
+    completed: dict[AttemptKey, AttemptProgress] = field(default_factory=dict)
+    unresolved: dict[AttemptKey, AttemptProgress] = field(default_factory=dict)
+
+    def start_attempt(self, scenario_id: str, seed: int) -> AttemptProgress:
+        """Start a new attempt and enter countdown before simulation stepping.
+
+        Returns
+        -------
+        AttemptProgress
+            New active attempt progress record.
+        """
+        attempt = AttemptProgress(key=AttemptKey(scenario_id=scenario_id, seed=seed))
+        self.active_attempt = attempt
+        self.countdown_remaining = max(0, int(self.countdown_steps))
+        self.state = (
+            ManualSessionState.COUNTDOWN
+            if self.countdown_remaining > 0
+            else ManualSessionState.RUNNING
+        )
+        return attempt
+
+    def advance_countdown(self) -> ManualSessionState:
+        """Advance one countdown tick and switch to running when it reaches zero.
+
+        Returns
+        -------
+        ManualSessionState
+            Current state after the countdown tick.
+        """
+        if self.state != ManualSessionState.COUNTDOWN:
+            return self.state
+        self.countdown_remaining = max(0, self.countdown_remaining - 1)
+        if self.countdown_remaining == 0:
+            self.state = ManualSessionState.RUNNING
+        return self.state
+
+    def pause(self) -> None:
+        """Pause a running attempt."""
+        if self.state == ManualSessionState.RUNNING:
+            self.state = ManualSessionState.PAUSED
+
+    def resume(self) -> None:
+        """Resume a paused attempt."""
+        if self.state == ManualSessionState.PAUSED:
+            self.state = ManualSessionState.RUNNING
+
+    def toggle_pause(self) -> ManualSessionState:
+        """Toggle between running and paused states.
+
+        Returns
+        -------
+        ManualSessionState
+            Current state after toggling.
+        """
+        if self.state == ManualSessionState.RUNNING:
+            self.pause()
+        elif self.state == ManualSessionState.PAUSED:
+            self.resume()
+        return self.state
+
+    def set_speed_multiplier(self, value: float) -> None:
+        """Set the simulation speed multiplier used by the interactive runner."""
+        if value <= 0:
+            raise ValueError("speed multiplier must be positive")
+        self.speed_multiplier = float(value)
+
+    def mark_terminal(
+        self,
+        *,
+        success: bool,
+        beat_baseline: bool,
+        failure_reason: str | None = None,
+    ) -> AttemptProgress:
+        """Mark the active attempt terminal and update progress indexes.
+
+        Returns
+        -------
+        AttemptProgress
+            Completed active attempt progress.
+        """
+        if self.active_attempt is None:
+            raise RuntimeError("cannot mark terminal without an active attempt")
+        self.active_attempt.success = success
+        self.active_attempt.beat_baseline = beat_baseline
+        self.active_attempt.failure_reason = failure_reason
+        self.completed[self.active_attempt.key] = self.active_attempt
+        if beat_baseline:
+            self.unresolved.pop(self.active_attempt.key, None)
+        else:
+            self.unresolved[self.active_attempt.key] = self.active_attempt
+        self.state = ManualSessionState.TERMINAL
+        return self.active_attempt
+
+    def retry_active(self) -> AttemptProgress:
+        """Restart the same scenario/seed with incremented retry count.
+
+        Returns
+        -------
+        AttemptProgress
+            New retry attempt progress.
+        """
+        if self.active_attempt is None:
+            raise RuntimeError("cannot retry without an active attempt")
+        retry = AttemptProgress(
+            key=self.active_attempt.key,
+            retry_count=self.active_attempt.retry_count + 1,
+        )
+        self.active_attempt = retry
+        self.countdown_remaining = max(0, int(self.countdown_steps))
+        self.state = (
+            ManualSessionState.COUNTDOWN
+            if self.countdown_remaining > 0
+            else ManualSessionState.RUNNING
+        )
+        return retry
+
+    @property
+    def should_step(self) -> bool:
+        """Return whether the runner should advance the environment now.
+
+        Returns
+        -------
+        bool
+            True when the session is in the running state.
+        """
+        return self.state == ManualSessionState.RUNNING

--- a/scripts/manual_control/export_bc_samples.py
+++ b/scripts/manual_control/export_bc_samples.py
@@ -1,0 +1,42 @@
+"""Export compact behavior-cloning samples from manual-control JSONL recordings."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from robot_sf.manual_control.export import (
+    export_demonstration_samples_from_jsonl,
+    write_demonstration_samples_jsonl,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Manual-control session JSONL produced by the manual recorder.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Destination JSONL path for compact BC samples.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the BC sample export command."""
+    args = parse_args()
+    samples = export_demonstration_samples_from_jsonl(args.input)
+    write_demonstration_samples_jsonl(samples, args.output)
+    print(f"wrote {len(samples)} manual-control BC samples to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_manual_control_baseline.py
+++ b/tests/test_manual_control_baseline.py
@@ -89,3 +89,14 @@ def test_baseline_manifest_serialization_is_json_compatible():
     assert manifest["policy_id"] == "best-policy"
     assert manifest["metrics"]["snqi"]["direction"] == "higher_is_better"
     assert manifest["metadata"] == {"commit": "abc123"}
+
+
+def test_baseline_metric_rejects_negative_tolerance() -> None:
+    """Negative tolerances should fail closed instead of inverting comparisons."""
+    with pytest.raises(ValueError, match="non-negative"):
+        BaselineMetric(
+            name="snqi",
+            value=0.5,
+            direction=MetricDirection.HIGHER_IS_BETTER,
+            tolerance=-0.01,
+        )

--- a/tests/test_manual_control_baseline.py
+++ b/tests/test_manual_control_baseline.py
@@ -1,0 +1,91 @@
+"""Tests for manual-control baseline comparison helpers."""
+
+import pytest
+
+from robot_sf.manual_control.baseline import BaselineMetric, MetricDirection, PolicyBaseline
+
+
+def test_baseline_compare_higher_is_better_metric():
+    """Candidate should beat higher-is-better metric only above tolerance."""
+    baseline = PolicyBaseline(
+        policy_id="best-policy",
+        source="model/registry.yaml",
+        primary_metric="success_rate",
+        metrics={
+            "success_rate": BaselineMetric(
+                name="success_rate",
+                value=0.7,
+                direction=MetricDirection.HIGHER_IS_BETTER,
+                tolerance=0.01,
+            )
+        },
+    )
+
+    comparison = baseline.compare({"success_rate": 0.72})
+
+    assert comparison.beat_baseline is True
+    assert comparison.metric_results == {"success_rate": True}
+
+
+def test_baseline_compare_lower_is_better_metric():
+    """Candidate should beat lower-is-better metric only below tolerance."""
+    baseline = PolicyBaseline(
+        policy_id="best-policy",
+        source="model/registry.yaml",
+        primary_metric="collision_rate",
+        metrics={
+            "collision_rate": BaselineMetric(
+                name="collision_rate",
+                value=0.2,
+                direction=MetricDirection.LOWER_IS_BETTER,
+                tolerance=0.01,
+            )
+        },
+    )
+
+    comparison = baseline.compare({"collision_rate": 0.18})
+
+    assert comparison.beat_baseline is True
+    assert comparison.metric_results == {"collision_rate": True}
+
+
+def test_baseline_compare_requires_primary_candidate_metric():
+    """Missing primary candidate metric should fail closed."""
+    baseline = PolicyBaseline(
+        policy_id="best-policy",
+        source="model/registry.yaml",
+        primary_metric="snqi",
+        metrics={
+            "snqi": BaselineMetric(
+                name="snqi",
+                value=0.5,
+                direction=MetricDirection.HIGHER_IS_BETTER,
+            )
+        },
+    )
+
+    with pytest.raises(KeyError, match="candidate metric"):
+        baseline.compare({})
+
+
+def test_baseline_manifest_serialization_is_json_compatible():
+    """Baseline manifests should preserve source and metric direction."""
+    baseline = PolicyBaseline(
+        policy_id="best-policy",
+        source="model/registry.yaml",
+        primary_metric="snqi",
+        metrics={
+            "snqi": BaselineMetric(
+                name="snqi",
+                value=0.5,
+                direction=MetricDirection.HIGHER_IS_BETTER,
+            )
+        },
+        metadata={"commit": "abc123"},
+    )
+
+    manifest = baseline.to_manifest_dict()
+
+    assert manifest["policy_id"] == "best-policy"
+    assert manifest["metrics"]["snqi"]["direction"] == "higher_is_better"
+    assert manifest["metadata"] == {"commit": "abc123"}

--- a/tests/test_manual_control_export.py
+++ b/tests/test_manual_control_export.py
@@ -1,7 +1,9 @@
 """Tests for manual-control demonstration export helpers."""
 
 import json
+from pathlib import Path
 
+import numpy as np
 import pytest
 
 from robot_sf.manual_control.export import (
@@ -104,7 +106,10 @@ def test_write_demonstration_samples_jsonl(tmp_path):
         [
             _record(
                 training_sample=True,
-                observation={"obs": [1.0]},
+                observation={
+                    "obs": np.array([1.0], dtype=np.float32),
+                    "artifact": Path("output/manual/demo.jsonl"),
+                },
                 mapped_action=(0.5, 0.0),
             )
         ]
@@ -116,3 +121,7 @@ def test_write_demonstration_samples_jsonl(tmp_path):
     assert written_path == path
     rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
     assert rows == [samples[0].to_json_dict()]
+    assert rows[0]["observation"] == {
+        "obs": [1.0],
+        "artifact": "output/manual/demo.jsonl",
+    }

--- a/tests/test_manual_control_export.py
+++ b/tests/test_manual_control_export.py
@@ -1,0 +1,118 @@
+"""Tests for manual-control demonstration export helpers."""
+
+import json
+
+import pytest
+
+from robot_sf.manual_control.export import (
+    export_demonstration_samples,
+    export_demonstration_samples_from_jsonl,
+    write_demonstration_samples_jsonl,
+)
+from robot_sf.manual_control.recording import ManualControlRecord, ManualSessionMetadata
+from robot_sf.manual_control.session import AttemptKey
+
+
+def _record(
+    *,
+    event: str = "step",
+    training_sample: bool,
+    observation=None,
+    mapped_action=None,
+) -> ManualControlRecord:
+    """Build a minimal manual-control record for export tests."""
+    return ManualControlRecord.for_attempt(
+        event=event,
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=1,
+        step_idx=2,
+        session=ManualSessionMetadata(
+            session_id="session-1",
+            input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+        ),
+        input_keys=["w"],
+        mapped_action=mapped_action,
+        observation=observation,
+        training_sample=training_sample,
+    )
+
+
+def test_export_demonstration_samples_filters_non_training_events():
+    """Pause/countdown-style records should not become BC samples."""
+    records = [
+        _record(event="pause", training_sample=False),
+        _record(
+            training_sample=True,
+            observation={"obs": [1.0]},
+            mapped_action=(0.5, 0.0),
+        ),
+    ]
+
+    samples = export_demonstration_samples(records)
+
+    assert len(samples) == 1
+    assert samples[0].to_json_dict() == {
+        "sample_schema": "manual_control_bc_v1",
+        "session_id": "session-1",
+        "scenario_id": "scenario-a",
+        "seed": 7,
+        "attempt_id": 1,
+        "step_idx": 2,
+        "observation": {"obs": [1.0]},
+        "action": [0.5, 0.0],
+        "input_keys": ["w"],
+    }
+
+
+def test_export_demonstration_samples_requires_observation_and_action():
+    """Training-marked records without aligned obs/action should fail closed."""
+    records = [_record(training_sample=True, observation={"obs": [1.0]}, mapped_action=None)]
+
+    with pytest.raises(ValueError, match="observation and mapped_action"):
+        export_demonstration_samples(records)
+
+
+def test_export_demonstration_samples_from_jsonl(tmp_path):
+    """JSONL convenience exporter should load records and filter samples."""
+    path = tmp_path / "manual.jsonl"
+    training_record = _record(
+        training_sample=True,
+        observation={"obs": [1.0]},
+        mapped_action=(0.5, 0.0),
+    )
+    pause_record = _record(event="pause", training_sample=False)
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(pause_record.to_json_dict()),
+                json.dumps(training_record.to_json_dict()),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    samples = export_demonstration_samples_from_jsonl(path)
+
+    assert len(samples) == 1
+    assert samples[0].action == (0.5, 0.0)
+
+
+def test_write_demonstration_samples_jsonl(tmp_path):
+    """Compact BC samples should be writable as one JSON object per line."""
+    samples = export_demonstration_samples(
+        [
+            _record(
+                training_sample=True,
+                observation={"obs": [1.0]},
+                mapped_action=(0.5, 0.0),
+            )
+        ]
+    )
+    path = tmp_path / "samples.jsonl"
+
+    written_path = write_demonstration_samples_jsonl(samples, path)
+
+    assert written_path == path
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert rows == [samples[0].to_json_dict()]

--- a/tests/test_manual_control_export_cli.py
+++ b/tests/test_manual_control_export_cli.py
@@ -1,0 +1,64 @@
+"""Tests for the manual-control BC export CLI."""
+
+import json
+
+from robot_sf.manual_control.recording import ManualControlRecord, ManualSessionMetadata
+from robot_sf.manual_control.session import AttemptKey
+from scripts.manual_control.export_bc_samples import main
+
+
+def test_export_bc_samples_cli_writes_compact_jsonl(monkeypatch, tmp_path, capsys):
+    """CLI should export only training-marked manual records."""
+    input_path = tmp_path / "manual.jsonl"
+    output_path = tmp_path / "samples.jsonl"
+    session = ManualSessionMetadata(
+        session_id="session-1",
+        input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+    )
+    training_record = ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=0,
+        step_idx=1,
+        session=session,
+        input_keys=["w"],
+        mapped_action=(0.5, 0.0),
+        observation={"obs": [1.0]},
+        training_sample=True,
+    )
+    pause_record = ManualControlRecord.for_attempt(
+        event="pause",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=0,
+        step_idx=2,
+        session=session,
+        training_sample=False,
+    )
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps(pause_record.to_json_dict()),
+                json.dumps(training_record.to_json_dict()),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "export_bc_samples.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert main() == 0
+
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["sample_schema"] == "manual_control_bc_v1"
+    assert rows[0]["action"] == [0.5, 0.0]
+    assert "wrote 1 manual-control BC samples" in capsys.readouterr().out

--- a/tests/test_manual_control_input_mapping.py
+++ b/tests/test_manual_control_input_mapping.py
@@ -1,0 +1,83 @@
+"""Tests for pure manual-control input mapping."""
+
+from robot_sf.manual_control.input_mapping import (
+    DifferentialDriveKeyboardMapper,
+    ManualKeyState,
+    mapper_for_robot_config,
+)
+from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+
+
+def test_manual_key_state_normalizes_labels():
+    """Raw key labels should normalize to lowercase symbolic names."""
+    state = ManualKeyState.from_keys([" W ", "LEFT", ""])
+
+    assert state.pressed == frozenset({"w", "left"})
+
+
+def test_differential_mapper_emits_delta_to_forward_left_target():
+    """Hold-to-command mapping should emit velocity deltas toward the target."""
+    mapper = DifferentialDriveKeyboardMapper(
+        DifferentialDriveSettings(max_linear_speed=2.0, max_angular_speed=1.0)
+    )
+
+    action = mapper.map_action(["w", "a"], current_velocity=(0.5, 0.25))
+
+    assert action == (1.5, 0.75)
+
+
+def test_differential_mapper_releases_to_stop():
+    """No movement keys should command a delta back to zero velocity."""
+    mapper = DifferentialDriveKeyboardMapper()
+
+    action = mapper.map_action([], current_velocity=(1.0, -0.5))
+
+    assert action == (-1.0, 0.5)
+
+
+def test_differential_mapper_blocks_reverse_unless_enabled():
+    """Backward key should brake when reverse driving is disabled."""
+    mapper = DifferentialDriveKeyboardMapper(DifferentialDriveSettings(allow_backwards=False))
+
+    action = mapper.map_action(["s"], current_velocity=(0.5, 0.0))
+
+    assert action == (-0.5, 0.0)
+
+
+def test_differential_mapper_allows_reverse_when_configured():
+    """Backward key should target negative max speed when reverse is enabled."""
+    mapper = DifferentialDriveKeyboardMapper(
+        DifferentialDriveSettings(max_linear_speed=2.0, allow_backwards=True)
+    )
+
+    action = mapper.map_action(["down"], current_velocity=(0.5, 0.0))
+
+    assert action == (-2.5, 0.0)
+
+
+def test_differential_mapper_metadata_versions_recordings():
+    """Mapper metadata should identify the control mode for manifests."""
+    metadata = DifferentialDriveKeyboardMapper().metadata()
+
+    assert metadata["input_mapping_version"] == "manual_keyboard_diff_drive_hold_v1"
+    assert metadata["control_mode"] == "keyboard_hold"
+    assert metadata["robot_action_space"] == "differential_drive"
+
+
+def test_mapper_for_robot_config_selects_differential_drive_mapper():
+    """Manual mapper selection should support the MVP differential-drive path."""
+    mapper = mapper_for_robot_config(DifferentialDriveSettings())
+
+    assert isinstance(mapper, DifferentialDriveKeyboardMapper)
+
+
+def test_mapper_for_robot_config_fails_closed_for_unsupported_action_space():
+    """Unsupported action spaces should fail closed with the missing mapper named."""
+    try:
+        mapper_for_robot_config(BicycleDriveSettings())
+    except NotImplementedError as exc:
+        assert "BicycleDriveSettings" in str(exc)
+        assert "differential_drive" in str(exc)
+    else:  # pragma: no cover - defensive assertion style for clearer failure
+        raise AssertionError("expected NotImplementedError")

--- a/tests/test_manual_control_manifest.py
+++ b/tests/test_manual_control_manifest.py
@@ -1,0 +1,65 @@
+"""Tests for manual-control session manifests."""
+
+import json
+
+from robot_sf.manual_control.baseline import BaselineMetric, MetricDirection, PolicyBaseline
+from robot_sf.manual_control.manifest import ManualSessionManifest, write_manual_session_manifest
+from robot_sf.manual_control.recording import ManualSessionMetadata
+from robot_sf.manual_control.session import AttemptKey, AttemptProgress
+
+
+def test_manual_session_manifest_serializes_baseline_and_progress():
+    """Manifest should identify baseline, completed attempts, and artifacts."""
+    manifest = ManualSessionManifest(
+        session=ManualSessionMetadata(
+            session_id="session-1",
+            input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+            policy_to_beat="best-policy",
+            policy_to_beat_source="model/registry.yaml",
+        ),
+        baseline=PolicyBaseline(
+            policy_id="best-policy",
+            source="model/registry.yaml",
+            primary_metric="snqi",
+            metrics={
+                "snqi": BaselineMetric(
+                    name="snqi",
+                    value=0.5,
+                    direction=MetricDirection.HIGHER_IS_BETTER,
+                )
+            },
+        ),
+        completed_attempts=(
+            AttemptProgress(
+                key=AttemptKey("scenario-a", 7),
+                retry_count=1,
+                beat_baseline=True,
+                success=True,
+            ),
+        ),
+        artifacts={"records_jsonl": "manual.jsonl"},
+    )
+
+    payload = manifest.to_json_dict()
+
+    assert payload["manifest_schema"] == "manual_control_session_manifest_v1"
+    assert payload["baseline"]["policy_id"] == "best-policy"
+    assert payload["completed_attempts"][0]["scenario_id"] == "scenario-a"
+    assert payload["artifacts"] == {"records_jsonl": "manual.jsonl"}
+
+
+def test_write_manual_session_manifest(tmp_path):
+    """Manifest writer should persist sorted JSON."""
+    manifest = ManualSessionManifest(
+        session=ManualSessionMetadata(
+            session_id="session-1",
+            input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+        )
+    )
+    path = tmp_path / "manifest.json"
+
+    written_path = write_manual_session_manifest(manifest, path)
+
+    assert written_path == path
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["session"]["session_id"] == "session-1"

--- a/tests/test_manual_control_modes.py
+++ b/tests/test_manual_control_modes.py
@@ -33,3 +33,14 @@ def test_ensure_supported_mvp_mode_rejects_unimplemented_view_mode():
             control_mode=ManualControlMode.KEYBOARD_HOLD,
             view_mode=ManualViewMode.EGO_UP,
         )
+
+
+def test_ensure_supported_mvp_mode_accepts_supported_string_inputs():
+    """Public mode guards should accept the serialized MVP string values."""
+    ensure_supported_mvp_mode(control_mode="keyboard_hold", view_mode="fixed_map")
+
+
+def test_ensure_supported_mvp_mode_rejects_unknown_strings() -> None:
+    """Unknown serialized mode values should still fail closed."""
+    with pytest.raises(NotImplementedError, match="joystick"):
+        ensure_supported_mvp_mode(control_mode="joystick", view_mode="fixed_map")

--- a/tests/test_manual_control_modes.py
+++ b/tests/test_manual_control_modes.py
@@ -1,0 +1,35 @@
+"""Tests for manual-control mode identifiers."""
+
+import pytest
+
+from robot_sf.manual_control.modes import (
+    ManualControlMode,
+    ManualViewMode,
+    ensure_supported_mvp_mode,
+)
+
+
+def test_ensure_supported_mvp_mode_accepts_keyboard_hold_fixed_map():
+    """Current MVP mode pair should be accepted."""
+    ensure_supported_mvp_mode(
+        control_mode=ManualControlMode.KEYBOARD_HOLD,
+        view_mode=ManualViewMode.FIXED_MAP,
+    )
+
+
+def test_ensure_supported_mvp_mode_rejects_unimplemented_control_mode():
+    """Stretch control modes should fail closed until implemented."""
+    with pytest.raises(NotImplementedError, match="mouse_target"):
+        ensure_supported_mvp_mode(
+            control_mode=ManualControlMode.MOUSE_TARGET,
+            view_mode=ManualViewMode.FIXED_MAP,
+        )
+
+
+def test_ensure_supported_mvp_mode_rejects_unimplemented_view_mode():
+    """Stretch view modes should fail closed until implemented."""
+    with pytest.raises(NotImplementedError, match="ego_up"):
+        ensure_supported_mvp_mode(
+            control_mode=ManualControlMode.KEYBOARD_HOLD,
+            view_mode=ManualViewMode.EGO_UP,
+        )

--- a/tests/test_manual_control_recording.py
+++ b/tests/test_manual_control_recording.py
@@ -1,0 +1,103 @@
+"""Tests for manual-control JSONL recording contracts."""
+
+import json
+
+from robot_sf.manual_control.recording import (
+    ManualControlRecord,
+    ManualJsonlRecorder,
+    ManualSessionMetadata,
+    load_manual_jsonl_records,
+)
+from robot_sf.manual_control.session import AttemptKey
+
+
+def test_manual_control_record_serializes_schema_and_session_metadata():
+    """Manual records should keep session and attempt metadata together."""
+    session = ManualSessionMetadata(
+        session_id="session-1",
+        input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+        policy_to_beat="best-policy",
+        policy_to_beat_source="model/registry.yaml",
+    )
+
+    record = ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=2,
+        step_idx=3,
+        session=session,
+        input_keys=["w"],
+        mapped_action=(1.0, 0.0),
+        observation={"positions": [[1.0, 2.0]]},
+        training_sample=True,
+    )
+
+    payload = record.to_json_dict()
+
+    assert payload["record_schema"] == "manual_control_v1"
+    assert payload["scenario_id"] == "scenario-a"
+    assert payload["seed"] == 7
+    assert payload["attempt_id"] == 2
+    assert payload["session"]["policy_to_beat_source"] == "model/registry.yaml"
+    assert payload["training_sample"] is True
+
+
+def test_manual_jsonl_recorder_appends_records(tmp_path):
+    """ManualJsonlRecorder should append one JSON object per line."""
+    path = tmp_path / "manual.jsonl"
+    session = ManualSessionMetadata(
+        session_id="session-1",
+        input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+    )
+    record = ManualControlRecord.for_attempt(
+        event="pause",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=0,
+        step_idx=5,
+        session=session,
+        training_sample=False,
+    )
+
+    with ManualJsonlRecorder(path) as recorder:
+        recorder.write(record)
+
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert rows == [record.to_json_dict()]
+
+
+def test_load_manual_jsonl_records_round_trips_records(tmp_path):
+    """Manual JSONL records should load back into dataclass records."""
+    path = tmp_path / "manual.jsonl"
+    session = ManualSessionMetadata(
+        session_id="session-1",
+        input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+    )
+    record = ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=0,
+        step_idx=5,
+        session=session,
+        input_keys=["w"],
+        mapped_action=(1.0, 0.0),
+        observation={"obs": [1]},
+        training_sample=True,
+    )
+    path.write_text(json.dumps(record.to_json_dict()) + "\n", encoding="utf-8")
+
+    loaded = load_manual_jsonl_records(path)
+
+    assert loaded == [record]
+
+
+def test_load_manual_jsonl_records_rejects_unsupported_schema(tmp_path):
+    """Manual JSONL loading should fail closed for schema drift."""
+    path = tmp_path / "manual.jsonl"
+    path.write_text(json.dumps({"record_schema": "legacy"}) + "\n", encoding="utf-8")
+
+    try:
+        load_manual_jsonl_records(path)
+    except ValueError as exc:
+        assert "unsupported manual-control record schema" in str(exc)
+    else:  # pragma: no cover - defensive assertion style for clearer failure
+        raise AssertionError("expected ValueError")

--- a/tests/test_manual_control_recording.py
+++ b/tests/test_manual_control_recording.py
@@ -1,6 +1,10 @@
 """Tests for manual-control JSONL recording contracts."""
 
 import json
+from pathlib import Path
+
+import numpy as np
+import pytest
 
 from robot_sf.manual_control.recording import (
     ManualControlRecord,
@@ -101,3 +105,74 @@ def test_load_manual_jsonl_records_rejects_unsupported_schema(tmp_path):
         assert "unsupported manual-control record schema" in str(exc)
     else:  # pragma: no cover - defensive assertion style for clearer failure
         raise AssertionError("expected ValueError")
+
+
+def test_manual_control_record_serializes_numpy_values_and_paths() -> None:
+    """Manual record payloads should convert NumPy values and paths before JSON dumps."""
+    session = ManualSessionMetadata(
+        session_id="session-1",
+        input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+    )
+    record = ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=2,
+        step_idx=3,
+        session=session,
+        observation={
+            "positions": np.array([[1.0, 2.0]], dtype=np.float32),
+            "score": np.float32(0.5),
+            "artifact": Path("output/manual/demo.jsonl"),
+        },
+        metrics={"snqi": np.float64(0.75)},
+        training_sample=True,
+    )
+
+    payload = record.to_json_dict()
+    encoded = json.loads(json.dumps(payload))
+
+    assert encoded["observation"]["positions"] == [[1.0, 2.0]]
+    assert encoded["observation"]["score"] == pytest.approx(0.5)
+    assert encoded["observation"]["artifact"] == "output/manual/demo.jsonl"
+    assert encoded["metrics"]["snqi"] == pytest.approx(0.75)
+
+
+def test_load_manual_jsonl_records_validates_view_mode_and_training_sample(tmp_path):
+    """Manual JSONL loading should fail closed on invalid mode and sample types."""
+    path = tmp_path / "manual.jsonl"
+    record = ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey("scenario-a", 7),
+        attempt_id=0,
+        step_idx=5,
+        session=ManualSessionMetadata(
+            session_id="session-1",
+            input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+        ),
+        training_sample=True,
+    ).to_json_dict()
+
+    record["session"]["view_mode"] = "panorama"
+    path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported manual-control view mode"):
+        load_manual_jsonl_records(path)
+
+    record["session"]["view_mode"] = "fixed_map"
+    record["training_sample"] = "false"
+    path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="training_sample must be a boolean"):
+        load_manual_jsonl_records(path)
+
+
+def test_load_manual_jsonl_records_reports_line_number_for_invalid_payload(tmp_path):
+    """Manual JSONL loading should wrap malformed payloads with their line number."""
+    path = tmp_path / "manual.jsonl"
+    path.write_text(
+        json.dumps({"record_schema": "manual_control_v1", "session": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="manual-control line 1"):
+        load_manual_jsonl_records(path)

--- a/tests/test_manual_control_replay.py
+++ b/tests/test_manual_control_replay.py
@@ -1,0 +1,36 @@
+"""Tests for manual-control replay helpers."""
+
+from robot_sf.manual_control.recording import ManualControlRecord, ManualSessionMetadata
+from robot_sf.manual_control.replay import group_records_by_attempt
+from robot_sf.manual_control.session import AttemptKey
+
+
+def _record(scenario_id: str, seed: int, attempt_id: int, step_idx: int) -> ManualControlRecord:
+    """Build a minimal manual-control record."""
+    return ManualControlRecord.for_attempt(
+        event="step",
+        attempt_key=AttemptKey(scenario_id, seed),
+        attempt_id=attempt_id,
+        step_idx=step_idx,
+        session=ManualSessionMetadata(
+            session_id="session-1",
+            input_mapping_version="manual_keyboard_diff_drive_hold_v1",
+        ),
+    )
+
+
+def test_group_records_by_attempt_orders_attempts_and_steps():
+    """Replay grouping should preserve attempt identity and sort records by step."""
+    records = [
+        _record("scenario-b", 1, 0, 2),
+        _record("scenario-a", 1, 1, 3),
+        _record("scenario-a", 1, 1, 1),
+    ]
+
+    replays = group_records_by_attempt(records)
+
+    assert [(replay.key.scenario_id, replay.key.seed, replay.attempt_id) for replay in replays] == [
+        ("scenario-a", 1, 1),
+        ("scenario-b", 1, 0),
+    ]
+    assert [record.step_idx for record in replays[0].records] == [1, 3]

--- a/tests/test_manual_control_session.py
+++ b/tests/test_manual_control_session.py
@@ -1,5 +1,7 @@
 """Tests for manual-control session state management."""
 
+import math
+
 import pytest
 
 from robot_sf.manual_control.session import ManualSessionController, ManualSessionState
@@ -67,3 +69,12 @@ def test_speed_multiplier_must_be_positive():
 
     with pytest.raises(ValueError, match="positive"):
         controller.set_speed_multiplier(0)
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_speed_multiplier_must_be_finite(value: float) -> None:
+    """Speed multipliers should reject non-finite values."""
+    controller = ManualSessionController()
+
+    with pytest.raises(ValueError, match="positive"):
+        controller.set_speed_multiplier(value)

--- a/tests/test_manual_control_session.py
+++ b/tests/test_manual_control_session.py
@@ -1,0 +1,69 @@
+"""Tests for manual-control session state management."""
+
+import pytest
+
+from robot_sf.manual_control.session import ManualSessionController, ManualSessionState
+
+
+def test_session_starts_with_countdown_then_runs():
+    """Starting an attempt should gate stepping behind the countdown."""
+    controller = ManualSessionController(countdown_steps=2)
+
+    attempt = controller.start_attempt("scenario-a", 7)
+
+    assert attempt.retry_count == 0
+    assert controller.state == ManualSessionState.COUNTDOWN
+    assert controller.should_step is False
+    assert controller.advance_countdown() == ManualSessionState.COUNTDOWN
+    assert controller.advance_countdown() == ManualSessionState.RUNNING
+    assert controller.should_step is True
+
+
+def test_session_pause_resume_toggles_stepping():
+    """Pause and resume should only affect running attempts."""
+    controller = ManualSessionController(countdown_steps=0)
+    controller.start_attempt("scenario-a", 7)
+
+    assert controller.toggle_pause() == ManualSessionState.PAUSED
+    assert controller.should_step is False
+    assert controller.toggle_pause() == ManualSessionState.RUNNING
+    assert controller.should_step is True
+
+
+def test_terminal_attempt_tracks_unresolved_when_baseline_not_beaten():
+    """Terminal attempts should record unresolved scenario/seeds."""
+    controller = ManualSessionController(countdown_steps=0)
+    attempt = controller.start_attempt("scenario-a", 7)
+
+    result = controller.mark_terminal(
+        success=False,
+        beat_baseline=False,
+        failure_reason="collision",
+    )
+
+    assert result is attempt
+    assert controller.state == ManualSessionState.TERMINAL
+    assert controller.completed[attempt.key].failure_reason == "collision"
+    assert controller.unresolved[attempt.key].beat_baseline is False
+
+
+def test_terminal_attempt_clears_unresolved_when_baseline_is_beaten():
+    """A later successful retry should clear the unresolved case."""
+    controller = ManualSessionController(countdown_steps=0)
+    attempt = controller.start_attempt("scenario-a", 7)
+    controller.mark_terminal(success=False, beat_baseline=False, failure_reason="timeout")
+    retry = controller.retry_active()
+
+    controller.mark_terminal(success=True, beat_baseline=True)
+
+    assert retry.retry_count == 1
+    assert attempt.key not in controller.unresolved
+    assert controller.completed[attempt.key].beat_baseline is True
+
+
+def test_speed_multiplier_must_be_positive():
+    """Speed multipliers should fail closed for invalid values."""
+    controller = ManualSessionController()
+
+    with pytest.raises(ValueError, match="positive"):
+        controller.set_speed_multiplier(0)


### PR DESCRIPTION
## Summary
Adds manual-control MVP foundations: keyboard-hold differential-drive input mapping, session/attempt state, append-only JSONL recording, replay grouping, manifest writing, baseline comparison, and behavior-cloning sample export helpers.

## Linked Issues
- Relates to #1151
- Foundation slice only; #1151 remains open for the interactive Pygame runner, UI controls, overlays, runner wiring, and end-to-end session artifact path.
- Relates to #1152
- Relates to #1153
- Relates to #1154

## What Changed
- Added `robot_sf/manual_control/` with pure helpers for input mapping, supported modes, session lifecycle, recording, replay grouping, manifest generation, baseline comparison, and demonstration export.
- Added `scripts/manual_control/export_bc_samples.py` for converting manual-control JSONL recordings into compact BC-sample JSONL.
- Added context notes for the manual-control MVP foundation and the separate web-game data-collection path.
- Added focused tests for every new helper surface and the export CLI.

## Why It Matters
- Added value: creates the schema-safe, testable foundation needed before adding interactive pygame UI or web-game collection surfaces.
- Expected impact: manual-control data collection can be built on stable recording/export primitives instead of ad-hoc logs.
- Why this is worth merging now: this PR is intentionally non-UI and keeps the first slice reviewable while unblocking follow-up manual-control work.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_manual_control_*.py -q`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Targeted tests: 32 passed in 6.34s after style/docstring cleanup.
  - PR readiness: 3385 passed, 18 skipped, 6 warnings in 256.63s.
  - Freshness stamp: `output/validation/pr_ready/issue-1151-manual-control-foundations.json` for head `da0e0a1d28e07c4a6fa931e0040c5fb25fc63458`.
- Benchmarks or smoke tests, if applicable: no benchmark result claim; this PR adds manual-control data/schema foundations only.

## Risks / Rollout
- Compatibility risks: low. This is a new package and CLI.
- Failure modes: unsupported control/view modes fail closed until explicit mapper/view implementations are added.
- Rollback or fallback plan: revert this PR; no existing runtime path depends on it by default.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1151_manual_control_mvp_foundation.md`
  - `docs/context/issue_1154_web_game_data_collection_path.md`
- Relevant design or provenance notes: this intentionally supports keyboard-hold + fixed-map + differential-drive only; steering/view/replay/web-game UX remain follow-up work.
- Any assumptions that need to be preserved: generated coverage output and PR-readiness stamps under `output/` are local validation byproducts and should remain ignored, not promoted as durable artifacts.

## Follow-Up Issues
- Deferred work: #1152 steering/view experiments, #1153 rewind/replay/storage optimization, and #1154 web-game collection path are related but not closed by this foundation PR.
- Issues opened for follow-up: none; existing issues already cover the deferred surfaces.

## Reviewer Notes
- Anything a reviewer should verify closely: schema shape in `ManualControlRecord`, fail-closed mode checks, and BC export assumptions.
- Any known limitations: no interactive pygame UI is included in this PR; changed-file coverage has warning-only gaps but full PR readiness passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual control framework with keyboard input mapping, session state/controller, append-only JSONL recording, replay grouping, BC sample export CLI, baseline comparison, and session manifest generation.

* **Documentation**
  * Added manual-control MVP foundation doc and web-game data collection roadmap; updated docs index and changelog.

* **Tests**
  * Added comprehensive pytest coverage for mapping, recording, export, replay, manifest, baseline, modes, and session controller behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1166)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
