### PR TITLE
feat: add hazard traceability mapping (#1270)

### DIFF
--- a/configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+++ b/configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
@@ -1,0 +1,86 @@
+schema_version: hazard_traceability.v1
+id: low_speed_public_space_hazards_v1
+claim_boundary: Hazard traceability records intended scenario coverage only; it is not safety proof.
+hazards:
+  - id: robot_pedestrian_collision
+    description: Robot contact or collision with a pedestrian actor.
+    severity: safety
+    supporting_metrics:
+      - collision_rate
+    evidence_fields:
+      - termination_reason
+      - metrics.collision
+      - metrics.collision_rate
+  - id: near_miss
+    description: Close interaction without contact that should be visible in proximity metrics.
+    severity: safety
+    supporting_metrics:
+      - min_ttc
+      - pet
+    evidence_fields:
+      - metrics.min_ttc
+      - metrics.pet
+      - metrics.min_clearance
+  - id: blind_corner_emergence
+    description: Pedestrian emergence or visibility-limited interaction near a corner or occluder.
+    severity: safety
+    supporting_metrics:
+      - min_ttc
+      - clearance
+    evidence_fields:
+      - scenario.metadata.visibility
+      - scenario.metadata.occlusion
+      - metrics.min_ttc
+  - id: keep_clear_violation
+    description: Robot or pedestrian intrusion into a keep-clear or platform hazard region.
+    severity: operational
+    supporting_metrics:
+      - keep_clear_intrusion_s
+    evidence_fields:
+      - scenario.metadata.platform_semantics
+      - metrics.keep_clear_intrusion_s
+  - id: pedestrian_flow_disruption
+    description: Robot motion disrupts intended pedestrian flow, dwell, or crossing behavior.
+    severity: social
+    supporting_metrics:
+      - comfort_exposure_s
+      - path_efficiency
+    evidence_fields:
+      - scenario.metadata.flow
+      - metrics.comfort_exposure_s
+      - metrics.path_efficiency
+scenario_mappings:
+  - id: station_platform_family
+    scenario_families:
+      - station_platform
+    hazards:
+      - robot_pedestrian_collision
+      - near_miss
+      - keep_clear_violation
+      - pedestrian_flow_disruption
+    notes: Station-platform scenarios exercise dwell, flow disruption, and platform-region semantics.
+  - id: classic_crossing_family
+    scenario_families:
+      - classic_crossing
+      - crossing
+    hazards:
+      - robot_pedestrian_collision
+      - near_miss
+      - pedestrian_flow_disruption
+    notes: Crossing scenarios exercise pedestrian-flow interaction and proximity risk.
+  - id: blind_corner_fixture
+    scenario_ids:
+      - francis2023_blind_corner
+      - observation_visibility_blind_corner_smoke
+    hazards:
+      - blind_corner_emergence
+      - near_miss
+    notes: Blind-corner fixtures exercise visibility-limited emergence risk.
+provenance:
+  source_issue: https://github.com/ll7/robot_sf_ll7/issues/1270
+  authored_by: robot_sf_ll7
+  source_files:
+    - configs/scenarios/sets/station_platform_candidate_pack_issue736.yaml
+    - configs/scenarios/classic_interactions.yaml
+    - configs/scenarios/single/observation_visibility_blind_corner_smoke.yaml
+  notes: Initial traceability mapping for low-speed public-space benchmark and falsification metadata.

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 ### Benchmarking & Metrics
 
 * **[Benchmark Spec (Classic Interactions)](./benchmark_spec.md)** - Scenario split + seeds, baseline categories, reproducible commands, and metric caveats
+* **[Hazard Traceability](./hazard_traceability.md)** - `hazard_traceability.v1` schema, typed loader, fixture, and coverage summary for scenario-to-hazard evidence caveats
 * **[Scenario Contracts](./scenario_contracts.md)** - `scenario_contract.v1` schema, typed loader, fixture, and boundary between authored intent, certification, and benchmark evidence
 * **[Scenario Certification](./scenario_certification.md)** - `scenario_cert.v1` schema, CLI, labels, and fail-closed benchmark eligibility rules
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
@@ -367,6 +368,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * [**Single Pedestrians**](./single_pedestrians.md) - Define individual pedestrians with goals or trajectories in SVG/JSON/code
 * [**Multi-Pedestrian Example**](../examples/example_multi_pedestrian.py) - Demonstrates multiple single pedestrians (goal, trajectory, static) in one scenario
 * [**Scenario Specification Checklist**](./scenario_spec_checklist.md) - Authoring checklist for per-scenario/archetype/manifest files
+* [**Hazard Traceability**](./hazard_traceability.md) - Summarize intended hazard coverage for scenario IDs or families without treating traceability as safety proof
 * [**Scenario Contracts**](./scenario_contracts.md) - Validate authored scenario-intent contracts before certification or benchmark execution
 * [**Scenario Certification**](./scenario_certification.md) - Generate machine-readable validity, feasibility, stress-only, and hard-but-solvable certificates for scenario manifests
 * [**Issue #1240 Scenario Coverage Entropy**](./context/issue_1240_scenario_coverage_entropy.md) - Config-only entropy and novelty report for diagnostic scenario-set curation; not benchmark-success evidence

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -475,6 +475,7 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #974 CARLA Availability Boolean Field](issue_974_carla_availability_boolean_field.md)
   adds an explicit boolean to CARLA availability metadata and CLI JSON output.
 - [Issue #976 CARLA Availability Schema Version](issue_976_carla_availability_schema_version.md)
+- [Issue #1270 Hazard Traceability Mapping](issue_1270_hazard_traceability.md)
   adds a schema version to CARLA availability metadata for stable script consumption.
 - [Issue #978 CARLA Availability JSON Schema](issue_978_carla_availability_json_schema.md)
   adds a JSON Schema for validating CARLA availability metadata.

--- a/docs/context/issue_1270_hazard_traceability.md
+++ b/docs/context/issue_1270_hazard_traceability.md
@@ -1,0 +1,37 @@
+# Issue #1270 Hazard Traceability Mapping
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1270>
+
+## Summary
+
+Issue #1270 adds `hazard_traceability.v1`, a compact mapping from scenario IDs or scenario families
+to intended low-speed public-space hazards and supporting evidence fields.
+
+## Implemented Surfaces
+
+- `robot_sf/benchmark/schemas/hazard_traceability.v1.json` defines the JSON Schema.
+- `robot_sf/benchmark/hazard_traceability.py` provides typed loading, JSON Schema validation,
+  semantic validation, and coverage summary generation.
+- `configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml` is the first tracked
+  traceability mapping.
+- `docs/hazard_traceability.md` documents the contract boundary and authoring guidance.
+
+## Boundary
+
+Hazard traceability records intended coverage. It does not prove hazard mitigation, certify safety,
+or replace benchmark execution. Any claim that cites hazard coverage still needs scenario
+certification, benchmark artifacts, seeds, metrics, and outcome evidence.
+
+## Validation
+
+Targeted validation for this issue should include:
+
+```bash
+uv run pytest tests/benchmark/test_hazard_traceability.py -q
+uv run ruff check robot_sf/benchmark/hazard_traceability.py tests/benchmark/test_hazard_traceability.py
+uv run ruff format --check robot_sf/benchmark/hazard_traceability.py tests/benchmark/test_hazard_traceability.py
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+git diff --check origin/main...HEAD
+```
+
+Run the repository PR readiness gate after syncing with latest `origin/main` before PR handoff.

--- a/docs/hazard_traceability.md
+++ b/docs/hazard_traceability.md
@@ -1,0 +1,70 @@
+# Hazard Traceability
+
+[← Back to Documentation Index](./README.md)
+
+`hazard_traceability.v1` maps benchmark scenario IDs or scenario families to the hazards they are
+intended to exercise and to the metrics or evidence fields that can support claims about those
+hazards.
+
+This is traceability metadata only. It is not a safety case, legal certification, success metric,
+or proof that a planner mitigates a hazard.
+
+## Contract Boundary
+
+Use the related surfaces for different jobs:
+
+- `hazard_traceability.v1`: intended links from scenarios to hazards and supporting evidence fields.
+- `scenario_contract.v1`: authored scenario intent and scenario-specific assumptions.
+- `scenario_cert.v1`: fail-closed feasibility and benchmark eligibility classification.
+- benchmark episode records and reports: executed planner behavior, metrics, seeds, and outcomes.
+
+Traceability helps report coverage gaps and caveats. It does not replace benchmark execution.
+
+## Public Files
+
+- Schema:
+  [`robot_sf/benchmark/schemas/hazard_traceability.v1.json`](../robot_sf/benchmark/schemas/hazard_traceability.v1.json)
+- Loader:
+  [`robot_sf/benchmark/hazard_traceability.py`](../robot_sf/benchmark/hazard_traceability.py)
+- Fixture:
+  [`configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml`](../configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml)
+
+The first fixture covers low-speed public-space hazards such as collision, near miss, blind-corner
+emergence, keep-clear violation, and pedestrian-flow disruption.
+
+## Library API
+
+```python
+from pathlib import Path
+
+from robot_sf.benchmark.hazard_traceability import (
+    load_hazard_traceability,
+    summarize_hazard_coverage,
+)
+
+mapping = load_hazard_traceability(
+    Path("configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml")
+)
+summary = summarize_hazard_coverage(
+    mapping,
+    scenario_families=["station_platform"],
+)
+```
+
+`load_hazard_traceability(...)` validates JSON Schema first and raises
+`HazardTraceabilityValidationError` with JSON-pointer-style paths for invalid sections.
+`summarize_hazard_coverage(...)` emits a compact `hazard-traceability-coverage.v1` dictionary with
+covered hazards, unmapped scenario IDs/families, and supporting metrics/evidence fields.
+
+## Authoring Guidance
+
+Keep v1 mappings conservative:
+
+- use stable hazard IDs rather than prose-only labels,
+- link every hazard to metrics or evidence fields that can actually appear in benchmark artifacts,
+- report unsupported or unmapped scenario inputs as coverage gaps,
+- state the claim boundary in the mapping,
+- avoid using a hazard mapping as proof that a planner solved the hazard.
+
+Future BenchmarkClaim artifacts can consume hazard summaries to state coverage caveats, but they
+still need scenario certification and benchmark run evidence.

--- a/robot_sf/benchmark/hazard_traceability.py
+++ b/robot_sf/benchmark/hazard_traceability.py
@@ -1,0 +1,315 @@
+"""Typed loader for ``hazard_traceability.v1`` benchmark mapping payloads."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+HAZARD_TRACEABILITY_SCHEMA_VERSION = "hazard_traceability.v1"
+HAZARD_COVERAGE_SUMMARY_SCHEMA_VERSION = "hazard-traceability-coverage.v1"
+HAZARD_TRACEABILITY_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "hazard_traceability.v1.json"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HazardDefinition:
+    """Stable hazard definition and evidence fields."""
+
+    id: str
+    description: str
+    severity: str
+    supporting_metrics: list[str]
+    evidence_fields: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioHazardMapping:
+    """Mapping from scenario IDs or families to hazard IDs."""
+
+    id: str
+    scenario_ids: list[str]
+    scenario_families: list[str]
+    hazards: list[str]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class HazardTraceabilityProvenance:
+    """Provenance metadata for a traceability mapping."""
+
+    source_issue: str
+    authored_by: str
+    source_files: list[str]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class HazardTraceability:
+    """Typed ``hazard_traceability.v1`` payload."""
+
+    schema_version: str
+    id: str
+    hazards: list[HazardDefinition]
+    scenario_mappings: list[ScenarioHazardMapping]
+    claim_boundary: str
+    provenance: HazardTraceabilityProvenance
+    extensions: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the mapping to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation suitable for JSON Schema validation.
+        """
+
+        payload = asdict(self)
+        if not payload["extensions"]:
+            payload.pop("extensions")
+        return payload
+
+
+class HazardTraceabilityValidationError(ValueError):
+    """Raised when a hazard traceability mapping fails validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_hazard_traceability_schema() -> dict[str, Any]:
+    """Load the public ``hazard_traceability.v1`` JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(HAZARD_TRACEABILITY_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_hazard_traceability(path: Path) -> HazardTraceability:
+    """Load one hazard traceability mapping from YAML or JSON.
+
+    Returns:
+        Typed hazard traceability mapping.
+    """
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise HazardTraceabilityValidationError(["expected a mapping payload"], source=path)
+    return hazard_traceability_from_dict(raw, source=path)
+
+
+def hazard_traceability_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> HazardTraceability:
+    """Validate and convert a mapping into typed hazard traceability metadata.
+
+    Returns:
+        Typed hazard traceability mapping.
+    """
+
+    errors = _schema_validation_errors(payload)
+    errors.extend(_semantic_validation_errors(payload))
+    if errors:
+        raise HazardTraceabilityValidationError(errors, source=source)
+
+    return _mapping_from_payload(payload)
+
+
+def summarize_hazard_coverage(
+    mapping: HazardTraceability,
+    *,
+    scenario_ids: Iterable[str] = (),
+    scenario_families: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Summarize hazards covered by scenario IDs or families.
+
+    Returns:
+        JSON-safe coverage summary with covered hazards, unmapped inputs, and supporting evidence.
+    """
+
+    requested_ids = [str(value) for value in scenario_ids]
+    requested_families = [str(value) for value in scenario_families]
+    covered_hazards: set[str] = set()
+    mapped_ids: set[str] = set()
+    mapped_families: set[str] = set()
+
+    for item in mapping.scenario_mappings:
+        if set(item.scenario_ids).intersection(requested_ids):
+            covered_hazards.update(item.hazards)
+            mapped_ids.update(set(item.scenario_ids).intersection(requested_ids))
+        if set(item.scenario_families).intersection(requested_families):
+            covered_hazards.update(item.hazards)
+            mapped_families.update(set(item.scenario_families).intersection(requested_families))
+
+    hazards_by_id = {hazard.id: hazard for hazard in mapping.hazards}
+    ordered_hazards = sorted(covered_hazards)
+    return {
+        "schema_version": HAZARD_COVERAGE_SUMMARY_SCHEMA_VERSION,
+        "traceability_id": mapping.id,
+        "scenario_ids": requested_ids,
+        "scenario_families": requested_families,
+        "covered_hazards": ordered_hazards,
+        "unmapped_scenario_ids": sorted(set(requested_ids) - mapped_ids),
+        "unmapped_scenario_families": sorted(set(requested_families) - mapped_families),
+        "supporting_metrics_by_hazard": {
+            hazard_id: list(hazards_by_id[hazard_id].supporting_metrics)
+            for hazard_id in ordered_hazards
+        },
+        "evidence_fields_by_hazard": {
+            hazard_id: list(hazards_by_id[hazard_id].evidence_fields)
+            for hazard_id in ordered_hazards
+        },
+        "claim_boundary": mapping.claim_boundary,
+    }
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors for one mapping payload."""
+
+    validator = Draft202012Validator(load_hazard_traceability_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return cross-field validation errors not expressible in the JSON Schema."""
+
+    errors: list[str] = []
+    hazard_ids = _declared_hazard_ids(payload.get("hazards"), errors)
+    errors.extend(_scenario_mapping_hazard_errors(payload.get("scenario_mappings"), hazard_ids))
+    return errors
+
+
+def _declared_hazard_ids(raw_hazards: Any, errors: list[str]) -> set[str]:
+    """Collect declared hazard IDs while recording duplicates.
+
+    Returns:
+        Set of unique hazard IDs declared in the payload.
+    """
+
+    hazard_ids: set[str] = set()
+    if not isinstance(raw_hazards, list):
+        return hazard_ids
+    for index, hazard in enumerate(raw_hazards):
+        if not isinstance(hazard, Mapping):
+            continue
+        hazard_id = hazard.get("id")
+        if not isinstance(hazard_id, str):
+            continue
+        if hazard_id in hazard_ids:
+            errors.append(f"/hazards/{index}/id: duplicate hazard id '{hazard_id}'")
+        hazard_ids.add(hazard_id)
+    return hazard_ids
+
+
+def _scenario_mapping_hazard_errors(raw_mappings: Any, hazard_ids: set[str]) -> list[str]:
+    """Return errors for scenario mappings that name unknown hazard IDs.
+
+    Returns:
+        List of semantic validation error strings.
+    """
+
+    errors: list[str] = []
+    if not isinstance(raw_mappings, list):
+        return errors
+    for mapping_index, item in enumerate(raw_mappings):
+        if not isinstance(item, Mapping):
+            continue
+        for hazard_id in item.get("hazards", []):
+            if isinstance(hazard_id, str) and hazard_id not in hazard_ids:
+                errors.append(
+                    f"/scenario_mappings/{mapping_index}/hazards: unknown hazard id '{hazard_id}'",
+                )
+    return errors
+
+
+def _mapping_from_payload(payload: Mapping[str, Any]) -> HazardTraceability:
+    """Build typed hazard traceability from a schema-valid payload.
+
+    Returns:
+        Typed hazard traceability mapping.
+    """
+
+    provenance = payload["provenance"]
+    return HazardTraceability(
+        schema_version=str(payload["schema_version"]),
+        id=str(payload["id"]),
+        hazards=[
+            HazardDefinition(
+                id=str(hazard["id"]),
+                description=str(hazard["description"]),
+                severity=str(hazard["severity"]),
+                supporting_metrics=list(hazard["supporting_metrics"]),
+                evidence_fields=list(hazard["evidence_fields"]),
+            )
+            for hazard in payload["hazards"]
+        ],
+        scenario_mappings=[
+            ScenarioHazardMapping(
+                id=str(item["id"]),
+                scenario_ids=list(item.get("scenario_ids", [])),
+                scenario_families=list(item.get("scenario_families", [])),
+                hazards=list(item["hazards"]),
+                notes=str(item["notes"]),
+            )
+            for item in payload["scenario_mappings"]
+        ],
+        claim_boundary=str(payload["claim_boundary"]),
+        provenance=HazardTraceabilityProvenance(
+            source_issue=str(provenance["source_issue"]),
+            authored_by=str(provenance["authored_by"]),
+            source_files=list(provenance["source_files"]),
+            notes=str(provenance["notes"]),
+        ),
+        extensions=dict(payload.get("extensions", {})),
+    )
+
+
+def _json_pointer(path_elems: Iterable[Any]) -> str:
+    """Render a validation error path as an RFC6901-style JSON pointer.
+
+    Returns:
+        JSON pointer string, or an empty string for the root path.
+    """
+
+    parts: list[str] = []
+    for part in path_elems:
+        if isinstance(part, int):
+            parts.append(str(part))
+        else:
+            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
+    return "/" + "/".join(parts) if parts else ""
+
+
+__all__ = [
+    "HAZARD_COVERAGE_SUMMARY_SCHEMA_VERSION",
+    "HAZARD_TRACEABILITY_SCHEMA_FILE",
+    "HAZARD_TRACEABILITY_SCHEMA_VERSION",
+    "HazardDefinition",
+    "HazardTraceability",
+    "HazardTraceabilityProvenance",
+    "HazardTraceabilityValidationError",
+    "ScenarioHazardMapping",
+    "hazard_traceability_from_dict",
+    "load_hazard_traceability",
+    "load_hazard_traceability_schema",
+    "summarize_hazard_coverage",
+]

--- a/robot_sf/benchmark/hazard_traceability.py
+++ b/robot_sf/benchmark/hazard_traceability.py
@@ -145,17 +145,19 @@ def summarize_hazard_coverage(
 
     requested_ids = [str(value) for value in scenario_ids]
     requested_families = [str(value) for value in scenario_families]
+    requested_id_set = set(requested_ids)
+    requested_family_set = set(requested_families)
     covered_hazards: set[str] = set()
     mapped_ids: set[str] = set()
     mapped_families: set[str] = set()
 
     for item in mapping.scenario_mappings:
-        if set(item.scenario_ids).intersection(requested_ids):
+        matched_ids = requested_id_set.intersection(item.scenario_ids)
+        matched_families = requested_family_set.intersection(item.scenario_families)
+        if matched_ids or matched_families:
             covered_hazards.update(item.hazards)
-            mapped_ids.update(set(item.scenario_ids).intersection(requested_ids))
-        if set(item.scenario_families).intersection(requested_families):
-            covered_hazards.update(item.hazards)
-            mapped_families.update(set(item.scenario_families).intersection(requested_families))
+            mapped_ids.update(matched_ids)
+            mapped_families.update(matched_families)
 
     hazards_by_id = {hazard.id: hazard for hazard in mapping.hazards}
     ordered_hazards = sorted(covered_hazards)
@@ -165,8 +167,8 @@ def summarize_hazard_coverage(
         "scenario_ids": requested_ids,
         "scenario_families": requested_families,
         "covered_hazards": ordered_hazards,
-        "unmapped_scenario_ids": sorted(set(requested_ids) - mapped_ids),
-        "unmapped_scenario_families": sorted(set(requested_families) - mapped_families),
+        "unmapped_scenario_ids": sorted(requested_id_set - mapped_ids),
+        "unmapped_scenario_families": sorted(requested_family_set - mapped_families),
         "supporting_metrics_by_hazard": {
             hazard_id: list(hazards_by_id[hazard_id].supporting_metrics)
             for hazard_id in ordered_hazards

--- a/robot_sf/benchmark/schemas/hazard_traceability.v1.json
+++ b/robot_sf/benchmark/schemas/hazard_traceability.v1.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/hazard_traceability.v1.json",
+  "title": "RobotSF Hazard Traceability (v1)",
+  "description": "Mapping from scenario families or IDs to intended hazards and supporting evidence fields. This is traceability metadata, not safety proof.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "hazards",
+    "scenario_mappings",
+    "claim_boundary",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "hazard_traceability.v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$"
+    },
+    "hazards": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/hazard"
+      }
+    },
+    "scenario_mappings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/scenario_mapping"
+      }
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "string_list": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "optional_string_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "hazard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "description",
+        "severity",
+        "supporting_metrics",
+        "evidence_fields"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "safety",
+            "comfort",
+            "social",
+            "operational"
+          ]
+        },
+        "supporting_metrics": {
+          "$ref": "#/$defs/string_list"
+        },
+        "evidence_fields": {
+          "$ref": "#/$defs/string_list"
+        }
+      }
+    },
+    "scenario_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "hazards",
+        "notes"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "scenario_ids"
+          ]
+        },
+        {
+          "required": [
+            "scenario_families"
+          ]
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$"
+        },
+        "scenario_ids": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "scenario_families": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "hazards": {
+          "$ref": "#/$defs/string_list"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_issue",
+        "authored_by",
+        "source_files",
+        "notes"
+      ],
+      "properties": {
+        "source_issue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authored_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_files": {
+          "$ref": "#/$defs/string_list"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/tests/benchmark/test_hazard_traceability.py
+++ b/tests/benchmark/test_hazard_traceability.py
@@ -1,0 +1,128 @@
+"""Tests for the ``hazard_traceability.v1`` mapping contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.benchmark.hazard_traceability import (
+    HAZARD_TRACEABILITY_SCHEMA_VERSION,
+    HazardTraceabilityValidationError,
+    hazard_traceability_from_dict,
+    load_hazard_traceability,
+    load_hazard_traceability_schema,
+    summarize_hazard_coverage,
+)
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "hazard_traceability"
+    / "low_speed_public_space_v1.yaml"
+)
+
+
+def test_load_fixture_as_typed_hazard_traceability_mapping() -> None:
+    """Representative hazard mappings should validate independently of benchmark runs."""
+
+    mapping = load_hazard_traceability(FIXTURE_PATH)
+
+    assert mapping.schema_version == HAZARD_TRACEABILITY_SCHEMA_VERSION
+    assert mapping.id == "low_speed_public_space_hazards_v1"
+    assert [hazard.id for hazard in mapping.hazards] == [
+        "robot_pedestrian_collision",
+        "near_miss",
+        "blind_corner_emergence",
+        "keep_clear_violation",
+        "pedestrian_flow_disruption",
+    ]
+    assert mapping.hazards[0].supporting_metrics == ["collision_rate"]
+    assert mapping.scenario_mappings[0].scenario_families == ["station_platform"]
+
+    jsonschema.validate(mapping.to_dict(), load_hazard_traceability_schema())
+
+
+def test_invalid_hazard_mapping_sections_fail_closed_with_json_paths() -> None:
+    """Malformed hazard traceability payloads should expose actionable paths."""
+
+    payload = load_hazard_traceability(FIXTURE_PATH).to_dict()
+    invalid_cases = [
+        (
+            lambda candidate: candidate.__setitem__(
+                "schema_version",
+                "hazard_traceability.v2",
+            ),
+            "/schema_version",
+            "hazard_traceability.v1",
+        ),
+        (
+            lambda candidate: candidate["hazards"][0].__setitem__("severity", "catastrophic"),
+            "/hazards/0/severity",
+            "catastrophic",
+        ),
+        (
+            lambda candidate: candidate["hazards"][0].__setitem__("supporting_metrics", []),
+            "/hazards/0/supporting_metrics",
+            "should be non-empty",
+        ),
+        (
+            lambda candidate: candidate["scenario_mappings"][0].__setitem__(
+                "hazards",
+                ["missing_hazard"],
+            ),
+            "/scenario_mappings/0/hazards",
+            "unknown hazard id 'missing_hazard'",
+        ),
+    ]
+
+    for mutate, expected_path, expected_fragment in invalid_cases:
+        candidate = deepcopy(payload)
+        mutate(candidate)
+        with pytest.raises(HazardTraceabilityValidationError) as exc_info:
+            hazard_traceability_from_dict(candidate, source=FIXTURE_PATH)
+        message = str(exc_info.value)
+        assert expected_path in message
+        assert expected_fragment in message
+
+
+def test_hazard_coverage_summary_reports_supported_and_unknown_hazards() -> None:
+    """Coverage summaries should make unsupported hazards explicit."""
+
+    mapping = load_hazard_traceability(FIXTURE_PATH)
+
+    summary = summarize_hazard_coverage(
+        mapping,
+        scenario_families=["station_platform", "unknown_family"],
+    )
+
+    assert summary["schema_version"] == "hazard-traceability-coverage.v1"
+    assert summary["covered_hazards"] == [
+        "keep_clear_violation",
+        "near_miss",
+        "pedestrian_flow_disruption",
+        "robot_pedestrian_collision",
+    ]
+    assert summary["unmapped_scenario_families"] == ["unknown_family"]
+    assert summary["supporting_metrics_by_hazard"]["near_miss"] == ["min_ttc", "pet"]
+    assert summary["evidence_fields_by_hazard"]["keep_clear_violation"] == [
+        "scenario.metadata.platform_semantics",
+        "metrics.keep_clear_intrusion_s",
+    ]
+
+
+def test_hazard_coverage_summary_filters_by_scenario_id() -> None:
+    """Scenario IDs should resolve independently of family-only summaries."""
+
+    mapping = load_hazard_traceability(FIXTURE_PATH)
+
+    summary = summarize_hazard_coverage(
+        mapping,
+        scenario_ids=["francis2023_blind_corner", "missing_scenario"],
+    )
+
+    assert summary["covered_hazards"] == ["blind_corner_emergence", "near_miss"]
+    assert summary["unmapped_scenario_ids"] == ["missing_scenario"]


### PR DESCRIPTION
## Summary
Adds a versioned `hazard_traceability.v1` contract plus typed loader and coverage summary helper so benchmark hazards can be mapped to scenario families, metrics, and evidence artifacts without relying on free-text issue notes.

## Linked Issues
- Closes #1270
- Relates to #1235
- Relates to #1245

## What Changed
- Added `robot_sf/benchmark/hazard_traceability.py` with schema loading, semantic validation, and `summarize_hazard_coverage(...)`.
- Added `robot_sf/benchmark/schemas/hazard_traceability.v1.json` and a reference config at `configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml`.
- Added focused tests in `tests/benchmark/test_hazard_traceability.py`.
- Documented the contract in `docs/hazard_traceability.md`, `docs/README.md`, and `docs/context/issue_1270_hazard_traceability.md`.

## Why It Matters
- Added value: makes hazard-to-scenario/metric/evidence traceability explicit and machine-checkable.
- Expected impact: improves benchmark governance and safety-case reviewability without changing simulator runtime behavior.
- Why this is worth merging now: it gives follow-up benchmark governance work a stable schema instead of another ad-hoc documentation layer.

## Validation / Proof
- Commands run:
  - `./.venv/bin/python -m pytest tests/benchmark/test_hazard_traceability.py -q`
  - `./.venv/bin/ruff check robot_sf/benchmark/hazard_traceability.py tests/benchmark/test_hazard_traceability.py`
  - `./.venv/bin/ruff format --check robot_sf/benchmark/hazard_traceability.py tests/benchmark/test_hazard_traceability.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check origin/main...HEAD`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted pytest: 4 passed.
  - Full PR readiness: 3630 passed, 11 skipped, 6 warnings in 450.25s.
  - Changed-file coverage warning only: `robot_sf/benchmark/hazard_traceability.py: 94.4% [WARN]`, above the required minimum.
- Benchmarks or smoke tests, if applicable:
  - Not run; this is schema/config/docs/test support for benchmark traceability and does not change planner or simulation behavior.

## Risks / Rollout
- Compatibility risks: additive only; existing scenario contracts, metrics, and benchmark configs are unchanged.
- Failure modes: malformed mappings now fail closed through schema or semantic validation.
- Rollback or fallback plan: remove the new schema/config/docs/module/tests; no migration is required for existing workflows.

## Docs / Provenance
- Updated docs: `docs/hazard_traceability.md`, `docs/README.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_1270_hazard_traceability.md` records scope and validation evidence.
- Artifact decision: `output/coverage/` was generated by pytest coverage and remains ignored/disposable; no durable artifact dependency was introduced.

## Follow-Up Issues
- Deferred work: integrate hazard coverage summaries into benchmark campaign reports once the surrounding governance/reporting lane is ready.
- Issues opened for follow-up: none in this PR.

## Reviewer Notes
- Verify the contract vocabulary and hazard taxonomy fit the intended safety-case language.
- Known limitation: the new helper summarizes declared coverage; it does not yet compute coverage from executed benchmark run manifests.
