### PR TITLE
docs: assess ml-intern as bounded experiment assistant (#1181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1181 `ml-intern` bounded-assistant assessment note, including the local-only
+  proof ladder, trace/privacy boundary, verified Robot SF prompt/context stack, and the explicit
+  recommendation to keep `ml-intern` as a bounded experiment assistant rather than a replacement
+  for the repository's local/HPC/SLURM proof-first workflow.
 * Added the issue-1151 manual-control MVP foundation surface: append-only JSONL recording,
   fail-closed mode/session helpers, baseline comparison primitives, and BC export utilities now
   reject invalid mode values, non-finite speed multipliers, negative tolerances, and malformed

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Policy Search Portfolio Overview](./context/policy_search/portfolio_overview_2026-05-05.md)** - Current non-training policy-search portfolio ranking, promotion status, and h500 horizon evidence pointers
 * **[Agent Index](./AGENT_INDEX.md)** - Agent-oriented index of training, benchmarking, observations, and artifacts
 * **[AI Repo Overview](./ai/repo_overview.md)** - Short orientation for Codex-style agents: where to read first, core repo areas, and common failure modes
+* **[Issue #1181 `ml-intern` Bounded Assistant Assessment](./context/issue_1181_ml_intern_experiment_assistant.md)** - Safe-use boundary for evaluating `huggingface/ml-intern` against Robot SF without replacing the local/SLURM proof-first workflow
 * **[AI Coding Workflow](./ai/ai-workflow.md)** - End-to-end AI issue-to-PR workflow, validation gates, review loop, and traceability conventions
 * **[AI Planner Zoo Context](./ai/planner_zoo_context.md)** - Planner-zoo integration context, readiness framing, and provenance/adapter questions to answer explicitly
 * **[AI Context Packing Decision](./ai/context_packing.md)** - Current decision and rationale for using Repomix as the default focused-context bundler

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -80,6 +80,8 @@ knowledge, not every transient iteration detail.
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
 * Goal-driven agent loops:
   [goal_driven_agent_loops_2026-05-13.md](goal_driven_agent_loops_2026-05-13.md)
+* `ml-intern` bounded assistant assessment:
+  [issue_1181_ml_intern_experiment_assistant.md](issue_1181_ml_intern_experiment_assistant.md)
 * Route-clearance certification: [issue_1105_route_clearance_certification.md](issue_1105_route_clearance_certification.md)
 * Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)
 * Open-issues implementation status:

