### PR TITLE
workflow: add issue forms for backlog lanes

### DIFF
--- a/.github/ISSUE_TEMPLATE/blocked-external-artifact.yml
+++ b/.github/ISSUE_TEMPLATE/blocked-external-artifact.yml
@@ -1,0 +1,107 @@
+name: Blocked external artifact or runtime
+description: Track work blocked by unavailable datasets, models, runtimes, licenses, or external stores.
+title: "blocked: "
+labels:
+  - blocked
+  - workflow
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for issues that cannot proceed until an external asset, runtime,
+        license, model, dataset, or artifact pointer is available.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / Problem
+      description: Explain the capability or validation blocked by the missing external input.
+      placeholder: What would this issue do once unblocked?
+    validations:
+      required: true
+  - type: textarea
+    id: unavailable_artifact
+    attributes:
+      label: Unavailable asset or runtime
+      description: Name the missing dataset, model, checkpoint, CARLA runtime, image, license, or store pointer.
+      placeholder: |
+        Missing item:
+        Expected source:
+        Current local status:
+    validations:
+      required: true
+  - type: textarea
+    id: unblock_condition
+    attributes:
+      label: Unblock condition
+      description: State exactly what evidence makes this issue ready.
+      placeholder: This becomes ready when...
+    validations:
+      required: true
+  - type: textarea
+    id: fail_closed_policy
+    attributes:
+      label: Fail-closed policy
+      description: Describe how tools should behave while the external input is absent.
+      placeholder: Missing runtime/artifact should produce...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      placeholder: |
+        In scope:
+        Non-goals:
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Blocker is visible.
+        - [ ] Unblock condition is testable.
+        - [ ] Fail-closed behavior is documented.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Testing
+      description: Provide the availability check, smoke command, or docs validation.
+      placeholder: rtk uv run --active ...
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_policy
+    attributes:
+      label: Artifact policy
+      description: Identify durable pointer/checksum requirements and local cache boundaries.
+      placeholder: |
+        Evidence category:
+        Durable source:
+        Local cache/output policy:
+    validations:
+      required: true
+  - type: dropdown
+    id: blocked_ready_state
+    attributes:
+      label: Blocked / ready state
+      options:
+        - blocked by external asset/runtime
+        - blocked by license decision
+        - blocked by artifact publication
+        - ready after durable pointer is recorded
+    validations:
+      required: true
+  - type: textarea
+    id: estimate_metadata
+    attributes:
+      label: Estimate metadata
+      placeholder: |
+        Effort once unblocked (h):
+        Complexity:
+        Risk:
+        Uncertainty:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,96 @@
+name: Epic
+description: Define a parent issue with explicit children, blockers, and acceptance boundaries.
+title: "epic: "
+labels:
+  - epic
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for parent issues. Keep implementation in child issues unless the epic is
+        deliberately small enough to complete as one PR.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / Problem
+      description: State the parent outcome and why it should be tracked as an epic.
+      placeholder: This epic coordinates...
+    validations:
+      required: true
+  - type: textarea
+    id: child_issues
+    attributes:
+      label: Child issues or child-creation task
+      description: Link existing child issues or state the task that will create them.
+      placeholder: |
+        Children:
+        Child-creation gap:
+    validations:
+      required: true
+  - type: dropdown
+    id: blocked_ready_state
+    attributes:
+      label: Blocked / ready state
+      options:
+        - ready for child sequencing
+        - blocked by missing child issues
+        - blocked by external runtime or artifact
+        - blocked by maintainer decision
+        - execution-only
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: Define the parent boundary and what belongs in child issues.
+      placeholder: |
+        In scope:
+        Non-goals:
+        Child issue boundaries:
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define how the epic closes.
+      placeholder: |
+        - [ ] Children are linked or explicitly deferred.
+        - [ ] Blockers have unblock conditions.
+        - [ ] Final validation and evidence boundary is recorded.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Testing
+      description: State the final validation gate or explain why children own validation.
+      placeholder: |
+        Epic-level validation:
+        Child-owned validation:
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_policy
+    attributes:
+      label: Artifact policy
+      description: Identify expected durable evidence categories across the epic.
+      placeholder: |
+        Evidence categories:
+        Durable storage:
+        Local output policy:
+    validations:
+      required: true
+  - type: textarea
+    id: estimate_metadata
+    attributes:
+      label: Estimate metadata
+      description: Capture parent-level effort and uncertainty.
+      placeholder: |
+        Parent effort (h):
+        Child effort range:
+        Complexity:
+        Uncertainty:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/execution-run.yml
+++ b/.github/ISSUE_TEMPLATE/execution-run.yml
@@ -1,0 +1,131 @@
+name: Execution run
+description: Track a long-running local, SLURM, or release execution with artifact and decision state.
+title: "execution: "
+labels:
+  - workflow
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for execution-only work such as long training, SLURM campaigns,
+        release runs, or other jobs where status and artifact handoff matter.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / Problem
+      description: State what the run is meant to prove or decide.
+      placeholder: This run should determine...
+    validations:
+      required: true
+  - type: textarea
+    id: runtime_location
+    attributes:
+      label: Runtime and execution location
+      description: Identify host, tmux/SLURM/job id, resources, and expected duration.
+      placeholder: |
+        Host/cluster:
+        Job/session id:
+        Resources:
+        Runtime estimate:
+    validations:
+      required: true
+  - type: dropdown
+    id: current_phase
+    attributes:
+      label: Current phase
+      options:
+        - planned
+        - queued
+        - running
+        - failed
+        - completed awaiting analysis
+        - analyzed
+    validations:
+      required: true
+  - type: input
+    id: owner_agent_handoff
+    attributes:
+      label: Owner / agent handoff
+      description: Name the current owner, agent, or handoff target.
+      placeholder: "@user, agent id, or handoff note"
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_root
+    attributes:
+      label: Artifact root
+      description: Record local scratch root and durable promotion target.
+      placeholder: |
+        Local output/scratch:
+        Durable evidence target:
+        Files that must not be committed:
+    validations:
+      required: true
+  - type: input
+    id: last_log_timestamp
+    attributes:
+      label: Last log timestamp
+      description: Record the latest observed log/update time with timezone.
+      placeholder: "2026-05-16 10:15 Europe/Berlin"
+    validations:
+      required: true
+  - type: textarea
+    id: next_decision
+    attributes:
+      label: Next decision point
+      description: State the next maintainer or agent decision and the evidence needed.
+      placeholder: After the run, decide whether to...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      placeholder: |
+        In scope:
+        Non-goals:
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Runtime status is recorded.
+        - [ ] Summary evidence is captured.
+        - [ ] Follow-up decision is explicit.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Testing
+      description: Include launch, monitor, analysis, and smoke commands.
+      placeholder: |
+        Launch:
+        Monitor:
+        Analyze:
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_policy
+    attributes:
+      label: Artifact policy
+      description: Classify outputs using the artifact evidence vocabulary.
+      placeholder: |
+        Evidence category:
+        output/ or scratch policy:
+        Durable pointer or summary:
+    validations:
+      required: true
+  - type: textarea
+    id: estimate_metadata
+    attributes:
+      label: Estimate metadata
+      placeholder: |
+        Effort to launch (h):
+        Runtime estimate:
+        Analysis effort (h):
+        Uncertainty:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/research-validation.yml
+++ b/.github/ISSUE_TEMPLATE/research-validation.yml
@@ -1,0 +1,105 @@
+name: Research validation
+description: Propose a bounded research or benchmark-validation question with proof expectations.
+title: "research: "
+labels:
+  - research
+  - validation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for research-validation work that needs a clear hypothesis, evidence grade,
+        artifact policy, and executable validation path before implementation starts.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / Problem
+      description: State the research question and why it matters now.
+      placeholder: What question should this issue answer?
+    validations:
+      required: true
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis
+      description: State the expected result or decision this issue should test.
+      placeholder: We expect that...
+    validations:
+      required: true
+  - type: dropdown
+    id: evidence_grade
+    attributes:
+      label: Evidence grade
+      description: How strong is the current evidence behind this issue?
+      options:
+        - observed
+        - inferred
+        - speculative
+        - blocked
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List in-scope work, non-goals, variables, and comparison boundaries.
+      placeholder: |
+        In scope:
+        Non-goals:
+        Controls/comparators:
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this research issue is done?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: validation_command
+    attributes:
+      label: Validation command
+      description: Provide the canonical command or explain why this is docs-only.
+      placeholder: rtk uv run --active ...
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_policy
+    attributes:
+      label: Artifact policy
+      description: Identify expected evidence category and durable storage boundary.
+      placeholder: |
+        Evidence category:
+        output/ usage:
+        Durable pointer or tracked evidence:
+    validations:
+      required: true
+  - type: dropdown
+    id: blocked_ready_state
+    attributes:
+      label: Blocked / ready state
+      description: Select the current execution state.
+      options:
+        - ready
+        - blocked by prerequisite implementation
+        - blocked by external asset/runtime
+        - execution-only
+        - decision required
+    validations:
+      required: true
+  - type: textarea
+    id: estimate_metadata
+    attributes:
+      label: Estimate metadata
+      description: Capture effort, complexity, risk, and uncertainty.
+      placeholder: |
+        Effort (h):
+        Complexity:
+        Risk:
+        Uncertainty:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/test-debt.yml
+++ b/.github/ISSUE_TEMPLATE/test-debt.yml
@@ -1,0 +1,103 @@
+name: Test debt
+description: Track skipped, flaky, weak, or missing tests with a concrete validation target.
+title: "test: "
+labels:
+  - test
+  - validation
+  - technical-debt
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when the main work is improving test coverage, retiring skips,
+        or turning weak validation into a reliable proof.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / Problem
+      description: Describe the test gap and why it matters.
+      placeholder: Which behavior is not currently protected?
+    validations:
+      required: true
+  - type: textarea
+    id: test_evidence
+    attributes:
+      label: Skipped or failing test evidence
+      description: Link the skip, failure, weak assertion, or missing coverage evidence.
+      placeholder: |
+        Test path:
+        Current failure/skip:
+        Why this is debt:
+    validations:
+      required: true
+  - type: textarea
+    id: intended_behavior
+    attributes:
+      label: Intended behavior
+      description: State the contract that the test should enforce.
+      placeholder: The system should...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: Bound the test work and avoid unrelated refactors.
+      placeholder: |
+        In scope:
+        Non-goals:
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define the done state.
+      placeholder: |
+        - [ ] Test fails for the intended reason before the fix when practical.
+        - [ ] Test passes after the fix.
+        - [ ] Related targeted suite passes.
+    validations:
+      required: true
+  - type: textarea
+    id: targeted_validation
+    attributes:
+      label: Targeted validation
+      description: Name the test command that proves the change.
+      placeholder: rtk uv run --active pytest ...
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_policy
+    attributes:
+      label: Artifact policy
+      description: State whether outputs are disposable, tracked fixtures, or durable evidence.
+      placeholder: |
+        Evidence category:
+        output/ usage:
+        Fixture or durable evidence:
+    validations:
+      required: true
+  - type: dropdown
+    id: blocked_ready_state
+    attributes:
+      label: Blocked / ready state
+      options:
+        - ready
+        - blocked by flaky environment
+        - blocked by missing fixture
+        - blocked by external dependency
+        - decision required
+    validations:
+      required: true
+  - type: textarea
+    id: estimate_metadata
+    attributes:
+      label: Estimate metadata
+      placeholder: |
+        Effort (h):
+        Complexity:
+        Risk:
+        Uncertainty:
+    validations:
+      required: true

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -52,6 +52,14 @@ Use `gh-issue-creator` to turn the request into a repo-ready issue.
 
 Pick the narrowest GitHub issue template that fits the task:
 
