### PR TITLE
feat: add proxemic social acceptability metrics

### DIFF
--- a/docs/ped_metrics/metrics_spec.md
+++ b/docs/ped_metrics/metrics_spec.md
@@ -137,6 +137,36 @@ into aggregate-ready `ped_impact_*` fields such as `ped_impact_accel_delta_mean`
 `ped_impact_far_samples`, and `ped_impact_near_sample_frac`, then reports the normal
 mean/median/p95 summaries.
 
+### Social-Acceptability Pilot Metrics
+
+The opt-in pedestrian-impact switch also emits a bounded pilot set of
+`social_proxemic_*` metrics. These metrics are exploratory trajectory proxies for proxemic
+intrusion analysis. They are not a replacement for SNQI, collision/TTC/clearance reporting,
+paper headline metrics, or human-subject validation.
+
+Episode records preserve flat `social_proxemic_*` fields and include a structured
+`metrics.social_acceptability` block with `schema_version: social-acceptability-pilot.v1`.
+Aggregation flattens the structured block into scalar columns when only the block is present.
+
+Default parameter:
+
+- `social_proxemic_radius_m`: `1.2` meters of robot-pedestrian surface clearance.
+
+Canonical pilot reductions:
+
+- `social_proxemic_available`: true when a trajectory contains at least one timestep and at
+  least one pedestrian; false for K=0 or empty trajectories.
+- `social_proxemic_ped_count`: number of pedestrians in the episode.
+- `social_proxemic_intrusion_steps`: number of timesteps where at least one pedestrian has
+  surface clearance below `social_proxemic_radius_m`.
+- `social_proxemic_intrusion_frac`: `intrusion_steps / trajectory_timesteps`.
+- `social_proxemic_intrusion_area_m_s`: sum of
+  `max(social_proxemic_radius_m - clearance_m, 0) * dt` across pedestrians and timesteps.
+- `social_proxemic_min_clearance_m`: minimum finite robot-pedestrian surface clearance observed.
+
+Missing pedestrian trajectories fail gracefully: availability is false, counts and intrusion
+reductions are zero, and minimum clearance is omitted from sanitized JSON output when unavailable.
+
 ### Motion Quality Metrics
 
 #### Smoothness (Jerk)
@@ -206,4 +236,4 @@ For SNQI computation, metrics are normalized using baseline statistics:
 - Force threshold calibrated empirically for current fast-pysf physics model
 - SNQI methodology follows bounded composite-index practice with versioned weights, baseline normalization, and explicit contract diagnostics
 
-*Last updated: February 2026*
+*Last updated: May 2026*

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -153,6 +153,54 @@ def _resolve_group_key(
     )
 
 