--- a/docs/context/issue_1181_ml_intern_experiment_assistant.md
+++ b/docs/context/issue_1181_ml_intern_experiment_assistant.md
@@ -1,0 +1,218 @@
+# Issue 1181: `ml-intern` bounded experiment-assistant assessment
+
+Date: 2026-05-13
+Issue: #1181
+
+## Decision
+
+`huggingface/ml-intern` is a plausible **bounded experiment assistant** for `robot_sf_ll7`, but it
+should **not** become the repository runtime or replace the existing local/HPC/SLURM workflows.
+
+Recommended near-term use:
+
+- repo comprehension after reading the Robot SF context stack,
+- validation-plan drafting,
+- config/path scaffolding,
+- bounded local smoke execution,
+- and, only after local proof, a separate follow-up issue for one small remote sandbox/HF Job check.
+
+Not recommended in this issue:
+
+- long PPO or benchmark campaigns,
+- paper-facing benchmark execution,
+- CARLA/Unreal-heavy runs,
+- SLURM replacement,
+- or any workflow that treats fallback/degraded execution as valid benchmark evidence.
+
+## Why this fits Robot SF
+
+Robot SF already has a strong config-first and proof-first workflow:
+
+- repo guidance and execution policy live in `AGENTS.md` and `docs/dev_guide.md`,
+- issue-specific durable notes live under `docs/context/`,
+- examples expose small headless proof paths in `examples/README.md`,
+- PPO training has a canonical config-driven entrypoint in `scripts/training/train_ppo.py`,
+- and benchmark/training claims already require explicit validation rather than chat-only reasoning.
+
+That makes `ml-intern` most useful as an assistant that reads repo context first and proposes or
+executes **small, reviewable** steps against existing commands, rather than inventing a parallel
+workflow.
+
+## Upstream contract checked on 2026-05-13
+
+Observed from the upstream `huggingface/ml-intern` README / PyPI page:
+
+- install path is repo-local and tool-based:
+  - `git clone ...`
+  - `uv sync`
+  - `uv tool install -e .`
+- CLI supports:
+  - interactive mode: `ml-intern`
+  - headless mode: `ml-intern "prompt"`
+- supported model routing includes Anthropic, OpenAI, HF-router-backed models, and local
+  OpenAI-compatible endpoints (`ollama/`, `vllm/`, `lm_studio/`, `llamacpp/`)
+- default tool runtime is **local filesystem** (`bash`, `read`, `write`, `edit`)
+- remote sandbox tooling is opt-in via `--sandbox-tools` and requires `HF_TOKEN`
+- sandbox mode is intended for creating/replacing HF Space sandboxes and for testing remotely before
+  larger HF Jobs
+- traces are auto-uploaded by default to a **private** personal Hugging Face dataset
+  (`{hf_user}/ml-intern-sessions`)
+- trace upload can be disabled with:
+
+```json
+{ "share_traces": false }
+```
+
+## Trace / data-handling recommendation
+
+The default private trace upload is still a **real upload**, so unpublished research hypotheses,
+private experiment notes, internal review text, proprietary logs, or unredacted benchmark findings
+should not be sent to `ml-intern` casually.
+
+For Robot SF, the safe default is:
+
+1. use repo-local prompts that reference tracked files and commands,
+2. avoid pasting unpublished result narratives or secrets,
+3. prefer sanitized prompts for assessment/planning,
+4. disable trace uploads explicitly when handling sensitive or pre-publication material.
+
+This matters more for Robot SF than for a generic toy repo because benchmark wording, promotion
+claims, and artifact provenance are part of correctness.
+
+## Recommended Robot SF use cases
+
+Good first uses:
+
+- “read these repo files and propose a minimal validation plan”
+- “check whether this config/command path exists and summarize the workflow”
+- “review a PPO config and suggest bounded dry-run proof commands”
+- “compare two local docs/config surfaces and point out contract mismatches”
+
+Possible later use, but only after local proof:
+
+- one remote sandbox smoke for a bounded training or validation command,
+- one explicitly scoped HF Job follow-up with pinned install steps, timeout, hardware, and durable
+  artifact routing.
+
+## Non-goals and red lines
+
+Do **not** treat `ml-intern` as:
+
+- the canonical training launcher,
+- a substitute for `scripts/dev/` readiness gates,
+- a reason to skip `AGENTS.md` / `docs/dev_guide.md`,
+- a new dependency to add to `pyproject.toml`,
+- or a benchmark execution path whose fallback/degraded results are acceptable evidence.
+
+If a future remote run cannot preserve repo-tracked configs, explicit artifact persistence, and
+proof-first validation, it should stop rather than broadening the claim.
+
+## Verified local proof ladder
+
+The first validation ladder should stay local and bounded:
+
+1. **Repo comprehension only**
+   - Read:
+     - `AGENTS.md`
+     - `docs/ai/repo_overview.md`
+     - `examples/README.md`
+     - `scripts/training/train_ppo.py`
+   - Ask for a minimal validation plan before any edits or long commands.
+2. **One headless quickstart candidate**
+   - `uv run python examples/quickstart/01_basic_robot.py`
+3. **One targeted pytest candidate**
+   - `uv run pytest tests/integration/test_train_expert_ppo.py -q`
+4. **One PPO dry-run candidate**
+   - `uv run python scripts/training/train_ppo.py --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml --dry-run --log-level WARNING`
+
+The point of this ladder is not to outsource repository judgment. It is to check whether
+`ml-intern` can stay inside Robot SF's existing contracts while helping with bounded work.
+
+## First-use prompt for Robot SF
+
+Use a no-edit prompt first:
+
+```text
+You are assessing the Robot SF repository as a bounded experiment assistant.
+
+Before proposing any command, read these files first:
+- AGENTS.md
+- docs/ai/repo_overview.md
+- examples/README.md
+- scripts/training/train_ppo.py
+- docs/training/ppo_training_workflow.md
+
+Constraints:
+- Do not edit files.
+- Do not propose long training, SLURM jobs, CARLA/Unreal runs, or paper-facing benchmark campaigns.
+- Do not add dependencies.
+- Treat fallback or degraded benchmark behavior as failure, not success.
+- Prefer existing repo commands and configs.
+
+Task:
+1. Summarize the repository's execution rules relevant to a bounded assistant.
+2. Propose a minimal proof ladder using:
+   - one headless quickstart command,
+   - one targeted pytest command,
+   - one PPO --dry-run command.
+3. For each command, explain why it is low risk and what evidence it would produce.
+4. Call out any trace/privacy risk from using ml-intern on this repository.
+5. Stop after the plan; do not run anything.
+```
+
+## Verified local paths referenced by this assessment
+
+Checked on this branch:
+
+- `AGENTS.md`
+- `docs/ai/repo_overview.md`
+- `docs/context/README.md`
+- `examples/README.md`
+- `examples/quickstart/01_basic_robot.py`
+- `scripts/training/train_ppo.py`
+- `docs/training/ppo_training_workflow.md`
+- `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml`
+- `tests/integration/test_train_expert_ppo.py`
+
+## Validation
+
+Commands run on this branch:
+
+```bash
+source .venv/bin/activate
+uv run python examples/quickstart/01_basic_robot.py
+uv run pytest tests/integration/test_train_expert_ppo.py -q
+uv run python scripts/training/train_ppo.py \
+  --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml \
+  --dry-run \
+  --log-level WARNING
+BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh
+```
+
+Observed outcomes:
+
+- `examples/quickstart/01_basic_robot.py` completed successfully and produced the expected headless
+  environment reset plus 10-step rollout output.
+- `uv run pytest tests/integration/test_train_expert_ppo.py -q` passed: `43 passed in 22.72s`.
+- `train_ppo.py --dry-run` exited successfully against the documented canonical PPO config.
+- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed on this branch:
+  `3434 passed, 18 skipped, 3 warnings in 255.63s`.
+- The quickstart and dry-run both surfaced a known SVG obstacle repair warning for
+  `robot_sf/maps/uni_campus_big.svg`; this did not block the bounded assessment and is exactly the
+  kind of real repository signal a bounded assistant should report rather than hide.
+- The PPO dry-run also surfaced the expected cadence/seed warnings from the training config:
+  deprecated `evaluation.frequency_episodes` is ignored in favor of `evaluation.step_schedule`, and
+  `randomize_seeds` causes the provided training seeds to be ignored.
+
+## Follow-up boundary
+
+If this note holds up after the local proof ladder, the next acceptable follow-up is **one separate
+issue** for a single remote sandbox/HF Job smoke with:
+
+- pinned install/setup steps,
+- explicit hardware/runtime assumptions,
+- timeout and failure handling,
+- durable artifact routing,
+- and an explicit statement that it does not replace the canonical local/SLURM workflow.
+
+Follow-up tracker opened: #1191.


