### PR TITLE
feat: add BC pretraining device policy (#1213)

### DIFF
--- a/configs/training/ppo_imitation/bc_pretrain.yaml
+++ b/configs/training/ppo_imitation/bc_pretrain.yaml
@@ -6,3 +6,5 @@ bc_epochs: 10
 batch_size: 32
 learning_rate: 0.0003
 random_seeds: [42, 43, 44]
+# Use accelerators when available; set to "cpu" for deterministic/resource-constrained runs.
+device: auto

--- a/configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
+++ b/configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
@@ -12,3 +12,5 @@ bc_epochs: 20
 batch_size: 64
 learning_rate: 0.0003
 random_seeds: [111, 112, 113]
+# Use accelerators when available; set to "cpu" for deterministic/resource-constrained runs.
+device: auto

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1205,6 +1205,10 @@ uv run python scripts/training/train_ppo_with_pretrained_policy.py --config conf
 
 Set `--log-level DEBUG` if you need the full resolved-config dumps from the factory helpers (default is INFO to keep console noise down). Use `--backend <name>` to override the auto-selected simulator backend (defaults to the fastest available choice via `select_best_backend`). The end-to-end example auto-generates BC/ppo fine-tuning configs under `output/tmp/imitation_pipeline/`, so you only need to edit the YAML files when running the scripts manually.
 
+BC pre-training configs default to `device: auto`, which lets Stable-Baselines3 and
+`imitation` use available accelerators. Set `device: cpu` in the BC YAML when you need
+a deterministic or resource-constrained CPU-only run.
+
 **Also see:**
 - End-to-end example: `examples/advanced/16_imitation_learning_pipeline.py`
 - Detailed workflows: `specs/001-ppo-imitation-pretrain/quickstart.md`

--- a/docs/imitation_learning_pipeline.md
+++ b/docs/imitation_learning_pipeline.md
@@ -87,7 +87,9 @@ experiments. The automated example pipeline writes run-specific configs to
 `output/tmp/imitation_pipeline/` so you can keep the checked-in YAML focused on
 reusable defaults. For checkpoint-specific observation contracts, set `training_config`
 and `scenario_config` in the BC config, or rely on those paths from trajectory dataset
-metadata.
+metadata. BC pre-training uses `device: auto` by default so capable hosts can use
+available accelerators; set `device: cpu` when you need a deterministic or
+resource-constrained CPU-only run.
 
 **What happens:**
 - Loads trajectory dataset

--- a/robot_sf/training/imitation_config.py
+++ b/robot_sf/training/imitation_config.py
@@ -208,6 +208,7 @@ class BCPretrainingConfig:
     random_seeds: tuple[int, ...]
     training_config_path: Path | None = None
     scenario_config_path: Path | None = None
+    device: str = "auto"
 
     @classmethod
     def from_raw(  # noqa: PLR0913
@@ -222,6 +223,7 @@ class BCPretrainingConfig:
         random_seeds: tuple[int, ...] | list[int],
         training_config_path: Path | None = None,
         scenario_config_path: Path | None = None,
+        device: str = "auto",
     ) -> BCPretrainingConfig:
         """Create a config while coercing seeds to a canonical tuple.
 
@@ -239,6 +241,7 @@ class BCPretrainingConfig:
             random_seeds=ensure_seed_tuple(random_seeds),
             training_config_path=training_config_path.resolve() if training_config_path else None,
             scenario_config_path=scenario_config_path.resolve() if scenario_config_path else None,
+            device=str(device).strip() or "auto",
         )
 
 

--- a/robot_sf/training/imitation_config.py
+++ b/robot_sf/training/imitation_config.py
@@ -241,7 +241,7 @@ class BCPretrainingConfig:
             random_seeds=ensure_seed_tuple(random_seeds),
             training_config_path=training_config_path.resolve() if training_config_path else None,
             scenario_config_path=scenario_config_path.resolve() if scenario_config_path else None,
-            device=str(device).strip() or "auto",
+            device=str(device or "auto").strip() or "auto",
         )
 
 

--- a/robot_sf/training/imitation_config.py
+++ b/robot_sf/training/imitation_config.py
@@ -223,7 +223,7 @@ class BCPretrainingConfig:
         random_seeds: tuple[int, ...] | list[int],
         training_config_path: Path | None = None,
         scenario_config_path: Path | None = None,
-        device: str = "auto",
+        device: str | None = "auto",
     ) -> BCPretrainingConfig:
         """Create a config while coercing seeds to a canonical tuple.
 

--- a/scripts/training/pretrain_from_expert.py
+++ b/scripts/training/pretrain_from_expert.py
@@ -238,7 +238,7 @@ def _create_bc_trainer(
         "MlpPolicy",
         env,
         learning_rate=config.learning_rate,
-        device="cpu",
+        device=config.device,
         verbose=1,
     )
 
@@ -249,7 +249,7 @@ def _create_bc_trainer(
         policy=policy_model.policy,
         batch_size=config.batch_size,
         rng=np.random.default_rng(int(config.random_seeds[0])),
-        device="cpu",
+        device=config.device,
     )
 
     return trainer, policy_model
@@ -357,6 +357,7 @@ def load_bc_config(config_path: Path) -> BCPretrainingConfig:
         random_seeds=tuple(raw.get("random_seeds", [42])),
         training_config_path=resolve_config_path(raw.get("training_config"), base_dir=base_dir),
         scenario_config_path=resolve_config_path(raw.get("scenario_config"), base_dir=base_dir),
+        device=raw.get("device", "auto"),
     )
 
 

