### PR TITLE
docs: capture open issues implementation handoff

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,9 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 
 * **[Development Guide](./dev_guide.md)** - Primary reference for development workflows, setup, testing, quality gates, and coding standards
 * **[Context Notes Workflow](./context/README.md)** - Canonical rules for linked Markdown handoff notes, note updates vs new notes, stale-note handling, and discoverability
+* **[Open-Issues Implementation Status](./context/open_issues_implementation_status_2026-05-12.md)** - Handoff record for the May 2026 open-issues pass, including implemented slices, blocked items, and remaining follow-up surface
+* **[Open-Issues Maintainer Input Triage](./context/open_issues_maintainer_input_triage.md)** - Consolidated maintainer-decision inventory for open issues that still need scope, contract, or prioritization guidance
+* **[Open-Issues PR Split Strategy](./context/open_issues_pr_split_strategy_2026-05-13.md)** - PR packaging strategy and validation grouping for the open-issues implementation pass
 * **[Project Prioritization](./project_prioritization.md)** - Priority-score model, Project #5 field semantics, and the local/manual score-sync workflow
 * **[GitHub Workflow Batching](./context/issue_713_batch_first_issue_workflow.md)** - Batch issue cleanup first, defer Project #5 routing, and run derived score sync last
 * **[Policy Search Portfolio Overview](./context/policy_search/portfolio_overview_2026-05-05.md)** - Current non-training policy-search portfolio ranking, promotion status, and h500 horizon evidence pointers

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -80,6 +80,10 @@ knowledge, not every transient iteration detail.
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
 * Route-clearance certification: [issue_1105_route_clearance_certification.md](issue_1105_route_clearance_certification.md)
 * Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)
+* Open-issues implementation status:
+  [open_issues_implementation_status_2026-05-12.md](open_issues_implementation_status_2026-05-12.md)
+* Open-issues maintainer-input triage:
+  [open_issues_maintainer_input_triage.md](open_issues_maintainer_input_triage.md)
 * Open-issues PR split strategy:
   [open_issues_pr_split_strategy_2026-05-13.md](open_issues_pr_split_strategy_2026-05-13.md)
 * Note-maintenance skill:

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -80,6 +80,8 @@ knowledge, not every transient iteration detail.
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
 * Route-clearance certification: [issue_1105_route_clearance_certification.md](issue_1105_route_clearance_certification.md)
 * Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)
