### PR TITLE
docs: finish output-root cleanup for active results paths (#1186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated the issue-1186 post-`#243` output-root cleanup slice so remaining active benchmark and
+  baseline commands now point at `output/benchmarks/...`, the factory-performance baseline tooling
+  resolves its default path through canonical artifact helpers, and the social-navigation benchmark
+  runner no longer advertises a legacy `results/` output root.
 * Updated the issue-1180 `goal-pr-review` workflow so autonomous PR review defaults to a
   fix-first repair loop on writable branches: proof failures are now classified as auto-fixable
   now, deferred follow-up, or handoff-only blockers; safe actionable gaps should be repaired and

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,7 +404,7 @@ The figures orchestration script writes `baseline_table.md` by default. To obtai
 
 ```bash
 uv run python scripts/generate_figures.py \
-  --episodes results/episodes_sf_long_fix1.jsonl \
+  --episodes output/benchmarks/episodes_sf_long_fix1.jsonl \
   --auto-out-dir --no-pareto --table-tex \
   --dmetrics collisions,comfort_exposure,snqi --table-metrics collisions,comfort_exposure,snqi
 ```
@@ -413,7 +413,7 @@ uv run python scripts/generate_figures.py \
 
 ```bash
 uv run python -m robot_sf.benchmark.cli table \
-  --episodes results/episodes_sf_long_fix1.jsonl \
+  --episodes output/benchmarks/episodes_sf_long_fix1.jsonl \
   --metrics collisions,comfort_exposure,near_misses,snqi \
   --format tex > docs/figures/table_snqi.tex
 ```
@@ -438,8 +438,8 @@ Optional tuning:
 
 ```bash
      uv run robot_sf_bench aggregate \
-       --in results/episodes_sf_long_fix1.jsonl \
-       --out results/summary_ci.json \
+       --in output/benchmarks/episodes_sf_long_fix1.jsonl \
+       --out output/benchmarks/summary_ci.json \
        --bootstrap-samples 1000 --bootstrap-confidence 0.95 --bootstrap-seed 123
      ```
 
@@ -447,8 +447,8 @@ Optional tuning:
 
 ```bash
      uv run python scripts/generate_figures.py \
-       --episodes results/episodes_sf_long_fix1.jsonl \
-       --table-summary results/summary_ci.json \
+       --episodes output/benchmarks/episodes_sf_long_fix1.jsonl \
+       --table-summary output/benchmarks/summary_ci.json \
        --table-metrics collisions,comfort_exposure,snqi \
        --table-stats mean,median,p95 \
        --table-include-ci --table-tex --no-pareto \
@@ -467,11 +467,11 @@ Example (custom suffix for 90% CIs):
 
 ```bash
 uv run robot_sf_bench aggregate \
-  --in results/episodes.jsonl --out results/summary_ci90.json \
+  --in output/benchmarks/episodes.jsonl --out output/benchmarks/summary_ci90.json \
   --bootstrap-samples 1000 --bootstrap-confidence 0.90
 uv run python scripts/generate_figures.py \
-  --episodes results/episodes.jsonl \
-  --table-summary results/summary_ci90.json \
+  --episodes output/benchmarks/episodes.jsonl \
+  --table-summary output/benchmarks/summary_ci90.json \
   --table-metrics collisions,snqi \
   --table-stats mean,median \
   --table-include-ci --ci-column-suffix ci90 --table-tex \

--- a/docs/baselines/social_force.md
+++ b/docs/baselines/social_force.md
@@ -43,14 +43,14 @@ planner.close()
 robot_sf_bench run \
     --matrix scenarios/test_scenarios.yaml \
     --algo baseline_sf \
-    --out results/social_force_results.jsonl
+    --out output/benchmarks/social_force_results.jsonl
 
 # Use custom configuration
 robot_sf_bench run \
     --matrix scenarios/test_scenarios.yaml \
     --algo baseline_sf \
     --config configs/baselines/social_force_custom.yaml \
-    --out results/social_force_custom.jsonl
+    --out output/benchmarks/social_force_custom.jsonl
 ```
 
 ## Configuration

--- a/docs/benchmark_full_classic.md
+++ b/docs/benchmark_full_classic.md
@@ -21,7 +21,7 @@ All outputs are deterministic given the scenario matrix file and master seed.
 ```bash
 uv run python scripts/classic_benchmark_full.py \
   --scenarios configs/scenarios/classic_interactions.yaml \
-  --output results/full_classic_run_01 \
+  --output output/benchmarks/full_classic_run_01 \
   --workers 2 --seed 123 --algo ppo \
   --initial-episodes 2 --max-episodes 4 --batch-size 2 \
   --target-collision-half-width 0.05 \
@@ -32,7 +32,7 @@ Smoke mode (fast placeholder artifacts):
 ```bash
 uv run python scripts/classic_benchmark_full.py \
   --scenarios configs/scenarios/classic_interactions.yaml \
-  --output results/full_classic_smoke \
+  --output output/benchmarks/full_classic_smoke \
   --smoke --initial-episodes 1 --max-episodes 1
 ```
 
@@ -173,7 +173,7 @@ Typical workflow:
 ```bash
 uv run python scripts/classic_benchmark_full.py \
   --scenarios configs/scenarios/classic_interactions.yaml \
-  --output results/full_classic_final \
+  --output output/benchmarks/full_classic_final \
   --seed 123 \
   --initial-episodes 2 \
   --max-episodes 4 \

--- a/scripts/perf/baseline_factory_creation.py
+++ b/scripts/perf/baseline_factory_creation.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from loguru import logger
 
+from robot_sf.common.artifact_paths import resolve_artifact_path
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -97,14 +99,19 @@ def _percentile(values: list[float], p: float) -> float:
     return d0 + d1
 
 
+def _resolve_output_path(path: Path) -> Path:
+    """Resolve a baseline output path through the canonical artifact policy."""
+    return resolve_artifact_path(path)
+
+
 def main() -> None:
-    """TODO docstring. Document this function."""
+    """Measure factory construction timings and write the baseline JSON artifact."""
     parser = argparse.ArgumentParser(description="Baseline factory creation timing")
     parser.add_argument("--iterations", type=int, default=30, help="Creations per factory")
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("results/factory_perf_baseline.json"),
+        default=Path("benchmarks/factory_perf_baseline.json"),
         help="Output JSON path",
     )
     args = parser.parse_args()
@@ -127,7 +134,7 @@ def main() -> None:
     # Pedestrian env requires a robot_model; skip unless trivial to supply (future enhancement)
     # Placeholder: could load a lightweight mock or stub policy; omitted for neutral baseline.
 
-    out_path: Path = args.output
+    out_path = _resolve_output_path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "timestamp": datetime.now(UTC).isoformat(),

--- a/scripts/run_social_navigation_benchmark.py
+++ b/scripts/run_social_navigation_benchmark.py
@@ -18,7 +18,7 @@ Usage:
 The script will:
 - Use the classic_interactions.yaml scenario matrix
 - Run all baseline algorithms (SF, PPO, Random)
-- Generate comprehensive outputs under results/social_nav_benchmark_YYYYMMDD_HHMMSS/
+- Generate comprehensive outputs under output/benchmarks/social_nav_benchmark_YYYYMMDD_HHMMSS/
 - Produce plots, videos, and statistical reports
 """
 
@@ -38,6 +38,7 @@ try:
     from robot_sf.benchmark.baseline_stats import run_and_compute_baseline
     from robot_sf.benchmark.cli import DEFAULT_SCHEMA_PATH
     from robot_sf.benchmark.full_classic.orchestrator import run_full_benchmark
+    from robot_sf.common.artifact_paths import resolve_artifact_path
     from robot_sf.render.helper_catalog import ensure_output_dir
     from scripts.classic_benchmark_full import BenchmarkCLIConfig
 except ImportError as e:
@@ -73,6 +74,11 @@ def create_baseline_configs(
         disable_videos=False,
         max_videos=2,  # Generate videos for representative episodes
     )
+
+
+def _resolve_output_root(timestamp: str) -> Path:
+    """Resolve the benchmark output root under the canonical benchmarks artifact tree."""
+    return resolve_artifact_path(Path("benchmarks") / f"social_nav_benchmark_{timestamp}")
 
 
 def run_baseline_benchmark(algo: str, scenario_matrix: str, output_root: str) -> dict[str, Any]:
@@ -327,7 +333,7 @@ def main() -> int:
 
     # Create timestamped output directory
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_root = root / f"results/social_nav_benchmark_{timestamp}"
+    output_root = _resolve_output_root(timestamp)
     ensure_output_dir(output_root)
 
     logger.info("Starting Social Navigation Benchmark")

--- a/tests/perf/test_factory_creation_perf.py
+++ b/tests/perf/test_factory_creation_perf.py
@@ -1,7 +1,7 @@
 """T015: Performance regression guard for factory creation (FR-017).
 
 Compares current mean creation times against baseline in
-`results/factory_perf_baseline.json`. Fails if mean exceeds baseline by >5%.
+`output/benchmarks/factory_perf_baseline.json`. Fails if mean exceeds baseline by >5%.
 Skips if baseline file missing (developer must run baseline script first).
 
 NOTE: Ensures fast demo mode is disabled to reflect real creation cost.
@@ -15,10 +15,11 @@ from pathlib import Path
 
 import pytest
 
+from robot_sf.common.artifact_paths import resolve_artifact_path
 from robot_sf.gym_env.environment_factory import make_image_robot_env, make_robot_env
 from robot_sf.gym_env.unified_config import ImageRobotConfig, RobotSimulationConfig
 
-BASELINE_PATH = Path("results/factory_perf_baseline.json")
+BASELINE_PATH = resolve_artifact_path(Path("benchmarks/factory_perf_baseline.json"))
 THRESHOLD = 1.15  # +15% hard budget (tightened per T031 spec compliance)
 SOFT_THRESHOLD = 1.30  # soft warn band (>15% and <=30%)
 ITERATIONS = 2  # keep light for CI; baseline may have been generated with more

--- a/tests/test_output_root_migration.py
+++ b/tests/test_output_root_migration.py
@@ -1,0 +1,73 @@
+"""Regression tests for remaining user-facing output-root migration helpers.
+
+These tests verify that the bounded #1186 cleanup keeps actively used scripts on
+the canonical `output/benchmarks` artifact tree. They matter because the issue
+updates documented defaults and helper-backed script paths rather than changing
+artifact semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING
+
+from scripts import run_social_navigation_benchmark
+from scripts.perf import baseline_factory_creation
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _StubEnv:
+    """Minimal environment stub used to exercise factory timing script output wiring."""
+
+    def reset(self) -> None:
+        """Simulate a no-op reset."""
+
+    def close(self) -> None:
+        """Simulate a no-op close."""
+
+
+def test_factory_baseline_script_writes_under_benchmarks_artifact_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify the factory baseline script writes to `output/benchmarks` via artifact helpers."""
+    monkeypatch.setenv("ROBOT_SF_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        baseline_factory_creation,
+        "make_robot_env",
+        lambda config, debug=False: _StubEnv(),
+    )
+    monkeypatch.setattr(
+        baseline_factory_creation,
+        "make_image_robot_env",
+        lambda config, debug=False: _StubEnv(),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["baseline_factory_creation.py", "--iterations", "1"],
+    )
+
+    baseline_factory_creation.main()
+
+    output_path = tmp_path / "benchmarks" / "factory_perf_baseline.json"
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert output_path.exists()
+    assert payload["iterations"] == 1
+    assert set(payload["results"]) == {"make_robot_env", "make_image_robot_env"}
+
+
+def test_social_navigation_benchmark_output_root_uses_benchmarks_category(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify the benchmark runner resolves its timestamped root under `output/benchmarks`."""
+    monkeypatch.setenv("ROBOT_SF_ARTIFACT_ROOT", str(tmp_path))
+
+    resolved = run_social_navigation_benchmark._resolve_output_root("20260513_000000")
+
+    assert resolved == tmp_path / "benchmarks" / "social_nav_benchmark_20260513_000000"


### PR DESCRIPTION
## Summary
Finish the remaining active `results/` → `output/` cleanup slice for the user-facing docs and workflow surfaces named in #1186. The touched scripts now resolve benchmark artifacts through the canonical artifact helpers, and the linked docs/examples no longer teach stale `results/` paths for this bounded slice.

## Linked Issues
- Closes #1186
- Relates to #243

## What Changed
- Updated the scoped docs examples in `docs/README.md`, `docs/baselines/social_force.md`, and `docs/benchmark_full_classic.md` to use `output/benchmarks/...`.
- Switched `scripts/perf/baseline_factory_creation.py` and `tests/perf/test_factory_creation_perf.py` to the canonical benchmark artifact path and helper-backed resolution.
- Updated `scripts/run_social_navigation_benchmark.py` to resolve its timestamped root under the benchmarks artifact category.
- Added focused regression coverage in `tests/test_output_root_migration.py` and recorded the workflow change in `CHANGELOG.md`.

## Why It Matters
- Added value: active docs and default script outputs now match the repository artifact-root policy instead of sending users to legacy `results/` paths.
- Expected impact: new contributors can follow the linked benchmark/baseline docs without landing in contradictory output locations.
- Why this is worth merging now: it completes a small, evidence-backed post-`#243` cleanup slice without changing artifact semantics.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_output_root_migration.py -q`
  - `uv run python scripts/perf/baseline_factory_creation.py --iterations 1 --output benchmarks/factory_perf_baseline_issue1186.json`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - The scoped grep over the named files no longer found legacy `results/` commands; the only remaining match is the docs index migration note itself.
  - The focused regression tests passed and verified helper-backed output-root resolution for the two changed scripts.
  - The baseline timing smoke wrote to `output/benchmarks/factory_perf_baseline_issue1186.json`.
- Benchmarks or smoke tests, if applicable:
  - The post-merge readiness gate passed on the branch after the path/default cleanup.

## Risks / Rollout
- Compatibility risks: low; this is a bounded doc/default-path cleanup that keeps artifact semantics unchanged.
- Failure modes: if downstream workflows still rely on legacy `results/` locations outside this slice, they will need their own follow-up cleanup rather than silent compatibility shims here.
- Rollback or fallback plan: revert the touched doc/default updates and restore the previous paths.

## Docs / Provenance
- Updated docs:
  - `docs/README.md`
  - `docs/baselines/social_force.md`
  - `docs/benchmark_full_classic.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - The canonical artifact-root policy remains the one documented in `docs/README.md` and implemented by `robot_sf/common/artifact_paths.py`.
- Any assumptions that need to be preserved:
  - This issue stays limited to active user-facing surfaces rather than a repo-wide historical scrub of every legacy `results/` mention.

## Follow-Up Issues
- Deferred work:
  - None in this bounded slice.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - The changed script defaults honor `ROBOT_SF_ARTIFACT_ROOT` overrides and still land under the benchmarks artifact category.
- Any known limitations:
  - Historical or inactive docs outside the scoped issue files may still mention `results/`; this PR intentionally does not rewrite those broader surfaces.