### PR DESCRIPTION
## Summary
Assess `huggingface/ml-intern` as a bounded Robot SF experiment assistant and record the safe-use
boundary as a durable context note, without adding a new runtime dependency or changing canonical
training/benchmark workflows.

## Linked Issues
- Closes #1181
- Relates to #1191

## What Changed
- Added `docs/context/issue_1181_ml_intern_experiment_assistant.md` as the canonical assessment note
  for `ml-intern` in Robot SF.
- Recorded the upstream CLI/runtime/trace contract relevant to this repo: local filesystem tools by
  default, opt-in sandbox runtime, and private-by-default trace uploads with explicit opt-out.
- Recorded a bounded Robot SF proof ladder and a no-edit first-use prompt that forces `ml-intern` to
  read the repo context stack before proposing commands.
- Linked the new note from `docs/context/README.md`, `docs/README.md`, and `CHANGELOG.md`.
- Opened follow-up issue #1191 for the deferred single remote sandbox/HF Job smoke.

## Why It Matters
- Added value: gives the repo a concrete go/no-go boundary for using `ml-intern` without weakening
  provenance or benchmark safety.
- Expected impact: contributors can use `ml-intern` for bounded planning and smoke validation while
  avoiding accidental trace leakage, runtime sprawl, or overclaim.
- Why this is worth merging now: the assessment closes an open workflow question and turns it into a
  tracked, reusable note plus a separate follow-up boundary.

## Validation / Proof
- Commands run:
  - `source .venv/bin/activate && uv run python examples/quickstart/01_basic_robot.py`
  - `source .venv/bin/activate && uv run pytest tests/integration/test_train_expert_ppo.py -q`
  - `source .venv/bin/activate && uv run python scripts/training/train_ppo.py --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml --dry-run --log-level WARNING`
  - `source .venv/bin/activate && BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
  - `git fetch origin main && git merge --no-edit origin/main && source .venv/bin/activate && BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - The quickstart completed successfully with the expected headless rollout output.
  - `tests/integration/test_train_expert_ppo.py` passed (`43 passed in 22.72s`).
  - The documented canonical PPO dry-run path exited successfully.
  - The post-sync readiness gate passed against `origin/main` (`3435 passed, 17 skipped, 3 warnings`).
- Benchmarks or smoke tests, if applicable:
  - This is a docs/workflow change, so the smoke evidence is bounded local validation rather than a
    benchmark claim.

## Risks / Rollout
- Compatibility risks: low; the change adds guidance and links, not runtime behavior.
- Failure modes: future users could still misuse `ml-intern` if they ignore the trace/privacy and
  bounded-scope rules in the note.
- Rollback or fallback plan: revert the note/index/changelog changes and keep `ml-intern` untracked
  in repo guidance if the assessment proves misleading.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1181_ml_intern_experiment_assistant.md`
  - `docs/context/README.md`
  - `docs/README.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - The issue note records the upstream `ml-intern` contract checked on 2026-05-13 and the verified
    local Robot SF proof ladder.
- Any assumptions that need to be preserved:
  - `ml-intern` remains an optional bounded assistant, not a project dependency or canonical
    execution path.

## Follow-Up Issues
- Deferred work:
  - One explicitly bounded remote sandbox/HF Job smoke only after the local proof boundary.
- Issues opened for follow-up:
  - #1191 `Evaluate one remote ml-intern sandbox/HF Job smoke for Robot SF`

## Reviewer Notes
- Anything a reviewer should verify closely:
  - The trace/privacy boundary and the no-edit first-use prompt are strict enough for unpublished
    Robot SF work.
  - The note does not overclaim remote-runtime readiness from local-only evidence.
- Any known limitations:
  - No remote sandbox/HF Job run was attempted in this issue by design.

## Artifact Persistence
- Local ignored outputs created during validation stayed under `output/coverage/`,
  `output/benchmarks/ppo_imitation/`, and dry-run checkpoint/report paths under `output/benchmarks/expert_policies/`.
- These are disposable validation artifacts for a docs/workflow change; no durable upload or tracked
  manifest is required for this PR.
