### PR TITLE
bench: add nominal shared-space matrix

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -7,6 +7,8 @@ This directory supports a mix of **per-scenario**, **per-archetype**, and
 
 - `classic_interactions.yaml`, `francis2023.yaml`: manifest entry points for the two suites.
 - `classic_interactions_francis2023.yaml`: combined manifest for both suites.
+- `nominal_v1.yaml`: compact nominal shared-space calibration matrix for routine, low-stress
+  planner checks. It is intentionally separate from stress, adversarial, and camera-ready evidence.
 - `confirmation_v1.yaml`: compact confirmation matrix with issue-596 atomic and sparse
   interaction archetypes for non-paper robustness checks.
 - `single/`: one scenario per file (manual fine-tuning and small edits).
@@ -164,3 +166,7 @@ uv run python scripts/tools/policy_analysis_run.py \
 - `sanity_v1.yaml` is a non-paper-facing nominal calibration manifest for issue #1083. It selects
   four low-ambiguity scenes from existing validated surfaces so `goal` and `orca` can be checked
   on easy deployment-like cases before hard-matrix failures are interpreted.
+- `nominal_v1.yaml` is a small shared-space calibration matrix for issue #1273. It selects one
+  straight open-space route, one gentle crossing, one low-density doorway, and one low-density
+  bottleneck. Use it for local sanity checks and nominal-vs-stress interpretation; do not treat
+  success on this matrix as stress robustness or safety evidence.

--- a/configs/scenarios/nominal_v1.yaml
+++ b/configs/scenarios/nominal_v1.yaml
@@ -1,0 +1,30 @@
+## Nominal Shared-Space Scenario Matrix v1
+#
+# Purpose:
+#   Provide a compact, low-stress calibration surface for routine shared-space
+#   planner competence. Keep these results separate from stress, adversarial,
+#   and camera-ready evidence: nominal success is a sanity check, not a safety
+#   or robustness claim.
+#
+# Canonical validation:
+#   robot_sf_bench validate-config --matrix configs/scenarios/nominal_v1.yaml
+#   robot_sf_bench preview-scenarios --matrix configs/scenarios/nominal_v1.yaml
+#
+# Smoke example:
+#   robot_sf_bench run --matrix configs/scenarios/nominal_v1.yaml \
+#     --algo simple_policy --out output/benchmarks/nominal_v1/episodes.jsonl \
+#     --workers 1 --no-resume
+
+includes:
+  - sets/verified_simple_subset_v1.yaml
+  - archetypes/classic_doorway.yaml
+  - archetypes/classic_bottleneck.yaml
+
+select_scenarios:
+  - empty_map_8_directions_east
+  - single_ped_crossing_orthogonal
+  - classic_doorway_low
+  - classic_bottleneck_low
+
+map_search_paths:
+  - ../../maps/svg_maps

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -18,6 +18,10 @@ runtime/readiness metadata; training reward totals are not benchmark-success evi
 [Robot SF Environment Contract And Training Provenance](./training/environment_contract.md) and the
 [benchmark fallback policy](./context/issue_691_benchmark_fallback_policy.md).
 
+For routine, low-stress planner calibration, use `configs/scenarios/nominal_v1.yaml`. This matrix
+is intentionally separate from stress, adversarial, and camera-ready surfaces; nominal success is a
+sanity check for basic shared-space competence, not safety or robustness evidence.
+
 ### Canonical Schema Location
 
 **Single source of truth**: `robot_sf/benchmark/schemas/`

--- a/tests/benchmark/test_nominal_v1_matrix.py
+++ b/tests/benchmark/test_nominal_v1_matrix.py
@@ -29,7 +29,7 @@ def test_nominal_v1_matrix_loads_expected_calibration_scenarios(
         "single_ped_crossing_orthogonal",
         "classic_doorway_low",
         "classic_bottleneck_low",
-    ]
+    ], f"Unexpected scenario list in nominal_v1 matrix: {names}"
 
 
 def test_nominal_v1_matrix_has_low_stress_metadata(
@@ -42,13 +42,19 @@ def test_nominal_v1_matrix_has_low_stress_metadata(
         "single_ped_crossing_orthogonal",
         "doorway",
         "bottleneck",
-    }
+    }, f"Unexpected nominal_v1 archetypes: {sorted(archetypes)}"
 
     for scenario in scenarios:
-        assert len(scenario.get("seeds", [])) >= 3
+        name = scenario["name"]
+        assert len(scenario.get("seeds", [])) >= 3, (
+            f"Scenario '{name}' must provide at least 3 seeds for variance checks."
+        )
         metadata = scenario["metadata"]
         assert (
             metadata.get("density") in {"low", "none"}
             or metadata.get("density_advisory") == "zero_baseline_route_spawn"
+        ), f"Scenario '{name}' has non-nominal density metadata: {metadata}"
+        max_episode_steps = scenario["simulation_config"]["max_episode_steps"]
+        assert max_episode_steps <= 500, (
+            f"Scenario '{name}' exceeds the 500-step nominal horizon limit: {max_episode_steps}"
         )
