### PR TITLE
feat: add optimizer-backed adversarial sampler pilot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -272,6 +272,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Issue #601 CrowdNav Feasibility Note](./context/issue_601_crowdnav_feasibility_note.md)** - Family assessment, canonical source anchors, and integration shape decision for CrowdNav attention-based crowd navigation
 * **[Issue #695 `safe_control` Feasibility Note](./context/issue_695_safe_control_feasibility_note.md)** - External safety-controller assessment showing the current path is blocked by missing runtime dependencies, unclear license metadata, and a waypoint-tracking contract mismatch
 * **[Issue #581 Paper Evidence Delta Report](./context/issue_581_paper_evidence_delta.md)** - Canonical corrected benchmark artifact handoff, planner-quality claim boundary, and AMV paper-ingestion checklist
+* **[Issue #1236 Optimizer Adversarial Sampler](./context/issue_1236_optimizer_adversarial_sampler.md)** - Optuna-backed adversarial sampler pilot, synthetic comparison helper, and non-paper-facing evidence boundary
 * **[Planner Quality Audit Workflow](./benchmark_planner_quality_audit.md)** - Build the planner decision table, classify headline suitability, and record paper-faithfulness parity gaps
 
 ### Tooling

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -392,6 +392,9 @@ why a change was made rather than a full issue execution transcript.
   evidence collection path for diagnosing low CPU utilization without launching new jobs.
 * [Issue #869 Adversarial Runner](issue_869_adversarial_runner.md) - programmable adversarial
   scenario search API, bundle contract, certification boundary, and deferred optimizer scope.
+* [Issue #1236 Optimizer Adversarial Sampler](issue_1236_optimizer_adversarial_sampler.md) -
+  Optuna-backed feedback sampler pilot, synthetic comparison helper, and non-paper-facing evidence
+  boundary.
 * [Issue #923 Multi-Ped Adversarial Candidate Schema](issue_923_multi_ped_adversarial_schema.md) -
   schema-only first slice under #870 for scripted multi-pedestrian adversarial candidates.
 * [Issue #936 Multi-Ped Adversarial Overrides](issue_936_multi_ped_adversarial_overrides.md)

--- a/docs/context/issue_1236_optimizer_adversarial_sampler.md
+++ b/docs/context/issue_1236_optimizer_adversarial_sampler.md
@@ -1,0 +1,74 @@
+# Issue #1236 Optimizer-Backed Adversarial Sampler Pilot
+
+## Goal
+
+Issue #1236 asks whether optimizer-backed adversarial samplers can find lower-SNQI or
+failure-inducing candidates more efficiently than the existing random and coordinate-refinement
+samplers. This note records the first bounded implementation and its evidence boundary.
+
+## Decision
+
+The first optimizer pilot uses `optuna`, which is already in `pyproject.toml`, instead of adding a
+new CMA-ES or Bayesian-optimization dependency. `OptunaCandidateSampler` implements the existing
+`FeedbackCandidateSampler` contract through Optuna's ask/tell API, so
+`run_adversarial_search(...)` remains unchanged and preserves deterministic sequential manifest
+ordering.
+
+The sampler:
+
+- maps the current `SearchSpaceConfig` scalar bounds to Optuna suggestions,
+- emits `CandidateSpec` values that still pass normal search-space validation,
+- receives objective feedback through `observe(evaluation)`,
+- records invalid or unscored proposals as failed Optuna trials,
+- raises an actionable error if `optuna` is unavailable.
+
+## Implementation Surfaces
+
+- `robot_sf/adversarial/samplers.py` adds `OptunaCandidateSampler`.
+- `robot_sf/adversarial/__init__.py` exports the sampler for pilot harnesses.
+- `scripts/tools/compare_adversarial_samplers.py` runs random, coordinate, and optuna samplers on
+  the same `SearchConfig` and emits an `adversarial-sampler-comparison.v1` JSON summary.
+- `tests/adversarial/test_adversarial_search.py` covers deterministic proposals, feedback,
+  dependency failure, and the synthetic comparison helper.
+
+## Validation
+
+Red proof:
+
+```bash
+uv run --active pytest tests/adversarial/test_adversarial_search.py -q -k 'optuna_candidate_sampler'
+```
+
+This initially failed during collection because `OptunaCandidateSampler` did not exist.
+
+Green targeted proof:
+
+```bash
+uv run --active pytest tests/adversarial/test_adversarial_search.py -q -k 'optuna_candidate_sampler or sampler_comparison_synthetic'
+uv run --active ruff check robot_sf/adversarial/samplers.py robot_sf/adversarial/__init__.py scripts/tools/compare_adversarial_samplers.py tests/adversarial/test_adversarial_search.py
+```
+
+Synthetic comparison smoke:
+
+```bash
+uv run --active python scripts/tools/compare_adversarial_samplers.py \
+  --output-dir output/adversarial/issue1236_sampler_comparison \
+  --budget 3 \
+  --seed 123 \
+  --synthetic \
+  --out-json output/adversarial/issue1236_sampler_comparison/summary.json
+```
+
+The smoke wrote deterministic manifests for `random`, `coordinate`, and `optuna`. On this tiny
+synthetic surface, `random` had the best objective at budget 3 (`-0.1583`) while coordinate
+(`-1.05`) and optuna (`-1.0641`) did not improve. That is a useful negative/neutral pilot signal,
+not evidence against optimizer search generally; repeated seeds and real benchmark evaluation are
+still needed before making claims about efficiency.
+
+## Follow-Up Boundary
+
+This PR does not promote optimizer-backed adversarial search to paper-facing evidence and does not
+add candidate-level parallelism. A stronger follow-up should run repeated-seed comparisons on
+`configs/scenarios/templates/crossing_ttc.yaml` with
+`configs/adversarial/crossing_ttc_space.yaml`, report first-failure iteration and invalid-candidate
+rate, and preserve replay bundle paths for any claimed counterexamples.

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -19,7 +19,11 @@ from robot_sf.adversarial.runtime import (
     multi_ped_config_to_single_pedestrian_definitions,
     validate_multi_ped_runtime_plausibility,
 )
-from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
+from robot_sf.adversarial.samplers import (
+    CoordinateRefinementSampler,
+    OptunaCandidateSampler,
+    RandomCandidateSampler,
+)
 from robot_sf.adversarial.search import run_adversarial_search
 
 __all__ = [
@@ -28,6 +32,7 @@ __all__ = [
     "CoordinateRefinementSampler",
     "MultiPedAdversarialConfig",
     "MultiPedCandidateSpec",
+    "OptunaCandidateSampler",
     "Pose2D",
     "RandomCandidateSampler",
     "SearchConfig",

--- a/robot_sf/adversarial/samplers.py
+++ b/robot_sf/adversarial/samplers.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import math
+from importlib import import_module
 from random import Random
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from robot_sf.adversarial.config import CandidateSpec, Pose2D, RangeConfig, SearchSpaceConfig
 
@@ -164,6 +165,89 @@ class CoordinateRefinementSampler:
                 ),
             )
         raise AssertionError(f"unknown refinement dimension: {dimension}")
+
+
+class OptunaCandidateSampler:
+    """Optuna-backed feedback sampler for bounded adversarial search pilots.
+
+    The sampler uses Optuna's ask/tell API so the existing sequential adversarial
+    runner can provide objective feedback through ``observe`` without changing
+    the runner contract.
+    """
+
+    def __init__(self, search_space: SearchSpaceConfig, *, seed: int) -> None:
+        """Initialize an Optuna study with deterministic sampler seed."""
+        optuna = _import_optuna()
+        sampler = optuna.samplers.TPESampler(seed=int(seed))
+        self._study = optuna.create_study(direction="maximize", sampler=sampler)
+        self._trial_state = optuna.trial.TrialState
+        self._search_space = search_space
+        self._pending_trials: list[tuple[CandidateSpec, Any]] = []
+
+    def sample(self) -> CandidateSpec:
+        """Return the next optimizer proposal within the configured bounds."""
+        trial = self._study.ask()
+        candidate = CandidateSpec(
+            start=Pose2D(
+                _suggest_float(trial, "start.x", self._search_space.start_x),
+                _suggest_float(trial, "start.y", self._search_space.start_y),
+            ),
+            goal=Pose2D(
+                _suggest_float(trial, "goal.x", self._search_space.goal_x),
+                _suggest_float(trial, "goal.y", self._search_space.goal_y),
+            ),
+            spawn_time_s=_suggest_float(trial, "spawn_time_s", self._search_space.spawn_time_s),
+            pedestrian_speed_mps=_suggest_float(
+                trial,
+                "pedestrian_speed_mps",
+                self._search_space.pedestrian_speed_mps,
+            ),
+            pedestrian_delay_s=_suggest_float(
+                trial, "pedestrian_delay_s", self._search_space.pedestrian_delay_s
+            ),
+            scenario_seed=_suggest_int(trial, "scenario_seed", self._search_space.scenario_seed),
+        )
+        self._pending_trials.append((candidate, trial))
+        return candidate
+
+    def observe(self, evaluation: CandidateEvaluation) -> None:
+        """Tell Optuna the objective value for a completed proposal."""
+        for index, (candidate, trial) in enumerate(self._pending_trials):
+            if candidate == evaluation.candidate:
+                self._pending_trials.pop(index)
+                score = evaluation.objective_value
+                if score is None or not math.isfinite(float(score)):
+                    self._study.tell(trial, state=self._trial_state.FAIL)
+                    return
+                self._study.tell(trial, float(score))
+                return
+
+
+def _import_optuna() -> Any:
+    """Import Optuna or raise an actionable optional-dependency error."""
+    try:
+        return import_module("optuna")
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "OptunaCandidateSampler requires optuna. Install project dependencies with "
+            "`uv sync --all-extras` before using the optimizer-backed adversarial sampler."
+        ) from exc
+
+
+def _suggest_float(trial: Any, name: str, bounds: RangeConfig) -> float:
+    """Suggest a float while supporting degenerate fixed ranges."""
+    if bounds.min == bounds.max:
+        return float(bounds.min)
+    return float(trial.suggest_float(name, float(bounds.min), float(bounds.max)))
+
+
+def _suggest_int(trial: Any, name: str, bounds: RangeConfig) -> int:
+    """Suggest an integer while supporting degenerate fixed ranges."""
+    low = int(bounds.min)
+    high = int(bounds.max)
+    if low == high:
+        return low
+    return int(trial.suggest_int(name, low, high))
 
 
 def _midpoint(bounds: RangeConfig) -> float:

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,6 +13,7 @@ from robot_sf.adversarial.bundle import write_trajectory_csv
 from robot_sf.adversarial.certification import passed_status
 from robot_sf.adversarial.config import CandidateEvaluation, SearchConfig
 from robot_sf.adversarial.samplers import (
+    CandidateSampler,
     CoordinateRefinementSampler,
     OptunaCandidateSampler,
     RandomCandidateSampler,
@@ -39,7 +40,7 @@ class SamplerComparisonRow:
     num_failed_evaluations: int
 
 
-def build_sampler(name: str, search_space: SearchSpaceConfig, *, seed: int):
+def build_sampler(name: str, search_space: SearchSpaceConfig, *, seed: int) -> CandidateSampler:
     """Build a named adversarial sampler."""
     key = name.strip().lower()
     if key == "random":
@@ -61,24 +62,10 @@ def run_sampler_comparison(
     rows: list[SamplerComparisonRow] = []
     for offset, sampler_name in enumerate(sampler_names):
         sampler_output_dir = config.output_dir / sampler_name
-        sampler_config = SearchConfig(
-            policy=config.policy,
-            scenario_template=config.scenario_template,
-            search_space_path=config.search_space_path,
-            search_space=config.search_space,
-            objective=config.objective,
+        sampler_config = replace(
+            config,
             output_dir=sampler_output_dir,
-            budget=config.budget,
             seed=config.seed + offset,
-            algo_config_path=config.algo_config_path,
-            horizon=config.horizon,
-            dt=config.dt,
-            workers=config.workers,
-            record_forces=config.record_forces,
-            require_certification=config.require_certification,
-            benchmark_profile=config.benchmark_profile,
-            snqi_weights_path=config.snqi_weights_path,
-            snqi_baseline_path=config.snqi_baseline_path,
         )
         result = run_adversarial_search(
             sampler_config,

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -1,0 +1,213 @@
+"""Compare adversarial candidate samplers on a bounded search config."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.adversarial.attribution import attribution_from_episode_record
+from robot_sf.adversarial.bundle import write_trajectory_csv
+from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.config import CandidateEvaluation, SearchConfig
+from robot_sf.adversarial.samplers import (
+    CoordinateRefinementSampler,
+    OptunaCandidateSampler,
+    RandomCandidateSampler,
+)
+from robot_sf.adversarial.search import run_adversarial_search
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from robot_sf.adversarial.config import CandidateSpec, SearchSpaceConfig
+
+
+@dataclass(frozen=True)
+class SamplerComparisonRow:
+    """One sampler result row for the comparison report."""
+
+    sampler: str
+    manifest_path: str
+    best_bundle_path: str | None
+    best_objective_value: float | None
+    num_candidates: int
+    num_valid_candidates: int
+    num_invalid_candidates: int
+    num_failed_evaluations: int
+
+
+def build_sampler(name: str, search_space: SearchSpaceConfig, *, seed: int):
+    """Build a named adversarial sampler."""
+    key = name.strip().lower()
+    if key == "random":
+        return RandomCandidateSampler(search_space, seed=seed)
+    if key == "coordinate":
+        return CoordinateRefinementSampler(search_space, seed=seed)
+    if key == "optuna":
+        return OptunaCandidateSampler(search_space, seed=seed)
+    raise ValueError("sampler must be one of: random, coordinate, optuna")
+
+
+def run_sampler_comparison(
+    *,
+    config: SearchConfig,
+    sampler_names: Sequence[str],
+    synthetic: bool,
+) -> list[SamplerComparisonRow]:
+    """Run the configured search once per sampler and return compact rows."""
+    rows: list[SamplerComparisonRow] = []
+    for offset, sampler_name in enumerate(sampler_names):
+        sampler_output_dir = config.output_dir / sampler_name
+        sampler_config = SearchConfig(
+            policy=config.policy,
+            scenario_template=config.scenario_template,
+            search_space_path=config.search_space_path,
+            search_space=config.search_space,
+            objective=config.objective,
+            output_dir=sampler_output_dir,
+            budget=config.budget,
+            seed=config.seed + offset,
+            algo_config_path=config.algo_config_path,
+            horizon=config.horizon,
+            dt=config.dt,
+            workers=config.workers,
+            record_forces=config.record_forces,
+            require_certification=config.require_certification,
+            benchmark_profile=config.benchmark_profile,
+            snqi_weights_path=config.snqi_weights_path,
+            snqi_baseline_path=config.snqi_baseline_path,
+        )
+        result = run_adversarial_search(
+            sampler_config,
+            sampler=build_sampler(sampler_name, config.search_space, seed=config.seed + offset),
+            evaluator=_synthetic_evaluator if synthetic else None,
+            certifier=(
+                (lambda _candidate, _path, _required: passed_status("synthetic comparison"))
+                if synthetic
+                else None
+            ),
+        )
+        rows.append(
+            SamplerComparisonRow(
+                sampler=sampler_name,
+                manifest_path=result.manifest_path.as_posix(),
+                best_bundle_path=(
+                    result.best_bundle_path.as_posix() if result.best_bundle_path else None
+                ),
+                best_objective_value=result.best_objective_value,
+                num_candidates=result.num_candidates,
+                num_valid_candidates=result.num_valid_candidates,
+                num_invalid_candidates=result.num_invalid_candidates,
+                num_failed_evaluations=result.num_failed_evaluations,
+            )
+        )
+    return rows
+
+
+def _synthetic_evaluator(
+    config: SearchConfig,
+    candidate: CandidateSpec,
+    scenario_yaml_path: Path,
+    candidate_dir: Path,
+) -> CandidateEvaluation:
+    """Write a small deterministic episode record for sampler-comparison smoke tests."""
+    del config
+    target_x = 1.0
+    synthetic_snqi = abs(float(candidate.start.x) - target_x) + (
+        0.05 * float(candidate.pedestrian_delay_s)
+    )
+    record = {
+        "episode_id": f"synthetic-{candidate.scenario_seed}",
+        "seed": int(candidate.scenario_seed),
+        "status": "success",
+        "steps": 1,
+        "termination_reason": "success",
+        "outcome": {"route_complete": True, "collision": False, "timeout": False},
+        "metrics": {"snqi": float(synthetic_snqi), "success": 1.0},
+    }
+    episode_path = candidate_dir / "episode_records.jsonl"
+    episode_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    trajectory_path = write_trajectory_csv(candidate_dir / "trajectory.csv", record)
+    return CandidateEvaluation(
+        candidate=candidate,
+        certification_status=passed_status("synthetic comparison"),
+        objective_value=None,
+        failure_attribution=attribution_from_episode_record(record),
+        episode_record_path=episode_path,
+        trajectory_csv_path=trajectory_path,
+        scenario_yaml_path=scenario_yaml_path,
+        bundle_path=candidate_dir,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario-template",
+        type=Path,
+        default=Path("configs/scenarios/templates/crossing_ttc.yaml"),
+    )
+    parser.add_argument(
+        "--search-space",
+        type=Path,
+        default=Path("configs/adversarial/crossing_ttc_space.yaml"),
+    )
+    parser.add_argument("--policy", default="goal")
+    parser.add_argument("--objective", default="worst_case_snqi")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--budget", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--sampler",
+        action="append",
+        dest="samplers",
+        choices=("random", "coordinate", "optuna"),
+        default=None,
+        help="Sampler to run; repeat to select multiple. Defaults to all three.",
+    )
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Use a deterministic synthetic evaluator instead of running benchmark episodes.",
+    )
+    parser.add_argument("--out-json", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the sampler comparison CLI."""
+    args = parse_args(argv)
+    config = SearchConfig.from_files(
+        policy=args.policy,
+        scenario_template=args.scenario_template,
+        search_space=args.search_space,
+        objective=args.objective,
+        output_dir=args.output_dir,
+        budget=args.budget,
+        seed=args.seed,
+    )
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=tuple(args.samplers or ("random", "coordinate", "optuna")),
+        synthetic=bool(args.synthetic),
+    )
+    payload = {
+        "schema_version": "adversarial-sampler-comparison.v1",
+        "rows": [asdict(r) for r in rows],
+    }
+    if args.out_json is not None:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -35,12 +35,17 @@ from robot_sf.adversarial.runtime import (
     build_multi_ped_adversarial_robot_config,
     multi_ped_config_to_single_pedestrian_definitions,
 )
-from robot_sf.adversarial.samplers import CoordinateRefinementSampler, RandomCandidateSampler
+from robot_sf.adversarial.samplers import (
+    CoordinateRefinementSampler,
+    OptunaCandidateSampler,
+    RandomCandidateSampler,
+)
 from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.ped_npc.ped_population import populate_single_pedestrians
+from scripts.tools.compare_adversarial_samplers import run_sampler_comparison
 
 _MULTI_PED_FAMILY_FIXTURES = (
     (
@@ -859,6 +864,95 @@ def test_coordinate_refinement_sampler_improves_synthetic_objective(tmp_path: Pa
     assert [candidate.start.x for candidate in sampled[:2]] == [1.0, 2.0]
     assert result.best_bundle_path == config.output_dir / "candidate_0001"
     assert result.best_objective_value == pytest.approx(-0.0)
+
+
+def test_optuna_candidate_sampler_is_deterministic_and_feedback_capable(
+    tmp_path: Path,
+) -> None:
+    """Optuna-backed sampling should be deterministic and accept scored feedback."""
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    config = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+        seed=19,
+    )
+
+    left = OptunaCandidateSampler(config.search_space, seed=19)
+    right = OptunaCandidateSampler(config.search_space, seed=19)
+    first = left.sample()
+    assert first == right.sample()
+
+    left.observe(
+        CandidateEvaluation(
+            candidate=first,
+            certification_status=passed_status(),
+            objective_value=0.25,
+            failure_attribution=None,
+            episode_record_path=None,
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+        )
+    )
+    second = left.sample()
+
+    assert config.search_space.validate_candidate(second) == []
+    assert second.scenario_seed == int(second.scenario_seed)
+
+
+def test_optuna_candidate_sampler_reports_missing_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The optimizer sampler should fail with an actionable dependency error."""
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    config = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+    )
+    monkeypatch.setitem(sys.modules, "optuna", None)
+
+    with pytest.raises(RuntimeError, match="OptunaCandidateSampler requires optuna"):
+        OptunaCandidateSampler(config.search_space, seed=7)
+
+
+def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
+    """Comparison helper should run random, coordinate, and optuna samplers."""
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    config = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "comparison",
+        budget=2,
+        seed=23,
+    )
+
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random", "coordinate", "optuna"),
+        synthetic=True,
+    )
+
+    assert [row.sampler for row in rows] == ["random", "coordinate", "optuna"]
+    assert {row.num_candidates for row in rows} == {2}
+    assert all(Path(row.manifest_path).exists() for row in rows)
+    assert all(row.num_failed_evaluations == 0 for row in rows)
 
 
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1236.

## Summary
- Adds `OptunaCandidateSampler`, an Optuna-backed `FeedbackCandidateSampler` using the existing ask/tell API and no new dependency.
- Adds `scripts/tools/compare_adversarial_samplers.py` to compare random, coordinate, and optuna samplers on the same adversarial `SearchConfig`, with a synthetic smoke mode for fast reproducible checks.
- Records the pilot boundary in `docs/context/issue_1236_optimizer_adversarial_sampler.md`, including the negative/neutral tiny synthetic result and the non-paper-facing interpretation.

## Validation
- Red proof: `uv run --active pytest tests/adversarial/test_adversarial_search.py -q -k 'optuna_candidate_sampler'` initially failed because `OptunaCandidateSampler` was missing.
- `uv run --active pytest tests/adversarial/test_adversarial_search.py -q -k 'optuna_candidate_sampler or sampler_comparison_synthetic'` -> 3 passed, 35 deselected.
- `uv run --active pytest tests/adversarial/test_adversarial_search.py -q` -> 38 passed.
- `uv run --active ruff check robot_sf/adversarial scripts/tools/compare_adversarial_samplers.py tests/adversarial/test_adversarial_search.py` -> passed.
- Synthetic smoke: `uv run --active python scripts/tools/compare_adversarial_samplers.py --output-dir output/adversarial/issue1236_sampler_comparison --budget 3 --seed 123 --synthetic --out-json output/adversarial/issue1236_sampler_comparison/summary.json` -> wrote random/coordinate/optuna manifests; tiny surface did not show an Optuna win.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3558 passed, 12 skipped, 6 warnings; changed-file coverage cleared the 80% minimum (`samplers.py` 84.3%).
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed.

## Notes
- `output/adversarial/issue1236_sampler_comparison/*` and `output/coverage/*` are ignored local validation artifacts and are not part of the PR.
- This remains a bounded pilot, not paper-facing evidence or a claim that optimizer-backed search is stronger under small budgets.