+def _flatten_pedestrian_impact_block(base: dict[str, Any], ped_impact: Any) -> None:
+    """Flatten schema-backed pedestrian-impact reductions into ``base``."""
+    if not isinstance(ped_impact, dict):
+        return
+    reductions = ped_impact.get("canonical_reductions") or {}
+    if isinstance(reductions, dict):
+        for source_key, target_key in (
+            ("accel_delta_mean", "ped_impact_accel_delta_mean"),
+            ("accel_delta_median", "ped_impact_accel_delta_median"),
+            ("accel_delta_valid_pedestrians", "ped_impact_accel_delta_valid"),
+            ("turn_rate_delta_mean", "ped_impact_turn_rate_delta_mean"),
+            ("turn_rate_delta_median", "ped_impact_turn_rate_delta_median"),
+            ("turn_rate_delta_valid_pedestrians", "ped_impact_turn_rate_delta_valid"),
+        ):
+            base[target_key] = reductions.get(source_key)
+    sample_counts = ped_impact.get("sample_counts") or {}
+    if isinstance(sample_counts, dict):
+        for source_key, target_key in (
+            ("pedestrians", "ped_impact_ped_count"),
+            ("near_samples", "ped_impact_near_samples"),
+            ("far_samples", "ped_impact_far_samples"),
+            ("near_sample_frac", "ped_impact_near_sample_frac"),
+        ):
+            base[target_key] = sample_counts.get(source_key)
+
+
+def _flatten_social_acceptability_block(base: dict[str, Any], social_acceptability: Any) -> None:
+    """Flatten schema-backed social-acceptability pilot reductions into ``base``."""
+    if not isinstance(social_acceptability, dict):
+        return
+    base["social_proxemic_available"] = social_acceptability.get("available")
+    parameters = social_acceptability.get("parameters") or {}
+    if isinstance(parameters, dict):
+        base["social_proxemic_radius_m"] = parameters.get("proxemic_radius_m")
+    sample_counts = social_acceptability.get("sample_counts") or {}
+    if isinstance(sample_counts, dict):
+        base["social_proxemic_ped_count"] = sample_counts.get("pedestrians")
+        base["social_proxemic_intrusion_steps"] = sample_counts.get("timesteps")
+    proxemic = social_acceptability.get("proxemic") or {}
+    if isinstance(proxemic, dict):
+        for source_key, target_key in (
+            ("intrusion_frac", "social_proxemic_intrusion_frac"),
+            ("intrusion_area_m_s", "social_proxemic_intrusion_area_m_s"),
+            ("min_clearance_m", "social_proxemic_min_clearance_m"),
+        ):
+            base[target_key] = proxemic.get(source_key)
+
+
 def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     """Flatten metrics dict into a flat per-episode row.
 
@@ -167,6 +215,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     metrics = dict(rec.get("metrics") or {})
     fq = metrics.pop("force_quantiles", {}) or {}
     ped_impact = metrics.pop("pedestrian_impact", {}) or {}
+    social_acceptability = metrics.pop("social_acceptability", {}) or {}
     inter_robot = metrics.pop("inter_robot", {}) or {}
     # Flatten known force quantiles
     for qk in ("q50", "q90", "q95"):
@@ -174,27 +223,8 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
         base[key] = fq.get(qk)
     # Flatten the schema-backed pedestrian-impact block for records that do not also carry
     # legacy flat ped_impact_* keys.
-    if isinstance(ped_impact, dict):
-        reductions = ped_impact.get("canonical_reductions") or {}
-        if isinstance(reductions, dict):
-            for source_key, target_key in (
-                ("accel_delta_mean", "ped_impact_accel_delta_mean"),
-                ("accel_delta_median", "ped_impact_accel_delta_median"),
-                ("accel_delta_valid_pedestrians", "ped_impact_accel_delta_valid"),
-                ("turn_rate_delta_mean", "ped_impact_turn_rate_delta_mean"),
-                ("turn_rate_delta_median", "ped_impact_turn_rate_delta_median"),
-                ("turn_rate_delta_valid_pedestrians", "ped_impact_turn_rate_delta_valid"),
-            ):
-                base[target_key] = reductions.get(source_key)
-        sample_counts = ped_impact.get("sample_counts") or {}
-        if isinstance(sample_counts, dict):
-            for source_key, target_key in (
-                ("pedestrians", "ped_impact_ped_count"),
-                ("near_samples", "ped_impact_near_samples"),
-                ("far_samples", "ped_impact_far_samples"),
-                ("near_sample_frac", "ped_impact_near_sample_frac"),
-            ):
-                base[target_key] = sample_counts.get(source_key)
+    _flatten_pedestrian_impact_block(base, ped_impact)
+    _flatten_social_acceptability_block(base, social_acceptability)
     if isinstance(inter_robot, dict):
         for key, value in inter_robot.items():
             base[str(key)] = value

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2307,6 +2307,7 @@ def compute_all_metrics(
     experimental_ped_impact: bool = False,
     ped_impact_radius_m: float = 2.0,
     ped_impact_window_steps: int = 5,
+    social_proxemic_radius_m: float = 1.2,
 ) -> dict[str, float]:
     """Compute all defined metrics for an episode and return them as a mapping.
 