+- `research-validation.yml` for bounded research questions with explicit evidence grade,
+  artifact policy, and validation command.
+- `test-debt.yml` for skipped, failing, flaky, weak, or missing tests.
+- `blocked-external-artifact.yml` for unavailable datasets, models, runtimes, licenses, or
+  artifact pointers.
+- `execution-run.yml` for long local, SLURM, or release executions with current phase and next
+  decision point.
+- `epic.yml` for parent issues that need child links or a child-creation task.
 - `issue_default.md` for mixed or vague requests.
 - `documentation.md` for guides and workflow docs.
 - `benchmark_experiment.md` for benchmark or scenario work.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1294,6 +1294,13 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
 Use the following templates for specific tasks.
 
 - [issue template](../.github/ISSUE_TEMPLATE/issue_default.md) - Agent-ready fallback for small executable tasks
+- YAML issue forms for common backlog lanes:
+  [research validation](../.github/ISSUE_TEMPLATE/research-validation.yml),
+  [test debt](../.github/ISSUE_TEMPLATE/test-debt.yml),
+  [blocked external artifact/runtime](../.github/ISSUE_TEMPLATE/blocked-external-artifact.yml),
+  [execution run](../.github/ISSUE_TEMPLATE/execution-run.yml), and
+  [epic](../.github/ISSUE_TEMPLATE/epic.yml). These supplement the Markdown templates; they do
+  not replace the fallback template.
 - [issue creator skill](../.agents/skills/gh-issue-creator/SKILL.md) - Turn vague prompts into structured issues
 - [issue template auditor skill](../.agents/skills/gh-issue-template-auditor/SKILL.md) - Review and repair underspecified issues
 - [priority assessor skill](../.agents/skills/gh-issue-priority-assessor/SKILL.md) - Review Project #5 priority inputs against the rubric and explain plausibility

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -18,15 +18,55 @@ SKILL_FILES = [
     ROOT / ".agents" / "skills" / "gh-issue-priority-assessor" / "SKILL.md",
 ]
 KNOWN_LABELS = {
+    "agent",
+    "benchmark",
+    "blocked",
     "bug",
     "documentation",
     "enhancement",
-    "refactor",
-    "benchmark",
-    "validation",
-    "agent",
-    "research",
+    "epic",
     "local planner",
+    "refactor",
+    "research",
+    "technical-debt",
+    "test",
+    "validation",
+    "workflow",
+}
+
+EXPECTED_ISSUE_FORMS = {
+    "blocked-external-artifact.yml": [
+        "Unavailable asset or runtime",
+        "Unblock condition",
+        "Fail-closed policy",
+        "Artifact policy",
+    ],
+    "epic.yml": [
+        "Child issues or child-creation task",
+        "Blocked / ready state",
+        "Acceptance criteria",
+        "Estimate metadata",
+    ],
+    "execution-run.yml": [
+        "Runtime and execution location",
+        "Current phase",
+        "Owner / agent handoff",
+        "Artifact root",
+        "Last log timestamp",
+        "Next decision point",
+    ],
+    "research-validation.yml": [
+        "Hypothesis",
+        "Evidence grade",
+        "Artifact policy",
+        "Validation command",
+    ],
+    "test-debt.yml": [
+        "Skipped or failing test evidence",
+        "Intended behavior",
+        "Targeted validation",
+        "Acceptance criteria",
+    ],
 }
 
 
