### PR TITLE
feat: define scenario_contract.v1 governance schema

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -35,6 +35,16 @@ metadata:
       force_q95: null
 ```
 
+## Scenario Contracts
+
+Versioned scenario-intent contracts live under `contracts/`. `scenario_contract.v1` captures
+authored assumptions such as ODD, actors, invariants, observables, termination semantics, and
+provenance before a scenario is executed. It is a governance layer, not a benchmark result and not a
+replacement for `scenario_cert.v1` feasibility checks.
+
+See `docs/scenario_contracts.md` for the schema, loader API, and the boundary between intent
+contracts, certification, and executed benchmark evidence.
+
 ## Manifest (include) files
 
 Manifest files use `includes` (or `include` / `scenario_files`) to combine

--- a/configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
+++ b/configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
@@ -1,0 +1,97 @@
+# Governance contract fixture for one existing station-platform scenario.
+#
+# This file intentionally describes authored intent only. It does not certify the
+# scenario as benchmark-ready and does not change benchmark runner behavior.
+
+contracts:
+  - schema_version: scenario_contract.v1
+    id: station_platform_waiting_passengers_medium_contract
+    scenario_ref:
+      source: configs/scenarios/sets/station_platform_candidate_pack_issue736.yaml
+      scenario_name: station_platform_waiting_passengers_medium
+      scenario_family: station_platform
+    odd:
+      environment_type: indoor_public_transit
+      map_family: classic_station_platform
+      density: medium
+      flow: bidirectional_with_dwell
+      assumptions:
+        - Pedestrian flow is synthetic and map-local, not calibrated to a real transit station.
+        - Waiting behavior is represented by authored pedestrian pauses near access points.
+        - The scenario remains exploratory until certification and benchmark evidence are produced.
+    actors:
+      - id: robot
+        kind: robot
+        count:
+          minimum: 1
+          maximum: 1
+        motion_model: configured_robot_policy
+        assumptions:
+          - Robot kinematics come from the scenario runner configuration.
+          - The contract does not choose or promote a planner.
+      - id: waiting_passengers
+        kind: pedestrian
+        count:
+          minimum: 2
+          maximum: 2
+        motion_model: authored_waypoints_with_waits
+        assumptions:
+          - Waiting passengers follow deterministic waypoint and dwell annotations in the scenario YAML.
+          - The actor model is intended to probe platform dwell interactions, not crowd realism.
+    invariants:
+      - id: station_platform_source_surface
+        scope: authoring
+        severity: required
+        description: The contract must keep pointing at the maintained station-platform scenario YAML entry.
+      - id: no_benchmark_claim_without_cert
+        scope: pre_run
+        severity: required
+        description: Benchmark claims require scenario_cert.v1 and run evidence in addition to this contract.
+    observables:
+      - id: collision_rate
+        metric: collision_rate
+        source: benchmark_episode_metrics
+        required: true
+        interpretation: Detects whether dwell interactions introduce unsafe contacts.
+      - id: comfort_exposure_s
+        metric: comfort_exposure_s
+        source: benchmark_episode_metrics
+        required: true
+        interpretation: Interprets platform waiting behavior through comfort exposure rather than success alone.
+      - id: time_to_goal_s
+        metric: time_to_goal_s
+        source: benchmark_episode_metrics
+        required: false
+        interpretation: Helps distinguish dwell-induced slowdowns from hard failures.
+    termination_conditions:
+      - id: route_success
+        reason: success
+        source: benchmark_runner
+        description: The robot reaches the configured route goal under the benchmark runner.
+      - id: safety_collision
+        reason: collision
+        source: benchmark_runner
+        description: A robot collision outcome is treated as a safety failure, not a scenario certification failure.
+      - id: horizon_timeout
+        reason: max_steps
+        source: benchmark_runner
+        description: Max-step termination is an execution outcome and must be interpreted with planner evidence.
+    certification:
+      schema_version: scenario_cert.v1
+      required_before_benchmark_claim: true
+      expected_eligibility: eligible
+      notes: scenario_contract.v1 records intent; scenario_cert.v1 remains the feasibility and eligibility gate.
+    benchmark_eligibility:
+      intended_use: exploratory
+      requires_certification: true
+      claim_boundary: Use this contract to audit scenario intent only; do not cite it as benchmark evidence.
+      eligibility_hooks:
+        - scenario_cert.v1 must classify the scenario as eligible before headline benchmark use.
+        - Runtime benchmark evidence must be reported separately with planner, seed, and metric provenance.
+    provenance:
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/736
+      authored_by: robot_sf_ll7
+      source_files:
+        - configs/scenarios/sets/station_platform_candidate_pack_issue736.yaml
+        - maps/svg_maps/classic_station_platform.svg
+      notes: Fixture chosen because the scenario YAML already carries ad hoc intent metadata.

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 ### Benchmarking & Metrics
 
 * **[Benchmark Spec (Classic Interactions)](./benchmark_spec.md)** - Scenario split + seeds, baseline categories, reproducible commands, and metric caveats
+* **[Scenario Contracts](./scenario_contracts.md)** - `scenario_contract.v1` schema, typed loader, fixture, and boundary between authored intent, certification, and benchmark evidence
 * **[Scenario Certification](./scenario_certification.md)** - `scenario_cert.v1` schema, CLI, labels, and fail-closed benchmark eligibility rules
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
 * **[Issue #1073 Robot SF Empirical-Expansion Gate](./context/issue_1073_empirical_expansion_gate_2026_06_08.md)** - June 8 checkpoint rule for deciding whether Robot SF can move beyond dissertation-floor examples into bounded empirical expansion
@@ -362,6 +363,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * [**Single Pedestrians**](./single_pedestrians.md) - Define individual pedestrians with goals or trajectories in SVG/JSON/code
 * [**Multi-Pedestrian Example**](../examples/example_multi_pedestrian.py) - Demonstrates multiple single pedestrians (goal, trajectory, static) in one scenario
 * [**Scenario Specification Checklist**](./scenario_spec_checklist.md) - Authoring checklist for per-scenario/archetype/manifest files
+* [**Scenario Contracts**](./scenario_contracts.md) - Validate authored scenario-intent contracts before certification or benchmark execution
 * [**Scenario Certification**](./scenario_certification.md) - Generate machine-readable validity, feasibility, stress-only, and hard-but-solvable certificates for scenario manifests
 * **Classic Interaction Scenario Pack** (configs/scenarios/classic_interactions.yaml) – Canonical crossing, head‑on, overtaking, bottleneck, doorway, merging, T‑intersection, station-platform, and group crossing archetypes for benchmark coverage. See also [Issue #549 station-platform map rationale](./context/issue_549_station_platform_map.md).
 * **[Francis 2023 Scenario Pack](../maps/svg_maps/francis2023/readme.md)** - SVG maps +

--- a/docs/scenario_certification.md
+++ b/docs/scenario_certification.md
@@ -7,6 +7,11 @@ scenario manifests. It is intentionally conservative: malformed scenarios, missi
 kinodynamic violations, and clearly blocked dynamic setups are excluded before they can support
 benchmark claims.
 
+For authored scenario intent before execution, use
+[`scenario_contract.v1`](./scenario_contracts.md). A scenario contract records ODD assumptions,
+actor models, invariants, observables, termination semantics, and provenance; it does not replace
+the fail-closed feasibility and eligibility checks described here.
+
 ## Contract
 
 The public schema lives at
@@ -106,6 +111,9 @@ Programmatic tests can call `certify_map_definition(...)` directly with a `MapDe
 not generate adversarial scenarios, promote stress cases into headline benchmarks, or prove that a
 planner will solve a valid scenario. It only certifies that the scenario geometry and currently
 exposed robot/dynamic constraints are not malformed or impossible under the v1 checks.
