### PR TITLE
test: use durable paper handoff release fixture (#1231)

### DIFF
--- a/docs/context/issue_1062_paper_evidence_archive.md
+++ b/docs/context/issue_1062_paper_evidence_archive.md
@@ -56,6 +56,21 @@ tar -tzf output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_rel
 The SHA-256 should match
 `64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`.
 
+The paper handoff parity test consumes the same durable bundle without requiring a committed raw
+benchmark output. After downloading the archive above, run:
+
+```bash
+ROBOT_SF_PAPER_HANDOFF_BUNDLE=output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  uv run --active pytest tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table -q -rs
+```
+
+The test also discovers the archive automatically at
+`output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
+or an extracted bundle at
+`output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle`.
+It verifies the archive SHA-256 and the tracked embedded artifact checksums before asserting paper
+handoff parity.
+
 ## Validation Performed
 
 On 2026-05-09:

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
@@ -80,6 +80,19 @@ tar -xzf output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_rel
   -C output/benchmark_release_0_0_2
 ```
 
+The paper Results handoff parity test uses this same release source. It accepts either the
+downloaded archive or the extracted bundle through `ROBOT_SF_PAPER_HANDOFF_BUNDLE`, and it also
+auto-discovers the documented paths under `output/benchmark_release_0_0_2`:
+
+```bash
+ROBOT_SF_PAPER_HANDOFF_BUNDLE=output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  uv run --active pytest tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table -q -rs
+```
+
+Before using the bundle, the test verifies the archive SHA-256 from `release_metadata.json` and the
+tracked embedded artifact checksums for `publication_manifest.json`, `checksums.sha256`, and the
+SNQI diagnostics.
+
 ## Tracked Companion Files
 
 - `release_metadata.json`: compact release, asset, campaign, and embedded-artifact metadata.

--- a/tests/benchmark/test_paper_results_handoff.py
+++ b/tests/benchmark/test_paper_results_handoff.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
+import os
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -14,6 +17,12 @@ from robot_sf.benchmark.paper_results_handoff import (
     export_paper_results_handoff,
 )
 from scripts.tools import paper_results_handoff
+
+_RELEASE_METADATA_PATH = Path(
+    "docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json"
+)
+_RELEASE_OUTPUT_DIR = Path("output/benchmark_release_0_0_2")
+_PAPER_HANDOFF_BUNDLE_ENV = "ROBOT_SF_PAPER_HANDOFF_BUNDLE"
 
 
 def _write(path: Path, payload: str) -> None:
@@ -155,6 +164,123 @@ def _make_publication_bundle(bundle_dir: Path) -> None:
             ]
         )
         + "\n",