--- a/tests/integration/test_ppo_pretraining_pipeline.py
+++ b/tests/integration/test_ppo_pretraining_pipeline.py
@@ -83,6 +83,7 @@ def test_pretraining_pipeline_smoke(tmp_path, monkeypatch, minimal_trajectory_da
     assert bc_config.dataset_id == dataset_id
     assert bc_config.bc_epochs == 1
     assert bc_config.run_id == "test_bc_pretrain_run"
+    assert bc_config.device == "auto"
 
     # Verify dataset path resolution
     dataset_path = common.get_trajectory_dataset_path(dataset_id)
@@ -92,6 +93,101 @@ def test_pretraining_pipeline_smoke(tmp_path, monkeypatch, minimal_trajectory_da
     policy_dir = common.get_expert_policy_dir()
     assert policy_dir.exists()
     # Note: actual policy file created by pretrain script, not tested here
+
+
+def test_bc_pretraining_config_accepts_explicit_cpu_device():
+    """BC pre-training config should allow deterministic CPU-only runs."""
+    from robot_sf.training.imitation_config import BCPretrainingConfig
+
+    bc_config = BCPretrainingConfig.from_raw(
+        run_id="test_bc_cpu_run",
+        dataset_id="test_traj_minimal",
+        policy_output_id="test_bc_policy",
+        bc_epochs=1,
+        batch_size=2,
+        learning_rate=0.0003,
+        random_seeds=(42,),
+        device="cpu",
+    )
+
+    assert bc_config.device == "cpu"
+
+
+def test_default_bc_pretraining_config_loads_auto_device():
+    """Checked-in BC config should expose the default accelerator policy."""
+    from scripts.training.pretrain_from_expert import load_bc_config
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bc_config = load_bc_config(repo_root / "configs/training/ppo_imitation/bc_pretrain.yaml")
+
+    assert bc_config.device == "auto"
+
+
+def test_load_bc_config_accepts_cpu_device_override(tmp_path):
+    """BC YAML should be able to force a CPU-only pre-training run."""
+    from scripts.training.pretrain_from_expert import load_bc_config
+
+    config_path = tmp_path / "bc_pretrain_cpu.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "run_id: test_bc_cpu_run",
+                "dataset_id: test_traj_minimal",
+                "policy_output_id: test_bc_policy",
+                "bc_epochs: 1",
+                "batch_size: 2",
+                "learning_rate: 0.0003",
+                "random_seeds: [42]",
+                "device: cpu",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bc_config = load_bc_config(config_path)
+
+    assert bc_config.device == "cpu"
+
+
+def test_create_bc_trainer_threads_configured_device(monkeypatch):
+    """BC trainer construction should pass the configured device to both trainers."""
+    from robot_sf.training.imitation_config import BCPretrainingConfig
+    from scripts.training import pretrain_from_expert
+
+    captured: dict[str, str] = {}
+
+    class _FakePPO:
+        def __init__(self, _policy_name, _env, **kwargs):
+            captured["ppo_device"] = kwargs["device"]
+            self.policy = object()
+
+    class _FakeBCModule:
+        class BC:
+            def __init__(self, **kwargs):
+                captured["bc_device"] = kwargs["device"]
+
+    fake_env = SimpleNamespace(
+        observation_space=spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32),
+        action_space=spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32),
+    )
+    config = BCPretrainingConfig.from_raw(
+        run_id="test_bc_cpu_run",
+        dataset_id="test_traj_minimal",
+        policy_output_id="test_bc_policy",
+        bc_epochs=1,
+        batch_size=2,
+        learning_rate=0.0003,
+        random_seeds=(42,),
+        device="cpu",
+    )
+
+    monkeypatch.setattr(pretrain_from_expert, "PPO", _FakePPO)
+    monkeypatch.setattr(pretrain_from_expert, "_require_imitation_bc", lambda: _FakeBCModule)
+
+    pretrain_from_expert._create_bc_trainer(fake_env, [], config)
+
+    assert captured == {"ppo_device": "cpu", "bc_device": "cpu"}
 
 
 def test_fine_tuning_config_structure(tmp_path, monkeypatch):