+
+`scenario_contract.v1` may explain what a scenario is meant to exercise, but a valid intent
+contract does not make an excluded or uncertified scenario benchmark evidence.
 
 For h500 interpretation, layer planner-failure classification on top of certification rather than
 using h500 failures as certification evidence by themselves. Excluded or unresolved-certification

--- a/docs/scenario_contracts.md
+++ b/docs/scenario_contracts.md
@@ -1,0 +1,70 @@
+# Scenario Contracts
+
+[← Back to Documentation Index](./README.md)
+
+`scenario_contract.v1` is the machine-readable governance surface for authored scenario intent.
+It records what a scenario is meant to represent before execution: operating-design-domain
+assumptions, actor models, invariants, observables, termination semantics, provenance, and the
+eligibility hooks that must be satisfied before benchmark claims.
+
+It is deliberately separate from `scenario_cert.v1`.
+
+## Contract Boundary
+
+Use the two scenario surfaces for different jobs:
+
+- `scenario_contract.v1`: authored intent and reviewable assumptions.
+- `scenario_cert.v1`: fail-closed feasibility and benchmark eligibility classification.
+- benchmark episode records and reports: executed evidence for planner behavior, metrics, seeds,
+  and outcomes.
+
+A valid scenario contract is not proof that a scenario is feasible or benchmark-ready. Benchmark
+claims still require certification plus run evidence.
+
+## Public Files
+
+- Schema:
+  [`robot_sf/benchmark/schemas/scenario_contract.v1.json`](../robot_sf/benchmark/schemas/scenario_contract.v1.json)
+- Loader:
+  [`robot_sf/benchmark/scenario_contract.py`](../robot_sf/benchmark/scenario_contract.py)
+- Fixture:
+  [`configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml`](../configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml)
+
+The fixture uses the station-platform candidate pack because that YAML already carried exploratory
+intent metadata such as density, flow, coverage probes, and evaluation scope. The contract fixture
+normalizes one representative entry without changing any scenario runner behavior.
+
+## Library API
+
+```python
+from pathlib import Path
+
+from robot_sf.benchmark.scenario_contract import (
+    load_scenario_contracts,
+    validate_scenario_contract_references,
+)
+
+contracts = load_scenario_contracts(
+    Path("configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml")
+)
+errors = validate_scenario_contract_references(contracts[0], repo_root=Path("."))
+```
+
+`load_scenario_contracts(...)` validates JSON Schema first and raises
+`ScenarioContractValidationError` with JSON-pointer-style paths for invalid actor, invariant,
+observable, termination, or provenance fields. Reference validation is explicit so tools can decide
+whether to require local scenario YAML availability.
+
+## Authoring Guidance
+
+Keep v1 contracts narrow:
+
+- use closed enums for actor kind, termination reason, intended use, and ODD class,
+- put future or experimental vocabulary under `extensions` only when it cannot fit the v1 fields,
+- point `scenario_ref.source` at a maintained scenario YAML file,
+- set `certification.required_before_benchmark_claim: true` unless the file is a test fixture,
+- keep `benchmark_eligibility.claim_boundary` conservative and specific.
+
+Do not use a contract to promote a scenario into a paper-facing matrix. Promotion requires
+`scenario_cert.v1` eligibility, explicit scenario-set inclusion, seed policy, and benchmark run
+evidence.

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -158,6 +159,7 @@ class ScenarioContractValidationError(ValueError):
         super().__init__(prefix + "; ".join(errors))
 
 
