### PR TITLE
feat: add docs proof consistency checker (#1214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1214 docs/proof consistency checker surface: `scripts/validation/check_docs_proof_consistency.py`
+  now scans changed docs/evidence files for high-confidence PR handoff drift, the
+  `scripts/dev/check_docs_proof_consistency_diff.sh` wrapper exposes the branch-diff command, and
+  the contributor workflow docs now point at the new check before proof-heavy PR handoff.
 * Added the issue-1185 dummy-backend smoke surface: `robot_sf/sim/backends/dummy_backend.py`
   now exposes the map metadata and minimal simulator contract that `RobotEnv` expects, so
   `examples/advanced/01_backend_selection.py` can run headlessly in CI and stays covered by the

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -145,6 +145,11 @@ Before opening the PR, also run a first-pass self-review against the current dif
 [docs/context/pr_first_pass_review_audit_2026-05-14.md](../context/pr_first_pass_review_audit_2026-05-14.md).
 Treat it as a reviewer-lens pass, not another full test suite:
 
+- For docs/proof-heavy branches, run
+  `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` before PR creation to
+  catch high-confidence context/evidence drift such as missing context-note index links, absolute
+  local paths in tracked evidence, and durable evidence files that still point at ignored
+  `output/` artifacts.
 - docs/context changes: align PR-body validation, context-note validation, and exact proof output;
   add required `docs/README.md` and `docs/context/README.md` links.
 - schema, parser, path, JSON, artifact, and public-helper changes: check malformed payloads,

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -158,6 +158,7 @@ skills use the same commands:
 scripts/dev/ruff_fix_format.sh
 scripts/dev/run_tests_parallel.sh
 scripts/dev/run_ci_local.sh
+scripts/dev/check_docs_proof_consistency_diff.sh
 scripts/dev/sbatch_use_max_time.sh SLURM/Auxme/auxme_gpu.sl
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
@@ -190,6 +191,12 @@ longest functions, and optional pytest duration rows from a captured `--pytest-l
 Use `uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run-id> --top 10`
 when GitHub CI wall time drifts from local readiness and you need queue, job, and slowest-step
 timings from `gh run view` data.
+
+Use `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` before PR handoff when a
+branch adds or edits context notes, evidence bundles, or other proof-heavy docs surfaces. The
+checker is intentionally conservative: it only flags high-confidence issues such as missing
+`docs/context/README.md` links for new top-level context notes, tracked evidence files that still
+contain absolute local paths, and tracked evidence that links to ignored `output/` artifacts.
 
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 

--- a/scripts/dev/check_docs_proof_consistency_diff.sh
+++ b/scripts/dev/check_docs_proof_consistency_diff.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+uv run --active python scripts/validation/check_docs_proof_consistency.py --base "$BASE_REF"

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Check branch-diff docs/proof consistency for PR handoff.
+
+This helper is intentionally conservative. It only reports high-confidence
+mechanical problems in changed files relative to a base ref (default:
+``origin/main``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+_CONTEXT_README = Path("docs/context/README.md")
+_TOP_LEVEL_CONTEXT_DIR = Path("docs/context")
+_EVIDENCE_DIR = Path("docs/context/evidence")
+_ABSOLUTE_LOCAL_PATH_RE = re.compile(r"(?<!\w)(/home/[^\s`'\"<>)\]}]+|/Users/[^\s`'\"<>)\]}]+)")
+_OUTPUT_PATH_RE = re.compile(
+    r"(?<!\w)(?:output/[^\s`'\"<>)\]}]+|/home/[^\s`'\"<>)\]}]*/output/[^\s`'\"<>)\]}]+|/Users/[^\s`'\"<>)\]}]*/output/[^\s`'\"<>)\]}]+)"
+)
+_VALIDATION_SKIP_RE = re.compile(r"\bno validation commands were run\b", re.IGNORECASE)
+_COMMAND_HINT_RE = re.compile(
+    r"(`[^`\n]*(?:uv run|pytest|ruff|scripts/dev/|python )[^`\n]*`|```(?:bash|sh)?[\s\S]*?(?:uv run|pytest|ruff|scripts/dev/|python )[\s\S]*?```)",
+    re.IGNORECASE,
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)|<((?:\./)?[^ >]+)>")
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """Repository-relative file path plus git diff status."""
+
+    status: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One high-confidence docs/proof consistency problem."""
+
+    path: Path
+    message: str
+
+
+def _run(cmd: Sequence[str], *, cwd: Path | None = None) -> str:
+    """Run a subprocess and return stripped stdout."""
+    proc = subprocess.run(
+        list(cmd),
+        cwd=str(cwd) if cwd is not None else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({proc.returncode}): {' '.join(cmd)}\n{proc.stderr.strip()}".rstrip()
+        )
+    return proc.stdout.strip()
+
+
+def _repo_root() -> Path:
+    """Return the repository root for the current checkout."""
+    return Path(_run(["git", "rev-parse", "--show-toplevel"])).resolve()
+
+
+def _normalize_path(path: Path, repo_root: Path) -> Path:
+    """Return a repository-relative path when possible."""
+    if path.is_absolute():
+        try:
+            return path.resolve().relative_to(repo_root)
+        except ValueError:
+            return path
+    return path
+
+
+def _changed_files(base: str, repo_root: Path) -> list[ChangedFile]:
+    """Return changed files from the branch diff plus local worktree edits."""
+
+    def _parse_name_status(output: str, *, default_status: str | None = None) -> list[ChangedFile]:
+        parsed: list[ChangedFile] = []
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if default_status is not None:
+                parsed.append(ChangedFile(status=default_status, path=Path(stripped)))
+                continue
+            parts = stripped.split("\t", maxsplit=1)
+            if len(parts) != 2:
+                continue
+            status, raw_path = parts
+            parsed.append(ChangedFile(status=status, path=Path(raw_path)))
+        return parsed
+
+    combined: dict[Path, str] = {}
+    commands: list[tuple[list[str], str | None]] = [
+        (
+            ["git", "diff", "--name-status", "--diff-filter=ACMRT", f"{base}...HEAD"],
+            None,
+        ),
+        (["git", "diff", "--name-status", "--cached", "--diff-filter=ACMRT"], None),
+        (["git", "diff", "--name-status", "--diff-filter=ACMRT"], None),
+        (["git", "ls-files", "--others", "--exclude-standard"], "A"),
+    ]
+
+    for cmd, default_status in commands:
+        output = _run(cmd, cwd=repo_root)
+        for changed in _parse_name_status(output, default_status=default_status):
+            current = combined.get(changed.path)
+            if current == "A":
+                continue
+            combined[changed.path] = "A" if changed.status == "A" else changed.status
+
+    return [ChangedFile(status=status, path=path) for path, status in sorted(combined.items())]
+
+
+def _read_text(path: Path) -> str:
+    """Read UTF-8 text from a repository path."""
+    return path.read_text(encoding="utf-8")
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Remove fenced markdown code blocks from a document."""
+    return re.sub(r"```[\s\S]*?```", "", text)
+
+
+def _markdown_targets(text: str) -> list[str]:
+    """Extract markdown/autolink targets from a markdown string."""
+    targets: list[str] = []
+    for first, second in _MARKDOWN_LINK_RE.findall(text):
+        target = first or second
+        if target:
+            targets.append(target.strip())
+    return targets
+
+
+def _contains_link_target(targets: Iterable[str], expected: str) -> bool:
+    """Return whether a markdown target list references an expected relative path."""
+    normalized_expected = expected.lstrip("./")
+    expected_name = Path(normalized_expected).name
+    for target in targets:
+        candidate = target.lstrip("./")
+        if candidate == normalized_expected or candidate.endswith(f"/{normalized_expected}"):
+            return True
+        if Path(candidate).name == expected_name:
+            return True
+    return False
+
+
+def _context_readme_link_diagnostics(
+    changed_files: Iterable[ChangedFile],
+    *,
+    context_readme_text: str,
+) -> list[Diagnostic]:
+    """Flag added top-level docs/context notes missing from the context index."""
+    diagnostics: list[Diagnostic] = []
+    targets = _markdown_targets(context_readme_text)
+    for changed in changed_files:
+        if changed.status != "A":
+            continue
+        if changed.path.parent != _TOP_LEVEL_CONTEXT_DIR:
+            continue
+        if changed.path.suffix != ".md" or changed.path.name == "README.md":
+            continue
+        if _contains_link_target(targets, changed.path.name):
+            continue
+        diagnostics.append(
+            Diagnostic(
+                path=changed.path,
+                message="added context note is not linked from docs/context/README.md",
+            )
+        )
+    return diagnostics
+
+
+def _evidence_path_diagnostics(path: Path, text: str) -> list[Diagnostic]:
+    """Flag durable-evidence files that contain local absolute paths or output pointers."""
+    diagnostics: list[Diagnostic] = []
+    if not path.as_posix().startswith(_EVIDENCE_DIR.as_posix()):
+        return diagnostics
+
+    scan_text = _strip_fenced_code_blocks(text) if path.suffix == ".md" else text
+
+    if _ABSOLUTE_LOCAL_PATH_RE.search(scan_text):
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                message="tracked evidence should not contain absolute local filesystem paths",
+            )
+        )
+
+    if path.suffix == ".md":
+        link_targets = _markdown_targets(text)
+        if any(_OUTPUT_PATH_RE.search(target) for target in link_targets):
+            diagnostics.append(
+                Diagnostic(
+                    path=path,
+                    message="tracked evidence should not link to ignored output/ artifacts",
+                )
+            )
+    elif _OUTPUT_PATH_RE.search(scan_text):
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                message="tracked evidence should not point to ignored output/ artifacts",
+            )
+        )
+
+    return diagnostics
+
+
+def _validation_phrase_diagnostics(path: Path, text: str) -> list[Diagnostic]:
+    """Flag notes that claim no validation ran while also listing executed commands."""
+    if not path.as_posix().startswith(_TOP_LEVEL_CONTEXT_DIR.as_posix()):
+        return []
+    if path.suffix != ".md":
+        return []
+    if not _VALIDATION_SKIP_RE.search(text):
+        return []
+    if not _COMMAND_HINT_RE.search(text):
+        return []
+    return [
+        Diagnostic(
+            path=path,
+            message=(
+                "note says no validation commands were run but also includes executable validation command references"
+            ),
+        )
+    ]
+
+
+def _file_diagnostics(path: Path, text: str) -> list[Diagnostic]:
+    """Collect all diagnostics for one changed file."""
+    diagnostics: list[Diagnostic] = []
+    diagnostics.extend(_evidence_path_diagnostics(path, text))
+    diagnostics.extend(_validation_phrase_diagnostics(path, text))
+    return diagnostics
+
+
+def _collect_diagnostics(
+    changed_files: Iterable[ChangedFile],
+    *,
+    repo_root: Path,
+) -> list[Diagnostic]:
+    """Collect all docs/proof consistency diagnostics for the selected file set."""
+    diagnostics: list[Diagnostic] = []
+    changed_list = list(changed_files)
+    context_readme = repo_root / _CONTEXT_README
+    if context_readme.exists():
+        diagnostics.extend(
+            _context_readme_link_diagnostics(
+                changed_list,
+                context_readme_text=_read_text(context_readme),
+            )
+        )
+
+    for changed in changed_list:
+        full_path = repo_root / changed.path
+        if not full_path.exists() or not full_path.is_file():
+            continue
+        if full_path.suffix not in {".md", ".json", ".yaml", ".yml", ".txt"}:
+            continue
+        diagnostics.extend(_file_diagnostics(changed.path, _read_text(full_path)))
+    return diagnostics
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the docs/proof consistency checker."""
+    parser = argparse.ArgumentParser(
+        description="Check changed docs/proof surfaces for high-confidence consistency issues.",
+    )
+    parser.add_argument("--base", default="origin/main", help="Base ref to diff against.")
+    parser.add_argument(
+        "--path",
+        action="append",
+        default=[],
+        help="Optional repository-relative path(s) to check instead of the git diff.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit diagnostics as JSON instead of human-readable text.",
+    )
+    return parser.parse_args()
+
+
+def _selected_files(args: argparse.Namespace, repo_root: Path) -> list[ChangedFile]:
+    """Resolve the changed file set from explicit paths or the branch diff."""
+    if args.path:
+        return [
+            ChangedFile(status="M", path=_normalize_path(Path(raw_path), repo_root))
+            for raw_path in args.path
+        ]
+    return _changed_files(str(args.base), repo_root)
+
+
+def main() -> int:
+    """Run the docs/proof consistency checker."""
+    args = _parse_args()
+    repo_root = _repo_root()
+    changed_files = _selected_files(args, repo_root)
+    diagnostics = _collect_diagnostics(changed_files, repo_root=repo_root)
+
+    if args.json:
+        payload = [
+            {"path": diagnostic.path.as_posix(), "message": diagnostic.message}
+            for diagnostic in diagnostics
+        ]
+        print(json.dumps(payload, indent=2))
+    elif diagnostics:
+        for diagnostic in diagnostics:
+            print(f"ERROR {diagnostic.path.as_posix()}: {diagnostic.message}")
+    else:
+        checked = len(changed_files)
+        print(f"OK docs/proof consistency check passed for {checked} changed file(s).")
+
+    return 1 if diagnostics else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -66,6 +66,19 @@ def _run(cmd: Sequence[str], *, cwd: Path | None = None) -> str:
     return proc.stdout.strip()
 
 
+def _path_exists_in_ref(path: Path, ref: str, repo_root: Path) -> bool:
+    """Return whether a repository-relative path exists in a git ref."""
+    spec = f"{ref}:{path.as_posix()}"
+    proc = subprocess.run(
+        ["git", "cat-file", "-e", spec],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
 def _repo_root() -> Path:
     """Return the repository root for the current checkout."""
     return Path(_run(["git", "rev-parse", "--show-toplevel"])).resolve()
@@ -81,24 +94,32 @@ def _normalize_path(path: Path, repo_root: Path) -> Path:
     return path
 
 
+def _is_within_dir(path: Path, root: Path) -> bool:
+    """Return whether a repository-relative path is at or below a trusted root."""
+    return path == root or root in path.parents
+
+
+def _parse_name_status(output: str, *, default_status: str | None = None) -> list[ChangedFile]:
+    """Parse git --name-status output into ChangedFile rows."""
+    parsed: list[ChangedFile] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if default_status is not None:
+            parsed.append(ChangedFile(status=default_status, path=Path(stripped)))
+            continue
+        parts = stripped.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        raw_path = parts[-1]
+        parsed.append(ChangedFile(status=status, path=Path(raw_path)))
+    return parsed
+
+
 def _changed_files(base: str, repo_root: Path) -> list[ChangedFile]:
     """Return changed files from the branch diff plus local worktree edits."""
-
-    def _parse_name_status(output: str, *, default_status: str | None = None) -> list[ChangedFile]:
-        parsed: list[ChangedFile] = []
-        for line in output.splitlines():
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if default_status is not None:
-                parsed.append(ChangedFile(status=default_status, path=Path(stripped)))
-                continue
-            parts = stripped.split("\t", maxsplit=1)
-            if len(parts) != 2:
-                continue
-            status, raw_path = parts
-            parsed.append(ChangedFile(status=status, path=Path(raw_path)))
-        return parsed
 
     combined: dict[Path, str] = {}
     commands: list[tuple[list[str], str | None]] = [
@@ -138,7 +159,7 @@ def _markdown_targets(text: str) -> list[str]:
     for first, second in _MARKDOWN_LINK_RE.findall(text):
         target = first or second
         if target:
-            targets.append(target.strip())
+            targets.append(target.strip().split("#", maxsplit=1)[0])
     return targets
 
 
@@ -184,7 +205,7 @@ def _context_readme_link_diagnostics(
 def _evidence_path_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     """Flag durable-evidence files that contain local absolute paths or output pointers."""
     diagnostics: list[Diagnostic] = []
-    if not path.as_posix().startswith(_EVIDENCE_DIR.as_posix()):
+    if not _is_within_dir(path, _EVIDENCE_DIR):
         return diagnostics
 
     scan_text = _strip_fenced_code_blocks(text) if path.suffix == ".md" else text
@@ -219,7 +240,7 @@ def _evidence_path_diagnostics(path: Path, text: str) -> list[Diagnostic]:
 
 def _validation_phrase_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     """Flag notes that claim no validation ran while also listing executed commands."""
-    if not path.as_posix().startswith(_TOP_LEVEL_CONTEXT_DIR.as_posix()):
+    if not _is_within_dir(path, _TOP_LEVEL_CONTEXT_DIR):
         return []
     if path.suffix != ".md":
         return []
@@ -296,7 +317,16 @@ def _selected_files(args: argparse.Namespace, repo_root: Path) -> list[ChangedFi
     """Resolve the changed file set from explicit paths or the branch diff."""
     if args.path:
         return [
-            ChangedFile(status="M", path=_normalize_path(Path(raw_path), repo_root))
+            ChangedFile(
+                status=(
+                    "M"
+                    if _path_exists_in_ref(
+                        _normalize_path(Path(raw_path), repo_root), str(args.base), repo_root
+                    )
+                    else "A"
+                ),
+                path=_normalize_path(Path(raw_path), repo_root),
+            )
             for raw_path in args.path
         ]
     return _changed_files(str(args.base), repo_root)

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -94,9 +95,22 @@ def _normalize_path(path: Path, repo_root: Path) -> Path:
     return path
 
 
+def _normalize_explicit_path(raw_path: str, repo_root: Path) -> Path:
+    """Return a validated repository-relative path from a user-provided --path value."""
+    path = _normalize_path(Path(raw_path), repo_root)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"--path must stay within the repository root: {raw_path}")
+    return path
+
+
 def _is_within_dir(path: Path, root: Path) -> bool:
     """Return whether a repository-relative path is at or below a trusted root."""
     return path == root or root in path.parents
+
+
+def _is_added_status(status: str) -> bool:
+    """Return whether a git status represents a newly introduced file."""
+    return status == "A" or status.startswith("C")
 
 
 def _parse_name_status(output: str, *, default_status: str | None = None) -> list[ChangedFile]:
@@ -138,7 +152,7 @@ def _changed_files(base: str, repo_root: Path) -> list[ChangedFile]:
             current = combined.get(changed.path)
             if current == "A":
                 continue
-            combined[changed.path] = "A" if changed.status == "A" else changed.status
+            combined[changed.path] = "A" if _is_added_status(changed.status) else changed.status
 
     return [ChangedFile(status=status, path=path) for path, status in sorted(combined.items())]
 
@@ -183,7 +197,7 @@ def _context_readme_link_diagnostics(
     diagnostics: list[Diagnostic] = []
     targets = _markdown_targets(context_readme_text)
     for changed in changed_files:
-        if changed.status != "A":
+        if not _is_added_status(changed.status):
             continue
         if changed.path.parent != _TOP_LEVEL_CONTEXT_DIR:
             continue
@@ -305,19 +319,12 @@ def _parse_args() -> argparse.Namespace:
 def _selected_files(args: argparse.Namespace, repo_root: Path) -> list[ChangedFile]:
     """Resolve the changed file set from explicit paths or the branch diff."""
     if args.path:
-        return [
-            ChangedFile(
-                status=(
-                    "M"
-                    if _path_exists_in_ref(
-                        _normalize_path(Path(raw_path), repo_root), str(args.base), repo_root
-                    )
-                    else "A"
-                ),
-                path=_normalize_path(Path(raw_path), repo_root),
-            )
-            for raw_path in args.path
-        ]
+        selected: list[ChangedFile] = []
+        for raw_path in args.path:
+            path = _normalize_explicit_path(raw_path, repo_root)
+            status = "M" if _path_exists_in_ref(path, str(args.base), repo_root) else "A"
+            selected.append(ChangedFile(status=status, path=path))
+        return selected
     return _changed_files(str(args.base), repo_root)
 
 
@@ -325,7 +332,11 @@ def main() -> int:
     """Run the docs/proof consistency checker."""
     args = _parse_args()
     repo_root = _repo_root()
-    changed_files = _selected_files(args, repo_root)
+    try:
+        changed_files = _selected_files(args, repo_root)
+    except ValueError as exc:
+        print(f"ERROR {exc}", file=sys.stderr)
+        return 2
     diagnostics = _collect_diagnostics(changed_files, repo_root=repo_root)
 
     if args.json:

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -166,12 +166,10 @@ def _markdown_targets(text: str) -> list[str]:
 def _contains_link_target(targets: Iterable[str], expected: str) -> bool:
     """Return whether a markdown target list references an expected relative path."""
     normalized_expected = expected.lstrip("./")
-    expected_name = Path(normalized_expected).name
+    repo_relative_expected = f"{_TOP_LEVEL_CONTEXT_DIR.as_posix()}/{normalized_expected}"
     for target in targets:
         candidate = target.lstrip("./")
-        if candidate == normalized_expected or candidate.endswith(f"/{normalized_expected}"):
-            return True
-        if Path(candidate).name == expected_name:
+        if candidate in {normalized_expected, repo_relative_expected}:
             return True
     return False
 
@@ -218,16 +216,7 @@ def _evidence_path_diagnostics(path: Path, text: str) -> list[Diagnostic]:
             )
         )
 
-    if path.suffix == ".md":
-        link_targets = _markdown_targets(text)
-        if any(_OUTPUT_PATH_RE.search(target) for target in link_targets):
-            diagnostics.append(
-                Diagnostic(
-                    path=path,
-                    message="tracked evidence should not link to ignored output/ artifacts",
-                )
-            )
-    elif _OUTPUT_PATH_RE.search(scan_text):
+    if _OUTPUT_PATH_RE.search(scan_text):
         diagnostics.append(
             Diagnostic(
                 path=path,

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -1,0 +1,111 @@
+"""Tests for the docs/proof consistency checker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validation.check_docs_proof_consistency import (
+    ChangedFile,
+    _collect_diagnostics,
+    _context_readme_link_diagnostics,
+)
+
+
+def test_missing_context_note_index_link_is_reported() -> None:
+    """New top-level context notes should be linked from the context README."""
+    diagnostics = _context_readme_link_diagnostics(
+        [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
+        context_readme_text="# Context Notes Workflow\n",
+    )
+
+    assert diagnostics == [
+        type(diagnostics[0])(
+            path=Path("docs/context/issue_999_example.md"),
+            message="added context note is not linked from docs/context/README.md",
+        )
+    ]
+
+
+def test_absolute_local_path_in_tracked_evidence_is_reported(tmp_path: Path) -> None:
+    """Tracked evidence should not preserve machine-local absolute paths."""
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "# Context Notes Workflow\n", encoding="utf-8"
+    )
+    evidence = repo_root / "docs/context/evidence/report.md"
+    evidence.write_text("Artifact came from /home/user/output/report.json.\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/evidence/report.md"))],
+        repo_root=repo_root,
+    )
+
+    assert any(
+        "absolute local filesystem paths" in diagnostic.message for diagnostic in diagnostics
+    )
+
+
+def test_output_pointer_in_tracked_evidence_is_reported(tmp_path: Path) -> None:
+    """Tracked evidence should not link to ignored output artifacts."""
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "# Context Notes Workflow\n", encoding="utf-8"
+    )
+    evidence = repo_root / "docs/context/evidence/report.md"
+    evidence.write_text("[artifact](output/reports/run.json)\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/evidence/report.md"))],
+        repo_root=repo_root,
+    )
+
+    assert any("ignored output/ artifacts" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_context_note_output_command_is_allowed(tmp_path: Path) -> None:
+    """Regular context notes may still mention output paths in reproducible commands."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text(
+        "Run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` and inspect `output/coverage/coverage.json` locally.\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == []
+
+
+def test_stale_no_validation_phrase_with_commands_is_reported(tmp_path: Path) -> None:
+    """Notes should not claim no validation ran while listing executed commands."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text(
+        "No validation commands were run during this pass.\n\n"
+        "- `uv run pytest tests/test_cli.py -q`\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    assert any(
+        "no validation commands were run" in diagnostic.message for diagnostic in diagnostics
+    )

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import argparse
+import subprocess
 from pathlib import Path
 
 from scripts.validation.check_docs_proof_consistency import (
     ChangedFile,
     _collect_diagnostics,
     _context_readme_link_diagnostics,
+    _parse_name_status,
+    _selected_files,
 )
 
 
