### PR TITLE
fix: surface camera preflight parse failures

### DIFF
--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -803,10 +803,19 @@ def _build_route_clearance_warnings(
             continue
         try:
             map_def = convert_map(str(map_path))
-        except (OSError, ValueError, RuntimeError):
-            logger.opt(exception=True).debug(
-                "Skipping route-clearance preflight for scenario '{}' due to map parse failure.",
-                scenario.get("name", "unknown"),
+        except (OSError, ValueError, RuntimeError) as exc:
+            scenario_name = str(
+                scenario.get("name")
+                or scenario.get("scenario_id")
+                or scenario.get("id")
+                or "unknown"
+            )
+            logger.opt(exception=True).warning(
+                "Skipping route-clearance preflight for scenario '{}' on map '{}' due to map "
+                "parse failure: {}",
+                scenario_name,
+                map_path,
+                exc,
             )
             continue
         route_lines, warning_scope = _scenario_route_lines(map_def, scenario)

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -804,12 +804,7 @@ def _build_route_clearance_warnings(
         try:
             map_def = convert_map(str(map_path))
         except (OSError, ValueError, RuntimeError) as exc:
-            scenario_name = str(
-                scenario.get("name")
-                or scenario.get("scenario_id")
-                or scenario.get("id")
-                or "unknown"
-            )
+            scenario_name = _campaign_scenario_id(scenario)
             logger.opt(exception=True).warning(
                 "Skipping route-clearance preflight for scenario '{}' on map '{}' due to map "
                 "parse failure: {}",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 import yaml
+from loguru import logger
 
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
 from robot_sf.benchmark.camera_ready_campaign import (
@@ -2754,6 +2755,75 @@ def test_prepare_campaign_preflight_emits_route_clearance_warnings(
     manifest_payload = prepared["manifest_payload"]
     assert manifest_payload["route_clearance_warning_count"] == 1
     assert manifest_payload["route_clearance_warnings"] == warnings
+
+
+def test_prepare_campaign_preflight_warns_when_route_clearance_map_parse_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Map parse failures should be visible without DEBUG logging."""
+    broken_map_path = tmp_path / "broken.svg"
+    broken_map_path.write_text("<svg><path d='broken'/></svg>\n", encoding="utf-8")
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "- name: parse_failure_case",
+                f"  map_file: {broken_map_path.as_posix()}",
+                "  seeds: [111]",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: parse_visibility_contract",
+                f"scenario_matrix: {scenario_path.as_posix()}",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    planner_group: core",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fail_convert_map(_path: str) -> object:
+        raise ValueError("invalid SVG path data")
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.camera_ready_campaign.convert_map",
+        fail_convert_map,
+    )
+    captured: list[str] = []
+
+    def capture_message(message: object) -> None:
+        captured.append(str(message))
+
+    handle = logger.add(capture_message, level="WARNING", format="{level}:{message}")
+    try:
+        cfg = load_campaign_config(config_path)
+        prepared = prepare_campaign_preflight(
+            cfg,
+            output_root=tmp_path / "out",
+            label="parse",
+        )
+    finally:
+        logger.remove(handle)
+
+    validate_payload = json.loads(
+        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
+    )
+    assert validate_payload["route_clearance_warning_count"] == 0
+
+    log_text = "\n".join(captured)
+    assert "WARNING:" in log_text
+    assert "parse_failure_case" in log_text
+    assert broken_map_path.as_posix() in log_text
+    assert "invalid SVG path data" in log_text
 
 
 def test_prepare_campaign_preflight_attaches_route_clearance_certifications(


### PR DESCRIPTION
## Summary
Surface camera-ready route-clearance preflight map parse failures at warning level while preserving the existing skip-on-failure behavior.

## Linked Issues
- Closes #1277

## What Changed
- Changed `robot_sf/benchmark/camera_ready_campaign.py` so route-clearance preflight parse failures log a warning with scenario name, map path, and root cause.
- Added a regression test that runs campaign preflight with a malformed map parse path and captures warning-level Loguru output.

## Why It Matters
- Added value: default benchmark runs now show why route-clearance preflight was skipped for a scenario.
- Expected impact: diagnostic visibility improves without changing benchmark outputs, planner execution, or route-clearance warning semantics.
- Why this is worth merging now: the issue is narrow and removes a debugging blind spot in camera-ready preflight.

## Validation / Proof
- Commands run:
  - `uv run --active pytest tests/benchmark/test_camera_ready_campaign.py::test_prepare_campaign_preflight_warns_when_route_clearance_map_parse_fails -q`
  - `uv run --active pytest tests/benchmark/test_camera_ready_campaign.py::test_prepare_campaign_preflight_emits_route_clearance_warnings tests/benchmark/test_camera_ready_campaign.py::test_prepare_campaign_preflight_warns_when_route_clearance_map_parse_fails tests/benchmark/test_camera_ready_campaign.py::test_prepare_campaign_preflight_attaches_route_clearance_certifications -q`
  - `uv run --active ruff check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: the new regression test failed before the production change because no warning-level message was captured, then passed after the log promotion.
- Benchmarks or smoke tests, if applicable: full PR readiness passed with `3627 passed, 11 skipped, 3 warnings`; changed-file coverage reported `robot_sf/benchmark/camera_ready_campaign.py: 90.1% [WARN]` as a non-failing warning.

## Risks / Rollout
- Compatibility risks: low; this only changes log level and message content for an already-handled exception path.
- Failure modes: warning output may become more visible for invalid scenario map inputs.
- Rollback or fallback plan: revert the single logging change if warning verbosity is too high.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: benchmark skip-on-failure behavior is intentionally unchanged.
- Any assumptions that need to be preserved: fallback/degraded execution is still not treated as benchmark success evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that the warning includes enough scenario and map context while keeping the preflight payload unchanged.
