### PR TITLE
test: retire render encode placeholder skip (#1217)

### DIFF
--- a/tests/visuals/test_render_encode_split.py
+++ b/tests/visuals/test_render_encode_split.py
@@ -60,18 +60,18 @@ def test_render_encode_split_tests_do_not_use_unconditional_skip_markers():
     """Guard this file against permanent placeholder skips in the default suite."""
     tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
     skipped_tests: list[str] = []
-    for node in tree.body:
+    for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
             continue
         for decorator in node.decorator_list:
+            func = decorator.func if isinstance(decorator, ast.Call) else decorator
             if (
-                isinstance(decorator, ast.Call)
-                and isinstance(decorator.func, ast.Attribute)
-                and decorator.func.attr == "skip"
-                and isinstance(decorator.func.value, ast.Attribute)
-                and decorator.func.value.attr == "mark"
-                and isinstance(decorator.func.value.value, ast.Name)
-                and decorator.func.value.value.id == "pytest"
+                isinstance(func, ast.Attribute)
+                and func.attr == "skip"
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "mark"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id == "pytest"
             ):
                 skipped_tests.append(node.name)
     assert skipped_tests == []

--- a/tests/visuals/test_render_encode_split.py
+++ b/tests/visuals/test_render_encode_split.py
@@ -9,24 +9,23 @@ so the test focuses on schema presence and numeric consistency when available.
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
-
-import pytest
 
 from robot_sf.benchmark.full_classic.orchestrator import run_full_benchmark
 from tests.perf_utils.minimal_matrix import write_minimal_matrix
 
 
 class _Cfg:  # minimal inline config mirroring other tests
-    """TODO docstring. Document this class."""
+    """Minimal benchmark config for render/encode timing tests."""
 
     def __init__(self, tmp_path: Path, renderer: str = "synthetic"):
-        """TODO docstring. Document this function.
+        """Create a one-episode benchmark config rooted at ``tmp_path``.
 
         Args:
-            tmp_path: TODO docstring.
-            renderer: TODO docstring.
+            tmp_path: Directory used for the benchmark matrix and output artifacts.
+            renderer: Video renderer mode to request from the benchmark pipeline.
         """
         tmp_path.mkdir(parents=True, exist_ok=True)
         self.output_root = str(tmp_path)
@@ -49,19 +48,40 @@ class _Cfg:  # minimal inline config mirroring other tests
 
 
 def _read_json(path: Path):
-    """TODO docstring. Document this function.
+    """Read a UTF-8 JSON file.
 
     Args:
-        path: TODO docstring.
+        path: JSON file path.
     """
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def test_render_encode_split_tests_do_not_use_unconditional_skip_markers():
+    """Guard this file against permanent placeholder skips in the default suite."""
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    skipped_tests: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        for decorator in node.decorator_list:
+            if (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr == "skip"
+                and isinstance(decorator.func.value, ast.Attribute)
+                and decorator.func.value.attr == "mark"
+                and isinstance(decorator.func.value.value, ast.Name)
+                and decorator.func.value.value.id == "pytest"
+            ):
+                skipped_tests.append(node.name)
+    assert skipped_tests == []
+
+
 def test_performance_manifest_has_render_encode_keys(tmp_path):
-    """TODO docstring. Document this function.
+    """Synthetic rendering writes render/encode timing keys in the performance manifest.
 
     Args:
-        tmp_path: TODO docstring.
+        tmp_path: Pytest temporary directory for generated benchmark artifacts.
     """
     cfg = _Cfg(tmp_path)
     run_full_benchmark(cfg)
@@ -79,19 +99,3 @@ def test_performance_manifest_has_render_encode_keys(tmp_path):
     # If render time present, encode time must also be present and non-null
     if rtime is not None:
         assert etime is not None and etime >= 0, (rtime, etime)
-
-
-@pytest.mark.skip(reason="SimulationView specific assertion not yet implemented in headless CI")
-def test_sim_view_mode_sets_render_time_when_available(tmp_path):  # pragma: no cover - placeholder
-    """TODO docstring. Document this function.
-
-    Args:
-        tmp_path: TODO docstring.
-    """
-    cfg = _Cfg(tmp_path / "sim_view", renderer="sim-view")
-    run_full_benchmark(cfg)
-    perf_path = Path(cfg.output_root) / "reports" / "performance_visuals.json"
-    data = _read_json(perf_path)
-    # In real environment with SimulationView + moviepy this should be non-null.
-    # Kept as placeholder for future environment with pygame available.
-    assert "first_video_render_time_s" in data


### PR DESCRIPTION
## Summary
Removed the permanent SimulationView placeholder skip from `tests/visuals/test_render_encode_split.py` and added an AST-level guard so the file cannot reintroduce unconditional `pytest.mark.skip` decorators for tests.

## Linked Issues
- Closes #1217

## What Changed
- Removed `test_sim_view_mode_sets_render_time_when_available`, which was a non-executable placeholder in the default suite.
- Added `test_render_encode_split_tests_do_not_use_unconditional_skip_markers`.
- Cleaned stale TODO docstrings in the touched test file.

## Why It Matters
- Added value: the render encode split test file now reports only executable coverage in the default targeted run.
- Expected impact: no runtime benchmark behavior change; this is test-signal cleanup.
- Why this is worth merging now: it closes the observed residual permanent skip tracked in #1217.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/visuals/test_render_encode_split.py -q -rs` -> red before fix: `1 failed, 1 passed, 1 skipped`; failure named the skipped placeholder.
  - `uv run pytest tests/visuals/test_render_encode_split.py -q -rs` -> green after fix: `2 passed`.
  - `uv run ruff check --fix tests/visuals/test_render_encode_split.py && uv run ruff format tests/visuals/test_render_encode_split.py` -> passed.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> `3536 passed, 12 skipped, 3 warnings in 262.47s`; changed-file coverage found no matching include-pattern files and docstring TODO gate passed.
- Evidence that the change works here:
  - The targeted run no longer reports the SimulationView placeholder skip.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; no runtime benchmark behavior changed.

## Risks / Rollout
- Compatibility risks: low; only test cleanup and no production behavior change.
- Failure modes: future unconditional skips in this file now fail the targeted test.
- Rollback or fallback plan: restore the removed placeholder only with an explicit opt-in marker/job if maintainers decide the sim-view assertion is valuable.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #1217.
- Any assumptions that need to be preserved: SimulationView non-null render-time behavior remains optional/deferred; this PR removes the placeholder from the default suite rather than claiming sim-view coverage.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that removing the placeholder is acceptable versus creating a non-default sim-view lane.
- Known limitation: this does not add SimulationView-specific render-time coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation mechanisms to improve overall code quality and prevent test regressions
  * Removed a skipped placeholder test
  * Refined test documentation and added utility helpers for test data handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->