+@lru_cache(maxsize=1)
 def load_scenario_contract_schema() -> dict[str, Any]:
     """Load the public ``scenario_contract.v1`` JSON schema.
 

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -1,0 +1,445 @@
+"""Typed loader for ``scenario_contract.v1`` governance payloads."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+CONTRACT_SCHEMA_VERSION = "scenario_contract.v1"
+CERT_SCHEMA_VERSION = "scenario_cert.v1"
+SCENARIO_CONTRACT_SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_contract.v1.json"
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRef:
+    """Reference from a governance contract to an authored scenario surface."""
+
+    source: str
+    scenario_name: str
+    scenario_family: str
+
+
+@dataclass(frozen=True, slots=True)
+class OperatingDesignDomain:
+    """Scenario operating-design-domain assumptions."""
+
+    environment_type: str
+    map_family: str
+    density: str
+    flow: str
+    assumptions: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class CountRange:
+    """Inclusive actor count range."""
+
+    minimum: int
+    maximum: int
+
+
+@dataclass(frozen=True, slots=True)
+class ActorContract:
+    """Authored actor assumption in a scenario contract."""
+
+    id: str
+    kind: str
+    count: CountRange
+    motion_model: str
+    assumptions: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantContract:
+    """Invariant that must hold for the authored scenario intent."""
+
+    id: str
+    scope: str
+    severity: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class ObservableContract:
+    """Observable metric or signal expected when the scenario is executed."""
+
+    id: str
+    metric: str
+    source: str
+    required: bool
+    interpretation: str
+
+
+@dataclass(frozen=True, slots=True)
+class TerminationConditionContract:
+    """Termination semantics the scenario contract expects consumers to interpret."""
+
+    id: str
+    reason: str
+    source: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioCertificationCompatibility:
+    """Compatibility hook connecting intent contracts to ``scenario_cert.v1``."""
+
+    schema_version: str
+    required_before_benchmark_claim: bool
+    expected_eligibility: str
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkEligibilityHooks:
+    """Benchmark-use guardrails attached to a scenario contract."""
+
+    intended_use: str
+    requires_certification: bool
+    claim_boundary: str
+    eligibility_hooks: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceContract:
+    """Provenance for an authored scenario contract."""
+
+    source_issue: str
+    authored_by: str
+    source_files: list[str]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioContract:
+    """Typed ``scenario_contract.v1`` payload."""
+
+    schema_version: str
+    id: str
+    scenario_ref: ScenarioRef
+    odd: OperatingDesignDomain
+    actors: list[ActorContract]
+    invariants: list[InvariantContract]
+    observables: list[ObservableContract]
+    termination_conditions: list[TerminationConditionContract]
+    certification: ScenarioCertificationCompatibility
+    benchmark_eligibility: BenchmarkEligibilityHooks
+    provenance: ProvenanceContract
+    extensions: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the contract to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation suitable for JSON Schema validation.
+        """
+
+        payload = asdict(self)
+        if not payload["extensions"]:
+            payload.pop("extensions")
+        return payload
+
+
+class ScenarioContractValidationError(ValueError):
+    """Raised when a scenario contract fails schema or reference validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+def load_scenario_contract_schema() -> dict[str, Any]:
+    """Load the public ``scenario_contract.v1`` JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(SCENARIO_CONTRACT_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_scenario_contracts(path: Path) -> list[ScenarioContract]:
+    """Load one or more scenario contracts from YAML or JSON.
+
+    Accepted shapes are a single contract mapping, a list of contract mappings, or
+    ``{"contracts": [...]}``.
+
+    Returns:
+        Typed scenario contracts in file order.
+    """
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    payloads = _contract_payloads(raw, source=path)
+    return [
+        scenario_contract_from_dict(payload, source=f"{path.as_posix()}[{index}]")
+        for index, payload in enumerate(payloads)
+    ]
+
+
+def scenario_contract_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> ScenarioContract:
+    """Validate and convert a mapping into a typed scenario contract.
+
+    Returns:
+        Typed scenario contract.
+    """
+
+    errors = _schema_validation_errors(payload)
+    errors.extend(_semantic_validation_errors(payload))
+    if errors:
+        raise ScenarioContractValidationError(errors, source=source)
+
+    return _contract_from_payload(payload)
+
+
+def validate_scenario_contract_references(
+    contract: ScenarioContract,
+    *,
+    repo_root: Path = Path("."),
+) -> list[str]:
+    """Validate that a contract references an existing scenario YAML entry.
+
+    Returns:
+        List of reference errors. An empty list means the references resolved.
+    """
+
+    errors: list[str] = []
+    scenario_path = repo_root / contract.scenario_ref.source
+    if not scenario_path.exists():
+        return [f"scenario_ref.source '{contract.scenario_ref.source}' does not exist"]
+
+    from robot_sf.training.scenario_loader import load_scenarios  # noqa: PLC0415
+
+    try:
+        scenarios = load_scenarios(scenario_path)
+    except Exception as exc:
+        return [f"scenario_ref.source '{contract.scenario_ref.source}' could not be loaded: {exc}"]
+
+    scenario_names = set(_scenario_names_from_payload(scenarios))
+    if contract.scenario_ref.scenario_name not in scenario_names:
+        errors.append(
+            f"scenario_ref.scenario_name '{contract.scenario_ref.scenario_name}' was not found in "
+            f"{contract.scenario_ref.source}",
+        )
+    return errors
+
+
+def _contract_payloads(raw: Any, *, source: Path) -> list[Mapping[str, Any]]:
+    """Normalize supported file shapes into a list of contract mappings.
+
+    Returns:
+        Contract payload mappings in file order.
+    """
+
+    if isinstance(raw, Mapping) and "contracts" in raw:
+        raw_contracts = raw["contracts"]
+    else:
+        raw_contracts = raw
+
+    if isinstance(raw_contracts, Mapping):
+        return [raw_contracts]
+    if isinstance(raw_contracts, list) and all(isinstance(item, Mapping) for item in raw_contracts):
+        return raw_contracts
+    raise ScenarioContractValidationError(
+        ["expected a contract mapping, a list of mappings, or a top-level 'contracts' list"],
+        source=source,
+    )
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors for one contract payload."""
+
+    validator = Draft202012Validator(load_scenario_contract_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return cross-field validation errors not expressible in draft-2020-12 JSON Schema."""
+
+    errors: list[str] = []
+    actors = payload.get("actors")
+    if isinstance(actors, list):
+        for index, actor in enumerate(actors):
+            if not isinstance(actor, Mapping):
+                continue
+            count = actor.get("count")
+            if not isinstance(count, Mapping):
+                continue
+            minimum = count.get("minimum")
+            maximum = count.get("maximum")
+            if isinstance(minimum, int) and isinstance(maximum, int) and maximum < minimum:
+                errors.append(
+                    f"/actors/{index}/count: maximum {maximum} is smaller than minimum {minimum}",
+                )
+    return errors
+
+
+def _contract_from_payload(payload: Mapping[str, Any]) -> ScenarioContract:
+    """Build a typed contract from a schema-valid payload.
+
+    Returns:
+        Typed scenario contract.
+    """
+
+    scenario_ref = payload["scenario_ref"]
+    odd = payload["odd"]
+    certification = payload["certification"]
+    benchmark_eligibility = payload["benchmark_eligibility"]
+    provenance = payload["provenance"]
+    return ScenarioContract(
+        schema_version=str(payload["schema_version"]),
+        id=str(payload["id"]),
+        scenario_ref=ScenarioRef(
+            source=str(scenario_ref["source"]),
+            scenario_name=str(scenario_ref["scenario_name"]),
+            scenario_family=str(scenario_ref["scenario_family"]),
+        ),
+        odd=OperatingDesignDomain(
+            environment_type=str(odd["environment_type"]),
+            map_family=str(odd["map_family"]),
+            density=str(odd["density"]),
+            flow=str(odd["flow"]),
+            assumptions=list(odd["assumptions"]),
+        ),
+        actors=[_actor_from_payload(actor) for actor in payload["actors"]],
+        invariants=[
+            InvariantContract(
+                id=str(invariant["id"]),
+                scope=str(invariant["scope"]),
+                severity=str(invariant["severity"]),
+                description=str(invariant["description"]),
+            )
+            for invariant in payload["invariants"]
+        ],
+        observables=[
+            ObservableContract(
+                id=str(observable["id"]),
+                metric=str(observable["metric"]),
+                source=str(observable["source"]),
+                required=bool(observable["required"]),
+                interpretation=str(observable["interpretation"]),
+            )
+            for observable in payload["observables"]
+        ],
+        termination_conditions=[
+            TerminationConditionContract(
+                id=str(condition["id"]),
+                reason=str(condition["reason"]),
+                source=str(condition["source"]),
+                description=str(condition["description"]),
+            )
+            for condition in payload["termination_conditions"]
+        ],
+        certification=ScenarioCertificationCompatibility(
+            schema_version=str(certification["schema_version"]),
+            required_before_benchmark_claim=bool(certification["required_before_benchmark_claim"]),
+            expected_eligibility=str(certification["expected_eligibility"]),
+            notes=str(certification["notes"]),
+        ),
+        benchmark_eligibility=BenchmarkEligibilityHooks(
+            intended_use=str(benchmark_eligibility["intended_use"]),
+            requires_certification=bool(benchmark_eligibility["requires_certification"]),
+            claim_boundary=str(benchmark_eligibility["claim_boundary"]),
+            eligibility_hooks=list(benchmark_eligibility["eligibility_hooks"]),
+        ),
+        provenance=ProvenanceContract(
+            source_issue=str(provenance["source_issue"]),
+            authored_by=str(provenance["authored_by"]),
+            source_files=list(provenance["source_files"]),
+            notes=str(provenance["notes"]),
+        ),
+        extensions=dict(payload.get("extensions", {})),
+    )
+
+
+def _actor_from_payload(actor: Mapping[str, Any]) -> ActorContract:
+    """Build an actor contract from a schema-valid payload.
+
+    Returns:
+        Typed actor contract.
+    """
+
+    count = actor["count"]
+    return ActorContract(
+        id=str(actor["id"]),
+        kind=str(actor["kind"]),
+        count=CountRange(minimum=int(count["minimum"]), maximum=int(count["maximum"])),
+        motion_model=str(actor["motion_model"]),
+        assumptions=list(actor["assumptions"]),
+    )
+
+
+def _scenario_names_from_payload(raw: Any) -> list[str]:
+    """Extract direct scenario names from a scenario YAML payload.
+
+    Returns:
+        Scenario names declared directly in the payload.
+    """
+
+    scenarios = raw.get("scenarios") if isinstance(raw, Mapping) else raw
+    if not isinstance(scenarios, list):
+        return []
+
+    names: list[str] = []
+    for scenario in scenarios:
+        if not isinstance(scenario, Mapping):
+            continue
+        name = scenario.get("name") or scenario.get("id") or scenario.get("scenario_id")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def _json_pointer(path_elems: Iterable[Any]) -> str:
+    """Render a validation error path as an RFC6901-style JSON pointer.
+
+    Returns:
+        JSON pointer string, or an empty string for the root path.
+    """
+
+    parts: list[str] = []
+    for part in path_elems:
+        if isinstance(part, int):
+            parts.append(str(part))
+        else:
+            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
+    return "/" + "/".join(parts) if parts else ""
+
+
+__all__ = [
+    "CERT_SCHEMA_VERSION",
+    "CONTRACT_SCHEMA_VERSION",
+    "SCENARIO_CONTRACT_SCHEMA_FILE",
+    "ActorContract",
+    "BenchmarkEligibilityHooks",
+    "CountRange",
+    "InvariantContract",
+    "ObservableContract",
+    "OperatingDesignDomain",
+    "ProvenanceContract",
+    "ScenarioCertificationCompatibility",
+    "ScenarioContract",
+    "ScenarioContractValidationError",
+    "ScenarioRef",
+    "TerminationConditionContract",
+    "load_scenario_contract_schema",
+    "load_scenario_contracts",
+    "scenario_contract_from_dict",
+    "validate_scenario_contract_references",
+]

--- a/robot_sf/benchmark/schemas/scenario_contract.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_contract.v1.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/scenario_contract.v1.json",
+  "title": "RobotSF Scenario Contract (v1)",
+  "description": "Authored scenario-intent governance contract. This is not a runtime benchmark result or a scenario_cert.v1 feasibility certificate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scenario_ref",
+    "odd",
+    "actors",
+    "invariants",
+    "observables",
+    "termination_conditions",
+    "certification",
+    "benchmark_eligibility",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "scenario_contract.v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$"
+    },
+    "scenario_ref": {
+      "$ref": "#/$defs/scenario_ref"
+    },
+    "odd": {
+      "$ref": "#/$defs/operating_design_domain"
+    },
+    "actors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/actor"
+      }
+    },
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/invariant"
+      }
+    },
+    "observables": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/observable"
+      }
+    },
+    "termination_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/termination_condition"
+      }
+    },
+    "certification": {
+      "$ref": "#/$defs/certification"
+    },
+    "benchmark_eligibility": {
+      "$ref": "#/$defs/benchmark_eligibility"
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "string_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "scenario_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "scenario_name",
+        "scenario_family"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scenario_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scenario_family": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "operating_design_domain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "environment_type",
+        "map_family",
+        "density",
+        "flow",
+        "assumptions"
+      ],
+      "properties": {
+        "environment_type": {
+          "type": "string",
+          "enum": [
+            "indoor_public_transit",
+            "indoor_corridor",
+            "indoor_room",
+            "outdoor_walkway",
+            "synthetic_atomic",
+            "mixed",
+            "unspecified"
+          ]
+        },
+        "map_family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "density": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "mixed",
+            "stress",
+            "unspecified"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "minLength": 1
+        },
+        "assumptions": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "count_range": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimum",
+        "maximum"
+      ],
+      "properties": {
+        "minimum": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maximum": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "count",
+        "motion_model",
+        "assumptions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "robot",
+            "pedestrian",
+            "pedestrian_group",
+            "static_obstacle",
+            "semantic_region"
+          ]
+        },
+        "count": {
+          "$ref": "#/$defs/count_range"
+        },
+        "motion_model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "assumptions": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "invariant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "scope",
+        "severity",
+        "description"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "authoring",
+            "pre_run",
+            "runtime",
+            "post_run"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "required",
+            "advisory"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "observable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "metric",
+        "source",
+        "required",
+        "interpretation"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "interpretation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "termination_condition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "reason",
+        "source",
+        "description"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "reason": {
+          "type": "string",
+          "enum": [
+            "success",
+            "collision",
+            "max_steps",
+            "truncated",
+            "terminated",
+            "excluded",
+            "unknown"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "certification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "required_before_benchmark_claim",
+        "expected_eligibility",
+        "notes"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "scenario_cert.v1"
+        },
+        "required_before_benchmark_claim": {
+          "type": "boolean"
+        },
+        "expected_eligibility": {
+          "type": "string",
+          "enum": [
+            "eligible",
+            "stress_only",
+            "excluded",
+            "unknown"
+          ]
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "benchmark_eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intended_use",
+        "requires_certification",
+        "claim_boundary",
+        "eligibility_hooks"
+      ],
+      "properties": {
+        "intended_use": {
+          "type": "string",
+          "enum": [
+            "fixture",
+            "exploratory",
+            "stress",
+            "paper_candidate",
+            "paper_baseline"
+          ]
+        },
+        "requires_certification": {
+          "type": "boolean"
+        },
+        "claim_boundary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "eligibility_hooks": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_issue",
+        "authored_by",
+        "source_files",
+        "notes"
+      ],
+      "properties": {
+        "source_issue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authored_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_files": {
+          "$ref": "#/$defs/string_list"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/tests/benchmark/test_scenario_contract.py
+++ b/tests/benchmark/test_scenario_contract.py
@@ -1,0 +1,105 @@
+"""Tests for the ``scenario_contract.v1`` governance schema."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.benchmark.scenario_contract import (
+    CONTRACT_SCHEMA_VERSION,
+    ScenarioContractValidationError,
+    load_scenario_contract_schema,
+    load_scenario_contracts,
+    scenario_contract_from_dict,
+    validate_scenario_contract_references,
+)
+
+FIXTURE_PATH = Path(
+    "configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml"
+)
+
+
+def test_load_fixture_contract_as_typed_governance_payload() -> None:
+    """Representative contracts should validate independently of benchmark execution."""
+
+    contracts = load_scenario_contracts(FIXTURE_PATH)
+
+    assert len(contracts) == 1
+    contract = contracts[0]
+    assert contract.schema_version == CONTRACT_SCHEMA_VERSION
+    assert contract.id == "station_platform_waiting_passengers_medium_contract"
+    assert (
+        contract.scenario_ref.source
+        == "configs/scenarios/sets/station_platform_candidate_pack_issue736.yaml"
+    )
+    assert contract.scenario_ref.scenario_name == "station_platform_waiting_passengers_medium"
+    assert contract.certification.schema_version == "scenario_cert.v1"
+    assert contract.certification.required_before_benchmark_claim is True
+    assert contract.benchmark_eligibility.intended_use == "exploratory"
+    assert contract.observables[0].metric == "collision_rate"
+
+    jsonschema.validate(contract.to_dict(), load_scenario_contract_schema())
+
+
+def test_invalid_contract_sections_fail_closed_with_json_paths() -> None:
+    """Invalid actor, invariant, observable, and termination definitions fail closed."""
+
+    payload = load_scenario_contracts(FIXTURE_PATH)[0].to_dict()
+    invalid_cases = [
+        (
+            lambda candidate: candidate["actors"][0].__setitem__(
+                "kind",
+                "unsupported_actor_kind",
+            ),
+            "/actors/0/kind",
+            "unsupported_actor_kind",
+        ),
+        (
+            lambda candidate: candidate["invariants"][0].pop("description"),
+            "/invariants/0",
+            "description",
+        ),
+        (
+            lambda candidate: candidate["observables"][0].__setitem__("required", "yes"),
+            "/observables/0/required",
+            "'yes' is not of type 'boolean'",
+        ),
+        (
+            lambda candidate: candidate["termination_conditions"][0].__setitem__(
+                "reason",
+                "timeout",
+            ),
+            "/termination_conditions/0/reason",
+            "timeout",
+        ),
+    ]
+
+    for mutate, expected_path, expected_fragment in invalid_cases:
+        candidate = deepcopy(payload)
+        mutate(candidate)
+        with pytest.raises(ScenarioContractValidationError) as exc_info:
+            scenario_contract_from_dict(candidate, source=FIXTURE_PATH)
+        message = str(exc_info.value)
+        assert expected_path in message
+        assert expected_fragment in message
+
+
+def test_fixture_contract_resolves_existing_scenario_surface() -> None:
+    """Contract fixtures should point at existing scenario YAML entries, not synthetic names."""
+
+    contract = load_scenario_contracts(FIXTURE_PATH)[0]
+
+    assert validate_scenario_contract_references(contract, repo_root=Path(".")) == []
+
+    missing = replace(
+        contract,
+        scenario_ref=replace(contract.scenario_ref, scenario_name="missing_station_platform_case"),
+    )
+    assert validate_scenario_contract_references(missing, repo_root=Path(".")) == [
+        "scenario_ref.scenario_name 'missing_station_platform_case' was not found in "
+        "configs/scenarios/sets/station_platform_candidate_pack_issue736.yaml",
+    ]