@@ -24,6 +28,23 @@ def test_missing_context_note_index_link_is_reported() -> None:
             message="added context note is not linked from docs/context/README.md",
         )
     ]
+
+
+def test_context_note_anchor_link_counts_as_index_link() -> None:
+    """Anchored links should satisfy the context-note discoverability check."""
+    diagnostics = _context_readme_link_diagnostics(
+        [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
+        context_readme_text="- [Issue 999 Example](issue_999_example.md#validation)\n",
+    )
+
+    assert diagnostics == []
+
+
+def test_parse_name_status_uses_new_path_for_rename() -> None:
+    """Rename rows should track the current worktree path, not the old path pair."""
+    changed = _parse_name_status("R100\tdocs/context/old.md\tdocs/context/new.md\n")
+
+    assert changed == [ChangedFile(status="R100", path=Path("docs/context/new.md"))]
 
 
 def test_absolute_local_path_in_tracked_evidence_is_reported(tmp_path: Path) -> None:
@@ -62,6 +83,24 @@ def test_output_pointer_in_tracked_evidence_is_reported(tmp_path: Path) -> None:
     )
 
     assert any("ignored output/ artifacts" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_prefix_sibling_of_evidence_dir_is_not_treated_as_tracked_evidence(tmp_path: Path) -> None:
+    """Only the real evidence directory should trigger durable-evidence checks."""
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence_backup").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "# Context Notes Workflow\n", encoding="utf-8"
+    )
+    note = repo_root / "docs/context/evidence_backup/report.md"
+    note.write_text("[artifact](output/reports/run.json)\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/evidence_backup/report.md"))],
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == []
 
 
 def test_context_note_output_command_is_allowed(tmp_path: Path) -> None:
