### PR TITLE
docs: prefer sibling worktree containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,16 @@ Execution rules:
 
 When working in a linked Git worktree, detect bootstrap state before running expensive commands.
 
+- For manually created worktrees, prefer a sibling container next to the main checkout instead of a
+  directory inside the repository. Use `<repo-name>.worktrees/<branch-or-issue-slug>`; for this
+  checkout, that means paths like
+  `/home/luttkule/git/robot_sf_ll7.worktrees/issue-123-short-description`.
+- Honor an explicit user or native-tool worktree location first. If no preference is given, prefer
+  an existing sibling `../robot_sf_ll7.worktrees/` container, then an existing project-local
+  `.worktrees/` or `worktrees/` container only when it is already established and ignored. Default
+  new manual worktree containers to the sibling `../robot_sf_ll7.worktrees/` path.
+- Name branch/worktree directories with the issue number and a short feature slug when possible,
+  for example `issue-123-short-description`.
 - Treat the checkout as a linked worktree when `.git` is a file pointing into `.git/worktrees/...`,
   or when `git rev-parse --git-common-dir` resolves to a different path than
   `git rev-parse --git-dir`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ When working in a linked Git worktree, detect bootstrap state before running exp
 - For manually created worktrees, prefer a sibling container next to the main checkout instead of a
   directory inside the repository. Use `<repo-name>.worktrees/<branch-or-issue-slug>`; for this
   checkout, that means paths like
-  `/home/luttkule/git/robot_sf_ll7.worktrees/issue-123-short-description`.
+  `../robot_sf_ll7.worktrees/issue-123-short-description`.
 - Honor an explicit user or native-tool worktree location first. If no preference is given, prefer
   an existing sibling `../robot_sf_ll7.worktrees/` container, then an existing project-local
   `.worktrees/` or `worktrees/` container only when it is already established and ignored. Default

--- a/docs/context/slurm_multi_worktree_branch_workflow.md
+++ b/docs/context/slurm_multi_worktree_branch_workflow.md
@@ -16,11 +16,12 @@ Create one worktree per active branch:
 
 ```bash
 cd /home/luttkule/git/robot_sf_ll7
+mkdir -p ../robot_sf_ll7.worktrees
 git fetch origin codex/193-feature-extractor-evaluation
 git worktree add -b codex/193-feature-extractor-evaluation \
-  ../robot_sf_ll7_193_feature_extractor \
+  ../robot_sf_ll7.worktrees/codex-193-feature-extractor-evaluation \
   origin/codex/193-feature-extractor-evaluation
-cd ../robot_sf_ll7_193_feature_extractor
+cd ../robot_sf_ll7.worktrees/codex-193-feature-extractor-evaluation
 ```
 
 If the local branch already exists, omit `-b codex/193-feature-extractor-evaluation` and pass the
@@ -62,11 +63,11 @@ started or copied its run files.
 When the same machine policy should apply to every worktree on the same host, symlink it:
 
 ```bash
-ln -s ../robot_sf_ll7/local.machine.md ../robot_sf_ll7_193_feature_extractor/local.machine.md
+ln -s /home/luttkule/git/robot_sf_ll7/local.machine.md local.machine.md
 ```
 
-Use a relative symlink when both worktrees live under the same parent directory. If the target
-worktree lives elsewhere, use an absolute path instead.
+Use an absolute symlink when the sibling container adds another path segment, as shown above. If
+both worktrees live directly under the same parent directory, a relative symlink is also fine.
 
 ## Virtual Environment Boundary
 

--- a/docs/context/slurm_multi_worktree_branch_workflow.md
+++ b/docs/context/slurm_multi_worktree_branch_workflow.md
@@ -15,7 +15,7 @@ there is to use the node for lightweight orchestration only and submit real comp
 Create one worktree per active branch:
 
 ```bash
-cd /home/luttkule/git/robot_sf_ll7
+cd ~/git/robot_sf_ll7
 mkdir -p ../robot_sf_ll7.worktrees
 git fetch origin codex/193-feature-extractor-evaluation
 git worktree add -b codex/193-feature-extractor-evaluation \
@@ -63,11 +63,11 @@ started or copied its run files.
 When the same machine policy should apply to every worktree on the same host, symlink it:
 
 ```bash
-ln -s /home/luttkule/git/robot_sf_ll7/local.machine.md local.machine.md
+ln -s ../../robot_sf_ll7/local.machine.md local.machine.md
 ```
 
-Use an absolute symlink when the sibling container adds another path segment, as shown above. If
-both worktrees live directly under the same parent directory, a relative symlink is also fine.
+Use a relative symlink with `../../` when the sibling container adds another path segment, as shown
+above. If both worktrees live directly under the same parent directory, a single `../` is also fine.
 
 ## Virtual Environment Boundary
 

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -60,7 +60,7 @@ Git worktree per branch. Submit from the worktree whose branch, configs, and SLU
 be used by the job:
 
 ```bash
-cd /home/luttkule/git/robot_sf_ll7
+cd ~/git/robot_sf_ll7
 mkdir -p ../robot_sf_ll7.worktrees
 git fetch origin codex/193-feature-extractor-evaluation
 git worktree add -b codex/193-feature-extractor-evaluation \
