### PR TITLE
fix: enforce seeded robot reset determinism (#1222)

### DIFF
--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -75,7 +75,11 @@ _ASYMMETRIC_CRITIC_STATE_KEY = "critic_privileged_state"
 
 @contextmanager
 def _temporary_global_reset_seed(seed: int | None):
-    """Temporarily seed legacy global RNGs used by route sampling during reset."""
+    """Temporarily seed legacy global RNGs used by route sampling during reset.
+
+    This scope is intentionally narrow and restores caller-owned RNG state afterward, but
+    it still assumes resets do not run concurrently in the same Python process.
+    """
     if seed is None:
         yield
         return
@@ -654,6 +658,7 @@ class RobotEnv(BaseEnv):
 
         # Store last action executed by the robot
         self.last_action = None
+        self.applied_seed: int | None = None
         self._latest_observation: Any = None
         # Enable occupancy grid overlay visualization if requested
         if self.sim_ui and getattr(env_config, "show_occupancy_grid", False):

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -13,9 +13,11 @@ It also defines the action and observation spaces for the robot.
 import hashlib
 import importlib
 import json
+import random
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
@@ -69,6 +71,24 @@ _TELEMETRY_ANALYZER_STEP_METRIC_KEYS: tuple[str, ...] = (
     "jerk_mean",
 )
 _ASYMMETRIC_CRITIC_STATE_KEY = "critic_privileged_state"
+
+
+@contextmanager
+def _temporary_global_reset_seed(seed: int | None):
+    """Temporarily seed legacy global RNGs used by route sampling during reset."""
+    if seed is None:
+        yield
+        return
+
+    random_state = random.getstate()
+    numpy_state = np.random.get_state()
+    random.seed(int(seed))
+    np.random.seed(int(seed))
+    try:
+        yield
+    finally:
+        random.setstate(random_state)
+        np.random.set_state(numpy_state)
 
 
 @dataclass(slots=True)
@@ -1001,99 +1021,104 @@ class RobotEnv(BaseEnv):
         """Reset the environment and start a new episode.
 
         Args:
-            seed: Optional random seed forwarded to ``BaseEnv`` reset.
+            seed: Optional random seed applied to Gymnasium and reset route sampling.
             options: Optional Gymnasium reset options.
 
         Returns:
             tuple: ``(obs, info)`` with the initial observation and placeholder info dict.
         """
-        super().reset(seed=seed, options=options)
-        self._telemetry_episode_id += 1
-        # Reset last_action
-        self.last_action = None
-        # Reset internal simulator state
-        self.simulator.reset_state()
-        # Reset the environment's state and return the initial observation
-        obs = self.state.reset()
-        self._prime_snqi_proxy_state()
+        if seed is not None:
+            self.applied_seed = int(seed)
 
-        # T044: Wrap observation as dict if observation space was converted for grid inclusion
-        if getattr(self, "_wrap_obs_as_dict", False) and not isinstance(obs, dict):
-            obs = {"agent_obs": obs}
+        with _temporary_global_reset_seed(seed):
+            super().reset(seed=seed, options=options)
+            self._telemetry_episode_id += 1
+            # Reset last_action
+            self.last_action = None
+            # Reset internal simulator state
+            self.simulator.reset_state()
+            # Reset the environment's state and return the initial observation
+            obs = self.state.reset()
+            self._prime_snqi_proxy_state()
 
-        # T043: Generate initial occupancy grid if enabled
-        if self.occupancy_grid is not None:
-            # Extract obstacles from map
-            obstacles, obstacle_polygons = self._normalize_obstacles_for_grid(
-                self.map_def.obstacles, self.map_def.bounds
-            )
-            # Extract pedestrian positions and radii from simulator
-            ped_positions = self.simulator.ped_pos
-            ped_radii = getattr(self.simulator, "ped_radii", None)
-            if ped_radii is None:
-                # Default pedestrian radius if not available
-                ped_radii = [0.35] * len(ped_positions)
-            pedestrians = [
-                (tuple(pos), radius) for pos, radius in zip(ped_positions, ped_radii, strict=True)
-            ]
-            # Get robot pose (already in RobotPose format: ((x, y), theta))
-            robot_pose = self.simulator.robot_poses[0]
-            # Generate grid (allow grid config to opt into ego frame)
-            self.occupancy_grid.generate(
-                obstacles=obstacles,
-                pedestrians=pedestrians,
-                robot_pose=robot_pose,
-                ego_frame=False,
-                obstacle_polygons=obstacle_polygons,
-            )
-            # Add grid to observation
-            if self.include_grid_in_observation:
-                obs["occupancy_grid"] = self.occupancy_grid.to_observation()
-                # Flatten metadata into individual fields for SB3 compatibility
-                obs.update(
-                    _flatten_occupancy_grid_metadata(self.occupancy_grid.metadata_observation())
-                )
-                logger.debug(
-                    f"Initial occupancy grid generated: "
-                    f"obstacles={len(obstacles)}, pedestrians={len(pedestrians)}"
-                )
-        obs = self._attach_asymmetric_critic_state(obs)
-        self._latest_observation = obs
+            # T044: Wrap observation as dict if observation space was converted for grid inclusion
+            if getattr(self, "_wrap_obs_as_dict", False) and not isinstance(obs, dict):
+                obs = {"agent_obs": obs}
 
-        # Handle recording for both systems
-        if self.recording_enabled:
-            if self.use_jsonl_recording:
-                # End previous episode if active, then start a new one
-                try:
-                    self.end_episode_recording()
-                except (
-                    RuntimeError,
-                    ValueError,
-                    AttributeError,
-                ):  # pragma: no cover - safe if none active
-                    pass
-                config_hash = _stable_config_hash(self.env_config)
-                telemetry_path = None
-                if self._telemetry_session is not None and self.env_config.telemetry_record:
-                    telemetry_path = str(self._telemetry_session.telemetry_path)
-                telemetry_episode_id = (
-                    self._telemetry_episode_id if telemetry_path is not None else None
+            # T043: Generate initial occupancy grid if enabled
+            if self.occupancy_grid is not None:
+                # Extract obstacles from map
+                obstacles, obstacle_polygons = self._normalize_obstacles_for_grid(
+                    self.map_def.obstacles, self.map_def.bounds
                 )
-                self.start_episode_recording(
-                    config_hash=config_hash,
-                    telemetry_path=telemetry_path,
-                    telemetry_episode_id=telemetry_episode_id,
+                # Extract pedestrian positions and radii from simulator
+                ped_positions = self.simulator.ped_pos
+                ped_radii = getattr(self.simulator, "ped_radii", None)
+                if ped_radii is None:
+                    # Default pedestrian radius if not available
+                    ped_radii = [0.35] * len(ped_positions)
+                pedestrians = [
+                    (tuple(pos), radius)
+                    for pos, radius in zip(ped_positions, ped_radii, strict=True)
+                ]
+                # Get robot pose (already in RobotPose format: ((x, y), theta))
+                robot_pose = self.simulator.robot_poses[0]
+                # Generate grid (allow grid config to opt into ego frame)
+                self.occupancy_grid.generate(
+                    obstacles=obstacles,
+                    pedestrians=pedestrians,
+                    robot_pose=robot_pose,
+                    ego_frame=False,
+                    obstacle_polygons=obstacle_polygons,
                 )
-            else:
-                # Legacy pickle recording
-                self.save_recording()
+                # Add grid to observation
+                if self.include_grid_in_observation:
+                    obs["occupancy_grid"] = self.occupancy_grid.to_observation()
+                    # Flatten metadata into individual fields for SB3 compatibility
+                    obs.update(
+                        _flatten_occupancy_grid_metadata(self.occupancy_grid.metadata_observation())
+                    )
+                    logger.debug(
+                        f"Initial occupancy grid generated: "
+                        f"obstacles={len(obstacles)}, pedestrians={len(pedestrians)}"
+                    )
+            obs = self._attach_asymmetric_critic_state(obs)
+            self._latest_observation = obs
 
-        # info is necessary for the gym environment, but useless at the moment
-        info = {"info": "test"}
-        # Reset telemetry timing on new episode
-        self._last_wall_time = time.perf_counter()
-        self._frame_idx = 0
-        return obs, info
+            # Handle recording for both systems
+            if self.recording_enabled:
+                if self.use_jsonl_recording:
+                    # End previous episode if active, then start a new one
+                    try:
+                        self.end_episode_recording()
+                    except (
+                        RuntimeError,
+                        ValueError,
+                        AttributeError,
+                    ):  # pragma: no cover - safe if none active
+                        pass
+                    config_hash = _stable_config_hash(self.env_config)
+                    telemetry_path = None
+                    if self._telemetry_session is not None and self.env_config.telemetry_record:
+                        telemetry_path = str(self._telemetry_session.telemetry_path)
+                    telemetry_episode_id = (
+                        self._telemetry_episode_id if telemetry_path is not None else None
+                    )
+                    self.start_episode_recording(
+                        config_hash=config_hash,
+                        telemetry_path=telemetry_path,
+                        telemetry_episode_id=telemetry_episode_id,
+                    )
+                else:
+                    # Legacy pickle recording
+                    self.save_recording()
+
+            # info is necessary for the gym environment, but useless at the moment
+            info = {"info": "test"}
+            # Reset telemetry timing on new episode
+            self._last_wall_time = time.perf_counter()
+            self._frame_idx = 0
+            return obs, info
 
     def _emit_telemetry(
         self,

--- a/tests/factories/test_seed_determinism.py
+++ b/tests/factories/test_seed_determinism.py
@@ -1,10 +1,11 @@
-"""T016: Seed determinism test.
+"""Factory/reset seed determinism tests.
 
-Ensures two environments created with same seed yield identical initial observation arrays.
-If observation is not an array, test performs a simple equality check.
+Explicit factory and reset seeds should yield identical initial observation arrays.
 """
 
 from __future__ import annotations
+
+import random
 
 import numpy as np
 import pytest
@@ -32,36 +33,59 @@ def _extract_numeric(obs):
     try:
         return np.asarray(obs, dtype=float)
     except Exception as e:  # pragma: no cover
-        raise pytest.skip(f"Cannot extract numeric observation: {e}")
+        raise AssertionError(f"Cannot extract numeric observation: {e}") from e
 
 
 @pytest.mark.parametrize("debug", [False])
 def test_seed_determinism(debug):
-    """TODO docstring. Document this function.
+    """Explicit same-seed factory/reset calls should produce matching reset observations.
 
     Args:
-        debug: TODO docstring.
+        debug: Whether to create the environment in visual debug mode.
     """
-    config1 = RobotSimulationConfig()
-    config2 = RobotSimulationConfig()
-    # Assign same seed before creation if attribute exists
-    if hasattr(config1, "seed"):
-        config1.seed = SEED  # type: ignore[attr-defined]
-    if hasattr(config2, "seed"):
-        config2.seed = SEED  # type: ignore[attr-defined]
-    env1 = make_robot_env(config=config1, debug=debug)
-    env2 = make_robot_env(config=config2, debug=debug)
-    obs1 = env1.reset()
-    obs2 = env2.reset()
-    arr1 = _extract_numeric(obs1)
-    arr2 = _extract_numeric(obs2)
-    assert arr1.shape == arr2.shape
-    # Focus on a stable slice (exclude potential velocity noise row if present)
-    rows_to_compare = min(2, arr1.shape[0])
-    slice1 = arr1[:rows_to_compare]
-    slice2 = arr2[:rows_to_compare]
-    if not np.allclose(slice1, slice2, rtol=1e-6, atol=1e-8):  # pragma: no cover - diagnostic path
-        # If still divergent, treat as currently non-deterministic and skip (documenting need for deterministic reset)
-        pytest.skip("Environment reset appears stochastic; determinism not enforced yet.")
-    env1.close()
-    env2.close()
+    env1 = make_robot_env(config=RobotSimulationConfig(), debug=debug, seed=SEED)
+    env2 = make_robot_env(config=RobotSimulationConfig(), debug=debug, seed=SEED)
+    try:
+        obs1 = env1.reset(seed=SEED)
+        obs2 = env2.reset(seed=SEED)
+        arr1 = _extract_numeric(obs1)
+        arr2 = _extract_numeric(obs2)
+        assert arr1.shape == arr2.shape
+
+        # Focus on the robot/pedestrian rows and avoid coupling the test to future
+        # observation extensions appended after the stable state rows.
+        rows_to_compare = min(2, arr1.shape[0])
+        np.testing.assert_allclose(
+            arr1[:rows_to_compare],
+            arr2[:rows_to_compare],
+            rtol=1e-6,
+            atol=1e-8,
+        )
+    finally:
+        env1.close()
+        env2.close()
+
+
+def test_seeded_reset_does_not_leak_global_rng_state():
+    """Seeded reset should not advance caller-owned Python or NumPy RNG state."""
+    env = make_robot_env(config=RobotSimulationConfig(), debug=False, seed=SEED)
+    outer_random_state = random.getstate()
+    outer_numpy_state = np.random.get_state()
+    try:
+        random.seed(9876)
+        np.random.seed(9876)
+        expected_random_state = random.getstate()
+        expected_numpy_state = np.random.get_state()
+
+        env.reset(seed=SEED)
+        actual = (random.random(), np.random.random())
+
+        random.setstate(expected_random_state)
+        np.random.set_state(expected_numpy_state)
+        expected = (random.random(), np.random.random())
+
+        assert actual == expected
+    finally:
+        random.setstate(outer_random_state)
+        np.random.set_state(outer_numpy_state)
+        env.close()

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -38,7 +38,9 @@ def _load_atomic_topology_smoke_scenario(name: str) -> dict[str, object]:
         if scenario.get("name") != name:
             continue
         selected = dict(scenario)
-        selected["seeds"] = [59621]
+        # Explicit reset seeding makes this smoke use the seed literally; keep a
+        # deterministic success seed so the test continues to exercise policy-stack execution.
+        selected["seeds"] = [4]
         map_file = selected.get("map_file")
         if isinstance(map_file, str) and map_file.strip():
             map_path = Path(map_file)


### PR DESCRIPTION
## Summary
Enforces the explicit robot reset seed contract by making `RobotEnv.reset(seed=...)` deterministic for legacy route-sampling RNGs while restoring caller-owned Python/NumPy RNG state afterward.

## Linked Issues
- Closes #1222

## What Changed
- Added a temporary global RNG seed scope around seeded `RobotEnv` reset route sampling.
- Updated `tests/factories/test_seed_determinism.py` to use the supported `make_robot_env(..., seed=...)` plus `env.reset(seed=...)` path and removed the xfail-like skip.
- Added a regression check that seeded reset does not leak Python or NumPy global RNG state to callers.
- Updated the policy-stack corridor smoke fixture to use a deterministic success seed now that reset seeding is honored literally.

## Why It Matters
- Added value: same-seed robot reset behavior now fails or passes honestly instead of being skipped.
- Expected impact: reproducibility checks can catch reset drift; unseeded resets remain stochastic.
- Why this is worth merging now: it closes a default-suite skip that hid seed determinism failures.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/factories/test_seed_determinism.py tests/integration/test_single_episode_run.py -q -rs` -> red before fix: `2 passed, 1 skipped`; skip was `Environment reset appears stochastic; determinism not enforced yet`.
  - `uv run pytest tests/factories/test_seed_determinism.py -q -rs` -> red after test tightening and before reset fix: deterministic assertion failed on mismatched reset observations.
  - `uv run ruff check --fix robot_sf/gym_env/robot_env.py tests/factories/test_seed_determinism.py tests/planner/test_policy_stack_v1.py && uv run ruff format robot_sf/gym_env/robot_env.py tests/factories/test_seed_determinism.py tests/planner/test_policy_stack_v1.py` -> passed.
  - `uv run pytest tests/factories/test_seed_determinism.py tests/integration/test_single_episode_run.py tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner -q -rs` -> `5 passed`.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> first run exposed the policy-stack smoke seed mismatch; after fixing the deterministic success seed, rerun passed with `3537 passed, 12 skipped, 3 warnings in 265.37s`. Changed-file coverage reported `robot_sf/gym_env/robot_env.py: 81.5% [WARN]`, above the 80% minimum, and docstring TODO gate passed.
- Evidence that the change works here:
  - The factory seed-determinism test now passes without skips and asserts same-seed observations directly.
  - The new RNG-state test proves seeded reset does not advance caller-owned global Python/NumPy RNG state.
- Benchmarks or smoke tests, if applicable:
  - Policy-stack atomic corridor smoke passes under the corrected deterministic reset semantics.

## Risks / Rollout
- Compatibility risks: medium-low; seeded resets now make route sampling deterministic where previous behavior depended on ambient global RNG state.
- Failure modes: any test or workflow relying on ambient RNG side effects around `env.reset(seed=...)` may need an explicit seed fixture update.
- Rollback or fallback plan: remove the temporary reset seed scope to restore ambient RNG behavior, but that would reintroduce the skipped determinism gap.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #1222.
- Any assumptions that need to be preserved: unseeded resets are still intentionally stochastic; this PR only tightens explicit seeded reset behavior.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- The temporary seed scope is intentionally narrow and restores caller RNG state to avoid leaking global random-state mutations from environment reset.
- Ignored coverage output under `output/coverage` was inspected as disposable validation output; no durable artifact promotion needed.