@@ -40,6 +80,14 @@ def _load_template(path: Path) -> tuple[dict[str, object], str]:
     assert isinstance(frontmatter, dict), f"{path} frontmatter must be a YAML mapping"
     body = match.group(2)
     return frontmatter, body
+
+
+def _load_form(path: Path) -> dict[str, object]:
+    """Parse a GitHub issue form YAML file."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict), f"{path} must be a YAML mapping"
+    return payload
 
 
 def test_issue_templates_parse_and_include_required_sections() -> None:
@@ -85,6 +133,32 @@ def test_specialized_issue_templates_include_domain_specific_sections() -> None:
             assert marker in body, f"missing marker {marker!r} in {name}"
 
 
+def test_issue_forms_cover_common_backlog_lanes() -> None:
+    """Verify YAML issue forms guide the common backlog lanes added for issue 1256."""
+
+    for form_name, markers in EXPECTED_ISSUE_FORMS.items():
+        form_path = TEMPLATE_DIR / form_name
+        assert form_path.exists(), f"missing issue form {form_name}"
+        form = _load_form(form_path)
+        assert form["name"]
+        assert form["description"]
+        labels = form.get("labels", [])
+        assert isinstance(labels, list)
+        assert set(labels).issubset(KNOWN_LABELS), f"unknown label(s) in {form_name}: {labels}"
+        body = form.get("body")
+        assert isinstance(body, list) and body, f"{form_name} body must be a non-empty list"
+        serialized = yaml.safe_dump(form, sort_keys=True)
+        for marker in markers:
+            assert marker in serialized, f"missing marker {marker!r} in {form_name}"
+
+
+def test_issue_form_config_keeps_existing_templates_available() -> None:
+    """Verify adding issue forms does not disable existing Markdown templates."""
+
+    config = _load_form(TEMPLATE_DIR / "config.yml")
+    assert config["blank_issues_enabled"] is True
+
+
 def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     """Verify the docs and skills point at real repo files and commands.
 
