### PR TITLE
feat: add CARLA Docker runtime preflight (#1179)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Issue #1181/#1191 `ml-intern` Workflow Extraction](./context/issue_1181_ml_intern_experiment_assistant.md)** -
   Safe-use boundary and 2026-05-15 decision to extract `ml-intern` workflow ideas into Robot SF's
   Codex-native proof-first practice instead of running the CLI smoke by default
+* **[Issue #1179 CARLA Docker Runtime](./context/issue_1179_carla_docker_runtime.md)** - Pinned `carlasim/carla:0.9.16` preflight/smoke command, local Docker-daemon blocker, and boundary before live replay semantics
 * **[Issue #1237 Adversarial Failure Archive](./context/issue_1237_adversarial_failure_archive.md)** - Compact `adversarial_failure_archive.v1` manifests for deterministic adversarial failure grouping and replay pointers without copying raw bundles
 * **[AI Coding Workflow](./ai/ai-workflow.md)** - End-to-end AI issue-to-PR workflow, validation gates, review loop, and traceability conventions
 * **[PR First-Pass Review Audit](./context/pr_first_pass_review_audit_2026-05-14.md)** - Recent merged-PR review findings and the pre-opening self-review checklist for reducing repeated reviewer fixes

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -467,8 +467,8 @@ why a change was made rather than a full issue execution transcript.
   exports one scenario-loader entry through `scenario_cert.v1` into a neutral CARLA T0 payload, 
   stacked on the issue #942 map-definition adapter.
 * [Issue #948 CARLA T0 Scenario File Export](issue_948_carla_t0_scenario_file_export.md)
-  batch-loads scenario manifests into ordered neutral export payload records, stacked on the issue
-  #946 scenario-entry helper.
+  batch-loads scenario manifests into ordered neutral export payload records, stacked on the
+  Issue #946 scenario-entry helper.
 * [Issue #950 CARLA T0 Export Record Writer](issue_950_carla_t0_export_record_writer.md)
   writes ordered neutral export records to deterministic JSON files plus a local manifest, stacked
   on the issue #948 scenario-file helper.
@@ -488,8 +488,8 @@ why a change was made rather than a full issue execution transcript.
   documents the first CARLA transfer boundary: neutral export first, optional oracle replay later, 
   and fail-closed `not-available` / `failed` statuses instead of fallback parity claims.
 * [Issue #962 CARLA T0 Manifest Payload Loader](issue_962_carla_t0_manifest_payload_loader.md)
-  loads and validates all payloads referenced by a local T0 export manifest, stacked on the issue
-  #960 path resolver.
+  loads and validates all payloads referenced by a local T0 export manifest, stacked on the
+  Issue #960 path resolver.
 * [Issue #964 CARLA T0 Batch Validation CLI](issue_964_carla_t0_batch_validation_cli.md)
   exposes the issue #962 manifest payload loader through a CARLA-free batch validation project
   script.
@@ -541,6 +541,9 @@ why a change was made rather than a full issue execution transcript.
 - [Issue #1003 CARLA T1 Oracle Replay Smoke](issue_1003_carla_t1_oracle_smoke.md)
   adds a setup-only T1 oracle replay smoke command for one T0 export manifest payload, with
   schema-catalog validation and fail-closed `not-available` behavior when CARLA is absent.
+- [Issue #1179 CARLA Docker Runtime](issue_1179_carla_docker_runtime.md)
+  records the pinned `carlasim/carla:0.9.16` Docker runtime interface, preflight/smoke command,
+  local no-sudo Docker blocker, and boundary before true live replay semantics.
 
 ## DreamerV3 Notes
 

--- a/docs/context/issue_1179_carla_docker_runtime.md
+++ b/docs/context/issue_1179_carla_docker_runtime.md
@@ -1,0 +1,89 @@
+# Issue #1179 CARLA Docker Runtime
+
+Issue: [#1179](https://github.com/ll7/robot_sf_ll7/issues/1179)
+Parent epic: [#872](https://github.com/ll7/robot_sf_ll7/issues/872)
+Downstream live replay: [#1169](https://github.com/ll7/robot_sf_ll7/issues/1169)
+Runner prerequisite: [#1119](https://github.com/ll7/robot_sf_ll7/issues/1119)
+
+## Decision
+
+Add an opt-in CARLA Docker runtime interface for the pinned image
+`carlasim/carla:0.9.16`. The interface keeps normal Robot-SF and CARLA T0/T1 import paths
+CARLA-free while giving maintainers a deterministic preflight and lifecycle command for a Linux
+x86_64 NVIDIA Docker host.
+
+The runtime command checks prerequisites before starting CARLA and reports `not-available` instead
+of treating missing Docker, GPU, NVIDIA Container Toolkit, ports, image storage, or Python API
+support as successful simulator evidence.
+
+## Implemented Path
+
+* Runtime helper: `robot_sf_carla_bridge/docker_runtime.py`
+* CLI: `robot-sf-carla-docker-runtime`
+* Package script: `pyproject.toml`
+* Contract tests: `tests/carla_bridge/test_docker_runtime.py`
+
+Recommended command sequence on a CARLA-capable host:
+
+```bash
+uv run robot-sf-carla-docker-runtime preflight --json
+uv run robot-sf-carla-docker-runtime smoke --pull --json
+```
+
+The `smoke --pull` path reuses `carlasim/carla:0.9.16` when present, otherwise it checks Docker
+storage before pulling. It requires at least `50 GiB` free and warns below `80 GiB`. The smoke path
+starts the server container with explicit `2000-2002` port mappings, connects the host-side Python
+client, records client/server version and map metadata, captures a Docker log tail, and stops the
+container in success and failure paths.
+
+## Boundary
+
+This is runtime substrate evidence only. It does not replay Robot-SF scenarios, spawn actors from
+T0 payloads, compare metrics, run training, or prove CARLA transfer. True replay semantics remain
+with #1169.
+
+The default client placement remains Option A from #1179: server in Docker, Python client from the
+Robot-SF repo command path using `carla==0.9.16` or a matching bundled wheel. Option B, a companion
+client container, is still only a fallback if host-side Python compatibility fails on the target
+runner.
+
+## Local Validation
+
+Passing CARLA-free contract checks:
+
+```bash
+rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t1_replay_smoke.py tests/carla_bridge/test_docker_runtime.py -q
+```
+
+Result: `14 passed`.
+
+Broader CARLA bridge regression suite:
+
+```bash
+rtk uv run pytest tests/carla_bridge -q
+```
+
+Result: `71 passed`.
+
+Host-side Python package resolver check:
+
+```bash
+rtk uv pip install --dry-run 'carla==0.9.16'
+```
+
+Result: uv resolved the package for this Python 3.12.3 environment and reported it would install
+`carla==0.9.16`. The package was not installed into the normal repo environment.
+
+Local runtime preflight:
+
+```bash
+rtk uv run robot-sf-carla-docker-runtime preflight --skip-api-check --json
+```
+
+Observed on `Linux x86_64` with an NVIDIA GeForce RTX 3080: status `not-available`,
+`missing_capability: docker-daemon`, because Docker Engine 29.4.2 client reports `Server: null` and
+fails with permission denied while connecting to `unix:///var/run/docker.sock`.
+
+This local result is a precise runtime blocker, not live CARLA proof. A Docker/NVIDIA-capable host
+still needs to run `robot-sf-carla-docker-runtime smoke --pull --json` to record image digest,
+client/server versions, active map, Docker command, status, and log tail.

--- a/docs/context/issue_1179_carla_docker_runtime.md
+++ b/docs/context/issue_1179_carla_docker_runtime.md
@@ -65,6 +65,23 @@ rtk uv run pytest tests/carla_bridge -q
 
 Result: `71 passed`.
 
+Post-merge PR readiness gate:
+
+```bash
+rtk bash -lc 'PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh'
+```
+
+Result: Ruff passed, the full pytest suite reported `3702 passed, 10 skipped`, and the touched
+definition TODO ratchet passed.
+
+Docs proof consistency:
+
+```bash
+rtk bash -lc 'BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh'
+```
+
+Result: passed for the changed docs files.
+
 Host-side Python package resolver check:
 
 ```bash
@@ -87,3 +104,7 @@ fails with permission denied while connecting to `unix:///var/run/docker.sock`.
 This local result is a precise runtime blocker, not live CARLA proof. A Docker/NVIDIA-capable host
 still needs to run `robot-sf-carla-docker-runtime smoke --pull --json` to record image digest,
 client/server versions, active map, Docker command, status, and log tail.
+
+Generated `output/coverage/` files from validation remain ignored and disposable. No generated
+CARLA Docker image, benchmark bundle, model checkpoint, or durable runtime artifact was produced on
+this host.

--- a/docs/context/issue_1179_carla_docker_runtime.md
+++ b/docs/context/issue_1179_carla_docker_runtime.md
@@ -56,6 +56,7 @@ rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t1_
 ```
 
 Result: `14 passed`.
+Post-review rerun after Docker runtime robustness fixes: `18 passed`.
 
 Broader CARLA bridge regression suite:
 
@@ -64,6 +65,7 @@ rtk uv run pytest tests/carla_bridge -q
 ```
 
 Result: `71 passed`.
+Post-review rerun after Docker runtime robustness fixes: `75 passed`.
 
 Post-merge PR readiness gate:
 
@@ -73,6 +75,8 @@ rtk bash -lc 'PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_che
 
 Result: Ruff passed, the full pytest suite reported `3702 passed, 10 skipped`, and the touched
 definition TODO ratchet passed.
+Post-review rerun after Docker runtime robustness fixes: `3706 passed, 10 skipped`, with the
+touched-definition TODO ratchet still passing.
 
 Docs proof consistency:
 

--- a/docs/context/issue_1179_carla_docker_runtime.md
+++ b/docs/context/issue_1179_carla_docker_runtime.md
@@ -57,6 +57,8 @@ rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t1_
 
 Result: `14 passed`.
 Post-review rerun after Docker runtime robustness fixes: `18 passed`.
+Second post-review rerun after image validation, CUDA pull, image metadata, and startup-cleanup
+hardening: `22 passed`.
 
 Broader CARLA bridge regression suite:
 
@@ -66,6 +68,8 @@ rtk uv run pytest tests/carla_bridge -q
 
 Result: `71 passed`.
 Post-review rerun after Docker runtime robustness fixes: `75 passed`.
+Second post-review rerun after image validation, CUDA pull, image metadata, and startup-cleanup
+hardening: `79 passed`.
 
 Post-merge PR readiness gate:
 
@@ -77,6 +81,8 @@ Result: Ruff passed, the full pytest suite reported `3702 passed, 10 skipped`, a
 definition TODO ratchet passed.
 Post-review rerun after Docker runtime robustness fixes: `3706 passed, 10 skipped`, with the
 touched-definition TODO ratchet still passing.
+Second post-review rerun after image validation, CUDA pull, image metadata, and startup-cleanup
+hardening: `3710 passed, 10 skipped`, with the touched-definition TODO ratchet still passing.
 
 Docs proof consistency:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -496,6 +496,7 @@ robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export
 robot-sf-check-carla = "robot_sf_carla_bridge.cli:check_carla_availability_main"
 robot-sf-catalog-carla-schemas = "robot_sf_carla_bridge.cli:catalog_carla_schemas_main"
 robot-sf-carla-t1-oracle-smoke = "robot_sf_carla_bridge.cli:replay_t1_oracle_smoke_main"
+robot-sf-carla-docker-runtime = "robot_sf_carla_bridge.cli:carla_docker_runtime_main"
 robot-sf-migrate-artifacts = "scripts.tools.migrate_artifacts:main"
 
 # Note: uv-specific config removed to avoid duplicate-config warnings with uv.toml

--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -4,12 +4,24 @@ The package must remain usable without CARLA installed. Runtime replay integrati
 the availability helpers before importing or invoking CARLA-specific APIs.
 """
 
+from robot_sf_carla_bridge import docker_runtime
 from robot_sf_carla_bridge.availability import (
     AVAILABILITY_SCHEMA_VERSION,
     CarlaUnavailableError,
     check_carla_availability,
     load_availability_schema,
     require_carla,
+)
+from robot_sf_carla_bridge.docker_runtime import (
+    CARLA_DOCKER_IMAGE,
+    CARLA_DOCKER_RUNTIME_SCHEMA_VERSION,
+    CARLA_PYTHON_API_REQUIREMENT,
+    CommandResult,
+    build_carla_client_health_summary,
+    build_carla_server_container_command,
+    run_carla_docker_preflight,
+    run_carla_docker_runtime_smoke,
+    validate_carla_image,
 )
 from robot_sf_carla_bridge.export import (
     BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION,
@@ -57,6 +69,9 @@ from robot_sf_carla_bridge.schema_catalog import (
 __all__ = [
     "AVAILABILITY_SCHEMA_VERSION",
     "BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION",
+    "CARLA_DOCKER_IMAGE",
+    "CARLA_DOCKER_RUNTIME_SCHEMA_VERSION",
+    "CARLA_PYTHON_API_REQUIREMENT",
     "DEFAULT_PARITY_METRICS",
     "EXPORT_MANIFEST_SCHEMA_VERSION",
     "EXPORT_SCHEMA_VERSION",
@@ -64,6 +79,7 @@ __all__ = [
     "T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION",
     "CarlaUnavailableError",
     "CertificateRef",
+    "CommandResult",
     "MetricParityRow",
     "PedestrianReplaySpec",
     "Pose2D",
@@ -71,6 +87,8 @@ __all__ = [
     "ScenarioReplayRef",
     "SimulationSpec",
     "Waypoint2D",
+    "build_carla_client_health_summary",
+    "build_carla_server_container_command",
     "build_export_payload",
     "build_export_payload_from_map_definition",
     "build_export_payload_from_scenario_entry",
@@ -78,6 +96,7 @@ __all__ = [
     "build_t1_oracle_replay_smoke_setup",
     "check_carla_availability",
     "compare_oracle_replay_metrics",
+    "docker_runtime",
     "list_carla_bridge_schema_catalog",
     "load_availability_schema",
     "load_batch_validation_summary_schema",
@@ -89,7 +108,10 @@ __all__ = [
     "read_export_payload",
     "require_carla",
     "resolve_export_manifest_payload_paths",
+    "run_carla_docker_preflight",
+    "run_carla_docker_runtime_smoke",
     "select_t0_export_payload",
+    "validate_carla_image",
     "validate_export_payload",
     "validate_t1_replay_catalog_payload",
     "write_export_payload",

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -14,6 +14,10 @@ from robot_sf_carla_bridge.availability import (
     check_carla_availability,
     load_availability_schema,
 )
+from robot_sf_carla_bridge.docker_runtime import (
+    run_carla_docker_preflight,
+    run_carla_docker_runtime_smoke,
+)
 from robot_sf_carla_bridge.export import (
     BATCH_VALIDATION_SUMMARY_SCHEMA_VERSION,
     build_export_payloads_from_scenario_file,
@@ -304,6 +308,66 @@ def replay_t1_oracle_smoke_main(argv: list[str] | None = None) -> int:
         f"{summary['selected_payload']['scenario_id']} ready for CARLA T1 oracle replay setup\n"
     )
     return 0
+
+
+def carla_docker_runtime_main(argv: list[str] | None = None) -> int:
+    """Run the opt-in pinned CARLA Docker runtime preflight or smoke workflow.
+
+    Returns:
+        Process-style exit code.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Preflight or smoke-test the pinned CARLA 0.9.16 Docker runtime."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    preflight = subparsers.add_parser("preflight", help="Check host prerequisites only.")
+    preflight.add_argument("--json", action="store_true", help="Print a machine-readable status.")
+    preflight.add_argument(
+        "--pull",
+        action="store_true",
+        help="Pull carlasim/carla:0.9.16 when missing after disk-space checks pass.",
+    )
+    preflight.add_argument(
+        "--skip-api-check",
+        action="store_true",
+        help="Skip host-side carla==0.9.16 import validation.",
+    )
+
+    smoke = subparsers.add_parser(
+        "smoke", help="Start CARLA, connect a Python client, and stop it."
+    )
+    smoke.add_argument("--json", action="store_true", help="Print a machine-readable status.")
+    smoke.add_argument(
+        "--pull",
+        action="store_true",
+        help="Pull carlasim/carla:0.9.16 when missing after disk-space checks pass.",
+    )
+    smoke.add_argument(
+        "--startup-timeout-s",
+        type=float,
+        default=120.0,
+        help="Seconds to wait for Python-client connectivity.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.command == "preflight":
+        status = run_carla_docker_preflight(
+            pull=args.pull,
+            require_carla_api=not args.skip_api_check,
+        )
+    else:
+        status = run_carla_docker_runtime_smoke(
+            pull=args.pull,
+            startup_timeout_s=args.startup_timeout_s,
+        )
+
+    exit_code = 0 if status["status"] in {"available", "connected"} else 1
+    if args.json:
+        sys.stdout.write(f"{json.dumps(status, sort_keys=True)}\n")
+    else:
+        sys.stdout.write(f"{status['status']}: {status['reason']}\n")
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/robot_sf_carla_bridge/docker_runtime.py
+++ b/robot_sf_carla_bridge/docker_runtime.py
@@ -1,0 +1,438 @@
+"""Pinned CARLA Docker runtime preflight and lifecycle helpers."""
+
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from robot_sf_carla_bridge.availability import check_carla_availability, require_carla
+
+CARLA_DOCKER_RUNTIME_SCHEMA_VERSION = "carla-docker-runtime.v1"
+CARLA_DOCKER_IMAGE = "carlasim/carla:0.9.16"
+CARLA_PYTHON_API_REQUIREMENT = "carla==0.9.16"
+CARLA_DEFAULT_CONTAINER_NAME = "robot-sf-carla-0-9-16"
+CARLA_DEFAULT_HOST = "127.0.0.1"
+CARLA_DEFAULT_RPC_PORT = 2000
+CARLA_PORTS = (2000, 2001, 2002)
+CARLA_PULL_MIN_FREE_GIB = 50
+CARLA_PULL_WARN_FREE_GIB = 80
+NVIDIA_DOCKER_TEST_IMAGE = "nvidia/cuda:12.4.1-base-ubuntu22.04"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Captured command result used by injectable CARLA Docker runners."""
+
+    args: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner(Protocol):
+    """Callable command runner protocol used for Docker/CARLA runtime tests."""
+
+    def __call__(self, command: list[str], *, timeout_s: float) -> CommandResult:
+        """Run one command with a timeout."""
+
+
+def run_command(command: list[str], *, timeout_s: float = 30.0) -> CommandResult:
+    """Run one host command and capture text output for runtime evidence.
+
+    Returns:
+        Captured command result with args, return code, stdout, and stderr.
+    """
+
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+    )
+    return CommandResult(
+        args=list(command),
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def validate_carla_image(image: str) -> str:
+    """Return a CARLA image reference only when it is explicitly pinned."""
+
+    if not image or image.endswith(":latest") or ":" not in image:
+        raise ValueError("CARLA Docker image must be pinned; do not use carlasim/carla:latest")
+    return image
+
+
+def build_carla_server_container_command(
+    *,
+    image: str = CARLA_DOCKER_IMAGE,
+    container_name: str = CARLA_DEFAULT_CONTAINER_NAME,
+    rpc_port: int = CARLA_DEFAULT_RPC_PORT,
+) -> list[str]:
+    """Build the pinned, headless CARLA server container command.
+
+    Returns:
+        Docker command argv with explicit CARLA port mappings and offscreen flags.
+    """
+
+    image = validate_carla_image(image)
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "--detach",
+        "--gpus",
+        "all",
+        "--name",
+        container_name,
+    ]
+    for port in CARLA_PORTS:
+        command.extend(["-p", f"{port}:{port}"])
+    command.extend(
+        [
+            image,
+            "/bin/bash",
+            "-lc",
+            f"./CarlaUE4.sh -RenderOffScreen -nosound -carla-rpc-port={rpc_port}",
+        ]
+    )
+    return command
+
+
+def check_carla_runtime_ports(
+    ports: tuple[int, ...] = CARLA_PORTS,
+    *,
+    host: str = CARLA_DEFAULT_HOST,
+) -> list[int]:
+    """Return CARLA host ports that cannot be bound before container startup."""
+
+    unavailable: list[int] = []
+    for port in ports:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+            except OSError:
+                unavailable.append(port)
+    return unavailable
+
+
+def run_carla_docker_preflight(  # noqa: C901
+    *,
+    image: str = CARLA_DOCKER_IMAGE,
+    runner: CommandRunner = run_command,
+    pull: bool = False,
+    require_carla_api: bool = True,
+) -> dict[str, Any]:
+    """Check pinned CARLA Docker prerequisites without starting replay semantics.
+
+    Returns:
+        Machine-readable availability status and evidence for each preflight check.
+    """
+
+    image = validate_carla_image(image)
+    status: dict[str, Any] = {
+        "schema_version": CARLA_DOCKER_RUNTIME_SCHEMA_VERSION,
+        "status": "available",
+        "reason": "CARLA Docker runtime prerequisites are available",
+        "image": image,
+        "python_api_requirement": CARLA_PYTHON_API_REQUIREMENT,
+        "host": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+        },
+        "ports": list(CARLA_PORTS),
+        "checks": [],
+    }
+
+    docker_version = runner(["docker", "version", "--format", "{{json .}}"], timeout_s=10.0)
+    docker_payload = _parse_json(docker_version.stdout)
+    if (
+        docker_version.returncode != 0
+        or not isinstance(docker_payload, dict)
+        or "Server" not in docker_payload
+        or docker_payload["Server"] is None
+    ):
+        return _not_available(
+            status,
+            check={
+                "name": "docker_daemon",
+                "status": "not-available",
+                "command": docker_version.args,
+                "stdout": docker_version.stdout,
+                "stderr": docker_version.stderr,
+            },
+            missing_capability="docker-daemon",
+            reason="Docker daemon is not reachable without sudo",
+        )
+    status["checks"].append({"name": "docker_daemon", "status": "available"})
+    status["docker"] = docker_payload
+
+    if platform.system() != "Linux" or platform.machine().lower() not in {"x86_64", "amd64"}:
+        return _not_available(
+            status,
+            check={"name": "host_platform", "status": "not-available"},
+            missing_capability="linux-x86_64-host",
+            reason="CARLA Docker runtime success path requires Linux x86_64",
+        )
+    status["checks"].append({"name": "host_platform", "status": "available"})
+
+    nvidia_smi = runner(
+        ["nvidia-smi", "--query-gpu=name,driver_version,memory.total", "--format=csv,noheader"],
+        timeout_s=10.0,
+    )
+    if nvidia_smi.returncode != 0:
+        return _not_available(
+            status,
+            check={
+                "name": "nvidia_gpu",
+                "status": "not-available",
+                "command": nvidia_smi.args,
+                "stderr": nvidia_smi.stderr,
+            },
+            missing_capability="nvidia-gpu",
+            reason="NVIDIA GPU is not visible on the host",
+        )
+    status["checks"].append(
+        {"name": "nvidia_gpu", "status": "available", "summary": nvidia_smi.stdout.strip()}
+    )
+
+    nvidia_docker = runner(
+        ["docker", "run", "--rm", "--gpus", "all", NVIDIA_DOCKER_TEST_IMAGE, "nvidia-smi"],
+        timeout_s=120.0,
+    )
+    if nvidia_docker.returncode != 0:
+        return _not_available(
+            status,
+            check={
+                "name": "nvidia_container_toolkit",
+                "status": "not-available",
+                "command": nvidia_docker.args,
+                "stderr": nvidia_docker.stderr,
+            },
+            missing_capability="nvidia-container-toolkit",
+            reason="NVIDIA Container Toolkit is not available through Docker",
+        )
+    status["checks"].append({"name": "nvidia_container_toolkit", "status": "available"})
+
+    blocked_ports = check_carla_runtime_ports(CARLA_PORTS)
+    if blocked_ports:
+        return _not_available(
+            status,
+            check={"name": "ports", "status": "not-available", "blocked": blocked_ports},
+            missing_capability="carla-ports",
+            reason=f"CARLA ports are not free: {blocked_ports}",
+        )
+    status["checks"].append({"name": "ports", "status": "available"})
+
+    image_inspect = runner(["docker", "image", "inspect", image], timeout_s=30.0)
+    if image_inspect.returncode != 0:
+        storage = _docker_storage_status(runner)
+        status["docker_storage"] = storage
+        if storage.get("free_gib", 0.0) < CARLA_PULL_MIN_FREE_GIB:
+            return _not_available(
+                status,
+                check={"name": "docker_storage", "status": "not-available", **storage},
+                missing_capability="docker-storage",
+                reason=f"At least {CARLA_PULL_MIN_FREE_GIB} GiB free is required before pulling {image}",
+            )
+        if storage.get("free_gib", 0.0) < CARLA_PULL_WARN_FREE_GIB:
+            status.setdefault("warnings", []).append(
+                f"Docker storage has less than {CARLA_PULL_WARN_FREE_GIB} GiB free; CARLA "
+                "image layers, extraction, logs, and runtime artifacts can consume substantial space."
+            )
+        if not pull:
+            return _not_available(
+                status,
+                check={"name": "carla_image", "status": "not-available", "image": image},
+                missing_capability="carla-image",
+                reason=f"{image} is not present locally; rerun with --pull to fetch the pinned image",
+            )
+        pull_result = runner(["docker", "pull", image], timeout_s=3600.0)
+        if pull_result.returncode != 0:
+            return _not_available(
+                status,
+                check={
+                    "name": "carla_image_pull",
+                    "status": "failed",
+                    "command": pull_result.args,
+                    "stderr": pull_result.stderr,
+                },
+                missing_capability="carla-image",
+                reason=f"Failed to pull pinned CARLA image {image}",
+            )
+        image_inspect = runner(["docker", "image", "inspect", image], timeout_s=30.0)
+    image_metadata = _image_metadata(image_inspect.stdout)
+    status["image_digest"] = image_metadata.get("digest")
+    status["image_size_bytes"] = image_metadata.get("size_bytes")
+    status["checks"].append({"name": "carla_image", "status": "available", **image_metadata})
+
+    if require_carla_api:
+        carla_status = check_carla_availability()
+        if carla_status["status"] != "available":
+            return _not_available(
+                status,
+                check={"name": "carla_python_api", **carla_status},
+                missing_capability="carla-python-api",
+                reason=f"{CARLA_PYTHON_API_REQUIREMENT} is not importable from the repo command path",
+            )
+        status["checks"].append({"name": "carla_python_api", "status": "available"})
+
+    return status
+
+
+def build_carla_client_health_summary(
+    *,
+    host: str = CARLA_DEFAULT_HOST,
+    port: int = CARLA_DEFAULT_RPC_PORT,
+    timeout_s: float = 10.0,
+) -> dict[str, Any]:
+    """Connect to a live CARLA server and return client/server version and map metadata.
+
+    Returns:
+        Client connectivity summary with version and map metadata.
+    """
+
+    carla_module = require_carla()
+    client = carla_module.Client(host, port)
+    client.set_timeout(timeout_s)
+    world = client.get_world()
+    carla_map = world.get_map()
+    return {
+        "status": "connected",
+        "host": host,
+        "port": port,
+        "client_version": client.get_client_version(),
+        "server_version": client.get_server_version(),
+        "map": getattr(carla_map, "name", None),
+        "boundary": "client-connectivity-only",
+    }
+
+
+def run_carla_docker_runtime_smoke(
+    *,
+    image: str = CARLA_DOCKER_IMAGE,
+    container_name: str = CARLA_DEFAULT_CONTAINER_NAME,
+    runner: CommandRunner = run_command,
+    pull: bool = False,
+    startup_timeout_s: float = 120.0,
+    retry_interval_s: float = 2.0,
+    log_tail_lines: int = 80,
+) -> dict[str, Any]:
+    """Start the pinned CARLA server container, prove client connectivity, and clean up.
+
+    Returns:
+        Runtime status with preflight evidence, Docker command, health check, logs, and cleanup.
+    """
+
+    preflight = run_carla_docker_preflight(image=image, runner=runner, pull=pull)
+    if preflight["status"] != "available":
+        return preflight
+
+    command = build_carla_server_container_command(image=image, container_name=container_name)
+    start = runner(command, timeout_s=60.0)
+    container_id = start.stdout.strip() or container_name
+    summary: dict[str, Any] = {
+        **preflight,
+        "docker_command": command,
+        "container": {"name": container_name, "id": container_id},
+    }
+    if start.returncode != 0:
+        summary.update(
+            {
+                "status": "failed",
+                "reason": "Failed to start pinned CARLA server container",
+                "stderr": start.stderr,
+            }
+        )
+        return summary
+
+    deadline = time.monotonic() + startup_timeout_s
+    last_error: Exception | None = None
+    try:
+        while True:
+            try:
+                summary["health"] = build_carla_client_health_summary()
+                summary["status"] = "connected"
+                summary["reason"] = "Python client connected to the pinned CARLA Docker server"
+                return summary
+            except (AttributeError, OSError, RuntimeError, TimeoutError) as exc:
+                last_error = exc
+                if time.monotonic() >= deadline:
+                    summary["status"] = "failed"
+                    summary["reason"] = str(exc)
+                    return summary
+                time.sleep(retry_interval_s)
+    finally:
+        logs = runner(
+            ["docker", "logs", "--tail", str(log_tail_lines), container_id], timeout_s=30.0
+        )
+        summary["logs_tail"] = logs.stdout if logs.returncode == 0 else logs.stderr
+        stop = runner(["docker", "stop", container_id], timeout_s=30.0)
+        summary["cleanup"] = {
+            "command": stop.args,
+            "returncode": stop.returncode,
+            "stdout": stop.stdout,
+            "stderr": stop.stderr,
+        }
+        if last_error is not None and summary.get("status") != "connected":
+            summary["reason"] = str(last_error)
+
+
+def _not_available(
+    status: dict[str, Any],
+    *,
+    check: dict[str, Any],
+    missing_capability: str,
+    reason: str,
+) -> dict[str, Any]:
+    status["status"] = "not-available"
+    status["reason"] = reason
+    status["missing_capability"] = missing_capability
+    status["checks"].append(check)
+    return status
+
+
+def _parse_json(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _docker_storage_status(runner: CommandRunner) -> dict[str, Any]:
+    result = runner(["docker", "info", "--format", "{{json .DockerRootDir}}"], timeout_s=10.0)
+    docker_root = _parse_json(result.stdout) if result.returncode == 0 else None
+    if not isinstance(docker_root, str) or not docker_root:
+        docker_root = "/"
+    usage = shutil.disk_usage(docker_root)
+    total = usage.total if hasattr(usage, "total") else usage[0]
+    free = usage.free if hasattr(usage, "free") else usage[2]
+    return {
+        "path": docker_root,
+        "free_gib": free / 1024**3,
+        "total_gib": total / 1024**3,
+    }
+
+
+def _image_metadata(inspect_stdout: str) -> dict[str, Any]:
+    payload = _parse_json(inspect_stdout)
+    if isinstance(payload, list) and payload:
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        return {}
+    repo_digests = payload.get("RepoDigests") or []
+    digest = repo_digests[0].split("@", maxsplit=1)[-1] if repo_digests else payload.get("Id")
+    return {
+        "digest": digest,
+        "size_bytes": payload.get("Size"),
+    }

--- a/robot_sf_carla_bridge/docker_runtime.py
+++ b/robot_sf_carla_bridge/docker_runtime.py
@@ -82,8 +82,10 @@ def run_command(command: list[str], *, timeout_s: float = 30.0) -> CommandResult
 def validate_carla_image(image: str) -> str:
     """Return a CARLA image reference only when it is explicitly pinned."""
 
-    if not image or image.endswith(":latest") or ":" not in image:
-        raise ValueError("CARLA Docker image must be pinned; do not use carlasim/carla:latest")
+    if image != CARLA_DOCKER_IMAGE:
+        raise ValueError(
+            f"CARLA Docker image must be pinned to {CARLA_DOCKER_IMAGE}; got {image!r}"
+        )
     return image
 
 
@@ -222,7 +224,16 @@ def run_carla_docker_preflight(  # noqa: C901
     )
 
     nvidia_docker = runner(
-        ["docker", "run", "--rm", "--gpus", "all", NVIDIA_DOCKER_TEST_IMAGE, "nvidia-smi"],
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--pull=never",
+            "--gpus",
+            "all",
+            NVIDIA_DOCKER_TEST_IMAGE,
+            "nvidia-smi",
+        ],
         timeout_s=120.0,
     )
     if nvidia_docker.returncode != 0:
@@ -286,7 +297,26 @@ def run_carla_docker_preflight(  # noqa: C901
                 reason=f"Failed to pull pinned CARLA image {image}",
             )
         image_inspect = runner(["docker", "image", "inspect", image], timeout_s=30.0)
+    if image_inspect.returncode != 0:
+        return _not_available(
+            status,
+            check={
+                "name": "carla_image_inspect",
+                "status": "failed",
+                "command": image_inspect.args,
+                "stderr": image_inspect.stderr,
+            },
+            missing_capability="carla-image",
+            reason=f"Failed to inspect image metadata for {image}",
+        )
     image_metadata = _image_metadata(image_inspect.stdout)
+    if not image_metadata.get("digest") or image_metadata.get("size_bytes") is None:
+        return _not_available(
+            status,
+            check={"name": "carla_image", "status": "failed", "image": image},
+            missing_capability="carla-image",
+            reason=f"Image metadata for {image} is missing digest or size information",
+        )
     status["image_digest"] = image_metadata.get("digest")
     status["image_size_bytes"] = image_metadata.get("size_bytes")
     status["checks"].append({"name": "carla_image", "status": "available", **image_metadata})
@@ -356,24 +386,25 @@ def run_carla_docker_runtime_smoke(
     command = build_carla_server_container_command(image=image, container_name=container_name)
     start = runner(command, timeout_s=60.0)
     container_id = start.stdout.strip() or container_name
+    started = start.returncode == 0
     summary: dict[str, Any] = {
         **preflight,
         "docker_command": command,
         "container": {"name": container_name, "id": container_id},
     }
-    if start.returncode != 0:
-        summary.update(
-            {
-                "status": "failed",
-                "reason": "Failed to start pinned CARLA server container",
-                "stderr": start.stderr,
-            }
-        )
-        return summary
 
     deadline = time.monotonic() + startup_timeout_s
     last_error: Exception | None = None
     try:
+        if not started:
+            summary.update(
+                {
+                    "status": "failed",
+                    "reason": "Failed to start pinned CARLA server container",
+                    "stderr": start.stderr,
+                }
+            )
+            return summary
         while True:
             try:
                 summary["health"] = build_carla_client_health_summary()

--- a/robot_sf_carla_bridge/docker_runtime.py
+++ b/robot_sf_carla_bridge/docker_runtime.py
@@ -49,19 +49,34 @@ def run_command(command: list[str], *, timeout_s: float = 30.0) -> CommandResult
         Captured command result with args, return code, stdout, and stderr.
     """
 
-    completed = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout_s,
-    )
-    return CommandResult(
-        args=list(command),
-        returncode=completed.returncode,
-        stdout=completed.stdout,
-        stderr=completed.stderr,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        return CommandResult(
+            args=list(command),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+    except FileNotFoundError:
+        return CommandResult(
+            args=list(command),
+            returncode=127,
+            stdout="",
+            stderr=f"Command not found: {command[0]}",
+        )
+    except subprocess.TimeoutExpired:
+        return CommandResult(
+            args=list(command),
+            returncode=124,
+            stdout="",
+            stderr=f"Command timed out after {timeout_s}s",
+        )
 
 
 def validate_carla_image(image: str) -> str:
@@ -95,7 +110,7 @@ def build_carla_server_container_command(
         "--name",
         container_name,
     ]
-    for port in CARLA_PORTS:
+    for port in (rpc_port, rpc_port + 1, rpc_port + 2):
         command.extend(["-p", f"{port}:{port}"])
     command.extend(
         [
@@ -111,7 +126,7 @@ def build_carla_server_container_command(
 def check_carla_runtime_ports(
     ports: tuple[int, ...] = CARLA_PORTS,
     *,
-    host: str = CARLA_DEFAULT_HOST,
+    host: str = "",
 ) -> list[int]:
     """Return CARLA host ports that cannot be bound before container startup."""
 
@@ -365,7 +380,7 @@ def run_carla_docker_runtime_smoke(
                 summary["status"] = "connected"
                 summary["reason"] = "Python client connected to the pinned CARLA Docker server"
                 return summary
-            except (AttributeError, OSError, RuntimeError, TimeoutError) as exc:
+            except Exception as exc:  # noqa: BLE001 - CARLA client may raise custom API errors.
                 last_error = exc
                 if time.monotonic() >= deadline:
                     summary["status"] = "failed"

--- a/tests/carla_bridge/test_docker_runtime.py
+++ b/tests/carla_bridge/test_docker_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -36,6 +37,72 @@ def test_build_carla_server_container_command_maps_ports_and_runs_headless() -> 
     assert "carlasim/carla:0.9.16" in command
     assert "-RenderOffScreen" in " ".join(command)
     assert "-carla-rpc-port=2000" in " ".join(command)
+
+
+def test_build_carla_server_container_command_derives_ports_from_rpc_port() -> None:
+    """Custom RPC ports should keep Docker mappings and CARLA startup args aligned."""
+    from robot_sf_carla_bridge.docker_runtime import build_carla_server_container_command
+
+    command = build_carla_server_container_command(rpc_port=2100)
+
+    assert "2100:2100" in command
+    assert "2101:2101" in command
+    assert "2102:2102" in command
+    assert "2000:2000" not in command
+    assert "-carla-rpc-port=2100" in " ".join(command)
+
+
+def test_run_command_reports_missing_executable_without_traceback() -> None:
+    """Host prerequisite probes should fail closed when a binary is absent."""
+    from robot_sf_carla_bridge.docker_runtime import run_command
+
+    result = run_command(["robot-sf-missing-cmd-for-test"], timeout_s=0.1)
+
+    assert result.returncode == 127
+    assert result.stdout == ""
+    assert result.stderr == "Command not found: robot-sf-missing-cmd-for-test"
+
+
+def test_run_command_reports_timeout_without_traceback(monkeypatch) -> None:
+    """Hung host commands should become machine-readable command results."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.docker_runtime import run_command
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["docker", "version"], timeout=3.5)
+
+    monkeypatch.setattr(docker_runtime.subprocess, "run", fake_run)
+
+    result = run_command(["docker", "version"], timeout_s=3.5)
+
+    assert result.returncode == 124
+    assert result.stdout == ""
+    assert result.stderr == "Command timed out after 3.5s"
+
+
+def test_check_carla_runtime_ports_defaults_to_all_interfaces(monkeypatch) -> None:
+    """The preflight check should match Docker's all-interface port binding behavior."""
+    from robot_sf_carla_bridge import docker_runtime
+
+    bind_calls: list[tuple[str, int]] = []
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def setsockopt(self, *args) -> None:
+            return None
+
+        def bind(self, address: tuple[str, int]) -> None:
+            bind_calls.append(address)
+
+    monkeypatch.setattr(docker_runtime.socket, "socket", lambda *args, **kwargs: FakeSocket())
+
+    assert docker_runtime.check_carla_runtime_ports((2000,)) == []
+    assert bind_calls == [("", 2000)]
 
 
 def test_preflight_reports_not_available_when_docker_daemon_is_unreachable() -> None:

--- a/tests/carla_bridge/test_docker_runtime.py
+++ b/tests/carla_bridge/test_docker_runtime.py
@@ -17,6 +17,10 @@ def test_carla_docker_runtime_uses_pinned_0_9_16_image() -> None:
 
     with pytest.raises(ValueError, match="must be pinned"):
         validate_carla_image("carlasim/carla:latest")
+    with pytest.raises(ValueError, match="carlasim/carla:0.9.16"):
+        validate_carla_image("carlasim/carla:0.9.15")
+    with pytest.raises(ValueError, match="carlasim/carla:0.9.16"):
+        validate_carla_image("localhost:5000/carlasim/carla")
 
 
 def test_build_carla_server_container_command_maps_ports_and_runs_headless() -> None:
@@ -143,7 +147,7 @@ def test_preflight_requires_50_gib_free_before_pull_when_image_absent(monkeypatc
                 "",
             )
         ),
-        ("docker", "run", "--rm", "--gpus", "all"): CommandResult(
+        ("docker", "run", "--rm", "--pull=never", "--gpus", "all"): CommandResult(
             ["docker", "run"],
             0,
             "NVIDIA-SMI 580.142\n",
@@ -178,6 +182,92 @@ def test_preflight_requires_50_gib_free_before_pull_when_image_absent(monkeypatc
     assert status["missing_capability"] == "docker-storage"
     assert "50 GiB" in status["reason"]
     assert status["docker_storage"]["free_gib"] == pytest.approx(49.0)
+
+
+def test_preflight_nvidia_container_check_does_not_pull_test_image() -> None:
+    """NVIDIA runtime probing should not download CUDA images unless explicitly prepared."""
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    observed_commands: list[list[str]] = []
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        observed_commands.append(command)
+        if command[:2] == ["docker", "version"]:
+            return CommandResult(command, 0, '{"Server": {}}', "")
+        if command[:1] == ["nvidia-smi"]:
+            return CommandResult(command, 0, "NVIDIA GeForce RTX 3080, 580.142, 10240 MiB\n", "")
+        if command[:2] == ["docker", "run"]:
+            return CommandResult(command, 1, "", "pull access denied")
+        raise AssertionError(f"unexpected command: {command}")
+
+    status = run_carla_docker_preflight(runner=fake_runner, require_carla_api=False)
+
+    docker_run = next(command for command in observed_commands if command[:2] == ["docker", "run"])
+    assert "--pull=never" in docker_run
+    assert status["status"] == "not-available"
+    assert status["missing_capability"] == "nvidia-container-toolkit"
+
+
+def test_preflight_fails_when_post_pull_image_inspect_fails(monkeypatch) -> None:
+    """Pulled images should not be marked available until metadata inspection succeeds."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    image_inspect_count = 0
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        nonlocal image_inspect_count
+        if command[:2] == ["docker", "version"]:
+            return CommandResult(command, 0, '{"Server": {}}', "")
+        if command[:1] == ["nvidia-smi"]:
+            return CommandResult(command, 0, "NVIDIA GeForce RTX 3080, 580.142, 10240 MiB\n", "")
+        if command[:2] == ["docker", "run"]:
+            return CommandResult(command, 0, "NVIDIA-SMI 580.142\n", "")
+        if command[:3] == ["docker", "image", "inspect"]:
+            image_inspect_count += 1
+            return CommandResult(command, 1, "", "No such image metadata")
+        if command[:2] == ["docker", "info"]:
+            return CommandResult(command, 0, '"/var/lib/docker"\n', "")
+        if command[:2] == ["docker", "pull"]:
+            return CommandResult(command, 0, "pulled\n", "")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(
+        docker_runtime.shutil, "disk_usage", lambda path: (100, 80 * 1024**3, 80 * 1024**3)
+    )
+    monkeypatch.setattr(docker_runtime, "check_carla_runtime_ports", lambda ports: [])
+
+    status = run_carla_docker_preflight(runner=fake_runner, pull=True, require_carla_api=False)
+
+    assert image_inspect_count == 2
+    assert status["status"] == "not-available"
+    assert status["missing_capability"] == "carla-image"
+    assert status["checks"][-1]["name"] == "carla_image_inspect"
+
+
+def test_preflight_requires_image_digest_and_size(monkeypatch) -> None:
+    """Image metadata without digest or size should fail before runtime evidence is trusted."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        if command[:2] == ["docker", "version"]:
+            return CommandResult(command, 0, '{"Server": {}}', "")
+        if command[:1] == ["nvidia-smi"]:
+            return CommandResult(command, 0, "NVIDIA GeForce RTX 3080, 580.142, 10240 MiB\n", "")
+        if command[:2] == ["docker", "run"]:
+            return CommandResult(command, 0, "NVIDIA-SMI 580.142\n", "")
+        if command[:3] == ["docker", "image", "inspect"]:
+            return CommandResult(command, 0, json.dumps([{"RepoDigests": [], "Size": None}]), "")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(docker_runtime, "check_carla_runtime_ports", lambda ports: [])
+
+    status = run_carla_docker_preflight(runner=fake_runner, require_carla_api=False)
+
+    assert status["status"] == "not-available"
+    assert status["missing_capability"] == "carla-image"
+    assert "missing digest or size" in status["reason"]
 
 
 def test_build_carla_client_health_summary_records_versions_and_map(monkeypatch) -> None:
@@ -289,4 +379,44 @@ def test_runtime_smoke_stops_container_when_health_check_fails(monkeypatch) -> N
     assert summary["reason"] == "client failed"
     assert summary["container"]["id"] == "container-123"
     assert summary["logs_tail"] == "log tail\n"
+    assert any(command[:2] == ["docker", "stop"] for command in commands)
+
+
+def test_runtime_smoke_attempts_cleanup_when_container_start_fails(monkeypatch) -> None:
+    """Startup failures should still produce log-tail and cleanup evidence."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_runtime_smoke
+
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        commands.append(command)
+        if command[:2] == ["docker", "run"]:
+            return CommandResult(command, 1, "", "startup failed")
+        if command[:2] == ["docker", "logs"]:
+            return CommandResult(command, 1, "", "no logs")
+        if command[:2] == ["docker", "stop"]:
+            return CommandResult(command, 1, "", "no such container")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(
+        docker_runtime,
+        "run_carla_docker_preflight",
+        lambda **kwargs: {
+            "schema_version": "carla-docker-runtime.v1",
+            "status": "available",
+            "reason": "CARLA Docker runtime prerequisites are available",
+            "image": "carlasim/carla:0.9.16",
+            "image_digest": "sha256:abc",
+            "checks": [],
+        },
+    )
+
+    summary = run_carla_docker_runtime_smoke(runner=fake_runner)
+
+    assert summary["status"] == "failed"
+    assert summary["reason"] == "Failed to start pinned CARLA server container"
+    assert summary["stderr"] == "startup failed"
+    assert summary["logs_tail"] == "no logs"
+    assert summary["cleanup"]["stderr"] == "no such container"
     assert any(command[:2] == ["docker", "stop"] for command in commands)

--- a/tests/carla_bridge/test_docker_runtime.py
+++ b/tests/carla_bridge/test_docker_runtime.py
@@ -1,0 +1,225 @@
+"""CARLA-free tests for the pinned Docker runtime interface."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_carla_docker_runtime_uses_pinned_0_9_16_image() -> None:
+    """The runtime contract should never default to CARLA latest."""
+    from robot_sf_carla_bridge.docker_runtime import CARLA_DOCKER_IMAGE, validate_carla_image
+
+    assert CARLA_DOCKER_IMAGE == "carlasim/carla:0.9.16"
+
+    with pytest.raises(ValueError, match="must be pinned"):
+        validate_carla_image("carlasim/carla:latest")
+
+
+def test_build_carla_server_container_command_maps_ports_and_runs_headless() -> None:
+    """The server command should expose CARLA ports explicitly and run offscreen."""
+    from robot_sf_carla_bridge.docker_runtime import build_carla_server_container_command
+
+    command = build_carla_server_container_command(container_name="robot-sf-carla-test")
+
+    assert command[:4] == ["docker", "run", "--rm", "--detach"]
+    assert "--gpus" in command
+    assert command[command.index("--gpus") + 1] == "all"
+    assert "--name" in command
+    assert command[command.index("--name") + 1] == "robot-sf-carla-test"
+    assert "-p" in command
+    assert "2000:2000" in command
+    assert "2001:2001" in command
+    assert "2002:2002" in command
+    assert "carlasim/carla:0.9.16" in command
+    assert "-RenderOffScreen" in " ".join(command)
+    assert "-carla-rpc-port=2000" in " ".join(command)
+
+
+def test_preflight_reports_not_available_when_docker_daemon_is_unreachable() -> None:
+    """No-sudo Docker daemon failure should stop before GPU/image/runtime work."""
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        assert command[:2] == ["docker", "version"]
+        assert timeout_s > 0
+        return CommandResult(
+            args=command,
+            returncode=1,
+            stdout='{"Client": {"Version": "29.4.2"}, "Server": null}',
+            stderr="permission denied while trying to connect to the docker API",
+        )
+
+    status = run_carla_docker_preflight(runner=fake_runner)
+
+    assert status["status"] == "not-available"
+    assert status["reason"] == "Docker daemon is not reachable without sudo"
+    assert status["missing_capability"] == "docker-daemon"
+    assert status["checks"][0]["name"] == "docker_daemon"
+    assert status["checks"][0]["status"] == "not-available"
+
+
+def test_preflight_requires_50_gib_free_before_pull_when_image_absent(monkeypatch) -> None:
+    """Absent images should fail before pull when Docker storage has too little free space."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    responses = {
+        ("docker", "version"): CommandResult(["docker", "version"], 0, '{"Server": {}}', ""),
+        ("nvidia-smi", "--query-gpu=name,driver_version,memory.total", "--format=csv,noheader"): (
+            CommandResult(
+                ["nvidia-smi"],
+                0,
+                "NVIDIA GeForce RTX 3080, 580.142, 10240 MiB\n",
+                "",
+            )
+        ),
+        ("docker", "run", "--rm", "--gpus", "all"): CommandResult(
+            ["docker", "run"],
+            0,
+            "NVIDIA-SMI 580.142\n",
+            "",
+        ),
+        ("docker", "image", "inspect", "carlasim/carla:0.9.16"): CommandResult(
+            ["docker", "image", "inspect"],
+            1,
+            "",
+            "No such image",
+        ),
+        ("docker", "info", "--format", "{{json .DockerRootDir}}"): CommandResult(
+            ["docker", "info"],
+            0,
+            '"/var/lib/docker"\n',
+            "",
+        ),
+    }
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        for prefix, result in responses.items():
+            if tuple(command[: len(prefix)]) == prefix:
+                return result
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(docker_runtime.shutil, "disk_usage", lambda path: (100, 100, 49 * 1024**3))
+    monkeypatch.setattr(docker_runtime, "check_carla_runtime_ports", lambda ports: [])
+
+    status = run_carla_docker_preflight(runner=fake_runner, require_carla_api=False)
+
+    assert status["status"] == "not-available"
+    assert status["missing_capability"] == "docker-storage"
+    assert "50 GiB" in status["reason"]
+    assert status["docker_storage"]["free_gib"] == pytest.approx(49.0)
+
+
+def test_build_carla_client_health_summary_records_versions_and_map(monkeypatch) -> None:
+    """Health checks should summarize live client/server/map state without replay claims."""
+    from robot_sf_carla_bridge import docker_runtime
+
+    class FakeClient:
+        """Small fake for the subset of the CARLA client API used by the health check."""
+
+        def __init__(self, host: str, port: int) -> None:
+            self.host = host
+            self.port = port
+            self.timeout = None
+
+        def set_timeout(self, timeout_s: float) -> None:
+            self.timeout = timeout_s
+
+        def get_client_version(self) -> str:
+            return "0.9.16"
+
+        def get_server_version(self) -> str:
+            return "0.9.16"
+
+        def get_world(self):
+            return SimpleNamespace(get_map=lambda: SimpleNamespace(name="Town01"))
+
+    fake_carla = SimpleNamespace(Client=FakeClient)
+    monkeypatch.setattr(docker_runtime, "require_carla", lambda: fake_carla)
+
+    summary = docker_runtime.build_carla_client_health_summary(host="127.0.0.1", port=2000)
+
+    assert summary == {
+        "status": "connected",
+        "host": "127.0.0.1",
+        "port": 2000,
+        "client_version": "0.9.16",
+        "server_version": "0.9.16",
+        "map": "Town01",
+        "boundary": "client-connectivity-only",
+    }
+
+
+def test_carla_docker_runtime_cli_prints_preflight_json(monkeypatch, capsys) -> None:
+    """The packaged CLI should expose a machine-readable preflight status."""
+    import robot_sf_carla_bridge.cli as cli_module
+    from robot_sf_carla_bridge.cli import carla_docker_runtime_main
+
+    monkeypatch.setattr(
+        cli_module,
+        "run_carla_docker_preflight",
+        lambda **kwargs: {
+            "schema_version": "carla-docker-runtime.v1",
+            "status": "not-available",
+            "reason": "Docker daemon is not reachable without sudo",
+            "image": "carlasim/carla:0.9.16",
+            "checks": [],
+        },
+    )
+
+    exit_code = carla_docker_runtime_main(["preflight", "--json"])
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out)["image"] == "carlasim/carla:0.9.16"
+
+
+def test_runtime_smoke_stops_container_when_health_check_fails(monkeypatch) -> None:
+    """Lifecycle failures should still collect logs and remove the CARLA container."""
+    from robot_sf_carla_bridge import docker_runtime
+    from robot_sf_carla_bridge.availability import CarlaUnavailableError
+    from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_runtime_smoke
+
+    commands: list[list[str]] = []
+
+    def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
+        commands.append(command)
+        if command[:2] == ["docker", "run"]:
+            return CommandResult(command, 0, "container-123\n", "")
+        if command[:2] == ["docker", "logs"]:
+            return CommandResult(command, 0, "log tail\n", "")
+        if command[:2] == ["docker", "stop"]:
+            return CommandResult(command, 0, "container-123\n", "")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(
+        docker_runtime,
+        "run_carla_docker_preflight",
+        lambda **kwargs: {
+            "schema_version": "carla-docker-runtime.v1",
+            "status": "available",
+            "reason": "CARLA Docker runtime prerequisites are available",
+            "image": "carlasim/carla:0.9.16",
+            "image_digest": "sha256:abc",
+            "checks": [],
+        },
+    )
+    monkeypatch.setattr(
+        docker_runtime,
+        "build_carla_client_health_summary",
+        lambda **kwargs: (_ for _ in ()).throw(CarlaUnavailableError("client failed")),
+    )
+
+    summary = run_carla_docker_runtime_smoke(
+        runner=fake_runner,
+        startup_timeout_s=0,
+        retry_interval_s=0,
+    )
+
+    assert summary["status"] == "failed"
+    assert summary["reason"] == "client failed"
+    assert summary["container"]["id"] == "container-123"
+    assert summary["logs_tail"] == "log tail\n"
+    assert any(command[:2] == ["docker", "stop"] for command in commands)

--- a/tests/carla_bridge/test_t0_export_cli.py
+++ b/tests/carla_bridge/test_t0_export_cli.py
@@ -417,6 +417,9 @@ def test_export_t0_cli_is_packaged_as_project_script() -> None:
     assert pyproject["project"]["scripts"]["robot-sf-carla-t1-oracle-smoke"] == (
         "robot_sf_carla_bridge.cli:replay_t1_oracle_smoke_main"
     )
+    assert pyproject["project"]["scripts"]["robot-sf-carla-docker-runtime"] == (
+        "robot_sf_carla_bridge.cli:carla_docker_runtime_main"
+    )
     hatchling_packages = pyproject["tool"]["hatchling"]["build"]["targets"]["wheel"]["packages"]
     assert {"include": "robot_sf_carla_bridge"} in hatchling_packages
     assert (


### PR DESCRIPTION
## Summary
Adds an opt-in CARLA Docker runtime interface for pinned `carlasim/carla:0.9.16`, including host preflight, explicit CARLA port mappings, lifecycle cleanup, and client health-check reporting without making CARLA a normal dependency.

## Linked Issues
- Closes #1179
- Relates to #872
- Relates to #1111
- Relates to #1169

## What Changed
- Added `robot_sf_carla_bridge/docker_runtime.py` with pinned image validation, Docker/NVIDIA/platform/port/storage/API preflight, headless server command construction, live client health summary, log-tail capture, and cleanup.
- Added `robot-sf-carla-docker-runtime` with `preflight` and `smoke` subcommands.
- Added CARLA-free unit coverage for pinned image rejection, no-sudo Docker diagnostics, disk threshold behavior, health-check summary shape, CLI JSON output, and cleanup on smoke failure.
- Added `docs/context/issue_1179_carla_docker_runtime.md` and linked it from the docs indexes.

## Why It Matters
- Added value: turns vague CARLA-capable host setup into a concrete, reproducible runtime contract.
- Expected impact: #1169 can depend on a preflight/smoke command instead of mixing Docker/NVIDIA/runtime failures with replay semantics.
- Why now: #1179 is the runtime substrate blocker for live CARLA replay work.

## Validation / Proof
- `rtk uv run pytest tests/carla_bridge/test_docker_runtime.py -q` -> `7 passed`
- `rtk uv run pytest tests/carla_bridge/test_runtime.py tests/carla_bridge/test_t1_replay_smoke.py tests/carla_bridge/test_docker_runtime.py -q` -> `14 passed`
- `rtk uv run pytest tests/carla_bridge -q` -> `71 passed`
- `rtk uv run ruff check robot_sf_carla_bridge tests/carla_bridge/test_docker_runtime.py tests/carla_bridge/test_t0_export_cli.py` -> passed
- `rtk uv run ruff format --check robot_sf_carla_bridge tests/carla_bridge/test_docker_runtime.py tests/carla_bridge/test_t0_export_cli.py` -> passed
- `rtk bash -lc 'BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh'` -> passed
- `rtk uv pip install --dry-run 'carla==0.9.16'` -> resolved and would install; package was not installed into the repo env
- `rtk uv run robot-sf-carla-docker-runtime preflight --skip-api-check --json` -> fail-closed `not-available`, `missing_capability: docker-daemon`
- Final synced gate: `rtk bash -lc 'PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> `3702 passed, 10 skipped`, TODO-docstring ratchet passed

## Risks / Rollout
- Compatibility risks: live CARLA startup still depends on Linux x86_64, Docker daemon access without sudo, NVIDIA GPU visibility, NVIDIA Container Toolkit, free ports `2000-2002`, and host-side `carla==0.9.16`.
- Failure modes: unsupported hosts return `not-available`; container startup/client failures return `failed` and still attempt log capture plus `docker stop`.
- Rollback or fallback plan: the feature is opt-in and only exposed through the CARLA bridge package/CLI; normal non-CARLA imports remain CARLA-free.

## Docs / Provenance
- Updated docs: `docs/context/issue_1179_carla_docker_runtime.md`, `docs/context/README.md`, `docs/README.md`
- Relevant design or provenance notes: preserves #1179 Option A client placement and explicit `2000-2002` port-mapping decisions.
- Artifact decision: validation generated ignored `output/coverage/` files only; no generated CARLA image, benchmark bundle, model checkpoint, or durable runtime artifact was produced on this host.

## Follow-Up Issues
- Deferred work: run `robot-sf-carla-docker-runtime smoke --pull --json` on a Docker/NVIDIA-capable host and use the result to continue #1169 live replay work.
- Issues opened for follow-up: none; #1169 already tracks true live replay semantics and #1111 tracks setup-only host proof.

## Reviewer Notes
- Please check that `docker_runtime.py` stays import-safe without CARLA and that the `smoke` command cleanup path cannot skip `docker stop` after a client health-check failure.
- Known limitation: this host cannot access `/var/run/docker.sock`, so the PR records concrete `docker-daemon` not-available evidence rather than live CARLA image digest/client-server proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CARLA Docker Runtime CLI tool with `preflight` subcommand for host prerequisite validation and `smoke` subcommand for runtime connectivity testing.
  * Supports both human-readable and JSON output formats.

* **Documentation**
  * Added CARLA Docker Runtime documentation covering configuration, validation steps, and integration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->