### PR TITLE
docs: replace telemetry placeholder docstrings (#1268)

### DIFF
--- a/robot_sf/telemetry/progress.py
+++ b/robot_sf/telemetry/progress.py
@@ -53,13 +53,13 @@ class ProgressTracker:
         log_fn: LogFunction | None = None,
         time_provider: TimeProvider | None = None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Initialize step entries and persist the initial step index.
 
         Args:
-            steps: TODO docstring.
-            writer: TODO docstring.
-            log_fn: TODO docstring.
-            time_provider: TODO docstring.
+            steps: Ordered pipeline steps to track. At least one step is required.
+            writer: Optional manifest writer that receives step-index updates.
+            log_fn: Optional status logging callback. Defaults to ``logger.info``.
+            time_provider: Optional clock callback for deterministic tests.
         """
         if not steps:
             raise ValueError("ProgressTracker requires at least one step definition")
@@ -97,10 +97,10 @@ class ProgressTracker:
             return deepcopy(self._entries)
 
     def start_step(self, step_id: str) -> None:
-        """TODO docstring. Document this function.
+        """Mark a pending or skipped step as running and log its ETA snapshot.
 
         Args:
-            step_id: TODO docstring.
+            step_id: Identifier from the configured step definitions.
         """
         with self._lock:
             entry = self._get_entry_locked(step_id)
@@ -122,10 +122,10 @@ class ProgressTracker:
         self._log_once(step_id, message)
 
     def complete_step(self, step_id: str) -> None:
-        """TODO docstring. Document this function.
+        """Mark a running or never-started step complete and record duration.
 
         Args:
-            step_id: TODO docstring.
+            step_id: Identifier from the configured step definitions.
         """
         with self._lock:
             entry = self._get_entry_locked(step_id)
@@ -151,11 +151,11 @@ class ProgressTracker:
         self._log_once(step_id, message)
 
     def fail_step(self, step_id: str, *, reason: str | None = None) -> None:
-        """TODO docstring. Document this function.
+        """Mark a step failed and emit a failure status message.
 
         Args:
-            step_id: TODO docstring.
-            reason: TODO docstring.
+            step_id: Identifier from the configured step definitions.
+            reason: Optional human-readable failure reason appended to the log.
         """
         with self._lock:
             entry = self._get_entry_locked(step_id)
@@ -176,11 +176,11 @@ class ProgressTracker:
         self._emit_log(message)
 
     def skip_step(self, step_id: str, *, reason: str | None = None) -> None:
-        """TODO docstring. Document this function.
+        """Mark a pending step skipped without consuming elapsed time.
 
         Args:
-            step_id: TODO docstring.
-            reason: TODO docstring.
+            step_id: Identifier from the configured step definitions.
+            reason: Optional human-readable skip reason appended to the log.
         """
         with self._lock:
             entry = self._get_entry_locked(step_id)
@@ -205,31 +205,31 @@ class ProgressTracker:
         self._emit_log(message)
 
     def current_step(self) -> StepExecutionEntry | None:
-        """TODO docstring. Document this function.
+        """Return the currently running step entry.
 
 
         Returns:
-            TODO docstring.
+            Running step entry, or ``None`` when no step is running.
         """
         with self._lock:
             return self._current_step_locked()
 
     def completed_steps(self) -> int:
-        """TODO docstring. Document this function.
+        """Count completed steps.
 
 
         Returns:
-            TODO docstring.
+            Number of entries with ``COMPLETED`` status.
         """
         with self._lock:
             return sum(1 for entry in self._entries if entry.status == StepStatus.COMPLETED)
 
     def total_steps(self) -> int:
-        """TODO docstring. Document this function.
+        """Count configured pipeline steps.
 
 
         Returns:
-            TODO docstring.
+            Total number of tracked step entries.
         """
         with self._lock:
             return len(self._entries)
@@ -285,12 +285,12 @@ class ProgressTracker:
         mark_failed: bool = False,
         reason: str | None = None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Persist guard state and notify the heartbeat callback.
 
         Args:
-            status: TODO docstring.
-            mark_failed: TODO docstring.
-            reason: TODO docstring.
+            status: Pipeline status passed to the heartbeat callback.
+            mark_failed: Whether to convert the active step to failed before flushing.
+            reason: Optional failure reason used when ``mark_failed`` is true.
         """
         log_message: str | None = None
         with self._lock:
@@ -304,13 +304,13 @@ class ProgressTracker:
             callback(status)
 
     def _mark_running_step_failed_locked(self, reason: str | None) -> str | None:
-        """TODO docstring. Document this function.
+        """Convert the current running step to failed while the tracker lock is held.
 
         Args:
-            reason: TODO docstring.
+            reason: Optional failure reason included in the formatted status line.
 
         Returns:
-            TODO docstring.
+            Failure log message for the changed step, or ``None`` if no step changed.
         """
         entry = self._current_step_locked()
         if entry is None or entry.status == StepStatus.FAILED:
@@ -330,11 +330,11 @@ class ProgressTracker:
         )
 
     def _current_step_locked(self) -> StepExecutionEntry | None:
