### PR TITLE
workflow: align imitation warm-start env contract

### DIFF
--- a/SLURM/Auxme/issue_1108_bc_warm_start.sl
+++ b/SLURM/Auxme/issue_1108_bc_warm_start.sl
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=issue1108-bcppo
+#SBATCH --account=mitarbeiter
+#SBATCH --partition=a30
+#SBATCH --qos=a30-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=96G
+#SBATCH --time=1-12:00:00
+#SBATCH --gres=gpu:1
+#SBATCH --output=output/slurm/%j-issue1108-bc-warm-start.out
+
+set -euo pipefail
+
+PROJECT_ROOT=$(git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null || echo "${SLURM_SUBMIT_DIR:-$(pwd)}")
+LOCAL_OUTPUT_ROOT=${PROJECT_ROOT}/output/slurm
+SCRATCH_ROOT=${AUXME_SCRATCH_ROOT:-${LOCAL_OUTPUT_ROOT}}
+MODULE_LIST=${AUXME_MODULES:-"gcc/13.2.0"}
+CUDA_MODULE=${AUXME_CUDA_MODULE:-cuda/12.1}
+RESULTS_ROOT=${AUXME_RESULTS_DIR:-${LOCAL_OUTPUT_ROOT}/issue1108-bcppo-job-${SLURM_JOB_ID}}
+WORKDIR=${SLURM_TMPDIR:-/tmp/${USER}/${SLURM_JOB_ID}}
+LOG_LEVEL=${ISSUE1108_LOG_LEVEL:-WARNING}
+DATASET_ID=${ISSUE1108_DATASET_ID:-issue_749_b60iopxt_v10_eval_trajectories}
+SOURCE_POLICY_ID=${ISSUE1108_SOURCE_POLICY_ID:-ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200}
+SCENARIO_CONFIG=${ISSUE1108_SCENARIO_CONFIG:-configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml}
+BC_CONFIG=${ISSUE1108_BC_CONFIG:-configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml}
+PPO_CONFIG=${ISSUE1108_PPO_CONFIG:-configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml}
+EPISODES=${ISSUE1108_EPISODES:-141}
+SEEDS=${ISSUE1108_SEEDS:-"111 112 113"}
+MODULES_AVAILABLE=0
+RUN_OUTPUT_DIR=""
+
+if ! git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[issue1108] PROJECT_ROOT is not inside a git work tree: ${PROJECT_ROOT}" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [[ -n "${RUN_OUTPUT_DIR}" && -d "${RUN_OUTPUT_DIR}" ]]; then
+    mkdir -p "${RESULTS_ROOT}"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --partial --prune-empty-dirs "${RUN_OUTPUT_DIR}/" "${RESULTS_ROOT}/" || true
+    else
+      cp -r "${RUN_OUTPUT_DIR}/." "${RESULTS_ROOT}/" || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+ensure_module_command() {
+  if command -v module >/dev/null 2>&1; then
+    MODULES_AVAILABLE=1
+    return 0
+  fi
+
+  local init_script
+  for init_script in /etc/profile.d/modules.sh /usr/share/Modules/init/bash; do
+    if [[ -f "${init_script}" ]]; then
+      # shellcheck disable=SC1090
+      source "${init_script}" >/dev/null 2>&1 || true
+    fi
+    if command -v module >/dev/null 2>&1; then
+      MODULES_AVAILABLE=1
+      return 0
+    fi
+  done
+
+  echo "[issue1108] module command is unavailable; continuing without module loads." >&2
+  return 0
+}
+
+run_in_allocation() {
+  if command -v srun >/dev/null 2>&1; then
+    echo "[issue1108] Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
+    srun --cpu_bind=cores --gpus-per-node=1 "$@"
+  else
+    echo "[issue1108] srun unavailable on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}; PATH=${PATH}" >&2
+    echo "[issue1108] Running directly in the batch allocation." >&2
+    "$@"
+  fi
+}
+
+ensure_module_command
+
+if [[ "${MODULES_AVAILABLE}" == "1" ]]; then
+  module purge
+  for mod in ${MODULE_LIST}; do
+    [[ -z "${mod}" ]] && continue
+    echo "[issue1108] Loading module ${mod}"
+    module load "${mod}"
+  done
+  if [[ -n "${CUDA_MODULE}" ]]; then
+    echo "[issue1108] Loading CUDA module ${CUDA_MODULE}"
+    module load "${CUDA_MODULE}"
+  fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "[issue1108] uv is not available in PATH." >&2
+  exit 1
+fi
+
+cd "${PROJECT_ROOT}"
+
+for path in "${SCENARIO_CONFIG}" "${BC_CONFIG}" "${PPO_CONFIG}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "[issue1108] Required path not found: ${path}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "${WORKDIR}" "${LOCAL_OUTPUT_ROOT}"
+export ROBOT_SF_ARTIFACT_ROOT=${WORKDIR}/results
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+export PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:256
+export SDL_VIDEODRIVER=${SDL_VIDEODRIVER:-dummy}
+export MPLBACKEND=${MPLBACKEND:-Agg}
+export LOGURU_LEVEL=${LOGURU_LEVEL:-${LOG_LEVEL}}
+export UV_PROJECT_ENVIRONMENT=${ISSUE1108_UV_ENV_DIR:-${WORKDIR}/uv_env}
+RUN_OUTPUT_DIR=${ROBOT_SF_ARTIFACT_ROOT}
+mkdir -p "${ROBOT_SF_ARTIFACT_ROOT}" "$(dirname "${UV_PROJECT_ENVIRONMENT}")"
+
+echo "[issue1108] PROJECT_ROOT=${PROJECT_ROOT}"
+echo "[issue1108] ROBOT_SF_ARTIFACT_ROOT=${ROBOT_SF_ARTIFACT_ROOT}"
+echo "[issue1108] UV_PROJECT_ENVIRONMENT=${UV_PROJECT_ENVIRONMENT}"
+echo "[issue1108] RESULTS_ROOT=${RESULTS_ROOT}"
+echo "[issue1108] DATASET_ID=${DATASET_ID}"
+echo "[issue1108] SOURCE_POLICY_ID=${SOURCE_POLICY_ID}"
+echo "[issue1108] SCENARIO_CONFIG=${SCENARIO_CONFIG}"
+echo "[issue1108] BC_CONFIG=${BC_CONFIG}"
+echo "[issue1108] PPO_CONFIG=${PPO_CONFIG}"
+echo "[issue1108] EPISODES=${EPISODES}"
+echo "[issue1108] SEEDS=${SEEDS}"
+
+uv sync --group imitation
+
+# shellcheck disable=SC2206
+SEED_ARGS=(${SEEDS})
+
+run_in_allocation \
+  uv run python scripts/training/collect_expert_trajectories.py \
+  --dataset-id "${DATASET_ID}" \
+  --policy-id "${SOURCE_POLICY_ID}" \
+  --episodes "${EPISODES}" \
+  --scenario-config "${SCENARIO_CONFIG}" \
+  --env-config "${PPO_CONFIG}" \
+  --seeds "${SEED_ARGS[@]}"
+
+run_in_allocation \
+  uv run --group imitation python scripts/training/pretrain_from_expert.py \
+  --config "${BC_CONFIG}"
+
+run_in_allocation \
+  uv run python scripts/training/train_ppo_with_pretrained_policy.py \
+  --config "${PPO_CONFIG}"
+
+echo "[issue1108] BC warm-start PPO chain completed. Artifacts will sync to ${RESULTS_ROOT}"