@@ -2326,6 +2327,8 @@ def compute_all_metrics(
             impact metrics.
         ped_impact_window_steps: Trailing smoothing window length (timesteps) used by
             experimental pedestrian impact metrics.
+        social_proxemic_radius_m: Personal-space radius used by exploratory social acceptability
+            metrics when ``experimental_ped_impact`` is enabled.
 
     Returns:
         dict[str, float]: Mapping from metric name (e.g., ``success``, ``force_q50``,
@@ -2401,7 +2404,12 @@ def compute_all_metrics(
                 window_steps=ped_impact_window_steps,
             )
         )
-        values.update(experimental_social_acceptability_metrics(data))
+        values.update(
+            experimental_social_acceptability_metrics(
+                data,
+                proxemic_radius_m=social_proxemic_radius_m,
+            )
+        )
     return values
 
 

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -462,6 +462,58 @@ def experimental_ped_impact_metrics(
     return metrics
 
 
+def experimental_social_acceptability_metrics(
+    data: EpisodeData,
+    *,
+    proxemic_radius_m: float = 1.2,
+) -> dict[str, float]:
+    """Compute optional trajectory-only social-acceptability pilot metrics.
+
+    The pilot summarizes robot-pedestrian personal-space intrusion from surface
+    clearance samples. It is a deterministic proxy for review and falsification
+    workflows, not a validated human-subject social-compliance score.
+
+    Returns:
+        Mapping of ``social_proxemic_*`` scalar metrics.
+    """
+    radius = (
+        float(proxemic_radius_m)
+        if math.isfinite(proxemic_radius_m) and proxemic_radius_m > 0.0
+        else 1.2
+    )
+    step_count = int(data.robot_pos.shape[0]) if data.robot_pos.ndim >= 2 else 0
+    ped_count = int(data.peds_pos.shape[1]) if data.peds_pos.ndim >= 2 else 0
+    metrics: dict[str, float] = {
+        "social_proxemic_available": 1.0 if step_count > 0 and ped_count > 0 else 0.0,
+        "social_proxemic_radius_m": radius,
+        "social_proxemic_ped_count": float(ped_count),
+        "social_proxemic_intrusion_steps": 0.0,
+        "social_proxemic_intrusion_frac": 0.0,
+        "social_proxemic_intrusion_area_m_s": 0.0,
+        "social_proxemic_min_clearance_m": float("nan"),
+    }
+    if step_count <= 0 or ped_count == 0:
+        return metrics
+
+    clearances = _compute_clearance_matrix(data)
+    if clearances.size == 0:
+        return metrics
+    finite = np.isfinite(clearances)
+    if not finite.any():
+        return metrics
+
+    intrusion_depth = np.where(finite, np.maximum(radius - clearances, 0.0), 0.0)
+    intrusion_mask = intrusion_depth > 0.0
+    intrusion_steps = int(np.count_nonzero(np.any(intrusion_mask, axis=1)))
+    metrics["social_proxemic_intrusion_steps"] = float(intrusion_steps)
+    metrics["social_proxemic_intrusion_frac"] = (
+        float(intrusion_steps / step_count) if step_count > 0 else 0.0
+    )
+    metrics["social_proxemic_intrusion_area_m_s"] = float(np.sum(intrusion_depth) * data.dt)
+    metrics["social_proxemic_min_clearance_m"] = float(np.min(clearances[finite]))
+    return metrics
+
+
 # --- Metric stub functions ---
 def success(data: EpisodeData, *, horizon: int) -> float:
     """Return 1 if goal reached before horizon with zero collisions else 0.
@@ -2278,7 +2330,8 @@ def compute_all_metrics(
     Returns:
         dict[str, float]: Mapping from metric name (e.g., ``success``, ``force_q50``,
         ``force_gradient_norm_mean``) to the computed scalar value. When
-        ``experimental_ped_impact`` is enabled, additional ``ped_impact_*`` keys are included.
+        ``experimental_ped_impact`` is enabled, additional ``ped_impact_*`` and
+        exploratory ``social_proxemic_*`` keys are included.
     """
     if shortest_path_len is None:
         shortest_path_len = float(np.linalg.norm(data.robot_pos[0] - data.goal))  # simple fallback
@@ -2348,6 +2401,7 @@ def compute_all_metrics(
                 window_steps=ped_impact_window_steps,
             )
         )
+        values.update(experimental_social_acceptability_metrics(data))
     return values
 
 
@@ -2390,19 +2444,26 @@ def post_process_metrics(
         "ped_impact_far_samples",
         "ped_impact_accel_delta_valid",
         "ped_impact_turn_rate_delta_valid",
+        "social_proxemic_ped_count",
+        "social_proxemic_intrusion_steps",
     ):
         if count_key in metrics and metrics[count_key] is not None:
             try:
                 metrics[count_key] = int(metrics[count_key])
             except Exception:  # pragma: no cover
                 pass
-    for valid_key in ("time_to_goal_success_only_valid", "time_to_goal_ideal_ratio_valid"):
+    for valid_key in (
+        "time_to_goal_success_only_valid",
+        "time_to_goal_ideal_ratio_valid",
+        "social_proxemic_available",
+    ):
         if valid_key in metrics and metrics[valid_key] is not None:
             try:
                 metrics[valid_key] = bool(int(metrics[valid_key]))
             except Exception:  # pragma: no cover
                 pass
     _attach_pedestrian_impact_block(metrics)
+    _attach_social_acceptability_block(metrics)
     return _sanitize_metrics(metrics)
 
 
@@ -2447,6 +2508,41 @@ def _attach_pedestrian_impact_block(metrics: dict[str, Any]) -> None:
     }
 
 
