### PR TITLE
feat: classify multi-AMV planner support (#1168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1128 multi-AMV episode extension surface: `multi_amv_episode_extension(...)`
+  now emits an additive namespaced `multi_amv` block for smoke outputs, requires explicit
+  planner status, omits optional planner notes when absent, and keeps invalid single-robot or
+  empty-metric inputs fail-closed through targeted regression coverage and the documented
+  multi-AMV smoke validation path.
+
 * Added the issue-857 horizon-alignment experiment surfaces: manifest-level `scenario_overrides`
   support in `robot_sf/training/scenario_loader.py`, the new
   `configs/scenarios/sets/ppo_full_maintained_eval_v1_horizon100.yaml` eval/training surface,

--- a/docs/README.md
+++ b/docs/README.md
@@ -198,6 +198,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Full Classic Interaction Benchmark](./benchmark_full_classic.md)** - Complete guide: episodes, aggregation, effect sizes, adaptive precision, plots, videos, scaling metrics
 * **[Benchmark Artifact Publication](./benchmark_artifact_publication.md)** - Public artifact policy, DOI-ready export bundles, release/Zenodo workflow
 * **[Multi-AMV Benchmark First Slice](./multi_amv_benchmark.md)** - Minimal multi-robot scenario surface, validation smoke, and inter-robot metric block
+* **[Issue #1128 Multi-AMV Episode Extension](./context/issue_1128_multi_amv_episode_extension.md)** - Additive episode-output block for multi-AMV smoke runs, explicit planner-status contract, and fail-closed validation notes
 * **[Real-World Trajectory Import](./real_world_trajectory_import.md)** - Narrow Stanford Drone Dataset annotation importer, normalization contract, and provenance workflow
 * **[Benchmark Visual Artifacts](./benchmark_visuals.md)** - SimulationView & synthetic video pipeline, performance metrics
 * **[Metrics Specification](./dev/issues/social-navigation-benchmark/metrics_spec.md)** - Formal definitions of benchmark metrics (includes per-pedestrian force quantiles)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -166,6 +166,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1092 Multi-AMV First Slice](issue_1092_multi_amv_first_slice.md)
   records the minimal multi-robot scenario surface, smoke runner, inter-robot metrics, and deferred
   fleet-integration boundary.
