### PR TITLE
feat: add benchmark parquet analytics export (#1238)

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -151,3 +151,41 @@ Add new checks in `robot_sf/maps/verification/rules.py` (follow existing pattern
 - Spot-check the first line of `episodes.jsonl`: `record["algo"] == record["scenario_params"]["algo"]`.
 - Confirm aggregate outputs include `_meta.effective_group_key` and, when applicable, warnings describing any missing algorithms.
 - Treat `AggregationMetadataError` as a signal to regenerate the episode data—legacy files lacking mirrored metadata are no longer accepted silently.
+
+## Parquet Analytics Export
+
+`episodes.jsonl` remains the source of truth for benchmark runs. For larger campaign analysis,
+convert it into Parquet tables with the optional analytics extra:
+
+```bash
+uv sync --extra analytics
+uv run robot_sf_bench export-parquet \
+  --in output/benchmarks/classic_interactions/episodes.jsonl \
+  --out-dir output/benchmarks/classic_interactions/parquet
+```
+
+The export writes:
+
+- `episodes.parquet`: one fixed top-level row per episode.
+- `metrics.parquet`: long-form typed metric rows keyed by `episode_id` and dotted `metric_path`.
+- `scenario_params.parquet`: long-form scenario parameter rows keyed by dotted `param_path`.
+- `algorithm_metadata.parquet`: long-form planner metadata rows keyed by dotted `metadata_path`.
+- `metadata.json`: source JSONL hashes, row counts, table files, and export schema version.
+- `duckdb_examples.sql`: copy-paste SQL examples for grouped safety metrics and failure mining.
+
+Example DuckDB query:
+
+```sql
+SELECT
+    e.algo,
+    e.scenario_family,
+    AVG(CASE WHEN m.metric_path = 'min_ttc' THEN m.value_number END) AS avg_min_ttc,
+    AVG(CASE WHEN m.metric_path = 'clearance' THEN m.value_number END) AS avg_clearance
+FROM read_parquet('episodes.parquet') AS e
+JOIN read_parquet('metrics.parquet') AS m USING (episode_id)
+GROUP BY e.algo, e.scenario_family
+ORDER BY e.algo, e.scenario_family;
+```
+
+Use `--overwrite` only when replacing a known derived export. The metadata file records that the
+Parquet files are derived views so downstream reports can trace back to the canonical JSONL input.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ analysis = [
     "matplotlib>=3.9.2",
     "pandas>=2.2.3",
 ]
+analytics = [
+    "duckdb>=1.4.0",
+    "pyarrow>=23.0.0",
+]
 viz = [
     "matplotlib>=3.9.2",
     "seaborn>=0.13.2",

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -34,6 +34,7 @@ from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.failure_extractor import extract_failures as _extract_failures
 from robot_sf.benchmark.fallback_policy import availability_payload, benchmark_run_exit_code
 from robot_sf.benchmark.observation_noise import load_observation_noise_spec
+from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
 from robot_sf.benchmark.planner_inclusion import (
     DEFAULT_INCLUSION_MATRIX,
     InclusionCriteria,
@@ -469,6 +470,29 @@ def _handle_aggregate(args) -> int:
             logging.debug("Logging 'Aggregated summary' failed", exc_info=True)
         return 0
     except Exception:  # pragma: no cover - error path
+        return 2
+
+
+def _handle_export_parquet(args) -> int:
+    """Export benchmark episode JSONL records to Parquet analytics tables.
+
+    Returns:
+        Exit code (0 success, 2 failure).
+    """
+    try:
+        result = export_episodes_jsonl_to_parquet(
+            args.in_path,
+            args.out_dir,
+            overwrite=bool(args.overwrite),
+        )
+        logging.info(
+            "Parquet analytics export written to %s (%d episode records)",
+            result.output_dir,
+            result.record_count,
+        )
+        return 0
+    except Exception:
+        logging.exception("Parquet analytics export failed")
         return 2
 
 
@@ -1477,6 +1501,24 @@ def _add_aggregate_subparser(
     p.set_defaults(cmd="aggregate")
 
 
+def _add_export_parquet_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the export-parquet subcommand parser."""
+    p = subparsers.add_parser(
+        "export-parquet",
+        help="Convert benchmark episode JSONL into Parquet analytics tables",
+    )
+    p.add_argument("--in", dest="in_path", required=True, help="Input episodes JSONL path")
+    p.add_argument("--out-dir", required=True, help="Output directory for Parquet tables")
+    p.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace existing export files in the output directory",
+    )
+    p.set_defaults(cmd="export-parquet")
+
+
 def _add_snqi_ablate_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -1833,6 +1875,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_run_subparser(subparsers)
     _add_summary_subparser(subparsers)
     _add_aggregate_subparser(subparsers)
+    _add_export_parquet_subparser(subparsers)
     _add_seed_variance_subparser(subparsers)
     _add_extract_failures_subparser(subparsers)
     _add_snqi_ablate_subparser(subparsers)
@@ -2281,6 +2324,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "run": _handle_run,
         "summary": _handle_summary,
         "aggregate": _handle_aggregate,
+        "export-parquet": _handle_export_parquet,
         "seed-variance": _handle_seed_variance,
         "extract-failures": _handle_extract_failures,
         "snqi-ablate": _handle_snqi_ablate,

--- a/robot_sf/benchmark/parquet_export.py
+++ b/robot_sf/benchmark/parquet_export.py
@@ -12,8 +12,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from robot_sf.benchmark.aggregate import read_jsonl
-
 try:  # Optional analytics dependency; validated when export is invoked.
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -73,7 +71,7 @@ def export_episodes_jsonl_to_parquet(
     duckdb_examples_path = out_dir / "duckdb_examples.sql"
     _ensure_can_write([*table_paths.values(), metadata_path, duckdb_examples_path], overwrite)
 
-    records = read_jsonl(paths)
+    records = _read_jsonl_files(paths)
     rows = _build_rows(records)
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -144,6 +142,9 @@ def _schemas(pa: Any) -> dict[str, Any]:
                 ("episode_id", pa.string()),
                 ("scenario_id", pa.string()),
                 ("seed", pa.int64()),
+                ("started_at_utc", pa.string()),
+                ("finished_at_utc", pa.string()),
+                ("total_runtime_sec", pa.float64()),
                 ("algo", pa.string()),
                 ("scenario_family", pa.string()),
                 ("termination_reason", pa.string()),
@@ -223,6 +224,9 @@ def _episode_row(record: Mapping[str, Any], episode_id: str) -> dict[str, Any]:
         "episode_id": episode_id,
         "scenario_id": _string_or_none(record.get("scenario_id")),
         "seed": _int_or_none(record.get("seed")),
+        "started_at_utc": _resolve_started_at_utc(record),
+        "finished_at_utc": _resolve_finished_at_utc(record),
+        "total_runtime_sec": _resolve_total_runtime_sec(record),
         "algo": _resolve_algo(record),
         "scenario_family": _resolve_scenario_family(record),
         "termination_reason": _string_or_none(record.get("termination_reason")),
@@ -331,6 +335,17 @@ def _int_or_none(value: Any) -> int | None:
         return None
     if isinstance(value, int):
         return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    """Coerce a numeric value when possible."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
     return None
 
 
@@ -354,6 +369,53 @@ def _json_dumps(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
 
 
+def _resolve_started_at_utc(record: Mapping[str, Any]) -> str | None:
+    """Resolve episode start time from canonical or legacy provenance fields."""
+    return _string_or_none(record.get("started_at_utc")) or _string_or_none(
+        _nested_value(record, "timestamps.start")
+    )
+
+
+def _resolve_finished_at_utc(record: Mapping[str, Any]) -> str | None:
+    """Resolve episode finish time from canonical or legacy provenance fields."""
+    return _string_or_none(record.get("finished_at_utc")) or _string_or_none(
+        _nested_value(record, "timestamps.end")
+    )
+
+
+def _resolve_total_runtime_sec(record: Mapping[str, Any]) -> float | None:
+    """Resolve episode runtime from known benchmark provenance fields."""
+    for value in (
+        record.get("total_runtime_sec"),
+        record.get("runtime_sec"),
+        record.get("wall_time_sec"),
+        record.get("total_runtime"),
+    ):
+        number = _float_or_none(value)
+        if number is not None:
+            return number
+    return None
+
+
+def _read_jsonl_files(paths: Sequence[Path]) -> list[dict[str, Any]]:
+    """Read benchmark episode JSONL files, failing closed on malformed source data."""
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        if not path.is_file():
+            raise FileNotFoundError(f"Benchmark episode JSONL input is not a file: {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                text = line.strip()
+                if not text:
+                    continue
+                try:
+                    record = json.loads(text)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"{path}:{line_number} is not valid JSON: {exc.msg}") from exc
+                records.append(record)
+    return records
+
+
 def _build_metadata(
     *,
     paths: Sequence[Path],
@@ -370,7 +432,7 @@ def _build_metadata(
         "source_files": [
             {
                 "path": str(path),
-                "sha256": _path_sha256(path) if path.exists() else None,
+                "sha256": _path_sha256(path) if path.is_file() else None,
             }
             for path in paths
         ],

--- a/robot_sf/benchmark/parquet_export.py
+++ b/robot_sf/benchmark/parquet_export.py
@@ -1,0 +1,435 @@
+"""Parquet analytics export for benchmark episode JSONL records."""
+
+# ruff: noqa: DOC201
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.aggregate import read_jsonl
+
+try:  # Optional analytics dependency; validated when export is invoked.
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except ModuleNotFoundError:  # pragma: no cover - environment dependent
+    pa = None
+    pq = None
+
+EXPORT_SCHEMA_VERSION = "benchmark_parquet_export.v1"
+
+_TABLE_FILENAMES = {
+    "episodes": "episodes.parquet",
+    "metrics": "metrics.parquet",
+    "scenario_params": "scenario_params.parquet",
+    "algorithm_metadata": "algorithm_metadata.parquet",
+}
+
+
+@dataclass(frozen=True)
+class ParquetExportResult:
+    """Summary of files written by a benchmark Parquet export."""
+
+    output_dir: Path
+    record_count: int
+    table_paths: dict[str, Path]
+    metadata_path: Path
+    duckdb_examples_path: Path
+
+
+def export_episodes_jsonl_to_parquet(
+    input_paths: Sequence[str | Path] | str | Path,
+    output_dir: str | Path,
+    *,
+    overwrite: bool = False,
+) -> ParquetExportResult:
+    """Convert benchmark episode JSONL records into Parquet analytics tables.
+
+    JSONL remains the canonical source artifact. The exported tables are derived
+    views intended for SQL analytics, campaign comparison, and failure mining.
+
+    Args:
+        input_paths: One or more benchmark episode JSONL files.
+        output_dir: Directory that receives the Parquet tables and metadata.
+        overwrite: Replace existing export files when True.
+
+    Returns:
+        Summary of the generated files and row counts.
+
+    Raises:
+        FileExistsError: If export files already exist and overwrite is False.
+        RuntimeError: If the optional PyArrow dependency is unavailable.
+    """
+    pa, pq = _load_pyarrow()
+    paths = _normalize_paths(input_paths)
+    out_dir = Path(output_dir)
+    table_paths = {name: out_dir / filename for name, filename in _TABLE_FILENAMES.items()}
+    metadata_path = out_dir / "metadata.json"
+    duckdb_examples_path = out_dir / "duckdb_examples.sql"
+    _ensure_can_write([*table_paths.values(), metadata_path, duckdb_examples_path], overwrite)
+
+    records = read_jsonl(paths)
+    rows = _build_rows(records)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    schemas = _schemas(pa)
+    for table_name, table_rows in rows.items():
+        table = pa.Table.from_pylist(table_rows, schema=schemas[table_name])
+        pq.write_table(table, table_paths[table_name])
+
+    metadata = _build_metadata(
+        paths=paths,
+        record_count=len(records),
+        rows=rows,
+        table_paths=table_paths,
+    )
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    duckdb_examples_path.write_text(_duckdb_examples_sql(), encoding="utf-8")
+
+    return ParquetExportResult(
+        output_dir=out_dir,
+        record_count=len(records),
+        table_paths=table_paths,
+        metadata_path=metadata_path,
+        duckdb_examples_path=duckdb_examples_path,
+    )
+
+
+def _load_pyarrow() -> tuple[Any, Any]:
+    """Load PyArrow modules only when the export path is used."""
+    if pa is None or pq is None:  # pragma: no cover - environment dependent
+        msg = (
+            "Parquet export requires optional analytics dependencies. "
+            "Install them with `uv sync --extra analytics` or `uv sync --all-extras`."
+        )
+        raise RuntimeError(msg)
+    return pa, pq
+
+
+def _normalize_paths(input_paths: Sequence[str | Path] | str | Path) -> list[Path]:
+    """Normalize one or more input paths."""
+    if isinstance(input_paths, str | Path):
+        return [Path(input_paths)]
+    return [Path(path) for path in input_paths]
+
+
+def _ensure_can_write(paths: Sequence[Path], overwrite: bool) -> None:
+    """Fail before partial writes when export files already exist."""
+    if overwrite:
+        return
+    existing = [path for path in paths if path.exists()]
+    if existing:
+        names = ", ".join(str(path) for path in existing)
+        raise FileExistsError(f"Parquet export output already exists: {names}")
+
+
+def _schemas(pa: Any) -> dict[str, Any]:
+    """Return fixed PyArrow schemas for all exported tables."""
+    typed_value_fields = [
+        ("value_number", pa.float64()),
+        ("value_bool", pa.bool_()),
+        ("value_text", pa.string()),
+        ("value_json", pa.string()),
+    ]
+    return {
+        "episodes": pa.schema(
+            [
+                ("episode_id", pa.string()),
+                ("scenario_id", pa.string()),
+                ("seed", pa.int64()),
+                ("algo", pa.string()),
+                ("scenario_family", pa.string()),
+                ("termination_reason", pa.string()),
+                ("version", pa.string()),
+                ("outcome_json", pa.string()),
+                ("integrity_json", pa.string()),
+                ("record_json_sha256", pa.string()),
+            ]
+        ),
+        "metrics": pa.schema(
+            [
+                ("episode_id", pa.string()),
+                ("metric_path", pa.string()),
+                *typed_value_fields,
+            ]
+        ),
+        "scenario_params": pa.schema(
+            [
+                ("episode_id", pa.string()),
+                ("param_path", pa.string()),
+                *typed_value_fields,
+            ]
+        ),
+        "algorithm_metadata": pa.schema(
+            [
+                ("episode_id", pa.string()),
+                ("metadata_path", pa.string()),
+                *typed_value_fields,
+            ]
+        ),
+    }
+
+
+def _build_rows(records: Sequence[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Build normalized table rows from benchmark episode records."""
+    episode_rows: list[dict[str, Any]] = []
+    metric_rows: list[dict[str, Any]] = []
+    scenario_param_rows: list[dict[str, Any]] = []
+    algorithm_metadata_rows: list[dict[str, Any]] = []
+
+    for record in records:
+        episode_id = str(record.get("episode_id", ""))
+        episode_rows.append(_episode_row(record, episode_id))
+        metric_rows.extend(
+            _key_value_rows(
+                episode_id=episode_id,
+                source=record.get("metrics"),
+                path_column="metric_path",
+            )
+        )
+        scenario_param_rows.extend(
+            _key_value_rows(
+                episode_id=episode_id,
+                source=record.get("scenario_params"),
+                path_column="param_path",
+            )
+        )
+        algorithm_metadata_rows.extend(
+            _key_value_rows(
+                episode_id=episode_id,
+                source=record.get("algorithm_metadata"),
+                path_column="metadata_path",
+            )
+        )
+
+    return {
+        "episodes": episode_rows,
+        "metrics": metric_rows,
+        "scenario_params": scenario_param_rows,
+        "algorithm_metadata": algorithm_metadata_rows,
+    }
+
+
+def _episode_row(record: Mapping[str, Any], episode_id: str) -> dict[str, Any]:
+    """Build the fixed top-level episode row."""
+    return {
+        "episode_id": episode_id,
+        "scenario_id": _string_or_none(record.get("scenario_id")),
+        "seed": _int_or_none(record.get("seed")),
+        "algo": _resolve_algo(record),
+        "scenario_family": _resolve_scenario_family(record),
+        "termination_reason": _string_or_none(record.get("termination_reason")),
+        "version": _string_or_none(record.get("version")),
+        "outcome_json": _json_or_none(record.get("outcome")),
+        "integrity_json": _json_or_none(record.get("integrity")),
+        "record_json_sha256": hashlib.sha256(_json_dumps(record).encode("utf-8")).hexdigest(),
+    }
+
+
+def _key_value_rows(
+    *,
+    episode_id: str,
+    source: Any,
+    path_column: str,
+) -> list[dict[str, Any]]:
+    """Convert a nested mapping into long-form typed key/value rows."""
+    if not isinstance(source, Mapping):
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for path, value in _iter_leaf_values(source):
+        value_columns = _typed_value_columns(value)
+        rows.append({"episode_id": episode_id, path_column: path, **value_columns})
+    return rows
+
+
+def _iter_leaf_values(source: Mapping[str, Any], prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten nested mappings into dotted leaf paths."""
+    rows: list[tuple[str, Any]] = []
+    for key in sorted(source):
+        value = source[key]
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, Mapping) and value:
+            rows.extend(_iter_leaf_values(value, path))
+        else:
+            rows.append((path, value))
+    return rows
+
+
+def _typed_value_columns(value: Any) -> dict[str, Any]:
+    """Represent a Python value across stable typed Parquet columns."""
+    value_number = None
+    value_bool = None
+    value_text = None
+    value_json = None
+    if isinstance(value, bool):
+        value_bool = value
+    elif isinstance(value, int | float):
+        value_number = float(value)
+    elif isinstance(value, str):
+        value_text = value
+    elif value is not None:
+        value_json = _json_dumps(value)
+    return {
+        "value_number": value_number,
+        "value_bool": value_bool,
+        "value_text": value_text,
+        "value_json": value_json,
+    }
+
+
+def _resolve_algo(record: Mapping[str, Any]) -> str | None:
+    """Resolve the planner/algorithm identifier with benchmark metadata fallbacks."""
+    for value in (
+        _nested_value(record, "scenario_params.algo"),
+        record.get("algo"),
+        _nested_value(record, "algorithm_metadata.algorithm"),
+        _nested_value(record, "algorithm_metadata.canonical_algorithm"),
+    ):
+        text = _string_or_none(value)
+        if text:
+            return text
+    return None
+
+
+def _resolve_scenario_family(record: Mapping[str, Any]) -> str | None:
+    """Resolve a scenario-family key suitable for grouped analytics."""
+    for value in (
+        _nested_value(record, "scenario_params.scenario_family"),
+        _nested_value(record, "scenario_params.family"),
+        record.get("scenario_family"),
+    ):
+        text = _string_or_none(value)
+        if text:
+            return text
+    scenario_id = _string_or_none(record.get("scenario_id"))
+    if scenario_id and "_" in scenario_id:
+        return scenario_id.split("_", maxsplit=1)[0]
+    return scenario_id
+
+
+def _nested_value(source: Mapping[str, Any], path: str) -> Any:
+    """Resolve a dotted path from a nested mapping."""
+    current: Any = source
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _int_or_none(value: Any) -> int | None:
+    """Coerce an integer-like value when possible."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _string_or_none(value: Any) -> str | None:
+    """Coerce non-empty string-like values."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _json_or_none(value: Any) -> str | None:
+    """Serialize structured values for fixed top-level episode columns."""
+    if value is None:
+        return None
+    return _json_dumps(value)
+
+
+def _json_dumps(value: Any) -> str:
+    """Serialize JSON deterministically for hashes and stored JSON columns."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _build_metadata(
+    *,
+    paths: Sequence[Path],
+    record_count: int,
+    rows: Mapping[str, Sequence[Mapping[str, Any]]],
+    table_paths: Mapping[str, Path],
+) -> dict[str, Any]:
+    """Build export metadata and provenance."""
+    return {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "created_at_utc": datetime.now(UTC).isoformat(),
+        "jsonl_is_source_of_truth": True,
+        "record_count": record_count,
+        "source_files": [
+            {
+                "path": str(path),
+                "sha256": _path_sha256(path) if path.exists() else None,
+            }
+            for path in paths
+        ],
+        "tables": {
+            table_name: {
+                "file": table_paths[table_name].name,
+                "rows": len(table_rows),
+            }
+            for table_name, table_rows in rows.items()
+        },
+    }
+
+
+def _path_sha256(path: Path) -> str:
+    """Return a SHA-256 digest for an input file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _duckdb_examples_sql() -> str:
+    """Return example DuckDB queries for the exported table layout."""
+    return """-- Robot SF benchmark Parquet analytics examples.
+-- Run from the export directory, or replace the file paths with absolute paths.
+
+-- Grouped safety metrics by planner and scenario family.
+WITH metric_values AS (
+    SELECT
+        e.algo,
+        e.scenario_family,
+        m.metric_path,
+        m.value_number
+    FROM read_parquet('episodes.parquet') AS e
+    JOIN read_parquet('metrics.parquet') AS m USING (episode_id)
+)
+SELECT
+    algo,
+    scenario_family,
+    AVG(CASE WHEN metric_path = 'min_ttc' THEN value_number END) AS avg_min_ttc,
+    AVG(CASE WHEN metric_path = 'clearance' THEN value_number END) AS avg_clearance,
+    SUM(CASE WHEN metric_path = 'collisions' THEN value_number ELSE 0 END) AS collisions
+FROM metric_values
+GROUP BY algo, scenario_family
+ORDER BY algo, scenario_family;
+
+-- Failure and near-miss mining.
+SELECT
+    e.episode_id,
+    e.algo,
+    e.scenario_id,
+    e.scenario_family,
+    e.termination_reason,
+    m.value_number AS min_ttc
+FROM read_parquet('episodes.parquet') AS e
+LEFT JOIN read_parquet('metrics.parquet') AS m
+    ON e.episode_id = m.episode_id AND m.metric_path = 'min_ttc'
+WHERE e.termination_reason IN ('collision', 'deadlock', 'timeout')
+   OR m.value_number < 0.5
+ORDER BY e.algo, min_ttc NULLS LAST;
+"""

--- a/tests/benchmark/test_parquet_export.py
+++ b/tests/benchmark/test_parquet_export.py
@@ -21,7 +21,7 @@ def _episode(
     episode_id: str,
     algo: str,
     scenario_family: str,
-    seed: int,
+    seed: int | float,
     min_ttc: float,
     clearance: float,
     success: bool,
@@ -57,6 +57,11 @@ def _episode(
         "termination_reason": termination_reason,
         "outcome": {"collision_event": not success},
         "integrity": {"seed": seed},
+        "timestamps": {
+            "start": "2026-05-16T08:00:00+00:00",
+            "end": "2026-05-16T08:00:01.250000+00:00",
+        },
+        "wall_time_sec": 1.25,
     }
 
 
@@ -111,6 +116,9 @@ def test_export_parquet_writes_stable_tables_and_metadata(tmp_path: Path) -> Non
     assert [row["episode_id"] for row in episodes] == ["ep-a", "ep-b"]
     assert episodes[0]["algo"] == "planner_a"
     assert episodes[0]["scenario_family"] == "crossing"
+    assert episodes[0]["started_at_utc"] == "2026-05-16T08:00:00+00:00"
+    assert episodes[0]["finished_at_utc"] == "2026-05-16T08:00:01.250000+00:00"
+    assert episodes[0]["total_runtime_sec"] == 1.25
 
     metrics = pq.read_table(result.output_dir / "metrics.parquet").to_pylist()
     metric_paths = {(row["episode_id"], row["metric_path"]) for row in metrics}
@@ -151,6 +159,46 @@ def test_export_parquet_refuses_to_overwrite_existing_outputs(tmp_path: Path) ->
     export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
 
     with pytest.raises(FileExistsError, match="already exists"):
+        export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
+
+
+def test_export_parquet_coerces_integer_like_float_seed(tmp_path: Path) -> None:
+    """Exact integer floats should not be dropped from integer columns."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    _write_jsonl(
+        episodes_path,
+        [
+            _episode(
+                episode_id="ep-a",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=11.0,
+                min_ttc=1.25,
+                clearance=0.42,
+                success=True,
+                termination_reason="goal_reached",
+            )
+        ],
+    )
+
+    result = export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
+
+    episodes = pq.read_table(result.output_dir / "episodes.parquet").to_pylist()
+    assert episodes[0]["seed"] == 11
+
+
+def test_export_parquet_rejects_directory_input(tmp_path: Path) -> None:
+    """Source paths must be files so provenance hashing cannot open a directory."""
+    with pytest.raises(FileNotFoundError, match="not a file"):
+        export_episodes_jsonl_to_parquet(tmp_path, tmp_path / "analytics")
+
+
+def test_export_parquet_reports_malformed_json_line(tmp_path: Path) -> None:
+    """Malformed source JSONL should fail with file and line number context."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    episodes_path.write_text('{"episode_id": "ok"}\n{"episode_id":\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"episodes\.jsonl:2 is not valid JSON"):
         export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
 
 

--- a/tests/benchmark/test_parquet_export.py
+++ b/tests/benchmark/test_parquet_export.py
@@ -1,0 +1,198 @@
+"""Tests for benchmark JSONL to Parquet analytics export."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _episode(
+    *,
+    episode_id: str,
+    algo: str,
+    scenario_family: str,
+    seed: int,
+    min_ttc: float,
+    clearance: float,
+    success: bool,
+    termination_reason: str,
+) -> dict[str, Any]:
+    """Build a schema-like benchmark episode fixture."""
+    return {
+        "version": "v1",
+        "episode_id": episode_id,
+        "scenario_id": f"{scenario_family}_dense_004",
+        "seed": seed,
+        "algo": algo,
+        "scenario_params": {
+            "algo": algo,
+            "scenario_family": scenario_family,
+            "density": 8,
+            "spawn": {"pedestrian_count": 10},
+        },
+        "algorithm_metadata": {
+            "algorithm": algo,
+            "status": "ok",
+            "planner_kinematics": {"execution_mode": "native"},
+        },
+        "metrics": {
+            "min_ttc": min_ttc,
+            "clearance": clearance,
+            "success": success,
+            "collisions": 0.0 if success else 1.0,
+            "pedestrian_impact": {
+                "canonical_reductions": {"accel_delta_mean": 0.1 if success else 0.4}
+            },
+        },
+        "termination_reason": termination_reason,
+        "outcome": {"collision_event": not success},
+        "integrity": {"seed": seed},
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    """Write benchmark records as JSONL."""
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_export_parquet_writes_stable_tables_and_metadata(tmp_path: Path) -> None:
+    """Exporter should normalize benchmark JSONL into fixed analytics tables."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    _write_jsonl(
+        episodes_path,
+        [
+            _episode(
+                episode_id="ep-a",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=11,
+                min_ttc=1.25,
+                clearance=0.42,
+                success=True,
+                termination_reason="goal_reached",
+            ),
+            _episode(
+                episode_id="ep-b",
+                algo="planner_b",
+                scenario_family="crossing",
+                seed=12,
+                min_ttc=0.2,
+                clearance=0.05,
+                success=False,
+                termination_reason="collision",
+            ),
+        ],
+    )
+
+    result = export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
+
+    assert result.record_count == 2
+    assert result.output_dir == tmp_path / "analytics"
+    assert (result.output_dir / "episodes.parquet").is_file()
+    assert (result.output_dir / "metrics.parquet").is_file()
+    assert (result.output_dir / "scenario_params.parquet").is_file()
+    assert (result.output_dir / "algorithm_metadata.parquet").is_file()
+    assert (result.output_dir / "duckdb_examples.sql").is_file()
+
+    episodes = pq.read_table(result.output_dir / "episodes.parquet").to_pylist()
+    assert [row["episode_id"] for row in episodes] == ["ep-a", "ep-b"]
+    assert episodes[0]["algo"] == "planner_a"
+    assert episodes[0]["scenario_family"] == "crossing"
+
+    metrics = pq.read_table(result.output_dir / "metrics.parquet").to_pylist()
+    metric_paths = {(row["episode_id"], row["metric_path"]) for row in metrics}
+    assert ("ep-a", "min_ttc") in metric_paths
+    assert ("ep-a", "pedestrian_impact.canonical_reductions.accel_delta_mean") in metric_paths
+
+    params = pq.read_table(result.output_dir / "scenario_params.parquet").to_pylist()
+    param_paths = {(row["episode_id"], row["param_path"]) for row in params}
+    assert ("ep-a", "spawn.pedestrian_count") in param_paths
+
+    metadata = json.loads((result.output_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["schema_version"] == "benchmark_parquet_export.v1"
+    assert metadata["jsonl_is_source_of_truth"] is True
+    assert metadata["record_count"] == 2
+    assert metadata["tables"]["episodes"]["rows"] == 2
+    assert metadata["source_files"][0]["sha256"]
+
+
+def test_export_parquet_refuses_to_overwrite_existing_outputs(tmp_path: Path) -> None:
+    """Existing exports should require explicit overwrite to avoid silent replacement."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    _write_jsonl(
+        episodes_path,
+        [
+            _episode(
+                episode_id="ep-a",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=11,
+                min_ttc=1.25,
+                clearance=0.42,
+                success=True,
+                termination_reason="goal_reached",
+            )
+        ],
+    )
+
+    export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "analytics")
+
+
+def test_cli_export_parquet_supports_duckdb_fixture_query(tmp_path: Path) -> None:
+    """CLI export should produce Parquet files DuckDB can query deterministically."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    _write_jsonl(
+        episodes_path,
+        [
+            _episode(
+                episode_id="ep-a",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=11,
+                min_ttc=1.25,
+                clearance=0.42,
+                success=True,
+                termination_reason="goal_reached",
+            ),
+            _episode(
+                episode_id="ep-b",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=12,
+                min_ttc=0.75,
+                clearance=0.38,
+                success=True,
+                termination_reason="goal_reached",
+            ),
+        ],
+    )
+    out_dir = tmp_path / "analytics"
+
+    assert cli_main(["export-parquet", "--in", str(episodes_path), "--out-dir", str(out_dir)]) == 0
+
+    rows = duckdb.sql(
+        f"""
+        SELECT e.algo, e.scenario_family, AVG(m.value_number) AS avg_min_ttc
+        FROM read_parquet('{out_dir / "episodes.parquet"}') AS e
+        JOIN read_parquet('{out_dir / "metrics.parquet"}') AS m USING (episode_id)
+        WHERE m.metric_path = 'min_ttc'
+        GROUP BY e.algo, e.scenario_family
+        """
+    ).fetchall()
+    assert rows == [("planner_a", "crossing", 1.0)]

--- a/uv.lock
+++ b/uv.lock
@@ -1011,6 +1011,42 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b0/d13e7e396d86c245290b3e93f692a2d27c2fe99f857aaf9205003c00c978/duckdb-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7f69164b048e498b9e9140a24343108a5ae5f17bfb3485185f55fdf9b1aa924d", size = 30020978, upload-time = "2026-04-13T11:28:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7b/ae1ec7f516394aa55501d1949af1f731be8d9d7433f0acc3f4632a0ba484/duckdb-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81fc4fbf0b5e25840b39ba2a10b78c6953c0314d5d0434191e7898f34ab1bba3", size = 15947821, upload-time = "2026-04-13T11:28:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a5/cae0105e01a85f85ead61723bb42dab14c2f8ec49f91e67a2372c02574a4/duckdb-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56d38b3c4e0ef2abb58898d0fd423933999ed535c45e75e9d9f72e1d5fed69b8", size = 14201656, upload-time = "2026-04-13T11:28:58.316Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/46c57e8813ac33762bddc9545610ed648751c5b6a379abf2dc6035505ce4/duckdb-1.5.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:376856066c65ccd55fcb3a380bbe33a71ce089fc4623d229ffc6e82251afdb6d", size = 19285181, upload-time = "2026-04-13T11:29:01.041Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/67694010693ec8c8c975e6991f48ef886d35ecbdaa2f287234882a403c21/duckdb-1.5.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c69907354ffee94ba8cf782daf0480dab7557f21ce27fffa6c0ea8f74ed4b8e2", size = 21394852, upload-time = "2026-04-13T11:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9f/2b1618c5a93949a70dcf105293db7e27bb2b2cc4aeb1ff46b806f430ec81/duckdb-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:d9b4f5430bf4f05d4c0dc4c55c75def3a5af4be0343be20fa2bfc577343fbfc9", size = 13095526, upload-time = "2026-04-13T11:29:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/cb39e0d94a32f5333e819112fd01439a31f541f9c56a31b66f9bd209704b/duckdb-1.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:2323c1195c10fb2bb982fc0218c730b43d1b92a355d61e68e3c5f3ac9d44c34f", size = 13946215, upload-time = "2026-04-13T11:29:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4761,6 +4797,10 @@ analysis = [
     { name = "pandas" },
     { name = "seaborn" },
 ]
+analytics = [
+    { name = "duckdb" },
+    { name = "pyarrow" },
+]
 dev = [
     { name = "black" },
     { name = "jupyter" },
@@ -4813,6 +4853,7 @@ imitation = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "cython", marker = "extra == 'orca'", specifier = ">=3.0.0" },
+    { name = "duckdb", marker = "extra == 'analytics'", specifier = ">=1.4.0" },
     { name = "geopandas", specifier = ">=0.14" },
     { name = "gymnasium", specifier = ">=0.29,<1.2" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -4834,6 +4875,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.4.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "psutil", specifier = ">=6.1.0" },
+    { name = "pyarrow", marker = "extra == 'analytics'", specifier = ">=23.0.0" },
     { name = "pygame", specifier = ">=2.6.1" },
     { name = "pyproj", specifier = ">=3.6" },
     { name = "pyrvo2", marker = "extra == 'orca'", directory = "third_party/python-rvo2" },
@@ -4867,7 +4909,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.67.0" },
     { name = "wandb", specifier = ">=0.18.7" },
 ]
-provides-extras = ["dev", "gpu", "docs", "rllib", "progress", "analysis", "viz", "sacadrl", "orca", "socnav"]
+provides-extras = ["dev", "gpu", "docs", "rllib", "progress", "analysis", "analytics", "viz", "sacadrl", "orca", "socnav"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
Adds a Parquet-first analytics export path for benchmark episode JSONL files, with fixed episode rows, long-form metric/scenario/algorithm metadata tables, export provenance metadata, and DuckDB example queries.

## Linked Issues
- Closes #1238

## What Changed
- Added `robot_sf.benchmark.parquet_export.export_episodes_jsonl_to_parquet`.
- Added `robot_sf_bench export-parquet --in <episodes.jsonl> --out-dir <dir> [--overwrite]`.
- Declared an optional `analytics` extra for `duckdb` and `pyarrow`.
- Documented the JSONL-source-of-truth boundary and example DuckDB query in `docs/benchmark.md`.
- Added fixture tests that read generated Parquet files and run a deterministic DuckDB query.

## Why It Matters
- Added value: benchmark campaign analysis can use columnar files and SQL without replacing canonical JSONL artifacts.
- Expected impact: easier planner/scenario-family comparisons, failure mining, and row-count/provenance auditing.
- Why this is worth merging now: the exporter is additive and gives upcoming benchmark governance work a stable analytics substrate.

## Validation / Proof
- `uv sync --all-extras`
- Red proof: `./.venv/bin/python -m pytest tests/benchmark/test_parquet_export.py -q` initially failed because `duckdb` was not declared/installed.
- `./.venv/bin/python -m pytest tests/benchmark/test_parquet_export.py -q` -> `3 passed in 16.04s`.
- `./.venv/bin/robot_sf_bench export-parquet --in output/tmp/parquet_export_smoke/episodes.jsonl --out-dir output/tmp/parquet_export_smoke/parquet` -> succeeded and wrote the derived Parquet tables plus metadata/examples.
- `./.venv/bin/ruff check robot_sf/benchmark tests/benchmark` -> passed.
- `./.venv/bin/ruff format --check robot_sf/benchmark tests/benchmark` -> passed.
- `git diff --check` -> passed.
- `./.venv/bin/python -m pytest tests/benchmark -q` -> `393 passed, 1 skipped in 30.52s`.
- After syncing with `origin/main`, `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `3551 passed, 13 skipped, 3 warnings in 409.17s`; changed-file coverage warnings only (`robot_sf/benchmark/cli.py` 86.6%, `robot_sf/benchmark/parquet_export.py` 90.7%).

## Risks / Rollout
- Compatibility risks: additive CLI/API only; JSONL remains the canonical artifact.
- Failure modes: export fails closed when output files already exist unless `--overwrite` is passed; missing optional analytics dependencies produce an actionable error.
- Rollback or fallback plan: remove the `export-parquet` subcommand and optional `analytics` extra; existing benchmark JSONL workflows are unaffected.

## Docs / Provenance
- Updated docs: `docs/benchmark.md`.
- Relevant design or provenance notes: `metadata.json` records source JSONL path hashes, record count, row counts per table, and the export schema version.
- Artifact persistence decision: ignored `output/coverage/` and `output/tmp/parquet_export_smoke/` are disposable local validation artifacts; no generated output is required as a durable dependency.

## Follow-Up Issues
- Deferred work: none opened.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check the long-form key/value layout in `metrics.parquet`, `scenario_params.parquet`, and `algorithm_metadata.parquet`; it intentionally avoids unstable wide schemas while keeping DuckDB pivot queries explicit.