+    )
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest for a local file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_release_metadata() -> dict[str, object]:
+    """Load the tracked publication release metadata used by the canonical test."""
+    return json.loads(_RELEASE_METADATA_PATH.read_text(encoding="utf-8"))
+
+
+def _verify_sha256(path: Path, expected: str, *, label: str) -> None:
+    """Assert that ``path`` exists and matches the expected SHA-256."""
+    assert path.exists(), f"Missing {label}: {path}"
+    assert _sha256(path) == expected, f"Unexpected SHA-256 for {label}: {path}"
+
+
+def _verify_release_bundle_contents(bundle_dir: Path, metadata: dict[str, object]) -> None:
+    """Verify tracked embedded checksums inside an extracted release bundle."""
+    assets = metadata["assets"]
+    assert isinstance(assets, dict)
+    for key, value in assets.items():
+        if not key.startswith("embedded_"):
+            continue
+        assert isinstance(value, dict)
+        path_in_archive = value["path_in_archive"]
+        expected_sha256 = value["sha256"]
+        assert isinstance(path_in_archive, str)
+        assert isinstance(expected_sha256, str)
+        archive_relative = Path(path_in_archive)
+        bundle_relative = (
+            Path(*archive_relative.parts[1:])
+            if archive_relative.parts and archive_relative.parts[0] == bundle_dir.name
+            else archive_relative
+        )
+        _verify_sha256(
+            bundle_dir / bundle_relative,
+            expected_sha256,
+            label=f"{key} in release bundle",
+        )
+
+
+def _extract_release_archive(
+    archive_path: Path,
+    *,
+    tmp_path: Path,
+    metadata: dict[str, object],
+) -> Path:
+    """Verify and extract the tracked release archive into ``tmp_path``."""
+    assets = metadata["assets"]
+    publication_bundle = metadata["publication_bundle"]
+    assert isinstance(assets, dict)
+    assert isinstance(publication_bundle, dict)
+    archive_metadata = assets["bundle_archive"]
+    assert isinstance(archive_metadata, dict)
+    archive_sha256 = archive_metadata["sha256"]
+    bundle_name = publication_bundle["bundle_name"]
+    assert isinstance(archive_sha256, str)
+    assert isinstance(bundle_name, str)
+
+    _verify_sha256(archive_path, archive_sha256, label="release archive")
+    with tarfile.open(archive_path, "r:gz") as archive:
+        archive.extractall(tmp_path, filter="data")
+    bundle_dir = tmp_path / bundle_name
+    _verify_release_bundle_contents(bundle_dir, metadata)
+    return bundle_dir
+
+
+def _resolve_durable_release_bundle(tmp_path: Path) -> Path:
+    """Resolve the durable release fixture or skip with the documented hydration command."""
+    metadata = _load_release_metadata()
+    assets = metadata["assets"]
+    publication_bundle = metadata["publication_bundle"]
+    assert isinstance(assets, dict)
+    assert isinstance(publication_bundle, dict)
+    archive_metadata = assets["bundle_archive"]
+    assert isinstance(archive_metadata, dict)
+    archive_name = archive_metadata["name"]
+    bundle_name = publication_bundle["bundle_name"]
+    assert isinstance(archive_name, str)
+    assert isinstance(bundle_name, str)
+
+    env_value = os.environ.get(_PAPER_HANDOFF_BUNDLE_ENV)
+    if env_value:
+        configured_path = Path(env_value).expanduser()
+        if configured_path.is_dir():
+            _verify_release_bundle_contents(configured_path, metadata)
+            return configured_path
+        if configured_path.is_file():
+            return _extract_release_archive(configured_path, tmp_path=tmp_path, metadata=metadata)
+        pytest.fail(
+            f"{_PAPER_HANDOFF_BUNDLE_ENV} must point to an extracted bundle directory "
+            f"or the release archive: {configured_path}"
+        )
+
+    default_archive = _RELEASE_OUTPUT_DIR / archive_name
+    if default_archive.exists():
+        return _extract_release_archive(default_archive, tmp_path=tmp_path, metadata=metadata)
+
+    default_bundle = _RELEASE_OUTPUT_DIR / bundle_name
+    if default_bundle.exists():
+        _verify_release_bundle_contents(default_bundle, metadata)
+        return default_bundle
+
+    pytest.skip(
+        "durable release 0.0.2 publication bundle is not hydrated; run "
+        "`mkdir -p output/benchmark_release_0_0_2 && "
+        "gh release download 0.0.2 --pattern "
+        "'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' "
+        "--dir output/benchmark_release_0_0_2` or set "
+        f"{_PAPER_HANDOFF_BUNDLE_ENV} to the archive or extracted bundle"
     )
 
 
