### PR TITLE
docs: extract ml-intern workflow guidance (#1191)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Policy Search Portfolio Overview](./context/policy_search/portfolio_overview_2026-05-05.md)** - Current non-training policy-search portfolio ranking, promotion status, and h500 horizon evidence pointers
 * **[Agent Index](./AGENT_INDEX.md)** - Agent-oriented index of training, benchmarking, observations, and artifacts
 * **[AI Repo Overview](./ai/repo_overview.md)** - Short orientation for Codex-style agents: where to read first, core repo areas, and common failure modes
-* **[Issue #1181 `ml-intern` Bounded Assistant Assessment](./context/issue_1181_ml_intern_experiment_assistant.md)** - Safe-use boundary for evaluating `huggingface/ml-intern` against Robot SF without replacing the local/SLURM proof-first workflow
+* **[Issue #1181/#1191 `ml-intern` Workflow Extraction](./context/issue_1181_ml_intern_experiment_assistant.md)** - Safe-use boundary for `huggingface/ml-intern`, plus the #1191 decision to extract no-edit planning, budget, trace/privacy, and one-smoke-before-campaign practices into the Codex-native workflow instead of running a paid CLI smoke by default
 * **[AI Coding Workflow](./ai/ai-workflow.md)** - End-to-end AI issue-to-PR workflow, validation gates, review loop, and traceability conventions
 * **[PR First-Pass Review Audit](./context/pr_first_pass_review_audit_2026-05-14.md)** - Recent merged-PR review findings and the pre-opening self-review checklist for reducing repeated reviewer fixes
 * **[AI Planner Zoo Context](./ai/planner_zoo_context.md)** - Planner-zoo integration context, readiness framing, and provenance/adapter questions to answer explicitly

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -74,6 +74,9 @@ Then branch by task type:
   durable Markdown handoff context
 - `docs/ai/ai-workflow.md`: end-to-end issue-to-PR workflow, validation gates, review loop, and
   traceability conventions
+- `docs/context/issue_1181_ml_intern_experiment_assistant.md`: extracted `ml-intern` workflow
+  practices for Codex-native use, including no-edit planning, budgeted runs, trace/privacy defaults,
+  and the one-smoke-before-campaign rule
 - `CLAUDE.md` + `memory/MEMORY.md`: startup-oriented memory/index pair for agent runtimes that
   support imported project instructions
 - `.agents/skills/quality-playbook/`, `.agents/skills/agentic-eval/`,

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -80,7 +80,7 @@ knowledge, not every transient iteration detail.
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
 * Goal-driven agent loops:
   [goal_driven_agent_loops_2026-05-13.md](goal_driven_agent_loops_2026-05-13.md)
-* `ml-intern` bounded assistant assessment:
+* `ml-intern` bounded assistant assessment and #1191 workflow extraction:
   [issue_1181_ml_intern_experiment_assistant.md](issue_1181_ml_intern_experiment_assistant.md)
 * Route-clearance certification: [issue_1105_route_clearance_certification.md](issue_1105_route_clearance_certification.md)
 * Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -80,7 +80,7 @@ knowledge, not every transient iteration detail.
 * AI-facing orientation: [docs/ai/repo_overview.md](../ai/repo_overview.md)
 * Goal-driven agent loops:
   [goal_driven_agent_loops_2026-05-13.md](goal_driven_agent_loops_2026-05-13.md)
-* `ml-intern` bounded assistant assessment and #1191 workflow extraction:
+* ML-Intern Bounded Assistant Assessment and #1191 Workflow Extraction:
   [issue_1181_ml_intern_experiment_assistant.md](issue_1181_ml_intern_experiment_assistant.md)
 * Route-clearance certification: [issue_1105_route_clearance_certification.md](issue_1105_route_clearance_certification.md)
 * Negative route-clearance repair: [issue_1130_negative_route_clearance_repair.md](issue_1130_negative_route_clearance_repair.md)

--- a/docs/context/issue_1181_ml_intern_experiment_assistant.md
+++ b/docs/context/issue_1181_ml_intern_experiment_assistant.md
@@ -31,7 +31,7 @@ Not recommended in this issue:
 - SLURM replacement,
 - or any workflow that treats fallback/degraded execution as valid benchmark evidence.
 
-## Issue #1191 outcome: extract concepts, defer runtime smoke
+## Issue #1191 Outcome: Extract Concepts, Defer Runtime Smoke
 
 Issue #1191 was initially scoped as an `imech192` SLURM setup-and-submit smoke for `ml-intern`.
 During the 2026-05-15 audit, the setup check found:
@@ -48,7 +48,7 @@ and repo-local skills to apply the useful ideas directly. A future `ml-intern` s
 reasonable only for a narrow Hugging Face-specific task where its native model, dataset, Space, or
 HF Jobs context provides a clear advantage over the existing workflow.
 
-## Extracted practices to keep
+## Extracted Practices to Keep
 
 The useful `ml-intern` concepts are workflow controls, not the specific executable:
 

--- a/docs/context/issue_1181_ml_intern_experiment_assistant.md
+++ b/docs/context/issue_1181_ml_intern_experiment_assistant.md
@@ -2,11 +2,18 @@
 
 Date: 2026-05-13
 Issue: #1181
+Follow-up: #1191
 
 ## Decision
 
 `huggingface/ml-intern` is a plausible **bounded experiment assistant** for `robot_sf_ll7`, but it
 should **not** become the repository runtime or replace the existing local/HPC/SLURM workflows.
+
+Update on 2026-05-15 for #1191: do **not** spend API budget on an `ml-intern` runtime smoke for the
+current Robot SF workflow. The incremental value of the CLI is small here because the repository
+already has the core execution discipline through Codex skills, context notes, SLURM-aware local
+machine policy, proof-first validation, and GitHub workflow. Treat `ml-intern` runtime execution as
+optional/deferred, while extracting its useful workflow concepts into the Codex-native workflow.
 
 Recommended near-term use:
 
@@ -14,7 +21,7 @@ Recommended near-term use:
 - validation-plan drafting,
 - config/path scaffolding,
 - bounded local smoke execution,
-- and, only after local proof, a separate follow-up issue for one small remote sandbox/HF Job check.
+- and a separate cost/privacy decision before any remote sandbox, HF Job, or paid CLI runtime check.
 
 Not recommended in this issue:
 
@@ -23,6 +30,50 @@ Not recommended in this issue:
 - CARLA/Unreal-heavy runs,
 - SLURM replacement,
 - or any workflow that treats fallback/degraded execution as valid benchmark evidence.
+
+## Issue #1191 outcome: extract concepts, defer runtime smoke
+
+Issue #1191 was initially scoped as an `imech192` SLURM setup-and-submit smoke for `ml-intern`.
+During the 2026-05-15 audit, the setup check found:
+
+- `ml-intern` was not installed in the worktree environment,
+- no explicit model credential or local OpenAI-compatible endpoint was present,
+- a Codex/ChatGPT subscription is not a substitute for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  `HF_TOKEN`, or a local endpoint credential,
+- and Robot SF already has the valuable workflow primitives that `ml-intern` would be asked to
+  demonstrate.
+
+Recommendation: keep the `ml-intern` CLI out of the required Robot SF workflow for now. Use Codex
+and repo-local skills to apply the useful ideas directly. A future `ml-intern` smoke remains
+reasonable only for a narrow Hugging Face-specific task where its native model, dataset, Space, or
+HF Jobs context provides a clear advantage over the existing workflow.
+
+## Extracted practices to keep
+
+The useful `ml-intern` concepts are workflow controls, not the specific executable:
+
+1. **No-edit planning pass**
+   - Start uncertain agent tasks by reading the context stack and proposing a bounded proof ladder.
+   - For Robot SF, the first prompt should name the exact files to read and require the assistant to
+     stop after a plan unless execution is explicitly in scope.
+2. **Budgeted agent runs**
+   - Before exploratory work, declare allowed commands, forbidden commands, max iterations or time
+     budget, stop condition, and cost/risk class.
+   - Avoid broad "improve this repo" prompts against paid or trace-uploading external tools.
+3. **Trace/privacy defaults**
+   - Do not paste secrets, unpublished benchmark interpretations, private review text, or raw
+     internal logs into external agent tools.
+   - Disable trace upload where the tool supports it, especially for pre-publication or
+     benchmark-facing work.
+4. **One-smoke-before-campaign rule**
+   - New assistant workflows, remote sandboxes, and experiment runners must prove one small command
+     first, then fail closed or proceed with an explicit follow-up.
+   - A fallback, degraded, or broadened run is not success evidence.
+5. **Optional HF-specific lane**
+   - Reconsider `ml-intern` for Hugging Face-heavy work such as model, dataset, Space, or HF Jobs
+     exploration.
+   - Keep normal Robot SF issue execution on Codex plus repo-local skills unless the HF-specific
+     value is concrete.
 
 ## Why this fits Robot SF
 
@@ -88,7 +139,7 @@ Good first uses:
 - “review a PPO config and suggest bounded dry-run proof commands”
 - “compare two local docs/config surfaces and point out contract mismatches”
 
-Possible later use, but only after local proof:
+Possible later use, but only after local proof and a new cost/privacy decision:
 
 - one remote sandbox smoke for a bounded training or validation command,
 - one explicitly scoped HF Job follow-up with pinned install steps, timeout, hardware, and durable
@@ -125,8 +176,9 @@ The first validation ladder should stay local and bounded:
 4. **One PPO dry-run candidate**
    - `uv run python scripts/training/train_ppo.py --config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml --dry-run --log-level WARNING`
 
-The point of this ladder is not to outsource repository judgment. It is to check whether
-`ml-intern` can stay inside Robot SF's existing contracts while helping with bounded work.
+The point of this ladder is not to outsource repository judgment. For current Robot SF work, this
+ladder is better used as a Codex-native pattern. It should check that any assistant stays inside the
+existing contracts while helping with bounded work.
 
 ## First-use prompt for Robot SF
 
@@ -206,8 +258,15 @@ Observed outcomes:
 
 ## Follow-up boundary
 
-If this note holds up after the local proof ladder, the next acceptable follow-up is **one separate
-issue** for a single remote sandbox/HF Job smoke with:
+The #1191 decision supersedes the earlier default of running a follow-up `ml-intern` smoke. The
+current follow-up boundary is:
+
+- Codex-native extraction is in scope for #1191.
+- `ml-intern` runtime execution is optional/deferred, not required.
+- A future runtime smoke should be opened only when there is a concrete Hugging Face-specific value
+  proposition and an explicit cost/privacy budget decision.
+
+If a future runtime smoke is approved, it should be a separate issue with:
 
 - pinned install/setup steps,
 - explicit hardware/runtime assumptions,
@@ -215,4 +274,4 @@ issue** for a single remote sandbox/HF Job smoke with:
 - durable artifact routing,
 - and an explicit statement that it does not replace the canonical local/SLURM workflow.
 
-Follow-up tracker opened: #1191.
+Follow-up tracker: #1191.


### PR DESCRIPTION
## Summary
Reframed the `ml-intern` follow-up from a paid/runtime smoke into a Codex-native workflow extraction, preserving the useful practices without adding a new required agent runtime.

## Linked Issues
- Closes #1191
- Relates to #1181

## What Changed
- Updated `docs/context/issue_1181_ml_intern_experiment_assistant.md` with the #1191 decision to defer `ml-intern` runtime execution and extract the useful workflow controls instead.
- Documented the reusable practices: no-edit planning pass, budgeted agent runs, trace/privacy defaults, one-smoke-before-campaign rule, and an optional HF-specific lane.
- Updated `docs/README.md`, `docs/context/README.md`, and `docs/ai/repo_overview.md` so the revised guidance is discoverable from normal entry points.
- Reframed GitHub issue #1191 to match this docs-only extraction scope and removed the stale `slurm` / `imech192` routing labels.

## Why It Matters
- Added value: keeps the practical `ml-intern` workflow lessons while avoiding extra API spend, trace-upload risk, and a second agent runtime for normal Robot SF work.
- Expected impact: future agents can apply the useful pattern through Codex and repo-local skills without treating `ml-intern` as required infrastructure.
- Why this is worth merging now: it closes the open decision loop from #1181/#1191 and prevents a low-value paid smoke from becoming the default next step.

## Validation / Proof
- Commands run:
  - `git fetch origin main && git merge origin/main`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - referenced-path existence check for the touched docs and linked workflow files
  - `git diff --check`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` via SLURM job `12475` on `l40s`
  - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
- Evidence that the change works here:
  - AI config links validated: `7 symlinks`.
  - Readiness job `12475` completed successfully: `3534 passed, 14 skipped, 4 warnings in 468.53s`.
  - Freshness stamp matches committed head `2c69d858ff09dd5e3c2e896af78be867a4fd56c1` for `origin/main`.
- Benchmarks or smoke tests, if applicable:
  - No benchmark campaign was run; this is a docs/workflow guidance change.

## Risks / Rollout
- Compatibility risks: none expected; no code, configs, dependencies, or executable skill files changed.
- Failure modes: future `ml-intern` runtime use could still be worthwhile for HF-heavy work, but it now requires a separate cost/privacy decision instead of being assumed.
- Rollback or fallback plan: revert the docs commit if the team wants #1191 to return to a concrete runtime smoke.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1181_ml_intern_experiment_assistant.md`
  - `docs/context/README.md`
  - `docs/README.md`
  - `docs/ai/repo_overview.md`
- Relevant design or provenance notes:
  - Parent context note: `docs/context/issue_1181_ml_intern_experiment_assistant.md`
  - Issue-audit decision recorded in #1191.
- Any assumptions that need to be preserved:
  - A Codex/ChatGPT subscription is not a substitute for an explicit `ml-intern` model credential.
  - External agent traces and API spend require explicit scope, budget, and privacy handling.

## Follow-Up Issues
- Deferred work: future `ml-intern` runtime execution only if a concrete Hugging Face-specific task justifies it.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please review the changed context note as executable workflow guidance for future agents.
- Artifact persistence: ignored `output/coverage/`, `output/validation/pr_ready/`, and `output/slurm/pr1191_*` files are disposable local validation byproducts and were not committed.
- Known validation note: an earlier committed-head readiness attempt, SLURM job `12474` on `a30`, hit a transient 60s timeout in `examples/quickstart/01_basic_robot.py`; rerun job `12475` on `l40s` passed the full readiness gate.