+def _attach_social_acceptability_block(metrics: dict[str, Any]) -> None:
+    """Attach an exploratory social-acceptability block when pilot metrics are present."""
+    if "social_proxemic_radius_m" not in metrics:
+        return
+
+    metrics["social_acceptability"] = {
+        "schema_version": "social-acceptability-pilot.v1",
+        "status": "exploratory",
+        "parameters": {
+            "proxemic_radius_m": metrics.get("social_proxemic_radius_m"),
+        },
+        "units": {
+            "clearance": "m",
+            "intrusion_area": "m*s",
+            "intrusion_fraction": "fraction",
+            "sample_counts": "count",
+        },
+        "available": metrics.get("social_proxemic_available"),
+        "sample_counts": {
+            "pedestrians": metrics.get("social_proxemic_ped_count"),
+            "timesteps": metrics.get("social_proxemic_intrusion_steps"),
+        },
+        "proxemic": {
+            "intrusion_steps": metrics.get("social_proxemic_intrusion_steps"),
+            "intrusion_frac": metrics.get("social_proxemic_intrusion_frac"),
+            "intrusion_area_m_s": metrics.get("social_proxemic_intrusion_area_m_s"),
+            "min_clearance_m": metrics.get("social_proxemic_min_clearance_m"),
+        },
+        "interpretation": (
+            "Exploratory trajectory-only proxemic proxy; not a replacement for SNQI, "
+            "headline safety metrics, or human-subject validation."
+        ),
+    }
+
+
 def _sanitize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
     """Remove NaN/inf metric entries to keep JSON serialization clean.
 
@@ -2484,6 +2580,7 @@ __all__ = [
     "curvature_mean",
     "distance_to_human_min",
     "energy",
+    "experimental_social_acceptability_metrics",
     "failure_to_progress",
     "force_exceed_events",
     "force_gradient_norm_mean",

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -478,6 +478,102 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "social_acceptability": {
+                    "type": "object",
+                    "description": "Schema-backed exploratory social-acceptability pilot block for opt-in proxemic reductions.",
+                    "required": [
+                        "schema_version",
+                        "status",
+                        "parameters",
+                        "units",
+                        "available",
+                        "sample_counts",
+                        "proxemic",
+                        "interpretation"
+                    ],
+                    "properties": {
+                        "schema_version": {
+                            "const": "social-acceptability-pilot.v1"
+                        },
+                        "status": {
+                            "const": "exploratory"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "proxemic_radius_m": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0
+                                }
+                            },
+                            "required": [
+                                "proxemic_radius_m"
+                            ],
+                            "additionalProperties": true
+                        },
+                        "units": {
+                            "type": "object",
+                            "properties": {
+                                "clearance": {
+                                    "const": "m"
+                                },
+                                "intrusion_area": {
+                                    "const": "m*s"
+                                },
+                                "intrusion_fraction": {
+                                    "const": "fraction"
+                                },
+                                "sample_counts": {
+                                    "const": "count"
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "available": {
+                            "type": "boolean"
+                        },
+                        "sample_counts": {
+                            "type": "object",
+                            "properties": {
+                                "pedestrians": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "timesteps": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "proxemic": {
+                            "type": "object",
+                            "properties": {
+                                "intrusion_steps": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "intrusion_frac": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                },
+                                "intrusion_area_m_s": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "min_clearance_m": {
+                                    "type": "number"
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "interpretation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": true
                 }
             },
             "additionalProperties": {

--- a/tests/contract/test_episode_schema.py
+++ b/tests/contract/test_episode_schema.py
@@ -118,6 +118,58 @@ def test_episode_schema_validates_pedestrian_impact_block() -> None:
         jsonschema.validate(instance=record, schema=schema)
 
 
+def test_episode_schema_validates_social_acceptability_block() -> None:
+    """The social-acceptability pilot block should be schema-backed when present."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_social_acceptability",
+        "version": "v1",
+        "scenario_id": "sc_social_acceptability",
+        "seed": 123,
+        "metrics": {
+            "collisions": 0,
+            "near_misses": 0,
+            "social_acceptability": {
+                "schema_version": "social-acceptability-pilot.v1",
+                "status": "exploratory",
+                "parameters": {"proxemic_radius_m": 1.2},
+                "units": {
+                    "clearance": "m",
+                    "intrusion_area": "m*s",
+                    "intrusion_fraction": "fraction",
+                    "sample_counts": "count",
+                },
+                "available": True,
+                "sample_counts": {"pedestrians": 1, "timesteps": 2},
+                "proxemic": {
+                    "intrusion_steps": 2,
+                    "intrusion_frac": 0.5,
+                    "intrusion_area_m_s": 0.9,
+                    "min_clearance_m": 0.1,
+                },
+                "interpretation": "Exploratory trajectory-only proxemic proxy.",
+            },
+        },
+        "termination_reason": "max_steps",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+    }
+
+    jsonschema.validate(instance=record, schema=schema)
+    record["metrics"]["social_acceptability"]["schema_version"] = "wrong"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+    record["metrics"]["social_acceptability"]["schema_version"] = "social-acceptability-pilot.v1"
+    record["metrics"]["social_acceptability"]["sample_counts"]["pedestrians"] = 1.5
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+
 def test_episode_schema_rejects_collision_event_without_collision_metric() -> None:
     """New v1 records should not report collision_event=true with zero collision count."""
     schema = _load_schema()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -254,6 +254,85 @@ def test_compute_aggregates_flattens_pedestrian_impact_block() -> None:
     assert metrics["ped_impact_near_samples"]["mean"] == 5.0
 
 
