### PR TITLE
docs: replace benchmark script docstring placeholders

### DIFF
--- a/scripts/analyze_feature_extractors.py
+++ b/scripts/analyze_feature_extractors.py
@@ -49,13 +49,13 @@ class FeatureExtractorAnalyzer:
         self.analysis_dir.mkdir(exist_ok=True)
 
     def _load_from_summary(self, payload: dict) -> tuple[dict, dict]:
-        """TODO docstring. Document this function.
+        """Convert a compact multi-extractor summary payload into analyzer fields.
 
         Args:
-            payload: TODO docstring.
+            payload: Parsed summary JSON containing `extractor_results`.
 
         Returns:
-            TODO docstring.
+            Pair of normalized extractor result mapping and run metadata mapping.
         """
         records = payload.get("extractor_results", [])
         results: dict[str, dict] = {}
@@ -219,7 +219,7 @@ class FeatureExtractorAnalyzer:
 
     # ---- Visualization helpers (kept small for C901 compliance) ----
     def _set_plot_style(self) -> None:
-        """TODO docstring. Document this function."""
+        """Apply a preferred Matplotlib style with a default-style fallback."""
         preferred_styles = ["seaborn-v0_8", "seaborn"]
         for style in preferred_styles:
             if style in plt.style.available:
@@ -231,13 +231,13 @@ class FeatureExtractorAnalyzer:
             warnings.warn(f"Could not apply matplotlib style: {exc}", stacklevel=2)
 
     def _plot_reward_bar(self, df: pd.DataFrame) -> str | None:
-        """TODO docstring. Document this function.
+        """Create the best-reward bar chart when reward data is available.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame from `create_summary_dataframe`.
 
         Returns:
-            TODO docstring.
+            Saved plot path, or `None` when the required reward column is absent.
         """
         if "best_reward" not in df.columns or not df["best_reward"].notna().any():
             return None
@@ -271,13 +271,13 @@ class FeatureExtractorAnalyzer:
         return str(plot_path)
 
     def _plot_parameter_efficiency(self, df: pd.DataFrame) -> str | None:
-        """TODO docstring. Document this function.
+        """Plot reward against parameter count for completed extractors.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame with parameter and reward columns.
 
         Returns:
-            TODO docstring.
+            Saved plot path, or `None` when required columns are unavailable.
         """
         if not all(col in df.columns for col in ["total_parameters", "best_reward"]):
             return None
@@ -310,13 +310,13 @@ class FeatureExtractorAnalyzer:
         return str(plot_path)
 
     def _plot_training_time(self, df: pd.DataFrame) -> str | None:
-        """TODO docstring. Document this function.
+        """Create a bar chart comparing extractor training times.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame with `training_time` values in seconds.
 
         Returns:
-            TODO docstring.
+            Saved plot path, or `None` when no training-time data is present.
         """
         if "training_time" not in df.columns or not df["training_time"].notna().any():
             return None
@@ -350,13 +350,13 @@ class FeatureExtractorAnalyzer:
         return str(plot_path)
 
     def _plot_multi_metric_radar(self, df: pd.DataFrame) -> str | None:
-        """TODO docstring. Document this function.
+        """Create a normalized radar chart across available extractor metrics.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame containing reward, speed, and optional parameter data.
 
         Returns:
-            TODO docstring.
+            Saved plot path, or `None` when the radar chart cannot be produced.
         """
         if len(df) <= 1:
             return None
@@ -436,11 +436,10 @@ class FeatureExtractorAnalyzer:
 
     # ---- Report helper methods ----
     def _build_report_header(self) -> list[str]:
-        """TODO docstring. Document this function.
-
+        """Build the static report title and training-configuration section.
 
         Returns:
-            TODO docstring.
+            Markdown lines for the beginning of the analysis report.
         """
         return [
             "# Feature Extractor Comparison Analysis Report",
@@ -457,13 +456,13 @@ class FeatureExtractorAnalyzer:
         ]
 
     def _build_rankings_section(self, analysis: dict) -> list[str]:
-        """TODO docstring. Document this function.
+        """Build Markdown ranking sections from computed analysis results.
 
         Args:
-            analysis: TODO docstring.
+            analysis: Dictionary returned by `analyze_performance`.
 
         Returns:
-            TODO docstring.
+            Markdown lines describing reward, parameter, and speed rankings.
         """
         lines: list[str] = ["### Performance Rankings", ""]
         rankings = analysis.get("rankings", {})
@@ -494,13 +493,13 @@ class FeatureExtractorAnalyzer:
         return lines
 
     def _build_detailed_results_table(self, df: pd.DataFrame) -> list[str]:
-        """TODO docstring. Document this function.
+        """Build the per-extractor Markdown results table.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame for completed extractor runs.
 
         Returns:
-            TODO docstring.
+            Markdown table lines with reward, parameter, and timing columns.
         """
         lines: list[str] = [
             "### Detailed Results",
@@ -522,13 +521,13 @@ class FeatureExtractorAnalyzer:
         return lines
 
     def _build_insights_section(self, df: pd.DataFrame) -> list[str]:
-        """TODO docstring. Document this function.
+        """Build brief Markdown insight bullets from the summary DataFrame.
 
         Args:
-            df: TODO docstring.
+            df: Summary DataFrame for completed extractor runs.
 
         Returns:
-            TODO docstring.
+            Markdown lines identifying best, smallest, and fastest extractors when available.
         """
         lines: list[str] = ["", "## Key Insights", ""]
         if df.empty or "best_reward" not in df.columns:

--- a/scripts/benchmark_workers.py
+++ b/scripts/benchmark_workers.py
@@ -1,4 +1,4 @@
-"""TODO docstring. Document this module."""
+"""Benchmark `run_batch` throughput with different worker counts."""
 
 from __future__ import annotations
 
@@ -14,13 +14,13 @@ SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
 
 
 def _make_scenarios(repeats: int) -> list[dict]:
-    """TODO docstring. Document this function.
+    """Build the fixed smoke scenario used by the worker-count benchmark.
 
     Args:
-        repeats: TODO docstring.
+        repeats: Number of repeated jobs to request for the scenario.
 
     Returns:
-        TODO docstring.
+        Single-scenario matrix accepted by `robot_sf.benchmark.runner.run_batch`.
     """
     return [
         {
@@ -38,15 +38,15 @@ def _make_scenarios(repeats: int) -> list[dict]:
 
 
 def bench(workers: int, repeats: int, out_dir: Path) -> dict:
-    """TODO docstring. Document this function.
+    """Run the smoke batch once and report elapsed time for a worker count.
 
     Args:
-        workers: TODO docstring.
-        repeats: TODO docstring.
-        out_dir: TODO docstring.
+        workers: Number of parallel workers to pass to `run_batch`.
+        repeats: Number of jobs to run for the fixed scenario.
+        out_dir: Directory where benchmark episode JSONL files are written.
 
     Returns:
-        TODO docstring.
+        Summary containing worker count, repeats, elapsed seconds, and run counts.
     """
     ensure_output_dir(out_dir)
     out_file = out_dir / f"episodes_w{workers}.jsonl"
@@ -75,11 +75,10 @@ def bench(workers: int, repeats: int, out_dir: Path) -> dict:
 
 
 def main() -> int:
-    """TODO docstring. Document this function.
-
+    """Parse CLI options, run each worker-count benchmark, and write summary JSON.
 
     Returns:
-        TODO docstring.
+        Process exit code; zero indicates the benchmark summary was written.
     """
     parser = argparse.ArgumentParser(description="Benchmark run_batch with varying workers")
     parser.add_argument("--max-workers", type=int, default=2)

--- a/scripts/snqi_weight_optimization.py
+++ b/scripts/snqi_weight_optimization.py
@@ -73,15 +73,15 @@ try:  # pragma: no cover - optional dependency
         desc: str | None = None,
         total: int | None = None,
     ) -> Iterator:  # type: ignore[name-defined]
-        """TODO docstring. Document this function.
+        """Wrap an iterable in `tqdm` when the optional dependency is installed.
 
         Args:
-            iterable: TODO docstring.
-            desc: TODO docstring.
-            total: TODO docstring.
+            iterable: Values to iterate over.
+            desc: Optional progress-bar label.
+            total: Optional total item count for progress reporting.
 
         Returns:
-            TODO docstring.
+            Iterator that yields the original values while updating progress.
         """
         return tqdm(iterable, desc=desc, total=total)  # type: ignore[no-any-return]
 
@@ -94,15 +94,15 @@ except Exception:
         total: int | None = None,
     ) -> Iterator:  # type: ignore[unused-argument]
         # Fallback: ignore progress parameters when tqdm unavailable
-        """TODO docstring. Document this function.
+        """Return a plain iterator when `tqdm` is unavailable.
 
         Args:
-            iterable: TODO docstring.
-            desc: TODO docstring.
-            total: TODO docstring.
+            iterable: Values to iterate over.
+            desc: Ignored progress-bar label.
+            total: Ignored total item count.
 
         Returns:
-            TODO docstring.
+            Iterator over the original values without progress reporting.
         """
         return iter(iterable)
 
@@ -132,11 +132,11 @@ class SNQIWeightOptimizer:
     """
 
     def __init__(self, episodes_data: list[dict], baseline_stats: dict[str, dict[str, float]]):
-        """TODO docstring. Document this function.
+        """Store optimization inputs and the canonical SNQI weight order.
 
         Args:
-            episodes_data: TODO docstring.
-            baseline_stats: TODO docstring.
+            episodes_data: Episode dictionaries containing metric payloads.
+            baseline_stats: Normalization medians and p95 values keyed by metric name.
         """
         self.episodes = episodes_data
         self.baseline_stats = baseline_stats
@@ -148,15 +148,15 @@ class SNQIWeightOptimizer:
         simplex: bool,
         total: float = 10.0,
     ) -> dict[str, float]:
-        """TODO docstring. Document this function.
+        """Optionally rescale weights so their sum equals a target total.
 
         Args:
-            weights: TODO docstring.
-            simplex: TODO docstring.
-            total: TODO docstring.
+            weights: Candidate SNQI weight mapping.
+            simplex: Whether to project the mapping onto a fixed-sum simplex.
+            total: Desired sum when simplex projection is enabled.
 
         Returns:
-            TODO docstring.
+            Original weights or a rescaled copy preserving relative proportions.
         """
         if not simplex:
             return weights
@@ -166,25 +166,25 @@ class SNQIWeightOptimizer:
         return {k: (v / s) * total for k, v in weights.items()}
 
     def _episode_snqi(self, metrics: dict[str, float], weights: dict[str, float]) -> float:
-        """TODO docstring. Document this function.
+        """Compute SNQI for one episode metrics payload.
 
         Args:
-            metrics: TODO docstring.
-            weights: TODO docstring.
+            metrics: Episode metric values.
+            weights: Candidate SNQI weights.
 
         Returns:
-            TODO docstring.
+            SNQI score normalized with this optimizer's baseline statistics.
         """
         return compute_snqi(metrics, weights, self.baseline_stats)
 
     def compute_ranking_stability(self, weights: dict[str, float]) -> float:
-        """TODO docstring. Document this function.
+        """Estimate ranking stability for a candidate weight mapping.
 
         Args:
-            weights: TODO docstring.
+            weights: Candidate SNQI weights.
 
         Returns:
-            TODO docstring.
+            Stability score in the approximate range [0, 1].
         """
         if len(self.episodes) < 2:
             return 1.0
@@ -325,14 +325,14 @@ class SNQIWeightOptimizer:
         stagnant_iters = 0
 
         def _callback(xk: np.ndarray, _convergence: float) -> bool:
-            """TODO docstring. Document this function.
+            """Update progress and decide whether differential evolution should stop early.
 
             Args:
-                xk: TODO docstring.
-                _convergence: TODO docstring.
+                xk: Current SciPy candidate vector.
+                _convergence: SciPy convergence estimate, unused by this callback.
 
             Returns:
-                TODO docstring.
+                `True` when early stopping should terminate optimization.
             """
             nonlocal best_positive_obj, stagnant_iters
             current_positive = -self.objective_function(xk, simplex=simplex)
@@ -427,18 +427,18 @@ class SNQIWeightOptimizer:
         early_stop_patience: int,
         early_stop_min_delta: float,
     ) -> OptimizationResult:
