### PR TITLE
test: require jsonschema visual schema dependency (#1221)

### DIFF
--- a/tests/visuals/test_performance_schema_validation.py
+++ b/tests/visuals/test_performance_schema_validation.py
@@ -2,41 +2,35 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
 
 SCHEMA_PATH = Path("specs/127-enhance-benchmark-visual/contracts/performance_visuals.schema.json")
-jsonschema_spec = importlib.util.find_spec("jsonschema")
-pytestmark = pytest.mark.skipif(jsonschema_spec is None, reason="jsonschema not installed")
-if jsonschema_spec:  # type: ignore
-    import jsonschema  # type: ignore
 
 
 def _schema():
-    """TODO docstring. Document this function."""
+    """Load the performance visual schema from disk."""
     return json.loads(SCHEMA_PATH.read_text())
 
 
 def _validate(inst):
-    """TODO docstring. Document this function.
+    """Validate an instance against the performance visual schema.
 
     Args:
-        inst: TODO docstring.
+        inst: Candidate performance visual payload.
     """
-    jsonschema.validate(instance=inst, schema=_schema())  # type: ignore
+    jsonschema.validate(instance=inst, schema=_schema())
 
 
 def test_valid_minimal():
-    """TODO docstring. Document this function."""
+    """Minimal performance visual metrics should satisfy the schema."""
     _validate({"plots_time_s": 0.5, "plots_over_budget": False, "video_over_budget": False})
 
 
 def test_missing_required_field():
-    """TODO docstring. Document this function."""
-    import pytest as _pytest
-
-    with _pytest.raises(Exception):
+    """Performance visual metrics should require plot timing."""
+    with pytest.raises(jsonschema.ValidationError):
         _validate({"plots_over_budget": False, "video_over_budget": False})

--- a/tests/visuals/test_plot_schema_validation.py
+++ b/tests/visuals/test_plot_schema_validation.py
@@ -2,44 +2,40 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
 
 SCHEMA_PATH = Path("specs/127-enhance-benchmark-visual/contracts/plot_artifacts.schema.json")
-jsonschema_spec = importlib.util.find_spec("jsonschema")
-pytestmark = pytest.mark.skipif(jsonschema_spec is None, reason="jsonschema not installed")
-if jsonschema_spec:  # type: ignore
-    import jsonschema  # type: ignore
 
 
 def _schema():
-    """TODO docstring. Document this function."""
+    """Load the plot artifact schema from disk."""
     return json.loads(SCHEMA_PATH.read_text())
 
 
 def _validate(inst):
-    """TODO docstring. Document this function.
+    """Validate an instance against the plot artifact schema.
 
     Args:
-        inst: TODO docstring.
+        inst: Candidate plot artifact payload.
     """
-    jsonschema.validate(instance=inst, schema=_schema())  # type: ignore
+    jsonschema.validate(instance=inst, schema=_schema())
 
 
 def test_valid_empty():
-    """TODO docstring. Document this function."""
+    """Empty artifact lists should satisfy the plot schema."""
     _validate({"artifacts": []})
 
 
 def test_success_entry():
-    """TODO docstring. Document this function."""
+    """Successful plot entries should validate when filename is present."""
     _validate({"artifacts": [{"name": "plot1", "status": "success", "filename": "plot1.pdf"}]})
 
 
 def test_success_missing_filename():
-    """TODO docstring. Document this function."""
-    with pytest.raises(Exception):
+    """Successful plot entries should require a filename."""
+    with pytest.raises(jsonschema.ValidationError):
         _validate({"artifacts": [{"name": "p1", "status": "success"}]})

--- a/tests/visuals/test_schema_validation_dependency_policy.py
+++ b/tests/visuals/test_schema_validation_dependency_policy.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-SCHEMA_TEST_PATHS = (
-    Path("tests/visuals/test_video_schema_validation.py"),
-    Path("tests/visuals/test_plot_schema_validation.py"),
-    Path("tests/visuals/test_performance_schema_validation.py"),
-)
+VISUAL_TEST_DIR = Path(__file__).resolve().parent
+REPO_ROOT = VISUAL_TEST_DIR.parents[1]
+SCHEMA_TEST_PATHS = tuple(sorted(VISUAL_TEST_DIR.glob("test_*_schema_validation.py")))
 
 
 def test_visual_schema_tests_require_declared_jsonschema_dependency():
@@ -18,13 +16,16 @@ def test_visual_schema_tests_require_declared_jsonschema_dependency():
 
     for path in SCHEMA_TEST_PATHS:
         tree = ast.parse(path.read_text(encoding="utf-8"))
+        relative_path = path.relative_to(REPO_ROOT)
         for node in ast.walk(tree):
             if _is_jsonschema_find_spec_call(node):
-                offenders.append(f"{path}: importlib.util.find_spec('jsonschema')")
+                offenders.append(
+                    f"{relative_path}:{node.lineno}: importlib.util.find_spec('jsonschema')"
+                )
             if _is_pytest_skipif_call(node):
-                offenders.append(f"{path}: pytest.mark.skipif")
+                offenders.append(f"{relative_path}:{node.lineno}: pytest.mark.skipif")
 
-    assert offenders == []
+    assert not offenders, "Found prohibited dependency guards:\n" + "\n".join(offenders)
 
 
 def _is_jsonschema_find_spec_call(node: ast.AST) -> bool:

--- a/tests/visuals/test_schema_validation_dependency_policy.py
+++ b/tests/visuals/test_schema_validation_dependency_policy.py
@@ -1,0 +1,52 @@
+"""Dependency policy checks for visual schema validation tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SCHEMA_TEST_PATHS = (
+    Path("tests/visuals/test_video_schema_validation.py"),
+    Path("tests/visuals/test_plot_schema_validation.py"),
+    Path("tests/visuals/test_performance_schema_validation.py"),
+)
+
+
+def test_visual_schema_tests_require_declared_jsonschema_dependency():
+    """Visual schema tests should fail clearly if the declared dependency is missing."""
+    offenders: list[str] = []
+
+    for path in SCHEMA_TEST_PATHS:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if _is_jsonschema_find_spec_call(node):
+                offenders.append(f"{path}: importlib.util.find_spec('jsonschema')")
+            if _is_pytest_skipif_call(node):
+                offenders.append(f"{path}: pytest.mark.skipif")
+
+    assert offenders == []
+
+
+def _is_jsonschema_find_spec_call(node: ast.AST) -> bool:
+    """Return whether node probes jsonschema availability with importlib."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "find_spec"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "jsonschema"
+    )
+
+
+def _is_pytest_skipif_call(node: ast.AST) -> bool:
+    """Return whether node applies a pytest skip-if marker."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "skipif"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "mark"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "pytest"
+    )

--- a/tests/visuals/test_video_schema_validation.py
+++ b/tests/visuals/test_video_schema_validation.py
@@ -4,44 +4,37 @@ Covers:
 - Successful validation of a minimal valid manifest
 - Failure on missing required field
 - Failure when success status missing filename
-Skips if jsonschema not installed.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
 
 SCHEMA_PATH = Path("specs/127-enhance-benchmark-visual/contracts/video_artifacts.schema.json")
 
-jsonschema_spec = importlib.util.find_spec("jsonschema")
-pytestmark = pytest.mark.skipif(jsonschema_spec is None, reason="jsonschema not installed")
-
-if jsonschema_spec:  # type: ignore
-    import jsonschema  # type: ignore
-
 
 def load_schema():  # pragma: no cover - trivial IO helper
-    """TODO docstring. Document this function."""
+    """Load the video artifact schema from disk."""
     return json.loads(SCHEMA_PATH.read_text())
 
 
 def validate(instance):
     """Validate instance against video schema."""
     schema = load_schema()
-    jsonschema.validate(instance=instance, schema=schema)  # type: ignore
+    jsonschema.validate(instance=instance, schema=schema)
 
 
 def test_valid_minimal_manifest():
-    """TODO docstring. Document this function."""
+    """Empty artifact lists should satisfy the video schema."""
     validate({"artifacts": []})  # empty list allowed
 
 
 def test_valid_success_entry():
-    """TODO docstring. Document this function."""
+    """Successful video entries should validate when filename is present."""
     validate(
         {
             "artifacts": [
@@ -57,14 +50,12 @@ def test_valid_success_entry():
 
 
 def test_missing_required_field():
-    # Expect schema validation failure due to missing required 'episode_id' field
-    """TODO docstring. Document this function."""
-    with pytest.raises(jsonschema.ValidationError):  # type: ignore[name-defined]
+    """Video entries should require an episode id."""
+    with pytest.raises(jsonschema.ValidationError):
         validate({"artifacts": [{"renderer": "synthetic", "status": "skipped"}]})
 
 
 def test_success_without_filename_fails():
-    # Success status requires a filename according to schema
-    """TODO docstring. Document this function."""
-    with pytest.raises(jsonschema.ValidationError):  # type: ignore[name-defined]
+    """Successful video entries should require a filename."""
+    with pytest.raises(jsonschema.ValidationError):
         validate({"artifacts": [{"episode_id": "1", "renderer": "synthetic", "status": "success"}]})


### PR DESCRIPTION
## Summary
Removes optional `jsonschema` skip guards from the visual schema validation tests now that `jsonschema` is a declared dependency, and adds a small policy guard to keep those skips from returning.

## Linked Issues
- Closes #1221

## What Changed
- Replaced `importlib.util.find_spec("jsonschema")` plus module-level `pytest.mark.skipif` with direct `jsonschema` imports in the three visual schema test modules.
- Tightened negative assertions to expect `jsonschema.ValidationError` instead of broad exceptions.
- Added `tests/visuals/test_schema_validation_dependency_policy.py` to detect reintroduced `jsonschema` dependency probes or `pytest.mark.skipif` guards in these schema tests.
- Replaced stale TODO docstrings in the touched schema test helpers and cases.

## Why It Matters
- Added value: declared dependency drift now fails clearly instead of silently skipping visual schema validation.
- Expected impact: no schema contract changes; existing positive and negative validation cases still run.
- Why this is worth merging now: it closes a residual optional-dependency skip in validation coverage tracked by #1221.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/visuals/test_schema_validation_dependency_policy.py -q` -> red before fix: `1 failed`; failure listed the three `find_spec("jsonschema")` probes and three `pytest.mark.skipif` guards.
  - `uv run ruff check --fix tests/visuals/test_video_schema_validation.py tests/visuals/test_plot_schema_validation.py tests/visuals/test_performance_schema_validation.py tests/visuals/test_schema_validation_dependency_policy.py && uv run ruff format tests/visuals/test_video_schema_validation.py tests/visuals/test_plot_schema_validation.py tests/visuals/test_performance_schema_validation.py tests/visuals/test_schema_validation_dependency_policy.py` -> passed.
  - `uv run pytest tests/visuals/test_video_schema_validation.py tests/visuals/test_plot_schema_validation.py tests/visuals/test_performance_schema_validation.py tests/visuals/test_schema_validation_dependency_policy.py -q -rs` -> `10 passed` with no skips.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> `3536 passed, 13 skipped, 3 warnings in 267.32s`; changed-file coverage found no matching include-pattern files and docstring TODO gate passed.
- Evidence that the change works here:
  - The targeted run executes all schema tests plus the policy guard with no `jsonschema` skip path.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; no benchmark or artifact-generation behavior changed.

## Risks / Rollout
- Compatibility risks: low; `jsonschema>=4.23.0` is already declared in `pyproject.toml`.
- Failure modes: environments with incomplete dependency installs will now fail these tests clearly instead of skipping them.
- Rollback or fallback plan: restore the skip guard only if maintainers decide `jsonschema` should return to an optional dependency.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #1221.
- Any assumptions that need to be preserved: MoviePy/ffmpeg optional-path behavior is unchanged.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Ignored coverage output under `output/coverage` was inspected as disposable validation output; no durable artifact promotion needed.
