### PR TITLE
feat: add ODD contract schema (#1269)

### DIFF
--- a/configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+++ b/configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
@@ -1,0 +1,85 @@
+# Minimal public-space micromobility ODD declaration for benchmark claim boundaries.
+#
+# This file describes operating assumptions only. It does not certify safety,
+# promote scenarios into a paper matrix, or change benchmark runner behavior.
+
+contracts:
+  - schema_version: odd_contract.v1
+    id: low_speed_public_space_v1
+    operating_context:
+      environment_types:
+        - indoor_public_transit
+        - outdoor_walkway
+        - synthetic_atomic
+      map_families:
+        - classic_station_platform
+        - classic_crossing
+        - classic_corridor
+        - synthetic_atomic
+      surface_conditions:
+        - dry_flat_floor_or_pavement
+      visibility:
+        - unobstructed_line_of_sight_unless_scenario_declares_occlusion
+      semantic_features:
+        - pedestrian_flow
+        - static_obstacles
+        - keep_clear_regions
+        - hazard_regions
+    agents:
+      actor_types:
+        - autonomous_micromobility_robot
+        - pedestrian
+        - pedestrian_group
+        - static_obstacle
+      pedestrian_motion_models:
+        - social_force
+        - authored_waypoints
+        - benchmark_adapter
+      robot_kinematics:
+        - differential_drive
+        - bicycle_drive
+        - holonomic
+    speed_limits:
+      max_robot_speed_mps: 2.5
+      max_pedestrian_speed_mps: 2.0
+      notes: Speed bounds describe low-speed public-space simulation assumptions, not legal limits.
+    pedestrian_density:
+      density_bins:
+        - low
+        - medium
+        - high
+      max_pedestrians_per_scene: 12
+      notes: Density bins are benchmark categories and are not calibrated to a real pedestrian dataset.
+    observation:
+      observation_modes:
+        - goal_state
+        - socnav_state
+        - sensor_fusion_state
+      sensor_assumptions:
+        - Perfect simulator state may be used unless a scenario or benchmark config declares observation noise.
+        - Visibility and occlusion filters must be declared separately when they are part of the claim.
+    exclusions:
+      - public-road autonomy
+      - wet_or_icy_surface_dynamics
+      - vehicle_traffic_interaction
+      - legal_safety_certification
+      - human_subject_acceptability_validation
+    claim_boundaries:
+      evidence_status: metadata_only
+      supported_claims:
+        - benchmark_evidence_boundary
+        - counterexample_operating_assumptions
+      non_claims:
+        - safety_certification
+        - legal_compliance
+        - real_world_deployment_readiness
+      caveats:
+        - ODD metadata bounds evidence; it does not prove planner safety.
+        - Scenario certification and benchmark run artifacts remain separate required evidence.
+    provenance:
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/1269
+      authored_by: robot_sf_ll7
+      source_files:
+        - docs/scenario_contracts.md
+        - configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
+      notes: Initial ODD contract fixture for low-speed public-space benchmark and falsification metadata.

--- a/configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
+++ b/configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
@@ -19,6 +19,10 @@ contracts:
         - Pedestrian flow is synthetic and map-local, not calibrated to a real transit station.
         - Waiting behavior is represented by authored pedestrian pauses near access points.
         - The scenario remains exploratory until certification and benchmark evidence are produced.
+    odd_contract_ref:
+      source: configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+      contract_id: low_speed_public_space_v1
+      required_for_benchmark_claim: true
     actors:
       - id: robot
         kind: robot

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 ### Benchmarking & Metrics
 
 * **[Benchmark Spec (Classic Interactions)](./benchmark_spec.md)** - Scenario split + seeds, baseline categories, reproducible commands, and metric caveats
+* **[ODD Contracts](./odd_contracts.md)** - `odd_contract.v1` schema, typed loader, fixture, and boundary for benchmark and falsification evidence assumptions
 * **[Scenario Contracts](./scenario_contracts.md)** - `scenario_contract.v1` schema, typed loader, fixture, and boundary between authored intent, certification, and benchmark evidence
 * **[Scenario Certification](./scenario_certification.md)** - `scenario_cert.v1` schema, CLI, labels, and fail-closed benchmark eligibility rules
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
@@ -367,6 +368,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * [**Single Pedestrians**](./single_pedestrians.md) - Define individual pedestrians with goals or trajectories in SVG/JSON/code
 * [**Multi-Pedestrian Example**](../examples/example_multi_pedestrian.py) - Demonstrates multiple single pedestrians (goal, trajectory, static) in one scenario
 * [**Scenario Specification Checklist**](./scenario_spec_checklist.md) - Authoring checklist for per-scenario/archetype/manifest files
+* [**ODD Contracts**](./odd_contracts.md) - Validate operating-assumption metadata that bounds benchmark and falsification evidence without certifying safety
 * [**Scenario Contracts**](./scenario_contracts.md) - Validate authored scenario-intent contracts before certification or benchmark execution
 * [**Scenario Certification**](./scenario_certification.md) - Generate machine-readable validity, feasibility, stress-only, and hard-but-solvable certificates for scenario manifests
 * [**Issue #1240 Scenario Coverage Entropy**](./context/issue_1240_scenario_coverage_entropy.md) - Config-only entropy and novelty report for diagnostic scenario-set curation; not benchmark-success evidence

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -475,6 +475,7 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #974 CARLA Availability Boolean Field](issue_974_carla_availability_boolean_field.md)
   adds an explicit boolean to CARLA availability metadata and CLI JSON output.
 - [Issue #976 CARLA Availability Schema Version](issue_976_carla_availability_schema_version.md)
+- [Issue #1269 ODD Contract Schema](issue_1269_odd_contract_schema.md)
   adds a schema version to CARLA availability metadata for stable script consumption.
 - [Issue #978 CARLA Availability JSON Schema](issue_978_carla_availability_json_schema.md)
   adds a JSON Schema for validating CARLA availability metadata.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -475,8 +475,9 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #974 CARLA Availability Boolean Field](issue_974_carla_availability_boolean_field.md)
   adds an explicit boolean to CARLA availability metadata and CLI JSON output.
 - [Issue #976 CARLA Availability Schema Version](issue_976_carla_availability_schema_version.md)
-- [Issue #1269 ODD Contract Schema](issue_1269_odd_contract_schema.md)
   adds a schema version to CARLA availability metadata for stable script consumption.
+- [Issue #1269 ODD Contract Schema](issue_1269_odd_contract_schema.md)
+  adds a versioned ODD metadata contract for benchmark and falsification evidence boundaries.
 - [Issue #978 CARLA Availability JSON Schema](issue_978_carla_availability_json_schema.md)
   adds a JSON Schema for validating CARLA availability metadata.
 - [Issue #980 CARLA Availability Schema CLI](issue_980_carla_availability_schema_cli.md)

--- a/docs/context/issue_1269_odd_contract_schema.md
+++ b/docs/context/issue_1269_odd_contract_schema.md
@@ -1,0 +1,44 @@
+# Issue #1269 ODD Contract Schema
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1269>
+
+## Summary
+
+Issue #1269 adds `odd_contract.v1`, a small Operational Design Domain metadata contract for
+benchmark and falsification evidence. The contract records operating assumptions and non-claim
+boundaries without changing benchmark execution.
+
+## Implemented Surfaces
+
+- `robot_sf/benchmark/schemas/odd_contract.v1.json` defines the JSON Schema.
+- `robot_sf/benchmark/odd_contract.py` provides typed loading, JSON Schema validation, semantic
+  validation, and reference validation.
+- `configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml` is the first tracked ODD
+  declaration for low-speed public-space micromobility assumptions.
+- `scenario_contract.v1` now supports an optional `odd_contract_ref` block.
+- `configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml` references
+  the tracked ODD declaration as an example.
+- `docs/odd_contracts.md` documents the boundary and authoring guidance.
+
+## Boundary
+
+ODD metadata bounds evidence. It does not certify safety, establish legal compliance, promote a
+scenario into a paper matrix, or replace `scenario_cert.v1` and benchmark run artifacts.
+
+Scenario contracts and future BenchmarkClaim artifacts should reference ODD declarations by
+`source` and `contract_id` instead of duplicating all fields. This keeps claim assumptions
+auditable while preserving a single reviewable ODD source.
+
+## Validation
+
+Targeted validation for this issue should include:
+
+```bash
+uv run pytest tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py -q
+uv run ruff check robot_sf/benchmark/odd_contract.py robot_sf/benchmark/scenario_contract.py tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py
+uv run ruff format --check robot_sf/benchmark/odd_contract.py robot_sf/benchmark/scenario_contract.py tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+git diff --check origin/main...HEAD
+```
+
+Run the repository PR readiness gate after syncing with latest `origin/main` before PR handoff.

--- a/docs/odd_contracts.md
+++ b/docs/odd_contracts.md
@@ -1,0 +1,97 @@
+# ODD Contracts
+
+[← Back to Documentation Index](./README.md)
+
+`odd_contract.v1` is the machine-readable Operational Design Domain metadata surface for benchmark
+and falsification evidence. It records the operating assumptions that bound a result: public-space
+context, agent classes, speed envelope, pedestrian-density envelope, observation assumptions,
+explicit exclusions, claim boundaries, and provenance.
+
+An ODD contract is not a safety certificate, legal compliance claim, benchmark result, or scenario
+feasibility certificate. It is metadata that helps benchmark claims and counterexamples state what
+their evidence is allowed to cover.
+
+## Contract Boundary
+
+Use the related validation surfaces for different jobs:
+
+- `odd_contract.v1`: operating assumptions and non-claim boundaries for evidence artifacts.
+- `scenario_contract.v1`: authored scenario intent and scenario-specific assumptions.
+- `scenario_cert.v1`: fail-closed feasibility and benchmark eligibility classification.
+- benchmark episode records and reports: executed planner behavior, metrics, seeds, and outcomes.
+
+ODD metadata can bound a claim, but it cannot promote a scenario, certify safety, or replace
+execution evidence.
+
+## Public Files
+
+- Schema:
+  [`robot_sf/benchmark/schemas/odd_contract.v1.json`](../robot_sf/benchmark/schemas/odd_contract.v1.json)
+- Loader:
+  [`robot_sf/benchmark/odd_contract.py`](../robot_sf/benchmark/odd_contract.py)
+- Fixture:
+  [`configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml`](../configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml)
+
+The first fixture covers the current low-speed public-space micromobility lane used by benchmark
+and falsification work. It is intentionally conservative and records exclusions such as
+public-road autonomy, wet/icy dynamics, legal safety certification, and real-world deployment
+readiness.
+
+## Library API
+
+```python
+from pathlib import Path
+
+from robot_sf.benchmark.odd_contract import (
+    classify_odd_claim_boundary,
+    load_odd_contracts,
+    validate_odd_contract_references,
+)
+
+contracts = load_odd_contracts(
+    Path("configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml")
+)
+errors = validate_odd_contract_references(
+    source="configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+    contract_id=contracts[0].id,
+    repo_root=Path("."),
+)
+status = classify_odd_claim_boundary(contracts[0], "safety_certification")
+```
+
+`load_odd_contracts(...)` validates JSON Schema first and raises `OddContractValidationError` with
+JSON-pointer-style paths for invalid sections. Reference validation is explicit so callers can
+choose when local config availability is required.
+`classify_odd_claim_boundary(...)` returns `supported`, `excluded`, or `unknown` for compact claim
+IDs against `supported_claims`, `non_claims`, and `exclusions`.
+
+## Scenario Contract References
+
+`scenario_contract.v1` supports an optional `odd_contract_ref` block:
+
+```yaml
+odd_contract_ref:
+  source: configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+  contract_id: low_speed_public_space_v1
+  required_for_benchmark_claim: true
+```
+
+Use `validate_scenario_odd_contract_reference(...)` when a workflow needs to require that a
+scenario contract's ODD reference resolves.
+
+## Authoring Guidance
+
+Keep v1 declarations narrow:
+
+- set `claim_boundaries.evidence_status` to `metadata_only` until a consuming artifact has real
+  execution evidence,
+- include explicit `non_claims` for safety certification, legal compliance, and deployment
+  readiness,
+- keep `exclusions` concrete enough that report readers can distinguish covered assumptions from
+  out-of-scope extrapolation,
+- reference ODD contracts from scenario contracts or future BenchmarkClaim artifacts instead of
+  duplicating all fields,
+- update the schema version only for breaking shape or semantic changes.
+
+Do not cite ODD metadata by itself as proof that a planner is safe, robust, socially acceptable, or
+ready for real-world deployment.

--- a/docs/scenario_contracts.md
+++ b/docs/scenario_contracts.md
@@ -34,6 +34,18 @@ The fixture uses the station-platform candidate pack because that YAML already c
 intent metadata such as density, flow, coverage probes, and evaluation scope. The contract fixture
 normalizes one representative entry without changing any scenario runner behavior.
 
+Scenario contracts may also reference an ODD declaration instead of duplicating all operating
+assumptions:
+
+```yaml
+odd_contract_ref:
+  source: configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+  contract_id: low_speed_public_space_v1
+  required_for_benchmark_claim: true
+```
+
+See [ODD Contracts](./odd_contracts.md) for the ODD metadata boundary.
+
 ## Library API
 
 ```python
@@ -41,6 +53,7 @@ from pathlib import Path
 
 from robot_sf.benchmark.scenario_contract import (
     load_scenario_contracts,
+    validate_scenario_odd_contract_reference,
     validate_scenario_contract_references,
 )
 
@@ -48,6 +61,7 @@ contracts = load_scenario_contracts(
     Path("configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml")
 )
 errors = validate_scenario_contract_references(contracts[0], repo_root=Path("."))
+odd_errors = validate_scenario_odd_contract_reference(contracts[0], repo_root=Path("."))
 ```
 
 `load_scenario_contracts(...)` validates JSON Schema first and raises
@@ -60,6 +74,8 @@ whether to require local scenario YAML availability.
 Keep v1 contracts narrow:
 
 - use closed enums for actor kind, termination reason, intended use, and ODD class,
+- reference `odd_contract.v1` declarations for shared operating assumptions when benchmark claims
+  depend on ODD metadata,
 - put future or experimental vocabulary under `extensions` only when it cannot fit the v1 fields,
 - point `scenario_ref.source` at a maintained scenario YAML file,
 - set `certification.required_before_benchmark_claim: true` unless the file is a test fixture,

--- a/robot_sf/benchmark/odd_contract.py
+++ b/robot_sf/benchmark/odd_contract.py
@@ -189,7 +189,7 @@ def validate_odd_contract_references(
 
     try:
         contracts = load_odd_contracts(contract_path)
-    except Exception as exc:
+    except (OddContractValidationError, OSError, yaml.YAMLError) as exc:
         return [f"odd_contract_ref.source '{source}' could not be loaded: {exc}"]
 
     contract_ids = {contract.id for contract in contracts}

--- a/robot_sf/benchmark/odd_contract.py
+++ b/robot_sf/benchmark/odd_contract.py
@@ -1,0 +1,356 @@
+"""Typed loader for ``odd_contract.v1`` evidence-boundary payloads."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ODD_CONTRACT_SCHEMA_VERSION = "odd_contract.v1"
+ODD_CONTRACT_SCHEMA_FILE = Path(__file__).with_name("schemas") / "odd_contract.v1.json"
+
+
+@dataclass(frozen=True, slots=True)
+class OddOperatingContext:
+    """Public-space operating context covered by an ODD declaration."""
+
+    environment_types: list[str]
+    map_families: list[str]
+    surface_conditions: list[str]
+    visibility: list[str]
+    semantic_features: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class OddAgentEnvelope:
+    """Actor and motion-model assumptions for an ODD declaration."""
+
+    actor_types: list[str]
+    pedestrian_motion_models: list[str]
+    robot_kinematics: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class OddSpeedLimits:
+    """Speed envelope used to bound benchmark and falsification claims."""
+
+    max_robot_speed_mps: float
+    max_pedestrian_speed_mps: float
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class OddPedestrianDensity:
+    """Pedestrian-density envelope covered by an ODD declaration."""
+
+    density_bins: list[str]
+    max_pedestrians_per_scene: int
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class OddObservationEnvelope:
+    """Observation and sensing assumptions attached to an ODD declaration."""
+
+    observation_modes: list[str]
+    sensor_assumptions: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class OddClaimBoundaries:
+    """Evidence-boundary language for benchmark claims using this ODD."""
+
+    evidence_status: str
+    supported_claims: list[str]
+    non_claims: list[str]
+    caveats: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class OddProvenance:
+    """Provenance metadata for an ODD declaration."""
+
+    source_issue: str
+    authored_by: str
+    source_files: list[str]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class OddContract:
+    """Typed ``odd_contract.v1`` payload."""
+
+    schema_version: str
+    id: str
+    operating_context: OddOperatingContext
+    agents: OddAgentEnvelope
+    speed_limits: OddSpeedLimits
+    pedestrian_density: OddPedestrianDensity
+    observation: OddObservationEnvelope
+    exclusions: list[str]
+    claim_boundaries: OddClaimBoundaries
+    provenance: OddProvenance
+    extensions: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the contract to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation suitable for JSON Schema validation.
+        """
+
+        payload = asdict(self)
+        if not payload["extensions"]:
+            payload.pop("extensions")
+        return payload
+
+
+class OddContractValidationError(ValueError):
+    """Raised when an ODD contract fails schema or semantic validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_odd_contract_schema() -> dict[str, Any]:
+    """Load the public ``odd_contract.v1`` JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(ODD_CONTRACT_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_odd_contracts(path: Path) -> list[OddContract]:
+    """Load one or more ODD contracts from YAML or JSON.
+
+    Accepted shapes are a single contract mapping, a list of contract mappings, or
+    ``{"contracts": [...]}``.
+
+    Returns:
+        Typed ODD contracts in file order.
+    """
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    payloads = _contract_payloads(raw, source=path)
+    return [
+        odd_contract_from_dict(payload, source=f"{path.as_posix()}[{index}]")
+        for index, payload in enumerate(payloads)
+    ]
+
+
+def odd_contract_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> OddContract:
+    """Validate and convert a mapping into a typed ODD contract.
+
+    Returns:
+        Typed ODD contract.
+    """
+
+    errors = _schema_validation_errors(payload)
+    errors.extend(_semantic_validation_errors(payload))
+    if errors:
+        raise OddContractValidationError(errors, source=source)
+
+    return _contract_from_payload(payload)
+
+
+def validate_odd_contract_references(
+    *,
+    source: str,
+    contract_id: str,
+    repo_root: Path = Path("."),
+) -> list[str]:
+    """Validate that an ODD contract reference resolves to a known declaration.
+
+    Returns:
+        List of reference errors. An empty list means the reference resolved.
+    """
+
+    contract_path = repo_root / source
+    if not contract_path.exists():
+        return [f"odd_contract_ref.source '{source}' does not exist"]
+
+    try:
+        contracts = load_odd_contracts(contract_path)
+    except Exception as exc:
+        return [f"odd_contract_ref.source '{source}' could not be loaded: {exc}"]
+
+    contract_ids = {contract.id for contract in contracts}
+    if contract_id not in contract_ids:
+        return [f"odd_contract_ref.contract_id '{contract_id}' was not found in {source}"]
+    return []
+
+
+def classify_odd_claim_boundary(contract: OddContract, claim_id: str) -> str:
+    """Classify whether an ODD contract supports, excludes, or does not name a claim.
+
+    Returns:
+        ``"supported"``, ``"excluded"``, or ``"unknown"``.
+    """
+
+    normalized = str(claim_id).strip()
+    if normalized in set(contract.claim_boundaries.supported_claims):
+        return "supported"
+    if normalized in set(contract.claim_boundaries.non_claims) or normalized in set(
+        contract.exclusions
+    ):
+        return "excluded"
+    return "unknown"
+
+
+def _contract_payloads(raw: Any, *, source: Path) -> list[Mapping[str, Any]]:
+    """Normalize supported file shapes into a list of contract mappings.
+
+    Returns:
+        Contract payload mappings in file order.
+    """
+
+    if isinstance(raw, Mapping) and "contracts" in raw:
+        raw_contracts = raw["contracts"]
+    else:
+        raw_contracts = raw
+
+    if isinstance(raw_contracts, Mapping):
+        return [raw_contracts]
+    if isinstance(raw_contracts, list) and all(isinstance(item, Mapping) for item in raw_contracts):
+        return raw_contracts
+    raise OddContractValidationError(
+        ["expected a contract mapping, a list of mappings, or a top-level 'contracts' list"],
+        source=source,
+    )
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors for one ODD contract payload."""
+
+    validator = Draft202012Validator(load_odd_contract_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return cross-field validation errors not expressible in the JSON Schema."""
+
+    errors: list[str] = []
+    speed_limits = payload.get("speed_limits")
+    if isinstance(speed_limits, Mapping):
+        for key in ("max_robot_speed_mps", "max_pedestrian_speed_mps"):
+            value = speed_limits.get(key)
+            if isinstance(value, int | float) and value <= 0:
+                errors.append(f"/speed_limits/{key}: must be greater than 0")
+    return errors
+
+
+def _contract_from_payload(payload: Mapping[str, Any]) -> OddContract:
+    """Build a typed ODD contract from a schema-valid payload.
+
+    Returns:
+        Typed ODD contract.
+    """
+
+    context = payload["operating_context"]
+    agents = payload["agents"]
+    speed_limits = payload["speed_limits"]
+    density = payload["pedestrian_density"]
+    observation = payload["observation"]
+    boundaries = payload["claim_boundaries"]
+    provenance = payload["provenance"]
+    return OddContract(
+        schema_version=str(payload["schema_version"]),
+        id=str(payload["id"]),
+        operating_context=OddOperatingContext(
+            environment_types=list(context["environment_types"]),
+            map_families=list(context["map_families"]),
+            surface_conditions=list(context["surface_conditions"]),
+            visibility=list(context["visibility"]),
+            semantic_features=list(context["semantic_features"]),
+        ),
+        agents=OddAgentEnvelope(
+            actor_types=list(agents["actor_types"]),
+            pedestrian_motion_models=list(agents["pedestrian_motion_models"]),
+            robot_kinematics=list(agents["robot_kinematics"]),
+        ),
+        speed_limits=OddSpeedLimits(
+            max_robot_speed_mps=float(speed_limits["max_robot_speed_mps"]),
+            max_pedestrian_speed_mps=float(speed_limits["max_pedestrian_speed_mps"]),
+            notes=str(speed_limits["notes"]),
+        ),
+        pedestrian_density=OddPedestrianDensity(
+            density_bins=list(density["density_bins"]),
+            max_pedestrians_per_scene=int(density["max_pedestrians_per_scene"]),
+            notes=str(density["notes"]),
+        ),
+        observation=OddObservationEnvelope(
+            observation_modes=list(observation["observation_modes"]),
+            sensor_assumptions=list(observation["sensor_assumptions"]),
+        ),
+        exclusions=list(payload["exclusions"]),
+        claim_boundaries=OddClaimBoundaries(
+            evidence_status=str(boundaries["evidence_status"]),
+            supported_claims=list(boundaries["supported_claims"]),
+            non_claims=list(boundaries["non_claims"]),
+            caveats=list(boundaries["caveats"]),
+        ),
+        provenance=OddProvenance(
+            source_issue=str(provenance["source_issue"]),
+            authored_by=str(provenance["authored_by"]),
+            source_files=list(provenance["source_files"]),
+            notes=str(provenance["notes"]),
+        ),
+        extensions=dict(payload.get("extensions", {})),
+    )
+
+
+def _json_pointer(path_elems: Iterable[Any]) -> str:
+    """Render a validation error path as an RFC6901-style JSON pointer.
+
+    Returns:
+        JSON pointer string, or an empty string for the root path.
+    """
+
+    parts: list[str] = []
+    for part in path_elems:
+        if isinstance(part, int):
+            parts.append(str(part))
+        else:
+            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
+    return "/" + "/".join(parts) if parts else ""
+
+
+__all__ = [
+    "ODD_CONTRACT_SCHEMA_FILE",
+    "ODD_CONTRACT_SCHEMA_VERSION",
+    "OddAgentEnvelope",
+    "OddClaimBoundaries",
+    "OddContract",
+    "OddContractValidationError",
+    "OddObservationEnvelope",
+    "OddOperatingContext",
+    "OddPedestrianDensity",
+    "OddProvenance",
+    "OddSpeedLimits",
+    "classify_odd_claim_boundary",
+    "load_odd_contract_schema",
+    "load_odd_contracts",
+    "odd_contract_from_dict",
+    "validate_odd_contract_references",
+]

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -38,6 +38,15 @@ class OperatingDesignDomain:
 
 
 @dataclass(frozen=True, slots=True)
+class OddContractReference:
+    """Reference from a scenario contract to an ODD declaration."""
+
+    source: str
+    contract_id: str
+    required_for_benchmark_claim: bool
+
+
+@dataclass(frozen=True, slots=True)
 class CountRange:
     """Inclusive actor count range."""
 
@@ -132,6 +141,7 @@ class ScenarioContract:
     certification: ScenarioCertificationCompatibility
     benchmark_eligibility: BenchmarkEligibilityHooks
     provenance: ProvenanceContract
+    odd_contract_ref: OddContractReference | None = None
     extensions: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -142,6 +152,8 @@ class ScenarioContract:
         """
 
         payload = asdict(self)
+        if payload["odd_contract_ref"] is None:
+            payload.pop("odd_contract_ref")
         if not payload["extensions"]:
             payload.pop("extensions")
         return payload
@@ -239,6 +251,30 @@ def validate_scenario_contract_references(
     return errors
 
 
+def validate_scenario_odd_contract_reference(
+    contract: ScenarioContract,
+    *,
+    repo_root: Path = Path("."),
+) -> list[str]:
+    """Validate that a scenario contract's ODD reference resolves.
+
+    Returns:
+        List of reference errors. Contracts without an ODD reference return an empty list
+        so existing scenario contracts remain backward compatible.
+    """
+
+    if contract.odd_contract_ref is None:
+        return []
+
+    from robot_sf.benchmark.odd_contract import validate_odd_contract_references  # noqa: PLC0415
+
+    return validate_odd_contract_references(
+        source=contract.odd_contract_ref.source,
+        contract_id=contract.odd_contract_ref.contract_id,
+        repo_root=repo_root,
+    )
+
+
 def _contract_payloads(raw: Any, *, source: Path) -> list[Mapping[str, Any]]:
     """Normalize supported file shapes into a list of contract mappings.
 
@@ -304,6 +340,7 @@ def _contract_from_payload(payload: Mapping[str, Any]) -> ScenarioContract:
     certification = payload["certification"]
     benchmark_eligibility = payload["benchmark_eligibility"]
     provenance = payload["provenance"]
+    odd_contract_ref = payload.get("odd_contract_ref")
     return ScenarioContract(
         schema_version=str(payload["schema_version"]),
         id=str(payload["id"]),
@@ -365,6 +402,15 @@ def _contract_from_payload(payload: Mapping[str, Any]) -> ScenarioContract:
             authored_by=str(provenance["authored_by"]),
             source_files=list(provenance["source_files"]),
             notes=str(provenance["notes"]),
+        ),
+        odd_contract_ref=(
+            OddContractReference(
+                source=str(odd_contract_ref["source"]),
+                contract_id=str(odd_contract_ref["contract_id"]),
+                required_for_benchmark_claim=bool(odd_contract_ref["required_for_benchmark_claim"]),
+            )
+            if isinstance(odd_contract_ref, Mapping)
+            else None
         ),
         extensions=dict(payload.get("extensions", {})),
     )
@@ -433,6 +479,7 @@ __all__ = [
     "CountRange",
     "InvariantContract",
     "ObservableContract",
+    "OddContractReference",
     "OperatingDesignDomain",
     "ProvenanceContract",
     "ScenarioCertificationCompatibility",
@@ -444,4 +491,5 @@ __all__ = [
     "load_scenario_contracts",
     "scenario_contract_from_dict",
     "validate_scenario_contract_references",
+    "validate_scenario_odd_contract_reference",
 ]

--- a/robot_sf/benchmark/schemas/odd_contract.v1.json
+++ b/robot_sf/benchmark/schemas/odd_contract.v1.json
@@ -1,0 +1,259 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/odd_contract.v1.json",
+  "title": "RobotSF ODD Contract (v1)",
+  "description": "Operational Design Domain metadata that bounds benchmark and falsification evidence. This is not certification evidence or a runtime result.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "operating_context",
+    "agents",
+    "speed_limits",
+    "pedestrian_density",
+    "observation",
+    "exclusions",
+    "claim_boundaries",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "odd_contract.v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$"
+    },
+    "operating_context": {
+      "$ref": "#/$defs/operating_context"
+    },
+    "agents": {
+      "$ref": "#/$defs/agents"
+    },
+    "speed_limits": {
+      "$ref": "#/$defs/speed_limits"
+    },
+    "pedestrian_density": {
+      "$ref": "#/$defs/pedestrian_density"
+    },
+    "observation": {
+      "$ref": "#/$defs/observation"
+    },
+    "exclusions": {
+      "$ref": "#/$defs/string_list"
+    },
+    "claim_boundaries": {
+      "$ref": "#/$defs/claim_boundaries"
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "string_list": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "operating_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "environment_types",
+        "map_families",
+        "surface_conditions",
+        "visibility",
+        "semantic_features"
+      ],
+      "properties": {
+        "environment_types": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "indoor_public_transit",
+              "indoor_corridor",
+              "indoor_room",
+              "outdoor_walkway",
+              "synthetic_atomic",
+              "mixed",
+              "unspecified"
+            ]
+          }
+        },
+        "map_families": {
+          "$ref": "#/$defs/string_list"
+        },
+        "surface_conditions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "visibility": {
+          "$ref": "#/$defs/string_list"
+        },
+        "semantic_features": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor_types",
+        "pedestrian_motion_models",
+        "robot_kinematics"
+      ],
+      "properties": {
+        "actor_types": {
+          "$ref": "#/$defs/string_list"
+        },
+        "pedestrian_motion_models": {
+          "$ref": "#/$defs/string_list"
+        },
+        "robot_kinematics": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "speed_limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_robot_speed_mps",
+        "max_pedestrian_speed_mps",
+        "notes"
+      ],
+      "properties": {
+        "max_robot_speed_mps": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_pedestrian_speed_mps": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "pedestrian_density": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "density_bins",
+        "max_pedestrians_per_scene",
+        "notes"
+      ],
+      "properties": {
+        "density_bins": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "stress",
+              "mixed",
+              "unspecified"
+            ]
+          }
+        },
+        "max_pedestrians_per_scene": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observation_modes",
+        "sensor_assumptions"
+      ],
+      "properties": {
+        "observation_modes": {
+          "$ref": "#/$defs/string_list"
+        },
+        "sensor_assumptions": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_status",
+        "supported_claims",
+        "non_claims",
+        "caveats"
+      ],
+      "properties": {
+        "evidence_status": {
+          "type": "string",
+          "enum": [
+            "metadata_only",
+            "scenario_intent",
+            "benchmark_candidate",
+            "benchmark_evidence"
+          ]
+        },
+        "supported_claims": {
+          "$ref": "#/$defs/string_list"
+        },
+        "non_claims": {
+          "$ref": "#/$defs/string_list"
+        },
+        "caveats": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_issue",
+        "authored_by",
+        "source_files",
+        "notes"
+      ],
+      "properties": {
+        "source_issue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authored_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_files": {
+          "$ref": "#/$defs/string_list"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/benchmark/schemas/scenario_contract.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_contract.v1.json
@@ -33,6 +33,9 @@
     "odd": {
       "$ref": "#/$defs/operating_design_domain"
     },
+    "odd_contract_ref": {
+      "$ref": "#/$defs/odd_contract_ref"
+    },
     "actors": {
       "type": "array",
       "minItems": 1,
@@ -103,6 +106,29 @@
         "scenario_family": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "odd_contract_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "contract_id",
+        "required_for_benchmark_claim"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "contract_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "required_for_benchmark_claim": {
+          "type": "boolean"
         }
       }
     },

--- a/tests/benchmark/test_odd_contract.py
+++ b/tests/benchmark/test_odd_contract.py
@@ -1,0 +1,162 @@
+"""Tests for the ``odd_contract.v1`` benchmark evidence-boundary schema."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.benchmark.odd_contract import (
+    ODD_CONTRACT_SCHEMA_VERSION,
+    OddContractValidationError,
+    classify_odd_claim_boundary,
+    load_odd_contract_schema,
+    load_odd_contracts,
+    odd_contract_from_dict,
+    validate_odd_contract_references,
+)
+from robot_sf.benchmark.scenario_contract import (
+    load_scenario_contracts,
+    validate_scenario_odd_contract_reference,
+)
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "odd_contracts"
+    / "low_speed_public_space_v1.yaml"
+)
+
+SCENARIO_CONTRACT_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "scenarios"
+    / "contracts"
+    / "station_platform_candidate_pack_issue736_contracts.yaml"
+)
+
+
+def test_load_fixture_as_typed_odd_contract() -> None:
+    """Representative ODD contracts should validate independently of benchmark runs."""
+
+    contracts = load_odd_contracts(FIXTURE_PATH)
+
+    assert len(contracts) == 1
+    contract = contracts[0]
+    assert contract.schema_version == ODD_CONTRACT_SCHEMA_VERSION
+    assert contract.id == "low_speed_public_space_v1"
+    assert contract.operating_context.environment_types == [
+        "indoor_public_transit",
+        "outdoor_walkway",
+        "synthetic_atomic",
+    ]
+    assert contract.speed_limits.max_robot_speed_mps == pytest.approx(2.5)
+    assert contract.pedestrian_density.density_bins == ["low", "medium", "high"]
+    assert "safety_certification" in contract.claim_boundaries.non_claims
+
+    jsonschema.validate(contract.to_dict(), load_odd_contract_schema())
+
+
+def test_invalid_odd_contract_sections_fail_closed_with_json_paths() -> None:
+    """Malformed ODD declarations should fail with actionable JSON-pointer paths."""
+
+    payload = load_odd_contracts(FIXTURE_PATH)[0].to_dict()
+    invalid_cases = [
+        (
+            lambda candidate: candidate.__setitem__("schema_version", "odd_contract.v2"),
+            "/schema_version",
+            "odd_contract.v1",
+        ),
+        (
+            lambda candidate: candidate["speed_limits"].__setitem__("max_robot_speed_mps", 0),
+            "/speed_limits/max_robot_speed_mps",
+            "greater than 0",
+        ),
+        (
+            lambda candidate: candidate["pedestrian_density"].__setitem__("density_bins", []),
+            "/pedestrian_density/density_bins",
+            "should be non-empty",
+        ),
+        (
+            lambda candidate: candidate["claim_boundaries"].__setitem__(
+                "evidence_status",
+                "certified",
+            ),
+            "/claim_boundaries/evidence_status",
+            "certified",
+        ),
+    ]
+
+    for mutate, expected_path, expected_fragment in invalid_cases:
+        candidate = deepcopy(payload)
+        mutate(candidate)
+        with pytest.raises(OddContractValidationError) as exc_info:
+            odd_contract_from_dict(candidate, source=FIXTURE_PATH)
+        message = str(exc_info.value)
+        assert expected_path in message
+        assert expected_fragment in message
+
+
+def test_odd_contract_reference_validation_names_missing_files_and_ids() -> None:
+    """Reference validation should distinguish missing files from missing contract IDs."""
+
+    contract = load_odd_contracts(FIXTURE_PATH)[0]
+
+    assert (
+        validate_odd_contract_references(
+            source="configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+            contract_id=contract.id,
+            repo_root=Path("."),
+        )
+        == []
+    )
+
+    assert validate_odd_contract_references(
+        source="configs/benchmarks/odd_contracts/missing.yaml",
+        contract_id=contract.id,
+        repo_root=Path("."),
+    ) == ["odd_contract_ref.source 'configs/benchmarks/odd_contracts/missing.yaml' does not exist"]
+
+    assert validate_odd_contract_references(
+        source="configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+        contract_id="missing_odd",
+        repo_root=Path("."),
+    ) == [
+        "odd_contract_ref.contract_id 'missing_odd' was not found in "
+        "configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+    ]
+
+
+def test_odd_contract_classifies_supported_excluded_and_unknown_claims() -> None:
+    """ODD metadata should make out-of-scope claims executable, not only prose."""
+
+    contract = load_odd_contracts(FIXTURE_PATH)[0]
+
+    assert classify_odd_claim_boundary(contract, "benchmark_evidence_boundary") == "supported"
+    assert classify_odd_claim_boundary(contract, "safety_certification") == "excluded"
+    assert classify_odd_claim_boundary(contract, "public-road autonomy") == "excluded"
+    assert classify_odd_claim_boundary(contract, "real_world_deployment_readiness") == "excluded"
+    assert classify_odd_claim_boundary(contract, "untracked_claim") == "unknown"
+
+
+def test_scenario_contract_fixture_can_reference_odd_declaration() -> None:
+    """Scenario contracts should be able to point at ODD metadata by reference."""
+
+    contract = load_scenario_contracts(SCENARIO_CONTRACT_FIXTURE)[0]
+
+    assert contract.odd_contract_ref is not None
+    assert contract.odd_contract_ref.contract_id == "low_speed_public_space_v1"
+    assert validate_scenario_odd_contract_reference(contract, repo_root=Path(".")) == []
+
+    missing = replace(
+        contract,
+        odd_contract_ref=replace(contract.odd_contract_ref, contract_id="missing_odd"),
+    )
+    assert validate_scenario_odd_contract_reference(missing, repo_root=Path(".")) == [
+        "odd_contract_ref.contract_id 'missing_odd' was not found in "
+        "configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+    ]

--- a/tests/benchmark/test_odd_contract.py
+++ b/tests/benchmark/test_odd_contract.py
@@ -131,6 +131,23 @@ def test_odd_contract_reference_validation_names_missing_files_and_ids() -> None
     ]
 
 
+def test_odd_contract_reference_validation_reports_malformed_sources(tmp_path: Path) -> None:
+    """Reference validation should fail closed when the referenced ODD file is malformed."""
+
+    malformed = tmp_path / "malformed_odd.yaml"
+    malformed.write_text("contracts:\n  - schema_version: odd_contract.v2\n", encoding="utf-8")
+
+    errors = validate_odd_contract_references(
+        source=malformed.name,
+        contract_id="low_speed_public_space_v1",
+        repo_root=tmp_path,
+    )
+
+    assert len(errors) == 1
+    assert f"odd_contract_ref.source '{malformed.name}' could not be loaded" in errors[0]
+    assert "/schema_version" in errors[0]
+
+
 def test_odd_contract_classifies_supported_excluded_and_unknown_claims() -> None:
     """ODD metadata should make out-of-scope claims executable, not only prose."""
 


### PR DESCRIPTION
## Summary
Add `odd_contract.v1` as a versioned ODD metadata contract for benchmark and falsification evidence boundaries.

## Linked Issues
- Closes #1269
- Relates to #1235
- Relates to #1245

## What Changed
- Added `robot_sf/benchmark/odd_contract.py` with typed loading, JSON Schema validation, semantic validation, reference validation, and claim-boundary classification.
- Added `robot_sf/benchmark/schemas/odd_contract.v1.json` and the tracked fixture `configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml`.
- Extended `scenario_contract.v1` with optional `odd_contract_ref` metadata and linked the station-platform contract fixture to the ODD declaration.
- Added `docs/odd_contracts.md` and `docs/context/issue_1269_odd_contract_schema.md`, plus index updates.
- Added focused tests for valid, malformed, missing-reference, scenario-reference, and excluded-claim behavior.

## Why It Matters
- Added value: benchmark and adversarial evidence can now cite explicit operating assumptions instead of relying on prose-only caveats.
- Expected impact: metadata and validation only; benchmark execution, scenario execution, planner behavior, and metrics are unchanged.
- Why this is worth merging now: it provides the assumption layer needed by scenario contracts and future BenchmarkClaim artifacts without claiming certification.

## Validation / Proof
- Commands run:
  - `./.venv/bin/python -m pytest tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py -q`
  - `./.venv/bin/ruff check robot_sf/benchmark/odd_contract.py robot_sf/benchmark/scenario_contract.py tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py`
  - `./.venv/bin/ruff format --check robot_sf/benchmark/odd_contract.py robot_sf/benchmark/scenario_contract.py tests/benchmark/test_odd_contract.py tests/benchmark/test_scenario_contract.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check origin/main...HEAD`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted schema/reference tests passed; full readiness passed with `3631 passed, 11 skipped, 6 warnings` after syncing with latest `origin/main`.
- Benchmarks or smoke tests, if applicable: none; this is a schema/config/docs validation change, not benchmark execution.

## Risks / Rollout
- Compatibility risks: low. `odd_contract_ref` is optional and existing scenario contracts remain valid.
- Failure modes: readers could overinterpret ODD metadata as safety proof; docs, fixture caveats, and claim-boundary fields explicitly prevent that.
- Rollback or fallback plan: revert this metadata/schema/docs commit; no runtime data migration is required.

## Docs / Provenance
- Updated docs: `docs/odd_contracts.md`, `docs/scenario_contracts.md`, `docs/context/issue_1269_odd_contract_schema.md`, `docs/README.md`, `docs/context/README.md`.
- Relevant design or provenance notes: #1269 issue body and #1272 roadmap context.
- Any assumptions that need to be preserved: ODD metadata bounds evidence; it does not certify safety, legal compliance, or deployment readiness.

## Follow-Up Issues
- Deferred work: consume ODD references from future BenchmarkClaim artifacts once #1245 is unblocked.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please review the ODD vocabulary and non-claim wording closely.
- Known limitation: changed-files coverage reported warning-only goal gaps for `robot_sf/benchmark/odd_contract.py` at 95.8% and `robot_sf/benchmark/scenario_contract.py` at 93.3%; both are above the configured minimum.
- Artifact decision: pytest coverage output under `output/coverage/` is ignored local byproduct and not a durable artifact dependency.
