### PR TITLE
docs: make goal-pr-review fix actionable gaps

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -9,7 +9,7 @@ read the specific `SKILL.md` before applying a skill.
 - Discover and open improvement issues autonomously: `goal-issue-discovery`
 - Audit open issues with one user decision at a time: `issue-audit`
 - Implement eligible issue queues sequentially: `goal-issue-implementation`
-- Review open PRs and apply merge-ready after proof: `goal-pr-review`
+- Review open PRs, fix actionable gaps, and apply merge-ready after proof: `goal-pr-review`
 - Implement an issue end-to-end: `gh-issue-autopilot`
 - Sequence Project #5 issue batches: `gh-issue-sequencer`
 - Address PR review comments: `gh-pr-comment-fixer`
@@ -71,7 +71,7 @@ read the specific `SKILL.md` before applying a skill.
 | `experiment-context` | Finding canonical config-first training/evaluation paths, artifact lineage, and validation gates. |
 | `goal-issue-discovery` | Autonomously finding evidence-graded improvement opportunities and creating detailed GitHub issues. |
 | `goal-issue-implementation` | Sequentially implementing eligible open issues through branch, validation, push, and PR creation. |
-| `goal-pr-review` | Reviewing open PRs against linked issue contracts and applying `merge-ready` after full proof. |
+| `goal-pr-review` | Reviewing open PRs against linked issue contracts, fixing scoped writable gaps, and applying `merge-ready` after full proof. |
 | `gh-issue-autopilot` | Selecting or executing an issue through implementation, validation, push, and draft PR. |
 | `gh-issue-clarifier` | Tightening ambiguous GitHub issues and marking decision-required items when needed. |
 | `gh-issue-creator` | Creating structured GitHub issues from rough prompts with repo template conventions. |

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-pr-review
-description: "Autonomous goal loop that reviews open PRs against issue contracts and applies merge-ready after full proof."
+description: "Autonomous goal loop that reviews open PRs, fixes actionable gaps, and applies merge-ready after full proof."
 ---
 
 # Goal PR Review
@@ -8,8 +8,9 @@ description: "Autonomous goal loop that reviews open PRs against issue contracts
 ## Overview
 
 Use this skill when the user wants an autonomous review loop over open PRs. The loop reviews each PR
-against its linked issue contract, checks proof quality, captures deferred work as follow-up issues,
-and applies `merge-ready` only when the full proof bar passes.
+against its linked issue contract, checks proof quality, fixes actionable gaps on writable PR
+branches when safe, captures deferred work as follow-up issues, and applies `merge-ready` only when
+the full proof bar passes.
 
 This skill reuses `implementation-verification`, `pr-ready-check`, `gh-pr-comment-fixer`,
 `review-benchmark-change`, `gh-issue-creator`, and `context-note-maintainer`.
