### PR TITLE
docs: add PR first-pass review checklist

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -121,13 +121,25 @@ Use GitHub MCP / GitHub app tools as the source of truth when available before f
      manifest, or another explicit durable source.
    - Include the persistence decision in the PR body and any issue handoff comment.
 
-12. Push and open draft PR
+12. Run the first-pass self-review
+   - Use `docs/context/pr_first_pass_review_audit_2026-05-14.md` before pushing or opening the PR.
+   - For docs/context changes, verify index links and make validation statements match commands
+     actually run.
+   - For parser, schema, path, JSON, artifact, and public-helper changes, check malformed inputs,
+     missing values, empty collections, wrong shapes, non-finite numbers, path traversal, and
+     repository-relative path handling.
+   - For environment, benchmark, recording, and simulation-loop changes, check streaming behavior,
+     static Gymnasium spaces, random-state isolation, and per-step output size.
+   - For skill or workflow changes, read the changed text as executable instructions and make scope
+     boundaries, selected issue sets, and evidence destinations explicit.
+
+13. Push and open draft PR
    - `git push -u origin "$(git branch --show-current)"`
    - Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
    - Open draft PR linking issue:
      - `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`
 
-13. Create follow-up issues when needed
+14. Create follow-up issues when needed
    - For deferred but important work, create dedicated issues:
      - `gh issue create --title "<follow-up>" --body-file <body.md> --label "enhancement,technical-debt" --milestone "<milestone>"`
    - Add to project:
@@ -137,7 +149,7 @@ Use GitHub MCP / GitHub app tools as the source of truth when available before f
    - If you are processing a larger batch, finish all issue cleanup before the project-write pass
      and run score sync once at the end.
 
-14. Close loop metadata
+15. Close loop metadata
    - Parent issue:
      - keep open while PR is draft; use closing keyword in PR body (`Closes #<n>`) when ready.
    - Project:
@@ -151,5 +163,6 @@ Use GitHub MCP / GitHub app tools as the source of truth when available before f
   - ambiguity decisions taken (or why none were needed)
   - commands run for validation
   - local artifact persistence decision for generated `output/` files
+  - first-pass self-review result
   - follow-up issues created (if any) with labels/milestone/priority
   - draft PR URL

--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -96,7 +96,19 @@ After a successful rerun, record freshness evidence:
      - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
      - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
 
-6. Build the PR body from the repository template
+6. Run the first-pass self-review
+   - Use `docs/context/pr_first_pass_review_audit_2026-05-14.md` as the reviewer-lens checklist.
+   - For docs/context changes, verify index links and make validation statements match commands
+     actually run.
+   - For parser, schema, path, JSON, artifact, and public-helper changes, check malformed inputs,
+     missing values, empty collections, wrong shapes, non-finite numbers, path traversal, and
+     repository-relative path handling.
+   - For environment, benchmark, recording, and simulation-loop changes, check streaming behavior,
+     static Gymnasium spaces, random-state isolation, and per-step output size.
+   - For skill or workflow changes, read the changed text as executable instructions and make scope
+     boundaries, selected issue sets, and evidence destinations explicit.
+
+7. Build the PR body from the repository template
    - Start from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
    - Fill sections with repository-specific evidence:
      - summary of implementation,
@@ -108,12 +120,12 @@ After a successful rerun, record freshness evidence:
      - follow-up issues if any.
    - Do not remove sections; keep the template structure intact.
 
-7. Open the draft PR
+8. Open the draft PR
    - Preferred command:
      - `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`
    - Use a conventional commit/PR title prefix such as `feat:`, `fix:`, or `docs:`.
 
-8. Close the loop
+9. Close the loop
    - Keep the parent issue open while the PR is draft unless repository policy says otherwise.
    - Comment on the issue or PR when a follow-up item was intentionally deferred.
 
@@ -123,6 +135,7 @@ After a successful rerun, record freshness evidence:
 - Latest `origin/main` integrated into the feature branch before PR creation.
 - Ignored/generated `output/` artifacts inspected, classified, and either made durable or
   documented as disposable/local-only.