--- a/tests/benchmark/test_scenario_contract.py
+++ b/tests/benchmark/test_scenario_contract.py
@@ -18,8 +18,12 @@ from robot_sf.benchmark.scenario_contract import (
     validate_scenario_contract_references,
 )
 
-FIXTURE_PATH = Path(
-    "configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml"
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "scenarios"
+    / "contracts"
+    / "station_platform_candidate_pack_issue736_contracts.yaml"
 )
 
 


### PR DESCRIPTION
## Summary

- Defines `scenario_contract.v1` JSON Schema and typed Python loader/validator.
- Adds a station-platform contract fixture tied to existing scenario YAML and reference validation.
- Documents the boundary between authored intent (`scenario_contract.v1`), feasibility certification (`scenario_cert.v1`), and executed benchmark evidence.

Closes #1235

## Validation

- Red proof: `rtk uv run --active pytest tests/benchmark/test_scenario_contract.py -q` initially failed with `ModuleNotFoundError: No module named robot_sf.benchmark.scenario_contract`.
- `rtk uv run --active pytest tests/benchmark/test_scenario_contract.py -q` -> 3 passed.
- `rtk uv run --active pytest tests/benchmark/test_scenario_contract.py tests/scenario_certification/test_scenario_certification_v1.py tests/test_scenario_schema.py -q` -> 22 passed.
- `rtk uv run --active python scripts/tools/certify_scenarios.py configs/scenarios/sets/atomic_navigation_validation_fixtures_v1.yaml --output output/scenario_cert/issue1235_smoke.json` -> passed.
- `rtk uv run --active ruff check robot_sf/benchmark/scenario_contract.py tests/benchmark/test_scenario_contract.py` -> passed.
- `rtk git diff --check` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after syncing `origin/main` -> 3552 passed, 12 skipped, 3 warnings; changed-file coverage: `robot_sf/benchmark/scenario_contract.py` 93.9% (warning only against 100% goal, above 80% gate).

## Artifact Handling

- Generated `output/coverage/*` and `output/scenario_cert/issue1235_smoke.json` are ignored, disposable validation artifacts and are not part of the durable source contract.