-        """TODO docstring. Document this function.
+        """Return the running step while the tracker lock is held.
 
 
         Returns:
-            TODO docstring.
+            Running step entry, or ``None`` when all steps are idle/terminal.
         """
         for entry in self._entries:
             if entry.status == StepStatus.RUNNING:
@@ -342,34 +342,34 @@ class ProgressTracker:
         return None
 
     def _has_active_steps(self) -> bool:
-        """TODO docstring. Document this function.
+        """Return whether any step still needs progress or terminal handling.
 
 
         Returns:
-            TODO docstring.
+            ``True`` when a step is pending or running.
         """
         with self._lock:
             return self._has_active_steps_locked()
 
     def _has_active_steps_locked(self) -> bool:
-        """TODO docstring. Document this function.
+        """Return active-step state while the tracker lock is already held.
 
 
         Returns:
-            TODO docstring.
+            ``True`` when a step is pending or running.
         """
         return any(
             entry.status in (StepStatus.PENDING, StepStatus.RUNNING) for entry in self._entries
         )
 
     def _get_entry_locked(self, step_id: str) -> StepExecutionEntry:
-        """TODO docstring. Document this function.
+        """Look up a step entry by id while the tracker lock is held.
 
         Args:
-            step_id: TODO docstring.
+            step_id: Identifier from the configured step definitions.
 
         Returns:
-            TODO docstring.
+            Matching step execution entry.
         """
         for entry in self._entries:
             if entry.step_id == step_id:
@@ -434,11 +434,11 @@ class ProgressTracker:
         return message
 
     def _log_once(self, step_id: str, message: str) -> None:
-        """TODO docstring. Document this function.
+        """Emit a status message once per step/message pair.
 
         Args:
-            step_id: TODO docstring.
-            message: TODO docstring.
+            step_id: Step id used to deduplicate repeated status messages.
+            message: Status message to emit through the configured logger.
         """
         with self._log_lock:
             last = self._last_log_messages.get(step_id)
@@ -448,33 +448,33 @@ class ProgressTracker:
         self._emit_log(message)
 
     def _emit_log(self, message: str) -> None:
-        """TODO docstring. Document this function.
+        """Send a status message to the configured logging callback.
 
         Args:
-            message: TODO docstring.
+            message: Human-readable progress status line.
         """
         self._log_fn(message)
 
     def _write_index(self) -> None:
-        """TODO docstring. Document this function."""
+        """Persist the step index after acquiring the tracker lock."""
         with self._lock:
             self._write_index_locked()
 
     def _write_index_locked(self) -> None:
-        """TODO docstring. Document this function."""
+        """Persist the step index when a manifest writer is configured."""
         if self._writer is None:
             return
         self._writer.write_step_index(self._entries)
 
     @staticmethod
     def _format_duration(value: float | None) -> str:
-        """TODO docstring. Document this function.
+        """Format a duration for compact progress log output.
 
         Args:
-            value: TODO docstring.
+            value: Duration in seconds, or ``None`` when unknown.
 
         Returns:
