### PR TITLE
feat: normalize planner observation and action contracts

### DIFF
--- a/docs/benchmark_experimental_planners.md
+++ b/docs/benchmark_experimental_planners.md
@@ -7,6 +7,17 @@ This repository now distinguishes between:
 - `experimental-testing`: planners that are implemented and tested, but should not silently enter
   normal benchmark sweeps until they have demonstrated stable benchmark value
 
+## Planner Contract Boundary
+
+Benchmark-facing planners also publish planner contract metadata through
+`robot_sf.benchmark.algorithm_metadata`. The contract records the planner-facing observation mode,
+required inputs, normalization label, command space, action keys, and reset convention before a
+benchmark runner uses the planner.
+
+This metadata is a compatibility guard only. It makes mismatched observation/action assumptions
+fail before benchmark execution, but it is not performance evidence and must not be cited as proof
+that a planner is baseline-ready, paper-facing, or high quality.
+
 ## Testing-only planners
 
 The following planners are currently treated as testing-only and fail closed by default:

--- a/robot_sf/baselines/interface.py
+++ b/robot_sf/baselines/interface.py
@@ -7,7 +7,97 @@ SocialForce, PPO, Random, and future baselines.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ObservationContract:
+    """Planner-facing observation assumptions declared as lightweight metadata."""
+
+    mode: str
+    supported_modes: tuple[str, ...]
+    required_inputs: tuple[str, ...]
+    active_mode: str | None = None
+    frame: str = "world"
+    normalization: str = "raw"
+    pedestrian_ordering: str = "distance_ascending"
+    missing_value: str | None = None
+    notes: str = ""
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable observation contract payload."""
+        return {
+            "mode": self.mode,
+            "active_mode": self.active_mode or self.mode,
+            "supported_modes": list(self.supported_modes),
+            "required_inputs": list(self.required_inputs),
+            "frame": self.frame,
+            "normalization": self.normalization,
+            "pedestrian_ordering": self.pedestrian_ordering,
+            "missing_value": self.missing_value,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class ActionContract:
+    """Planner action assumptions before any benchmark/environment conversion."""
+
+    command_space: str
+    output_keys: tuple[str, ...]
+    frame: str = "robot"
+    normalization: str = "raw"
+    units: str = "mps_radps"
+    scaling: str = "none"
+    compatible_robot_kinematics: tuple[str, ...] = (
+        "differential_drive",
+        "bicycle_drive",
+        "holonomic",
+        "mixed",
+        "unknown",
+    )
+    notes: str = ""
+    bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable action contract payload."""
+        return {
+            "command_space": self.command_space,
+            "output_keys": list(self.output_keys),
+            "frame": self.frame,
+            "normalization": self.normalization,
+            "units": self.units,
+            "scaling": self.scaling,
+            "compatible_robot_kinematics": list(self.compatible_robot_kinematics),
+            "bounds": {key: list(value) for key, value in self.bounds.items()},
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class PlannerMetadata:
+    """First-class planner compatibility metadata for benchmark-facing workflows."""
+
+    planner_id: str
+    observation_contract: ObservationContract
+    action_contract: ActionContract
+    reset_contract: str = "seeded_reset"
+    scenario_requirements: tuple[str, ...] = ()
+    compatibility_scope: str = "metadata_only"
+    notes: str = ""
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable planner metadata payload."""
+        return {
+            "planner_id": self.planner_id,
+            "observation_contract": self.observation_contract.to_metadata(),
+            "action_contract": self.action_contract.to_metadata(),
+            "reset_contract": self.reset_contract,
+            "scenario_requirements": list(self.scenario_requirements),
+            "compatibility_scope": self.compatibility_scope,
+            "notes": self.notes,
+        }
 
 
 class PlannerProtocol(Protocol):
@@ -58,4 +148,9 @@ class PlannerProtocol(Protocol):
         """Release resources (models, files, etc.)."""
 
 
-__all__ = ["PlannerProtocol"]
+__all__ = [
+    "ActionContract",
+    "ObservationContract",
+    "PlannerMetadata",
+    "PlannerProtocol",
+]

--- a/robot_sf/baselines/interface.py
+++ b/robot_sf/baselines/interface.py
@@ -57,6 +57,7 @@ class ActionContract:
         "mixed",
         "unknown",
     )
+    active_robot_kinematics: str | None = None
     notes: str = ""
     bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
 
@@ -70,6 +71,7 @@ class ActionContract:
             "units": self.units,
             "scaling": self.scaling,
             "compatible_robot_kinematics": list(self.compatible_robot_kinematics),
+            "active_robot_kinematics": self.active_robot_kinematics,
             "bounds": {key: list(value) for key, value in self.bounds.items()},
             "notes": self.notes,
         }

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -946,6 +946,20 @@ def _action_frame(command_space: str) -> str:
     return "robot"
 
 
+def _compatible_robot_kinematics(
+    profile: dict[str, Any],
+    robot_kinematics: str | None,
+) -> tuple[str, ...]:
+    """Return the kinematics labels the action contract actually covers."""
+    explicit = profile.get("compatible_robot_kinematics")
+    if isinstance(explicit, (list, tuple)):
+        values = tuple(str(value).strip().lower() for value in explicit if str(value).strip())
+        if values:
+            return values
+    active = str(robot_kinematics or "").strip().lower()
+    return (active or "unknown",)
+
+
 def _observation_normalization(active_mode: str) -> str:
     """Return the normalization label for a planner observation mode."""
     if active_mode == "sensor_fusion_state":
@@ -988,13 +1002,7 @@ def planner_contract_for_algorithm(
         frame=_action_frame(command_space),
         normalization="raw",
         units="mps_radps",
-        compatible_robot_kinematics=(
-            "differential_drive",
-            "bicycle_drive",
-            "holonomic",
-            "mixed",
-            "unknown",
-        ),
+        compatible_robot_kinematics=_compatible_robot_kinematics(profile, robot_kinematics),
         active_robot_kinematics=(
             str(robot_kinematics)
             if robot_kinematics not in {None, "", "mixed", "unknown"}

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -685,6 +685,12 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "default_execution_mode": "mixed",
         "default_adapter_name": "ppo_action_to_unicycle",
     },
+    "sac": {
+        "planner_command_space": "unicycle_vw",
+        "supports_native_commands": True,
+        "supports_adapter_commands": False,
+        "default_execution_mode": "native",
+    },
     "guarded_ppo": {
         "planner_command_space": "mixed_vw_or_vxy",
         "supports_native_commands": True,

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -915,6 +915,8 @@ def resolve_observation_mode(algo: str, requested_mode: str | None = None) -> st
 def _action_output_keys(command_space: str) -> tuple[str, ...]:
     """Return canonical action payload keys for a command-space label."""
     command = command_space.strip().lower()
+    if command == "unicycle_vw":
+        return ("v", "omega")
     if command == "body_velocity_xy_plus_omega":
         return ("vx", "vy", "omega")
     if command == "holonomic_vxy_world" or "velocity_xy" in command:
@@ -925,7 +927,7 @@ def _action_output_keys(command_space: str) -> tuple[str, ...]:
         return ("v", "omega", "vx", "vy")
     if command == "mixed_vw_or_unicycle":
         return ("v", "omega")
-    return ("v", "omega")
+    raise ValueError(f"Unsupported planner command space: {command_space!r}")
 
 
 def _action_frame(command_space: str) -> str:
@@ -981,9 +983,16 @@ def planner_contract_for_algorithm(
         normalization="raw",
         units="mps_radps",
         compatible_robot_kinematics=(
-            (str(robot_kinematics),)
+            "differential_drive",
+            "bicycle_drive",
+            "holonomic",
+            "mixed",
+            "unknown",
+        ),
+        active_robot_kinematics=(
+            str(robot_kinematics)
             if robot_kinematics not in {None, "", "mixed", "unknown"}
-            else ("differential_drive", "bicycle_drive", "holonomic", "mixed", "unknown")
+            else None
         ),
         notes=str(profile.get("projection_policy") or profile.get("execution_detail") or ""),
     )

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from robot_sf.baselines.interface import ActionContract, ObservationContract, PlannerMetadata
 from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
 
 _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
@@ -911,6 +912,91 @@ def resolve_observation_mode(algo: str, requested_mode: str | None = None) -> st
     return active_mode
 
 
+def _action_output_keys(command_space: str) -> tuple[str, ...]:
+    """Return canonical action payload keys for a command-space label."""
+    command = command_space.strip().lower()
+    if command == "body_velocity_xy_plus_omega":
+        return ("vx", "vy", "omega")
+    if command == "holonomic_vxy_world" or "velocity_xy" in command:
+        return ("vx", "vy")
+    if command == "discrete_delta_v_and_delta_theta":
+        return ("delta_v", "delta_theta")
+    if command in {"mixed_vw_or_vxy", "randomized_vxy_or_vw"}:
+        return ("v", "omega", "vx", "vy")
+    if command == "mixed_vw_or_unicycle":
+        return ("v", "omega")
+    return ("v", "omega")
+
+
+def _action_frame(command_space: str) -> str:
+    """Return the frame label associated with a command-space label."""
+    command = command_space.strip().lower()
+    if command == "body_velocity_xy_plus_omega":
+        return "body"
+    if command == "holonomic_vxy_world" or "velocity_xy" in command:
+        return "world"
+    return "robot"
+
+
+def _observation_normalization(active_mode: str) -> str:
+    """Return the normalization label for a planner observation mode."""
+    if active_mode == "sensor_fusion_state":
+        return "normalized_by_space_high"
+    return "raw"
+
+
+def planner_contract_for_algorithm(
+    algo: str,
+    *,
+    observation_mode: str | None = None,
+    planner_kinematics: dict[str, Any] | None = None,
+    robot_kinematics: str | None = None,
+) -> PlannerMetadata:
+    """Return typed planner compatibility metadata for a benchmark algorithm.
+
+    The contract is declarative compatibility metadata. It does not certify
+    benchmark quality or performance.
+    """
+    canonical = canonical_algorithm_name(algo)
+    active_mode = resolve_observation_mode(canonical, observation_mode)
+    observation_spec = observation_spec_for_algorithm(canonical)
+    profile = dict(_KINEMATICS_PROFILE_BY_CANONICAL.get(canonical, {}))
+    if planner_kinematics is not None:
+        profile.update(planner_kinematics)
+    command_space = str(profile.get("planner_command_space", "unknown"))
+    observation = ObservationContract(
+        mode=str(observation_spec["default_mode"]),
+        active_mode=active_mode,
+        supported_modes=tuple(str(mode) for mode in observation_spec["supported_modes"]),
+        required_inputs=tuple(str(value) for value in observation_spec.get("inputs", ())),
+        frame="world",
+        normalization=_observation_normalization(active_mode),
+        pedestrian_ordering="distance_ascending",
+        notes=str(observation_spec.get("notes", "")),
+    )
+    action = ActionContract(
+        command_space=command_space,
+        output_keys=_action_output_keys(command_space),
+        frame=_action_frame(command_space),
+        normalization="raw",
+        units="mps_radps",
+        compatible_robot_kinematics=(
+            (str(robot_kinematics),)
+            if robot_kinematics not in {None, "", "mixed", "unknown"}
+            else ("differential_drive", "bicycle_drive", "holonomic", "mixed", "unknown")
+        ),
+        notes=str(profile.get("projection_policy") or profile.get("execution_detail") or ""),
+    )
+    return PlannerMetadata(
+        planner_id=canonical,
+        observation_contract=observation,
+        action_contract=action,
+        reset_contract="seeded_reset",
+        compatibility_scope="metadata_only",
+        notes="Compatibility metadata only; not a benchmark quality claim.",
+    )
+
+
 def _base_kinematics_metadata(
     canonical_algo: str,
     *,
@@ -1017,6 +1103,12 @@ def enrich_algorithm_metadata(
         merged["robot_kinematics"] = robot_kinematics
     merged["adapter_active"] = merged.get("execution_mode") in {"adapter", "mixed"}
     enriched["planner_kinematics"] = merged
+    enriched["planner_contract"] = planner_contract_for_algorithm(
+        canonical,
+        observation_mode=active_observation_mode,
+        planner_kinematics=merged,
+        robot_kinematics=str(merged.get("robot_kinematics", "unknown")),
+    ).to_metadata()
 
     if canonical == "random":
         enriched.setdefault("stochastic_reference", True)
@@ -1055,5 +1147,6 @@ __all__ = [
     "enrich_algorithm_metadata",
     "infer_execution_mode_from_counts",
     "observation_spec_for_algorithm",
+    "planner_contract_for_algorithm",
     "resolve_observation_mode",
 ]

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3283,7 +3283,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         except planner_commands.PlannerContractValidationError as exc:
             incompatible_kinematics[validation_kinematics] = str(exc)
     if incompatible_kinematics:
-        preflight["incompatible_scenario_kinematics"] = dict(sorted(incompatible_kinematics.items()))
+        preflight["incompatible_scenario_kinematics"] = dict(
+            sorted(incompatible_kinematics.items())
+        )
         if compatible_contract is None:
             preflight["status"] = "skipped"
             preflight["compatibility_status"] = "incompatible"

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3270,38 +3270,53 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     if algo.strip().lower() == "prediction_planner":
         algo_contract.update(_prediction_planner_metadata_overrides(policy_cfg))
     incompatible_kinematics: dict[str, str] = {}
+    incompatible_scenarios: dict[str, str] = {}
     compatible_contract: dict[str, Any] | None = None
-    for validation_kinematics in scenario_kinematics or [kinematics_tag]:
+    for scenario in filtered:
+        scenario_id = _scenario_id(scenario)
+        validation_kinematics = _scenario_robot_kinematics_label(scenario)
         try:
+            validation_algo, validation_cfg = _resolve_policy_search_candidate_runtime(
+                default_algo=algo,
+                algo_config_path=algo_config_path,
+                algo_config=raw_policy_cfg,
+                scenario=scenario,
+            )
+            validation_observation_mode = resolve_observation_mode(
+                validation_algo,
+                batch_observation_mode,
+            )
             compatible_contract = _validate_planner_contract(
-                algo=algo,
+                algo=validation_algo,
                 robot_kinematics=validation_kinematics,
-                algo_config=policy_cfg,
-                observation_mode=active_observation_mode,
+                algo_config=validation_cfg,
+                observation_mode=validation_observation_mode,
             )
             algo_contract["planner_contract"] = compatible_contract
         except planner_commands.PlannerContractValidationError as exc:
+            incompatible_scenarios[scenario_id] = str(exc)
             incompatible_kinematics[validation_kinematics] = str(exc)
     if incompatible_kinematics:
         preflight["incompatible_scenario_kinematics"] = dict(
             sorted(incompatible_kinematics.items())
         )
+        preflight["incompatible_scenarios"] = dict(sorted(incompatible_scenarios.items()))
         if compatible_contract is None:
             preflight["status"] = "skipped"
             preflight["compatibility_status"] = "incompatible"
             preflight["compatibility_reason"] = "; ".join(
-                f"{kinematics}: {reason}"
-                for kinematics, reason in sorted(incompatible_kinematics.items())
+                f"{scenario_id}: {reason}"
+                for scenario_id, reason in sorted(incompatible_scenarios.items())
             )
         else:
             runnable_jobs: list[tuple[dict[str, Any], int]] = []
             for scenario, seed in jobs:
-                scenario_kinematics_tag = _scenario_robot_kinematics_label(scenario)
-                if scenario_kinematics_tag in incompatible_kinematics:
+                if _scenario_id(scenario) in incompatible_scenarios:
                     preflight_skipped_jobs += 1
                     continue
                 runnable_jobs.append((scenario, seed))
             jobs = runnable_jobs
+            preflight["status"] = "partial"
             preflight["compatibility_status"] = "partial"
             preflight["skipped_jobs"] = preflight_skipped_jobs
     compatible, incompatible_reason = _planner_kinematics_compatibility(

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -223,6 +223,7 @@ _default_robot_command_space = planner_commands.default_robot_command_space
 _init_feasibility_metadata = planner_commands.init_feasibility_metadata
 _planner_kinematics_compatibility = planner_commands.planner_kinematics_compatibility
 _project_with_feasibility = planner_commands.project_with_feasibility
+_validate_planner_contract = planner_commands.validate_planner_contract
 
 
 def _holonomic_world_velocity_command(vx: float, vy: float) -> dict[str, float | str]:
@@ -2706,6 +2707,12 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario=scenario,
     )
     active_observation_mode = resolve_observation_mode(algo, observation_mode)
+    _validate_planner_contract(
+        algo=algo,
+        robot_kinematics=robot_kinematics,
+        algo_config=policy_cfg,
+        observation_mode=active_observation_mode,
+    )
     policy_fn, algo_meta = _build_policy(
         algo,
         policy_cfg,
@@ -3261,6 +3268,19 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     )
     if algo.strip().lower() == "prediction_planner":
         algo_contract.update(_prediction_planner_metadata_overrides(policy_cfg))
+    for validation_kinematics in scenario_kinematics or [kinematics_tag]:
+        try:
+            algo_contract["planner_contract"] = _validate_planner_contract(
+                algo=algo,
+                robot_kinematics=validation_kinematics,
+                algo_config=policy_cfg,
+                observation_mode=active_observation_mode,
+            )
+        except planner_commands.PlannerContractValidationError as exc:
+            preflight["status"] = "skipped"
+            preflight["compatibility_status"] = "incompatible"
+            preflight["compatibility_reason"] = str(exc)
+            break
     compatible, incompatible_reason = _planner_kinematics_compatibility(
         algo=algo,
         robot_kinematics=kinematics_tag,

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3229,6 +3229,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         seeds = _select_seeds(scenario, suite_seeds=suite_seeds, suite_key=suite_key)
         for seed in seeds:
             jobs.append((scenario, int(seed)))
+    preflight_skipped_jobs = 0
 
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -3268,19 +3269,39 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     )
     if algo.strip().lower() == "prediction_planner":
         algo_contract.update(_prediction_planner_metadata_overrides(policy_cfg))
+    incompatible_kinematics: dict[str, str] = {}
+    compatible_contract: dict[str, Any] | None = None
     for validation_kinematics in scenario_kinematics or [kinematics_tag]:
         try:
-            algo_contract["planner_contract"] = _validate_planner_contract(
+            compatible_contract = _validate_planner_contract(
                 algo=algo,
                 robot_kinematics=validation_kinematics,
                 algo_config=policy_cfg,
                 observation_mode=active_observation_mode,
             )
+            algo_contract["planner_contract"] = compatible_contract
         except planner_commands.PlannerContractValidationError as exc:
+            incompatible_kinematics[validation_kinematics] = str(exc)
+    if incompatible_kinematics:
+        preflight["incompatible_scenario_kinematics"] = dict(sorted(incompatible_kinematics.items()))
+        if compatible_contract is None:
             preflight["status"] = "skipped"
             preflight["compatibility_status"] = "incompatible"
-            preflight["compatibility_reason"] = str(exc)
-            break
+            preflight["compatibility_reason"] = "; ".join(
+                f"{kinematics}: {reason}"
+                for kinematics, reason in sorted(incompatible_kinematics.items())
+            )
+        else:
+            runnable_jobs: list[tuple[dict[str, Any], int]] = []
+            for scenario, seed in jobs:
+                scenario_kinematics_tag = _scenario_robot_kinematics_label(scenario)
+                if scenario_kinematics_tag in incompatible_kinematics:
+                    preflight_skipped_jobs += 1
+                    continue
+                runnable_jobs.append((scenario, seed))
+            jobs = runnable_jobs
+            preflight["compatibility_status"] = "partial"
+            preflight["skipped_jobs"] = preflight_skipped_jobs
     compatible, incompatible_reason = _planner_kinematics_compatibility(
         algo=algo,
         robot_kinematics=kinematics_tag,
@@ -3523,6 +3544,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "written": wrote,
         "successful_jobs": wrote,
         "failed_jobs": len(failures),
+        "skipped_jobs": preflight_skipped_jobs,
         "failures": failures,
         "out_path": str(out_path),
         "algorithm_readiness": {

--- a/robot_sf/benchmark/planner_command_contract.py
+++ b/robot_sf/benchmark/planner_command_contract.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
+
 if TYPE_CHECKING:
     from robot_sf.planner.kinematics_model import KinematicsModel
 
 _DEFAULT_KINEMATICS = "differential_drive"
+
+
+class PlannerContractValidationError(ValueError):
+    """Raised when planner observation/action metadata does not match a run request."""
 
 
 def default_robot_command_space(
@@ -112,9 +118,51 @@ def planner_kinematics_compatibility(
     return True, None
 
 
+def validate_planner_contract(
+    *,
+    algo: str,
+    robot_kinematics: str,
+    algo_config: dict[str, Any],
+    observation_mode: str | None = None,
+) -> dict[str, Any]:
+    """Validate planner observation/action compatibility before benchmark execution.
+
+    Returns:
+        dict[str, Any]: Serialized planner contract metadata for the requested planner.
+
+    Raises:
+        PlannerContractValidationError: If the planner is incompatible with the requested
+        observation mode, robot kinematics, or action contract.
+    """
+    algo_key = algo.strip().lower()
+    try:
+        contract = planner_contract_for_algorithm(algo_key, observation_mode=observation_mode)
+    except ValueError as exc:
+        raise PlannerContractValidationError(
+            f"Planner contract mismatch for planner '{algo_key}': {exc}"
+        ) from exc
+
+    compatible, reason = planner_kinematics_compatibility(
+        algo=algo_key,
+        robot_kinematics=robot_kinematics,
+        algo_config=algo_config,
+    )
+    if not compatible:
+        payload = contract.to_metadata()
+        action = payload["action_contract"]
+        raise PlannerContractValidationError(
+            "Planner contract mismatch for "
+            f"planner '{algo_key}' with robot_kinematics='{robot_kinematics}': {reason}. "
+            f"Declared command_space='{action['command_space']}'."
+        )
+    return contract.to_metadata()
+
+
 __all__ = [
+    "PlannerContractValidationError",
     "default_robot_command_space",
     "init_feasibility_metadata",
     "planner_kinematics_compatibility",
     "project_with_feasibility",
+    "validate_planner_contract",
 ]

--- a/robot_sf/benchmark/planner_command_contract.py
+++ b/robot_sf/benchmark/planner_command_contract.py
@@ -136,7 +136,11 @@ def validate_planner_contract(
     """
     algo_key = algo.strip().lower()
     try:
-        contract = planner_contract_for_algorithm(algo_key, observation_mode=observation_mode)
+        contract = planner_contract_for_algorithm(
+            algo_key,
+            observation_mode=observation_mode,
+            robot_kinematics=robot_kinematics,
+        )
     except ValueError as exc:
         raise PlannerContractValidationError(
             f"Planner contract mismatch for planner '{algo_key}': {exc}"

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -55,6 +55,8 @@ def test_enriched_metadata_embeds_typed_planner_contract_payload() -> None:
     assert contract["observation_contract"]["active_mode"] == "socnav_state"
     assert contract["action_contract"]["command_space"] == "unicycle_vw"
     assert contract["action_contract"]["output_keys"] == ["v", "omega"]
+    assert contract["action_contract"]["active_robot_kinematics"] == "differential_drive"
+    assert "holonomic" in contract["action_contract"]["compatible_robot_kinematics"]
     assert contract["compatibility_scope"] == "metadata_only"
 
 
@@ -62,6 +64,12 @@ def test_planner_contract_helper_rejects_unsupported_observation_mode() -> None:
     """Typed contract resolution should fail closed on invalid observation overrides."""
     with pytest.raises(ValueError, match="Observation mode 'goal_state' is not supported"):
         planner_contract_for_algorithm("orca", observation_mode="goal_state")
+
+
+def test_planner_contract_helper_rejects_unknown_command_space() -> None:
+    """Typed contract resolution should fail closed on unknown action contracts."""
+    with pytest.raises(ValueError, match="Unsupported planner command space"):
+        planner_contract_for_algorithm("unknown_algo")
 
 
 def test_random_baseline_metadata_marks_stochastic_reference() -> None:

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -9,6 +9,7 @@ from robot_sf.benchmark.algorithm_metadata import (
     enrich_algorithm_metadata,
     infer_execution_mode_from_counts,
     observation_spec_for_algorithm,
+    planner_contract_for_algorithm,
     resolve_observation_mode,
 )
 
@@ -37,6 +38,30 @@ def test_observation_spec_declares_supported_modes_and_rejects_invalid_override(
         excinfo.value
     )
     assert "socnav_state" in str(excinfo.value)
+
+
+def test_enriched_metadata_embeds_typed_planner_contract_payload() -> None:
+    """Algorithm metadata should expose normalized observation/action contract payloads."""
+    meta = enrich_algorithm_metadata(
+        algo="orca",
+        metadata={"status": "ok"},
+        execution_mode="adapter",
+        robot_kinematics="differential_drive",
+        observation_mode="socnav_state",
+    )
+
+    contract = meta["planner_contract"]
+    assert contract["planner_id"] == "orca"
+    assert contract["observation_contract"]["active_mode"] == "socnav_state"
+    assert contract["action_contract"]["command_space"] == "unicycle_vw"
+    assert contract["action_contract"]["output_keys"] == ["v", "omega"]
+    assert contract["compatibility_scope"] == "metadata_only"
+
+
+def test_planner_contract_helper_rejects_unsupported_observation_mode() -> None:
+    """Typed contract resolution should fail closed on invalid observation overrides."""
+    with pytest.raises(ValueError, match="Observation mode 'goal_state' is not supported"):
+        planner_contract_for_algorithm("orca", observation_mode="goal_state")
 
 
 def test_random_baseline_metadata_marks_stochastic_reference() -> None:

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -56,7 +56,7 @@ def test_enriched_metadata_embeds_typed_planner_contract_payload() -> None:
     assert contract["action_contract"]["command_space"] == "unicycle_vw"
     assert contract["action_contract"]["output_keys"] == ["v", "omega"]
     assert contract["action_contract"]["active_robot_kinematics"] == "differential_drive"
-    assert "holonomic" in contract["action_contract"]["compatible_robot_kinematics"]
+    assert contract["action_contract"]["compatible_robot_kinematics"] == ["differential_drive"]
     assert contract["compatibility_scope"] == "metadata_only"
 
 

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -100,6 +100,19 @@ def test_planner_kinematics_and_adapter_impact_fields() -> None:
     assert impact["adapted_steps"] == 0
 
 
+def test_sac_metadata_declares_native_unicycle_contract() -> None:
+    """SAC map-runner policy metadata should not fall back to unknown actions."""
+    meta = enrich_algorithm_metadata(algo="sac", metadata={"status": "ok"})
+    planner = meta["planner_kinematics"]
+    action = meta["planner_contract"]["action_contract"]
+
+    assert planner["planner_command_space"] == "unicycle_vw"
+    assert planner["supports_native_commands"] is True
+    assert planner["supports_adapter_commands"] is False
+    assert action["command_space"] == "unicycle_vw"
+    assert action["output_keys"] == ["v", "omega"]
+
+
 def test_safety_barrier_metadata_marks_testing_only_native_spike() -> None:
     """Safety-barrier metadata should expose the testing-only adapter contract."""
     meta = enrich_algorithm_metadata(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2634,6 +2634,9 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
     assert result["algorithm_metadata_contract"]["observation_spec"]["active_mode"] == (
         "socnav_state"
     )
+    planner_contract = result["algorithm_metadata_contract"]["planner_contract"]
+    assert planner_contract["observation_contract"]["active_mode"] == "socnav_state"
+    assert planner_contract["action_contract"]["command_space"] != "unknown"
     assert result["algorithm_metadata_contract"]["baseline_category"] == "classical"
     assert result["algorithm_metadata_contract"]["planner_kinematics"]["robot_kinematics"] in {
         "unknown",

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2871,6 +2871,70 @@ def test_run_map_batch_skips_incompatible_kinematics(
     assert "compatibility_reason" in result["preflight"]
 
 
+def test_run_map_batch_filters_per_scenario_kinematics_preflight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mixed-kinematics batches should still run entries with compatible contracts."""
+    scenarios = [
+        {
+            "name": "diff",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "differential_drive"},
+            "seeds": [1],
+        },
+        {
+            "name": "holo",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "holonomic"},
+            "seeds": [1],
+        },
+    ]
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+
+    from robot_sf.benchmark.planner_command_contract import (
+        PlannerContractValidationError,
+    )
+
+    def fake_validate_contract(**kwargs):
+        """Reject only holonomic entries to exercise per-scenario preflight filtering."""
+        if kwargs["robot_kinematics"] == "holonomic":
+            raise PlannerContractValidationError("holonomic contract blocked")
+        return {"action_contract": {"command_space": "unicycle_vw"}}
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._validate_planner_contract",
+        fake_validate_contract,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._run_map_job_worker",
+        lambda job: {"episode_id": f"{job[0]['name']}-{job[1]}"},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._write_validated",
+        lambda *args, **kwargs: None,
+    )
+
+    result = run_map_batch(
+        scenarios,
+        tmp_path / "out.jsonl",
+        schema_path=tmp_path / "schema.json",
+        algo="goal",
+        workers=1,
+        resume=False,
+    )
+
+    assert result["total_jobs"] == 1
+    assert result["written"] == 1
+    assert result["skipped_jobs"] == 1
+    assert result["preflight"]["compatibility_status"] == "partial"
+    assert result["preflight"]["incompatible_scenario_kinematics"] == {
+        "holonomic": "holonomic contract blocked"
+    }
+
+
 def test_run_map_batch_preserves_runtime_planner_contract_in_summary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2929,10 +2929,82 @@ def test_run_map_batch_filters_per_scenario_kinematics_preflight(
     assert result["total_jobs"] == 1
     assert result["written"] == 1
     assert result["skipped_jobs"] == 1
+    assert result["preflight"]["status"] == "partial"
     assert result["preflight"]["compatibility_status"] == "partial"
     assert result["preflight"]["incompatible_scenario_kinematics"] == {
         "holonomic": "holonomic contract blocked"
     }
+    assert result["preflight"]["incompatible_scenarios"] == {"holo": "holonomic contract blocked"}
+
+
+def test_run_map_batch_validates_effective_scenario_algo_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preflight should validate each scenario's resolved policy-search config."""
+    scenarios = [
+        {
+            "name": "s1",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "differential_drive"},
+            "seeds": [1],
+        },
+        {
+            "name": "s2",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "differential_drive"},
+            "seeds": [1],
+        },
+    ]
+    config_path = tmp_path / "policy_search.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "params": {"marker": "base"},
+                "scenario_overrides": {
+                    "s1": {"marker": "one"},
+                    "s2": {"marker": "two"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    seen_markers: list[str] = []
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+
+    def fake_validate_contract(**kwargs):
+        """Record the effective scenario config used during preflight validation."""
+        seen_markers.append(str(kwargs["algo_config"].get("marker")))
+        return {"action_contract": {"command_space": "unicycle_vw"}}
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._validate_planner_contract",
+        fake_validate_contract,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._run_map_job_worker",
+        lambda job: {"episode_id": f"{job[0]['name']}-{job[1]}"},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._write_validated",
+        lambda *args, **kwargs: None,
+    )
+
+    result = run_map_batch(
+        scenarios,
+        tmp_path / "out.jsonl",
+        schema_path=tmp_path / "schema.json",
+        algo="goal",
+        algo_config_path=str(config_path),
+        workers=1,
+        resume=False,
+    )
+
+    assert result["written"] == 2
+    assert seen_markers == ["one", "two"]
 
 
 def test_run_map_batch_preserves_runtime_planner_contract_in_summary(

--- a/tests/benchmark/test_planner_command_contract.py
+++ b/tests/benchmark/test_planner_command_contract.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import pytest
 
 from robot_sf.benchmark.planner_command_contract import (
+    PlannerContractValidationError,
     default_robot_command_space,
     init_feasibility_metadata,
     planner_kinematics_compatibility,
     project_with_feasibility,
+    validate_planner_contract,
 )
 from robot_sf.planner.kinematics_model import DifferentialDriveKinematicsModel
 
@@ -79,3 +81,19 @@ def test_planner_kinematics_compatibility_blocks_known_invalid_pairs() -> None:
         robot_kinematics="differential_drive",
         algo_config={"obs_mode": "image"},
     ) == (True, None)
+
+
+def test_validate_planner_contract_names_incompatible_action_fixture() -> None:
+    """Contract validation errors should name planner, kinematics, and remediation context."""
+    with pytest.raises(PlannerContractValidationError) as excinfo:
+        validate_planner_contract(
+            algo="rvo",
+            robot_kinematics="holonomic",
+            algo_config={},
+            observation_mode="socnav_state",
+        )
+
+    message = str(excinfo.value)
+    assert "planner 'rvo'" in message
+    assert "holonomic" in message
+    assert "contract mismatch" in message

--- a/tests/benchmark/test_planner_command_contract.py
+++ b/tests/benchmark/test_planner_command_contract.py
@@ -97,3 +97,17 @@ def test_validate_planner_contract_names_incompatible_action_fixture() -> None:
     assert "planner 'rvo'" in message
     assert "holonomic" in message
     assert "contract mismatch" in message
+
+
+def test_validate_planner_contract_returns_active_robot_kinematics() -> None:
+    """Returned contracts should describe the validated runtime kinematics."""
+    contract = validate_planner_contract(
+        algo="orca",
+        robot_kinematics="differential_drive",
+        algo_config={},
+        observation_mode="socnav_state",
+    )
+
+    action = contract["action_contract"]
+    assert action["active_robot_kinematics"] == "differential_drive"
+    assert action["compatible_robot_kinematics"] == ["differential_drive"]

--- a/tests/unit/test_planner_interface.py
+++ b/tests/unit/test_planner_interface.py
@@ -8,7 +8,9 @@ import numpy as np
 import pytest
 
 from robot_sf.baselines import get_baseline
+from robot_sf.baselines.interface import ActionContract, ObservationContract, PlannerMetadata
 from robot_sf.baselines.social_force import Observation
+from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
 
 
 class TestPlannerInterfaceCompliance:
@@ -259,3 +261,46 @@ class TestPlannerInterfaceCompliance:
             assert hasattr(planner, "configure")
             assert hasattr(planner, "close")
             planner.close()
+
+    def test_planner_contract_dataclasses_are_lightweight_metadata(self) -> None:
+        """Planner contracts should serialize without importing planner runtimes."""
+        observation = ObservationContract(
+            mode="socnav_state",
+            supported_modes=("socnav_state",),
+            required_inputs=("robot_state", "goal", "pedestrians"),
+            frame="world",
+            normalization="raw",
+            pedestrian_ordering="distance_ascending",
+        )
+        action = ActionContract(
+            command_space="unicycle_vw",
+            output_keys=("v", "omega"),
+            frame="robot",
+            normalization="raw",
+            units="mps_radps",
+        )
+        metadata = PlannerMetadata(
+            planner_id="unit_planner",
+            observation_contract=observation,
+            action_contract=action,
+            reset_contract="seeded_reset",
+        )
+
+        payload = metadata.to_metadata()
+
+        assert payload["planner_id"] == "unit_planner"
+        assert payload["observation_contract"]["supported_modes"] == ["socnav_state"]
+        assert payload["action_contract"]["output_keys"] == ["v", "omega"]
+        assert payload["reset_contract"] == "seeded_reset"
+
+    @pytest.mark.parametrize("algo", ["goal", "social_force", "orca", "ppo", "random"])
+    def test_core_benchmark_planners_publish_contract_metadata(self, algo: str) -> None:
+        """CI-smoke/core benchmark planners should declare observation and action contracts."""
+        contract = planner_contract_for_algorithm(algo)
+        payload = contract.to_metadata()
+
+        assert payload["planner_id"] == contract.planner_id
+        assert payload["observation_contract"]["active_mode"]
+        assert payload["observation_contract"]["required_inputs"]
+        assert payload["action_contract"]["command_space"] != "unknown"
+        assert payload["action_contract"]["output_keys"]


### PR DESCRIPTION
## Summary
Adds a first-class planner contract layer for benchmark-facing planners, with typed observation/action metadata and preflight validation before benchmark execution.

## Linked Issues
- Closes #1242

## What Changed
- Added lightweight `ObservationContract`, `ActionContract`, and `PlannerMetadata` dataclasses in `robot_sf/baselines/interface.py`.
- Added `planner_contract_for_algorithm()` and embedded `planner_contract` metadata in `robot_sf/benchmark/algorithm_metadata.py`.
- Added planner contract validation in `robot_sf/benchmark/planner_command_contract.py` and wired it into `robot_sf/benchmark/map_runner.py` preflight/episode setup.
- Extended planner interface, metadata, command-contract, and map-runner tests.
- Documented that planner contracts are compatibility metadata, not benchmark quality evidence, in `docs/benchmark_experimental_planners.md`.

## Why It Matters
- Added value: planner observation/action assumptions are visible before benchmark use.
- Expected impact: incompatible observation modes or known invalid planner/kinematics combinations fail closed with actionable contract errors.
- Why this is worth merging now: adversarial search, manual control, training, and benchmark workflows all depend on clear planner input/output semantics.

## Validation / Proof
- Red proof: targeted tests initially failed at collection because the contract dataclasses, registry helper, and validation hook did not exist.
- `rtk uv run --active pytest tests/unit/test_planner_interface.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_utils.py -q` -> 137 passed.
- `rtk uv run --active ruff check robot_sf/baselines/interface.py robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/planner_command_contract.py robot_sf/benchmark/map_runner.py tests/unit/test_planner_interface.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_utils.py` -> passed.
- After latest `origin/main` sync and commit: `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> 3557 passed, 13 skipped, 3 warnings.

## Risks / Rollout
- Compatibility risks: contract validation is additive and currently reuses existing observation-mode and kinematics compatibility rules.
- Failure modes: future planners with incomplete registry metadata may publish `unknown` command space until they are registered.
- Rollback or fallback plan: revert this commit to return to the previous metadata-only observation/kinematics checks.

## Docs / Provenance
- Updated docs: `docs/benchmark_experimental_planners.md`.
- Relevant design or provenance notes: this PR does not change metrics, planner behavior, scenario distributions, or benchmark readiness labels.
- Assumption to preserve: declared contracts are compatibility metadata only, not performance or paper-facing evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify the contract payload shape in `robot_sf/benchmark/algorithm_metadata.py` and the preflight skip/fail semantics in `robot_sf/benchmark/map_runner.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Planners now publish compatibility metadata (observation mode, command space, action format, kinematics requirements).
  * Benchmark runner validates planner-scenario compatibility before execution to fail fast on mismatches.
  * Batch runs filter jobs based on scenario-specific robot kinematics compatibility with detailed preflight reporting.
  * Enhanced error messages identify incompatible planner/kinematics combinations.

* **Documentation**
  * Added planner contract boundary clarification documenting compatibility metadata scope and limitations.

* **Tests**
  * Added contract validation, metadata serialization, and batch-filtering tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->