--- a/tests/integration/test_ppo_pretraining_pipeline.py
+++ b/tests/integration/test_ppo_pretraining_pipeline.py
@@ -113,6 +113,24 @@ def test_bc_pretraining_config_accepts_explicit_cpu_device():
     assert bc_config.device == "cpu"
 
 
+def test_bc_pretraining_config_treats_none_device_as_auto():
+    """Null device inputs should fall back to the default auto policy."""
+    from robot_sf.training.imitation_config import BCPretrainingConfig
+
+    bc_config = BCPretrainingConfig.from_raw(
+        run_id="test_bc_none_device",
+        dataset_id="test_traj_minimal",
+        policy_output_id="test_bc_policy",
+        bc_epochs=1,
+        batch_size=2,
+        learning_rate=0.0003,
+        random_seeds=(42,),
+        device=None,
+    )
+
+    assert bc_config.device == "auto"
+
+
 def test_default_bc_pretraining_config_loads_auto_device():
     """Checked-in BC config should expose the default accelerator policy."""
     from scripts.training.pretrain_from_expert import load_bc_config


### PR DESCRIPTION
## Summary
Adds an explicit config-driven BC pre-training `device` policy with `auto` as the default and CPU override support for deterministic or resource-constrained runs.

## Linked Issues
- Closes #1213

## What Changed
- Added `device` to `BCPretrainingConfig`, defaulting to `auto`.
- Threaded `config.device` into the Stable-Baselines3 PPO container and `imitation.algorithms.bc.BC` trainer.
- Added `device: auto` to the checked-in BC pre-training configs.
- Documented `auto` versus `cpu` in the imitation learning guide and dev guide.
- Added regression tests for default `auto`, explicit `cpu`, YAML override loading, and trainer propagation.

## Why It Matters
- Added value: BC warm-start hardware selection is now visible in config and reproducible in run handoff.
- Expected impact: GPU-capable hosts can use accelerator defaults without hardcoding CPU-only BC training; CPU remains an explicit opt-in.
- Why this is worth merging now: it resolves the policy ambiguity tracked in #1213 before the BC warm-start experiment path relies on hidden library behavior.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/integration/test_ppo_pretraining_pipeline.py -q -k 'bc_pretraining_config_accepts_explicit_cpu_device or default_bc_pretraining_config_loads_auto_device or create_bc_trainer_threads_configured_device or pretraining_pipeline_smoke'` -> red before implementation: `4 failed`; failures were missing `device` field/argument/propagation.
  - `uv run ruff check --fix robot_sf/training/imitation_config.py scripts/training/pretrain_from_expert.py tests/integration/test_ppo_pretraining_pipeline.py && uv run ruff format robot_sf/training/imitation_config.py scripts/training/pretrain_from_expert.py tests/integration/test_ppo_pretraining_pipeline.py` -> passed.
  - `uv run pytest tests/integration/test_ppo_pretraining_pipeline.py -q` -> `10 passed`.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> `3540 passed, 12 skipped, 3 warnings in 261.65s`; changed-file coverage reported `robot_sf/training/imitation_config.py: 91.3% [WARN]`, above the 80% minimum, and docstring TODO gate passed.
- Evidence that the change works here:
  - The targeted tests prove default `auto`, explicit YAML `cpu`, and propagation into both BC trainer construction points.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; this changes BC training configuration plumbing, not benchmark runtime behavior.

## Risks / Rollout
- Compatibility risks: low; configs without `device` still default to `auto`.
- Failure modes: accelerator selection remains delegated to SB3/imitation when `auto` is used, so host-specific accelerator availability can still affect performance.
- Rollback or fallback plan: set `device: cpu` in BC YAMLs to force the previous conservative execution policy.

## Docs / Provenance
- Updated docs: `docs/imitation_learning_pipeline.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: issue #1213 decision states default `auto`.
- Any assumptions that need to be preserved: this only affects BC pre-training, not PPO fine-tuning or other training device policies.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- The full readiness gate produced only existing-style TensorFlow/pygame noise plus the changed-file coverage warning noted above.
- Ignored coverage output under `output/coverage` was inspected as disposable validation output; no durable artifact promotion needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Behavioral cloning pretraining now supports configurable device selection, defaulting to automatic accelerator detection when available.
  * CPU-only mode available for deterministic or resource-constrained training runs.

* **Documentation**
  * Updated training guides explaining device configuration options and pretraining behavior.

* **Tests**
  * Added test coverage for device configuration in the pretraining pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->