@@ -346,30 +472,32 @@ def test_export_paper_results_handoff_serializes_missing_metrics_without_nan(
     assert rows[0]["near_misses_mean"] == ""
 
 
-def test_canonical_handoff_matches_frozen_campaign_table_when_available() -> None:
-    """Local canonical artifact should round-trip planner means when present."""
-    source = Path(
-        "output/benchmarks/publication/"
-        "paper_experiment_matrix_v1_issue579_snqi_v3_regen_20260318_163407_publication_bundle"
-    )
-    if not source.exists():
-        pytest.skip("canonical March 18 publication bundle is not present locally")
+def test_canonical_handoff_matches_durable_release_campaign_table(tmp_path: Path) -> None:
+    """Durable release artifact should round-trip planner means when hydrated."""
+    metadata = _load_release_metadata()
+    source = _resolve_durable_release_bundle(tmp_path)
 
     payload = build_paper_results_handoff_payload(
         source,
         confidence_settings={"bootstrap_samples": 0},
     )
     rows = {row["planner_key"]: row for row in payload["rows"]}
+    campaign = metadata["campaign"]
+    seed_policy = metadata["seed_policy"]
+    scope = metadata["scope"]
+    assert isinstance(campaign, dict)
+    assert isinstance(seed_policy, dict)
+    assert isinstance(scope, dict)
+    included_planners = scope["included_planners"]
+    assert isinstance(included_planners, list)
 
-    assert (
-        payload["campaign_id"]
-        == "paper_experiment_matrix_v1_issue579_snqi_v3_regen_20260318_163407"
-    )
+    assert payload["campaign_id"] == campaign["campaign_id"]
+    assert payload["row_count"] == len(included_planners)
     assert rows["orca"]["success_mean"] == pytest.approx(
         rows["orca"]["success_source_table_mean"],
         abs=5e-5,
     )
-    assert rows["orca"]["repeat_count"] == 47
+    assert rows["orca"]["repeat_count"] == seed_policy["repeat_count_per_planner_seed"]
     assert rows["ppo"]["collisions_mean"] == pytest.approx(
         rows["ppo"]["collisions_source_table_mean"],
         abs=5e-5,

--- a/tests/benchmark/test_paper_results_handoff.py
+++ b/tests/benchmark/test_paper_results_handoff.py
@@ -18,10 +18,16 @@ from robot_sf.benchmark.paper_results_handoff import (
 )
 from scripts.tools import paper_results_handoff
 
-_RELEASE_METADATA_PATH = Path(
-    "docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_METADATA_PATH = (
+    _REPO_ROOT
+    / "docs"
+    / "experiments"
+    / "publication"
+    / "20260414_benchmark_release_0_0_2"
+    / "release_metadata.json"
 )
-_RELEASE_OUTPUT_DIR = Path("output/benchmark_release_0_0_2")
+_RELEASE_OUTPUT_DIR = _REPO_ROOT / "output" / "benchmark_release_0_0_2"
 _PAPER_HANDOFF_BUNDLE_ENV = "ROBOT_SF_PAPER_HANDOFF_BUNDLE"
 
 


### PR DESCRIPTION
## Summary
Replaces the stale March 18 local-output paper handoff parity test with a durable release 0.0.2 path. The test now accepts the documented archive or extracted bundle, verifies tracked SHA-256 checksums, and skips only with the exact hydration command when the bundle is absent.

## Linked Issues
- Closes #1231

## What Changed
- Added checksum-aware release fixture resolution to tests/benchmark/test_paper_results_handoff.py.
- Renamed the canonical parity test to target the durable 0.0.2 release campaign instead of the local March 18 bundle.
- Updated docs/context/issue_1062_paper_evidence_archive.md and docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md with the test hydration path and env var.

## Why It Matters
- Added value: fresh checkouts now have a documented, durable way to run the frozen paper handoff parity check.
- Expected impact: avoids mistaking hidden local output state for benchmark evidence.
- Why this is worth merging now: #1062 already documented the durable release pointer; this wires the validation test to that source.

## Validation / Proof
- rtk ./.venv/bin/python -m pytest tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_frozen_campaign_table_when_available -q -rs: reproduced the old skip, 1 skipped because the March 18 local bundle was absent.
- rtk gh release download 0.0.2 --pattern paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz --dir output/benchmark_release_0_0_2: downloaded the durable release archive.
- rtk sha256sum output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz: matched 64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90.
- rtk ./.venv/bin/python -m pytest tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table -q -rs: 1 passed with hydrated release archive.
- Temporarily moved output/benchmark_release_0_0_2 aside, then reran the same target: 1 skipped with the exact gh release download command and ROBOT_SF_PAPER_HANDOFF_BUNDLE env var in the skip reason.
- rtk ./.venv/bin/python -m pytest tests/benchmark/test_paper_results_handoff.py -q: 8 passed.
- rtk ./.venv/bin/ruff check tests/benchmark/test_paper_results_handoff.py: passed.
- rtk ./.venv/bin/ruff format --check tests/benchmark/test_paper_results_handoff.py: passed.
- rtk git diff --check: passed.
- rtk env BASE_REF=origin/main PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh: passed; 3549 passed, 12 skipped, 6 warnings in 460.96s, then changed-files coverage and touched-definition docstring gates passed.

## Risks / Rollout
- Compatibility risks: low; this changes tests/docs only.
- Failure modes: the canonical parity target still skips by default in a fresh checkout until the durable release asset is hydrated, but the skip is explicit and actionable.
- Rollback or fallback plan: revert the test/docs commit to restore the previous local-output skip behavior.

## Docs / Provenance
- Updated docs/context/issue_1062_paper_evidence_archive.md.
- Updated docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md.
- Artifact decision: ignored output/benchmark_release_0_0_2 release tarball, output/coverage, and output/model_cache/tmp smoke artifacts are local disposable/cache artifacts; no generated output is staged or required as a new tracked dependency.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the checksum metadata path stays aligned with docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json.
- Known limitation: the test deliberately avoids network access during pytest; hydration remains an explicit pre-test step.