+def test_compute_aggregates_flattens_social_acceptability_block() -> None:
+    """Schema-backed social-acceptability pilot reductions should aggregate as scalars."""
+    records = [
+        {
+            "episode_id": "ep-1",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metric_parameters": {
+                "threshold_signature": "default",
+                "threshold_profile": {
+                    "profile_id": "default",
+                    "collision_distance_m": 0.3,
+                    "near_miss_distance_m": 0.6,
+                    "comfort_force_threshold": 2.0,
+                },
+            },
+            "metrics": {
+                "success": True,
+                "social_acceptability": {
+                    "schema_version": "social-acceptability-pilot.v1",
+                    "status": "exploratory",
+                    "parameters": {"proxemic_radius_m": 1.2},
+                    "available": True,
+                    "sample_counts": {"pedestrians": 1, "timesteps": 2},
+                    "proxemic": {
+                        "intrusion_steps": 2,
+                        "intrusion_frac": 0.5,
+                        "intrusion_area_m_s": 0.9,
+                        "min_clearance_m": 0.1,
+                    },
+                },
+            },
+        },
+        {
+            "episode_id": "ep-2",
+            "scenario_id": "sc-1",
+            "seed": 2,
+            "algo": "planner-a",
+            "metric_parameters": {
+                "threshold_signature": "default",
+                "threshold_profile": {
+                    "profile_id": "default",
+                    "collision_distance_m": 0.3,
+                    "near_miss_distance_m": 0.6,
+                    "comfort_force_threshold": 2.0,
+                },
+            },
+            "metrics": {
+                "success": True,
+                "social_acceptability": {
+                    "schema_version": "social-acceptability-pilot.v1",
+                    "status": "exploratory",
+                    "parameters": {"proxemic_radius_m": 1.2},
+                    "available": True,
+                    "sample_counts": {"pedestrians": 1, "timesteps": 1},
+                    "proxemic": {
+                        "intrusion_steps": 1,
+                        "intrusion_frac": 0.25,
+                        "intrusion_area_m_s": 0.3,
+                        "min_clearance_m": 0.4,
+                    },
+                },
+            },
+        },
+    ]
+
+    flat = flatten_metrics(records[0])
+    assert "social_acceptability" not in flat
+    assert flat["social_proxemic_intrusion_area_m_s"] == 0.9
+
+    summary = compute_aggregates(records, group_by="algo")
+
+    metrics = summary["planner-a"]
+    assert metrics["social_proxemic_intrusion_steps"]["mean"] == 1.5
+    assert metrics["social_proxemic_intrusion_frac"]["mean"] == 0.375
+    assert metrics["social_proxemic_intrusion_area_m_s"]["mean"] == 0.6
+
+
 def _paired_contrast_records() -> list[dict]:
     """Build synthetic records with a planted paired effect for group B over group A."""
     values_a = [1.0, 2.0, 3.0, 4.0, 5.0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -584,12 +584,48 @@ def test_experimental_ped_impact_metrics_are_opt_in() -> None:
 
     base = compute_all_metrics(ep, horizon=10)
     assert not any(key.startswith("ped_impact_") for key in base)
+    assert not any(key.startswith("social_proxemic_") for key in base)
 
     enabled = compute_all_metrics(ep, horizon=10, experimental_ped_impact=True)
     assert "ped_impact_radius_m" in enabled
     assert "ped_impact_window_steps" in enabled
     assert "ped_impact_accel_delta_valid" in enabled
     assert "ped_impact_turn_rate_delta_valid" in enabled
+    assert "social_proxemic_radius_m" in enabled
+    assert "social_proxemic_intrusion_steps" in enabled
+
+
+def test_experimental_social_acceptability_proxemic_intrusion() -> None:
+    """Proxemic intrusion should summarize personal-space clearance violations."""
+    ep = _make_episode(T=4, K=1)
+    ep.dt = 0.5
+    ep.robot_pos[:] = 0.0
+    radii_sum = ep.robot_radius + ep.ped_radius
+    clearances = np.array([1.5, 0.5, 0.1, 2.0])
+    ep.peds_pos[:, 0, 0] = radii_sum + clearances
+
+    vals = compute_all_metrics(ep, horizon=4, experimental_ped_impact=True)
+
+    assert vals["social_proxemic_available"] == 1.0
+    assert vals["social_proxemic_radius_m"] == 1.2
+    assert vals["social_proxemic_ped_count"] == 1.0
+    assert vals["social_proxemic_intrusion_steps"] == 2.0
+    assert vals["social_proxemic_intrusion_frac"] == 0.5
+    assert vals["social_proxemic_min_clearance_m"] == pytest.approx(0.1)
+    assert vals["social_proxemic_intrusion_area_m_s"] == pytest.approx(0.9)
+
+
+def test_experimental_social_acceptability_handles_empty_crowd() -> None:
+    """Proxemic pilot metrics should expose unavailable status for K=0."""
+    ep = _make_episode(T=4, K=0)
+    vals = compute_all_metrics(ep, horizon=4, experimental_ped_impact=True)
+
+    assert vals["social_proxemic_available"] == 0.0
+    assert vals["social_proxemic_ped_count"] == 0.0
+    assert vals["social_proxemic_intrusion_steps"] == 0.0
+    assert vals["social_proxemic_intrusion_frac"] == 0.0
+    assert vals["social_proxemic_intrusion_area_m_s"] == 0.0
+    assert math.isnan(vals["social_proxemic_min_clearance_m"])
 
 
 def test_experimental_ped_impact_near_vs_far_deltas() -> None:
@@ -655,6 +691,35 @@ def test_post_process_metrics_adds_schema_backed_pedestrian_impact_block() -> No
     assert block["canonical_reductions"]["accel_delta_mean"] == 0.75
     assert block["canonical_reductions"]["turn_rate_delta_mean"] == 0.20
     assert "interpretation" not in block
+
+
+def test_post_process_metrics_adds_social_acceptability_pilot_block() -> None:
+    """Post-processing should expose proxemic pilot metrics with exploratory provenance."""
+    metrics = post_process_metrics(
+        {
+            "success": 1.0,
+            "collisions": 0.0,
+            "social_proxemic_available": 1.0,
+            "social_proxemic_radius_m": 1.2,
+            "social_proxemic_ped_count": 2.0,
+            "social_proxemic_intrusion_steps": 3.0,
+            "social_proxemic_intrusion_frac": 0.25,
+            "social_proxemic_intrusion_area_m_s": 0.8,
+            "social_proxemic_min_clearance_m": 0.15,
+        },
+        snqi_weights=None,
+        snqi_baseline=None,
+    )
+
+    assert metrics["social_proxemic_intrusion_steps"] == 3
+    assert metrics["social_proxemic_ped_count"] == 2
+    block = metrics["social_acceptability"]
+    assert block["schema_version"] == "social-acceptability-pilot.v1"
+    assert block["status"] == "exploratory"
+    assert block["parameters"] == {"proxemic_radius_m": 1.2}
+    assert block["sample_counts"] == {"pedestrians": 2, "timesteps": 3}
+    assert block["proxemic"]["intrusion_area_m_s"] == 0.8
+    assert "not a replacement for SNQI" in block["interpretation"]
 
 
 def test_experimental_ped_impact_handles_empty_crowd() -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -594,6 +594,14 @@ def test_experimental_ped_impact_metrics_are_opt_in() -> None:
     assert "social_proxemic_radius_m" in enabled
     assert "social_proxemic_intrusion_steps" in enabled
 
+    custom_radius = compute_all_metrics(
+        ep,
+        horizon=10,
+        experimental_ped_impact=True,
+        social_proxemic_radius_m=0.75,
+    )
+    assert custom_radius["social_proxemic_radius_m"] == 0.75
+
 
 def test_experimental_social_acceptability_proxemic_intrusion() -> None:
     """Proxemic intrusion should summarize personal-space clearance violations."""


### PR DESCRIPTION
Closes #1241.

## Summary
- Adds opt-in `social_proxemic_*` pilot metrics under the existing `--experimental-ped-impact` gate.
- Adds a schema-backed `metrics.social_acceptability` block with exploratory provenance and aggregation flattening.
- Documents defaults, formulas, unavailable behavior, and the non-headline/non-SNQI interpretation.

## Validation
- Red proof: focused tests failed before implementation for missing `social_proxemic_*` keys and `metrics.social_acceptability`.
- `./.venv/bin/python -m pytest tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py -q -k "social_acceptability or ped_impact_metrics_are_opt_in"` -> 6 passed, 73 deselected.
- `./.venv/bin/python -m pytest tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py tests/unit/test_metrics_edge_cases.py tests/benchmark -q` -> 473 passed, 1 skipped.
- Tiny executable smoke check emitted `2.0 0.8999999999999999 social-acceptability-pilot.v1 0.8999999999999999`.
- `ruff check` / `ruff format --check` on changed Python files -> passed.
- `git diff --check` -> passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3553 passed, 13 skipped, 6 warnings in 432.75s.

## Notes
- Generated `output/coverage`, `output/tmp`, and `output/model_cache` artifacts are ignored validation/cache outputs and are not part of this PR.
- The new metrics are intentionally exploratory and opt-in; default benchmark outputs remain unchanged.