### PR TITLE
test: guard markdown issue references (#1267)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -885,6 +885,8 @@ Documentation should include:
 - Keep documentation up-to-date as code evolves
 - Use consistent formatting and follow markdown linting standards
 - Prefer GitHub-flavored Markdown (GFM) conventions so docs render correctly on GitHub
+- Write issue references as `Issue #123` in prose, lists, and tables instead of starting a
+  Markdown line with a bare `#123` token.
 - Avoid duplications. Link to existing documentation when relevant.
 - Always provide README.md files in new documentation folders for overview and reference.
 - When the document is longer than 50 lines, create a table of contents at the top for easy navigation. Ideally, use `markdown.extension.toc.create` to *Markdown All in One: Create Table of Contents*.

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -34,8 +34,10 @@ _COMMAND_HINT_RE = re.compile(
 )
 _MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)|<((?:\./)?[^ >]+)>")
 _LINE_START_ISSUE_REF_RE = re.compile(
-    r"^\s*(?:(?:[-*+]\s+)|(?:\d+[.)]\s+)|(?:>\s*)|(?:\|\s*))?#(?P<number>\d+)\b"
+    r"^(?:\s{0,3}|(?:\s*(?:(?:[-*+]\s+)|(?:\d+[.)]\s+)|(?:>\s*)|(?:\|\s*))))"
+    r"#(?P<number>\d+)\b"
 )
+_FENCE_START_RE = re.compile(r"^([`~]{3,})")
 
 
 @dataclass(frozen=True)
@@ -270,14 +272,16 @@ def _markdown_lines_outside_fences(text: str) -> Iterable[tuple[int, str]]:
     fence_marker: str | None = None
     for line_number, line in enumerate(text.splitlines(), 1):
         stripped = line.lstrip()
-        marker = stripped[:3]
-        if marker in {"```", "~~~"}:
-            if in_fence and marker == fence_marker:
+        indent = len(line) - len(stripped)
+        marker_match = _FENCE_START_RE.match(stripped) if indent < 4 else None
+        marker = marker_match.group(1) if marker_match else None
+        if marker is not None:
+            if in_fence and marker[0] == fence_marker:
                 in_fence = False
                 fence_marker = None
             elif not in_fence:
                 in_fence = True
-                fence_marker = marker
+                fence_marker = marker[0]
             continue
         if not in_fence:
             yield line_number, line

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -33,6 +33,9 @@ _COMMAND_HINT_RE = re.compile(
     re.IGNORECASE,
 )
 _MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)|<((?:\./)?[^ >]+)>")
+_LINE_START_ISSUE_REF_RE = re.compile(
+    r"^\s*(?:(?:[-*+]\s+)|(?:\d+[.)]\s+)|(?:>\s*)|(?:\|\s*))?#(?P<number>\d+)\b"
+)
 
 
 @dataclass(frozen=True)
@@ -261,11 +264,54 @@ def _validation_phrase_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     ]
 
 
+def _markdown_lines_outside_fences(text: str) -> Iterable[tuple[int, str]]:
+    """Yield Markdown source lines that are not inside fenced code blocks."""
+    in_fence = False
+    fence_marker: str | None = None
+    for line_number, line in enumerate(text.splitlines(), 1):
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if in_fence and marker == fence_marker:
+                in_fence = False
+                fence_marker = None
+            elif not in_fence:
+                in_fence = True
+                fence_marker = marker
+            continue
+        if not in_fence:
+            yield line_number, line
+
+
+def _issue_reference_style_diagnostics(path: Path, text: str) -> list[Diagnostic]:
+    """Flag bare line-start issue references that render poorly in Markdown."""
+    if path.suffix != ".md":
+        return []
+
+    diagnostics: list[Diagnostic] = []
+    for line_number, line in _markdown_lines_outside_fences(text):
+        match = _LINE_START_ISSUE_REF_RE.match(line)
+        if not match:
+            continue
+        issue_number = match.group("number")
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                message=(
+                    f"line {line_number}: bare issue reference #{issue_number} should use "
+                    f"'Issue #{issue_number}' at the start of Markdown prose, lists, or tables"
+                ),
+            )
+        )
+    return diagnostics
+
+
 def _file_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     """Collect all diagnostics for one changed file."""
     diagnostics: list[Diagnostic] = []
     diagnostics.extend(_evidence_path_diagnostics(path, text))
     diagnostics.extend(_validation_phrase_diagnostics(path, text))
+    diagnostics.extend(_issue_reference_style_diagnostics(path, text))
     return diagnostics
 
 

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -194,6 +194,74 @@ def test_stale_no_validation_phrase_with_commands_is_reported(tmp_path: Path) ->
     )
 
 
