### PR TITLE
docs: make goal-pr-review fix actionable PR gaps first (#1180)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -9,7 +9,7 @@ read the specific `SKILL.md` before applying a skill.
 - Discover and open improvement issues autonomously: `goal-issue-discovery`
 - Audit open issues with one user decision at a time: `issue-audit`
 - Implement eligible issue queues sequentially: `goal-issue-implementation`
-- Review open PRs and apply merge-ready after proof: `goal-pr-review`
+- Review open PRs, repair safe gaps, and apply merge-ready after proof: `goal-pr-review`
 - Implement an issue end-to-end: `gh-issue-autopilot`
 - Sequence Project #5 issue batches: `gh-issue-sequencer`
 - Address PR review comments: `gh-pr-comment-fixer`
@@ -71,7 +71,7 @@ read the specific `SKILL.md` before applying a skill.
 | `experiment-context` | Finding canonical config-first training/evaluation paths, artifact lineage, and validation gates. |
 | `goal-issue-discovery` | Autonomously finding evidence-graded improvement opportunities and creating detailed GitHub issues. |
 | `goal-issue-implementation` | Sequentially implementing eligible open issues through branch, validation, push, and PR creation. |
-| `goal-pr-review` | Reviewing open PRs against linked issue contracts and applying `merge-ready` after full proof. |
+| `goal-pr-review` | Reviewing open PRs against linked issue contracts, repairing safe actionable gaps on writable branches, and applying `merge-ready` only after full proof. |
 | `gh-issue-autopilot` | Selecting or executing an issue through implementation, validation, push, and draft PR. |
 | `gh-issue-clarifier` | Tightening ambiguous GitHub issues and marking decision-required items when needed. |
 | `gh-issue-creator` | Creating structured GitHub issues from rough prompts with repo template conventions. |

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-pr-review
-description: "Autonomous goal loop that reviews open PRs against issue contracts and applies merge-ready after full proof."
+description: "Autonomous goal loop that reviews open PRs against issue contracts, repairs safe actionable gaps on writable branches, and applies merge-ready only after full proof."
 ---
 
 # Goal PR Review
@@ -8,8 +8,9 @@ description: "Autonomous goal loop that reviews open PRs against issue contracts
 ## Overview
 
 Use this skill when the user wants an autonomous review loop over open PRs. The loop reviews each PR
-against its linked issue contract, checks proof quality, captures deferred work as follow-up issues,
-and applies `merge-ready` only when the full proof bar passes.
+against its linked issue contract, checks proof quality, repairs safe actionable gaps on writable
+branches, captures deferred work as follow-up issues, and applies `merge-ready` only when the full
+proof bar passes.
 
 This skill reuses `implementation-verification`, `pr-ready-check`, `gh-pr-comment-fixer`,
 `review-benchmark-change`, `gh-issue-creator`, and `context-note-maintainer`.
@@ -57,6 +58,22 @@ Apply `merge-ready` only when all are true:
 If any item fails, leave a concise review comment or issue/PR follow-up and do not apply
 `merge-ready`.
 
+Before leaving a `not merge-ready` outcome, classify each failed proof item with this decision tree:
+
+- auto-fixable now: the PR branch is writable, the fix stays within the linked issue or explicit PR
+  contract, the gap is mechanically fixable or a missing-proof repair, and no maintainer decision,
+  secret, external service, or heavy unavailable benchmark is required. Repair the branch, validate,
+  commit, push, and reassess.
+- deferred follow-up: the gap matters but would expand scope beyond the current PR contract. Create
+  a dedicated follow-up issue with `gh-issue-creator`, keep the PR scoped, and reassess whether the
+  remaining PR can still pass the proof bar.
+- handoff-only blocker: the branch is not writable, author intent is ambiguous, the change would
+  rewrite contributor history, or proof depends on unavailable external systems or maintainer
+  decisions. Leave a concise blocker comment with the exact next action required.
+
+Leave a `not merge-ready` comment only after the auto-fix path is impossible, unsafe, blocked, or
+still insufficient after a concrete repair attempt.
+
 ## Workflow
 
 1. Build the PR queue
@@ -72,15 +89,31 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
    - Use `review-benchmark-change` for benchmark-sensitive PRs.
 
 3. Resolve actionable gaps
-   - If review comments request fixes on the current branch, use `gh-pr-comment-fixer` when the PR
-     branch is checked out and writable.
+   - Classify each failed proof item as auto-fixable now, deferred follow-up, or handoff-only
+     blocker before writing comments.
+   - Confirm branch writability and scope alignment before editing: the branch must be checked out,
+     pushable, and the smallest repair must stay inside the linked issue or explicit PR contract.
+   - Use `gh-pr-comment-fixer` for concrete review-thread fixes when the current PR branch is
+     writable.
+   - Use `implementation-verification` to identify the missing proof surface and the smallest code,
+     test, or docs repair that closes it.
+   - After every fix attempt, run the narrowest validation that can falsify the repair, then rerun
+     the broader readiness proof, usually `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+     unless a different base or narrower documented proof is required.
+   - If ignored or generated `output/` artifacts are involved, classify their persistence before
+     pushing and mention the decision in the PR reply.
+   - Commit and push each successful repair before reassessing `merge-ready`.
    - If scope is deferred, create dedicated follow-up issues with `gh-issue-creator`.
-   - If evidence is missing but required, comment with the exact proof needed.
+   - If evidence remains blocked after safe repair attempts, comment with the exact blocker and the
+     proof or decision still needed.
 
 4. Apply or withhold `merge-ready`
    - Apply `merge-ready` only after the full proof bar passes.
+   - Reassess the full proof bar after each pushed repair; do not rely on pre-fix evidence.
    - Remove stale `merge-ready` if a later review finds the proof bar no longer passes.
    - Leave a short PR comment summarizing the proof basis when applying the label.
+   - If one repair lands but another blocker remains, leave a concise outcome comment covering what
+     was fixed, which validation passed, and why the PR still is not merge-ready.
 
 5. Continue or hand off
    - Continue until the PR queue is exhausted or the stop condition fires.
@@ -91,6 +124,8 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
 - Do not treat passing CI alone as enough for `merge-ready`.
 - Do not mark a PR merge-ready if linked issues remain semantically unresolved.
 - Do not ignore open review threads; resolve, answer, or convert them to follow-up issues.
+- Do not edit a PR branch unless it is writable and the repair is clearly inside scope.
+- Do not leave a passive blocker comment for a safe, scoped, mechanically fixable gap.
 - Do not merge PRs. This skill applies readiness signals only.
 
 ## Output Requirements
@@ -98,6 +133,7 @@ If any item fails, leave a concise review comment or issue/PR follow-up and do n
 Report:
 
 - PRs reviewed,
+- PRs repaired and the pushed commits,
 - `merge-ready` labels applied or removed,
 - validation or CI evidence used,
 - follow-up issues created,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+* Updated the issue-1180 `goal-pr-review` workflow so autonomous PR review defaults to a
+  fix-first repair loop on writable branches: proof failures are now classified as auto-fixable,
+  deferred follow-up, or handoff-only blockers; safe in-scope gaps should be repaired and
+  revalidated before withholding `merge-ready`; and the skill index plus shared goal-loop note now
+  reflect the new validation-and-reassess contract.
+
 * Added the issue-857 horizon-alignment experiment surfaces: manifest-level `scenario_overrides`
   support in `robot_sf/training/scenario_loader.py`, the new
   `configs/scenarios/sets/ppo_full_maintained_eval_v1_horizon100.yaml` eval/training surface,

--- a/docs/context/goal_driven_agent_loops_2026-05-13.md
+++ b/docs/context/goal_driven_agent_loops_2026-05-13.md
@@ -34,6 +34,7 @@ should delegate to existing repo-local skills for concrete work:
 - issue clarification and template repair: `gh-issue-clarifier`, `gh-issue-template-auditor`
 - queue routing: `gh-issue-sequencer`, `gh-issue-priority-assessor`
 - issue implementation: `gh-issue-autopilot`, `gh-pr-opener`
+- PR repair during review: `gh-pr-comment-fixer`, `gh-issue-creator`
 - verification: `implementation-verification`, `pr-ready-check`, `review-benchmark-change`
 - durable notes: `context-note-maintainer`
 
@@ -58,10 +59,14 @@ one branch, implements, validates, checks generated artifacts, commits, pushes, 
 before continuing. It stops instead of guessing when an issue is blocked, ambiguous, already covered
 by an open PR, or missing proof requirements.
 
-`goal-pr-review` reviews open PRs against linked issue contracts, not just CI state. It applies a
-dedicated `merge-ready` label only after the full proof bar passes: issue contract resolved, diff
-matches scope, checks or readiness proof are adequate, review threads are handled, generated
-artifacts are classified, and deferred work is captured as follow-up issues.
+`goal-pr-review` reviews open PRs against linked issue contracts, not just CI state. When the full
+proof bar fails, the default path is fix-first if the PR branch is writable and the smallest repair
+stays inside the issue or PR contract. The loop should classify each gap as auto-fixable now,
+deferred follow-up, or handoff-only blocker; repair safe gaps on-branch; rerun targeted proof plus
+the readiness gate; then reassess `merge-ready`. It applies a dedicated `merge-ready` label only
+after the full proof bar passes: issue contract resolved, diff matches scope, checks or readiness
+proof are adequate, review threads are handled, generated artifacts are classified, and deferred
+work is captured as follow-up issues.
 
 ## Deferred Scope
 


### PR DESCRIPTION
## Summary
Update the `goal-pr-review` skill so autonomous PR review defaults to repairing safe, in-scope proof gaps on writable PR branches before withholding `merge-ready`, and sync the indexed routing/context surfaces with that fix-first contract.

## Linked Issues
- Closes #1180

## What Changed
- Added an explicit decision tree to `.agents/skills/goal-pr-review/SKILL.md` for `auto-fixable now`, `deferred follow-up`, and `handoff-only blocker` proof failures.
- Required branch writability, scope alignment, targeted validation, commit/push evidence, and post-fix reassessment before a `not merge-ready` outcome.
- Kept the repair loop delegated to existing repo skills: `gh-pr-comment-fixer`, `implementation-verification`, `pr-ready-check`, and `gh-issue-creator`.
- Updated `.agents/skills/README.md`, `docs/context/goal_driven_agent_loops_2026-05-13.md`, and `CHANGELOG.md` to reflect the new fix-first PR review behavior.

## Why It Matters
- Added value: turns autonomous PR review from a passive blocker-reporting loop into a delivery-oriented fix, validate, and reassess loop when safe.
- Expected impact: fewer stale “not merge-ready” comments for mechanically fixable gaps and clearer handoff boundaries when repair is unsafe or blocked.
- Why this is worth merging now: the goal-loop skills are new enough that tightening the contract now prevents passive review behavior from becoming the default.

## Validation / Proof
- Commands run:
  - `UV_NO_CONFIG=1 python scripts/dev/check_skills.py`
  - `UV_NO_CONFIG=1 python scripts/tools/sync_ai_config.py --check`
  - `UV_NO_CONFIG=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `UV_NO_CONFIG=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after confirming the branch was already up to date with `origin/main`
- Evidence that the change works here:
  - Skill validation passed for all repo-local skills and README coverage.
  - AI config link validation passed.
  - The full readiness gate passed twice, including the required post-sync rerun.
  - The updated skill text now explicitly includes the fix-first decision tree, writable-branch guardrail, reusable-skill references, and the rule that `not merge-ready` comments come only after repair is impossible, unsafe, blocked, or insufficient.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; this is a skill/docs workflow change.

## Risks / Rollout
- Compatibility risks: low; this updates agent instructions rather than runtime behavior.
- Failure modes: an agent could still misclassify scope or writability if it ignores the stated guardrails, so reviewers should verify the new wording is strict enough.
- Rollback or fallback plan: revert the skill/docs/changelog update if the fix-first behavior proves too aggressive in practice.

## Docs / Provenance
- Updated docs:
  - `.agents/skills/goal-pr-review/SKILL.md`
  - `.agents/skills/README.md`
  - `docs/context/goal_driven_agent_loops_2026-05-13.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - The shared goal-loop note now records that `goal-pr-review` should repair safe gaps on-branch before withholding `merge-ready`.
- Any assumptions that need to be preserved:
  - Branch edits remain allowed only when the branch is writable and the repair stays inside the linked issue or explicit PR contract.

## Follow-Up Issues
- Deferred work:
  - None.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - Confirm the decision tree cleanly separates auto-fixable gaps from scope-expanding follow-ups and maintainer-blocked handoffs.
  - Confirm the post-fix validation and commit/push evidence requirements are strong enough to keep `merge-ready` proof-based.
- Any known limitations:
  - The implementation is documentation-only; behavior depends on agents following the skill contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated PR review workflow guidance with clearer procedures for gap classification (auto-fixable, deferred follow-up, or handoff-only blockers), branch writability validation, repair-and-revalidation cycles, and merge-ready application requirements.
  * Enhanced documentation consistency across workflow guides and skill references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->