@@ -82,7 +82,7 @@ waiting.
 worktree, symlink it from the original checkout:
 
 ```bash
-ln -s /home/luttkule/git/robot_sf_ll7/local.machine.md local.machine.md
+ln -s ../../robot_sf_ll7/local.machine.md local.machine.md
 ```
 
 Keep `.venv` branch-local unless the branches are known to have identical dependencies; most SLURM

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -61,11 +61,12 @@ be used by the job:
 
 ```bash
 cd /home/luttkule/git/robot_sf_ll7
+mkdir -p ../robot_sf_ll7.worktrees
 git fetch origin codex/193-feature-extractor-evaluation
 git worktree add -b codex/193-feature-extractor-evaluation \
-  ../robot_sf_ll7_193_feature_extractor \
+  ../robot_sf_ll7.worktrees/codex-193-feature-extractor-evaluation \
   origin/codex/193-feature-extractor-evaluation
-cd ../robot_sf_ll7_193_feature_extractor
+cd ../robot_sf_ll7.worktrees/codex-193-feature-extractor-evaluation
 scripts/dev/sbatch_use_max_time.sh SLURM/feature_extractor_comparison/run_comparison.slurm
 ```
 
@@ -81,7 +82,7 @@ waiting.
 worktree, symlink it from the original checkout:
 
 ```bash
-ln -s ../robot_sf_ll7/local.machine.md ../robot_sf_ll7_193_feature_extractor/local.machine.md
+ln -s /home/luttkule/git/robot_sf_ll7/local.machine.md local.machine.md
 ```
 
 Keep `.venv` branch-local unless the branches are known to have identical dependencies; most SLURM

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -31,7 +31,7 @@ uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_en
 
 When creating a new linked worktree, prefer a sibling container next to the main checkout rather
 than a directory inside the repository. For this checkout, use
-`/home/luttkule/git/robot_sf_ll7.worktrees/<branch-or-issue-slug>` unless a user or native tool
+`../robot_sf_ll7.worktrees/<branch-or-issue-slug>` unless a user or native tool
 chooses another location. Keep issue work readable with names such as
 `issue-123-short-description`.
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -29,8 +29,27 @@ uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_en
 
 ### Fresh linked-worktree bootstrap
 
-When creating a new linked worktree, bootstrap the local machine context before using Python tools.
-You can detect a linked worktree because `.git` is a file that points into
+When creating a new linked worktree, prefer a sibling container next to the main checkout rather
+than a directory inside the repository. For this checkout, use
+`/home/luttkule/git/robot_sf_ll7.worktrees/<branch-or-issue-slug>` unless a user or native tool
+chooses another location. Keep issue work readable with names such as
+`issue-123-short-description`.
+
+Example manual creation from the main checkout:
+
+```bash
+MAIN_REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_PARENT="$(dirname "$MAIN_REPO_ROOT")/$(basename "$MAIN_REPO_ROOT").worktrees"
+mkdir -p "$WORKTREE_PARENT"
+git fetch origin main
+git worktree add -b issue-123-short-description \
+  "$WORKTREE_PARENT/issue-123-short-description" \
+  origin/main
+cd "$WORKTREE_PARENT/issue-123-short-description"
+```
+
+Bootstrap the local machine context before using Python tools. You can detect a linked worktree
+because `.git` is a file that points into
 `<main checkout>/.git/worktrees/<worktree-name>`, and `git rev-parse --git-common-dir` resolves to
 the main checkout's `.git` directory instead of the worktree-local Git dir.
 


### PR DESCRIPTION
## Summary
Updates the repository worktree guidance to prefer sibling worktree containers such as
`robot_sf_ll7.worktrees/<branch-or-issue-slug>` instead of project-local `.worktrees/` by default.

## Linked Issues
- No linked issue; user-requested instruction cleanup.

## What Changed
- Added explicit sibling-container preference to `AGENTS.md`.
- Added a concrete manual worktree creation example to `docs/dev_guide.md`.
- Aligned SLURM multi-worktree examples with the sibling `robot_sf_ll7.worktrees/` convention.
- Addressed review feedback by replacing username-specific absolute paths with portable relative examples.

## Why It Matters
- Added value: keeps generated worktree checkouts outside the repository tree by default.
- Expected impact: reduces IDE/search/test-discovery surprises from nested repository directories.
- Why this is worth merging now: it codifies the worktree convention before more agent workflows
  depend on the older project-local fallback.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
- Evidence that the change works here:
  - PR readiness passed on commit `e51be76edbb744b2d5cb9497e3546b3f5c90e4b4`.
  - Test result: `3709 passed, 11 skipped, 3 warnings in 427.14s`.
  - CodeRabbit commit status is passing on the updated head.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; documentation-only change.

## Risks / Rollout
- Compatibility risks: existing project-local `.worktrees/` users can keep using it when already
  established and ignored.
- Failure modes: agents may still follow older external/plugin guidance until it is updated.
- Rollback or fallback plan: revert the docs-only commits.

## Docs / Provenance
- Updated docs:
  - `AGENTS.md`
  - `docs/dev_guide.md`
  - `docs/dev/slurm_submission.md`
  - `docs/context/slurm_multi_worktree_branch_workflow.md`
- Relevant design or provenance notes:
  - The change is based on the maintainer preference for sibling worktrees over nested
    repository-local worktrees.
- Any assumptions that need to be preserved:
  - Native worktree tools and explicit user preferences still override the default location.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the precedence order in `AGENTS.md` and the path examples in the SLURM docs for consistency.
- Generated ignored artifacts under `output/` are local validation byproducts only:
  coverage output, the PR readiness stamp, and test-generated predictive planner smoke/model-cache
  files. None are durable dependencies for this docs-only PR.