### PR TITLE
Add Docker repro smoke workflow

### DIFF
--- a/.github/workflows/benchmark-docker-repro-smoke.yml
+++ b/.github/workflows/benchmark-docker-repro-smoke.yml
@@ -1,0 +1,156 @@
+name: Benchmark Docker Repro Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/benchmark-docker-repro-smoke.yml"
+      - "docker/benchmark-repro.Dockerfile"
+      - "scripts/repro/**"
+      - "tests/repro/**"
+      - "docs/benchmark_docker_repro.md"
+      - "docs/context/issue_1086_docker_reproduction_path.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-repro-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      PYTHONUNBUFFERED: "1"
+      ROBOT_SF_REPRO_IMAGE: robot-sf-benchmark-repro:py312.3-uv0.11.9
+      ROBOT_SF_REPRO_OUTPUT_ROOT: output/docker_repro/benchmark_bundle_smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Qualify runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="output/docker_repro/runner_qualification"
+          mkdir -p "$out"
+
+          uname -a > "$out/uname.txt"
+          dpkg --print-architecture > "$out/dpkg_architecture.txt"
+
+          set +e
+          docker version --format '{{json .}}' > "$out/docker_version.json" 2> "$out/docker_version.err"
+          docker_version_status=$?
+          docker info --format '{{json .}}' > "$out/docker_info.json" 2> "$out/docker_info.err"
+          docker_info_status=$?
+          nvidia-smi > "$out/nvidia_smi.txt" 2>&1
+          nvidia_status=$?
+          docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi \
+            > "$out/nvidia_docker_smi.txt" 2>&1
+          nvidia_docker_status=$?
+          set -e
+
+          python - "$out" \
+            "$docker_version_status" \
+            "$docker_info_status" \
+            "$nvidia_status" \
+            "$nvidia_docker_status" <<'PY'
+          from __future__ import annotations
+
+          import json
+          import platform
+          import sys
+          from pathlib import Path
+
+          out = Path(sys.argv[1])
+          docker_version_status = int(sys.argv[2])
+          docker_info_status = int(sys.argv[3])
+          nvidia_status = int(sys.argv[4])
+          nvidia_docker_status = int(sys.argv[5])
+
+          def _read(path: Path) -> str:
+              return path.read_text(encoding="utf-8", errors="replace").strip()
+
+          def _json(path: Path) -> object | None:
+              if not path.is_file() or path.stat().st_size == 0:
+                  return None
+              return json.loads(path.read_text(encoding="utf-8"))
+
+          summary = {
+              "runner_os": platform.platform(),
+              "machine": platform.machine(),
+              "uname": _read(out / "uname.txt"),
+              "dpkg_architecture": _read(out / "dpkg_architecture.txt"),
+              "docker_daemon_available": docker_version_status == 0 and docker_info_status == 0,
+              "docker_version_status": docker_version_status,
+              "docker_info_status": docker_info_status,
+              "docker_version": _json(out / "docker_version.json"),
+              "docker_info": _json(out / "docker_info.json"),
+              "nvidia_smi_available": nvidia_status == 0,
+              "nvidia_smi_status": nvidia_status,
+              "nvidia_docker_available": nvidia_docker_status == 0,
+              "nvidia_docker_status": nvidia_docker_status,
+              "nvidia_smi_output": _read(out / "nvidia_smi.txt"),
+              "nvidia_docker_output": _read(out / "nvidia_docker_smi.txt"),
+          }
+          (out / "runner_qualification.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(summary, indent=2, sort_keys=True))
+          if not summary["docker_daemon_available"]:
+              raise SystemExit("Docker daemon is not available on this runner.")
+          PY
+
+      - name: Run Docker benchmark smoke
+        shell: bash
+        run: scripts/repro/run_benchmark_docker_smoke.sh
+
+      - name: Inspect built image
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p output/docker_repro
+          docker image inspect "$ROBOT_SF_REPRO_IMAGE" > output/docker_repro/image_inspect.json
+          docker image inspect --format '{{.Id}}' "$ROBOT_SF_REPRO_IMAGE" \
+            > output/docker_repro/image_id.txt
+
+      - name: Summarize Docker proof
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Benchmark Docker Repro Smoke"
+            echo
+            echo "Runner qualification:"
+            echo
+            python -m json.tool output/docker_repro/runner_qualification/runner_qualification.json
+            echo
+            if [ -f output/docker_repro/image_id.txt ]; then
+              echo "Image ID:"
+              echo
+              sed 's/^/    /' output/docker_repro/image_id.txt
+              echo
+            fi
+            if [ -f output/docker_repro/benchmark_bundle_smoke/manifest.json ]; then
+              echo "Smoke manifest:"
+              echo
+              python -m json.tool output/docker_repro/benchmark_bundle_smoke/manifest.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Docker repro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-docker-repro-smoke
+          path: |
+            output/docker_repro/runner_qualification/
+            output/docker_repro/image_inspect.json
+            output/docker_repro/image_id.txt
+            output/docker_repro/benchmark_bundle_smoke/
+          if-no-files-found: warn

--- a/docker/benchmark-repro.Dockerfile
+++ b/docker/benchmark-repro.Dockerfile
@@ -34,6 +34,7 @@ COPY third_party/python-rvo2 ./third_party/python-rvo2
 RUN uv sync --all-extras --frozen --no-install-project
 
 COPY . .
+RUN rm -rf third_party/python-rvo2/build
 RUN uv sync --all-extras --frozen
 
 ENTRYPOINT ["scripts/repro/benchmark_bundle_smoke.sh"]

--- a/docker/benchmark-repro.Dockerfile
+++ b/docker/benchmark-repro.Dockerfile
@@ -30,10 +30,10 @@ WORKDIR /workspace/robot_sf_ll7
 
 COPY pyproject.toml uv.lock ./
 COPY fast-pysf ./fast-pysf
+COPY third_party/python-rvo2 ./third_party/python-rvo2
 RUN uv sync --all-extras --frozen --no-install-project
 
 COPY . .
 RUN uv sync --all-extras --frozen
 
 ENTRYPOINT ["scripts/repro/benchmark_bundle_smoke.sh"]
-

--- a/docs/benchmark_docker_repro.md
+++ b/docs/benchmark_docker_repro.md
@@ -23,6 +23,23 @@ Default image tag:
 robot-sf-benchmark-repro:py312.3-uv0.11.9
 ```
 
+## GitHub Actions Runner Smoke
+
+The path-limited workflow `.github/workflows/benchmark-docker-repro-smoke.yml` runs the same
+wrapper when Docker reproduction files change, and it can also be triggered manually with
+`workflow_dispatch`.
+
+The workflow records runner qualification evidence before building the image:
+
+* runner OS and architecture
+* Docker daemon version and `docker info`
+* `nvidia-smi` availability
+* `docker run --gpus all ... nvidia-smi` availability
+
+GitHub-hosted `ubuntu-latest` can provide Docker daemon proof for the CPU/headless smoke. It is not
+expected to provide NVIDIA GPU evidence; the workflow records that as an explicit not-available
+condition rather than treating it as benchmark success.
+
 ## What Runs
 
 The smoke uses:

--- a/docs/context/issue_1086_docker_reproduction_path.md
+++ b/docs/context/issue_1086_docker_reproduction_path.md
@@ -86,6 +86,11 @@ the pinned Docker reproduction path. The workflow records runner OS/architecture
 version, `docker info`, `nvidia-smi`, and `docker run --gpus all ... nvidia-smi` evidence before it
 runs `scripts/repro/run_benchmark_docker_smoke.sh`.
 
+The first workflow execution caught that the Dockerfile's dependency-layer copy omitted the locked
+local `third_party/python-rvo2` dependency before `uv sync --all-extras --frozen
+--no-install-project`. The Dockerfile now copies `third_party/python-rvo2` alongside `fast-pysf`
+before the dependency sync so the frozen ORCA extra can resolve inside the image.
+
 The expected GitHub-hosted `ubuntu-latest` proof is CPU/headless Docker reproduction evidence. If
 NVIDIA hardware or NVIDIA Container Toolkit support is unavailable, the workflow records that as a
 runner limitation; it must not be reported as GPU or CARLA runtime readiness for #1179.

--- a/docs/context/issue_1086_docker_reproduction_path.md
+++ b/docs/context/issue_1086_docker_reproduction_path.md
@@ -52,6 +52,9 @@ Required checks for this branch:
 * targeted contract tests for the Dockerfile, scripts, docs, and context note
 * direct smoke script execution on the host
 * Docker wrapper execution when Docker is available
+* path-limited GitHub Actions workflow execution via
+  `.github/workflows/benchmark-docker-repro-smoke.yml` for Docker-capable runner qualification
+  and artifact capture
 * full PR readiness after syncing with `origin/main`
 
 ## 2026-05-09 Local Validation
@@ -75,3 +78,14 @@ ERROR: permission denied while trying to connect to the docker API at unix:///va
 The current user is not in the `docker` group for `/var/run/docker.sock`. The Docker build/run
 command remains the required final environment proof on a Docker-capable host or CI runner; this is
 tracked by follow-up issue #1119.
+
+## 2026-05-15 Runner Qualification Follow-up
+
+Issue #1119 adds `.github/workflows/benchmark-docker-repro-smoke.yml`, a path-limited workflow for
+the pinned Docker reproduction path. The workflow records runner OS/architecture, Docker daemon
+version, `docker info`, `nvidia-smi`, and `docker run --gpus all ... nvidia-smi` evidence before it
+runs `scripts/repro/run_benchmark_docker_smoke.sh`.
+
+The expected GitHub-hosted `ubuntu-latest` proof is CPU/headless Docker reproduction evidence. If
+NVIDIA hardware or NVIDIA Container Toolkit support is unavailable, the workflow records that as a
+runner limitation; it must not be reported as GPU or CARLA runtime readiness for #1179.

--- a/docs/context/issue_1086_docker_reproduction_path.md
+++ b/docs/context/issue_1086_docker_reproduction_path.md
@@ -91,6 +91,12 @@ local `third_party/python-rvo2` dependency before `uv sync --all-extras --frozen
 --no-install-project`. The Dockerfile now copies `third_party/python-rvo2` alongside `fast-pysf`
 before the dependency sync so the frozen ORCA extra can resolve inside the image.
 
+The next workflow execution reached the final project install but exposed a stale vendored RVO2
+build-tree issue: the dependency-layer install left `third_party/python-rvo2/build/RVO2` pointing at
+an isolated temporary CMake executable that no longer existed when the final `uv sync` reused the
+tree. The Dockerfile now clears `third_party/python-rvo2/build` before the final project sync so
+the vendored wheel build reconfigures from the copied source tree inside the final layer.
+
 The expected GitHub-hosted `ubuntu-latest` proof is CPU/headless Docker reproduction evidence. If
 NVIDIA hardware or NVIDIA Container Toolkit support is unavailable, the workflow records that as a
 runner limitation; it must not be reported as GPU or CARLA runtime readiness for #1179.

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -16,10 +16,17 @@ RELEASE_REPRO_DOC = ROOT / "docs" / "benchmark_release_reproducibility.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "benchmark-docker-repro-smoke.yml"
 
 
+def _read_text_file(path: Path) -> str:
+    """Read a UTF-8 text file after verifying it is a regular file."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Expected file does not exist: {path}")
+    return path.read_text(encoding="utf-8")
+
+
 def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
     """The Docker recipe should pin the main runtime surfaces used by the smoke."""
 
-    text = DOCKERFILE.read_text(encoding="utf-8")
+    text = _read_text_file(DOCKERFILE)
 
     assert "FROM python:3.12.3-slim-bookworm" in text
     assert "ARG UV_VERSION=0.11.9" in text
@@ -34,8 +41,8 @@ def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
 def test_benchmark_repro_scripts_define_one_command_smoke_contract() -> None:
     """The scripts should build the image and emit the documented benchmark artifacts."""
 
-    smoke = SMOKE_SCRIPT.read_text(encoding="utf-8")
-    wrapper = WRAPPER_SCRIPT.read_text(encoding="utf-8")
+    smoke = _read_text_file(SMOKE_SCRIPT)
+    wrapper = _read_text_file(WRAPPER_SCRIPT)
 
     assert SMOKE_SCRIPT.stat().st_mode & stat.S_IXUSR
     assert WRAPPER_SCRIPT.stat().st_mode & stat.S_IXUSR
@@ -56,10 +63,10 @@ def test_benchmark_repro_scripts_define_one_command_smoke_contract() -> None:
 def test_benchmark_repro_docs_are_discoverable_and_state_limits() -> None:
     """Documentation should expose the path, outputs, pinning, and determinism boundary."""
 
-    doc = DOC.read_text(encoding="utf-8")
-    context = CONTEXT_NOTE.read_text(encoding="utf-8")
-    docs_readme = DOCS_README.read_text(encoding="utf-8")
-    release_repro_doc = RELEASE_REPRO_DOC.read_text(encoding="utf-8")
+    doc = _read_text_file(DOC)
+    context = _read_text_file(CONTEXT_NOTE)
+    docs_readme = _read_text_file(DOCS_README)
+    release_repro_doc = _read_text_file(RELEASE_REPRO_DOC)
 
     for fragment in [
         "scripts/repro/run_benchmark_docker_smoke.sh",
@@ -82,11 +89,12 @@ def test_benchmark_repro_docs_are_discoverable_and_state_limits() -> None:
 def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
     """Docker CI proof should record runner capabilities before running the smoke."""
 
-    workflow = WORKFLOW.read_text(encoding="utf-8")
+    workflow = _read_text_file(WORKFLOW)
 
     for fragment in [
         "workflow_dispatch:",
         "pull_request:",
+        "paths:",
         "docker version --format",
         "docker info --format",
         "nvidia-smi",

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -27,6 +27,7 @@ def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
     assert "uv sync --all-extras --frozen --no-install-project" in text
     assert "uv sync --all-extras --frozen" in text
     assert "COPY third_party/python-rvo2 ./third_party/python-rvo2" in text
+    assert "rm -rf third_party/python-rvo2/build" in text
     assert 'ENTRYPOINT ["scripts/repro/benchmark_bundle_smoke.sh"]' in text
 
 

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -26,6 +26,7 @@ def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
     assert 'python -m pip install "uv==${UV_VERSION}"' in text
     assert "uv sync --all-extras --frozen --no-install-project" in text
     assert "uv sync --all-extras --frozen" in text
+    assert "COPY third_party/python-rvo2 ./third_party/python-rvo2" in text
     assert 'ENTRYPOINT ["scripts/repro/benchmark_bundle_smoke.sh"]' in text
 
 

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -13,6 +13,7 @@ DOC = ROOT / "docs" / "benchmark_docker_repro.md"
 CONTEXT_NOTE = ROOT / "docs" / "context" / "issue_1086_docker_reproduction_path.md"
 DOCS_README = ROOT / "docs" / "README.md"
 RELEASE_REPRO_DOC = ROOT / "docs" / "benchmark_release_reproducibility.md"
+WORKFLOW = ROOT / ".github" / "workflows" / "benchmark-docker-repro-smoke.yml"
 
 
 def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
@@ -74,3 +75,26 @@ def test_benchmark_repro_docs_are_discoverable_and_state_limits() -> None:
     assert "benchmark_docker_repro.md" in docs_readme
     assert "Benchmark Docker Reproduction Path" in release_repro_doc
     assert "Dockerfile: `docker/benchmark-repro.Dockerfile`" in context
+
+
+def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
+    """Docker CI proof should record runner capabilities before running the smoke."""
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for fragment in [
+        "workflow_dispatch:",
+        "pull_request:",
+        "docker version --format",
+        "docker info --format",
+        "nvidia-smi",
+        "docker run --rm --gpus all",
+        "scripts/repro/run_benchmark_docker_smoke.sh",
+        "runner_qualification.json",
+        "image_inspect.json",
+        "benchmark-docker-repro-smoke",
+    ]:
+        assert fragment in workflow
+
+    assert "docker_daemon_available" in workflow
+    assert "nvidia_docker_available" in workflow


### PR DESCRIPTION
## Summary
- Add a path-limited GitHub Actions workflow that qualifies the runner, runs the Docker benchmark reproduction smoke, records image metadata, and uploads proof artifacts.
- Fix the Docker repro image build for the locked vendored `third_party/python-rvo2` dependency by copying it into the dependency layer and clearing the stale build tree before final project sync.
- Document the #1119 runner proof boundary in the Docker reproduction context note.

## Validation
- `rtk uv run ruff check tests/repro/test_benchmark_docker_repro_contract.py`
- `rtk uv run pytest tests/repro/test_benchmark_docker_repro_contract.py -q` -> 4 passed
- `rtk bash -n scripts/repro/benchmark_bundle_smoke.sh scripts/repro/run_benchmark_docker_smoke.sh`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 rtk scripts/dev/pr_ready_check.sh` -> 3536 passed, 13 skipped, 3 warnings
- GitHub Actions `Benchmark Docker Repro Smoke` run 25919706769 -> success in 5m37s

## Docker Proof
- Runner: Linux-6.17.0-1013-azure-x86_64, dpkg architecture amd64, Docker 28.0.4, daemon available.
- NVIDIA: `nvidia-smi` unavailable and `docker run --gpus all ... nvidia-smi` unavailable on `ubuntu-latest`; recorded as a runner limitation, not GPU readiness.
- Image: `robot-sf-benchmark-repro:py312.3-uv0.11.9`, ID `sha256:2a73eec4e44e32caa269aa525ff5fcc6e2396f8b4e1135651e287e994a6ef5e5`.
- Smoke: native benchmark run, 3 jobs written, success mean 1.0, collisions mean 0.0.
- Uploaded artifact: `benchmark-docker-repro-smoke` from run 25919706769, including runner qualification, image inspect/id, manifest, logs, summary, and episode JSONL.

Closes #1119