-        """TODO docstring. Document this function.
+        """Run SciPy differential evolution and convert the result.
 
         Args:
-            maxiter: TODO docstring.
-            seed: TODO docstring.
-            show_progress: TODO docstring.
-            simplex: TODO docstring.
-            early_stop_patience: TODO docstring.
-            early_stop_min_delta: TODO docstring.
+            maxiter: Maximum differential-evolution iterations.
+            seed: Optional random seed forwarded to SciPy.
+            show_progress: Whether to show a progress bar when available.
+            simplex: Whether to evaluate candidates after fixed-sum projection.
+            early_stop_patience: Iterations without improvement before stopping; zero disables it.
+            early_stop_min_delta: Minimum positive objective improvement that resets patience.
 
         Returns:
-            TODO docstring.
+            Normalized optimization result with weights, objective score, and convergence info.
         """
         bounds = [(0.1, 3.0)] * len(self.weight_names)
         callback, pbar = self._build_de_callback(
@@ -469,13 +469,13 @@ class SNQIWeightOptimizer:
         """Execute SciPy differential_evolution with provided configuration."""
 
         def _wrapped(vec: np.ndarray) -> float:
-            """TODO docstring. Document this function.
+            """Evaluate a SciPy candidate vector with the configured simplex setting.
 
             Args:
-                vec: TODO docstring.
+                vec: Candidate weight vector from SciPy.
 
             Returns:
-                TODO docstring.
+                Negative heuristic objective value for minimization.
             """
             return self.objective_function(vec, simplex=simplex)
 