+- First-pass self-review completed against `docs/context/pr_first_pass_review_audit_2026-05-14.md`.
 - Fresh readiness proof from either:
   - a passing `pr_ready_freshness.py status`, or
   - a new `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` run plus a new stamp.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[AI Repo Overview](./ai/repo_overview.md)** - Short orientation for Codex-style agents: where to read first, core repo areas, and common failure modes
 * **[Issue #1181 `ml-intern` Bounded Assistant Assessment](./context/issue_1181_ml_intern_experiment_assistant.md)** - Safe-use boundary for evaluating `huggingface/ml-intern` against Robot SF without replacing the local/SLURM proof-first workflow
 * **[AI Coding Workflow](./ai/ai-workflow.md)** - End-to-end AI issue-to-PR workflow, validation gates, review loop, and traceability conventions
+* **[PR First-Pass Review Audit](./context/pr_first_pass_review_audit_2026-05-14.md)** - Recent merged-PR review findings and the pre-opening self-review checklist for reducing repeated reviewer fixes
 * **[AI Planner Zoo Context](./ai/planner_zoo_context.md)** - Planner-zoo integration context, readiness framing, and provenance/adapter questions to answer explicitly
 * **[AI Context Packing Decision](./ai/context_packing.md)** - Current decision and rationale for using Repomix as the default focused-context bundler
 * **[Awesome Copilot Adaptation](./ai/awesome_copilot_adaptation.md)** - Selective adaptation plan for Codex skills, including `autoresearch`,   `auto-improvement`, context-discovery, quality, and doc-sync skills

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -25,6 +25,7 @@ Read these first when working in this workflow:
 - [docs/context/README.md](../context/README.md)
 - [docs/context/issue_713_batch_first_issue_workflow.md](../context/issue_713_batch_first_issue_workflow.md)
 - [docs/context/issue_728_coding_agents_compatibility.md](../context/issue_728_coding_agents_compatibility.md)
+- [docs/context/pr_first_pass_review_audit_2026-05-14.md](../context/pr_first_pass_review_audit_2026-05-14.md)
 - [docs/project_prioritization.md](../project_prioritization.md)
 - [docs/dev/training_protocol_template.md](../dev/training_protocol_template.md)
 - [docs/context/issue_691_benchmark_fallback_policy.md](../context/issue_691_benchmark_fallback_policy.md)
@@ -139,6 +140,20 @@ The PR readiness gate also checks:
 - full test execution through the shared parallel wrapper.
 
 For benchmark-sensitive changes, use the canonical benchmark command or smoke path and treat fallback or degraded execution as diagnostic only, not as success.
+
+Before opening the PR, also run a first-pass self-review against the current diff using
+[docs/context/pr_first_pass_review_audit_2026-05-14.md](../context/pr_first_pass_review_audit_2026-05-14.md).
+Treat it as a reviewer-lens pass, not another full test suite:
+
+- docs/context changes: align PR-body validation, context-note validation, and exact proof output;
+  add required `docs/README.md` and `docs/context/README.md` links.
+- schema, parser, path, JSON, artifact, and public-helper changes: check malformed payloads,
+  missing values, wrong shapes, directories, absolute paths, traversal, `NaN`, `inf`, and negative
+  sentinels.
+- simulation-loop, recording, benchmark, or environment changes: check streaming behavior,
+  random-state isolation, static Gymnasium spaces, and per-step output size.
+- skill or agent workflow changes: read changed text as executable instructions and preserve
+  selected issue sets, scope boundaries, and evidence destinations.
 
 ### 7. Open the PR
 

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -90,6 +90,8 @@ knowledge, not every transient iteration detail.
   [open_issues_maintainer_input_triage.md](open_issues_maintainer_input_triage.md)
 * Open-issues PR split strategy:
   [open_issues_pr_split_strategy_2026-05-13.md](open_issues_pr_split_strategy_2026-05-13.md)
+* PR first-pass review audit:
+  [pr_first_pass_review_audit_2026-05-14.md](pr_first_pass_review_audit_2026-05-14.md)
 * Note-maintenance skill:
   [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 

--- a/docs/context/pr_first_pass_review_audit_2026-05-14.md
+++ b/docs/context/pr_first_pass_review_audit_2026-05-14.md
@@ -1,0 +1,165 @@
+# PR First-Pass Review Audit (2026-05-14)
+
+## Scope
+
+This audit sampled the roughly 30 most recent closed pull requests returned on
+2026-05-14 by:
+
+```bash
+gh pr list --repo ll7/robot_sf_ll7 --state closed --limit 30 \
+  --json number,title,createdAt,closedAt,mergedAt,author,headRefName,baseRefName,url
+```
+
+The sample covered PRs #1197 through #1131. All sampled PRs were merged. The goal was to identify
+why PRs were not perfect on first opening and to turn repeated review findings into a pre-opening
+review habit.
+
+Supporting inspection used:
+
+```bash
+gh pr view <n> --repo ll7/robot_sf_ll7 \
+  --json number,title,createdAt,mergedAt,reviews,comments,commits,files,additions,deletions
+gh api --paginate repos/ll7/robot_sf_ll7/pulls/<n>/comments
+gh api --paginate repos/ll7/robot_sf_ll7/issues/<n>/comments
+```
+
+## Quantitative Signals
+
+- 29 of 30 PRs had more than one commit after opening.
+- 26 of 30 PRs had at least one inline review comment.
+- The sample contained 91 inline review comments.
+- Review states were mostly `COMMENTED`, not `CHANGES_REQUESTED`, so the issue was usually
+  first-pass polish, missed edge cases, or proof consistency rather than complete implementation
+  failure.
+- PR #1197 was the cleanest recent example: one commit, no inline comments, and only summary/status
+  comments.
+
+## Main Failure Modes
+
+### 1. Durable docs and proof drift
+
+Repeated examples: #1192, #1178, #1171, #1166, #1161, #1160, #1133, #1139, #1137, #1140.
+
+Typical findings:
+
+- PR body validation counts did not match the context note.
+- New `docs/context/` pages were not discoverable from `docs/README.md` or `docs/context/README.md`.
+- Context notes still said no validation had run after the PR body claimed tests or readiness checks.
+- Durable evidence bundles kept local `output/` paths or absolute local paths instead of tracked,
+  repository-relative pointers.
+- Follow-up wording referenced stale files or omitted a previously agreed requirement.
+
+Why this escaped first pass:
+
+- The readiness gate checks tests and coverage, but it does not compare PR body claims against
+  context-note validation sections or docs indexes.
+- Agents treated docs updates as prose-only edits instead of checking them as durable navigation and
+  evidence surfaces.
+
+### 2. Fail-closed and edge-case validation gaps
+
+Repeated examples: #1184, #1177, #1176, #1166, #1164, #1161, #1160, #1159, #1158, #1135, #1132,
+#1131.
+
+Typical findings:
+
+- Optional hook commands masked real failures with `&& ... || true`.
+- JSON/YAML/path readers accepted malformed values, `None`, directories, absolute paths, traversal,
+  or unsupported types too late or too silently.
+- Numeric contracts did not reject `NaN`, `inf`, negative sentinels, or empty arrays with the wrong
+  shape.
+- Benchmark/planner status defaults allowed accidental smoke or degraded labels instead of making
+  status explicit.
+- Tests covered the happy path but missed malformed payloads, empty batches, or route/geometry
+  boundary relations.
+
+Why this escaped first pass:
+
+- Implementations were scoped to the requested feature path, while automated reviewers checked
+  adversarial inputs and contract boundaries.
+- The pre-PR workflow lacked an explicit "what would a reviewer break?" pass for public helpers,
+  schemas, and artifact readers.
+
+### 3. Resource and scalability hygiene
+
+Repeated examples: #1177, #1173, #1166, #1160, #1159, #1158, #1157.
+
+Typical findings:
+
+- JSONL loaders used `read_text().splitlines()` where streaming would avoid memory spikes.
+- Inner loops did repeated `np.linalg.norm` work instead of squared-distance calculations.
+- Global `np.random.seed` could leak state across environments.
+- Dynamic Gymnasium observation spaces risked wrapper/vector-env incompatibility.
+- Step recordings repeated static metadata each tick.
+- `np.inf` bounds were used with integer spaces.
+
+Why this escaped first pass:
+
+- Targeted tests proved correctness on small fixtures, but the self-review did not check the
+  repository's expected artifact sizes, simulation-loop frequency, or Gymnasium compatibility
+  contracts.
+
+### 4. Scope and wording ambiguity
+
+Repeated examples: #1183, #1182, #1178, #1176, #1170, #1137.
+
+Typical findings:
+
+- Agent skill instructions used broad wording such as "all open issues" without preserving the
+  selected issue set.
+- Review handoff language was ambiguous about whether evidence should be committed, commented, or
+  added to the PR description.
+- Documentation cleanup PRs missed nearby placeholders or created sentence fragments.
+
+Why this escaped first pass:
+
+- Review focused on satisfying the immediate issue rather than reading changed instructions as
+  executable prompts for future agents.
+
+## First-Pass Self-Review Checklist
+
+Run this checklist before opening draft PRs, after implementation and before final readiness proof:
+
+1. Evidence consistency
+   - Compare PR body validation, context-note validation, and actual terminal output.
+   - Remove stale "not run" statements once validation has run.
+   - Use repository-relative paths in docs, PR text, JSON evidence, and issue comments.
+   - If a new durable note is useful beyond the PR, link it from `docs/context/README.md` and
+     `docs/README.md`.
+
+2. Reviewer adversarial pass
+   - For parsers, schemas, config readers, artifact readers, and public helpers, check malformed
+     payloads, missing values, `None`, empty collections, wrong shapes, directories, absolute paths,
+     path traversal, `NaN`, `inf`, and negative sentinels.
+   - Add targeted tests for any boundary that could silently corrupt benchmark, planner, training,
+     or recording semantics.
+   - Do not mask real command failures when the dependency exists; optional dependencies should be
+     optional only when missing.
+
+3. Resource and runtime pass
+   - Stream large JSONL or artifact files instead of reading them fully when the format is line
+     oriented.
+   - Avoid global random-state mutation in environment reset paths.
+   - Keep Gymnasium spaces static after construction unless the PR is explicitly changing that
+     contract.
+   - Avoid repeated static metadata in per-step output records.
+
+4. Agent-instruction pass
+   - Treat skill and workflow docs as executable instructions.
+   - Preserve user-selected issue sets, scope boundaries, and handoff-only blockers explicitly.
+   - State where missing evidence belongs: committed note, PR comment, or PR body.
+
+## Recommended Process Change
+
+The readiness gate remains necessary, but it is not sufficient. Add a mandatory first-pass
+self-review step to AI-assisted PR opening workflows. The step should be lightweight and targeted to
+the diff:
+
+- docs/context changes trigger the evidence consistency checks,
+- schema/parser/path/JSON changes trigger the adversarial boundary checks,
+- simulation-loop, recording, benchmark, or environment changes trigger the resource/runtime checks,
+- skill or agent workflow changes trigger the executable-instruction checks.
+
+This audit is now linked from the AI workflow and PR-opening skill so future agents can run the
+checklist before opening PRs instead of waiting for Gemini or CodeRabbit to identify the same
+classes of issues.

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -69,15 +69,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-requested_args=()
 if [[ -n "$worker_override" ]]; then
-  requested_args=(--requested "$worker_override")
+  worker_spec="$(
+    uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" --requested "$worker_override" \
+      --show-reason 2> >(cat >&2)
+  )"
+else
+  worker_spec="$(
+    uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" --show-reason \
+      2> >(cat >&2)
+  )"
 fi