--- a/configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
+++ b/configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml
@@ -12,5 +12,51 @@ bc_epochs: 20
 batch_size: 64
 learning_rate: 0.0003
 random_seeds: [111, 112, 113]
-# Use accelerators when available; set to "cpu" for deterministic/resource-constrained runs.
-device: auto
+scenario_id: classic_bottleneck_low
+# Keep the imitation BC trainer on CPU for this run; the demonstrations are CPU tensors and
+# `device: auto` moved the supplied policy back to CUDA during the Auxme preflight.
+device: cpu
+env_overrides:
+  observation_mode: socnav_struct
+  use_occupancy_grid: true
+  include_grid_in_observation: true
+  predictive_foresight_enabled: true
+  predictive_foresight_model_id: predictive_proxy_selected_v2_full
+  predictive_foresight_device: cpu
+  predictive_foresight_max_agents: 16
+  predictive_foresight_horizon_steps: 8
+  predictive_foresight_rollout_dt: 0.2
+  predictive_foresight_near_distance: 0.7
+  predictive_foresight_front_corridor_length: 3.0
+  predictive_foresight_front_corridor_half_width: 1.0
+  robot_config:
+    type: differential_drive
+    max_linear_speed: 3.0
+    max_angular_speed: 1.0
+    allow_backwards: true
+  grid_config:
+    resolution: 0.2
+    width: 32.0
+    height: 32.0
+    channels: [obstacles, pedestrians, combined]
+    use_ego_frame: true
+    center_on_robot: true
+  peds_have_obstacle_forces: true
+  sim_config:
+    prf_config:
+      is_active: true
+    max_peds_per_group: 3
+env_factory_kwargs:
+  reward_name: route_completion_v3
+  reward_kwargs:
+    weights:
+      progress: 1.1
+      living: -0.015
+      collision: -15.0
+      near_miss: -3.0
+      ttc_risk: -2.8
+      comfort: -0.5
+      smoothness: -0.18
+      timeout: -6.5
+      stagnation: -2.0
+      terminal_bonus: 20.0

--- a/configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml
+++ b/configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml
@@ -12,5 +12,50 @@ scenario_config: ../../scenarios/sets/ppo_full_maintained_eval_v1.yaml
 total_timesteps: 10000000
 learning_rate: 0.0001
 random_seeds: [111, 112, 113]
+scenario_id: classic_bottleneck_low
 snqi_weights: ../../benchmarks/snqi_weights_camera_ready_v3.json
 snqi_baseline: ../../benchmarks/snqi_baseline_camera_ready_v3.json
+env_overrides:
+  observation_mode: socnav_struct
+  use_occupancy_grid: true
+  include_grid_in_observation: true
+  predictive_foresight_enabled: true
+  predictive_foresight_model_id: predictive_proxy_selected_v2_full
+  predictive_foresight_device: cpu
+  predictive_foresight_max_agents: 16
+  predictive_foresight_horizon_steps: 8
+  predictive_foresight_rollout_dt: 0.2
+  predictive_foresight_near_distance: 0.7
+  predictive_foresight_front_corridor_length: 3.0
+  predictive_foresight_front_corridor_half_width: 1.0
+  robot_config:
+    type: differential_drive
+    max_linear_speed: 3.0
+    max_angular_speed: 1.0
+    allow_backwards: true
+  grid_config:
+    resolution: 0.2
+    width: 32.0
+    height: 32.0
+    channels: [obstacles, pedestrians, combined]
+    use_ego_frame: true
+    center_on_robot: true
+  peds_have_obstacle_forces: true
+  sim_config:
+    prf_config:
+      is_active: true
+    max_peds_per_group: 3
+env_factory_kwargs:
+  reward_name: route_completion_v3
+  reward_kwargs:
+    weights:
+      progress: 1.1
+      living: -0.015
+      collision: -15.0
+      near_miss: -3.0
+      ttc_risk: -2.8
+      comfort: -0.5
+      smoothness: -0.18
+      timeout: -6.5
+      stagnation: -2.0
+      terminal_bonus: 20.0

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -196,6 +196,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1090 Observation Visibility](issue_1090_observation_visibility.md)
   records the planner-facing FOV/range/static-occlusion boundary, ground-truth separation, and
   dynamic-occlusion follow-up boundary.