@@ -527,13 +527,13 @@ class SNQIWeightOptimizer:
 
 
 def _load_initial_weights(path: Path) -> dict[str, float]:
-    """TODO docstring. Document this function.
+    """Load and validate an initial SNQI weight mapping from JSON.
 
     Args:
-        path: TODO docstring.
+        path: JSON file containing a metric-to-weight object.
 
     Returns:
-        TODO docstring.
+        Validated weight mapping keyed by SNQI weight name.
     """
     with open(path, encoding="utf-8") as f:
         raw = json.load(f)
@@ -567,13 +567,13 @@ def load_episodes_data(path: Path) -> tuple[list[dict[str, Any]], int]:
 
 
 def load_baseline_stats(path: Path) -> dict[str, dict[str, float]]:
-    """TODO docstring. Document this function.
+    """Load baseline normalization statistics from JSON.
 
     Args:
-        path: TODO docstring.
+        path: JSON file containing metric baseline statistics.
 
     Returns:
-        TODO docstring.
+        Baseline statistics mapping used by `compute_snqi`.
     """
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
@@ -586,13 +586,13 @@ def load_baseline_stats(path: Path) -> dict[str, dict[str, float]]:
 def _load_inputs(
     args: argparse.Namespace,
 ) -> tuple[list[dict], dict[str, dict[str, float]], int]:
-    """TODO docstring. Document this function.
+    """Load episodes and baseline statistics from parsed CLI arguments.
 
     Args:
-        args: TODO docstring.
+        args: Parsed arguments with `episodes` and `baseline` paths.
 
     Returns:
-        TODO docstring.
+        Tuple of valid episodes, baseline statistics, and skipped malformed-line count.
     """
     episodes, skipped = load_episodes_data(args.episodes)
     baseline_stats = load_baseline_stats(args.baseline)
@@ -600,11 +600,11 @@ def _load_inputs(
 
 
 def _select_best(results: dict[str, Any], method: str) -> None:
-    """TODO docstring. Document this function.
+    """Populate `results["recommended"]` from the requested optimization method.
 
     Args:
-        results: TODO docstring.
-        method: TODO docstring.
+        results: Mutable result dictionary containing optimizer outputs.
+        method: Requested method name: `grid`, `evolution`, or `both`.
     """
     if method == "both":
         best_method = "grid_search"
@@ -631,24 +631,23 @@ def _augment_metadata(
     original_episode_count: int | None = None,
     used_episode_count: int | None = None,
 ) -> None:
-    """TODO docstring. Document this function.
+    """Attach provenance metadata and a compact summary to optimization results.
 
     Args:
-        results: TODO docstring.
-        args: TODO docstring.
-        start_iso: TODO docstring.
-        start_perf: TODO docstring.
-        phase_timings: TODO docstring.
-        original_episode_count: TODO docstring.
-        used_episode_count: TODO docstring.
+        results: Mutable optimization results dictionary.
+        args: Parsed CLI arguments used for the run.
+        start_iso: ISO timestamp captured at run start.
+        start_perf: Perf-counter timestamp captured at run start.
+        phase_timings: Optional per-phase runtime measurements.
+        original_episode_count: Episode count before optional sampling.
+        used_episode_count: Episode count after optional sampling.
     """
 
     def _git_commit() -> str:
-        """TODO docstring. Document this function.
-
+        """Return the current short Git commit, or `UNKNOWN` outside a checkout.
 
         Returns:
-            TODO docstring.
+            Short commit hash for provenance metadata.
         """
         try:
             return (
@@ -763,11 +762,11 @@ def _detect_missing_baseline_metrics(
 
 
 def _print_summary(results: dict[str, Any], args: argparse.Namespace) -> None:
-    """TODO docstring. Document this function.
+    """Print the recommended weights and optional sensitivity summary.
 
     Args:
-        results: TODO docstring.
-        args: TODO docstring.
+        results: Optimization results containing a `recommended` entry.
+        args: Parsed CLI arguments controlling optional sensitivity output.
     """
     recommended = results["recommended"]
     print("\nOptimization Summary:")
@@ -1000,13 +999,13 @@ def run(args: argparse.Namespace) -> int:  # noqa: C901,PLR0912,PLR0915
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """TODO docstring. Document this function.
+    """Parse SNQI weight-optimization CLI arguments.
 
     Args:
-        argv: TODO docstring.
+        argv: Optional argument vector; uses `sys.argv` when omitted.
 
     Returns:
-        TODO docstring.
+        Parsed argument namespace for `run`.
     """
     parser = argparse.ArgumentParser(description="Optimize SNQI weights")
     parser.add_argument("--episodes", type=Path, required=True, help="Episodes JSONL file")
@@ -1115,13 +1114,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:  # pragma: no cover
-    """TODO docstring. Document this function.
+    """CLI entry point for SNQI weight optimization.
 
     Args:
-        argv: TODO docstring.
+        argv: Optional argument vector; uses `sys.argv` when omitted.
 
     Returns:
-        TODO docstring.
+        Process exit code from `run`.
     """
     args = parse_args(argv)
     _apply_log_level(getattr(args, "log_level", None))


### PR DESCRIPTION
## Summary
Replace placeholder `TODO docstring` text in the benchmark worker, feature-extractor analysis, and SNQI weight-optimization scripts with concise descriptions of current behavior.

## Linked Issues
- Closes #1276

## What Changed
- Updated `scripts/benchmark_workers.py` module/helper docstrings.
- Updated `scripts/analyze_feature_extractors.py` summary-loading, plotting, and report-helper docstrings.
- Updated `scripts/snqi_weight_optimization.py` progress, optimizer, I/O, metadata, summary, parser, and entry-point docstrings.

## Why It Matters
- Added value: benchmark-support scripts are easier for contributors and agents to inspect without misleading placeholder text.
- Expected impact: documentation clarity only; no CLI arguments, output schemas, optimization logic, plotting behavior, or benchmark semantics changed.
- Why this is worth merging now: the issue is bounded to three files and removes all directly observed placeholders.

## Validation / Proof
- Commands run:
  - `rg -n "TODO docstring" scripts/benchmark_workers.py scripts/analyze_feature_extractors.py scripts/snqi_weight_optimization.py`
  - `uv run --active ruff format --check scripts/benchmark_workers.py scripts/analyze_feature_extractors.py scripts/snqi_weight_optimization.py`
  - `uv run --active ruff check scripts/benchmark_workers.py scripts/analyze_feature_extractors.py scripts/snqi_weight_optimization.py`
  - `uv run --active python scripts/benchmark_workers.py --help`
  - `uv run --active python scripts/analyze_feature_extractors.py --help`
  - `uv run --active python scripts/snqi_weight_optimization.py --help`
  - `uv run --active pytest tests/test_snqi_*.py -q`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: the placeholder scan returns no matches in the three target scripts.
- Benchmarks or smoke tests, if applicable: full PR readiness passed with `3626 passed, 11 skipped, 3 warnings`; no changed executable files matched the changed-files coverage include patterns.

## Risks / Rollout
- Compatibility risks: low; docstring-only change.
- Failure modes: inaccurate wording could mislead future maintainers, so reviewer attention should focus on whether the descriptions match current behavior.
- Rollback or fallback plan: revert the docstring-only commit.

## Docs / Provenance
- Updated docs: inline script docstrings only.
- Relevant design or provenance notes: no benchmark output, planner behavior, optimization math, or schema contract changed.
- Any assumptions that need to be preserved: these scripts remain behavior-preserving utilities.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please skim the SNQI helper docstrings for semantic accuracy; the code paths are intentionally unchanged.