+* [Issue #1168 Multi-AMV Planner Support Classification](issue_1168_multi_amv_planner_support.md)
+  records the current planner-family inventory, fail-closed support gate, and the boundary between
+  goal-controller smoke execution and real multi-AMV planner support.
 * [Issue #1091 SDD Importer](issue_1091_sdd_importer.md)
   records the one-dataset-first real-world trajectory import boundary, SDD license assumptions,
   importer outputs, and deferred generalization scope.

--- a/docs/context/issue_1128_multi_amv_episode_extension.md
+++ b/docs/context/issue_1128_multi_amv_episode_extension.md
@@ -1,0 +1,52 @@
+# Issue 1128 multi-AMV episode extension
+
+Date: 2026-05-12
+
+## Scope implemented so far
+
+This branch adds a namespaced, additive multi-AMV episode extension block and updates the existing multi-AMV smoke runner to emit it.
+
+Implemented files:
+
+- `robot_sf/benchmark/multi_amv.py`
+- `scripts/validation/run_multi_amv_smoke.py`
+- `tests/benchmark/test_multi_amv.py`
+
+## Record shape
+
+`multi_amv_episode_extension(...)` returns:
+
+```json
+{
+  "multi_amv": {
+    "enabled": true,
+    "num_robots": 2,
+    "near_miss_distance_m": 1.0,
+    "collision_distance_m": 0.4,
+    "deadlock_speed_mps": 0.05,
+    "deadlock_window_steps": 10,
+    "planner_status": "goal_controller_smoke",
+    "planner_note": "...",
+    "metrics": {
+      "inter_robot": {}
+    }
+  }
+}
+```
+
+The block is intentionally namespaced so existing single-robot episode consumers can ignore it without schema migration.
+
+## Fail-closed behavior
+
+The helper raises `ValueError` when called with fewer than two robots or empty inter-robot metrics.
+
+## Remaining work
+
+- Integrate multi-AMV execution into the primary benchmark command path or document the equivalent primary subcommand.
+- Carry the `multi_amv.metrics.inter_robot` block into aggregate reports.
+- Document planner support beyond the current goal-controller smoke path, or emit explicit unavailable/fail-closed statuses.
+- Add schema/report regression tests covering coexistence with single-robot outputs.
+
+## Validation status
+
+No validation commands have been run for this partial implementation in this pass.

--- a/docs/context/issue_1128_multi_amv_episode_extension.md
+++ b/docs/context/issue_1128_multi_amv_episode_extension.md
@@ -26,7 +26,6 @@ Implemented files:
     "deadlock_speed_mps": 0.05,
     "deadlock_window_steps": 10,
     "planner_status": "goal_controller_smoke",
-    "planner_note": "...",
     "metrics": {
       "inter_robot": {}
     }
@@ -35,6 +34,8 @@ Implemented files:
 ```
 
 The block is intentionally namespaced so existing single-robot episode consumers can ignore it without schema migration.
+`planner_status` is required so callers keep the planner mode explicit, and the optional
+`planner_note` field is omitted when no note is provided.
 
 ## Fail-closed behavior
 
@@ -49,4 +50,10 @@ The helper raises `ValueError` when called with fewer than two robots or empty i
 
 ## Validation status
 
-No validation commands have been run for this partial implementation in this pass.
+Validation has been run for this implementation slice:
+
+- `UV_NO_CONFIG=1 python -m pytest tests/benchmark/test_multi_amv.py -q`
+- `UV_NO_CONFIG=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+
+These checks cover the additive namespaced record shape, fail-closed single-robot and
+empty-metrics paths, and the branch-wide readiness gate for the main-based PR branch.

--- a/docs/context/issue_1168_multi_amv_planner_support.md
+++ b/docs/context/issue_1168_multi_amv_planner_support.md
@@ -1,0 +1,57 @@
+# Issue #1168 Multi-AMV Planner Support Classification
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1168>
+
+## Decision
+
+The multi-AMV benchmark surface currently supports only `goal_controller_smoke` as a native smoke
+execution path. It is not real planner-family support and must not be reported as a coordinated
+fleet planner.
+
+All existing single-robot benchmark planner families fail closed or remain research-only until they
+define a multi-AMV contract for action shape, robot identity, inter-robot collision responsibility,
+and metadata reporting.
+
+## Minimum planner contract
+
+A non-smoke multi-AMV planner must define:
+
+- Action shape for all robots, currently expected as a stable fleet action tensor.
+- Robot identity semantics so action rows and metrics map to the same robot across the episode.
+- Collision responsibility across robot-robot, robot-pedestrian, and robot-obstacle interactions.
+- Metadata reporting that records support mode as `native`, `adapter`, `not_available`, or
+  `research_only`.
+- Benchmark output metadata that distinguishes smoke execution from planner-family support.
+
+## Inventory
+
+The code inventory lives in `robot_sf.benchmark.multi_amv.multi_amv_planner_support_inventory`.
+
+Current classification:
+
+- `goal_controller_smoke`: `native`, but only for the minimal smoke runner.
+- `goal`: `not_available`.
+- `social_force`: `research_only`.
+- `orca`: `not_available`; this is the first plausible non-trivial candidate, but it needs an
+  explicit adapter before benchmark use.
+- `ppo`: `not_available`.
+- `guarded_ppo`: `not_available`.
+- `sacadrl`: `not_available`.
+- `teb`: `research_only`.
+
+## Fail-closed behavior
+
+`ensure_multi_amv_planner_supported` raises before benchmark execution when a planner family lacks a
+multi-AMV contract. Passing `require_non_smoke=True` also rejects `goal_controller_smoke`, which
+prevents smoke output from being promoted as real planner support.
+
+## Validation
+
+Use:
+
+```bash
+uv run pytest tests/benchmark/test_multi_amv.py -q
+```
+
+Full PR readiness should use the stacked base branch for changed-file coverage while this work
+depends on `#1128`.

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -141,6 +141,42 @@ def inter_robot_metrics(
     }
 
 
+def multi_amv_episode_extension(
+    *,
+    settings: MultiAmvSettings,
+    inter_robot: dict[str, float | bool],
+    planner_status: str = "goal_controller_smoke",
+    planner_note: str | None = None,
+) -> dict[str, Any]:
+    """Build an additive episode-record block for multi-AMV benchmark outputs.
+
+    The block is intentionally namespaced under ``multi_amv`` so single-robot
+    episode consumers can ignore it without schema migration.
+
+    Returns
+    -------
+    dict[str, Any]
+        Namespaced episode extension containing settings, planner status, and inter-robot metrics.
+    """
+    if settings.num_robots < 2:
+        raise ValueError("multi-AMV episode extension requires at least two robots")
+    if not inter_robot:
+        raise ValueError("inter_robot metrics must be non-empty")
+    return {
+        "multi_amv": {
+            "enabled": True,
+            "num_robots": int(settings.num_robots),
+            "near_miss_distance_m": float(settings.near_miss_distance_m),
+            "collision_distance_m": float(settings.collision_distance_m),
+            "deadlock_speed_mps": float(settings.deadlock_speed_mps),
+            "deadlock_window_steps": int(settings.deadlock_window_steps),
+            "planner_status": str(planner_status),
+            "planner_note": planner_note,
+            "metrics": {"inter_robot": dict(inter_robot)},
+        }
+    }
+
+
 def _count_true_runs(values: np.ndarray) -> int:
     """Count contiguous true runs in a boolean sequence.
 

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -145,7 +145,7 @@ def multi_amv_episode_extension(
     *,
     settings: MultiAmvSettings,
     inter_robot: dict[str, float | bool],
-    planner_status: str = "goal_controller_smoke",
+    planner_status: str,
     planner_note: str | None = None,
 ) -> dict[str, Any]:
     """Build an additive episode-record block for multi-AMV benchmark outputs.
@@ -162,7 +162,7 @@ def multi_amv_episode_extension(
         raise ValueError("multi-AMV episode extension requires at least two robots")
     if not inter_robot:
         raise ValueError("inter_robot metrics must be non-empty")
-    return {
+    payload: dict[str, Any] = {
         "multi_amv": {
             "enabled": True,
             "num_robots": int(settings.num_robots),
@@ -171,10 +171,12 @@ def multi_amv_episode_extension(
             "deadlock_speed_mps": float(settings.deadlock_speed_mps),
             "deadlock_window_steps": int(settings.deadlock_window_steps),
             "planner_status": str(planner_status),
-            "planner_note": planner_note,
             "metrics": {"inter_robot": dict(inter_robot)},
         }
     }
+    if planner_note is not None:
+        payload["multi_amv"]["planner_note"] = planner_note
+    return payload
 
 
 def _count_true_runs(values: np.ndarray) -> int:

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -184,7 +184,9 @@ def multi_amv_planner_support(planner_family: str) -> MultiAmvPlannerSupport:
         return _MULTI_AMV_PLANNER_SUPPORT[normalized]
     except KeyError as exc:
         known = ", ".join(sorted(_MULTI_AMV_PLANNER_SUPPORT))
-        raise ValueError(f"unknown multi-AMV planner family {planner_family!r}; known: {known}") from exc
+        raise ValueError(
+            f"unknown multi-AMV planner family {planner_family!r}; known: {known}"
+        ) from exc
 
 
 def ensure_multi_amv_planner_supported(

--- a/robot_sf/benchmark/multi_amv.py
+++ b/robot_sf/benchmark/multi_amv.py
@@ -8,6 +8,7 @@ fleet-optimization abstraction.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 import numpy as np
@@ -22,6 +23,197 @@ class MultiAmvSettings:
     collision_distance_m: float = 0.4
     deadlock_speed_mps: float = 0.05
     deadlock_window_steps: int = 10
+
+
+class MultiAmvPlannerSupportStatus(StrEnum):
+    """Support status for running a planner family in multi-AMV scenarios."""
+
+    NATIVE = "native"
+    ADAPTER = "adapter"
+    NOT_AVAILABLE = "not_available"
+    RESEARCH_ONLY = "research_only"
+
+
+@dataclass(frozen=True)
+class MultiAmvPlannerSupport:
+    """Planner-family support classification for multi-AMV execution."""
+
+    planner_family: str
+    support_status: MultiAmvPlannerSupportStatus
+    contract_kind: str
+    action_shape: str
+    robot_identity: str
+    collision_responsibility: str
+    metadata_reporting: str
+    rationale: str
+
+    def to_json_dict(self) -> dict[str, str]:
+        """Return JSON-compatible support metadata.
+
+        Returns
+        -------
+        dict[str, str]
+            Planner support classification and minimum contract fields.
+        """
+        return {
+            "planner_family": self.planner_family,
+            "support_status": self.support_status.value,
+            "contract_kind": self.contract_kind,
+            "action_shape": self.action_shape,
+            "robot_identity": self.robot_identity,
+            "collision_responsibility": self.collision_responsibility,
+            "metadata_reporting": self.metadata_reporting,
+            "rationale": self.rationale,
+        }
+
+
+_MULTI_AMV_PLANNER_SUPPORT: dict[str, MultiAmvPlannerSupport] = {
+    "goal_controller_smoke": MultiAmvPlannerSupport(
+        planner_family="goal_controller_smoke",
+        support_status=MultiAmvPlannerSupportStatus.NATIVE,
+        contract_kind="goal_controller_smoke",
+        action_shape="array[num_robots, 2] unicycle velocity commands",
+        robot_identity="implicit row order from MultiRobotEnv simulators",
+        collision_responsibility="smoke runner only; not a coordinated fleet planner",
+        metadata_reporting="planner_support block plus inter-robot metrics",
+        rationale=(
+            "Supported only as the minimal smoke controller used to exercise multi-AMV "
+            "episode records; it is not benchmark-comparable planner-family support."
+        ),
+    ),
+    "goal": MultiAmvPlannerSupport(
+        planner_family="goal",
+        support_status=MultiAmvPlannerSupportStatus.NOT_AVAILABLE,
+        contract_kind="single_robot_planner",
+        action_shape="single robot action; no fleet action tensor",
+        robot_identity="missing",
+        collision_responsibility="missing inter-robot coordination contract",
+        metadata_reporting="not available",
+        rationale="The single-robot goal planner does not define multi-robot identity or actions.",
+    ),
+    "social_force": MultiAmvPlannerSupport(
+        planner_family="social_force",
+        support_status=MultiAmvPlannerSupportStatus.RESEARCH_ONLY,
+        contract_kind="pedestrian_dynamics_or_single_robot_baseline",
+        action_shape="not defined for coordinated robot fleet control",
+        robot_identity="missing",
+        collision_responsibility="research question; no benchmark contract yet",
+        metadata_reporting="not available",
+        rationale="Social-force behavior can inform research, but no multi-AMV planner adapter exists.",
+    ),
+    "orca": MultiAmvPlannerSupport(
+        planner_family="orca",
+        support_status=MultiAmvPlannerSupportStatus.NOT_AVAILABLE,
+        contract_kind="single_robot_or_pairwise_adapter_missing",
+        action_shape="not defined for all robots with stable robot ids",
+        robot_identity="missing",
+        collision_responsibility="missing fleet-level responsibility and metadata contract",
+        metadata_reporting="not available",
+        rationale=(
+            "ORCA is the first plausible non-trivial candidate, but it needs an explicit "
+            "multi-robot adapter before benchmark use."
+        ),
+    ),
+    "ppo": MultiAmvPlannerSupport(
+        planner_family="ppo",
+        support_status=MultiAmvPlannerSupportStatus.NOT_AVAILABLE,
+        contract_kind="single_robot_policy",
+        action_shape="single policy action; no multi-robot observation/action schema",
+        robot_identity="missing",
+        collision_responsibility="missing learned fleet-control contract",
+        metadata_reporting="not available",
+        rationale="Existing PPO checkpoints are trained for single-robot environment contracts.",
+    ),
+    "guarded_ppo": MultiAmvPlannerSupport(
+        planner_family="guarded_ppo",
+        support_status=MultiAmvPlannerSupportStatus.NOT_AVAILABLE,
+        contract_kind="single_robot_policy_with_guard",
+        action_shape="single policy action; no multi-robot observation/action schema",
+        robot_identity="missing",
+        collision_responsibility="missing learned fleet-control contract",
+        metadata_reporting="not available",
+        rationale="Guarded PPO inherits the single-robot PPO contract and is not fleet-aware.",
+    ),
+    "sacadrl": MultiAmvPlannerSupport(
+        planner_family="sacadrl",
+        support_status=MultiAmvPlannerSupportStatus.NOT_AVAILABLE,
+        contract_kind="single_robot_policy",
+        action_shape="single robot action",
+        robot_identity="missing",
+        collision_responsibility="missing fleet-control contract",
+        metadata_reporting="not available",
+        rationale="SA-CADRL support is single-robot and has no multi-AMV adapter.",
+    ),
+    "teb": MultiAmvPlannerSupport(
+        planner_family="teb",
+        support_status=MultiAmvPlannerSupportStatus.RESEARCH_ONLY,
+        contract_kind="testing_only_single_robot_planner",
+        action_shape="single robot trajectory command",
+        robot_identity="missing",
+        collision_responsibility="research-only until a fleet adapter exists",
+        metadata_reporting="not available",
+        rationale="TEB is testing-only in this repo and not a coordinated multi-AMV planner.",
+    ),
+}
+
+
+def multi_amv_planner_support_inventory() -> dict[str, dict[str, str]]:
+    """Return planner-family multi-AMV support inventory.
+
+    Returns
+    -------
+    dict[str, dict[str, str]]
+        JSON-compatible support records keyed by planner family.
+    """
+    return {
+        planner_family: support.to_json_dict()
+        for planner_family, support in sorted(_MULTI_AMV_PLANNER_SUPPORT.items())
+    }
+
+
+def multi_amv_planner_support(planner_family: str) -> MultiAmvPlannerSupport:
+    """Return the multi-AMV support classification for a planner family.
+
+    Returns
+    -------
+    MultiAmvPlannerSupport
+        Support classification for the requested planner family.
+    """
+    normalized = str(planner_family).strip().lower().replace("-", "_")
+    try:
+        return _MULTI_AMV_PLANNER_SUPPORT[normalized]
+    except KeyError as exc:
+        known = ", ".join(sorted(_MULTI_AMV_PLANNER_SUPPORT))
+        raise ValueError(f"unknown multi-AMV planner family {planner_family!r}; known: {known}") from exc
+
+
+def ensure_multi_amv_planner_supported(
+    planner_family: str,
+    *,
+    require_non_smoke: bool = False,
+) -> MultiAmvPlannerSupport:
+    """Fail closed when a planner family lacks a multi-AMV execution contract.
+
+    Returns
+    -------
+    MultiAmvPlannerSupport
+        Support classification for allowed planner families.
+    """
+    support = multi_amv_planner_support(planner_family)
+    if support.support_status not in {
+        MultiAmvPlannerSupportStatus.NATIVE,
+        MultiAmvPlannerSupportStatus.ADAPTER,
+    }:
+        raise ValueError(
+            f"planner family {support.planner_family!r} is {support.support_status.value} "
+            f"for multi-AMV scenarios: {support.rationale}"
+        )
+    if require_non_smoke and support.contract_kind == "goal_controller_smoke":
+        raise ValueError(
+            "multi-AMV goal_controller_smoke is a smoke controller, not non-trivial "
+            "planner-family support"
+        )
+    return support
 
 
 def multi_amv_settings_from_scenario(scenario: dict[str, Any]) -> MultiAmvSettings:
@@ -145,6 +337,7 @@ def multi_amv_episode_extension(
     *,
     settings: MultiAmvSettings,
     inter_robot: dict[str, float | bool],
+    planner_family: str = "goal_controller_smoke",
     planner_status: str = "goal_controller_smoke",
     planner_note: str | None = None,
 ) -> dict[str, Any]:
@@ -162,6 +355,7 @@ def multi_amv_episode_extension(
         raise ValueError("multi-AMV episode extension requires at least two robots")
     if not inter_robot:
         raise ValueError("inter_robot metrics must be non-empty")
+    planner_support = multi_amv_planner_support(planner_family)
     return {
         "multi_amv": {
             "enabled": True,
@@ -170,7 +364,9 @@ def multi_amv_episode_extension(
             "collision_distance_m": float(settings.collision_distance_m),
             "deadlock_speed_mps": float(settings.deadlock_speed_mps),
             "deadlock_window_steps": int(settings.deadlock_window_steps),
+            "planner_family": planner_support.planner_family,
             "planner_status": str(planner_status),
+            "planner_support": planner_support.to_json_dict(),
             "planner_note": planner_note,
             "metrics": {"inter_robot": dict(inter_robot)},
         }

--- a/scripts/validation/run_multi_amv_smoke.py
+++ b/scripts/validation/run_multi_amv_smoke.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 
 from robot_sf.benchmark.multi_amv import (
+    ensure_multi_amv_planner_supported,
     inter_robot_metrics,
     multi_amv_episode_extension,
     multi_amv_settings_from_scenario,
@@ -65,6 +66,7 @@ def run_smoke(*, scenario_path: Path, horizon: int) -> dict[str, Any]:
     """Run the first scenario in ``scenario_path`` and return a metrics record."""
     scenario = dict(load_scenarios(scenario_path)[0])
     settings = multi_amv_settings_from_scenario(scenario)
+    planner_support = ensure_multi_amv_planner_supported("goal_controller_smoke")
     config = _multi_robot_config_from_scenario(scenario, scenario_path)
     config.sim_config.sim_time_in_secs = max(
         config.sim_config.time_per_step_in_secs,
@@ -95,8 +97,9 @@ def run_smoke(*, scenario_path: Path, horizon: int) -> dict[str, Any]:
         **multi_amv_episode_extension(
             settings=settings,
             inter_robot=metrics,
+            planner_family=planner_support.planner_family,
             planner_status="goal_controller_smoke",
-            planner_note="Minimal multi-AMV smoke runner uses internal goal-directed actions.",
+            planner_note=planner_support.rationale,
         ),
     }
 

--- a/scripts/validation/run_multi_amv_smoke.py
+++ b/scripts/validation/run_multi_amv_smoke.py
@@ -11,7 +11,11 @@ from typing import Any
 
 import numpy as np
 
-from robot_sf.benchmark.multi_amv import inter_robot_metrics, multi_amv_settings_from_scenario
+from robot_sf.benchmark.multi_amv import (
+    inter_robot_metrics,
+    multi_amv_episode_extension,
+    multi_amv_settings_from_scenario,
+)
 from robot_sf.gym_env.environment_factory import make_multi_robot_env
 from robot_sf.gym_env.unified_config import MultiRobotConfig
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
@@ -88,14 +92,12 @@ def run_smoke(*, scenario_path: Path, horizon: int) -> dict[str, Any]:
         "scenario_id": scenario.get("name") or scenario.get("scenario_id") or scenario.get("id"),
         "horizon": horizon,
         "steps_recorded": int(robot_positions.shape[0]),
-        "multi_amv": {
-            "num_robots": settings.num_robots,
-            "near_miss_distance_m": settings.near_miss_distance_m,
-            "collision_distance_m": settings.collision_distance_m,
-            "deadlock_speed_mps": settings.deadlock_speed_mps,
-            "deadlock_window_steps": settings.deadlock_window_steps,
-        },
-        "metrics": {"inter_robot": metrics},
+        **multi_amv_episode_extension(
+            settings=settings,
+            inter_robot=metrics,
+            planner_status="goal_controller_smoke",
+            planner_note="Minimal multi-AMV smoke runner uses internal goal-directed actions.",
+        ),
     }
 
 

--- a/tests/benchmark/test_multi_amv.py
+++ b/tests/benchmark/test_multi_amv.py
@@ -9,8 +9,11 @@ import pytest
 
 from robot_sf.benchmark.multi_amv import (
     MultiAmvSettings,
+    ensure_multi_amv_planner_supported,
     inter_robot_metrics,
     multi_amv_episode_extension,
+    multi_amv_planner_support,
+    multi_amv_planner_support_inventory,
     multi_amv_settings_from_scenario,
 )
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
@@ -106,7 +109,10 @@ def test_multi_amv_episode_extension_is_additive_and_namespaced() -> None:
     assert set(block) == {"multi_amv"}
     assert block["multi_amv"]["enabled"] is True
     assert block["multi_amv"]["num_robots"] == 2
+    assert block["multi_amv"]["planner_family"] == "goal_controller_smoke"
     assert block["multi_amv"]["planner_status"] == "goal_controller_smoke"
+    assert block["multi_amv"]["planner_support"]["support_status"] == "native"
+    assert block["multi_amv"]["planner_support"]["contract_kind"] == "goal_controller_smoke"
     assert block["multi_amv"]["metrics"]["inter_robot"] == metrics
 
 
@@ -154,3 +160,32 @@ def test_multi_robot_config_from_scenario_preserves_base_fields(
     assert config.use_planner is True
     assert config.planner_clearance_margin == pytest.approx(0.75)
     assert config.num_robots == 3
+
+
+def test_multi_amv_planner_support_inventory_classifies_known_families() -> None:
+    """Planner support inventory should distinguish smoke from real planner support."""
+    inventory = multi_amv_planner_support_inventory()
+
+    assert inventory["goal_controller_smoke"]["support_status"] == "native"
+    assert inventory["goal_controller_smoke"]["contract_kind"] == "goal_controller_smoke"
+    assert inventory["orca"]["support_status"] == "not_available"
+    assert inventory["ppo"]["support_status"] == "not_available"
+    assert inventory["teb"]["support_status"] == "research_only"
+
+
+def test_ensure_multi_amv_planner_supported_fails_closed_for_single_robot_planners() -> None:
+    """Unsupported planner/multi-AMV combinations should fail before benchmark execution."""
+    with pytest.raises(ValueError, match="not_available.*multi-AMV"):
+        ensure_multi_amv_planner_supported("orca")
+
+
+def test_ensure_multi_amv_planner_supported_can_reject_smoke_for_non_trivial_support() -> None:
+    """Goal-controller smoke should not be mistaken for non-trivial planner-family support."""
+    with pytest.raises(ValueError, match="not non-trivial"):
+        ensure_multi_amv_planner_supported("goal_controller_smoke", require_non_smoke=True)
+
+
+def test_multi_amv_planner_support_rejects_unknown_family() -> None:
+    """Unknown planner families should fail closed with the known inventory named."""
+    with pytest.raises(ValueError, match="unknown multi-AMV planner family"):
+        multi_amv_planner_support("not-a-planner")

--- a/tests/benchmark/test_multi_amv.py
+++ b/tests/benchmark/test_multi_amv.py
@@ -10,6 +10,7 @@ import pytest
 from robot_sf.benchmark.multi_amv import (
     MultiAmvSettings,
     inter_robot_metrics,
+    multi_amv_episode_extension,
     multi_amv_settings_from_scenario,
 )
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
@@ -88,6 +89,34 @@ def test_inter_robot_metrics_handles_empty_trajectory() -> None:
     assert metrics["inter_robot_collision_events"] == pytest.approx(0.0)
     assert metrics["inter_robot_near_miss_events"] == pytest.approx(0.0)
     assert metrics["deadlock_detected"] is False
+
+
+def test_multi_amv_episode_extension_is_additive_and_namespaced() -> None:
+    """Multi-AMV episode data should live in a namespaced optional block."""
+    settings = MultiAmvSettings(num_robots=2)
+    metrics = {"robot_count": 2.0, "pair_count": 1.0, "deadlock_detected": False}
+
+    block = multi_amv_episode_extension(
+        settings=settings,
+        inter_robot=metrics,
+        planner_status="goal_controller_smoke",
+        planner_note="first-slice smoke planner",
+    )
+
+    assert set(block) == {"multi_amv"}
+    assert block["multi_amv"]["enabled"] is True
+    assert block["multi_amv"]["num_robots"] == 2
+    assert block["multi_amv"]["planner_status"] == "goal_controller_smoke"
+    assert block["multi_amv"]["metrics"]["inter_robot"] == metrics
+
+
+def test_multi_amv_episode_extension_requires_multi_robot_metrics() -> None:
+    """The extension should fail closed when called outside multi-robot scope."""
+    with pytest.raises(ValueError, match="at least two robots"):
+        multi_amv_episode_extension(
+            settings=MultiAmvSettings(num_robots=1),
+            inter_robot={"robot_count": 1.0},
+        )
 
 
 def test_multi_amv_smoke_scenario_passes_schema() -> None:

--- a/tests/benchmark/test_multi_amv.py
+++ b/tests/benchmark/test_multi_amv.py
@@ -116,7 +116,30 @@ def test_multi_amv_episode_extension_requires_multi_robot_metrics() -> None:
         multi_amv_episode_extension(
             settings=MultiAmvSettings(num_robots=1),
             inter_robot={"robot_count": 1.0},
+            planner_status="test",
         )
+
+
+def test_multi_amv_episode_extension_requires_non_empty_metrics() -> None:
+    """The extension should fail closed when called with empty metrics."""
+    with pytest.raises(ValueError, match="metrics must be non-empty"):
+        multi_amv_episode_extension(
+            settings=MultiAmvSettings(num_robots=2),
+            inter_robot={},
+            planner_status="test",
+        )
+
+
+def test_multi_amv_episode_extension_omits_optional_planner_note() -> None:
+    """Planner note should stay absent when callers do not provide one."""
+    block = multi_amv_episode_extension(
+        settings=MultiAmvSettings(num_robots=2),
+        inter_robot={"robot_count": 2.0, "pair_count": 1.0},
+        planner_status="explicit-status",
+    )
+
+    assert block["multi_amv"]["planner_status"] == "explicit-status"
+    assert "planner_note" not in block["multi_amv"]
 
 
 def test_multi_amv_smoke_scenario_passes_schema() -> None:


### PR DESCRIPTION
## Summary
- Add a multi-AMV planner support inventory with `native`, `adapter`, `not_available`, and `research_only` statuses.
- Add `ensure_multi_amv_planner_supported` fail-closed preflight behavior, including a `require_non_smoke` guard so goal-controller smoke is not mistaken for real planner support.
- Add planner-support metadata to the multi-AMV episode extension and smoke runner output.
- Add a context note documenting the minimum planner contract and current family classifications.

Closes #1168
Depends on #1161

## Validation
- `uv run pytest tests/benchmark/test_multi_amv.py -q` -> 11 passed in 14.66s
- `BASE_REF=origin/issue-1128-multi-amv-episode-extension PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> 3360 passed, 17 skipped, 3 warnings in 248.41s
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/issue-1128-multi-amv-episode-extension` -> passed for head `9c06e2ef496afc80d5fc13ed3706adac7b2d9791`

## Artifacts
- Generated ignored local validation outputs under `output/coverage/` and `output/validation/pr_ready/`; no durable artifact is required for this contract/classification change.

## Notes
- This PR is stacked on `issue-1128-multi-amv-episode-extension` because #1168 depends on #1128's multi-AMV episode extension.
- ORCA is explicitly recorded as the first plausible non-trivial candidate, but `not_available` until a real multi-robot adapter exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-AMV planner support is now classified and validated with fail-closed checks for unsupported planner families.
  * Episode metadata now includes planner family and support status information.

* **Documentation**
  * Added comprehensive documentation for multi-AMV planner support requirements, inventory classification, and the distinction between smoke execution and real multi-robot planner support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1174)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->