+* [Issue #1108 BC Warm-Start PPO Execution](issue_1108_bc_warm_start_execution.md)
+  records the imitation observation-contract blocker, unblock patch, one-episode real collection
+  preflight, and Slurm job IDs for the #749 BC-preinitialized PPO chain.
 * [Issue #1083 Sanity V1 Nominal Matrix](issue_1083_sanity_v1_nominal_matrix.md)
   records the non-paper-facing nominal calibration matrix, smoke config, baseline threshold, and
   local proof run for easier deployment-like scenes.

--- a/docs/context/issue_1108_bc_warm_start_execution.md
+++ b/docs/context/issue_1108_bc_warm_start_execution.md
@@ -1,0 +1,178 @@
+# Issue #1108 BC Warm-Start PPO Execution
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1108>
+
+## Goal
+
+Run the #749 BC-preinitialized PPO experiment chain against the v10 warm-start contract:
+
+1. collect expert trajectories from
+   `ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200`,
+2. train `issue_749_bc_preinit_v10_policy` with behavioral cloning,
+3. fine-tune `issue_749_ppo_finetune_v10_warm_start`,
+4. compare the final checkpoint against `27dbe5xu` and `b60iopxt`.
+
+## Blocker Found
+
+The 2026-05-14 preflight stopped in trajectory collection because the imitation pipeline did not
+share a stable observation contract:
+
+* the collector built default `drive_state`/`rays` envs while the b60iopxt checkpoint expects
+  SocNav + occupancy-grid dict observations,
+* applying the source env overrides exposed the next mismatch: current SocNav emits
+  `robot_velocity_xy` and `robot_angular_velocity`, while the older checkpoint saved a 20-key dict
+  observation space,
+* BC and PPO fine-tune also built default envs, so a collector-only workaround would not make the
+  chain valid.
+
+## Unblock Implemented
+
+The imitation pipeline now carries and applies env contract metadata:
+
+* `configs/training/ppo_imitation/bc_pretrain_issue_749_v10_warm_start.yaml`
+* `configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml`
+* `scripts/training/collect_expert_trajectories.py`
+* `scripts/training/imitation_env_contract.py`
+* `scripts/training/pretrain_from_expert.py`
+* `scripts/training/train_ppo_with_pretrained_policy.py`
+
+Collection also resolves expert checkpoints through `model/registry.yaml` when the
+`output/benchmarks/expert_policies/<policy>.zip` link is absent, and adapts live dict observations
+to the loaded checkpoint's saved observation space before `policy.predict(...)`. The dataset still
+stores the target v10 observation payload.
+
+## Validation
+
+Earlier lightweight checks on the Auxme login node passed before the 2026-05-17 merge with
+`origin/main`. Those branch-local checks are superseded by the post-merge validation below.
+
+Functional preflight:
+
+```bash
+LOGURU_LEVEL=WARNING uv run python scripts/training/collect_expert_trajectories.py \
+  --dataset-id issue_749_b60iopxt_v10_eval_trajectories \
+  --policy-id ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 \
+  --episodes 1 \
+  --scenario-config configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml \
+  --env-config configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml \
+  --seeds 111
+```
+
+Result: passed. The local manifest reported `quality=validated`, `episode_count=1`,
+`dry_run=false`, `env_contract_config=configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml`,
+and `observation_mode=socnav_struct`.
+
+Dry-run BC and PPO fine-tune also completed after the preflight dataset existed. Those dry-run
+checkpoints are non-evidence and must not be promoted.
+
+BC device smoke after the 2026-05-15 Slurm failures:
+
+```bash
+uv run --group imitation python - <<'PY'
+# Constructed a tiny Gym env and one imitation Trajectory, then called
+# scripts.training.pretrain_from_expert._create_bc_trainer(...).
+PY
+```
+
+Result: passed after pinning both the SB3 PPO wrapper and the imitation BC trainer to CPU:
+`ppo_device cpu`, `bc_policy_device cpu`.
+
+Post-merge checks after syncing `issue-1108-bc-warm-start-ppo` with `origin/main` on
+2026-05-17:
+
+```bash
+uv run python -m py_compile robot_sf/training/imitation_config.py \
+  scripts/training/imitation_env_contract.py scripts/training/collect_expert_trajectories.py \
+  scripts/training/pretrain_from_expert.py scripts/training/train_ppo_with_pretrained_policy.py
+uv run ruff check robot_sf/training/imitation_config.py scripts/training/imitation_env_contract.py \
+  scripts/training/collect_expert_trajectories.py scripts/training/pretrain_from_expert.py \
+  scripts/training/train_ppo_with_pretrained_policy.py tests/training/test_imitation_env_contract.py \
+  tests/training/test_pretrain_from_expert.py tests/training/test_train_ppo_with_pretrained_policy.py \
+  tests/integration/test_ppo_pretraining_pipeline.py
+uv run ruff format --check robot_sf/training/imitation_config.py \
+  scripts/training/imitation_env_contract.py scripts/training/collect_expert_trajectories.py \
+  scripts/training/pretrain_from_expert.py scripts/training/train_ppo_with_pretrained_policy.py \
+  tests/training/test_imitation_env_contract.py tests/training/test_pretrain_from_expert.py \
+  tests/training/test_train_ppo_with_pretrained_policy.py \
+  tests/integration/test_ppo_pretraining_pipeline.py
+uv run pytest tests/training/test_imitation_env_contract.py \
+  tests/training/test_pretrain_from_expert.py \
+  tests/training/test_train_ppo_with_pretrained_policy.py \
+  tests/integration/test_ppo_pretraining_pipeline.py -q
+bash -n SLURM/Auxme/issue_1108_bc_warm_start.sl
+```
+
+Result: passed (`22 passed` for the targeted pytest set). The merge resolution now uses
+`scripts/training/imitation_env_contract.py` as the shared environment-contract boundary instead
+of the deleted `robot_sf/training/env_overrides.py` helper.
+
+## Slurm Submission
+
+First attempt:
+
+* job: `12461`
+* result: failed immediately before training
+* cause: wrapper used `uv sync --all-extras --group imitation`, which selects incompatible
+  dependency sets (`rllib` conflicts with `imitation`)
+
+Second attempt:
+
+* job: `12462`
+* partition/QoS: `a30` / `a30-gpu`
+* node at startup: `auxme-imech172`
+* result: failed in BC after collecting the full 141-episode dataset
+* log: `output/slurm/12462-issue1108-bc-warm-start.out`
+* result root after job exit:
+  `output/slurm/issue1108-bcppo-job-12462/`
+* cause: BC env still used the default scenario contract, producing flat observations of length
+  `77163` while the collected dataset used the pinned scenario length `77095`
+
+Third attempt:
+
+* job: `12463`
+* partition/QoS: `a30` / `a30-gpu`
+* result: failed in BC after collecting the full 141-episode dataset
+* log: `output/slurm/12463-issue1108-bc-warm-start.out`
+* result root after job exit:
+  `output/slurm/issue1108-bcppo-job-12463/`
+* cause: imitation BC moved the policy to CUDA while demonstration action tensors remained on CPU
+
+Fourth attempt:
+
+* job: `12471`
+* partition/QoS: `a30` / `a30-gpu`
+* result: failed in BC after collecting the full 141-episode dataset
+* log: `output/slurm/12471-issue1108-bc-warm-start.out`
+* result root after job exit:
+  `output/slurm/issue1108-bcppo-job-12471/`
+* cause: setting `device="cpu"` on the SB3 PPO wrapper was insufficient because
+  `imitation.algorithms.bc.BC` also has `device="auto"` and moved the supplied policy to CUDA
+
+Fifth attempt:
+
+* job: `12472`
+* partition/QoS: `a30` / `a30-gpu`
+* status checked at 2026-05-15 12:38 Europe/Berlin: running
+* log: `output/slurm/12472-issue1108-bc-warm-start.out`
+* evidence so far: collection completed, BC completed (`12472.1` completed with exit `0:0`), and
+  PPO fine-tune launched (`12472.2` running; observed `total_timesteps=10240`, `success_rate=0.01`)
+* result root after job exit:
+  `output/slurm/issue1108-bcppo-job-12472/`
+
+The checked-in launcher was patched after submission to use a job-local uv environment via
+`UV_PROJECT_ENVIRONMENT=${WORKDIR}/uv_env` for future resubmits. Job `12462` had already started
+with the previous launcher and temporarily adjusted the worktree `.venv`; this is local-only and
+not part of the durable evidence.
+
+## Follow-Up Boundary
+
+Issue #1108 is not complete when job `12472` is merely running. Completion still requires:
+
+* full 141-episode dataset manifest,
+* real BC checkpoint and manifest,
+* real PPO fine-tuned checkpoint and manifest,
+* durable artifact pointers for dataset/checkpoints,
+* policy-analysis comparison against `27dbe5xu` and `b60iopxt`,
+* an outcome statement covering final score and sample efficiency.
+
+Local files under `output/` remain cache/non-evidence until promoted through a durable pointer.

--- a/docs/context/issue_749_bc_preinit_ppo_launch_packet.md
+++ b/docs/context/issue_749_bc_preinit_ppo_launch_packet.md
@@ -55,12 +55,13 @@ uv run python scripts/training/collect_expert_trajectories.py \
   --episodes 141 \
   --scenario-config configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml \
   --training-config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml \
+  --env-config configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml \
   --seeds 111 112 113
 ```
 
-The `--training-config` flag is required for this source checkpoint because it applies the
-BR-06 training `env_overrides` and lets collection persist the checkpoint-compatible observation
-contract for BC and PPO fine-tuning.
+The `--training-config` flag records the source expert provenance, while `--env-config` applies
+the issue-specific v10 warm-start env contract and factory kwargs. Collection persists the
+checkpoint-compatible observation contract for BC and PPO fine-tuning.
 
 Run BC pretraining:
 
@@ -119,6 +120,7 @@ uv run python scripts/training/collect_expert_trajectories.py \
   --episodes 1 \
   --scenario-config configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml \
   --training-config configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml \
+  --env-config configs/training/ppo_imitation/ppo_finetune_issue_749_v10_warm_start.yaml \
   --seeds 111 \
   --dry-run
 uv run --group imitation python scripts/training/pretrain_from_expert.py \

--- a/robot_sf/training/imitation_config.py
+++ b/robot_sf/training/imitation_config.py
@@ -152,9 +152,11 @@ class TrajectoryCollectionConfig:
     output_format: str
     random_seeds: tuple[int, ...]
     scenario_id: str | None = None
+    env_overrides: dict[str, object] = field(default_factory=dict)
+    env_factory_kwargs: dict[str, object] = field(default_factory=dict)
 
     @classmethod
-    def from_raw(
+    def from_raw(  # noqa: PLR0913
         cls,
         *,
         dataset_id: str,
@@ -165,6 +167,8 @@ class TrajectoryCollectionConfig:
         output_format: str,
         random_seeds: tuple[int, ...] | list[int],
         scenario_id: str | None = None,
+        env_overrides: dict[str, object] | None = None,
+        env_factory_kwargs: dict[str, object] | None = None,
     ) -> TrajectoryCollectionConfig:
         """Create a config while coercing sequences to canonical tuples.
 
@@ -181,6 +185,8 @@ class TrajectoryCollectionConfig:
             output_format=output_format,
             random_seeds=ensure_seed_tuple(random_seeds),
             scenario_id=scenario_id,
+            env_overrides=dict(env_overrides or {}),
+            env_factory_kwargs=dict(env_factory_kwargs or {}),
         )
 
 
@@ -208,6 +214,9 @@ class BCPretrainingConfig:
     random_seeds: tuple[int, ...]
     training_config_path: Path | None = None
     scenario_config_path: Path | None = None
+    scenario_id: str | None = None
+    env_overrides: dict[str, object] = field(default_factory=dict)
+    env_factory_kwargs: dict[str, object] = field(default_factory=dict)
     device: str = "auto"
 
     @classmethod
@@ -223,6 +232,9 @@ class BCPretrainingConfig:
         random_seeds: tuple[int, ...] | list[int],
         training_config_path: Path | None = None,
         scenario_config_path: Path | None = None,
+        scenario_id: str | None = None,
+        env_overrides: dict[str, object] | None = None,
+        env_factory_kwargs: dict[str, object] | None = None,
         device: str | None = "auto",
     ) -> BCPretrainingConfig:
         """Create a config while coercing seeds to a canonical tuple.
@@ -241,6 +253,9 @@ class BCPretrainingConfig:
             random_seeds=ensure_seed_tuple(random_seeds),
             training_config_path=training_config_path.resolve() if training_config_path else None,
             scenario_config_path=scenario_config_path.resolve() if scenario_config_path else None,
+            scenario_id=str(scenario_id) if scenario_id else None,
+            env_overrides=dict(env_overrides or {}),
+            env_factory_kwargs=dict(env_factory_kwargs or {}),
             device=str(device or "auto").strip() or "auto",
         )
 
@@ -259,6 +274,9 @@ class PPOFineTuningConfig:
     dataset_id: str | None = None
     training_config_path: Path | None = None
     scenario_config_path: Path | None = None
+    scenario_id: str | None = None
+    env_overrides: dict[str, object] = field(default_factory=dict)
+    env_factory_kwargs: dict[str, object] = field(default_factory=dict)
 
     @classmethod
     def from_raw(  # noqa: PLR0913
@@ -274,6 +292,9 @@ class PPOFineTuningConfig:
         dataset_id: str | None = None,
         training_config_path: Path | None = None,
         scenario_config_path: Path | None = None,
+        scenario_id: str | None = None,
+        env_overrides: dict[str, object] | None = None,
+        env_factory_kwargs: dict[str, object] | None = None,
     ) -> PPOFineTuningConfig:
         """Create a config while coercing seeds to a canonical tuple.
 
@@ -292,6 +313,9 @@ class PPOFineTuningConfig:
             dataset_id=str(dataset_id).strip() if dataset_id else None,
             training_config_path=training_config_path.resolve() if training_config_path else None,
             scenario_config_path=scenario_config_path.resolve() if scenario_config_path else None,
+            scenario_id=str(scenario_id) if scenario_id else None,
+            env_overrides=dict(env_overrides or {}),
+            env_factory_kwargs=dict(env_factory_kwargs or {}),
         )
 
 

--- a/scripts/training/collect_expert_trajectories.py
+++ b/scripts/training/collect_expert_trajectories.py
@@ -11,6 +11,7 @@ import argparse
 import shlex
 import subprocess
 import sys
+from collections.abc import Mapping as RuntimeMapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -37,7 +38,6 @@ from robot_sf.training.scenario_loader import (
     select_scenario,
 )
 from scripts.training.imitation_env_contract import (
-    load_training_env_overrides,
     observation_contract_from_space,
 )
 from scripts.training.train_ppo import _apply_env_overrides
@@ -50,14 +50,14 @@ def _resolve_scenario_config(
     scenario_arg: Path | None,
     training_config: Path | None,
 ) -> Path:
-    """TODO docstring. Document this function.
+    """Resolve the scenario config used for trajectory collection.
 
     Args:
-        scenario_arg: TODO docstring.
-        training_config: TODO docstring.
+        scenario_arg: Explicit scenario config path from the CLI.
+        training_config: Training config used as a fallback source for ``scenario_config``.
 
     Returns:
-        TODO docstring.
+        Absolute path to the scenario config.
     """
     if scenario_arg is not None:
         return scenario_arg.resolve()
@@ -75,12 +75,40 @@ def _resolve_scenario_config(
     return scenario_path
 
 
+def _load_env_contract(config_path: Path | None) -> tuple[dict[str, object], dict[str, object]]:
+    """Load env overrides and factory kwargs from a training-style YAML file."""
+    if config_path is None:
+        return {}, {}
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    env_overrides = raw.get("env_overrides") or {}
+    env_factory_kwargs = raw.get("env_factory_kwargs") or {}
+    if not isinstance(env_overrides, RuntimeMapping):
+        raise TypeError(f"{config_path}: env_overrides must be a mapping")
+    if not isinstance(env_factory_kwargs, RuntimeMapping):
+        raise TypeError(f"{config_path}: env_factory_kwargs must be a mapping")
+    return dict(env_overrides), dict(env_factory_kwargs)
+
+
+def _resolve_expert_checkpoint(policy_id: str) -> Path:
+    """Resolve an expert checkpoint from local output or the model registry."""
+    checkpoint = common.get_expert_policy_dir() / f"{policy_id}.zip"
+    if checkpoint.exists():
+        return checkpoint
+    try:
+        return resolve_model_path(policy_id, allow_download=True)
+    except (KeyError, RuntimeError, ValueError) as exc:
+        raise FileNotFoundError(
+            f"Expert policy checkpoint not found at {checkpoint}, and registry lookup for "
+            f"'{policy_id}' failed."
+        ) from exc
+
+
 def _git_commit_hash() -> str | None:
-    """TODO docstring. Document this function.
+    """Return the current Git commit hash for manifest provenance when available.
 
 
     Returns:
-        TODO docstring.
+        Commit hash string, or ``None`` when Git metadata cannot be read.
     """
     try:
         result = subprocess.run(
@@ -95,23 +123,23 @@ def _git_commit_hash() -> str | None:
 
 
 def _command_line() -> str:
-    """TODO docstring. Document this function.
+    """Return the shell-escaped command line used for the current process.
 
 
     Returns:
-        TODO docstring.
+        Command-line string suitable for manifest provenance.
     """
     return " ".join(shlex.quote(arg) for arg in sys.argv)
 
 
 def _zero_action(space: Any) -> np.ndarray:
-    """TODO docstring. Document this function.
+    """Create a zero-valued action compatible with an action space.
 
     Args:
-        space: TODO docstring.
+        space: Gymnasium action space exposing a shape.
 
     Returns:
-        TODO docstring.
+        Zero action array matching the space shape.
     """
     shape = getattr(space, "shape", ())
     dtype = float
@@ -173,7 +201,6 @@ def _record_dataset(
     scenario_label: str,
     scenario: Mapping[str, Any],
     scenario_path: Path,
-    env_overrides: Mapping[str, object],
     observation_adapter: Callable[[Mapping[str, Any]], Any] | None = None,
 ) -> tuple[dict[str, list[np.ndarray]], dict[str, int]]:
     """Record all requested episodes for one scenario.
@@ -185,7 +212,6 @@ def _record_dataset(
         scenario_label: Scenario identifier used for coverage metadata.
         scenario: Scenario payload selected from the scenario manifest.
         scenario_path: Path to the scenario manifest used to build the env config.
-        env_overrides: Training-config environment overrides to apply before env construction.
         observation_adapter: Optional adapter matching raw env observations to the policy contract.
 
     Returns:
@@ -201,8 +227,8 @@ def _record_dataset(
     for episode in range(config.episodes):
         seed = int(config.random_seeds[episode % len(config.random_seeds)])
         env_config = build_robot_config_from_scenario(scenario, scenario_path=scenario_path)
-        _apply_env_overrides(env_config, env_overrides)
-        env = make_robot_env(config=env_config, seed=seed)
+        _apply_env_overrides(env_config, config.env_overrides)
+        env = make_robot_env(config=env_config, seed=seed, **config.env_factory_kwargs)
         try:
             positions, actions, observations = _record_episode(
                 env,
@@ -225,13 +251,13 @@ def _write_dataset(
     episode_count: int,
     metadata: Mapping[str, Any],
 ) -> None:
-    """TODO docstring. Document this function.
+    """Write the collected trajectory arrays and metadata to an NPZ dataset.
 
     Args:
-        path: TODO docstring.
-        arrays: TODO docstring.
-        episode_count: TODO docstring.
-        metadata: TODO docstring.
+        path: Output NPZ path.
+        arrays: Collected positions, actions, and observations by episode.
+        episode_count: Number of recorded episodes.
+        metadata: Dataset provenance and environment-contract metadata.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     np.savez(
@@ -245,11 +271,11 @@ def _write_dataset(
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """TODO docstring. Document this function.
+    """Build the CLI argument parser for expert trajectory collection.
 
 
     Returns:
-        TODO docstring.
+        Configured argument parser.
     """
     parser = argparse.ArgumentParser(
         description="Collect expert trajectory datasets using an expert PPO policy."
@@ -272,7 +298,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--training-config",
         type=Path,
         default=None,
-        help="Expert training config to derive scenario metadata from.",
+        help="Training config to derive scenario metadata and env contract from.",
+    )
+    parser.add_argument(
+        "--env-config",
+        type=Path,
+        default=None,
+        help=(
+            "Training-style YAML whose env_overrides/env_factory_kwargs should be used during "
+            "collection. Defaults to --training-config when omitted."
+        ),
     )
     parser.add_argument(
         "--seeds",
@@ -321,7 +356,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     scenario_path = _resolve_scenario_config(args.scenario_config, args.training_config)
     training_config_path = args.training_config.resolve() if args.training_config else None
-    env_overrides = load_training_env_overrides(training_config_path)
+    env_contract_path = args.env_config or args.training_config
+    env_overrides, env_factory_kwargs = _load_env_contract(env_contract_path)
     seeds_arg: Sequence[int] | None = args.seeds
     if args.override_seed:
         override = tuple(int(value) for value in args.override_seed)
@@ -347,6 +383,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         scenario_overrides=(),
         output_format=args.output_format,
         random_seeds=seed_values,
+        env_overrides=env_overrides,
+        env_factory_kwargs=env_factory_kwargs,
     )
 
     common.set_global_seed(int(collection_config.random_seeds[0]))
@@ -355,9 +393,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     observation_contract: dict[str, object] | None = None
     observation_adapter: Callable[[Mapping[str, Any]], Any] | None = None
     if not args.dry_run:
-        checkpoint = common.get_expert_policy_dir() / f"{collection_config.source_policy_id}.zip"
-        if not checkpoint.exists():
-            checkpoint = resolve_model_path(collection_config.source_policy_id)
+        checkpoint = _resolve_expert_checkpoint(collection_config.source_policy_id)
         policy = PPO.load(str(checkpoint))
         observation_contract = observation_contract_from_space(policy.observation_space)
         observation_adapter = resolve_policy_obs_adapter(policy)
@@ -369,7 +405,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         scenario_label=scenario_label,
         scenario=selected_scenario,
         scenario_path=scenario_path,
-        env_overrides=env_overrides,
         observation_adapter=observation_adapter,
     )
 
@@ -382,10 +417,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         "scenario_label": scenario_label,
         "scenario_id": collection_config.scenario_id,
         "scenario_overrides": list(collection_config.scenario_overrides),
+        "env_contract_config": str(env_contract_path) if env_contract_path is not None else None,
+        "env_overrides": dict(collection_config.env_overrides),
+        "env_factory_kwargs": dict(collection_config.env_factory_kwargs),
         "random_seeds": list(collection_config.random_seeds),
         "scenario_coverage": coverage,
         "training_config": str(training_config_path) if training_config_path else None,
-        "env_overrides": env_overrides,
         "observation_contract": observation_contract,
         "command": _command_line(),
         "git_commit": _git_commit_hash(),

--- a/scripts/training/imitation_env_contract.py
+++ b/scripts/training/imitation_env_contract.py
@@ -61,6 +61,19 @@ def load_training_env_overrides(training_config_path: Path | None) -> dict[str, 
     return dict(overrides)
 
 
+def load_training_env_factory_kwargs(training_config_path: Path | None) -> dict[str, object]:
+    """Load ``env_factory_kwargs`` from an expert training config."""
+    raw = _load_training_config_mapping(training_config_path)
+    if raw is None:
+        return {}
+    kwargs = raw.get("env_factory_kwargs", {})
+    if kwargs is None:
+        return {}
+    if not isinstance(kwargs, dict):
+        raise ValueError("training config env_factory_kwargs must be a mapping")
+    return dict(kwargs)
+
+
 def resolve_scenario_config_path(
     *,
     scenario_config_path: Path | None,
@@ -83,6 +96,8 @@ def make_training_contract_env(
     scenario_id: str | None = None,
     seed: int | None = None,
     observation_keys: Sequence[str] | None = None,
+    env_overrides: dict[str, object] | None = None,
+    env_factory_kwargs: dict[str, object] | None = None,
 ) -> Any:
     """Create an env using training-config overrides and optional observation-key filtering."""
     resolved_scenario_path = resolve_scenario_config_path(
@@ -99,8 +114,13 @@ def make_training_contract_env(
             scenario_path=resolved_scenario_path,
         )
 
-    _apply_env_overrides(env_config, load_training_env_overrides(training_config_path))
-    env = make_robot_env(config=env_config, seed=seed)
+    resolved_overrides = load_training_env_overrides(training_config_path)
+    resolved_overrides.update(env_overrides or {})
+    resolved_factory_kwargs = load_training_env_factory_kwargs(training_config_path)
+    resolved_factory_kwargs.update(env_factory_kwargs or {})
+
+    _apply_env_overrides(env_config, resolved_overrides)
+    env = make_robot_env(config=env_config, seed=seed, **resolved_factory_kwargs)
     if observation_keys:
         obs_space = getattr(env, "observation_space", None)
         if not isinstance(obs_space, spaces.Dict):

--- a/scripts/training/pretrain_from_expert.py
+++ b/scripts/training/pretrain_from_expert.py
@@ -275,8 +275,11 @@ def run_bc_pretraining(
         or _dataset_contract_path(dataset, "training_config"),
         scenario_config_path=config.scenario_config_path
         or _dataset_contract_path(dataset, "scenario_config"),
+        scenario_id=config.scenario_id,
         seed=int(config.random_seeds[0]) if config.random_seeds else None,
         observation_keys=_observation_keys_from_dataset(dataset),
+        env_overrides=config.env_overrides,
+        env_factory_kwargs=config.env_factory_kwargs,
     )
     raw_observation_space = env.observation_space
     env = maybe_flatten_env_observations(env, context="BC pre-training")
@@ -357,6 +360,9 @@ def load_bc_config(config_path: Path) -> BCPretrainingConfig:
         random_seeds=tuple(raw.get("random_seeds", [42])),
         training_config_path=resolve_config_path(raw.get("training_config"), base_dir=base_dir),
         scenario_config_path=resolve_config_path(raw.get("scenario_config"), base_dir=base_dir),
+        scenario_id=raw.get("scenario_id"),
+        env_overrides=dict(raw.get("env_overrides") or {}),
+        env_factory_kwargs=dict(raw.get("env_factory_kwargs") or {}),
         device=raw.get("device", "auto"),
     )
 

--- a/scripts/training/train_ppo_with_pretrained_policy.py
+++ b/scripts/training/train_ppo_with_pretrained_policy.py
@@ -104,8 +104,11 @@ def _make_finetuning_env(config: PPOFineTuningConfig, *, context: str):
         or _metadata_path(metadata, "training_config"),
         scenario_config_path=config.scenario_config_path
         or _metadata_path(metadata, "scenario_config"),
+        scenario_id=config.scenario_id,
         seed=config.random_seeds[0] if config.random_seeds else None,
         observation_keys=_metadata_observation_keys(metadata),
+        env_overrides=config.env_overrides,
+        env_factory_kwargs=config.env_factory_kwargs,
     )
     return maybe_flatten_env_observations(env, context=context)
 
@@ -371,6 +374,9 @@ def load_ppo_finetuning_config(config_path: Path) -> PPOFineTuningConfig:
         dataset_id=raw.get("dataset_id"),
         training_config_path=resolve_config_path(raw.get("training_config"), base_dir=base_dir),
         scenario_config_path=resolve_config_path(raw.get("scenario_config"), base_dir=base_dir),
+        scenario_id=raw.get("scenario_id"),
+        env_overrides=dict(raw.get("env_overrides") or {}),
+        env_factory_kwargs=dict(raw.get("env_factory_kwargs") or {}),
     )
 
 

--- a/tests/integration/test_ppo_pretraining_pipeline.py
+++ b/tests/integration/test_ppo_pretraining_pipeline.py
@@ -249,6 +249,12 @@ def test_issue_749_warm_start_configs_load():
     assert fine_tune_config.snqi_weights_path.name == "snqi_weights_camera_ready_v3.json"
     assert fine_tune_config.snqi_baseline_path is not None
     assert fine_tune_config.snqi_baseline_path.name == "snqi_baseline_camera_ready_v3.json"
+    assert bc_config.env_overrides["observation_mode"] == "socnav_struct"
+    assert fine_tune_config.env_overrides["observation_mode"] == "socnav_struct"
+    assert bc_config.env_overrides["predictive_foresight_enabled"] is True
+    assert fine_tune_config.env_overrides["include_grid_in_observation"] is True
+    assert bc_config.env_factory_kwargs["reward_name"] == "route_completion_v3"
+    assert fine_tune_config.env_factory_kwargs["reward_name"] == "route_completion_v3"
 
 
 def test_issue_749_warm_start_configs_define_env_contract():


### PR DESCRIPTION
## Summary
Aligns the issue 749/issue 1108 imitation warm-start pipeline around a shared environment contract so trajectory collection, BC pretraining, and PPO fine-tuning use compatible scenario/env metadata after the latest `main` imitation-contract changes.

This is an unblocker PR related to issue 1108. It does **not** complete issue 1108 because the full SLURM experiment artifacts, durable pointers, and policy-analysis comparison are still outstanding.

## Linked Issues
- Relates to issue 1108
- Relates to issue 749

## What Changed
- Added the Auxme launcher for the issue-1108 BC warm-start PPO chain.
- Extended imitation configs with scenario/env contract metadata and CPU BC device control for the Auxme CUDA mismatch.
- Threaded training-config env overrides/factory kwargs through `scripts/training/imitation_env_contract.py` and the collection/BC/fine-tune scripts.
- Recorded the execution history and remaining evidence boundary in `docs/context/issue_1108_bc_warm_start_execution.md`.
- Added/updated targeted integration coverage for the BC device path and warm-start config loading.

## Why It Matters
- Added value: removes the observation-space/device mismatch that blocked the warm-start chain before the actual long-running PPO evidence can be trusted.
- Expected impact: makes the pipeline fail on real experiment outcomes rather than on avoidable collector/BC/fine-tune contract drift.
- Why this is worth merging now: it preserves a validated, latest-main-compatible unblocker while issue 1108 remains a SLURM/artifact follow-up.

## Validation / Proof
- Commands run:
  - `uv run python -m py_compile robot_sf/training/imitation_config.py scripts/training/imitation_env_contract.py scripts/training/collect_expert_trajectories.py scripts/training/pretrain_from_expert.py scripts/training/train_ppo_with_pretrained_policy.py`
  - `bash -n SLURM/Auxme/issue_1108_bc_warm_start.sl`
  - `uv run ruff check robot_sf/training/imitation_config.py scripts/training/imitation_env_contract.py scripts/training/collect_expert_trajectories.py scripts/training/pretrain_from_expert.py scripts/training/train_ppo_with_pretrained_policy.py tests/training/test_imitation_env_contract.py tests/training/test_pretrain_from_expert.py tests/training/test_train_ppo_with_pretrained_policy.py tests/integration/test_ppo_pretraining_pipeline.py`
  - `uv run ruff format --check robot_sf/training/imitation_config.py scripts/training/imitation_env_contract.py scripts/training/collect_expert_trajectories.py scripts/training/pretrain_from_expert.py scripts/training/train_ppo_with_pretrained_policy.py tests/training/test_imitation_env_contract.py tests/training/test_pretrain_from_expert.py tests/training/test_train_ppo_with_pretrained_policy.py tests/integration/test_ppo_pretraining_pipeline.py`
  - `uv run pytest tests/training/test_imitation_env_contract.py tests/training/test_pretrain_from_expert.py tests/training/test_train_ppo_with_pretrained_policy.py tests/integration/test_ppo_pretraining_pipeline.py -q`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - targeted pytest: `22 passed`
  - final readiness gate: `3627 passed, 10 skipped, 3 warnings in 429.49s`
  - doc/proof consistency: passed for 12 changed files
  - touched-definition docstring TODO check: clean
- Benchmarks or smoke tests, if applicable:
  - No benchmark-strength SLURM rerun from this host. `local.machine.md` has `allow_slurm_submission: false`.

## Risks / Rollout
- Compatibility risks: config fields are additive and default to current behavior when omitted.
- Failure modes: the actual experiment can still fail on model quality, long-run training stability, or artifact publication after this unblocker.
- Rollback or fallback plan: revert this PR and keep the experiment blocked on the prior collector/BC/PPO contract mismatch.

## Docs / Provenance
- Updated docs:
  - `docs/context/README.md`
  - `docs/context/issue_1108_bc_warm_start_execution.md`
  - `docs/context/issue_749_bc_preinit_ppo_launch_packet.md`
- Relevant design or provenance notes: `docs/context/issue_1108_bc_warm_start_execution.md` records the earlier SLURM attempts and explicitly separates local cache output from durable evidence.
- Any assumptions that need to be preserved: worktree-local `output/` coverage files are disposable; issue completion still requires durable dataset/checkpoint pointers plus policy-analysis comparison against `27dbe5xu` and `b60iopxt`.

## Follow-Up Issues
- Deferred work: complete the experiment on a machine allowed to submit/inspect Auxme SLURM jobs, then publish durable artifacts and analysis results.
- Issues opened for follow-up: none; issue 1108 remains open for the deferred experiment evidence.

## Reviewer Notes
- Please verify closely that the collector, BC pretrain, and PPO fine-tune scripts all resolve the same scenario/env contract.
- Known limitation: this PR is intentionally draft and does not claim benchmark-strength experiment completion.
