### PR TITLE
feat: add adversarial seed-sensitivity explorer (#1271)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -277,6 +277,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Issue #695 `safe_control` Feasibility Note](./context/issue_695_safe_control_feasibility_note.md)** - External safety-controller assessment showing the current path is blocked by missing runtime dependencies, unclear license metadata, and a waypoint-tracking contract mismatch
 * **[Issue #581 Paper Evidence Delta Report](./context/issue_581_paper_evidence_delta.md)** - Canonical corrected benchmark artifact handoff, planner-quality claim boundary, and AMV paper-ingestion checklist
 * **[Issue #1236 Optimizer Adversarial Sampler](./context/issue_1236_optimizer_adversarial_sampler.md)** - Optuna-backed adversarial sampler pilot, synthetic comparison helper, and non-paper-facing evidence boundary
+* **[Issue #1271 Seed-Sensitivity Explorer](./context/issue_1271_seed_sensitivity_explorer.md)** - API and summary contract for replaying adversarial candidates over explicit seed grids while keeping failure persistence and artifact claims bounded
 * **[Planner Quality Audit Workflow](./benchmark_planner_quality_audit.md)** - Build the planner decision table, classify headline suitability, and record paper-faithfulness parity gaps
 
 ### Tooling

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -94,6 +94,8 @@ knowledge, not every transient iteration detail.
   [issue_1240_scenario_coverage_entropy.md](issue_1240_scenario_coverage_entropy.md)
 * Issue #1255 open-issue dependency graph:
   [issue_1255_open_issue_dependency_graph.md](issue_1255_open_issue_dependency_graph.md)
+* Issue #1271 seed-sensitivity explorer:
+  [issue_1271_seed_sensitivity_explorer.md](issue_1271_seed_sensitivity_explorer.md)
 * Artifact evidence vocabulary:
   [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md)
 * PR first-pass review audit:

--- a/docs/context/issue_1271_seed_sensitivity_explorer.md
+++ b/docs/context/issue_1271_seed_sensitivity_explorer.md
@@ -1,0 +1,81 @@
+# Issue #1271 Seed-Sensitivity Explorer
+
+## Goal
+
+Issue #1271 adds a small API for replaying one adversarial candidate across explicit scenario
+seeds so maintainers can classify a counterexample as a stable failure mode or a brittle
+single-seed artifact.
+
+## Contract
+
+The v1 surface is `robot_sf.adversarial.seed_sensitivity.run_seed_sensitivity`. It accepts an
+existing `SearchConfig`, a `CandidateSpec`, an explicit seed list, an output directory, and an
+evaluator compatible with `run_adversarial_search`. The helper writes replay candidate bundles and
+`seed_sensitivity_summary.json` with schema version `adversarial-seed-sensitivity.v1`.
+
+The summary records:
+
+* replay seeds and per-seed outcomes,
+* failure persistence rate over evaluated replays,
+* objective score spread when objective scores are available,
+* fail-closed certification exclusions,
+* classification: `stable_failure`, `brittle_failure`, or `no_failure`.
+
+Seed perturbations are intentionally allowed outside the original search-space seed range because
+the candidate geometry is fixed and the seed list is the controlled independent variable. Other
+contract checks still come from `SearchConfig.validate`, candidate materialization, certification,
+and the injected evaluator.
+
+## Evidence Boundary
+
+This is development evidence for adversarial analysis and a feeder to Issue #1237 failure archives.
+It is not a durable benchmark claim by itself. Generated summaries under `output/` remain local
+until promoted through the repository artifact policy with provenance, checksums, and a durable
+storage pointer.
+
+Fail-closed certification exclusions are recorded explicitly and do not count as persisted
+failures. Fallback or rejected perturbations therefore remain caveats, not successful
+counterexample evidence.
+
+## Validation
+
+Focused proof:
+
+```bash
+uv run --active pytest \
+  tests/adversarial/test_adversarial_search.py::test_seed_sensitivity_classifies_stable_and_brittle_failures \
+  tests/adversarial/test_adversarial_search.py::test_seed_sensitivity_records_fail_closed_rejected_perturbations \
+  -q
+```
+
+The tests cover stable failure classification, brittle failure classification, objective spread,
+summary-file creation, and fail-closed rejected perturbation accounting with injected evaluators so
+the proof does not require a long benchmark run.
+
+API smoke proof:
+
+```bash
+uv run --active python - <<'PY'
+# Build SearchConfig from configs/scenarios/templates/crossing_ttc.yaml and
+# configs/adversarial/crossing_ttc_space.yaml, inject a deterministic evaluator,
+# and call run_seed_sensitivity over seeds [100, 101].
+PY
+```
+
+Observed result: `stable_failure`, `failure_persistence_rate=0.5`,
+`objective_score_spread=11.0`, summary written to
+`output/adversarial/issue1271_seed_sensitivity_smoke/seed_sensitivity_summary.json`.
+That output is disposable local smoke evidence unless promoted through the artifact policy.
+
+Before PR handoff, also run:
+
+```bash
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+## Related
+
+* GitHub issue: <https://github.com/ll7/robot_sf_ll7/issues/1271>
+* Failure archive feeder: <https://github.com/ll7/robot_sf_ll7/issues/1237>
+* Existing optimizer sampler context: [issue_1236_optimizer_adversarial_sampler.md](issue_1236_optimizer_adversarial_sampler.md)

--- a/docs/context/issue_1271_seed_sensitivity_explorer.md
+++ b/docs/context/issue_1271_seed_sensitivity_explorer.md
@@ -65,6 +65,8 @@ PY
 Observed result: `stable_failure`, `failure_persistence_rate=0.5`,
 `objective_score_spread=11.0`, summary written to
 `output/adversarial/issue1271_seed_sensitivity_smoke/seed_sensitivity_summary.json`.
+A persistence rate at the configured threshold is enough for the v1 helper to flag the candidate
+as stable, but the small two-seed smoke still remains low-confidence development evidence.
 That output is disposable local smoke evidence unless promoted through the artifact policy.
 
 Before PR handoff, also run:

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -25,6 +25,11 @@ from robot_sf.adversarial.samplers import (
     RandomCandidateSampler,
 )
 from robot_sf.adversarial.search import run_adversarial_search
+from robot_sf.adversarial.seed_sensitivity import (
+    SeedSensitivityReplay,
+    SeedSensitivitySummary,
+    run_seed_sensitivity,
+)
 
 __all__ = [
     "CandidateEvaluation",
@@ -38,10 +43,13 @@ __all__ = [
     "SearchConfig",
     "SearchRunResult",
     "SearchSpaceConfig",
+    "SeedSensitivityReplay",
+    "SeedSensitivitySummary",
     "build_multi_ped_adversarial_robot_config",
     "materialize_multi_ped_scenario_payload",
     "materialize_multi_ped_single_pedestrian_overrides",
     "multi_ped_config_to_single_pedestrian_definitions",
     "run_adversarial_search",
+    "run_seed_sensitivity",
     "validate_multi_ped_runtime_plausibility",
 ]

--- a/robot_sf/adversarial/io.py
+++ b/robot_sf/adversarial/io.py
@@ -12,12 +12,14 @@ def read_first_jsonl_record(path: Path | None) -> dict[str, Any] | None:
     if path is None or not path.exists():
         return None
     with path.open(encoding="utf-8") as handle:
-        for line in handle:
+        for line_number, line in enumerate(handle, start=1):
             stripped = line.strip()
             if stripped:
                 try:
                     payload = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"{path}: invalid JSON on line {line_number}: {exc.msg}"
+                    ) from exc
                 return payload if isinstance(payload, dict) else None
     return None

--- a/robot_sf/adversarial/seed_sensitivity.py
+++ b/robot_sf/adversarial/seed_sensitivity.py
@@ -105,7 +105,7 @@ def run_seed_sensitivity(
     environment setup may reset process-global RNG state for each seed.
     """
     config.validate()
-    replay_seeds = tuple(int(seed) for seed in seeds)
+    replay_seeds = tuple(_coerce_replay_seed(seed) for seed in seeds)
     if not replay_seeds:
         raise ValueError("seeds must contain at least one replay seed")
     if not 0.0 <= min_persistence_rate <= 1.0:
@@ -181,6 +181,21 @@ def run_seed_sensitivity(
     )
     write_json(summary.summary_path, summary.to_json())
     return summary
+
+
+def _coerce_replay_seed(seed: Any) -> int:
+    """Return a replay seed without silently truncating non-integer values."""
+    if isinstance(seed, bool):
+        raise ValueError(f"seed values must be integers, got {seed!r}")
+    if isinstance(seed, int):
+        return seed
+    if isinstance(seed, float) and seed.is_integer():
+        return int(seed)
+    if isinstance(seed, str):
+        stripped = seed.strip()
+        if stripped and stripped.lstrip("+-").isdigit():
+            return int(stripped)
+    raise ValueError(f"seed values must be integers, got {seed!r}")
 
 
 def _default_certifier(

--- a/robot_sf/adversarial/seed_sensitivity.py
+++ b/robot_sf/adversarial/seed_sensitivity.py
@@ -151,11 +151,26 @@ def run_seed_sensitivity(
             )
             continue
 
-        evaluation = evaluator(config, replay_candidate, scenario_yaml_path, replay_dir)
-        evaluation = replace(evaluation, certification_status=certification_status)
-        score = objective(evaluation)
-        evaluation = evaluation.with_objective(score)
-        replays.append(_replay_from_evaluation(evaluation, started_at=replay_started_at))
+        try:
+            evaluation = evaluator(config, replay_candidate, scenario_yaml_path, replay_dir)
+            evaluation = replace(evaluation, certification_status=certification_status)
+            score = objective(evaluation)
+            evaluation = evaluation.with_objective(score)
+            replays.append(_replay_from_evaluation(evaluation, started_at=replay_started_at))
+        except Exception as exc:  # noqa: BLE001 - replay grids must fail closed per seed.
+            replays.append(
+                SeedSensitivityReplay(
+                    seed=seed,
+                    status="evaluation_failed",
+                    outcome="fail_closed_exclusion",
+                    reason=repr(exc),
+                    objective_value=None,
+                    bundle_path=replay_dir,
+                    episode_record_path=replay_dir / "episode_records.jsonl",
+                    trajectory_csv_path=None,
+                    started_at=replay_started_at,
+                )
+            )
 
     summary = _summarize(
         candidate=candidate,

--- a/robot_sf/adversarial/seed_sensitivity.py
+++ b/robot_sf/adversarial/seed_sensitivity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,7 @@ class SeedSensitivityReplay:
     bundle_path: Path | None
     episode_record_path: Path | None
     trajectory_csv_path: Path | None
+    started_at: str | None
 
     def to_json(self) -> dict[str, Any]:
         """Return a JSON-compatible replay payload."""
@@ -49,6 +51,7 @@ class SeedSensitivityReplay:
             "trajectory_csv_path": self.trajectory_csv_path.as_posix()
             if self.trajectory_csv_path
             else None,
+            "started_at": self.started_at,
         }
 
 
@@ -98,7 +101,8 @@ def run_seed_sensitivity(
     valid candidate, so seed values are not constrained by the original search
     space's sampled seed range. Certification still runs for every perturbation
     and rejects fail closed when the configured certification policy disallows a
-    replay.
+    replay. The replay loop is intentionally single-process: evaluators and
+    environment setup may reset process-global RNG state for each seed.
     """
     config.validate()
     replay_seeds = tuple(int(seed) for seed in seeds)
@@ -114,6 +118,7 @@ def run_seed_sensitivity(
 
     replays: list[SeedSensitivityReplay] = []
     for index, seed in enumerate(replay_seeds):
+        replay_started_at = datetime.now(UTC).isoformat()
         replay_candidate = replace(candidate, scenario_seed=seed)
         replay_dir = output_dir / f"replay_{index:04d}_seed_{seed}"
         scenario_yaml_path, _route_path = write_candidate_inputs(
@@ -141,6 +146,7 @@ def run_seed_sensitivity(
                     bundle_path=replay_dir,
                     episode_record_path=None,
                     trajectory_csv_path=None,
+                    started_at=replay_started_at,
                 )
             )
             continue
@@ -149,7 +155,7 @@ def run_seed_sensitivity(
         evaluation = replace(evaluation, certification_status=certification_status)
         score = objective(evaluation)
         evaluation = evaluation.with_objective(score)
-        replays.append(_replay_from_evaluation(evaluation))
+        replays.append(_replay_from_evaluation(evaluation, started_at=replay_started_at))
 
     summary = _summarize(
         candidate=candidate,
@@ -175,18 +181,29 @@ def _default_certifier(
     )
 
 
-def _replay_from_evaluation(evaluation: CandidateEvaluation) -> SeedSensitivityReplay:
+def _replay_from_evaluation(
+    evaluation: CandidateEvaluation,
+    *,
+    started_at: str | None = None,
+) -> SeedSensitivityReplay:
     """Convert a candidate evaluation into a seed-sensitivity replay row."""
     record = read_first_jsonl_record(evaluation.episode_record_path)
+    fallback_status = (
+        evaluation.failure_attribution.status
+        if evaluation.failure_attribution is not None
+        else "evaluated"
+    )
+    record_status = record.get("status") if record else None
     return SeedSensitivityReplay(
         seed=int(evaluation.candidate.scenario_seed),
-        status=str(record.get("status", "evaluated")) if record else "evaluated",
+        status=str(record_status) if record_status else fallback_status,
         outcome=_outcome_from_evaluation(evaluation, record),
         reason=_reason_from_evaluation(evaluation),
         objective_value=evaluation.objective_value,
         bundle_path=evaluation.bundle_path,
         episode_record_path=evaluation.episode_record_path,
         trajectory_csv_path=evaluation.trajectory_csv_path,
+        started_at=started_at,
     )
 
 

--- a/robot_sf/adversarial/seed_sensitivity.py
+++ b/robot_sf/adversarial/seed_sensitivity.py
@@ -1,0 +1,279 @@
+"""Seed-sensitivity replay helpers for adversarial counterexamples."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from robot_sf.adversarial.bundle import write_candidate_inputs, write_json
+from robot_sf.adversarial.certification import (
+    CertificationStatus,
+    candidate_allowed,
+    certify_candidate,
+)
+from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec, SearchConfig
+from robot_sf.adversarial.io import read_first_jsonl_record
+from robot_sf.adversarial.objectives import get_objective
+
+CandidateEvaluator = Callable[[SearchConfig, CandidateSpec, Path, Path], CandidateEvaluation]
+CandidateCertifier = Callable[[CandidateSpec, Path, bool], CertificationStatus]
+
+
+@dataclass(frozen=True)
+class SeedSensitivityReplay:
+    """One seed-perturbation replay result in a sensitivity summary."""
+
+    seed: int
+    status: str
+    outcome: str
+    reason: str | None
+    objective_value: float | None
+    bundle_path: Path | None
+    episode_record_path: Path | None
+    trajectory_csv_path: Path | None
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-compatible replay payload."""
+        return {
+            "seed": int(self.seed),
+            "status": self.status,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "objective_value": self.objective_value,
+            "bundle_path": self.bundle_path.as_posix() if self.bundle_path else None,
+            "episode_record_path": self.episode_record_path.as_posix()
+            if self.episode_record_path
+            else None,
+            "trajectory_csv_path": self.trajectory_csv_path.as_posix()
+            if self.trajectory_csv_path
+            else None,
+        }
+
+
+@dataclass(frozen=True)
+class SeedSensitivitySummary:
+    """Compact stability summary for one adversarial candidate across replay seeds."""
+
+    schema_version: str
+    candidate: CandidateSpec
+    seeds: tuple[int, ...]
+    classification: str
+    failure_persistence_rate: float
+    objective_score_spread: float | None
+    min_persistence_rate: float
+    num_fail_closed_exclusions: int
+    replays: tuple[SeedSensitivityReplay, ...]
+    summary_path: Path
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-compatible seed-sensitivity payload."""
+        return {
+            "schema_version": self.schema_version,
+            "candidate": self.candidate.to_json(),
+            "seeds": list(self.seeds),
+            "classification": self.classification,
+            "failure_persistence_rate": self.failure_persistence_rate,
+            "objective_score_spread": self.objective_score_spread,
+            "min_persistence_rate": self.min_persistence_rate,
+            "num_fail_closed_exclusions": self.num_fail_closed_exclusions,
+            "replays": [replay.to_json() for replay in self.replays],
+        }
+
+
+def run_seed_sensitivity(
+    config: SearchConfig,
+    *,
+    candidate: CandidateSpec,
+    seeds: Iterable[int],
+    output_dir: Path,
+    evaluator: CandidateEvaluator,
+    certifier: CandidateCertifier | None = None,
+    min_persistence_rate: float = 0.5,
+) -> SeedSensitivitySummary:
+    """Replay one adversarial candidate over explicit scenario seeds.
+
+    The explorer treats seed changes as controlled perturbations of an already
+    valid candidate, so seed values are not constrained by the original search
+    space's sampled seed range. Certification still runs for every perturbation
+    and rejects fail closed when the configured certification policy disallows a
+    replay.
+    """
+    config.validate()
+    replay_seeds = tuple(int(seed) for seed in seeds)
+    if not replay_seeds:
+        raise ValueError("seeds must contain at least one replay seed")
+    if not 0.0 <= min_persistence_rate <= 1.0:
+        raise ValueError("min_persistence_rate must be between 0 and 1")
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    objective = get_objective(config.objective)
+    active_certifier = certifier or _default_certifier
+
+    replays: list[SeedSensitivityReplay] = []
+    for index, seed in enumerate(replay_seeds):
+        replay_candidate = replace(candidate, scenario_seed=seed)
+        replay_dir = output_dir / f"replay_{index:04d}_seed_{seed}"
+        scenario_yaml_path, _route_path = write_candidate_inputs(
+            config=config,
+            candidate=replay_candidate,
+            candidate_dir=replay_dir,
+            index=index,
+        )
+        certification_status = active_certifier(
+            replay_candidate,
+            scenario_yaml_path,
+            config.require_certification,
+        )
+        if not candidate_allowed(
+            certification_status,
+            require_certification=config.require_certification,
+        ):
+            replays.append(
+                SeedSensitivityReplay(
+                    seed=seed,
+                    status=certification_status.status,
+                    outcome="fail_closed_exclusion",
+                    reason=certification_status.reason,
+                    objective_value=None,
+                    bundle_path=replay_dir,
+                    episode_record_path=None,
+                    trajectory_csv_path=None,
+                )
+            )
+            continue
+
+        evaluation = evaluator(config, replay_candidate, scenario_yaml_path, replay_dir)
+        evaluation = replace(evaluation, certification_status=certification_status)
+        score = objective(evaluation)
+        evaluation = evaluation.with_objective(score)
+        replays.append(_replay_from_evaluation(evaluation))
+
+    summary = _summarize(
+        candidate=candidate,
+        seeds=replay_seeds,
+        replays=tuple(replays),
+        min_persistence_rate=min_persistence_rate,
+        summary_path=output_dir / "seed_sensitivity_summary.json",
+    )
+    write_json(summary.summary_path, summary.to_json())
+    return summary
+
+
+def _default_certifier(
+    candidate: CandidateSpec,
+    scenario_yaml_path: Path,
+    require_certification: bool,
+) -> CertificationStatus:
+    """Run the default adversarial scenario-certification adapter."""
+    return certify_candidate(
+        candidate,
+        scenario_yaml_path=scenario_yaml_path,
+        require_certification=require_certification,
+    )
+
+
+def _replay_from_evaluation(evaluation: CandidateEvaluation) -> SeedSensitivityReplay:
+    """Convert a candidate evaluation into a seed-sensitivity replay row."""
+    record = read_first_jsonl_record(evaluation.episode_record_path)
+    return SeedSensitivityReplay(
+        seed=int(evaluation.candidate.scenario_seed),
+        status=str(record.get("status", "evaluated")) if record else "evaluated",
+        outcome=_outcome_from_evaluation(evaluation, record),
+        reason=_reason_from_evaluation(evaluation),
+        objective_value=evaluation.objective_value,
+        bundle_path=evaluation.bundle_path,
+        episode_record_path=evaluation.episode_record_path,
+        trajectory_csv_path=evaluation.trajectory_csv_path,
+    )
+
+
+def _outcome_from_evaluation(
+    evaluation: CandidateEvaluation,
+    record: dict[str, Any] | None,
+) -> str:
+    """Return the categorical outcome used for stability accounting."""
+    if (
+        evaluation.failure_attribution is not None
+        and evaluation.failure_attribution.primary_failure
+    ):
+        return evaluation.failure_attribution.primary_failure
+    if record is None:
+        return "unknown"
+    outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+    if bool(outcome.get("collision") or outcome.get("collision_event")):
+        return "collision"
+    if bool(outcome.get("timeout") or outcome.get("timeout_event")):
+        return "timeout"
+    if bool(outcome.get("route_complete")):
+        return "success"
+    return str(record.get("termination_reason", record.get("status", "unknown")))
+
+
+def _reason_from_evaluation(evaluation: CandidateEvaluation) -> str | None:
+    """Return a compact reason string for replay summaries."""
+    if evaluation.error:
+        return evaluation.error
+    if evaluation.failure_attribution is None:
+        return None
+    if evaluation.failure_attribution.reasons:
+        return "; ".join(evaluation.failure_attribution.reasons)
+    return None
+
+
+def _summarize(
+    *,
+    candidate: CandidateSpec,
+    seeds: tuple[int, ...],
+    replays: tuple[SeedSensitivityReplay, ...],
+    min_persistence_rate: float,
+    summary_path: Path,
+) -> SeedSensitivitySummary:
+    """Build aggregate persistence and objective-spread values."""
+    evaluated = [replay for replay in replays if replay.outcome != "fail_closed_exclusion"]
+    failures = [replay for replay in evaluated if _is_failure_outcome(replay.outcome)]
+    failure_persistence_rate = len(failures) / len(evaluated) if evaluated else 0.0
+    classification = _classification(
+        failure_persistence_rate=failure_persistence_rate,
+        has_failure=bool(failures),
+        min_persistence_rate=min_persistence_rate,
+    )
+    scores = [replay.objective_value for replay in evaluated if replay.objective_value is not None]
+    objective_score_spread = max(scores) - min(scores) if scores else None
+    return SeedSensitivitySummary(
+        schema_version="adversarial-seed-sensitivity.v1",
+        candidate=candidate,
+        seeds=seeds,
+        classification=classification,
+        failure_persistence_rate=float(failure_persistence_rate),
+        objective_score_spread=float(objective_score_spread)
+        if objective_score_spread is not None
+        else None,
+        min_persistence_rate=float(min_persistence_rate),
+        num_fail_closed_exclusions=sum(
+            1 for replay in replays if replay.outcome == "fail_closed_exclusion"
+        ),
+        replays=replays,
+        summary_path=summary_path,
+    )
+
+
+def _is_failure_outcome(outcome: str) -> bool:
+    """Return whether an outcome counts as a persisted counterexample failure."""
+    return outcome in {"collision", "timeout", "incomplete", "evaluation_error"}
+
+
+def _classification(
+    *,
+    failure_persistence_rate: float,
+    has_failure: bool,
+    min_persistence_rate: float,
+) -> str:
+    """Classify the replay grid as stable, brittle, or non-failing."""
+    if not has_failure:
+        return "no_failure"
+    if failure_persistence_rate >= min_persistence_rate:
+        return "stable_failure"
+    return "brittle_failure"

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -40,6 +40,7 @@ from robot_sf.adversarial.samplers import (
     OptunaCandidateSampler,
     RandomCandidateSampler,
 )
+from robot_sf.adversarial.seed_sensitivity import run_seed_sensitivity
 from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
@@ -925,6 +926,130 @@ def test_optuna_candidate_sampler_reports_missing_dependency(
 
     with pytest.raises(RuntimeError, match="OptunaCandidateSampler requires optuna"):
         OptunaCandidateSampler(config.search_space, seed=7)
+
+
+def test_seed_sensitivity_classifies_stable_and_brittle_failures(tmp_path: Path) -> None:
+    """Seed sensitivity should separate persistent failures from one-seed artifacts."""
+    config = _config(tmp_path)
+
+    def evaluator(
+        _config: SearchConfig,
+        candidate: CandidateSpec,
+        _scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        """Emit deterministic collision records for selected replay seeds."""
+        collision = candidate.scenario_seed in {7, 8}
+        record = {
+            "episode_id": f"seed-{candidate.scenario_seed}",
+            "seed": candidate.scenario_seed,
+            "status": "collision" if collision else "success",
+            "steps": 1,
+            "termination_reason": "collision" if collision else "success",
+            "outcome": {
+                "route_complete": not collision,
+                "collision": collision,
+                "timeout": False,
+            },
+            "metrics": {"success": 0.0 if collision else 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        trajectory_path = write_trajectory_csv(candidate_dir / "trajectory.csv", record)
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("seed sensitivity test"),
+            objective_value=None,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=trajectory_path,
+            scenario_yaml_path=_scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    stable = run_seed_sensitivity(
+        config,
+        candidate=_candidate(7),
+        seeds=[7, 8, 9],
+        output_dir=tmp_path / "stable",
+        evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: passed_status("seed sensitivity test"),
+        min_persistence_rate=0.5,
+    )
+    brittle = run_seed_sensitivity(
+        config,
+        candidate=_candidate(7),
+        seeds=[7, 9, 10],
+        output_dir=tmp_path / "brittle",
+        evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: passed_status("seed sensitivity test"),
+        min_persistence_rate=0.5,
+    )
+
+    assert stable.classification == "stable_failure"
+    assert stable.failure_persistence_rate == pytest.approx(2 / 3)
+    assert stable.objective_score_spread == pytest.approx(11.0)
+    assert [replay.outcome for replay in stable.replays] == ["collision", "collision", "success"]
+    assert (tmp_path / "stable" / "seed_sensitivity_summary.json").exists()
+
+    assert brittle.classification == "brittle_failure"
+    assert brittle.failure_persistence_rate == pytest.approx(1 / 3)
+
+
+def test_seed_sensitivity_records_fail_closed_rejected_perturbations(tmp_path: Path) -> None:
+    """Rejected perturbations should be recorded without weakening the failure denominator."""
+    config = _config(tmp_path, require_certification=True)
+    evaluated: list[int] = []
+
+    def evaluator(
+        _config: SearchConfig,
+        candidate: CandidateSpec,
+        _scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        """Emit a successful replay for certified perturbations."""
+        evaluated.append(candidate.scenario_seed)
+        record = {
+            "episode_id": f"seed-{candidate.scenario_seed}",
+            "seed": candidate.scenario_seed,
+            "status": "success",
+            "steps": 1,
+            "termination_reason": "success",
+            "outcome": {"route_complete": True, "collision": False, "timeout": False},
+            "metrics": {"success": 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("seed sensitivity test"),
+            objective_value=None,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=_scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    summary = run_seed_sensitivity(
+        config,
+        candidate=_candidate(7),
+        seeds=[7, 8],
+        output_dir=tmp_path / "rejected",
+        evaluator=evaluator,
+        certifier=lambda candidate, _path, _required: (
+            not_available_status("seed 8 rejected by certification")
+            if candidate.scenario_seed == 8
+            else passed_status("seed sensitivity test")
+        ),
+    )
+
+    assert evaluated == [7]
+    assert summary.num_fail_closed_exclusions == 1
+    assert summary.failure_persistence_rate == 0.0
+    assert summary.replays[1].status == "not_available"
+    assert summary.replays[1].outcome == "fail_closed_exclusion"
+    assert summary.replays[1].reason == "seed 8 rejected by certification"
 
 
 def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -990,6 +990,7 @@ def test_seed_sensitivity_classifies_stable_and_brittle_failures(tmp_path: Path)
     assert stable.failure_persistence_rate == pytest.approx(2 / 3)
     assert stable.objective_score_spread == pytest.approx(11.0)
     assert [replay.outcome for replay in stable.replays] == ["collision", "collision", "success"]
+    assert all(replay.started_at for replay in stable.replays)
     assert (tmp_path / "stable" / "seed_sensitivity_summary.json").exists()
 
     assert brittle.classification == "brittle_failure"
@@ -1050,6 +1051,7 @@ def test_seed_sensitivity_records_fail_closed_rejected_perturbations(tmp_path: P
     assert summary.replays[1].status == "not_available"
     assert summary.replays[1].outcome == "fail_closed_exclusion"
     assert summary.replays[1].reason == "seed 8 rejected by certification"
+    assert summary.replays[1].started_at
 
 
 def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
@@ -1379,12 +1381,13 @@ def test_failure_attribution_covers_primary_outcomes() -> None:
     assert error.to_json()["status"] == "evaluation_failed"
 
 
-def test_read_first_jsonl_record_skips_malformed_lines(tmp_path: Path) -> None:
-    """JSONL helper should fail soft for malformed records and keep scanning."""
+def test_read_first_jsonl_record_rejects_malformed_lines(tmp_path: Path) -> None:
+    """JSONL helper should fail closed for malformed records with source context."""
     path = tmp_path / "episode.jsonl"
     path.write_text("{bad json}\n\n" + json.dumps({"episode_id": "ok"}) + "\n", encoding="utf-8")
 
-    assert read_first_jsonl_record(path) == {"episode_id": "ok"}
+    with pytest.raises(ValueError, match=r"episode\.jsonl: invalid JSON on line 1"):
+        read_first_jsonl_record(path)
 
 
 def test_write_trajectory_csv_escapes_fields(tmp_path: Path) -> None:

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1110,6 +1110,59 @@ def test_seed_sensitivity_records_fail_closed_evaluator_rejections(tmp_path: Pat
     assert summary.replays[1].started_at
 
 
+def test_seed_sensitivity_rejects_non_integral_replay_seeds(tmp_path: Path) -> None:
+    """Replay seed coercion should reject lossy non-integer values."""
+    config = _config(tmp_path)
+
+    def evaluator(
+        _config: SearchConfig,
+        candidate: CandidateSpec,
+        _scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        """Return a no-failure replay for valid seeds."""
+        record = {
+            "episode_id": f"seed-{candidate.scenario_seed}",
+            "seed": candidate.scenario_seed,
+            "status": "success",
+            "steps": 1,
+            "termination_reason": "success",
+            "outcome": {"route_complete": True, "collision": False, "timeout": False},
+            "metrics": {"success": 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("seed sensitivity test"),
+            objective_value=None,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=_scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    summary = run_seed_sensitivity(
+        config,
+        candidate=_candidate(7),
+        seeds=["7", "+8", 9.0],
+        output_dir=tmp_path / "valid_seed_coercion",
+        evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: passed_status("seed sensitivity test"),
+    )
+    assert summary.seeds == (7, 8, 9)
+
+    with pytest.raises(ValueError, match="seed values must be integers"):
+        run_seed_sensitivity(
+            config,
+            candidate=_candidate(7),
+            seeds=[7, 8.5],
+            output_dir=tmp_path / "invalid_seed_coercion",
+            evaluator=evaluator,
+        )
+
+
 def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
     """Comparison helper should run random, coordinate, and optuna samplers."""
     template = tmp_path / "template.yaml"

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1054,6 +1054,62 @@ def test_seed_sensitivity_records_fail_closed_rejected_perturbations(tmp_path: P
     assert summary.replays[1].started_at
 
 
+def test_seed_sensitivity_records_fail_closed_evaluator_rejections(tmp_path: Path) -> None:
+    """Evaluator failures should be recorded per seed instead of aborting the summary."""
+    config = _config(tmp_path)
+    evaluated: list[int] = []
+
+    def evaluator(
+        _config: SearchConfig,
+        candidate: CandidateSpec,
+        _scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        """Reject one replay and emit a successful record for the other."""
+        evaluated.append(candidate.scenario_seed)
+        if candidate.scenario_seed == 8:
+            raise RuntimeError("seed 8 benchmark rejected")
+        record = {
+            "episode_id": f"seed-{candidate.scenario_seed}",
+            "seed": candidate.scenario_seed,
+            "status": "success",
+            "steps": 1,
+            "termination_reason": "success",
+            "outcome": {"route_complete": True, "collision": False, "timeout": False},
+            "metrics": {"success": 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("seed sensitivity test"),
+            objective_value=None,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=_scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    summary = run_seed_sensitivity(
+        config,
+        candidate=_candidate(7),
+        seeds=[7, 8],
+        output_dir=tmp_path / "rejected_evaluator",
+        evaluator=evaluator,
+        certifier=lambda _candidate, _path, _required: passed_status("seed sensitivity test"),
+    )
+
+    assert evaluated == [7, 8]
+    assert summary.num_fail_closed_exclusions == 1
+    assert summary.failure_persistence_rate == 0.0
+    assert summary.classification == "no_failure"
+    assert summary.replays[1].status == "evaluation_failed"
+    assert summary.replays[1].outcome == "fail_closed_exclusion"
+    assert "seed 8 benchmark rejected" in str(summary.replays[1].reason)
+    assert summary.replays[1].started_at
+
+
 def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
     """Comparison helper should run random, coordinate, and optuna samplers."""
     template = tmp_path / "template.yaml"


### PR DESCRIPTION
## Summary
Adds a v1 adversarial seed-sensitivity API that replays one candidate over an explicit seed grid and writes a compact stability summary.

## Linked Issues
- Closes #1271
- Relates to #1237

## What Changed
- Added `robot_sf.adversarial.seed_sensitivity.run_seed_sensitivity` plus summary/replay dataclasses.
- Exported the API from `robot_sf.adversarial`.
- Added injected-evaluator tests for stable failures, brittle failures, objective spread, summary-file creation, and fail-closed certification exclusions.
- Added `docs/context/issue_1271_seed_sensitivity_explorer.md` and linked it from `docs/context/README.md` and `docs/README.md`.

## Why It Matters
- Added value: counterexamples can now be classified as persistent failures versus one-seed artifacts before they feed archive or regression workflows.
- Expected impact: generated seed-sensitivity summaries improve adversarial failure triage without changing benchmark execution semantics.
- Why this is worth merging now: it is a bounded API-first slice that supports the Issue #1237 failure archive lane while keeping artifact and benchmark-claim boundaries explicit.

## Validation / Proof
- Commands run:
  - `uv run --active pytest tests/adversarial/test_adversarial_search.py::test_seed_sensitivity_classifies_stable_and_brittle_failures tests/adversarial/test_adversarial_search.py::test_seed_sensitivity_records_fail_closed_rejected_perturbations -q`
  - `uv run --active pytest tests/adversarial/test_adversarial_search.py -q`
  - `uv run --active ruff check robot_sf/adversarial/seed_sensitivity.py robot_sf/adversarial/__init__.py tests/adversarial/test_adversarial_search.py`
  - `uv run --active ruff format --check robot_sf/adversarial/seed_sensitivity.py robot_sf/adversarial/__init__.py tests/adversarial/test_adversarial_search.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - API smoke using `configs/scenarios/templates/crossing_ttc.yaml` and `configs/adversarial/crossing_ttc_space.yaml` with an injected deterministic evaluator over seeds `[100, 101]`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run --active python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - Focused tests: `2 passed`.
  - Adversarial test file: `40 passed`.
  - API smoke: `stable_failure`, `failure_persistence_rate=0.5`, `objective_score_spread=11.0`.
  - Full readiness after latest-main sync and commit: `3628 passed, 11 skipped, 3 warnings`; changed-file coverage `robot_sf/adversarial/seed_sensitivity.py: 85.2% [WARN]` above the 80% floor.
- Benchmarks or smoke tests, if applicable:
  - No benchmark campaign was run. The API smoke used tracked adversarial configs with an injected evaluator to avoid treating local generated output as benchmark evidence.

## Risks / Rollout
- Compatibility risks: low; this adds a new opt-in API and docs/tests only.
- Failure modes: small seed grids can still miss brittle behavior, and summaries are development evidence unless promoted through durable artifact policy.
- Rollback or fallback plan: revert the single feature commit to remove the API and docs.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1271_seed_sensitivity_explorer.md`
  - `docs/context/README.md`
  - `docs/README.md`
- Relevant design or provenance notes:
  - The context note records the v1 contract, classification semantics, fail-closed boundary, and Issue #1237 feeder relationship.
- Any assumptions that need to be preserved:
  - Fail-closed certification exclusions are caveats, not successful counterexample evidence.
  - Generated summaries under `output/` are local disposable evidence until promoted with durable provenance.

## Follow-Up Issues
- Deferred work: timing/speed perturbation policy is intentionally left out of the v1 seed-grid API.
- Issues opened for follow-up: #1294.

## Reviewer Notes
- Anything a reviewer should verify closely: check that the failure-persistence denominator and fail-closed exclusions match the desired v1 semantics.
- Any known limitations: the v1 helper covers explicit seed perturbations; timing/speed perturbations are not implemented in this first slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a seed-sensitivity explorer to evaluate replayed runs across multiple seeds with robustness classification and summary metrics.

* **Bug Fixes**
  * Improved error reporting for malformed JSONL so errors include the file path and offending line number.

* **Documentation**
  * Added comprehensive docs and examples for the seed-sensitivity explorer, validation checks, and usage guidance.

* **Tests**
  * Added coverage validating seed-sensitivity behaviors, error handling, and JSONL parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->