@@ -94,6 +168,11 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
 
     docs_text = DOCS_GUIDE.read_text(encoding="utf-8")
     assert "../.github/ISSUE_TEMPLATE/issue_default.md" in docs_text
+    assert "../.github/ISSUE_TEMPLATE/research-validation.yml" in docs_text
+    assert "../.github/ISSUE_TEMPLATE/test-debt.yml" in docs_text
+    assert "../.github/ISSUE_TEMPLATE/blocked-external-artifact.yml" in docs_text
+    assert "../.github/ISSUE_TEMPLATE/execution-run.yml" in docs_text
+    assert "../.github/ISSUE_TEMPLATE/epic.yml" in docs_text
     assert "../.agents/skills/gh-issue-creator/SKILL.md" in docs_text
     assert "../.agents/skills/gh-issue-template-auditor/SKILL.md" in docs_text
     assert "../.agents/skills/gh-issue-priority-assessor/SKILL.md" in docs_text


### PR DESCRIPTION
## Summary

- Adds five YAML issue forms for common backlog lanes: research validation, test debt, blocked external artifact/runtime, execution run, and epic.
- Keeps the existing Markdown issue templates and blank issues available.
- Updates issue workflow docs and template tests so the new forms stay discoverable and structurally checked.

Closes #1256

## Validation

- Red proof: `rtk uv run --active pytest tests/test_issue_templates.py -q` initially failed with `missing issue form blocked-external-artifact.yml`.
- `rtk uv run --active pytest tests/test_issue_templates.py -q` -> 5 passed.
- `rtk uv run --active ruff check tests/test_issue_templates.py` -> passed.
- `rtk uv run --active python scripts/validation/check_docs_proof_consistency.py --path docs/dev_guide.md --path docs/ai/ai-workflow.md` -> passed.
- Local YAML form structure smoke: parsed each `.github/ISSUE_TEMPLATE/*.yml`; forms report 9-13 fields with required validation fields.
- `rtk git diff --check` -> passed.
- After syncing `origin/main`, `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> 3551 passed, 12 skipped, 6 warnings; no changed Python coverage target.

## Artifact Handling

- Generated `output/coverage/*` is ignored, disposable validation output and is not part of the durable source contract.