-
-worker_spec="$(
-  uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" "${requested_args[@]}" --show-reason \
-    2> >(cat >&2)
-)"
 if [[ -z "$worker_spec" ]]; then
   echo "Failed to resolve pytest worker count." >&2
   exit 2

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -69,17 +69,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+requested_args=()
 if [[ -n "$worker_override" ]]; then
-  worker_spec="$(
-    uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" --requested "$worker_override" \
-      --show-reason 2> >(cat >&2)
-  )"
-else
-  worker_spec="$(
-    uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" --show-reason \
-      2> >(cat >&2)
-  )"
+  requested_args=(--requested "$worker_override")
 fi
+
+worker_spec="$(
+  uv run python "$SCRIPT_DIR/resolve_pytest_workers.py" ${requested_args[@]+"${requested_args[@]}"} \
+    --show-reason 2> >(cat >&2)
+)"
 if [[ -z "$worker_spec" ]]; then
   echo "Failed to resolve pytest worker count." >&2
   exit 2


### PR DESCRIPTION
## Summary
Adds a durable audit of the last 30 merged PRs and wires a first-pass self-review checklist into the AI PR-opening workflows. Also fixes the readiness test wrapper so it works on this shell when no explicit pytest worker override is provided.

## Linked Issues
- Relates to the May 14 PR first-pass review audit request.