@@ -108,4 +147,58 @@ def test_stale_no_validation_phrase_with_commands_is_reported(tmp_path: Path) ->
 
     assert any(
         "no validation commands were run" in diagnostic.message for diagnostic in diagnostics
+    )
+
+
+def test_explicit_path_new_context_note_is_treated_as_added(tmp_path: Path) -> None:
+    """Explicit path checks should still enforce added-note index-link validation."""
+    repo_root = tmp_path
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "# Context Notes Workflow\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", "docs/context/README.md"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "test fixture"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text("Fresh note body.\n", encoding="utf-8")
+
+    selected = _selected_files(
+        argparse.Namespace(path=[str(note)], base="HEAD"),
+        repo_root=repo_root,
+    )
+    diagnostics = _collect_diagnostics(selected, repo_root=repo_root)
+
+    assert selected == [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))]
+    assert any(
+        "not linked from docs/context/README.md" in diagnostic.message for diagnostic in diagnostics
     )

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -6,6 +6,8 @@ import argparse
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scripts.validation.check_docs_proof_consistency import (
     ChangedFile,
     _collect_diagnostics,
@@ -45,6 +47,18 @@ def test_context_note_same_basename_in_subdir_does_not_count_as_index_link() -> 
     diagnostics = _context_readme_link_diagnostics(
         [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
         context_readme_text="- [Archived Example](archive/issue_999_example.md)\n",
+    )
+
+    assert any(
+        "not linked from docs/context/README.md" in diagnostic.message for diagnostic in diagnostics
+    )
+
+
+def test_copied_context_note_requires_index_link() -> None:
+    """Copied top-level context notes should be handled like added notes."""
+    diagnostics = _context_readme_link_diagnostics(
+        [ChangedFile(status="C100", path=Path("docs/context/issue_999_example.md"))],
+        context_readme_text="# Context Notes Workflow\n",
     )
 
     assert any(
@@ -232,3 +246,16 @@ def test_explicit_path_new_context_note_is_treated_as_added(tmp_path: Path) -> N
     assert any(
         "not linked from docs/context/README.md" in diagnostic.message for diagnostic in diagnostics
     )
+
+
+def test_explicit_path_outside_repo_is_rejected(tmp_path: Path) -> None:
+    """Explicit path checks should not read files outside the repository root."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_path = tmp_path / "outside.md"
+
+    with pytest.raises(ValueError, match="repository root"):
+        _selected_files(
+            argparse.Namespace(path=[str(outside_path)], base="HEAD"),
+            repo_root=repo_root,
+        )

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -40,6 +40,18 @@ def test_context_note_anchor_link_counts_as_index_link() -> None:
     assert diagnostics == []
 
 
+def test_context_note_same_basename_in_subdir_does_not_count_as_index_link() -> None:
+    """A link to another note with the same basename should not index a top-level note."""
+    diagnostics = _context_readme_link_diagnostics(
+        [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
+        context_readme_text="- [Archived Example](archive/issue_999_example.md)\n",
+    )
+
+    assert any(
+        "not linked from docs/context/README.md" in diagnostic.message for diagnostic in diagnostics
+    )
+
+
 def test_parse_name_status_uses_new_path_for_rename() -> None:
     """Rename rows should track the current worktree path, not the old path pair."""
     changed = _parse_name_status("R100\tdocs/context/old.md\tdocs/context/new.md\n")
@@ -76,6 +88,24 @@ def test_output_pointer_in_tracked_evidence_is_reported(tmp_path: Path) -> None:
     )
     evidence = repo_root / "docs/context/evidence/report.md"
     evidence.write_text("[artifact](output/reports/run.json)\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/evidence/report.md"))],
+        repo_root=repo_root,
+    )
+
+    assert any("ignored output/ artifacts" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_inline_output_pointer_in_markdown_evidence_is_reported(tmp_path: Path) -> None:
+    """Markdown evidence should flag inline ignored-output pointers, not only links."""
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "# Context Notes Workflow\n", encoding="utf-8"
+    )
+    evidence = repo_root / "docs/context/evidence/report.md"
+    evidence.write_text("Manifest: `output/reports/run.json`\n", encoding="utf-8")
 
     diagnostics = _collect_diagnostics(
         [ChangedFile(status="M", path=Path("docs/context/evidence/report.md"))],


### PR DESCRIPTION
## Summary
Add a conservative docs/proof consistency checker for PR handoff and wire it into the contributor workflow as an explicit pre-PR command for proof-heavy branches.

## Linked Issues
- Closes #1214

## What Changed
- Added `scripts/validation/check_docs_proof_consistency.py`, a diff-scoped checker for high-confidence docs/proof drift.
- Added `scripts/dev/check_docs_proof_consistency_diff.sh` as the reusable wrapper command.
- Added focused tests in `tests/validation/test_check_docs_proof_consistency.py` covering missing context-note links, absolute local evidence paths, ignored `output/` evidence pointers, and allowed local-output mentions in normal context notes.
- Updated `docs/dev_guide.md`, `docs/ai/ai-workflow.md`, and `CHANGELOG.md` so the new command is discoverable in the repo workflow.

## Why It Matters
- Added value: catches recurring mechanical review misses before PR creation without trying to replace reviewer judgment.
- Expected impact: proof-heavy branches should surface missing context-note index links and unsafe durable-evidence path references locally instead of in review.
- Why this is worth merging now: it addresses a repeated review-comment class with a small conservative checker and keeps the first slice narrow enough to trust.

## Validation / Proof
- Commands run:
  - `uv run --active ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`
  - `uv run --active pytest tests/validation/test_check_docs_proof_consistency.py -q`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - the new focused tests pass,
  - the new checker passes on this branch diff after latest-main sync,
  - the full readiness gate passed after latest-main sync.
- Benchmarks or smoke tests, if applicable:
  - not applicable; this is contributor-workflow validation tooling.

## Risks / Rollout
- Compatibility risks: low; this adds a new optional checker command and workflow docs, not a runtime behavior change.
- Failure modes: the checker could be too noisy if heuristics expand beyond high-confidence cases.
- Rollback or fallback plan: narrow or remove individual rules in follow-up if reviewers find false positives.

## Docs / Provenance
- Updated docs:
  - `docs/dev_guide.md`
  - `docs/ai/ai-workflow.md`
  - `CHANGELOG.md`
- Relevant design or provenance notes:
  - issue #1214 is the contract for this first checker slice.
- Any assumptions that need to be preserved:
  - keep the checker conservative and diff-scoped,
  - treat `output/coverage/*` as disposable local validation artifacts rather than durable evidence.

## Follow-Up Issues
- Deferred work:
  - broader docs index coverage and any additional heuristics should be separate follow-ups if needed.
- Issues opened for follow-up:
  - none.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - that the checker rules stay high-confidence and do not overreach into semantic review.
- Any known limitations:
  - the first slice only checks a narrow set of docs/proof drift patterns and does not yet reason about PR body text directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a pre-PR validation step to the contributor workflow for docs/proof-heavy branches.

* **Chores**
  * Introduced a docs/proof consistency checker to flag missing context links, absolute local paths in tracked evidence, and references to ignored output artifacts.

* **Tests**
  * Expanded unit tests to cover linking rules, evidence-path checks, scoping behavior, and related validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1216)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->