### PR TITLE
workflow: add question-first experiment registry (#1243)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Project Prioritization](./project_prioritization.md)** - Priority-score model, Project #5 field semantics, and the local/manual score-sync workflow
 * **[GitHub Workflow Batching](./context/issue_713_batch_first_issue_workflow.md)** - Batch issue cleanup first, defer Project #5 routing, and run derived score sync last
 * **[Goal-Driven Agent Loops](./context/goal_driven_agent_loops_2026-05-13.md)** - Shared contract for autonomous issue discovery, issue implementation, PR review, and user-in-the-loop issue audit skills
+* **[Question-First Experiment Registry](../experiments/README.md)** - Register experiment intent, canonical configs, expected artifacts, and validation gates before launching runs
 * **[Policy Search Portfolio Overview](./context/policy_search/portfolio_overview_2026-05-05.md)** - Current non-training policy-search portfolio ranking, promotion status, and h500 horizon evidence pointers
 * **[Agent Index](./AGENT_INDEX.md)** - Agent-oriented index of training, benchmarking, observations, and artifacts
 * **[AI Repo Overview](./ai/repo_overview.md)** - Short orientation for Codex-style agents: where to read first, core repo areas, and common failure modes

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -225,6 +225,17 @@ The repository now keeps a repo-local Markdown memory layer under `memory/` for 
 agent context.
 
 - Start with `memory/MEMORY.md`, which acts as the concise index.
+- Store reusable memory in typed subdirectories such as `memory/architecture/`,
+  `memory/decisions/`, `memory/experiments/`, `memory/failures/`, and `memory/benchmarks/`.
+- Use the experiment naming pattern `memory/experiments/YYYY-MM-DD_<topic>.md`.
+- Keep `memory/MEMORY.md` short and push detail into linked topic files so it stays compatible with
+  Claude-style startup loading.
+- Use `docs/context/` for issue execution history and validation detail; use `memory/` only for
+  knowledge worth reusing across future sessions.
+- If Claude Code is in use, `CLAUDE.md` imports both `AGENTS.md` and `memory/MEMORY.md` so the
+  shared instructions and memory index load together.
+- Optional MCP integration should expose the Markdown files directly; do not add a retrieval
+  database or vector store unless the repository's retrieval-deferral policy changes.
 
 ### Question-first experiment registry
 
@@ -238,17 +249,6 @@ Validate the registry with:
 ```bash
 uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml
 ```
-- Store reusable memory in typed subdirectories such as `memory/architecture/`,
-  `memory/decisions/`, `memory/experiments/`, `memory/failures/`, and `memory/benchmarks/`.
-- Use the experiment naming pattern `memory/experiments/YYYY-MM-DD_<topic>.md`.
-- Keep `memory/MEMORY.md` short and push detail into linked topic files so it stays compatible with
-  Claude-style startup loading.
-- Use `docs/context/` for issue execution history and validation detail; use `memory/` only for
-  knowledge worth reusing across future sessions.
-- If Claude Code is in use, `CLAUDE.md` imports both `AGENTS.md` and `memory/MEMORY.md` so the
-  shared instructions and memory index load together.
-- Optional MCP integration should expose the Markdown files directly; do not add a retrieval
-  database or vector store unless the repository's retrieval-deferral policy changes.
 
 On macOS, `scripts/dev/run_tests_parallel.sh` uses a bounded fixed xdist worker count by
 default instead of `-n auto`, because the unbounded auto worker selection can leave local

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -225,6 +225,19 @@ The repository now keeps a repo-local Markdown memory layer under `memory/` for 
 agent context.
 
 - Start with `memory/MEMORY.md`, which acts as the concise index.
+
+### Question-first experiment registry
+
+Use `experiments/registry.yaml` for planned or active exploratory ML/search/manual-control runs that
+need a reviewable question, hypothesis, command, artifact expectation, evidence grade, and paper
+relevance before execution. This registry complements GitHub issues, W&B artifacts, local telemetry
+under `output/run-tracker/`, and publication bundles; it does not make local `output/` files durable.
+
+Validate the registry with:
+
+```bash
+uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml
+```
 - Store reusable memory in typed subdirectories such as `memory/architecture/`,
   `memory/decisions/`, `memory/experiments/`, `memory/failures/`, and `memory/benchmarks/`.
 - Use the experiment naming pattern `memory/experiments/YYYY-MM-DD_<topic>.md`.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,31 @@
+# Question-First Experiment Registry
+
+This directory records planned or active exploratory experiments before they run. It complements
+GitHub issues, W&B artifacts, model registries, and publication bundles; it does not make local
+`output/` files durable by itself.
+
+Each record must state:
+
+- `experiment_id`
+- `issue` and `issue_url`
+- `question`
+- `hypothesis`
+- `config`
+- `command`
+- `inputs`
+- `outputs`
+- `expected_artifacts`
+- `evidence_grade`
+- `paper_relevance`
+- `status`
+
+Use `paper_relevance: exploratory` for local pilots and early research runs. Use
+`paper_relevance: paper_facing` only when every local `output/` artifact listed in `outputs` or
+`expected_artifacts` has a durable `durable_reference`, such as a W&B artifact, model registry
+entry, release asset, or tracked evidence manifest.
+
+Validate the registry with:
+
+```bash
+uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml
+```

--- a/experiments/issue_1108_bc_warm_start_ppo.yaml
+++ b/experiments/issue_1108_bc_warm_start_ppo.yaml
@@ -1,0 +1,52 @@
+schema_version: experiment-record.v1
+experiment_id: issue_1108_bc_warm_start_ppo
+issue: 1108
+issue_url: https://github.com/ll7/robot_sf_ll7/issues/1108
+question: >
+  Does BC pretraining improve PPO v10 sample efficiency, final benchmark
+  strength, both, or neither compared with the existing 27dbe5xu and b60iopxt
+  references?
+hypothesis: >
+  A BC checkpoint trained from the issue-749 expert trajectory dataset will
+  warm-start PPO enough to improve early sample efficiency without weakening the
+  final policy-analysis comparison.
+config:
+  - configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
+  - configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml
+  - configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml
+command: |
+  uv run python scripts/training/collect_expert_trajectories.py \
+    --dataset-id issue_749_b60iopxt_v10_eval_trajectories \
+    --policy-id ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 \
+    --episodes 141 \
+    --scenario-config configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml \
+    --seeds 111 112 113
+  uv run --group imitation python scripts/training/pretrain_from_expert.py \
+    --config configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
+  uv run python scripts/training/train_ppo_with_pretrained_policy.py \
+    --config configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml
+inputs:
+  - path: configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
+  - path: configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml
+  - path: docs/context/issue_749_bc_preinit_ppo_launch_packet.md
+outputs:
+  - path: output/slurm/issue1108-bcppo-job-12462/
+    durable_reference: null
+    evidence_role: local staging only until promoted
+expected_artifacts:
+  - name: expert_trajectory_dataset_manifest
+    path: output/datasets/issue_749_b60iopxt_v10_eval_trajectories/manifest.yaml
+    durable_reference_required: true
+  - name: bc_checkpoint
+    path: output/imitation/issue_749_bc_preinit_v10_policy/
+    durable_reference_required: true
+  - name: ppo_finetuned_checkpoint
+    path: output/benchmarks/expert_policies/issue_749_ppo_finetune_v10_warm_start_finetuned.zip
+    durable_reference_required: true
+evidence_grade: observed
+paper_relevance: paper_candidate
+status: in_progress_slurm
+notes: >
+  Issue #1108 is execution-gated on Auxme/SLURM and durable artifact promotion.
+  Local output paths are not paper evidence until replaced by W&B, registry, or
+  release pointers.

--- a/experiments/issue_1151_manual_control_mvp_collection.yaml
+++ b/experiments/issue_1151_manual_control_mvp_collection.yaml
@@ -1,0 +1,41 @@
+schema_version: experiment-record.v1
+experiment_id: issue_1151_manual_control_mvp_collection
+issue: 1151
+issue_url: https://github.com/ll7/robot_sf_ll7/issues/1151
+question: >
+  Can a fixed local manual-control protocol produce replayable human
+  demonstrations that diagnose whether hard scenarios are policy-limited rather
+  than impossible?
+hypothesis: >
+  Once the local Pygame MVP runner lands, append-only manual-control sessions
+  with frozen baseline metadata will produce useful exploratory diagnostics and
+  BC-ready samples without making paper-facing claims.
+config:
+  - robot_sf/manual_control/
+  - scripts/manual_control/
+  - docs/context/issue_1151_manual_control_mvp_foundation.md
+command: |
+  uv run pytest tests/test_manual_control_*.py -q
+  # After #1219 lands, run the documented local Pygame MVP command for fixed
+  # scenario IDs and seeds before promoting any derived artifacts.
+inputs:
+  - path: robot_sf/manual_control/
+  - path: scripts/manual_control/
+  - path: docs/context/issue_1151_manual_control_mvp_foundation.md
+outputs:
+  - path: output/manual_control/issue1151_mvp_sessions/
+    durable_reference: null
+    evidence_role: local exploratory recording root
+expected_artifacts:
+  - name: manual_session_jsonl
+    path: output/manual_control/issue1151_mvp_sessions/session.jsonl
+  - name: manual_session_manifest
+    path: output/manual_control/issue1151_mvp_sessions/manifest.json
+  - name: bc_export
+    path: output/manual_control/issue1151_mvp_sessions/bc_samples.jsonl
+evidence_grade: observed
+paper_relevance: exploratory
+status: blocked_on_issue_1219
+notes: >
+  #1151 remains a parent epic. This record tracks the future collection
+  protocol, while #1219 owns the executable runner.

--- a/experiments/issue_1236_adversarial_optimizer_sampler.yaml
+++ b/experiments/issue_1236_adversarial_optimizer_sampler.yaml
@@ -1,0 +1,37 @@
+schema_version: experiment-record.v1
+experiment_id: issue_1236_adversarial_optimizer_sampler
+issue: 1236
+issue_url: https://github.com/ll7/robot_sf_ll7/issues/1236
+question: >
+  Do optimizer-backed adversarial samplers find lower-SNQI or failure-inducing
+  candidates more efficiently than the current random and coordinate-refinement
+  samplers?
+hypothesis: >
+  A bounded optimizer-backed feedback sampler will find a stronger
+  counterexample under the same candidate budget on the crossing TTC search
+  space.
+config:
+  - configs/adversarial/crossing_ttc_space.yaml
+command: |
+  uv run pytest tests/adversarial/test_adversarial_search.py -q
+  # After the optimizer-backed sampler lands in #1236, run a bounded random vs
+  # coordinate vs optimizer smoke using configs/adversarial/crossing_ttc_space.yaml
+  # and write the replayable bundle under output/adversarial/issue1236_optimizer_sampler_pilot/.
+inputs:
+  - path: configs/adversarial/crossing_ttc_space.yaml
+  - path: docs/context/issue_869_adversarial_runner.md
+outputs:
+  - path: output/adversarial/issue1236_optimizer_sampler_pilot/
+    durable_reference: null
+    evidence_role: exploratory local bundle
+expected_artifacts:
+  - name: sampler_comparison_manifest
+    path: output/adversarial/issue1236_optimizer_sampler_pilot/manifest.yaml
+  - name: best_counterexample_bundle
+    path: output/adversarial/issue1236_optimizer_sampler_pilot/best/
+evidence_grade: observed
+paper_relevance: exploratory
+status: planned
+notes: >
+  This pilot is explicitly not paper-facing until repeated-seed evidence and
+  durable replay bundles exist.

--- a/experiments/registry.yaml
+++ b/experiments/registry.yaml
@@ -1,0 +1,9 @@
+schema_version: experiment-registry.v1
+description: >
+  Question-first registry for exploratory Robot SF experiments. Records here
+  complement GitHub issues, W&B, model registries, and publication bundles; they
+  do not make local output artifacts durable by themselves.
+records:
+  - issue_1108_bc_warm_start_ppo.yaml
+  - issue_1236_adversarial_optimizer_sampler.yaml
+  - issue_1151_manual_control_mvp_collection.yaml

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -29,7 +29,6 @@ REQUIRED_RECORD_FIELDS = (
 )
 VALID_EVIDENCE_GRADES = {"proposal", "inferred", "observed"}
 VALID_PAPER_RELEVANCE = {"none", "exploratory", "paper_candidate", "paper_facing"}
-LOCAL_OUTPUT_PREFIXES = ("output/", "./output/")
 
 
 def validate_registry(registry_path: Path) -> list[str]:
@@ -153,8 +152,10 @@ def _iter_artifact_items(value: Any) -> Iterable[Mapping[str, Any]]:
 
 def _is_local_output_path(path: str) -> bool:
     """Return whether a path points at the disposable worktree output root."""
-    normalized = path.replace("\\", "/")
-    return normalized.startswith(LOCAL_OUTPUT_PREFIXES)
+    parts = Path(path).parts
+    if parts and parts[0] == ".":
+        parts = parts[1:]
+    return bool(parts and parts[0] == "output")
 
 
 def _is_missing(value: Any) -> bool:

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -1,0 +1,205 @@
+"""Validate the question-first experiment registry."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY_SCHEMA_VERSION = "experiment-registry.v1"
+RECORD_SCHEMA_VERSION = "experiment-record.v1"
+REQUIRED_RECORD_FIELDS = (
+    "experiment_id",
+    "issue",
+    "issue_url",
+    "question",
+    "hypothesis",
+    "config",
+    "command",
+    "inputs",
+    "outputs",
+    "expected_artifacts",
+    "evidence_grade",
+    "paper_relevance",
+    "status",
+)
+VALID_EVIDENCE_GRADES = {"proposal", "inferred", "observed"}
+VALID_PAPER_RELEVANCE = {"none", "exploratory", "paper_candidate", "paper_facing"}
+LOCAL_OUTPUT_PREFIXES = ("output/", "./output/")
+
+
+def validate_registry(registry_path: Path) -> list[str]:
+    """Return validation errors for an experiment registry."""
+    errors: list[str] = []
+    registry = _load_yaml_mapping(registry_path, errors, display=str(registry_path))
+    if registry is None:
+        return errors
+
+    if registry.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+        errors.append(
+            f"{registry_path}: expected schema_version {REGISTRY_SCHEMA_VERSION!r}, "
+            f"found {registry.get('schema_version')!r}"
+        )
+
+    records = registry.get("records")
+    if not isinstance(records, list) or not records:
+        errors.append(f"{registry_path}: records must be a non-empty list")
+        return errors
+
+    seen_ids: set[str] = set()
+    for record_entry in records:
+        if not isinstance(record_entry, str) or not record_entry:
+            errors.append(f"{registry_path}: record entries must be non-empty paths")
+            continue
+        record_path = (registry_path.parent / record_entry).resolve()
+        record = _load_yaml_mapping(record_path, errors, display=record_entry)
+        if record is None:
+            continue
+        _validate_record(record, record_entry, errors, seen_ids=seen_ids)
+
+    return errors
+
+
+def _validate_record(
+    record: Mapping[str, Any],
+    display_path: str,
+    errors: list[str],
+    *,
+    seen_ids: set[str],
+) -> None:
+    """Append validation errors for one experiment record."""
+    if record.get("schema_version") != RECORD_SCHEMA_VERSION:
+        errors.append(
+            f"{display_path}: expected schema_version {RECORD_SCHEMA_VERSION!r}, "
+            f"found {record.get('schema_version')!r}"
+        )
+
+    for field in REQUIRED_RECORD_FIELDS:
+        if _is_missing(record.get(field)):
+            errors.append(f"{display_path}: missing required field {field!r}")
+
+    experiment_id = record.get("experiment_id")
+    if isinstance(experiment_id, str):
+        if experiment_id in seen_ids:
+            errors.append(f"{display_path}: duplicate experiment_id {experiment_id!r}")
+        seen_ids.add(experiment_id)
+
+    _validate_vocab(
+        record.get("evidence_grade"),
+        "evidence_grade",
+        VALID_EVIDENCE_GRADES,
+        display_path,
+        errors,
+    )
+    paper_relevance = record.get("paper_relevance")
+    _validate_vocab(
+        paper_relevance,
+        "paper_relevance",
+        VALID_PAPER_RELEVANCE,
+        display_path,
+        errors,
+    )
+
+    if paper_relevance == "paper_facing":
+        for artifact in _iter_artifact_items(record.get("outputs")):
+            _validate_paper_facing_artifact(artifact, display_path, errors)
+        for artifact in _iter_artifact_items(record.get("expected_artifacts")):
+            _validate_paper_facing_artifact(artifact, display_path, errors)
+
+
+def _validate_paper_facing_artifact(
+    artifact: Mapping[str, Any],
+    display_path: str,
+    errors: list[str],
+) -> None:
+    """Reject paper-facing output artifacts that only point at local output paths."""
+    artifact_path = artifact.get("path")
+    if not isinstance(artifact_path, str) or not _is_local_output_path(artifact_path):
+        return
+    durable_reference = artifact.get("durable_reference")
+    if _is_missing(durable_reference):
+        errors.append(
+            f"{display_path}: paper-facing record references local-only output/ artifact "
+            f"without durable_reference: {artifact_path}"
+        )
+
+
+def _validate_vocab(
+    value: Any,
+    field_name: str,
+    allowed_values: set[str],
+    display_path: str,
+    errors: list[str],
+) -> None:
+    """Append an error when a controlled-vocabulary value is unknown."""
+    if value is not None and value not in allowed_values:
+        errors.append(f"{display_path}: {field_name} must be one of {sorted(allowed_values)}")
+
+
+def _iter_artifact_items(value: Any) -> Iterable[Mapping[str, Any]]:
+    """Yield artifact mappings from string or mapping lists."""
+    if not isinstance(value, list):
+        return
+    for item in value:
+        if isinstance(item, str):
+            yield {"path": item}
+        elif isinstance(item, Mapping):
+            yield item
+
+
+def _is_local_output_path(path: str) -> bool:
+    """Return whether a path points at the disposable worktree output root."""
+    normalized = path.replace("\\", "/")
+    return normalized.startswith(LOCAL_OUTPUT_PREFIXES)
+
+
+def _is_missing(value: Any) -> bool:
+    """Return whether a required registry value is absent or empty."""
+    if value is None:
+        return True
+    return value in ("", [], {})
+
+
+def _load_yaml_mapping(path: Path, errors: list[str], *, display: str) -> Mapping[str, Any] | None:
+    """Load a YAML file and return a mapping, appending errors instead of raising."""
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"{display}: cannot read YAML: {exc}")
+        return None
+    except yaml.YAMLError as exc:
+        errors.append(f"{display}: invalid YAML: {exc}")
+        return None
+    if not isinstance(payload, Mapping):
+        errors.append(f"{display}: YAML document must be a mapping")
+        return None
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the experiment registry validator CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "registry",
+        nargs="?",
+        default="experiments/registry.yaml",
+        type=Path,
+        help="Path to the experiment registry index.",
+    )
+    args = parser.parse_args(argv)
+
+    errors = validate_registry(args.registry)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print(f"validated experiment registry: {args.registry}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -16,7 +16,8 @@ def _write_yaml(path: Path, text: str) -> None:
 
 def test_checked_in_experiment_registry_validates() -> None:
     """The tracked experiment registry should satisfy the workflow contract."""
-    errors = validate_registry(Path("experiments/registry.yaml"))
+    repo_root = Path(__file__).parents[2]
+    errors = validate_registry(repo_root / "experiments/registry.yaml")
 
     assert errors == []
 

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -1,0 +1,97 @@
+"""Tests for the question-first experiment registry validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from scripts.tools.validate_experiment_registry import validate_registry
+
+
+def _write_yaml(path: Path, text: str) -> None:
+    """Write a YAML fixture with normalized leading whitespace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(text).strip() + "\n", encoding="utf-8")
+
+
+def test_checked_in_experiment_registry_validates() -> None:
+    """The tracked experiment registry should satisfy the workflow contract."""
+    errors = validate_registry(Path("experiments/registry.yaml"))
+
+    assert errors == []
+
+
+def test_validator_reports_missing_required_fields(tmp_path: Path) -> None:
+    """Experiment records must state the research question before execution."""
+    registry = tmp_path / "registry.yaml"
+    record = tmp_path / "missing.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - missing.yaml
+        """,
+    )
+    _write_yaml(
+        record,
+        """
+        schema_version: experiment-record.v1
+        experiment_id: missing-question
+        question: What does this run answer?
+        """,
+    )
+
+    errors = validate_registry(registry)
+
+    assert "missing.yaml: missing required field 'hypothesis'" in errors
+    assert "missing.yaml: missing required field 'command'" in errors
+    assert "missing.yaml: missing required field 'expected_artifacts'" in errors
+
+
+def test_validator_rejects_paper_facing_local_only_outputs(tmp_path: Path) -> None:
+    """Paper-facing records need durable references for output/ artifacts."""
+    registry = tmp_path / "registry.yaml"
+    record = tmp_path / "paper.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - paper.yaml
+        """,
+    )
+    _write_yaml(
+        record,
+        """
+        schema_version: experiment-record.v1
+        experiment_id: paper-local-only
+        issue: 1
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/1
+        question: Does this result support a paper claim?
+        hypothesis: It might, if durable evidence exists.
+        config: configs/example.yaml
+        command: uv run python scripts/example.py
+        inputs:
+          - path: configs/example.yaml
+        outputs:
+          - path: output/benchmarks/local_only
+        expected_artifacts:
+          - name: report
+            path: output/benchmarks/local_only/report.json
+        evidence_grade: observed
+        paper_relevance: paper_facing
+        status: planned
+        """,
+    )
+
+    errors = validate_registry(registry)
+
+    assert (
+        "paper.yaml: paper-facing record references local-only output/ artifact "
+        "without durable_reference: output/benchmarks/local_only"
+    ) in errors
+    assert (
+        "paper.yaml: paper-facing record references local-only output/ artifact "
+        "without durable_reference: output/benchmarks/local_only/report.json"
+    ) in errors


### PR DESCRIPTION
## Summary
Adds a tracked question-first experiment registry under `experiments/`, plus a validator CLI and tests that keep experiment intent, artifact expectations, evidence grade, and paper relevance explicit before execution.

## Linked Issues
- Closes #1243

## What Changed
- Added `experiments/registry.yaml` and three issue-linked seed records:
  - #1108 BC warm-start PPO experiment.
  - #1236 adversarial optimizer sampler pilot.
  - #1151 manual-control MVP collection protocol.
- Added `scripts/tools/validate_experiment_registry.py`.
- Added `tests/tools/test_validate_experiment_registry.py`.
- Linked the workflow from `docs/dev_guide.md`.

## Why It Matters
- Added value: exploratory runs now state the question, hypothesis, command, inputs, outputs, expected artifacts, evidence grade, and paper relevance before execution.
- Expected impact: local `output/` artifacts are less likely to be mistaken for paper-facing evidence.
- Why this is worth merging now: active training, adversarial-search, and manual-control work already spans issues, configs, context notes, W&B/model pointers, and local output roots.

## Validation / Proof
- Commands run:
  - `rtk uv run --active pytest tests/tools/test_validate_experiment_registry.py -q` passed with `3 passed in 5.80s`.
  - `rtk uv run --active python scripts/tools/validate_experiment_registry.py experiments/registry.yaml` passed.
  - `rtk uv run --active ruff check scripts/tools/validate_experiment_registry.py tests/tools/test_validate_experiment_registry.py` passed.
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` passed after the final `origin/main` sync with `3551 passed, 13 skipped, 6 warnings in 269.10s`.
- Evidence that the change works here: tests cover the checked-in registry, missing required fields, and rejection of paper-facing local-only `output/` artifacts without durable references.
- Benchmarks or smoke tests, if applicable: not applicable; this is workflow/provenance metadata.

## Risks / Rollout
- Compatibility risks: low; this is additive tracked metadata and a standalone validator.
- Failure modes: registry records can still go stale if maintainers stop updating them as issues evolve.
- Rollback or fallback plan: remove the registry and validator if the workflow is not adopted.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md` and `experiments/README.md`.
- Relevant design or provenance notes: the registry complements GitHub issues, W&B artifacts, `output/run-tracker/`, model registries, and publication bundles; it does not replace them.
- Any assumptions that need to be preserved: `paper_relevance: paper_facing` requires durable references for any local `output/` artifact paths.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- The pytest runs refreshed ignored coverage output under `output/coverage/`; those files are disposable validation artifacts and are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced experiment registry system to track planned and active exploratory experiments with standardized metadata fields.
  * Added validation tooling to ensure registry records meet required standards and data integrity checks.

* **Documentation**
  * Added comprehensive documentation describing experiment registry structure, mandatory field requirements, and validation process.

* **Tests**
  * Added validation tests for the experiment registry system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->