+def test_line_start_issue_reference_is_reported(tmp_path: Path) -> None:
+    """Markdown issue references should not start lines as bare #123 tokens."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text("#1108 needs a clearer reference style.\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    assert any("Issue #1108" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_preferred_issue_reference_form_is_allowed(tmp_path: Path) -> None:
+    """The preferred prose form should satisfy the issue-reference style guard."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text("Issue #1108 keeps this link readable in Markdown.\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == []
+
+
+def test_issue_reference_guard_handles_bullets_tables_and_headings(tmp_path: Path) -> None:
+    """Flag bare issue references in lists/tables without banning numeric headings."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text(
+        "# 2026 plan\n\n"
+        "- #1108 should use prose.\n"
+        "| #1262 | missing prefix |\n"
+        "```\n"
+        "#999 is only an example inside a code block\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    messages = [diagnostic.message for diagnostic in diagnostics]
+    assert any("Issue #1108" in message for message in messages)
+    assert any("Issue #1262" in message for message in messages)
+    assert not any("Issue #999" in message for message in messages)
+
+
 def test_explicit_path_new_context_note_is_treated_as_added(tmp_path: Path) -> None:
     """Explicit path checks should still enforce added-note index-link validation."""
     repo_root = tmp_path

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -262,6 +262,52 @@ def test_issue_reference_guard_handles_bullets_tables_and_headings(tmp_path: Pat
     assert not any("Issue #999" in message for message in messages)
 
 
+def test_issue_reference_guard_ignores_indented_code_blocks(tmp_path: Path) -> None:
+    """Four-space indented Markdown code blocks should not be prose diagnostics."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text("    #1108 is literal code, not prose.\n", encoding="utf-8")
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == []
+
+
+def test_issue_reference_guard_handles_indented_long_fences(tmp_path: Path) -> None:
+    """Markdown fences can be indented up to three spaces and longer than three ticks."""
+    repo_root = tmp_path
+    (repo_root / "docs/context").mkdir(parents=True)
+    (repo_root / "docs/context/README.md").write_text(
+        "- [Issue 999 Example](issue_999_example.md)\n",
+        encoding="utf-8",
+    )
+    note = repo_root / "docs/context/issue_999_example.md"
+    note.write_text(
+        "   ````python\n"
+        "#1108 is only sample code.\n"
+        "   ````\n"
+        "#1262 is prose and should be flagged.\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/issue_999_example.md"))],
+        repo_root=repo_root,
+    )
+
+    messages = [diagnostic.message for diagnostic in diagnostics]
+    assert not any("Issue #1108" in message for message in messages)
+    assert any("Issue #1262" in message for message in messages)
+
+
 def test_explicit_path_new_context_note_is_treated_as_added(tmp_path: Path) -> None:
     """Explicit path checks should still enforce added-note index-link validation."""
     repo_root = tmp_path


### PR DESCRIPTION
## Summary
Adds a changed-file Markdown style guard that flags bare line-start issue references like `#1108` and documents the preferred `Issue #1108` convention.

## Linked Issues
- Closes #1267

## What Changed
- Extended `scripts/validation/check_docs_proof_consistency.py` with a Markdown-only diagnostic for bare issue references at the start of prose, bullet, quote, or table-cell lines.
- Added focused validator tests for rejected bare references, accepted `Issue #...` prose, tables/bullets, numeric headings, and fenced code blocks.
- Documented the issue-reference convention in `docs/dev_guide.md`.

## Why It Matters
- Added value: catches a repeated review style issue before PR review.
- Expected impact: changed Markdown docs now get a lightweight local guard without requiring network calls.
- Why this is worth merging now: #1267 was opened from observed PR review churn and is a small, testable workflow hardening slice.

## Validation / Proof
- Red proof: `rtk uv run --active pytest tests/validation/test_check_docs_proof_consistency.py -q` failed with the new bare-reference tests before implementation.
- `rtk uv run --active pytest tests/validation/test_check_docs_proof_consistency.py -q` -> 16 passed.
- `rtk uv run --active ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py` -> passed.
- `BASE_REF=origin/main rtk scripts/dev/check_docs_proof_consistency_diff.sh` -> passed for the branch diff.
- `rtk uv run --active python scripts/validation/check_docs_proof_consistency.py --path docs/context/artifact_evidence_vocabulary.md` -> passed.
- `rtk uv run --active python scripts/validation/check_docs_proof_consistency.py --path docs/context/artifact_evidence_vocabulary.md --path docs/context/issue_1255_open_issue_dependency_graph.md` intentionally reports the historical bare references in the #1262-era note, proving the guard catches that review pattern.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> 3629 passed, 11 skipped, 3 warnings.
- `rtk git diff --check origin/main...HEAD` -> passed.

## Risks / Rollout
- Compatibility risks: low; the rule only runs on changed Markdown files selected by the existing validator.
- Failure modes: a touched historical note with many bare issue table entries will now need local cleanup or a deliberate separate baseline decision.
- Rollback or fallback plan: revert this commit to remove the style guard.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`.
- Relevant design or provenance notes: issue #1267 records the observed PR review cases.
- Any assumptions that need to be preserved: the first slice stays local/static and does not call GitHub.

## Follow-Up Issues
- Deferred work: repository-wide cleanup or a formal allowlist/baseline for old notes, if maintainers want repo-wide enforcement later.
- Issues opened for follow-up: none.

## Reviewer Notes
- First-pass self-review: the regex ignores fenced code and does not flag numeric headings such as `# 2026 plan`.
- Artifact handling: validation refreshed ignored `output/coverage/*` artifacts only; no durable artifact promotion is needed.
