### PR TITLE
ci: add explicit workflow job timeouts (#1232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   fast-feedback:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,6 +119,7 @@ jobs:
 
   smoke-artifacts:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -212,6 +214,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - fast-feedback
       - smoke-artifacts

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -6,12 +6,18 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+CI_JOB_TIMEOUTS = {
+    "fast-feedback": 45,
+    "smoke-artifacts": 30,
+    "ci": 5,
+}
 PHASE_PATTERN = re.compile(
     r"(?:^|\s)(?:\./)?scripts/dev/ci_driver\.sh(?P<args>(?:\s+--?[a-z0-9_-]+|\s+[a-z0-9_-]+)*)",
     re.MULTILINE,
@@ -81,6 +87,12 @@ def _workflow_text() -> str:
     return CI_WORKFLOW.read_text(encoding="utf-8")
 
 
+def _workflow_jobs() -> dict[str, Any]:
+    """Return the parsed CI workflow jobs mapping."""
+    workflow = yaml.safe_load(_workflow_text())
+    return workflow["jobs"]
+
+
 def test_extract_workflow_phases_handles_multiple_phase_args() -> None:
     """Capture all phase arguments from one workflow run stanza."""
 
@@ -142,3 +154,12 @@ def test_ci_workflow_does_not_download_apt_fast_at_runtime() -> None:
 
     assert "apt-fast" not in workflow_text
     assert "raw.githubusercontent.com/ilikenwf/apt-fast" not in workflow_text
+
+
+def test_ci_workflow_jobs_have_explicit_timeout_bounds() -> None:
+    """Keep every CI job bounded against hung GitHub Actions runs."""
+    jobs = _workflow_jobs()
+
+    assert set(CI_JOB_TIMEOUTS) == set(jobs)
+    for job_name, expected_timeout in CI_JOB_TIMEOUTS.items():
+        assert jobs[job_name]["timeout-minutes"] == expected_timeout

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -55,10 +55,10 @@ def _extract_workflow_phases(run_text: str) -> set[str]:
 
 def _workflow_phases() -> set[str]:
     """Return CI driver phases referenced by the GitHub Actions workflow."""
-    workflow = yaml.safe_load(_workflow_text())
+    workflow = yaml.safe_load(_workflow_text()) or {}
 
     referenced_phases: set[str] = set()
-    for job in workflow["jobs"].values():
+    for job in workflow.get("jobs", {}).values():
         for step in job.get("steps", []):
             run_text = step.get("run")
             if not run_text:
@@ -89,8 +89,8 @@ def _workflow_text() -> str:
 
 def _workflow_jobs() -> dict[str, Any]:
     """Return the parsed CI workflow jobs mapping."""
-    workflow = yaml.safe_load(_workflow_text())
-    return workflow["jobs"]
+    workflow = yaml.safe_load(_workflow_text()) or {}
+    return workflow.get("jobs", {})
 
 
 def test_extract_workflow_phases_handles_multiple_phase_args() -> None:
@@ -162,4 +162,4 @@ def test_ci_workflow_jobs_have_explicit_timeout_bounds() -> None:
 
     assert set(CI_JOB_TIMEOUTS) == set(jobs)
     for job_name, expected_timeout in CI_JOB_TIMEOUTS.items():
-        assert jobs[job_name]["timeout-minutes"] == expected_timeout
+        assert jobs[job_name].get("timeout-minutes") == expected_timeout


### PR DESCRIPTION
## Summary
Adds explicit timeout bounds to every job in `.github/workflows/ci.yml` and extends the CI workflow contract test so future CI jobs cannot silently omit a job-level timeout.

## Linked Issues
- Closes #1232

## What Changed
- Added `timeout-minutes` to the `fast-feedback`, `smoke-artifacts`, and aggregate `ci` jobs.
- Added a PyYAML-backed contract assertion in `tests/test_ci_driver_contract.py` for the expected CI job timeout policy.

## Why It Matters
- Added value: CI jobs now have predictable upper bounds instead of relying on GitHub defaults.
- Expected impact: hung or runaway CI jobs fail with a clearer resource boundary.
- Why this is worth merging now: issue #1006 runtime evidence shows normal unit-test CI around 12 minutes and smoke around 2 minutes, so the chosen 45/30/5 minute limits are conservative rather than aggressive.

## Validation / Proof
- Commands run:
  - `rtk uv run --active pytest tests/test_ci_driver_contract.py::test_ci_workflow_jobs_have_explicit_timeout_bounds -q` failed before the workflow timeout additions with `KeyError: 'timeout-minutes'`.
  - `rtk uv run --active pytest tests/test_ci_driver_contract.py -q` passed with `6 passed in 5.87s`.
  - `rtk uv run --active ruff check tests/test_ci_driver_contract.py` passed.
  - `rtk scripts/dev/ci_driver.sh --list-phases` listed `lint`, `typecheck`, `test`, `smoke`, and `artifact-policy`.
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` passed after the final `origin/main` sync with `3549 passed, 13 skipped, 3 warnings in 254.69s`.
- Evidence that the change works here: the new contract parses the workflow and asserts every current CI job has the expected timeout.
- Benchmarks or smoke tests, if applicable: not applicable; this is CI workflow hardening.

## Risks / Rollout
- Compatibility risks: low; GitHub Actions supports job-level `timeout-minutes`.
- Failure modes: if CI runtime grows substantially, the bounded jobs may fail at the timeout rather than hang indefinitely.
- Rollback or fallback plan: adjust the timeout values or revert the workflow/test change.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: timeout values are based on the runtime context in `docs/context/issue_1006_ci_runtime_drift.md`.
- Any assumptions that need to be preserved: keep timeout values generous relative to current runtime; do not use them to shorten validation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- The pytest run refreshed ignored coverage output under `output/coverage/`; those files are disposable validation artifacts and are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit timeout limits for CI pipeline jobs (per-job caps introduced: 45, 30 and 5 minutes).
* **Tests**
  * Added validation tests to ensure the CI workflow defines timeout bounds for every job and that each job’s timeout matches the expected configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->