-            TODO docstring.
+            Human-readable duration such as ``3s``, ``2m04s``, ``1h02m``, or ``--``.
         """
         if value is None:
             return "--"
@@ -511,14 +511,14 @@ class _FailureSafeGuard:
         flush_interval: float,
         signals: Sequence[int | signal.Signals] | None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Start the guard thread and install termination-signal handlers.
 
         Args:
-            has_work: TODO docstring.
-            flush_running: TODO docstring.
-            flush_failed: TODO docstring.
-            flush_interval: TODO docstring.
-            signals: TODO docstring.
+            has_work: Callback indicating whether a heartbeat flush is needed.
+            flush_running: Callback used for periodic running-state flushes.
+            flush_failed: Callback used before shutdown or handled termination signals.
+            flush_interval: Minimum seconds between background heartbeat flushes.
+            signals: Signals to intercept; defaults to SIGTERM/SIGINT where available.
         """
         self._has_work = has_work
         self._flush_running = flush_running
@@ -537,14 +537,14 @@ class _FailureSafeGuard:
         self._install_signal_handlers()
 
         def _cleanup() -> None:
-            """TODO docstring. Document this function."""
+            """Flush and restore handlers during interpreter shutdown."""
             self.close()
 
         self._atexit_callback = _cleanup
         atexit.register(self._atexit_callback)
 
     def close(self) -> None:
-        """TODO docstring. Document this function."""
+        """Stop the guard thread and restore signal/atexit state."""
         if self._shutdown.is_set():
             return
         self._shutdown.set()
@@ -557,14 +557,14 @@ class _FailureSafeGuard:
             self._atexit_callback = None
 
     def _run(self) -> None:
-        """TODO docstring. Document this function."""
+        """Flush running progress periodically while work remains active."""
         while not self._shutdown.wait(self._flush_interval):
             if not self._has_work():
                 continue
             self._flush_running()
 
     def _install_signal_handlers(self) -> None:
-        """TODO docstring. Document this function."""
+        """Install configured signal handlers on the main thread when possible."""
         if not self._signals:
             return
         if threading.current_thread() is not threading.main_thread():
@@ -578,7 +578,7 @@ class _FailureSafeGuard:
             self._previous_handlers[signum] = previous
 
     def _restore_signal_handlers(self) -> None:
-        """TODO docstring. Document this function."""
+        """Restore signal handlers saved during guard installation."""
         if not self._previous_handlers:
             return
         for signum, handler in self._previous_handlers.items():
@@ -587,11 +587,11 @@ class _FailureSafeGuard:
         self._previous_handlers.clear()
 
     def _handle_signal(self, signum: int, frame: FrameType | None) -> None:
-        """TODO docstring. Document this function.
+        """Flush a failure manifest before delegating to the previous signal handler.
 
         Args:
-            signum: TODO docstring.
-            frame: TODO docstring.
+            signum: Received signal number.
+            frame: Current interpreter frame supplied by ``signal``.
         """
         signal_name = self._signal_name(signum)
         self._flush_failed(f"Signal {signal_name}")
@@ -606,13 +606,13 @@ class _FailureSafeGuard:
 
     @staticmethod
     def _signal_name(signum: int) -> str:
-        """TODO docstring. Document this function.
+        """Return a readable signal name.
 
         Args:
-            signum: TODO docstring.
+            signum: Signal number.
 
         Returns:
-            TODO docstring.
+            Enum name for known signals, otherwise the numeric value as text.
         """
         try:
             return signal.Signals(signum).name
@@ -621,13 +621,13 @@ class _FailureSafeGuard:
 
     @staticmethod
     def _normalize_signals(signals: Sequence[int | signal.Signals] | None) -> tuple[int, ...]:
-        """TODO docstring. Document this function.
+        """Normalize optional signal enums/ints into unique signal numbers.
 
         Args:
-            signals: TODO docstring.
+            signals: Optional sequence of signal enums or integer signal numbers.
 
         Returns:
-            TODO docstring.
+            Tuple of unique signal numbers preserving input order.
         """
         if signals is None:
             return tuple(int(sig) for sig in _DEFAULT_FAILURE_SIGNALS)

--- a/robot_sf/telemetry/progress.py
+++ b/robot_sf/telemetry/progress.py
@@ -516,8 +516,9 @@ class _FailureSafeGuard:
         Args:
             has_work: Callback indicating whether a heartbeat flush is needed.
             flush_running: Callback used for periodic running-state flushes.
-            flush_failed: Callback used before shutdown or handled termination signals.
-            flush_interval: Minimum seconds between background heartbeat flushes.
+            flush_failed: Callback used when a handled termination signal is received.
+            flush_interval: Desired interval between background heartbeat flushes; values below
+                1.0 second are clamped.
             signals: Signals to intercept; defaults to SIGTERM/SIGINT where available.
         """
         self._has_work = has_work
@@ -537,7 +538,7 @@ class _FailureSafeGuard:
         self._install_signal_handlers()
 
         def _cleanup() -> None:
-            """Flush and restore handlers during interpreter shutdown."""
+            """Stop the guard and restore handlers during interpreter shutdown."""
             self.close()
 
         self._atexit_callback = _cleanup

--- a/robot_sf/telemetry/recommendations.py
+++ b/robot_sf/telemetry/recommendations.py
@@ -47,11 +47,13 @@ class RecommendationEngine:
         rules: RecommendationRules | None = None,
         total_memory_mb: float | None = None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Initialize an engine with optional thresholds and memory capacity.
 
         Args:
-            rules: TODO docstring.
-            total_memory_mb: TODO docstring.
+            rules: Thresholds used to classify telemetry samples. Defaults to
+                ``RecommendationRules``.
+            total_memory_mb: Total system memory in MiB used for memory-pressure
+                ratios. When omitted, the value is detected with psutil when available.
         """
         self._rules = rules or RecommendationRules()
         self._snapshots: list[TelemetrySnapshot] = []

--- a/robot_sf/telemetry/run_registry.py
+++ b/robot_sf/telemetry/run_registry.py
@@ -24,10 +24,11 @@ class RunRegistry:
     """Create per-run directories and prune historical runs when necessary."""
 
     def __init__(self, config: RunTrackerConfig) -> None:
-        """TODO docstring. Document this function.
+        """Bind the registry to a run-tracker configuration.
 
         Args:
-            config: TODO docstring.
+            config: Configuration that supplies the root directory and retention
+                count for run-tracker artifacts.
         """
         if not isinstance(config, RunTrackerConfig):  # pragma: no cover - runtime guard
             raise TypeError(f"config must be RunTrackerConfig, received {type(config)!r}")
@@ -35,11 +36,11 @@ class RunRegistry:
 
     @property
     def base_dir(self) -> Path:
-        """TODO docstring. Document this function.
+        """Return the root directory that contains all tracked run directories.
 
 
         Returns:
-            TODO docstring.
+            Path resolved from ``RunTrackerConfig.run_tracker_root``.
         """
         return Path(self._config.run_tracker_root)
 

--- a/robot_sf/telemetry/sampler.py
+++ b/robot_sf/telemetry/sampler.py
@@ -311,13 +311,13 @@ class TelemetrySampler:
 
     @staticmethod
     def _resource_memory_mb(notes: set[str]) -> float | None:
-        """Return process memory from ``resource.getrusage`` when psutil is absent.
+        """Return peak process memory from ``resource.getrusage`` when psutil is absent.
 
         Args:
             notes: Mutable set that receives availability markers.
 
         Returns:
-            Resident memory in MiB, normalized for Linux and macOS units, or
+            Peak resident memory in MiB, normalized for Linux and macOS units, or
             ``None`` when unavailable.
         """
         if resource is None:  # pragma: no cover - platform without resource

--- a/robot_sf/telemetry/sampler.py
+++ b/robot_sf/telemetry/sampler.py
@@ -58,15 +58,17 @@ class TelemetrySampler:
         frame_idx_provider: Callable[[], int | None] | None = None,
         status_provider: Callable[[], str | None] | None = None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Configure a background sampler for manifest telemetry snapshots.
 
         Args:
-            writer: TODO docstring.
-            progress_tracker: TODO docstring.
-            started_at: TODO docstring.
-            interval_seconds: TODO docstring.
-            time_provider: TODO docstring.
-            step_rate_provider: TODO docstring.
+            writer: Manifest writer that receives every collected snapshot.
+            progress_tracker: Optional tracker used to resolve the current step and
+                default completed-step throughput.
+            started_at: Run start time used by the default step-rate calculation.
+            interval_seconds: Desired sampling period; values below 0.5 seconds are
+                clamped to avoid overly tight polling.
+            time_provider: Optional clock callback, primarily for deterministic tests.
+            step_rate_provider: Optional callback that returns the current step rate.
             frame_idx_provider: Optional callback providing current frame index.
             status_provider: Optional callback providing run status string.
         """
@@ -113,22 +115,22 @@ class TelemetrySampler:
         self.stop()
 
     def __enter__(self) -> TelemetrySampler:
-        """TODO docstring. Document this function.
+        """Start sampling and return this sampler for context-manager use.
 
 
         Returns:
-            TODO docstring.
+            The running sampler instance.
         """
         self.start()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
-        """TODO docstring. Document this function.
+        """Stop sampling when leaving a context-manager block.
 
         Args:
-            exc_type: TODO docstring.
-            exc: TODO docstring.
-            tb: TODO docstring.
+            exc_type: Exception type raised by the managed block, if any.
+            exc: Exception instance raised by the managed block, if any.
+            tb: Traceback raised by the managed block, if any.
         """
         self.stop()
 
@@ -166,7 +168,7 @@ class TelemetrySampler:
         return snapshot
 
     def _run_loop(self) -> None:
-        """TODO docstring. Document this function."""
+        """Emit snapshots until stopped, preserving the configured interval."""
         while not self._stop_event.is_set():
             start = time.perf_counter()
             with contextlib.suppress(Exception):
@@ -176,11 +178,12 @@ class TelemetrySampler:
             self._stop_event.wait(timeout=sleep_for)
 
     def _collect_snapshot(self) -> TelemetrySnapshot:
-        """TODO docstring. Document this function.
+        """Collect one CPU, memory, GPU, progress, and status snapshot.
 
 
         Returns:
-            TODO docstring.
+            Snapshot with unavailable metrics left as ``None`` and explanatory
+            notes for recoverable sampling failures.
         """
         timestamp = self._clock()
         timestamp_ms = int(timestamp.timestamp() * 1000)
@@ -218,11 +221,11 @@ class TelemetrySampler:
         return snapshot
 
     def _resolve_current_step(self) -> str | None:
-        """TODO docstring. Document this function.
+        """Return the currently running progress step id, if one is available.
 
 
         Returns:
-            TODO docstring.
+            Current step id, or ``None`` when no tracker/active step can be read.
         """
         tracker = self._progress_tracker
         if tracker is None:
@@ -234,11 +237,12 @@ class TelemetrySampler:
         return None
 
     def _default_step_rate(self) -> float | None:
-        """TODO docstring. Document this function.
+        """Estimate completed pipeline steps per second from the tracker.
 
 
         Returns:
-            TODO docstring.
+            Completed-step rate, or ``None`` when no tracker or elapsed time is
+            available.
         """
         tracker = self._progress_tracker
         if tracker is None:
@@ -250,13 +254,13 @@ class TelemetrySampler:
         return completed / elapsed
 
     def _sample_process_cpu(self, notes: set[str]) -> float | None:
-        """TODO docstring. Document this function.
+        """Sample CPU usage for the current process.
 
         Args:
-            notes: TODO docstring.
+            notes: Mutable set that receives availability or error markers.
 
         Returns:
-            TODO docstring.
+            Process CPU percentage, or ``None`` when psutil is unavailable/fails.
         """
         if self._process is None:
             notes.add("psutil-unavailable")
@@ -269,13 +273,13 @@ class TelemetrySampler:
             return None
 
     def _sample_system_cpu(self, notes: set[str]) -> float | None:
-        """TODO docstring. Document this function.
+        """Sample whole-system CPU usage.
 
         Args:
-            notes: TODO docstring.
+            notes: Mutable set that receives availability or error markers.
 
         Returns:
-            TODO docstring.
+            System CPU percentage, or ``None`` when sampling is unavailable/fails.
         """
         if not self._system_cpu_fn:
             notes.add("system-cpu-unavailable")