## What Changed
- Added `docs/context/pr_first_pass_review_audit_2026-05-14.md` with PR sample scope, quantitative signals, repeated first-pass failure modes, and a targeted checklist.
- Linked the audit from `docs/README.md`, `docs/context/README.md`, and `docs/ai/ai-workflow.md`.
- Updated `.agents/skills/gh-pr-opener/SKILL.md` and `.agents/skills/gh-issue-autopilot/SKILL.md` so future PR handoffs run the first-pass checklist before opening.
- Fixed `scripts/dev/run_tests_parallel.sh` to avoid empty-array expansion under `set -u` on the default macOS Bash path.

## Why It Matters
- Added value: turns repeated Gemini/CodeRabbit findings into a pre-opening reviewer-lens checklist.
- Expected impact: fewer post-open fix commits for stale validation text, missing docs indexes, weak fail-closed boundaries, resource-hygiene issues, and ambiguous agent instructions.
- Why this is worth merging now: the last-30-PR sample showed 29/30 PRs had post-open commits and 26/30 had inline review comments, so the process gap is current and recurring.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py` -> validated 34 skills and README coverage.
  - `git diff --check` -> passed.
  - `scripts/dev/run_tests_parallel.sh --help` -> passed after the wrapper fix.
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on commit `55408b1a5d386e88dad616924e5748ea86f0447c` with `3496 passed, 14 skipped, 1 warning`.
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` and `status --base-ref origin/main` -> fresh stamp for commit `55408b1a5d386e88dad616924e5748ea86f0447c`.
- Evidence that the change works here: the readiness gate initially exposed the shell wrapper failure, the wrapper was fixed, and the full gate then completed successfully.
- Benchmarks or smoke tests, if applicable: not applicable; workflow/docs plus one shell wrapper fix.

## Risks / Rollout
- Compatibility risks: low. The skill/workflow changes add a checklist step; the shell wrapper preserves the same worker-resolution behavior while avoiding empty-array expansion.
- Failure modes: agents may still skip the checklist if they bypass the repo PR-opening workflows.
- Rollback or fallback plan: revert this PR to restore the previous workflow text and wrapper implementation.

## Docs / Provenance
- Updated docs:
  - `docs/context/pr_first_pass_review_audit_2026-05-14.md`
  - `docs/ai/ai-workflow.md`
  - `docs/README.md`
  - `docs/context/README.md`
- Relevant design or provenance notes: the audit note records the exact `gh` commands used for the PR sample and the recurring review categories.
- Any assumptions that need to be preserved: ignored `output/coverage` and `output/validation/pr_ready` files are local validation byproducts and should remain untracked.

## Follow-Up Issues
- Deferred work: none. If this does not reduce first-pass review comments after a later sample, open a deeper automation issue for machine-checking docs/proof consistency.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check whether the checklist is specific enough without making PR opening too heavyweight.
- The readiness wrapper fix is intentionally narrow: it only avoids expanding an empty Bash array under `set -u`.