-        assert scenario["simulation_config"]["max_episode_steps"] <= 500

--- a/tests/benchmark/test_nominal_v1_matrix.py
+++ b/tests/benchmark/test_nominal_v1_matrix.py
@@ -1,0 +1,54 @@
+"""Tests for the nominal_v1 shared-space scenario matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from robot_sf.training.scenario_loader import load_scenarios
+
+ROOT = Path(__file__).resolve().parents[2]
+NOMINAL_MATRIX = ROOT / "configs" / "scenarios" / "nominal_v1.yaml"
+
+
+@pytest.fixture(scope="module")
+def scenarios() -> list[dict[str, Any]]:
+    """Load the nominal matrix scenarios once for the module."""
+    return load_scenarios(NOMINAL_MATRIX)
+
+
+def test_nominal_v1_matrix_loads_expected_calibration_scenarios(
+    scenarios: list[dict[str, Any]],
+) -> None:
+    """Nominal v1 should expose the four low-stress calibration archetypes."""
+    names = [scenario["name"] for scenario in scenarios]
+    assert names == [
+        "empty_map_8_directions_east",
+        "single_ped_crossing_orthogonal",
+        "classic_doorway_low",
+        "classic_bottleneck_low",
+    ]
+
+
+def test_nominal_v1_matrix_has_low_stress_metadata(
+    scenarios: list[dict[str, Any]],
+) -> None:
+    """Each nominal scenario should stay low-density and interpretation-bounded."""
+    archetypes = {scenario["metadata"]["archetype"] for scenario in scenarios}
+    assert archetypes == {
+        "empty_map_8_directions",
+        "single_ped_crossing_orthogonal",
+        "doorway",
+        "bottleneck",
+    }
+
+    for scenario in scenarios:
+        assert len(scenario.get("seeds", [])) >= 3
+        metadata = scenario["metadata"]
+        assert (
+            metadata.get("density") in {"low", "none"}
+            or metadata.get("density_advisory") == "zero_baseline_route_spawn"
+        )
+        assert scenario["simulation_config"]["max_episode_steps"] <= 500


### PR DESCRIPTION
## Summary
Adds `configs/scenarios/nominal_v1.yaml`, a compact nominal shared-space calibration matrix for low-stress planner sanity checks.

## Linked Issues
- Closes #1273

## What Changed
- Added a four-scenario nominal matrix covering straight open-space motion, gentle crossing, low-density doorway, and low-density bottleneck cases.
- Documented the intended nominal-vs-stress interpretation boundary in `configs/scenarios/README.md` and `docs/benchmark.md`.
- Added tests that lock the selected scenario IDs, archetypes, low-stress metadata, seed availability, and short horizons.

## Why It Matters
- Added value: gives maintainers a small routine-calibration surface before interpreting stress/adversarial failures.
- Expected impact: benchmark tooling can load, preview, validate, and smoke-run the nominal matrix without changing existing stress or camera-ready matrices.
- Why this is worth merging now: it satisfies the low-risk matrix/config scope without weakening benchmark-success semantics.

## Validation / Proof
- `rtk uv run --active pytest tests/benchmark/test_nominal_v1_matrix.py -q` -> 2 passed after the expected red-file-missing failure.
- `rtk uv run --active robot_sf_bench validate-config --matrix configs/scenarios/nominal_v1.yaml` -> exit 0, 4 scenarios, no errors.
- `rtk uv run --active robot_sf_bench preview-scenarios --matrix configs/scenarios/nominal_v1.yaml` -> exit 0, 4 scenarios.
- `rtk uv run --active robot_sf_bench run --matrix configs/scenarios/nominal_v1.yaml --out output/benchmarks/nominal_v1_smoke/episodes.jsonl --algo simple_policy --workers 1 --no-resume --horizon 20 --no-video --structured-output json` -> native mode, 12 written, 0 failed.
- `rtk uv run --active pytest tests/benchmark/test_nominal_v1_matrix.py tests/benchmark/test_confirmation_v1_matrix.py tests/benchmark/test_runner_scenario_matrix_manifest.py -q` -> 6 passed.
- `BASE_REF=origin/main rtk scripts/dev/check_docs_proof_consistency_diff.sh` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` -> 3628 passed, 11 skipped, 3 warnings.

## Risks / Rollout
- Compatibility risks: low; this adds a new opt-in matrix and docs/tests only.
- Failure modes: nominal success could be overread as robustness evidence, so docs explicitly reject that interpretation.
- Rollback or fallback plan: remove the new manifest and test if the matrix proves misleading.

## Docs / Provenance
- Updated docs: `configs/scenarios/README.md`, `docs/benchmark.md`.
- Relevant design or provenance notes: uses existing scenario sources rather than adding new map assets.
- Any assumptions that need to be preserved: `nominal_v1` is calibration evidence only, not safety or stress robustness evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Known limitation: CLI validation warns on zero-density scenarios; those warnings are expected for nominal straight/single-ped cases and do not block config validation.