@@ -288,13 +292,13 @@ class TelemetrySampler:
             return None
 
     def _sample_memory_mb(self, notes: set[str]) -> float | None:
-        """TODO docstring. Document this function.
+        """Sample resident memory in MiB with a resource-module fallback.
 
         Args:
-            notes: TODO docstring.
+            notes: Mutable set that receives availability or error markers.
 
         Returns:
-            TODO docstring.
+            Resident memory in MiB, or ``None`` if no memory source is available.
         """
         if self._process is not None:
             try:
@@ -307,13 +311,14 @@ class TelemetrySampler:
 
     @staticmethod
     def _resource_memory_mb(notes: set[str]) -> float | None:
-        """TODO docstring. Document this function.
+        """Return process memory from ``resource.getrusage`` when psutil is absent.
 
         Args:
-            notes: TODO docstring.
+            notes: Mutable set that receives availability markers.
 
         Returns:
-            TODO docstring.
+            Resident memory in MiB, normalized for Linux and macOS units, or
+            ``None`` when unavailable.
         """
         if resource is None:  # pragma: no cover - platform without resource
             notes.add("resource-module-unavailable")
@@ -326,13 +331,13 @@ class TelemetrySampler:
 
     @staticmethod
     def _safe_call(func: Callable[[], object | None] | None) -> object | None:
-        """TODO docstring. Document this function.
+        """Call an optional provider without letting provider failures escape.
 
         Args:
-            func: TODO docstring.
+            func: Zero-argument provider callback.
 
         Returns:
-            TODO docstring.
+            Provider result, or ``None`` when the provider is missing or raises.
         """
         if func is None:
             return None


### PR DESCRIPTION
## Summary
Replaces generated placeholder TODO docstrings in the production telemetry package with concise contract-focused descriptions.

## Linked Issues
- Closes #1268

## What Changed
- Updated telemetry progress-tracker docstrings to describe lifecycle transitions, ETA state, failure-guard behavior, logging, and signal handling.
- Updated telemetry sampler docstrings to describe snapshot collection, optional providers, metric fallbacks, and context-manager behavior.
- Updated run-registry and recommendation-engine docstrings to describe configuration, retention, and threshold inputs.

## Why It Matters
- Added value: telemetry/progress code is easier for agents and contributors to inspect during long-running validation and experiment workflows.
- Expected impact: no runtime behavior changes; this is documentation-only inside existing Python docstrings.
- Why this is worth merging now: #1268 identified these placeholders as a bounded production telemetry cleanup slice.

## Validation / Proof
- `rtk rg -n "TODO docstring" robot_sf/telemetry` -> no matches.
- `rtk uv run --active pytest tests/test_tracking tests/telemetry -q` -> 16 passed, 1 skipped.
- `rtk uv run --active ruff check robot_sf/telemetry/progress.py robot_sf/telemetry/sampler.py robot_sf/telemetry/run_registry.py robot_sf/telemetry/recommendations.py` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` after committing the diff -> 3619 passed, 11 skipped, 3 warnings.
- `rtk git diff --check origin/main...HEAD` -> passed.

## Risks / Rollout
- Compatibility risks: none expected; code behavior is unchanged.
- Failure modes: inaccurate docstrings could mislead future maintainers, so wording was matched to the existing implementation and focused tests.
- Rollback or fallback plan: revert the docstring commit.

## Docs / Provenance
- Updated docs: production docstrings in `robot_sf/telemetry/`.
- Relevant design or provenance notes: issue #1268 is the observed placeholder cleanup contract.
- Any assumptions that need to be preserved: this PR intentionally leaves placeholder docstrings outside `robot_sf/telemetry/` for separate follow-up.

## Follow-Up Issues
- Deferred work: repository-wide placeholder cleanup outside telemetry remains out of scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- First-pass self-review: diff is docstring-only, no parser/schema/resource/runtime behavior changed.
- Artifact handling: validation refreshed ignored `output/coverage/*` artifacts only; no durable artifact promotion is needed.
