### PR TITLE
visualization: add trajectory debug export (#1244)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,6 +155,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
 * **[Issue #1073 Robot SF Empirical-Expansion Gate](./context/issue_1073_empirical_expansion_gate_2026_06_08.md)** - June 8 checkpoint rule for deciding whether Robot SF can move beyond dissertation-floor examples into bounded empirical expansion
 * **[Benchmark Static Dashboard](./benchmark_static_dashboard.md)** - Self-contained static HTML dashboard generation from camera-ready benchmark bundles
+* **[Trajectory Debug Visualization](./debug_visualization.md)** - Optional JSON/Rerun timeline export for inspecting one episode JSONL without treating debug artifacts as benchmark evidence
 * **[PR Promoted Planner Smoke](./benchmark_pr_promoted_planner_smoke.md)** - Pull-request micro-benchmark workflow, runtime target, and fail-closed summary contract
 * **[Issue #1065 Route-Clearance Warning Audit](./context/issue_1065_route_clearance_warning_audit.md)** - Paper and h500 route-clearance warning classification, planner-attribution boundary, and repair/certification follow-up
 * **[Issue #595 Seed-Variability Contract](./context/issue_595_seed_variability_contract.md)** - Frozen camera-ready artifact contract and pilot slice for paper-side seed variability analysis

--- a/docs/debug_visualization.md
+++ b/docs/debug_visualization.md
@@ -1,0 +1,42 @@
+# Trajectory Debug Visualization
+
+Related issue: `ll7/robot_sf_ll7#1244`
+
+`scripts/tools/rerun_debug_export.py` converts one episode JSONL file into a compact debug timeline
+for inspecting planner, pedestrian, and adversarial-failure behavior.
+
+The default export is dependency-free JSON:
+
+```bash
+uv run python scripts/tools/rerun_debug_export.py \
+  --source output/benchmarks/example/episodes.jsonl \
+  --output output/debug/example_timeline.json \
+  --format json
+```
+
+The JSON payload uses `schema_version: robot-sf-debug-timeline.v1` and records:
+
+- episode id, scenario id, seed, status, and terminal event,
+- per-frame robot pose,
+- per-frame pedestrian poses,
+- selected/proposed action when present,
+- TTC, PET, and clearance annotations when present in frame or episode metrics.
+
+An optional Rerun output path is available when `rerun-sdk` is installed in the active environment:
+
+```bash
+uv run python scripts/tools/rerun_debug_export.py \
+  --source output/benchmarks/example/episodes.jsonl \
+  --output output/debug/example_timeline.rrd \
+  --format rerun
+```
+
+If `rerun-sdk` is absent, the command fails closed with an install hint instead of adding a required
+dependency to the repository.
+
+## Evidence Boundary
+
+Debug timelines are diagnostic visualization artifacts. They do not replace episode JSONL,
+publication bundles, release manifests, benchmark summaries, or paper-facing evidence contracts.
+Keep generated timeline files under ignored `output/` unless a compact review fixture is explicitly
+needed.

--- a/scripts/tools/rerun_debug_export.py
+++ b/scripts/tools/rerun_debug_export.py
@@ -20,7 +20,10 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
             line = raw_line.strip()
             if not line:
                 continue
-            payload = json.loads(line)
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number} is not valid JSON") from exc
             if not isinstance(payload, dict):
                 raise ValueError(f"{path}:{line_number} is not a JSON object")
             records.append(payload)
@@ -175,9 +178,8 @@ def write_rerun_debug_export(*, source: Path, output: Path) -> Path:
     payload = build_debug_timeline(_load_jsonl(source), source_path=source)
     output.parent.mkdir(parents=True, exist_ok=True)
     rr.init("robot_sf_debug_export", spawn=False)
-    rr.save(str(output))
-    for episode in payload["episodes"]:
-        episode_id = episode["episode_id"] or "episode"
+    for index, episode in enumerate(payload["episodes"]):
+        episode_id = episode["episode_id"] or f"episode_{index}"
         for frame in episode["frames"]:
             step = frame["step"]
             if frame["time_s"] is not None:
@@ -197,6 +199,7 @@ def write_rerun_debug_export(*, source: Path, output: Path) -> Path:
                     f"{episode_id}/pedestrians",
                     rr.Points2D(pedestrian_points, radii=0.15),
                 )
+    rr.save(str(output))
     return output
 
 

--- a/scripts/tools/rerun_debug_export.py
+++ b/scripts/tools/rerun_debug_export.py
@@ -1,0 +1,237 @@
+"""Export episode trajectories to a lightweight debug timeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "robot-sf-debug-timeline.v1"
+ANNOTATION_KEYS = ("clearance", "min_clearance", "min_ttc", "pet", "ttc")
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL episode records from ``path``."""
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"{path}:{line_number} is not a JSON object")
+            records.append(payload)
+    if not records:
+        raise ValueError(f"No episode records found in {path}")
+    return records
+
+
+def _pose(value: Any) -> dict[str, float | None] | None:
+    """Normalize common pose shapes into x/y/theta fields."""
+    if isinstance(value, dict):
+        if "x" in value and "y" in value:
+            return {
+                "x": float(value["x"]),
+                "y": float(value["y"]),
+                "theta": float(value["theta"]) if value.get("theta") is not None else None,
+            }
+        if value.get("position") is not None:
+            return _pose(value["position"])
+    if isinstance(value, list | tuple) and len(value) >= 2:
+        return {
+            "x": float(value[0]),
+            "y": float(value[1]),
+            "theta": float(value[2]) if len(value) >= 3 and value[2] is not None else None,
+        }
+    return None
+
+
+def _robot_pose(frame: dict[str, Any]) -> dict[str, float | None] | None:
+    """Extract a robot pose from one trajectory frame."""
+    for key in ("robot", "robot_pose", "robot_position", "ego", "pose"):
+        pose = _pose(frame.get(key))
+        if pose is not None:
+            return pose
+    return _pose(frame)
+
+
+def _pedestrian_items(value: Any) -> list[tuple[str, Any]]:
+    """Return pedestrian id/payload pairs from mapping or list containers."""
+    if isinstance(value, dict):
+        return [(str(key), item) for key, item in value.items()]
+    if isinstance(value, list | tuple):
+        items: list[tuple[str, Any]] = []
+        for index, item in enumerate(value):
+            if isinstance(item, dict) and item.get("id") is not None:
+                items.append((str(item["id"]), item))
+            else:
+                items.append((str(index), item))
+        return items
+    return []
+
+
+def _pedestrians(frame: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract pedestrian pose entries from one trajectory frame."""
+    payload = frame.get("pedestrians", frame.get("pedestrian_positions"))
+    pedestrians: list[dict[str, Any]] = []
+    for entity_id, pedestrian in _pedestrian_items(payload):
+        pose = _pose(pedestrian)
+        if pose is not None:
+            pedestrians.append({"entity_id": entity_id, **pose})
+    return pedestrians
+
+
+def _annotations(record: dict[str, Any], frame: dict[str, Any]) -> dict[str, float]:
+    """Extract metric annotations for a frame, falling back to episode metrics."""
+    source = (
+        frame.get("metrics") if isinstance(frame.get("metrics"), dict) else record.get("metrics")
+    )
+    if not isinstance(source, dict):
+        return {}
+    annotations: dict[str, float] = {}
+    for key in ANNOTATION_KEYS:
+        value = source.get(key)
+        if isinstance(value, int | float):
+            annotations[key] = float(value)
+    return annotations
+
+
+def _action(frame: dict[str, Any]) -> Any:
+    """Extract the selected or proposed action from a frame when present."""
+    for key in ("action", "selected_action", "planner_action", "proposed_action"):
+        if key in frame:
+            return frame[key]
+    return None
+
+
+def _trajectory_frames(record: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert common trajectory_data frames into debug-timeline frames."""
+    trajectory = record.get("trajectory_data")
+    if not isinstance(trajectory, list):
+        return []
+    frames: list[dict[str, Any]] = []
+    for index, item in enumerate(trajectory):
+        if not isinstance(item, dict):
+            continue
+        frame = {
+            "step": int(item.get("step", index)),
+            "time_s": float(item["time_s"]) if item.get("time_s") is not None else None,
+            "robot": _robot_pose(item),
+            "pedestrians": _pedestrians(item),
+            "action": _action(item),
+            "annotations": _annotations(record, item),
+        }
+        frames.append(frame)
+    return frames
+
+
+def build_debug_timeline(records: list[dict[str, Any]], *, source_path: Path) -> dict[str, Any]:
+    """Build the debug timeline payload for episode records."""
+    episodes: list[dict[str, Any]] = []
+    frame_count = 0
+    for record in records:
+        frames = _trajectory_frames(record)
+        frame_count += len(frames)
+        terminal_event = record.get("termination_reason") or record.get("terminal_event")
+        episodes.append(
+            {
+                "episode_id": str(record.get("episode_id", "")),
+                "scenario_id": str(record.get("scenario_id", "")),
+                "seed": record.get("seed"),
+                "status": record.get("status"),
+                "terminal_event": terminal_event,
+                "frames": frames,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_path": source_path.as_posix(),
+        "summary": {"episodes": len(episodes), "frames": frame_count},
+        "episodes": episodes,
+    }
+
+
+def write_json_debug_export(*, source: Path, output: Path) -> Path:
+    """Write a JSON debug timeline for an episode JSONL source."""
+    payload = build_debug_timeline(_load_jsonl(source), source_path=source)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output
+
+
+def write_rerun_debug_export(*, source: Path, output: Path) -> Path:
+    """Write a Rerun recording when the optional SDK is installed."""
+    try:
+        import rerun as rr  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "Rerun export requires the optional 'rerun-sdk' package. "
+            "Install it in a disposable environment or use --format json."
+        ) from exc
+
+    payload = build_debug_timeline(_load_jsonl(source), source_path=source)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    rr.init("robot_sf_debug_export", spawn=False)
+    rr.save(str(output))
+    for episode in payload["episodes"]:
+        episode_id = episode["episode_id"] or "episode"
+        for frame in episode["frames"]:
+            step = frame["step"]
+            if frame["time_s"] is not None:
+                rr.set_time_seconds("time", float(frame["time_s"]))
+            else:
+                rr.set_time_sequence("step", int(step))
+            robot = frame["robot"]
+            if robot is not None:
+                rr.log(f"{episode_id}/robot", rr.Points2D([[robot["x"], robot["y"]]], radii=0.2))
+            pedestrian_points = [
+                [item["x"], item["y"]]
+                for item in frame["pedestrians"]
+                if item.get("x") is not None and item.get("y") is not None
+            ]
+            if pedestrian_points:
+                rr.log(
+                    f"{episode_id}/pedestrians",
+                    rr.Points2D(pedestrian_points, radii=0.15),
+                )
+    return output
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the debug-export CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, type=Path, help="Episode JSONL source path.")
+    parser.add_argument("--output", required=True, type=Path, help="Output debug artifact path.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "rerun"),
+        default="json",
+        help="Debug export format. Rerun requires optional rerun-sdk.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the trajectory debug export CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.format == "json":
+            write_json_debug_export(source=args.source, output=args.output)
+        else:
+            write_rerun_debug_export(source=args.source, output=args.output)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"wrote {args.format} debug timeline to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_rerun_debug_export.py
+++ b/tests/tools/test_rerun_debug_export.py
@@ -1,0 +1,100 @@
+"""Tests for optional trajectory debug export."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPORT_SCRIPT = REPO_ROOT / "scripts" / "tools" / "rerun_debug_export.py"
+
+
+def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    """Write JSONL records for debug-export fixtures."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _run_export(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the debug export CLI."""
+    return subprocess.run(
+        [sys.executable, str(EXPORT_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _episode_record() -> dict[str, object]:
+    """Return a tiny synthetic episode with trajectory, action, and metric annotations."""
+    return {
+        "episode_id": "episode-1",
+        "scenario_id": "crossing_dense_004",
+        "seed": 111,
+        "status": "failed",
+        "termination_reason": "collision",
+        "metrics": {"min_ttc": 0.8, "clearance": 0.25},
+        "trajectory_data": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "robot": {"x": 1.0, "y": 2.0, "theta": 0.1},
+                "pedestrians": {"ped-1": {"x": 3.0, "y": 4.0}},
+                "action": [0.5, 0.1],
+                "metrics": {"min_ttc": 1.5, "clearance": 0.7},
+            },
+            {
+                "step": 1,
+                "time_s": 0.4,
+                "robot": {"x": 1.2, "y": 2.1, "theta": 0.2},
+                "pedestrians": [{"id": "ped-1", "x": 2.8, "y": 3.8}],
+                "selected_action": {"linear": 0.4, "angular": -0.1},
+                "metrics": {"min_ttc": 0.8, "clearance": 0.25},
+            },
+        ],
+    }
+
+
+def test_json_debug_export_converts_episode_timeline(tmp_path: Path) -> None:
+    """JSON export should preserve poses, actions, terminal event, and annotations."""
+    source = tmp_path / "episodes.jsonl"
+    output = tmp_path / "debug_timeline.json"
+    _write_jsonl(source, [_episode_record()])
+
+    result = _run_export("--source", str(source), "--output", str(output), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "robot-sf-debug-timeline.v1"
+    assert payload["summary"] == {"episodes": 1, "frames": 2}
+    episode = payload["episodes"][0]
+    assert episode["episode_id"] == "episode-1"
+    assert episode["terminal_event"] == "collision"
+    assert episode["frames"][0]["robot"] == {"x": 1.0, "y": 2.0, "theta": 0.1}
+    assert episode["frames"][0]["pedestrians"] == [
+        {"entity_id": "ped-1", "x": 3.0, "y": 4.0, "theta": None}
+    ]
+    assert episode["frames"][0]["action"] == [0.5, 0.1]
+    assert episode["frames"][1]["action"] == {"linear": 0.4, "angular": -0.1}
+    assert episode["frames"][1]["annotations"] == {"clearance": 0.25, "min_ttc": 0.8}
+
+
+def test_rerun_export_fails_with_actionable_optional_dependency_message(
+    tmp_path: Path,
+) -> None:
+    """Rerun format should fail clearly when the optional package is unavailable."""
+    source = tmp_path / "episodes.jsonl"
+    output = tmp_path / "debug_timeline.rrd"
+    _write_jsonl(source, [_episode_record()])
+
+    result = _run_export("--source", str(source), "--output", str(output), "--format", "rerun")
+
+    assert result.returncode == 2
+    assert "Rerun export requires the optional 'rerun-sdk' package" in result.stderr
+    assert not output.exists()

--- a/tests/tools/test_rerun_debug_export.py
+++ b/tests/tools/test_rerun_debug_export.py
@@ -6,6 +6,11 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.tools import rerun_debug_export
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXPORT_SCRIPT = REPO_ROOT / "scripts" / "tools" / "rerun_debug_export.py"
@@ -98,3 +103,49 @@ def test_rerun_export_fails_with_actionable_optional_dependency_message(
     assert result.returncode == 2
     assert "Rerun export requires the optional 'rerun-sdk' package" in result.stderr
     assert not output.exists()
+
+
+def test_jsonl_loader_reports_malformed_json_line(tmp_path: Path) -> None:
+    """Malformed JSONL input should fail closed with the offending line number."""
+    source = tmp_path / "episodes.jsonl"
+    source.write_text(json.dumps(_episode_record()) + "\n{oops\n", encoding="utf-8")
+    output = tmp_path / "debug_timeline.json"
+
+    result = _run_export("--source", str(source), "--output", str(output), "--format", "json")
+
+    assert result.returncode == 1
+    assert f"{source}:2 is not valid JSON" in result.stderr
+    assert not output.exists()
+
+
+def test_rerun_export_saves_after_logging_and_disambiguates_missing_episode_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rerun export should save after log calls and avoid episode-id collisions."""
+    source = tmp_path / "episodes.jsonl"
+    output = tmp_path / "debug_timeline.rrd"
+    first = _episode_record()
+    second = _episode_record()
+    first.pop("episode_id")
+    second.pop("episode_id")
+    _write_jsonl(source, [first, second])
+
+    events: list[tuple[str, object]] = []
+
+    fake_rerun = SimpleNamespace(
+        init=lambda *args, **kwargs: events.append(("init", args)),
+        save=lambda path: events.append(("save", path)),
+        set_time_seconds=lambda *args: events.append(("time_seconds", args)),
+        set_time_sequence=lambda *args: events.append(("time_sequence", args)),
+        log=lambda path, payload: events.append(("log", path)),
+        Points2D=lambda points, radii=None: {"points": points, "radii": radii},
+    )
+    monkeypatch.setitem(sys.modules, "rerun", fake_rerun)
+
+    assert rerun_debug_export.write_rerun_debug_export(source=source, output=output) == output
+
+    assert events[-1] == ("save", str(output))
+    logged_paths = [payload for event, payload in events if event == "log"]
+    assert "episode_0/robot" in logged_paths
+    assert "episode_1/robot" in logged_paths


### PR DESCRIPTION
## Summary
Adds a dependency-free JSON trajectory debug export CLI for episode JSONL records, plus an optional Rerun output mode that fails closed with an actionable message when `rerun-sdk` is not installed.

## Linked Issues
- Closes #1244

## What Changed
- Added `scripts/tools/rerun_debug_export.py`.
- Added focused CLI tests in `tests/tools/test_rerun_debug_export.py` for JSON conversion and missing optional Rerun dependency behavior.
- Added `docs/debug_visualization.md` and linked it from `docs/README.md`.

## Why It Matters
- Added value: one episode JSONL can be inspected as a compact timeline with robot poses, pedestrian poses, actions, terminal event, and TTC/PET/clearance annotations.
- Expected impact: faster planner/adversarial failure diagnosis without changing benchmark metrics or required dependencies.
- Why this is worth merging now: adversarial and benchmark failure artifacts are becoming more central, and this keeps diagnostic visualization separate from paper-facing evidence.

## Validation / Proof
- Red proof: `rtk ./.venv/bin/python -m pytest tests/tools/test_rerun_debug_export.py -q` failed before implementation because `scripts/tools/rerun_debug_export.py` was missing.
- `rtk ./.venv/bin/python -m pytest tests/tools/test_rerun_debug_export.py -q`: passed with `2 passed in 10.65s`.
- `rtk ./.venv/bin/ruff check scripts/tools/rerun_debug_export.py tests/tools/test_rerun_debug_export.py`: passed.
- `rtk ./.venv/bin/ruff format --check scripts/tools/rerun_debug_export.py tests/tools/test_rerun_debug_export.py`: passed after formatting.
- `rtk git diff --check`: passed.
- `rtk env BASE_REF=origin/main PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh`: passed after latest-main sync with `3551 passed, 12 skipped, 7 warnings in 450.04s`; changed-files coverage and touched-definition docstring gates passed.
- Benchmarks or smoke tests: no benchmark behavior changed. The focused tests exercise the CLI smoke path on a synthetic episode JSONL fixture.

## Risks / Rollout
- Compatibility risks: low; this is additive tooling and docs.
- Failure modes: Rerun `.rrd` export depends on optional `rerun-sdk`; without it, the command exits 2 with a clear install/use-JSON message.
- Rollback or fallback plan: remove the CLI and docs; existing JSONL, replay, and visualization paths are unaffected.

## Docs / Provenance
- Updated docs: `docs/debug_visualization.md`, `docs/README.md`.
- Relevant design or provenance notes: debug timelines are diagnostic visualization artifacts only; they do not replace episode JSONL, publication bundles, release manifests, or benchmark summaries.
- Artifact decision: ignored `output/coverage`, `output/model_cache`, and `output/tmp` files are disposable/cache artifacts from validation. No debug timeline output or benchmark artifact is staged.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the Rerun path remains optional and that debug artifacts are not presented as benchmark evidence.
- Known limitation: the Rerun path is guarded by optional dependency availability; CI validates the fail-closed path, while JSON export is the dependency-free default.