+* Open-issues PR split strategy:
+  [open_issues_pr_split_strategy_2026-05-13.md](open_issues_pr_split_strategy_2026-05-13.md)
 * Note-maintenance skill:
   [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 

--- a/docs/context/open_issues_implementation_status_2026-05-12.md
+++ b/docs/context/open_issues_implementation_status_2026-05-12.md
@@ -1,0 +1,223 @@
+# Open issues implementation status pass
+
+Date: 2026-05-12
+
+## Scope
+
+This note summarizes the broad open-issue implementation pass that touched multiple low-risk slices across environment cleanup, manual-control foundations, planner features, visibility filtering, multi-AMV records, CARLA parity tooling, and documentation cleanup.
+
+No validation commands were run during this pass.
+
+## Implemented / partially implemented slices
+
+### #1150 / #1141 / #1146 legacy env cleanup
+
+Implemented:
+
+- Added `robot_sf/gym_env/crowd_sim_env.py` with `CrowdSimulationConfig` and `CrowdSimEnv`.
+- Added `make_crowd_sim_env(...)` to `robot_sf/gym_env/environment_factory.py`.
+- Removed `robot_sf/gym_env/simple_robot_env.py`.
+- Removed `robot_sf/gym_env/empty_robot_env.py` after replacing the useful crowd-only capability.
+- Added `tests/test_crowd_sim_env_contract.py`.
+- Updated refactoring docs and factory signature tests for the new crowd env surface.
+
+Remaining:
+
+- Run targeted env/factory tests.
+- Decide whether to close or split any remaining broad #1150 follow-ups after validation.
+
+### #1142 video FPS
+
+Implemented:
+
+- `SimulationView` now uses effective target FPS for video encoding when explicit `video_fps` is not set.
+- Added targeted coverage in `tests/visuals/test_sim_view_coverage_paths.py`.
+
+Remaining:
+
+- Run visual targeted tests.
+
+### #1143 / #1149 sensor history
+
+Implemented:
+
+- Documented SensorFusion temporal stack order as oldest-to-newest, current sample at `[-1]`.
+- Added shared `append_history_row(...)` helper and used it in both sensor fusion classes.
+- Added focused SensorFusion stack test.
+
+Remaining:
+
+- Run targeted sensor tests.
+
+### #1144 WheelSpeedState units
+
+Implemented:
+
+- Documented `WheelSpeedState` as left/right wheel angular velocities in radians per second.
+- Added targeted differential-drive test.
+
+Remaining:
+
+- Run targeted differential-drive tests.
+
+### #1145 TODO docstring cleanup
+
+Implemented:
+
+- Replaced clear TODO docstrings in several public modules touched or inspected during this pass, including goal sensor, simulator registry/config helpers, dummy backend, TensorBoard logging callback, fast-pysf wrapper, bicycle state, and render helper docstrings.
+
+Remaining:
+
+- Broad repository-wide placeholder cleanup remains out of scope for this pass.
+
+### #1147 classic_benchmark_full fail-closed
+
+Implemented:
+
+- Added `FullBenchmarkUnavailableError` fallback and CLI exit-code handling.
+- Added targeted CLI test for actionable stderr/no traceback behavior.
+
+Remaining:
+
+- Run benchmark-full CLI targeted tests.
+
+### #1148 env constructor defaults
+
+Implemented:
+
+- Changed env constructors touched in this pass to avoid shared config instance defaults.
+- Added constructor signature regression test.
+
+Remaining:
+
+- Run factory/signature tests.
+
+### #1151 / #1152 / #1153 / #1154 manual-control foundations
+
+Implemented:
+
+- Added `robot_sf/manual_control/` package foundations:
+  - `input_mapping.py`
+  - `modes.py`
+  - `session.py`
+  - `recording.py`
+  - `baseline.py`
+  - `export.py`
+  - `replay.py`
+  - `manifest.py`
+- Added CLI `scripts/manual_control/export_bc_samples.py`.
+- Added focused tests for input mapping, modes, session state, recording, baseline comparison, BC export, replay grouping, manifests, and export CLI.
+- Added context note `docs/context/issue_1151_manual_control_mvp_foundation.md`.
+- Added web-game context note `docs/context/issue_1154_web_game_data_collection_path.md` earlier in the pass.
+
+Remaining:
+
+- Implement the actual Pygame manual-control runner.
+- Wire runner events to session controller, mapper, recorder, manifest, and renderer overlays.
+- Validate the schema end to end before web-game work.
+- Implement alternate steering/view modes, rewind, and visual replay in follow-up passes.
+
+### #1138 predictive obstacle features
+
+Implemented:
+
+- Added `robot_sf/planner/obstacle_features.py` with deterministic `predictive_obstacle_features_v1` extractor.
+- Added schema metadata validation and `append_obstacle_features(...)` composition helper.
+- Added tests in `tests/planner/test_obstacle_features.py`.
+- Added context note `docs/context/issue_1138_predictive_obstacle_features_schema.md`.
+
+Remaining:
+
+- Wire collection, training/evaluation, checkpoint metadata, and runtime inference to the shared schema.
+- Add config-first runnable path only after lifecycle wiring exists.
+
+### #1124 dynamic pedestrian occlusion
+
+Implemented:
+
+- Added `dynamic_pedestrian_occlusion_mask(...)` helper.
+- Added opt-in `ObservationVisibilitySettings.dynamic_occlusion`, scenario-loader parsing, metadata propagation, and SocNav observation filtering.
+- Added tests for helper semantics, observation filtering, and scenario parsing.
+- Added context note `docs/context/issue_1124_dynamic_pedestrian_occlusion_contract.md`.
+
+Remaining:
+
+- Run targeted visibility tests and visibility smoke.
+
+### #1128 multi-AMV episode extension
+
+Implemented:
+
+- Added `multi_amv_episode_extension(...)` for additive namespaced multi-AMV episode blocks.
+- Updated `scripts/validation/run_multi_amv_smoke.py` to emit the same block.
+- Added tests in `tests/benchmark/test_multi_amv.py`.
+- Added context note `docs/context/issue_1128_multi_amv_episode_extension.md`.
+
+Remaining:
+
+- Integrate multi-AMV into primary benchmark command path or a documented equivalent.
+- Add aggregate report support.
+
+### #1110 / #872 CARLA parity tooling
+
+Implemented:
+
+- Added import-safe `robot_sf/carla_bridge/parity.py` and package export.
+- Added CLI `scripts/carla_bridge/compare_oracle_replay_metrics.py`.
+- Added tests under `tests/carla_bridge/`.
+- Added context note `docs/context/issue_1110_carla_oracle_replay_parity_adapter.md`.
+
+Remaining:
+
+- Wire to actual CARLA/Robot-SF replay artifact shapes after #1111 live smoke output exists.
+
+## Blocked or execution-only issues
+
+### #1119 Docker reproduction smoke
+
+Blocked on Docker-capable host/runner and digest/checksum evidence.
+
+### #1111 live CARLA T1 replay smoke
+
+Blocked on CARLA-capable host/runtime.
+
+### #1134 SocNavBench ETH map conversion
+
+Blocked on official SocNavBench/S3DIS ETH source assets staged locally with checksums.
+
+### #1126 SDD-derived scenario curation
+
+Blocked on official SDD source data staging, scene/video selection, scale assumptions, and importer run.
+
+### #1108 BC warm-start PPO experiment
+
+Execution/artifact task. Requires real BC pretraining, PPO fine-tuning, durable artifact promotion, and policy-analysis comparison.
+
+## Required validation before PR handoff
+
+At minimum, run targeted tests covering touched surfaces:
+
+```bash
+uv run pytest \
+  tests/test_crowd_sim_env_contract.py \
+  tests/test_environment_factory_signatures.py \
+  tests/differential_drive_test.py \
+  tests/test_sensor_fusion_stack.py \
+  tests/test_manual_control_*.py \
+  tests/planner/test_obstacle_features.py \
+  tests/test_socnav_dynamic_occlusion.py \
+  tests/test_socnav_observation.py \
+  tests/training/test_scenario_loader.py \
+  tests/benchmark/test_multi_amv.py \
+  tests/carla_bridge/test_parity.py \
+  tests/carla_bridge/test_parity_cli.py \
+  tests/visuals/test_sim_view_coverage_paths.py \
+  tests/benchmark_full/test_classic_benchmark_full_cli.py \
+  -q
+```
+
+Before PR handoff, run the repository PR readiness gate after syncing with latest `origin/main`.
+
+## Validation status
+
+No validation commands have been run during this pass.

--- a/docs/context/open_issues_maintainer_input_triage.md
+++ b/docs/context/open_issues_maintainer_input_triage.md
@@ -28,7 +28,10 @@ Initial recommendation:
 Deprecate first, then remove later if no external callers surface. Prefer folding #1141/#1146 into #1150 rather than implementing another active env path.
 
 Decision:
-Pending.
+Decided for this pass. Use `make_crowd_sim_env` as the replacement crowd-simulation
+surface, remove `SimpleRobotEnv`, and do not reuse `EmptyRobotEnv` as the implementation base.
+See the crowd-simulation decision updates below for the detailed factory, API, config,
+observation, recording, rendering, and package-placement contract.
 
 ### 2. SocNavBench ETH source assets
 
@@ -89,7 +92,10 @@ Initial recommendation:
 Opt-in, disabled by default, circular pedestrian body model, nearest pedestrian blocks line-of-sight, binary visibility only for v1.
 
 Decision:
-Pending.
+No longer pending for this pass. The v1 implementation direction is opt-in binary pedestrian
+visibility with the simple circular body model from the initial recommendation, tracked in #1124
+and PR #1159. Reopen maintainer input only if review expands the occlusion model beyond that v1
+scope.
 
 ### 7. SensorFusion temporal ordering
 
@@ -103,7 +109,9 @@ Initial recommendation:
 Oldest-to-newest, current frame at `[-1]`, because current code mostly follows that pattern.
 
 Decision:
-Pending.
+Decided for this pass: stacked sensor tensors are oldest-to-newest, with the current sample at
+`[-1]`. #1143/#1149 are tracked in PR #1157; reopen maintainer input only if review changes that
+ordering contract.
 
 ### 8. Multi-AMV first planner adapter
 

--- a/docs/context/open_issues_maintainer_input_triage.md
+++ b/docs/context/open_issues_maintainer_input_triage.md
@@ -1,0 +1,336 @@
+# Open Issues Maintainer Input Triage
+
+Date: 2026-05-12
+
+Purpose: track open issues where maintainer input is needed before implementation, and record decisions one question at a time.
+
+## Workflow
+
+- Ask one maintainer question at a time.
+- Discuss until the answer is clear.
+- Record the decision here.
+- Move to the next question only after common understanding is reached.
+
+## Current Priority Questions
+
+### 1. Legacy environment lifecycle
+
+Issues:
+- #1150 `refactor: simplify env surface by deprecating or removing legacy env modules`
+- #1141 `bug: complete or deprecate SimpleRobotEnv stub implementation`
+- #1146 `chore: replace mutable default env configuration in SimpleRobotEnv`
+- #1148 `refactor: unify env constructor config defaults and reduce duplicated setup plumbing`
+
+Question:
+Should `SimpleRobotEnv` / `EmptyRobotEnv` be removed, kept with deprecation warnings, or converted to aliases/wrappers?
+
+Initial recommendation:
+Deprecate first, then remove later if no external callers surface. Prefer folding #1141/#1146 into #1150 rather than implementing another active env path.
+
+Decision:
+Pending.
+
+### 2. SocNavBench ETH source assets
+
+Issue:
+- #1134 `bench: convert SocNavBench ETH map after official asset staging`
+
+Question:
+Can the official SocNavBench ETH assets be staged locally, with source path/checksums/license-safe provenance, or should the issue remain blocked?
+
+Decision:
+Pending.
+
+### 3. SDD curation target
+
+Issue:
+- #1126 `bench: curate first real SDD-derived benchmark scenario set`
+
+Question:
+Which real Stanford Drone Dataset scene/video should be curated first, and can the dataset be staged under the repository artifact policy?
+
+Initial recommendation:
+Pick one small canonical scene first and mark it exploratory until validated.
+
+Decision:
+Pending.
+
+### 4. Docker-capable runner
+
+Issue:
+- #1119 `ci: validate Docker benchmark reproduction smoke on Docker-capable runner`
+
+Question:
+Which Docker-capable host or CI runner should run the benchmark reproduction smoke?
+
+Decision:
+Pending.
+
+### 5. CARLA-capable host and version
+
+Issue:
+- #1111 `feat: run live CARLA T1 oracle replay smoke on a CARLA-capable host`
+
+Question:
+Is a CARLA-capable host available, and which CARLA version should be targeted?
+
+Decision:
+Pending.
+
+### 6. Dynamic pedestrian occlusion semantics
+
+Issue:
+- #1124 `bench: add dynamic pedestrian occlusion filtering for planner observations`
+
+Question:
+What dynamic occlusion semantics should v1 use?
+
+Initial recommendation:
+Opt-in, disabled by default, circular pedestrian body model, nearest pedestrian blocks line-of-sight, binary visibility only for v1.
+
+Decision:
+Pending.
+
+### 7. SensorFusion temporal ordering
+
+Issue:
+- #1143 `refactor: define SensorFusion temporal stacking contract for conv extractors`
+
+Question:
+Should stacked sensor tensors be ordered oldest-to-newest or newest-to-oldest?
+
+Initial recommendation:
+Oldest-to-newest, current frame at `[-1]`, because current code mostly follows that pattern.
+
+Decision:
+Pending.
+
+### 8. Multi-AMV first planner adapter
+
+Issue:
+- #1128 `bench: integrate multi-AMV runs into primary benchmark outputs`
+
+Question:
+Which non-trivial planner family should be the first multi-AMV adapter?
+
+Initial recommendation:
+Start with the simplest existing non-RL planner path before expanding.
+
+Decision:
+Pending.
+
+### 9. BC warm-start PPO execution environment
+
+Issue:
+- #1108 `research: run issue-749 BC warm-start PPO experiment`
+
+Question:
+Which execution environment should run the long training job, and where should durable artifacts be promoted?
+
+Decision:
+Pending.
+
+### 10. CARLA bridge packaging strategy
+
+Issue:
+- #872 `feat: CARLA oracle replay bridge`
+
+Question:
+Should the CARLA bridge live as an optional in-repo package or a separate package?
+
+Initial recommendation:
+Optional in-repo package guarded by dependency checks.
+
+Decision:
+Pending.
+
+## Issues That Do Not Currently Need Maintainer Input
+
+- #1149 `refactor: de-duplicate sensor history stack logic between fusion classes`
+- #1147 `bug: make classic_benchmark_full entrypoint fail-closed with actionable behavior`
+- #1145 `technical-debt: reduce TODO docstring placeholders in public modules`
+- #1144 `docs: clarify WheelSpeedState units in differential drive model`
+- #1142 `bug: align visualization video FPS with effective render cadence`
+- #1138 `feat: add deterministic obstacle features for predictive planner baseline`
+- #1110 `bench: compare CARLA oracle replay metrics against Robot-SF traces`
+
+## Decision Log
+
+- 2026-05-12: Maintainer requested one-question-at-a-time workflow. Created this triage note to preserve the assessment and record decisions.
+
+## Decision Update: Legacy environment lifecycle
+
+Date: 2026-05-12
+
+Maintainer clarification:
+- `make_pedestrian_env` is a trainable interface where a robot policy can be loaded and a pedestrian policy can be trained/evaluated against it.
+- The desired `EmptyRobotEnv`-style capability is different: a simple scene runner with only Social Force pedestrians simulated, useful even without a trainable ego-pedestrian interface.
+- The `EmptyRobotEnv` name is unclear; renaming around crowd/social-force simulation makes sense.
+
+Current assessment:
+- `SimpleRobotEnv` appears to be an unfinished Gymnasium/SB3-native sketch. It defines placeholder discrete spaces and no-op `step`, `render`, and `close`, and no references outside refactoring docs/code search were found.
+- `EmptyRobotEnv` should not be removed until the useful social-force-only pedestrian simulation capability is preserved or replaced by a clearly named supported factory path.
+
+Updated recommendation:
+- Remove `SimpleRobotEnv`; maintainer discussion classified it as an abandoned prototype.
+- Replace or rename `EmptyRobotEnv` into a clearer supported surface such as `make_social_force_crowd_env` / `make_crowd_sim_env`, preserving simple Social Force pedestrian simulation.
+- Update #1150/#1141 to reflect this distinction before implementation.
+
+## Decision Update: Crowd simulation factory naming
+
+Date: 2026-05-12
+
+Decision:
+Use `make_crowd_sim_env` as the supported factory entrypoint name for the preserved Social Force pedestrian/crowd simulation capability.
+
+Implication:
+- `EmptyRobotEnv` is replaced by this clearer factory surface.
+- `SimpleRobotEnv` has been removed from the supported target surface.
+
+## Decision Update: Crowd simulation API contract
+
+Date: 2026-05-12
+
+Decision:
+`make_crowd_sim_env` should expose a programmatic `step`/`reset` interface, not only playback/visualization.
+
+Functional intent:
+- Simulate Social Force pedestrians without requiring a robot or trainable ego-pedestrian policy.
+- Support data recording of pedestrian behavior in robot-free scenes.
+- Steps should advance automatically without a meaningful external action.
+- Headless stepping should be as fast as possible; visualization/recording should be optional and opt-in.
+
+Implication:
+- Prefer a Gymnasium-compatible API with an action space that is empty/no-op or otherwise clearly indicates autonomous stepping.
+- Keep visualization separate from the fast path.
+
+## Decision Update: Crowd simulation step action handling
+
+Date: 2026-05-12
+
+Decision:
+`make_crowd_sim_env` should support `step(action=None)`.
+
+Contract:
+- Callers may use `env.step()` for autonomous stepping.
+- Callers may also use Gymnasium-style `env.step(action)`.
+- Since crowd simulation has no external control input, non-`None` actions should be ignored with a warning rather than rejected.
+- The warning should make it clear that pedestrians advance autonomously and action input has no effect.
+
+## Decision Update: EmptyRobotEnv implementation strategy
+
+Date: 2026-05-12
+
+Evidence:
+A repository search for `EmptyRobotEnv` / `empty_robot_env` found no active code or test imports. References are limited to the legacy file itself and historical/refactoring docs.
+
+Decision:
+Do not reuse `EmptyRobotEnv` as the implementation base for `make_crowd_sim_env`.
+
+Implementation direction:
+- Remove `EmptyRobotEnv` as legacy/unreferenced code once `make_crowd_sim_env` exists.
+- Build `make_crowd_sim_env` as a clean implementation for the explicitly discussed Social Force crowd-simulation use case.
+- Update historical/refactoring docs only as needed to avoid stale references.
+
+## Decision Update: Crowd simulation config shape
+
+Date: 2026-05-12
+
+Decision:
+Add a narrow `CrowdSimulationConfig` for `make_crowd_sim_env`.
+
+Contract:
+- Reuse existing primitives such as `SimulationSettings`, `MapDefinitionPool`, map selection, telemetry/recording conventions, and seed/max-step style controls.
+- Do not inherit from robot-centered `EnvSettings` / `RobotSimulationConfig`.
+- Do not inherit from `PedestrianSimulationConfig`, because that config is for trainable ego-pedestrian-vs-robot workflows.
+- Avoid exposing robot, lidar, planner, image-observation, or predictive-foresight fields unless the crowd-only implementation actually needs them.
+
+Rationale:
+A narrow config avoids misleading users into thinking robot/planner/sensor knobs affect robot-free crowd simulation, while still avoiding a fully separate config ecosystem.
+
+## Decision Update: Crowd simulation observation shape
+
+Date: 2026-05-12
+
+Decision:
+`make_crowd_sim_env.reset()` and `make_crowd_sim_env.step()` should return a compact structured observation dict, not the benchmark episode schema.
+
+Initial observation direction:
+- Include pedestrian positions.
+- Include pedestrian velocities when available.
+- Include pedestrian goals/routes when available.
+- Keep benchmark episode export/recording as a separate adapter or optional recording layer.
+
+Rationale:
+The environment API should be lightweight and useful for direct programmatic simulation. Benchmark schemas can be produced from recorded states without forcing the env observation contract to mirror benchmark outputs.
+
+## Decision Update: Crowd simulation static metadata
+
+Date: 2026-05-12
+
+Decision:
+Keep fast stepping lean. Do not repeat static map geometry/obstacles in every `step()` observation.
+
+Contract:
+- `step()` returns dynamic pedestrian state only, plus minimal status fields needed for control flow.
+- Static scene metadata such as map geometry, obstacles, spawn/goal zones, and map id should be available from `reset()` info, env metadata, or a dedicated accessor.
+- Recording/export layers may combine static metadata with dynamic states when producing artifacts.
+
+## Decision Update: Crowd simulation recording scope
+
+Date: 2026-05-12
+
+Decision:
+Include optional JSONL-style recording in v1 of `make_crowd_sim_env`.
+
+Contract:
+- Recording should be opt-in.
+- Default headless stepping remains as fast as possible.
+- Recorded output should support pedestrian-only behavior analysis and later benchmark/artifact adapters.
+- Static metadata should be written once per run/manifest or reset record, not repeated in every step unless explicitly needed.
+
+## Decision Update: Crowd simulation package location
+
+Date: 2026-05-12
+
+Decision:
+Place the v1 crowd simulation env implementation under `robot_sf.gym_env`.
+
+Contract:
+- Add implementation module such as `robot_sf/gym_env/crowd_sim_env.py`.
+- Expose user-facing constructor as `make_crowd_sim_env` from `robot_sf/gym_env/environment_factory.py`.
+- Keep lower-level reusable simulator primitives in `robot_sf.sim` only if/when they naturally emerge.
+
+Rationale:
+The feature has env-style `step`/`reset`, observations, info, optional recording, and optional rendering. It is user-facing environment API, not only backend simulation glue.
+
+## Decision Update: Crowd simulation rendering scope
+
+Date: 2026-05-12
+
+Decision:
+`make_crowd_sim_env` should support rendering in v1.
+
+Contract:
+- Rendering should be optional and opt-in.
+- Default headless stepping remains as fast as possible.
+- Rendering should visualize Social Force pedestrian-only scenes without requiring a robot.
+- Rendering support should not force static map geometry into every step observation.
+- JSONL recording and rendering should be independently configurable.
+
+## Decision Update: Crowd simulation rendering and implementation surface
+
+Date: 2026-05-12
+
+Decision:
+`make_crowd_sim_env` should support rendering in v1 while keeping the default path headless and fast.
+
+Implementation direction:
+- Add a dedicated `CrowdSimEnv` rather than routing through `RobotEnv`.
+- Use `Simulator` with an empty robot list so Social Force pedestrians advance automatically.
+- Keep `step(action=None)` compatible with Gymnasium; non-`None` actions are ignored with a warning.
+- Return compact dynamic pedestrian observations: positions, velocities, current goals, latest forces, and step index.
+- Keep static scene metadata in `reset`/`step` info and optional recording metadata, not in every observation payload.
+- Lazily create `SimulationView` only for `render_mode` or video capture.
+- Pass a robot-free visual state to the renderer so rendering does not invent a fake robot.
+- Include optional compact JSONL recording for reset/step events.

--- a/docs/context/open_issues_pr_split_strategy_2026-05-13.md
+++ b/docs/context/open_issues_pr_split_strategy_2026-05-13.md
@@ -1,0 +1,276 @@
+# Open Issues PR Split Strategy (2026-05-13)
+
+## Goal
+
+Split the current broad open-issues implementation pass into reviewable branches and PRs instead of
+merging the mixed local state directly.
+
+This note is the handoff surface for extracting the current WIP snapshot into scoped PRs. It should
+be read together with:
+
+- `docs/context/open_issues_maintainer_input_triage.md`
+- `docs/context/open_issues_implementation_status_2026-05-12.md`
+- `docs/dev_guide.md`
+- `docs/context/README.md`
+
+## Current decision
+
+Do not merge the bulk local branch as one PR.
+
+Use the current worktree only as a WIP source snapshot, then create clean issue branches from latest
+`origin/main` and restore only the files needed for each scoped PR. This keeps review size small,
+reduces semantic coupling, and avoids landing partially validated issue work as a single large
+change.
+
+## Safety snapshot workflow
+
+1. Add this strategy note to the current mixed worktree.
+2. Create a WIP branch from the current checkout.
+3. Commit the full mixed state as a safety snapshot.
+4. Extract clean PR branches from `origin/main` by restoring selected paths from the WIP snapshot.
+5. Validate and open draft PRs one at a time.
+
+Recommended snapshot branch:
+
+```bash
+git switch -c wip/open-issues-bulk-snapshot-2026-05-13
+git add -A
+git commit -m "wip: snapshot open issue implementation pass"
+```
+
+## PR stack
+
+### PR 1: Crowd simulation and environment constructor cleanup
+
+Branch: `issue-1150-crowd-sim-env`
+
+Issues: `#1150`, `#1141`, `#1146`, `#1148`
+
+Scope:
+
+- add `robot_sf/gym_env/crowd_sim_env.py`
+- add `make_crowd_sim_env(...)` in `robot_sf/gym_env/environment_factory.py`
+- remove `EmptyRobotEnv` and `SimpleRobotEnv`
+- make maintained environment constructors safe to instantiate without sharing mutable config
+  defaults
+- keep fast no-robot stepping lean
+- support optional rendering and recording
+- ignore robot-policy inputs with a warning for the no-robot crowd surface
+
+Primary validation:
+
+```bash
+uv run pytest \
+  tests/test_crowd_sim_env_contract.py \
+  tests/test_environment_factory_signatures.py \
+  -q
+```
+
+### PR 2: Small correctness fixes
+
+Branch: `issue-1142-1144-1147-small-fixes`
+
+Issues: `#1142`, `#1144`, `#1147`
+
+Scope:
+
+- encode video at the configured target FPS when available
+- document and test `WheelSpeedState` as angular wheel speeds in rad/s
+- make `scripts/classic_benchmark_full.py` fail closed with an actionable error when unavailable
+- optionally include low-risk docstring cleanup touched by the same files
+
+Primary validation:
+
+```bash
+uv run pytest \
+  tests/visuals/test_sim_view_coverage_paths.py \
+  tests/differential_drive_test.py \
+  tests/benchmark_full/test_classic_benchmark_full_cli.py \
+  -q
+```
+
+### PR 3: Sensor history contract
+
+Branch: `issue-1143-1149-sensor-history-contract`
+
+Issues: `#1143`, `#1149`
+
+Scope:
+
+- document oldest-to-newest temporal ordering in stacked sensor history
+- centralize append semantics in `robot_sf/sensor/sensor_fusion.py`
+- update image sensor fusion to use the same helper
+
+Primary validation:
+
+```bash
+uv run pytest tests/test_sensor_fusion_stack.py -q
+```
+
+### PR 4: Dynamic pedestrian occlusion
+
+Branch: `issue-1124-dynamic-ped-occlusion`
+
+Issue: `#1124`
+
+Scope:
+
+- add opt-in dynamic pedestrian occlusion to SocNav observations
+- expose `observation_visibility.dynamic_occlusion`
+- preserve ground-truth separation and existing static-occlusion behavior
+
+Primary validation:
+
+```bash
+uv run pytest \
+  tests/test_socnav_dynamic_occlusion.py \
+  tests/test_socnav_observation.py \
+  tests/training/test_scenario_loader.py \
+  -q
+```
+
+### PR 5: Predictive obstacle feature schema
+
+Branch: `issue-1138-predictive-obstacle-features-v1`
+
+Issue: `#1138`
+
+Scope:
+
+- add `predictive_obstacle_features_v1`
+- expose deterministic nearest-local-obstacle features
+- keep unavailable obstacle data explicit with a sentinel and validity mask
+
+Primary validation:
+
+```bash
+uv run pytest tests/planner/test_obstacle_features.py -q
+```
+
+### PR 6: Multi-AMV episode extension
+
+Branch: `issue-1128-multi-amv-episode-extension`
+
+Issue: `#1128`
+
+Scope:
+
+- add namespaced `multi_amv` episode extension
+- fail closed for single-robot or missing metric inputs
+- update smoke runner output contract
+
+Primary validation:
+
+```bash
+uv run pytest tests/benchmark/test_multi_amv.py -q
+```
+
+### PR 7: CARLA oracle/replay parity adapter
+
+Branch: `issue-1110-carla-parity-adapter`
+
+Issue: `#1110`
+
+Scope:
+
+- add lightweight CARLA parity comparison utilities
+- add CLI for oracle-vs-replay metric comparison
+- keep degraded or missing inputs explicit, not benchmark-success evidence
+
+Primary validation:
+
+```bash
+uv run pytest tests/carla_bridge/test_parity.py tests/carla_bridge/test_parity_cli.py -q
+```
+
+### PR 8: Manual control MVP foundations
+
+Branch: `issue-1151-manual-control-foundations`
+
+Issues: `#1151`; references `#1152`, `#1153`, `#1154`
+
+Scope:
+
+- add keyboard-hold, fixed-map differential-drive manual input mapper
+- add attempt/session state, JSONL recording, manifest, replay grouping, baseline comparison, and
+  demonstration export helpers
+- keep web-game work as schema-aligned future work, not an implemented dependency
+
+Primary validation:
+
+```bash
+uv run pytest tests/test_manual_control_*.py -q
+```
+
+### PR 9: Docstring cleanup pass
+
+Branch: `issue-1145-docstring-cleanup-pass`
+
+Issue: `#1145`
+
+Scope:
+
+- include remaining docstring-only cleanup only if it is still useful after PRs 1-8
+- avoid mixing docstring cleanup into semantic PRs unless the touched file already belongs to that
+  PR
+
+Primary validation:
+
+```bash
+uv run ruff check robot_sf tests scripts
+```
+
+## Merge order
+
+Open and merge low-risk, dependency-light PRs first:
+
+1. PR 2: small correctness fixes
+2. PR 3: sensor history contract
+3. PR 1: crowd simulation environment
+4. PR 4: dynamic pedestrian occlusion
+5. PR 5: predictive obstacle features
+6. PR 6: multi-AMV episode extension
+7. PR 7: CARLA parity adapter
+8. PR 8: manual control foundations
+9. PR 9: remaining docstrings if still needed
+
+## Extraction pattern
+
+For each branch:
+
+```bash
+git fetch origin main
+git worktree add ../<branch-name> origin/main -b <branch-name>
+cd ../<branch-name>
+git restore --source wip/open-issues-bulk-snapshot-2026-05-13 -- <scoped paths>
+```
+
+Then run the PR-specific validation command, commit, push, and open a draft PR.
+
+Before creating a non-draft PR, follow the repository PR readiness rule:
+
+```bash
+git fetch origin main
+git merge origin/main
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Blocked or no-code issues
+
+Do not create implementation PRs from the current snapshot for issues that still need external
+evidence or assets:
+
+- `#1119`: Docker reproduction needs a Docker-capable host.
+- `#1111`: CARLA T1 needs a CARLA-capable host.
+- `#1134`: SocNavBench ETH needs official assets.
+- `#1126`: SDD importer needs official staged data.
+- `#1108`: BC/PPO experiment requires actual execution artifacts.
+- `#1154`: web-game collection depends on schema validation and a separate UI surface.
+
+Keep those issues as explicit blockers or planning comments until their external proof inputs
+exist.
+
+## Validation status
+
+No validation has been run for the mixed snapshot at the time this note was created. Each extracted
+PR must carry its own validation evidence before review.


### PR DESCRIPTION
## Summary
- Add a reusable handoff record for the open-issues implementation pass, including implemented PR split, remaining blockers, and maintainer-input triage.
- Link the new context notes from `docs/context/README.md` so future agents can find the decision trail.

Relates to #1110, #1124, #1128, #1138, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1148, #1149, #1150, #1151, #1152, #1153, #1154.

## Validation
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> 3353 passed, 18 skipped, 6 warnings in 263.49s
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` -> passed for head `1e2178f5920b56b05ecb995544fc5e1da4cc0081`

## Artifacts
- Generated ignored local validation outputs under `output/coverage/` and `output/validation/pr_ready/`; no durable artifact is required for this docs-only handoff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed open-issues implementation status note documenting progress, blockers, and follow-ups
  * Added a maintainer triage workflow note to track priority questions and decisions
  * Added a PR split/coordination strategy note for structured implementation and validation
  * Extended the docs index/Context Notes Workflow to link the new context notes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1171)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->