@@ -31,8 +32,9 @@ This skill reuses `implementation-verification`, `pr-ready-check`, `gh-pr-commen
 At the start of each goal, state:
 
 - PR set: all open PRs, non-draft PRs, a label/milestone filter, or explicit PR numbers,
-- write mode: PR comments, issue comments, follow-up issue creation, thread resolution when
-  appropriate, Project #5 routing, and `merge-ready` labeling are allowed by default,
+- write mode: PR branch fixes, commits, pushes, PR comments, issue comments, follow-up issue
+  creation, thread resolution when appropriate, Project #5 routing, and `merge-ready` labeling are
+  allowed by default,
 - stop condition: PR queue exhausted, optional time budget reached, validation blocker,
   GitHub/auth failure, or user stop,
 - exclusions, such as drafts, PRs by a specific author, benchmark-heavy validation, or external CI
@@ -57,6 +59,39 @@ Apply `merge-ready` only when all are true:
 If any item fails, leave a concise review comment or issue/PR follow-up and do not apply
 `merge-ready`.
 
+Before leaving that comment, first try to fix every failing item that is safely fixable on the PR
+branch. A passive "not merge-ready" comment is the fallback only after fixes are impossible, unsafe,
+blocked, or still insufficient after validation.
+
+## Fix-First Decision Tree
+
+Classify each unmet requirement before commenting:
+
+- Fixable now:
+  - the PR branch is checked out or can be checked out,
+  - the branch is writable and can be pushed without force-push or history rewrite,
+  - the fix stays inside the linked issue or explicit PR scope,
+  - the change is mechanical or evidence-backed, such as lint, formatting, missing docs, missing
+    validation note, generated-artifact classification, a small test adjustment, or a clear review
+    comment fix.
+- Deferred follow-up:
+  - the finding is real but outside the current PR contract,
+  - the fix would broaden scope or require separate design,
+  - the current PR can still satisfy its issue after a dedicated follow-up issue is created with
+    `gh-issue-creator`.
+- Handoff-only blocker:
+  - author intent is unclear,
+  - the issue contract is ambiguous,
+  - the branch is not writable,
+  - required proof depends on unavailable credentials, external services, unavailable CI, heavy
+    benchmark infrastructure, or maintainer decisions.
+
+For fixable-now gaps, edit the PR branch, run the narrowest relevant validation, commit, push, and
+then reassess the full proof bar. Use `gh-pr-comment-fixer` for review-thread/comment fixes,
+`implementation-verification` to map repaired claims back to code, docs, and tests,
+`pr-ready-check` when readiness proof is needed, and `gh-issue-creator` for deferred follow-ups.
+Do not duplicate those skills' detailed procedures here.
+
 ## Workflow
 
 1. Build the PR queue
@@ -72,15 +107,27 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
    - Use `review-benchmark-change` for benchmark-sensitive PRs.
 
 3. Resolve actionable gaps
-   - If review comments request fixes on the current branch, use `gh-pr-comment-fixer` when the PR
-     branch is checked out and writable.
-   - If scope is deferred, create dedicated follow-up issues with `gh-issue-creator`.
-   - If evidence is missing but required, comment with the exact proof needed.
+   - Check whether the PR branch is writable before editing. Prefer repository branches; treat fork
+     PRs as review-only unless the branch can be checked out and pushed through normal GitHub
+     permissions.
+   - Fix every fixable-now gap on the PR branch before leaving a "not merge-ready" comment.
+   - If review comments request fixes, use `gh-pr-comment-fixer` when the PR branch is checked out
+     and writable.
+   - If scope is deferred, create dedicated follow-up issues with `gh-issue-creator` and link them
+     from the PR.
+   - If evidence is missing but the proof can be produced locally, run the proof and update the PR
+     rather than asking the author to do it.
+   - If a blocker cannot be fixed safely, comment with the exact blocker and the smallest next
+     action needed.
 
 4. Apply or withhold `merge-ready`
    - Apply `merge-ready` only after the full proof bar passes.
    - Remove stale `merge-ready` if a later review finds the proof bar no longer passes.
+   - After any fix attempt, commit, push, and record the validation evidence before reassessing the
+     label.
    - Leave a short PR comment summarizing the proof basis when applying the label.
+   - Leave a "not merge-ready" comment only when attempted fixes are impossible, unsafe, blocked, or
+     insufficient after validation.
 
 5. Continue or hand off
    - Continue until the PR queue is exhausted or the stop condition fires.
@@ -91,6 +138,8 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
 - Do not treat passing CI alone as enough for `merge-ready`.
 - Do not mark a PR merge-ready if linked issues remain semantically unresolved.
 - Do not ignore open review threads; resolve, answer, or convert them to follow-up issues.
+- Do not make broad edits just to satisfy readiness; stay inside the issue/PR contract.
+- Do not rewrite contributor history or force-push unless the user explicitly authorizes it.
 - Do not merge PRs. This skill applies readiness signals only.
 
 ## Output Requirements
@@ -98,6 +147,7 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
 Report:
 
 - PRs reviewed,
+- fix commits pushed,
 - `merge-ready` labels applied or removed,
 - validation or CI evidence used,
 - follow-up issues created,

--- a/.agents/skills/issue-audit/SKILL.md
+++ b/.agents/skills/issue-audit/SKILL.md
@@ -33,7 +33,8 @@ At the start of the audit, state:
 - issue set, such as all open issues, a label, a milestone, a Project #5 slice, or a numbered list,
 - write mode: issue edits, comments, labels, project routing, issue splits, and consolidation are
   allowed after each user decision,
-- ordering: readiness blockers first,
+- ordering: `decision-required` blockers first; if none exist, continue through all open issues by
+  Project #5 priority and look for refinements,
 - stop condition: all selected issues are ready/tracked/blocked with a reason, the user stops, or
   an optional time budget is reached.
 
@@ -48,12 +49,18 @@ Prioritize the next question by readiness impact:
 5. Stale issues whose body conflicts with current repo state.
 6. Lower-risk template cleanup and metadata normalization.
 
-Do not spend user attention on already-actionable issues until readiness blockers are exhausted.
+When no open issue has a `decision-required` label, do not stop the audit. Continue across all open
+issues, starting with the highest Project #5 priority and then the strongest issue-level priority
+signals, and look for refinements that would make the issue more executable, better scoped, less
+duplicative, or easier to validate. Do not spend user attention on already-actionable issues until
+readiness blockers are exhausted.
 
 ## Workflow
 
 1. Gather issue state
    - Inspect open issues and Project #5 items.
+   - Check for `decision-required` issues first. If none exist, build a priority-ordered open-issue
+     queue and audit it for refinement opportunities instead of stopping.
    - Run or use `scripts/tools/issue_template_audit.py` where issue body readiness is unclear.
    - Inspect linked PRs, context notes, and relevant files before asking questions that repo
      exploration can answer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,7 @@ For issue management and delivery, use these local skills:
 - `.agents/skills/goal-issue-implementation/SKILL.md`
   - Sequential goal loop for implementing eligible open issues through branch, validation, push, and PR creation.
 - `.agents/skills/goal-pr-review/SKILL.md`
-  - Autonomous PR review loop that applies `merge-ready` only after the full proof bar passes.
+  - Autonomous PR review loop that fixes scoped writable gaps before applying `merge-ready` after the full proof bar passes.
 - `.agents/skills/gh-issue-autopilot/SKILL.md`
   - Autonomous issue-to-PR workflow: select next best issue, branch, implement, validate, push, and open draft PR.
 - `.agents/skills/gh-issue-clarifier/SKILL.md`

--- a/docs/context/goal_driven_agent_loops_2026-05-13.md
+++ b/docs/context/goal_driven_agent_loops_2026-05-13.md
@@ -58,10 +58,13 @@ one branch, implements, validates, checks generated artifacts, commits, pushes, 
 before continuing. It stops instead of guessing when an issue is blocked, ambiguous, already covered
 by an open PR, or missing proof requirements.
 
-`goal-pr-review` reviews open PRs against linked issue contracts, not just CI state. It applies a
-dedicated `merge-ready` label only after the full proof bar passes: issue contract resolved, diff
-matches scope, checks or readiness proof are adequate, review threads are handled, generated
-artifacts are classified, and deferred work is captured as follow-up issues.
+`goal-pr-review` reviews open PRs against linked issue contracts, not just CI state. When the full
+proof bar fails, the loop should fix actionable gaps on writable PR branches before leaving a
+passive "not merge-ready" comment. Fixes must stay inside the issue/PR contract, be committed and
+pushed, and be validated before reassessing readiness. It applies a dedicated `merge-ready` label
+only after the full proof bar passes: issue contract resolved, diff matches scope, checks or
+readiness proof are adequate, review threads are handled, generated artifacts are classified, and
+deferred work is captured as follow-up issues.
 
 ## Deferred Scope
 


### PR DESCRIPTION
## Summary
Updates `goal-pr-review` so the loop fixes scoped, writable PR gaps before falling back to passive "not merge-ready" comments. Also restores the missing `issue-audit` fallback-ordering change from `goal-agent-loop-skills` so audits continue through high-priority open issues when no `decision-required` items remain.

## Linked Issues
- Closes #1180
- Relates to #1178

## What Changed
- Added a fix-first decision tree to `goal-pr-review` for fixable-now, deferred follow-up, and handoff-only blockers.
- Updated skill routing/discoverability in `.agents/skills/README.md`, `AGENTS.md`, and the goal-loop context note.
- Restored the `issue-audit` rule to continue by Project #5 priority when no open issue has `decision-required`.

## Why It Matters
- Added value: PR review automation now aims to improve PRs directly when safe, not only report missing readiness.
- Expected impact: future review loops should produce fix commits and validation evidence for writable in-scope gaps.
- Why this is worth merging now: it tightens the new goal-loop skills while they are still being shaped.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `git diff --check`
- Evidence that the change works here:
  - `check_skills.py` validated 34 skills and README coverage.
  - AI config links validated 7 symlinks.
  - Diff whitespace check passed.
- Benchmarks or smoke tests, if applicable: not run; this is a skill/docs-only adaptation.

## Risks / Rollout
- Compatibility risks: low; no runtime code paths are changed.
- Failure modes: agents could over-edit PR branches if the fix-first guardrails are ignored.
- Rollback or fallback plan: revert the skill/context wording if the behavior proves too aggressive.

## Docs / Provenance
- Updated docs:
  - `.agents/skills/goal-pr-review/SKILL.md`
  - `.agents/skills/issue-audit/SKILL.md`
  - `.agents/skills/README.md`
  - `AGENTS.md`
  - `docs/context/goal_driven_agent_loops_2026-05-13.md`
- Relevant design or provenance notes: carries forward missing `issue-audit` behavior from `goal-agent-loop-skills` after #1178 was squash-merged.
- Any assumptions that need to be preserved: "not merge-ready" comments should be a fallback after safe fix attempts are impossible, blocked, or insufficient.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that the fix-first wording still prevents broad PR-scope expansion and force-push/rewrite behavior.
- Known limitation: broad test suite intentionally not run because this only changes skill/docs text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced PR review process: now specifies fixing actionable gaps on writable branches before applying merge-ready status.
  * Clarified merge-readiness criteria with explicit validation steps and decision framework.
  * Improved issue audit workflow to prioritize refinement opportunities and readiness blockers when processing open issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->