### PR TITLE
docs: clarify runtime docstrings (#1145)

### DIFF
--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -42,11 +42,11 @@ class BicycleDriveState:
 
     @property
     def pos(self) -> Vec2D:
-        """TODO docstring. Document this function.
+        """Return the current 2D position.
 
 
         Returns:
-            TODO docstring.
+            The ``(x, y)`` position component of the bicycle pose.
         """
         return self.pose[0]
 

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -132,16 +132,16 @@ class BicycleDriveRobot:
     movement: BicycleMotion = field(init=False)
 
     def __post_init__(self):
-        """TODO docstring. Document this function."""
+        """Create the motion helper bound to this robot's drive settings."""
         self.movement = BicycleMotion(self.config)
 
     @property
     def observation_space(self) -> spaces.Box:
-        """TODO docstring. Document this function.
-
+        """Return the bounded observation space for velocity and steering state.
 
         Returns:
-            TODO docstring.
+            A Box with lower and upper bounds derived from the configured velocity
+            and steering limits.
         """
         high = np.array([self.config.max_velocity, self.config.max_steer], dtype=np.float32)
         low = np.array([self.config.min_velocity, -self.config.max_steer], dtype=np.float32)
@@ -149,11 +149,11 @@ class BicycleDriveRobot:
 
     @property
     def action_space(self) -> spaces.Box:
-        """TODO docstring. Document this function.
-
+        """Return the bounded action space for acceleration and steering commands.
 
         Returns:
-            TODO docstring.
+            A Box with lower and upper bounds derived from the configured
+            acceleration and steering limits.
         """
         high = np.array([self.config.max_accel, self.config.max_steer], dtype=np.float32)
         low = np.array([-self.config.max_accel, -self.config.max_steer], dtype=np.float32)
@@ -161,31 +161,28 @@ class BicycleDriveRobot:
 
     @property
     def pos(self) -> Vec2D:
-        """TODO docstring. Document this function.
-
+        """Return the current 2D position of the robot.
 
         Returns:
-            TODO docstring.
+            The ``(x, y)`` position from the current bicycle-drive pose.
         """
         return self.state.pose[0]
 
     @property
     def pose(self) -> RobotPose:
-        """TODO docstring. Document this function.
-
+        """Return the full robot pose.
 
         Returns:
-            TODO docstring.
+            The current ``((x, y), theta)`` pose tuple.
         """
         return self.state.pose
 
     @property
     def current_speed(self) -> PolarVec2D:
-        """TODO docstring. Document this function.
-
+        """Return the robot's scalar speed paired with its current heading.
 
         Returns:
-            TODO docstring.
+            The current speed/orientation tuple exposed by the drive state.
         """
         return self.state.current_speed
 
@@ -207,12 +204,12 @@ class BicycleDriveRobot:
         self.state = BicycleDriveState(new_pose, 0)
 
     def parse_action(self, action: np.ndarray) -> BicycleAction:
-        """Reset vehicle to initial state.
+        """Convert a raw action array into the bicycle-drive action tuple.
 
         Args:
-            action: Unused action (kept for interface compatibility)
+            action: Array-like acceleration and steering command.
 
         Returns:
-            Initial observation dictionary
+            The ``(acceleration, steering_angle)`` tuple used by the drive model.
         """
         return (action[0], action[1])

--- a/robot_sf/sensor/goal_sensor.py
+++ b/robot_sf/sensor/goal_sensor.py
@@ -1,4 +1,4 @@
-"""TODO docstring. Document this module."""
+"""Goal-relative observation helpers for robot target sensors."""
 
 from math import atan2, dist
 
@@ -11,13 +11,13 @@ TARGET_DISTANCE_CAP_M = 50.0
 
 
 def norm_angle(angle: float) -> float:
-    """TODO docstring. Document this function.
+    """Normalize an angle to the ``[-pi, pi)`` interval.
 
     Args:
-        angle: TODO docstring.
+        angle: Angle in radians.
 
     Returns:
-        TODO docstring.
+        Equivalent wrapped angle in radians.
     """
     return (angle + np.pi) % (2 * np.pi) - np.pi
 

--- a/robot_sf/sim/backends/dummy_backend.py
+++ b/robot_sf/sim/backends/dummy_backend.py
@@ -18,10 +18,10 @@ class DummySimulator:
     """Minimal simulator that returns constant positions for testing."""
 
     def __init__(self, seed: int = 0):
-        """TODO docstring. Document this function.
+        """Initialize the deterministic dummy simulator.
 
         Args:
-            seed: TODO docstring.
+            seed: Seed used to reset the dummy random-number generator.
         """
         self.seed = seed
         self.rng = np.random.default_rng(seed)

--- a/robot_sf/sim/fast_pysf_wrapper.py
+++ b/robot_sf/sim/fast_pysf_wrapper.py
@@ -39,10 +39,10 @@ class FastPysfWrapper:
     """
 
     def __init__(self, simulator: pysf.Simulator):
-        """TODO docstring. Document this function.
+        """Wrap a PySocialForce simulator for force queries.
 
         Args:
-            simulator: TODO docstring.
+            simulator: Active PySocialForce simulator instance to query.
         """
         self.sim = simulator
         # Named caches for precomputed force grids. Each cache is a dict with
@@ -184,14 +184,14 @@ class FastPysfWrapper:
 
     def _compute_robot_force_at_point(self, p: np.ndarray, robot_state: dict) -> np.ndarray:
         # Defensive: try common names for robot interaction functions
-        """TODO docstring. Document this function.
+        """Compute robot-interaction force at a sample point when supported.
 
         Args:
-            p: TODO docstring.
-            robot_state: TODO docstring.
+            p: 2D point where the robot force should be evaluated.
+            robot_state: Backend-specific robot state passed to available force helpers.
 
         Returns:
-            TODO docstring.
+            Force vector for the point, or zeros when no compatible helper is available.
         """
         for name in ("robot_force", "robot_interaction_force_on_point", "force_robot"):
             if hasattr(pf_forces, name):

--- a/robot_sf/sim/registry.py
+++ b/robot_sf/sim/registry.py
@@ -22,12 +22,12 @@ _DEFAULT_PERFORMANCE_SCORE = 1000
 
 
 def register_backend(key: str, factory: SimulatorFactory, *, override: bool = False) -> None:
-    """TODO docstring. Document this function.
+    """Register a simulator backend factory under a string key.
 
     Args:
-        key: TODO docstring.
-        factory: TODO docstring.
-        override: TODO docstring.
+        key: Backend identifier used by factory and configuration code.
+        factory: Callable that creates a simulator facade for this backend.
+        override: Replace an existing registration when ``True``.
     """
     k = key.strip()
     if not k:
@@ -44,13 +44,13 @@ def register_backend(key: str, factory: SimulatorFactory, *, override: bool = Fa
 
 
 def get_backend(key: str) -> SimulatorFactory:
-    """TODO docstring. Document this function.
+    """Return the simulator backend factory registered for ``key``.
 
     Args:
-        key: TODO docstring.
+        key: Backend identifier to resolve.
 
     Returns:
-        TODO docstring.
+        Registered simulator factory.
     """
     try:
         return _REGISTRY[key]
@@ -60,11 +60,11 @@ def get_backend(key: str) -> SimulatorFactory:
 
 
 def list_backends() -> list[str]:
-    """TODO docstring. Document this function.
+    """List registered simulator backend keys.
 
 
     Returns:
-        TODO docstring.
+        Backend keys sorted lexicographically.
     """
     return sorted(_REGISTRY.keys())
 
@@ -101,13 +101,13 @@ def select_best_backend(preferred: str | None = None) -> str:
         )
 
     def _score(name: str) -> tuple[int, str]:
-        """TODO docstring. Document this function.
+        """Return the backend preference score used for automatic selection.
 
         Args:
-            name: TODO docstring.
+            name: Registered backend key.
 
         Returns:
-            TODO docstring.
+            Tuple ordered by performance preference, then name for stable ties.
         """
         return (_BACKEND_PERFORMANCE_ORDER.get(name, _DEFAULT_PERFORMANCE_SCORE), name)
 

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -1,4 +1,4 @@
-"""TODO docstring. Document this module."""
+"""Configuration dataclasses for simulator timing and pedestrian behavior."""
 
 from dataclasses import dataclass, field
 from math import ceil
@@ -110,20 +110,20 @@ class SimulationSettings:
 
     @property
     def max_sim_steps(self) -> int:
-        """TODO docstring. Document this function.
+        """Return the maximum number of fixed-time simulation steps.
 
 
         Returns:
-            TODO docstring.
+            Ceiling of episode duration divided by step duration.
         """
         return ceil(self.sim_time_in_secs / self.time_per_step_in_secs)
 
     @property
     def peds_per_area_m2(self) -> float:
-        """TODO docstring. Document this function.
+        """Return the pedestrian density for the configured difficulty.
 
 
         Returns:
-            TODO docstring.
+            Pedestrians per square meter selected from ``ped_density_by_difficulty``.
         """
         return self.ped_density_by_difficulty[self.difficulty]

--- a/robot_sf/tb_logging.py
+++ b/robot_sf/tb_logging.py
@@ -52,11 +52,11 @@ class BaseMetricsCallback(BaseCallback):
 
     # Define an abstract method for _on_step() if needed
     def _on_step(self) -> bool:
-        """TODO docstring. Document this function.
+        """Process one callback step in concrete metric loggers.
 
 
         Returns:
-            TODO docstring.
+            True to continue training, False to request early stopping.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary
- Replace placeholder TODO-style docstrings with concrete behavior descriptions in seven public/runtime modules.
- Keep the change docstring-only: no runtime logic, API, config, or test behavior is changed.

Closes #1145

## Validation
- `uv run ruff check robot_sf/robot/bicycle_drive.py robot_sf/sensor/goal_sensor.py robot_sf/sim/backends/dummy_backend.py robot_sf/sim/fast_pysf_wrapper.py robot_sf/sim/registry.py robot_sf/sim/sim_config.py robot_sf/tb_logging.py` -> passed
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> 3353 passed, 18 skipped, 6 warnings in 262.55s
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` -> passed for head `4cac25a72b37206e6bfcd7cb424f05c3856f05a9`

## Artifacts
- Generated ignored local validation outputs under `output/coverage/` and `output/validation/pr_ready/`; no durable artifact is required for this docstring-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docstrings across the simulation framework—covering drive state, sensor helpers, simulator backends, wrapper utilities, backend registry APIs, configuration properties, and metric logging callbacks—clarifying behavior, arguments, return values, and initialization semantics to improve clarity and usability for integrators and maintainers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1170)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->