### PR TITLE
perf: defer pygame initialization

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -284,6 +284,9 @@ knowledge, not every transient iteration detail.
   2026-05-05 refactor-prioritization snapshot.
 * [Issue #1006 GitHub CI Runtime Drift Diagnosis](./issue_1006_ci_runtime_drift.md)
   adds `scripts/dev/ci_timing_summary.py` and records timing evidence from PRs #1007 and #1008.
+* [Issue #1290 Lazy Pygame Initialization](./issue_1290_lazy_pygame_init.md)
+  records the lazy `SimulationView` proxy and pygame-free headless `make_robot_env(debug=False)`
+  import contract, plus the cold/warm smoke caveat that backend/JIT startup still dominates.
 * [Issue #513 High-Density Perf Gate Calibration](./issue_513_high_density_perf_gate.md)
   keeps `classic_cross_trap_high` advisory because no stable local trend-history window was
   available; documents the rerun evidence and non-blocking policy.

--- a/docs/context/issue_1290_lazy_pygame_init.md
+++ b/docs/context/issue_1290_lazy_pygame_init.md
@@ -27,7 +27,7 @@ is used.
   `debug=True` env creation.
 - Lazy-init regression tests:
   `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_lazy_pygame_init.py -q`
-  passed with `2 passed`.
+  passed with `5 passed`.
 - Adjacent rendering/recording tests:
   `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_pygame_headless.py tests/test_image_sensor.py tests/test_image_sensor_fusion.py tests/test_jsonl_recording.py tests/factories/test_recording_integration.py tests/factories/test_normalization.py tests/factories/test_incompatible_combinations.py -q`
   passed with `44 passed`.

--- a/docs/context/issue_1290_lazy_pygame_init.md
+++ b/docs/context/issue_1290_lazy_pygame_init.md
@@ -1,0 +1,49 @@
+# Issue #1290 Lazy Pygame Initialization
+
+## Scope
+
+Issue #1290 removes pygame/SDL import and initialization from the headless
+`make_robot_env(debug=False)` path. Rendering behavior remains available through
+`env.sim_ui` when debug or video recording is requested, but the actual
+`SimulationView` is now materialized only when a visual attribute or `render()`
+is used.
+
+## Implementation Notes
+
+- `robot_sf.render.sim_state` now owns the pygame-free `VisualizableAction` and
+  `VisualizableSimState` dataclasses.
+- `robot_sf.render.lazy_sim_view.LazySimulationView` preserves the existing
+  non-`None` `sim_ui` handle for debug/video configurations while deferring
+  `robot_sf.render.sim_view` import and `pygame.init()`.
+- Optional visual helpers in `occupancy_grid`, `image_sensor`,
+  `telemetry.visualization`, and bundled `pysocialforce` now import pygame only
+  when their visual code paths are used.
+
+## Validation Evidence
+
+- Red first:
+  `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_lazy_pygame_init.py -q`
+  initially failed because pygame was imported during both `debug=False` and
+  `debug=True` env creation.
+- Lazy-init regression tests:
+  `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_lazy_pygame_init.py -q`
+  passed with `2 passed`.
+- Adjacent rendering/recording tests:
+  `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_pygame_headless.py tests/test_image_sensor.py tests/test_image_sensor_fusion.py tests/test_jsonl_recording.py tests/factories/test_recording_integration.py tests/factories/test_normalization.py tests/factories/test_incompatible_combinations.py -q`
+  passed with `44 passed`.
+- Import probe:
+  after `from robot_sf.gym_env.environment_factory import make_robot_env` and
+  `make_robot_env(debug=False)`, `"pygame" in sys.modules` stayed `False`.
+- Cold/warm smoke, same command before and after:
+  `LOGURU_LEVEL=WARNING DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python -m robot_sf.benchmark.perf_cold_warm --cold-runs 1 --warm-runs 1 --episode-steps 3 ...`
+  recorded cold `env_create_sec` moving from `5.7666s` to `5.4446s` on this
+  machine. The remaining cold cost is dominated by map/backend/JIT startup, so
+  this smoke is supportive rather than a stable microbenchmark.
+
+## Remaining Limitations
+
+- Image observations, occupancy-grid pygame rendering, telemetry surface
+  conversion, and explicit `env.render()` still import pygame by design.
+- `perf_cold_warm` starts timing after module import, so the deterministic proof
+  for the issue contract is the isolated import probe rather than the noisy cold
+  `env_create_sec` sample alone.

--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -195,7 +195,10 @@ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
   `robot_sf.training.scenario_loader`) lets you verify hit/miss counts at runtime.
 
 ### Known Performance Bottlenecks
-1. **pygame/SDL initialization**: ~1s for headless setup
+1. **Cold backend/map startup**: first-process map parsing and FastPysf/JIT setup dominate
+   headless cold starts. Pygame/SDL is no longer imported by
+   `make_robot_env(debug=False)` after #1290; it is still initialized on explicit
+   rendering, image-observation, occupancy-grid rendering, or video paths.
 2. **FastPysf compilation**: JIT overhead on first use  
 3. **Large episode JSON**: Serialization cost grows with trajectory length
 4. **File I/O**: JSONL append becomes slow with very large files

--- a/fast-pysf/pysocialforce/__init__.py
+++ b/fast-pysf/pysocialforce/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "2.0.0"
 
+import importlib
+
 from .config import (
     DesiredForceConfig,
     GroupCoherenceForceConfig,
@@ -26,5 +28,16 @@ from .forces import (
 from .logging import logger
 from .map_config import Circle, GlobalRoute, Line2D, MapDefinition, Obstacle, Rect, Vec2D, Zone
 from .map_loader import load_map
-from .sim_view import SimulationView, VisualizableSimState, to_visualizable_state
 from .simulator import Simulator, Simulator_v2
+
+
+def __getattr__(name):
+    """Lazy-load pygame-backed visualization exports on demand.
+
+    Returns:
+        Any: Requested visualization object from ``pysocialforce.sim_view``.
+    """
+    if name in {"SimulationView", "VisualizableSimState", "to_visualizable_state"}:
+        sim_view = importlib.import_module("pysocialforce.sim_view")
+        return getattr(sim_view, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/robot_sf/gym_env/base_env.py
+++ b/robot_sf/gym_env/base_env.py
@@ -4,7 +4,9 @@ Provides common functionality for all environments.
 """
 
 import datetime
+import importlib
 import pickle
+from typing import TYPE_CHECKING
 
 from gymnasium import Env
 from loguru import logger
@@ -17,10 +19,24 @@ from robot_sf.planner import (
     PlannerConfig,
     attach_classic_global_planner,
 )
-from robot_sf.render.jsonl_recording import JSONLRecorder
-from robot_sf.render.sim_view import SimulationView, VisualizableSimState
+from robot_sf.render.lazy_sim_view import LazySimulationView
+from robot_sf.render.sim_state import VisualizableSimState
 from robot_sf.sim.registry import get_backend
 from robot_sf.sim.simulator import init_simulators
+
+if TYPE_CHECKING:
+    from robot_sf.render.jsonl_recording import JSONLRecorder
+    from robot_sf.render.sim_view import SimulationView
+
+
+def _make_jsonl_recorder(**kwargs):
+    """Create a JSONL recorder without importing recording/render modules on normal env startup.
+
+    Returns:
+        JSONLRecorder: Configured recorder instance.
+    """
+    module = importlib.import_module("robot_sf.render.jsonl_recording")
+    return module.JSONLRecorder(**kwargs)
 
 
 class BaseEnv(Env):
@@ -103,7 +119,7 @@ class BaseEnv(Env):
             # Use provided seed or generate from environment config
             seed = recording_seed if recording_seed is not None else getattr(env_config, "seed", 0)
 
-            self.jsonl_recorder = JSONLRecorder(
+            self.jsonl_recorder = _make_jsonl_recorder(
                 output_dir=self._recording_dir,
                 suite=suite_name,
                 scenario=scenario_name,
@@ -148,14 +164,14 @@ class BaseEnv(Env):
         self.last_action = None
 
         # Initialize sim_ui attribute (required for exit() method)
-        self.sim_ui = None
+        self.sim_ui: LazySimulationView | SimulationView | None = None
 
         # If in debug mode or video recording is enabled, create simulation view
         if debug or record_video:
             # Prefer config-driven render scaling when provided; else default to 20.
             scaling_value = getattr(env_config, "render_scaling", None)
             scaling_value = 20 if scaling_value is None else int(scaling_value)
-            self.sim_ui = SimulationView(
+            self.sim_ui = LazySimulationView(
                 scaling=scaling_value,
                 map_def=self.map_def,
                 obstacles=self.map_def.obstacles,

--- a/robot_sf/gym_env/env_util.py
+++ b/robot_sf/gym_env/env_util.py
@@ -1,6 +1,4 @@
-"""
-env_util
-"""
+"""env_util."""
 
 from enum import Enum
 

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -42,7 +42,7 @@ from robot_sf.gym_env.reward import route_completion_v2_reward
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.nav.occupancy_grid import OccupancyGrid
 from robot_sf.render.lidar_visual import render_lidar
-from robot_sf.render.sim_view import VisualizableAction, VisualizableSimState
+from robot_sf.render.sim_state import VisualizableAction, VisualizableSimState
 from robot_sf.robot.robot_state import RobotState
 from robot_sf.sensor.range_sensor import lidar_ray_scan
 from robot_sf.sensor.sensor_fusion import OBS_IMAGE, SensorFusion

--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -67,6 +67,7 @@ grid.render_pygame(surface=my_pygame_surface, robot_pose=robot_pose)
 
 from __future__ import annotations
 
+import importlib
 import math
 from dataclasses import dataclass, field
 from enum import Enum
@@ -79,11 +80,6 @@ from shapely.geometry import Point as _ShapelyPoint
 from shapely.geometry import Polygon as _ShapelyPolygon
 from shapely.prepared import PreparedGeometry, prep
 
-try:
-    import pygame
-except ImportError:  # pragma: no cover - handled at runtime
-    pygame = None
-
 if TYPE_CHECKING:
     from robot_sf.common.types import Circle2D, Line2D, RobotPose
 
@@ -92,6 +88,25 @@ from robot_sf.nav import occupancy_grid_utils as grid_utils
 
 # Threshold below which a cell/region is treated as free for spawning or visualization.
 OCCUPANCY_FREE_THRESHOLD = 0.05
+_PYGAME_UNLOADED = object()
+pygame: Any = _PYGAME_UNLOADED
+
+
+def _load_pygame():
+    """Import pygame only when optional occupancy-grid rendering is requested.
+
+    Returns:
+        module | None: Imported pygame module, or ``None`` when unavailable.
+    """
+    global pygame
+    if pygame is not _PYGAME_UNLOADED:
+        return pygame
+    try:
+        pygame = importlib.import_module("pygame")
+    except ImportError:  # pragma: no cover - handled at runtime
+        pygame = None
+        return None
+    return pygame
 
 
 class GridChannel(Enum):
@@ -882,6 +897,7 @@ class OccupancyGrid:
         if self._grid_data is None:
             raise RuntimeError("Grid has not been generated yet. Call generate() first.")
 
+        pygame = _load_pygame()
         if pygame is None:
             raise RuntimeError("Pygame is required for occupancy grid rendering")
 

--- a/robot_sf/render/lazy_sim_view.py
+++ b/robot_sf/render/lazy_sim_view.py
@@ -1,0 +1,98 @@
+"""Lazy proxy for constructing ``SimulationView`` only when rendering is used."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+class LazySimulationView:
+    """Defer pygame-backed ``SimulationView`` construction until first visual use."""
+
+    _DEFAULT_WIDTH = 1280
+    _DEFAULT_HEIGHT = 720
+
+    def __init__(self, **view_kwargs: Any) -> None:
+        """Store view construction arguments without importing pygame."""
+        object.__setattr__(self, "_view_kwargs", dict(view_kwargs))
+        object.__setattr__(self, "_pending_attrs", {})
+        object.__setattr__(self, "_view", None)
+        object.__setattr__(self, "record_video", bool(view_kwargs.get("record_video", False)))
+        object.__setattr__(self, "video_path", view_kwargs.get("video_path"))
+        object.__setattr__(self, "video_fps", view_kwargs.get("video_fps"))
+        object.__setattr__(self, "width", view_kwargs.get("width", self._DEFAULT_WIDTH))
+        object.__setattr__(self, "height", view_kwargs.get("height", self._DEFAULT_HEIGHT))
+
+    @property
+    def materialized(self) -> bool:
+        """Return whether the underlying ``SimulationView`` has been created."""
+        return self._view is not None
+
+    def _ensure_view(self) -> Any:
+        """Create and return the underlying pygame-backed view.
+
+        Returns:
+            Any: The materialized ``SimulationView`` instance.
+        """
+        view = self._view
+        if view is not None:
+            return view
+
+        sim_view_module = importlib.import_module("robot_sf.render.sim_view")
+        view = sim_view_module.SimulationView(**self._view_kwargs)
+        for name, value in self._pending_attrs.items():
+            setattr(view, name, value)
+        object.__setattr__(self, "_pending_attrs", {})
+        object.__setattr__(self, "_view", view)
+        return view
+
+    def __bool__(self) -> bool:
+        """A configured lazy view should behave like a present ``sim_ui`` handle.
+
+        Returns:
+            bool: Always ``True`` for configured lazy views.
+        """
+        return True
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the materialized view.
+
+        Returns:
+            Any: Attribute value from the materialized view.
+        """
+        return getattr(self._ensure_view(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Store pre-materialization mutations and replay them on first visual use."""
+        if name.startswith("_") or name in {
+            "record_video",
+            "video_path",
+            "video_fps",
+            "width",
+            "height",
+        }:
+            object.__setattr__(self, name, value)
+            return
+        view = self._view
+        if view is None:
+            self._pending_attrs[name] = value
+            return
+        setattr(view, name, value)
+
+    def render(self, *args: Any, **kwargs: Any) -> Any:
+        """Materialize the view and render a frame.
+
+        Returns:
+            Any: Result returned by ``SimulationView.render``.
+        """
+        return self._ensure_view().render(*args, **kwargs)
+
+    def exit_simulation(self, *args: Any, **kwargs: Any) -> Any:
+        """Close the materialized view, or no-op if rendering never started.
+
+        Returns:
+            Any: Result returned by ``SimulationView.exit_simulation`` when materialized.
+        """
+        if self._view is None:
+            return None
+        return self._view.exit_simulation(*args, **kwargs)

--- a/robot_sf/render/lazy_sim_view.py
+++ b/robot_sf/render/lazy_sim_view.py
@@ -64,7 +64,10 @@ class LazySimulationView:
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Store pre-materialization mutations and replay them on first visual use."""
-        if name.startswith("_") or name in {
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        if name in {
             "record_video",
             "video_path",
             "video_fps",
@@ -72,6 +75,11 @@ class LazySimulationView:
             "height",
         }:
             object.__setattr__(self, name, value)
+            view = self._view
+            if view is None:
+                self._view_kwargs[name] = value
+            else:
+                setattr(view, name, value)
             return
         view = self._view
         if view is None:

--- a/robot_sf/render/sim_state.py
+++ b/robot_sf/render/sim_state.py
@@ -1,0 +1,71 @@
+"""Pygame-free state payloads consumed by simulation renderers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from robot_sf.common.types import DifferentialDriveAction, PedPose, RobotPose, Vec2D
+    from robot_sf.ped_ego.unicycle_drive import UnicycleAction
+    from robot_sf.robot.bicycle_drive import BicycleAction
+
+
+@dataclass
+class VisualizableAction:
+    """Action payload rendered alongside an agent pose and goal."""
+
+    pose: RobotPose
+    action: DifferentialDriveAction | BicycleAction | UnicycleAction
+    goal: Vec2D
+
+
+@dataclass
+class VisualizableSimState:
+    """Renderer-friendly snapshot of a discrete simulator timestep."""
+
+    timestep: int
+    """The discrete timestep of the simulation."""
+
+    robot_action: VisualizableAction | None
+    """The action taken by the robot at this timestep."""
+
+    robot_pose: RobotPose
+    """The pose of the robot at this timestep."""
+
+    pedestrian_positions: np.ndarray
+    """The positions of pedestrians at this timestep."""
+
+    ray_vecs: np.ndarray
+    """The ray vectors associated with the robot's sensors."""
+
+    ped_actions: np.ndarray
+    """The actions taken by pedestrians at this timestep."""
+
+    ego_ped_pose: PedPose | None = None
+    """The pose of the ego pedestrian at this timestep. Defaults to None."""
+
+    ego_ped_ray_vecs: np.ndarray | None = None
+    """The ray vectors associated with the ego pedestrian's sensors. Defaults to None."""
+
+    ego_ped_action: VisualizableAction | None = None
+    """The action taken by the ego pedestrian at this timestep. Defaults to None."""
+
+    time_per_step_in_secs: float | None = None
+    """The time taken for each step in seconds. Defaults to None."""
+
+    planned_path: list[Vec2D] | None = None
+    """Optional planned path waypoints for debugging."""
+
+    observation_image: np.ndarray | None = None
+    """Optional image observation payload for observation-space visualization."""
+
+    def __post_init__(self) -> None:
+        """Validate and normalize renderer state defaults."""
+        if self.time_per_step_in_secs is None:
+            logger.warning("time_per_step_in_secs is None, defaulting to 0.1s.")
+            self.time_per_step_in_secs = 0.1

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -12,15 +12,15 @@ import pygame
 from loguru import logger
 
 from robot_sf.common.geometry import euclid_dist
-from robot_sf.common.types import DifferentialDriveAction, PedPose, RgbColor, RobotPose, Vec2D
+from robot_sf.common.types import PedPose, RgbColor, RobotPose, Vec2D
 from robot_sf.nav.map_config import MapDefinition, Obstacle
 from robot_sf.nav.occupancy_grid import (
     OCCUPANCY_FREE_THRESHOLD,
     GridChannel,
     OccupancyGrid,
 )
-from robot_sf.ped_ego.unicycle_drive import UnicycleAction
-from robot_sf.robot.bicycle_drive import BicycleAction
+from robot_sf.render.sim_state import VisualizableAction
+from robot_sf.render.sim_state import VisualizableSimState as _VisualizableSimState
 
 # Make moviepy optional
 try:
@@ -103,58 +103,11 @@ def _empty_map_definition() -> MapDefinition:
 
 
 @dataclass
-class VisualizableAction:
-    """Action payload rendered alongside an agent pose and goal."""
-
-    pose: RobotPose
-    action: DifferentialDriveAction | BicycleAction | UnicycleAction
-    goal: Vec2D
-
-
-@dataclass
-class VisualizableSimState:
-    """
-    VisualizableSimState represents a collection of properties to display
-    the simulator's state at a discrete timestep.
-    """
-
-    timestep: int
-    """The discrete timestep of the simulation."""
-
-    robot_action: VisualizableAction | None
-    """The action taken by the robot at this timestep."""
-
-    robot_pose: RobotPose
-    """The pose of the robot at this timestep."""
-
-    pedestrian_positions: np.ndarray
-    """The positions of pedestrians at this timestep."""
-
-    ray_vecs: np.ndarray
-    """The ray vectors associated with the robot's sensors."""
-
-    ped_actions: np.ndarray
-    """The actions taken by pedestrians at this timestep."""
-
-    ego_ped_pose: PedPose | None = None
-    """The pose of the ego pedestrian at this timestep. Defaults to None."""
-
-    ego_ped_ray_vecs: np.ndarray | None = None
-    """The ray vectors associated with the ego pedestrian's sensors. Defaults to None."""
-
-    ego_ped_action: VisualizableAction | None = None
-    """The action taken by the ego pedestrian at this timestep. Defaults to None."""
-
-    time_per_step_in_secs: float | None = None
-    """The time taken for each step in seconds. Defaults to None. Usually 0.1 seconds."""
-
-    planned_path: list[Vec2D] | None = None
-    """Optional planned path waypoints for debugging (world coordinates)."""
-    observation_image: np.ndarray | None = None
-    """Optional image observation payload for observation-space visualization."""
+class VisualizableSimState(_VisualizableSimState):
+    """Backward-compatible sim_view export using this module's patchable logger."""
 
     def __post_init__(self):
-        """validate the visualizable state"""
+        """Validate the visualizable state."""
         if self.time_per_step_in_secs is None:
             logger.warning("time_per_step_in_secs is None, defaulting to 0.1s.")
             self.time_per_step_in_secs = 0.1

--- a/robot_sf/sensor/image_sensor.py
+++ b/robot_sf/sensor/image_sensor.py
@@ -2,13 +2,26 @@
 Image sensor for capturing visual observations from the pygame rendering system.
 """
 
+from __future__ import annotations
+
+import importlib
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
-import pygame
 from gymnasium import spaces
 
-from robot_sf.render.sim_view import SimulationView
+if TYPE_CHECKING:
+    from robot_sf.render.sim_view import SimulationView
+
+
+def _load_pygame():
+    """Import pygame only when image capture or resizing is requested.
+
+    Returns:
+        module: Imported pygame module.
+    """
+    return importlib.import_module("pygame")
 
 
 @dataclass
@@ -61,6 +74,8 @@ class ImageSensor:
         if self.sim_view is None:
             raise ValueError("SimulationView not set. Call set_sim_view() first.")
 
+        pygame = _load_pygame()
+
         # Capture frame using pygame's surfarray
         frame_data = pygame.surfarray.array3d(self.sim_view.screen)
         # pygame.surfarray returns (width, height, channels), we need (height, width, channels)
@@ -99,6 +114,8 @@ class ImageSensor:
         np.ndarray
             The resized frame.
         """
+        pygame = _load_pygame()
+
         # Convert to pygame surface for resizing
         surface = pygame.surfarray.make_surface(frame.swapaxes(0, 1))
         resized_surface = pygame.transform.scale(

--- a/robot_sf/telemetry/visualization.py
+++ b/robot_sf/telemetry/visualization.py
@@ -7,6 +7,7 @@ light and headless-friendly.
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
 import matplotlib
@@ -16,14 +17,11 @@ import numpy as np
 matplotlib.use("Agg", force=True)
 from matplotlib import pyplot as plt
 
-try:  # Optional convenience when pygame is available
-    import pygame
-except ImportError:  # pragma: no cover - optional dependency
-    pygame = None
-
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
+
+    import pygame
 
 
 DEFAULT_TELEMETRY_METRICS = ("reward", "collisions", "min_ped_distance", "action_norm")
@@ -95,6 +93,14 @@ def render_metric_panel(
     return rgba
 
 
+def _load_pygame():
+    """Return pygame when available, importing it only for surface conversion."""
+    try:
+        return importlib.import_module("pygame")
+    except ImportError:  # pragma: no cover - optional dependency
+        return None
+
+
 def make_surface_from_rgba(rgba: np.ndarray) -> pygame.Surface | None:
     """Convert an RGBA array into a Pygame surface if pygame is available.
 
@@ -104,6 +110,7 @@ def make_surface_from_rgba(rgba: np.ndarray) -> pygame.Surface | None:
     Returns:
         pygame.Surface or None when pygame is unavailable.
     """
+    pygame = _load_pygame()
     if pygame is None:  # pragma: no cover - optional dependency
         return None
     if rgba.dtype != np.uint8:

--- a/tests/test_lazy_pygame_init.py
+++ b/tests/test_lazy_pygame_init.py
@@ -1,0 +1,119 @@
+"""Regression tests for lazy pygame initialization in robot environments."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+
+def _run_probe(code: str) -> str:
+    """Run an isolated Python probe and return stdout."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "DISPLAY": "",
+            "MPLBACKEND": "Agg",
+            "SDL_VIDEODRIVER": "dummy",
+            "SDL_AUDIODRIVER": "dummy",
+            "PYGAME_HIDE_SUPPORT_PROMPT": "hide",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def test_headless_robot_env_creation_does_not_import_pygame() -> None:
+    """Pure-simulation robot env creation should avoid importing pygame."""
+    stdout = _run_probe(
+        """
+import sys
+from robot_sf.gym_env.environment_factory import make_robot_env
+
+env = make_robot_env(debug=False)
+try:
+    print("pygame_imported", "pygame" in sys.modules)
+    print("sim_ui", getattr(env, "sim_ui", None))
+finally:
+    env.close()
+"""
+    )
+
+    assert "pygame_imported False" in stdout
+    assert "sim_ui None" in stdout
+
+
+def test_debug_robot_env_materializes_pygame_on_first_render() -> None:
+    """Debug robot envs should keep pygame lazy until the first render call."""
+    stdout = _run_probe(
+        """
+import sys
+from robot_sf.gym_env.environment_factory import make_robot_env
+
+env = make_robot_env(debug=True)
+try:
+    print("pygame_after_create", "pygame" in sys.modules)
+    print("sim_ui_present", getattr(env, "sim_ui", None) is not None)
+    env.reset(seed=123)
+    env.render()
+    print("pygame_after_render", "pygame" in sys.modules)
+finally:
+    env.close()
+"""
+    )
+
+    assert "pygame_after_create False" in stdout
+    assert "sim_ui_present True" in stdout
+    assert "pygame_after_render True" in stdout
+
+
+def test_lazy_simulation_view_replays_pending_attributes(monkeypatch) -> None:
+    """LazySimulationView should replay setup mutations on materialization."""
+    from robot_sf.render.lazy_sim_view import LazySimulationView
+
+    created = {}
+
+    class FakeSimulationView:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.render_calls = []
+            created["view"] = self
+
+        def render(self, *args, **kwargs):
+            self.render_calls.append((args, kwargs))
+            return "rendered"
+
+    def fake_import_module(name: str):
+        assert name == "robot_sf.render.sim_view"
+        return SimpleNamespace(SimulationView=FakeSimulationView)
+
+    monkeypatch.setattr("robot_sf.render.lazy_sim_view.importlib.import_module", fake_import_module)
+
+    view = LazySimulationView(record_video=True, width=320, height=200)
+    view.observation_space_mode = "grid"
+
+    assert bool(view)
+    assert view.materialized is False
+    assert view.record_video is True
+    assert view.render("state", target_fps=12) == "rendered"
+    assert view.materialized is True
+
+    materialized = created["view"]
+    assert materialized.kwargs["width"] == 320
+    assert materialized.observation_space_mode == "grid"
+    assert materialized.render_calls == [(("state",), {"target_fps": 12})]
+
+
+def test_pysocialforce_visualization_export_remains_available() -> None:
+    """The bundled pysocialforce package should still expose SimulationView lazily."""
+    import pysocialforce
+
+    assert pysocialforce.SimulationView.__name__ == "SimulationView"

--- a/tests/test_lazy_pygame_init.py
+++ b/tests/test_lazy_pygame_init.py
@@ -112,6 +112,44 @@ def test_lazy_simulation_view_replays_pending_attributes(monkeypatch) -> None:
     assert materialized.render_calls == [(("state",), {"target_fps": 12})]
 
 
+def test_lazy_simulation_view_propagates_tracked_attribute_mutations(monkeypatch) -> None:
+    """Tracked view attributes should stay synchronized before and after materialization."""
+    from robot_sf.render.lazy_sim_view import LazySimulationView
+
+    created = {}
+
+    class FakeSimulationView:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.width = kwargs["width"]
+            self.height = kwargs["height"]
+            self.record_video = kwargs["record_video"]
+            created["view"] = self
+
+        def render(self):
+            return "rendered"
+
+    def fake_import_module(name: str):
+        assert name == "robot_sf.render.sim_view"
+        return SimpleNamespace(SimulationView=FakeSimulationView)
+
+    monkeypatch.setattr("robot_sf.render.lazy_sim_view.importlib.import_module", fake_import_module)
+
+    view = LazySimulationView(record_video=False, width=320, height=200)
+    view.width = 640
+    view.record_video = True
+
+    assert view.render() == "rendered"
+
+    materialized = created["view"]
+    assert materialized.kwargs["width"] == 640
+    assert materialized.kwargs["record_video"] is True
+
+    view.height = 480
+
+    assert materialized.height == 480
+
+
 def test_pysocialforce_visualization_export_remains_available() -> None:
     """The bundled pysocialforce package should still expose SimulationView lazily."""
     import pysocialforce


### PR DESCRIPTION
## Summary
Defers pygame/SDL from pure headless robot env startup by splitting visual state payloads from the pygame-backed view and adding a lazy `SimulationView` proxy.

## Linked Issues
- Closes #1290

## What Changed
- Added pygame-free `robot_sf.render.sim_state` payloads and `LazySimulationView`.
- Deferred optional pygame imports in occupancy-grid rendering, image sensor capture, telemetry surface conversion, and bundled `pysocialforce` visualization exports.
- Added subprocess regression tests for `make_robot_env(debug=False)` and first-render materialization.
- Updated `docs/performance_notes.md` plus `docs/context/issue_1290_lazy_pygame_init.md`.

## Validation / Proof
- Red first: `tests/test_lazy_pygame_init.py` failed before the fix because pygame imported during env creation.
- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_lazy_pygame_init.py -q` -> `4 passed`.
- Adjacent rendering/recording group -> `46 passed`.
- Occupancy/image/pysocialforce group -> `46 passed`.
- Import probe: after importing `make_robot_env` and creating `make_robot_env(debug=False)`, `"pygame" in sys.modules` stayed `False`.
- Cold/warm smoke: cold `env_create_sec` changed from `5.7666s` to `5.4446s` on this machine; remaining cold cost is dominated by map/backend/JIT startup.
- PR readiness: `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/pr_ready_check.sh` -> `3631 passed, 10 skipped, 3 warnings`; changed-file coverage minimum passed; TODO-docstring gate passed.
- Type check: `uvx ty check ... --exit-zero` was advisory and reported pre-existing diagnostics in touched broad modules; no blocking exit.

## Risks / Rollout
- `env.sim_ui is not None` remains true for debug/video envs; visual attribute access materializes the real view.
- Pygame still imports intentionally for rendering, image capture, telemetry surface conversion, occupancy-grid pygame rendering, and video capture.
- Rollback: revert the lazy proxy and import deferrals.

## Docs / Provenance
- Updated docs: `docs/performance_notes.md`, `docs/context/README.md`.
- Context note: `docs/context/issue_1290_lazy_pygame_init.md`.
- Ignored `output/benchmarks/issue_1290/*`, `output/coverage/*`, and existing ignored cache/tmp artifacts are disposable local validation outputs; reviewable evidence is summarized here and in the context note.

## Follow-Up Issues
- None.