### PR TITLE
perf: cache RobotEnv occupancy grid obstacles

### DIFF
--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -1238,13 +1238,19 @@ class RobotEnv(BaseEnv):
         """
 
         cache_key = (id(self.map_def), id(self.map_def.obstacles), id(self.map_def.bounds))
-        if self._grid_obstacle_cache_key != cache_key or self._grid_obstacle_cache_value is None:
-            self._grid_obstacle_cache_value = self._normalize_obstacles_for_grid(
-                self.map_def.obstacles,
-                self.map_def.bounds,
-            )
-            self._grid_obstacle_cache_key = cache_key
-        return self._grid_obstacle_cache_value
+        if (
+            self._grid_obstacle_cache_key == cache_key
+            and self._grid_obstacle_cache_value is not None
+        ):
+            return self._grid_obstacle_cache_value
+
+        value = self._normalize_obstacles_for_grid(
+            self.map_def.obstacles,
+            self.map_def.bounds,
+        )
+        self._grid_obstacle_cache_key = cache_key
+        self._grid_obstacle_cache_value = value
+        return value
 
     def _prepare_visualizable_state(self):
         """Build a renderer-friendly simulation snapshot from the current environment state.

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -71,6 +71,8 @@ _TELEMETRY_ANALYZER_STEP_METRIC_KEYS: tuple[str, ...] = (
     "jerk_mean",
 )
 _ASYMMETRIC_CRITIC_STATE_KEY = "critic_privileged_state"
+_GridObstacleCacheKey = tuple[int, int, int]
+_GridObstacleCacheValue = tuple[list[Line2D], list[ShapelyPolygon]]
 
 
 @contextmanager
@@ -670,6 +672,8 @@ class RobotEnv(BaseEnv):
         self._frame_idx = 0
         self._telemetry_episode_id = -1
         self._snqi_proxy_state = _StepSNQIProxyState()
+        self._grid_obstacle_cache_key: _GridObstacleCacheKey | None = None
+        self._grid_obstacle_cache_value: _GridObstacleCacheValue | None = None
         self._prime_snqi_proxy_state()
 
     def _prime_snqi_proxy_state(self) -> None:
@@ -947,10 +951,7 @@ class RobotEnv(BaseEnv):
 
         # T044: Update occupancy grid if enabled
         if self.occupancy_grid is not None:
-            # Extract obstacles from map
-            obstacles, obstacle_polygons = self._normalize_obstacles_for_grid(
-                self.map_def.obstacles, self.map_def.bounds
-            )
+            obstacles, obstacle_polygons = self._get_static_grid_obstacles()
             # Extract updated pedestrian positions and radii
             ped_positions = self.simulator.ped_pos
             ped_radii = getattr(self.simulator, "ped_radii", None)
@@ -1052,10 +1053,8 @@ class RobotEnv(BaseEnv):
 
             # T043: Generate initial occupancy grid if enabled
             if self.occupancy_grid is not None:
-                # Extract obstacles from map
-                obstacles, obstacle_polygons = self._normalize_obstacles_for_grid(
-                    self.map_def.obstacles, self.map_def.bounds
-                )
+                self._clear_grid_obstacle_cache()
+                obstacles, obstacle_polygons = self._get_static_grid_obstacles()
                 # Extract pedestrian positions and radii from simulator
                 ped_positions = self.simulator.ped_pos
                 ped_radii = getattr(self.simulator, "ped_radii", None)
@@ -1223,6 +1222,29 @@ class RobotEnv(BaseEnv):
             _add_line(bound)
 
         return line_segments, polygons
+
+    def _clear_grid_obstacle_cache(self) -> None:
+        """Invalidate cached static grid geometry before a new episode begins."""
+
+        self._grid_obstacle_cache_key = None
+        self._grid_obstacle_cache_value = None
+
+    def _get_static_grid_obstacles(self) -> _GridObstacleCacheValue:
+        """Return normalized static map geometry for occupancy-grid generation.
+
+        Map obstacle and bound objects are static during a RobotEnv episode, so step() can reuse the
+        reset-time normalized primitives. The identity key still refreshes the cache if a caller
+        swaps the map, obstacle list, or bounds list before the next grid generation.
+        """
+
+        cache_key = (id(self.map_def), id(self.map_def.obstacles), id(self.map_def.bounds))
+        if self._grid_obstacle_cache_key != cache_key or self._grid_obstacle_cache_value is None:
+            self._grid_obstacle_cache_value = self._normalize_obstacles_for_grid(
+                self.map_def.obstacles,
+                self.map_def.bounds,
+            )
+            self._grid_obstacle_cache_key = cache_key
+        return self._grid_obstacle_cache_value
 
     def _prepare_visualizable_state(self):
         """Build a renderer-friendly simulation snapshot from the current environment state.

--- a/tests/test_occupancy_gymnasium.py
+++ b/tests/test_occupancy_gymnasium.py
@@ -19,6 +19,7 @@ import pytest
 from gymnasium import spaces
 
 from robot_sf.gym_env.environment_factory import make_robot_env
+from robot_sf.gym_env.robot_env import RobotEnv
 from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.nav.occupancy_grid import GridChannel, GridConfig, OccupancyGrid
 
@@ -383,6 +384,52 @@ class TestEnvironmentResetWithGrid:
 
 class TestEnvironmentStepWithGridUpdate:
     """Test T039: Environment step with occupancy observation updates."""
+
+    def test_step_reuses_cached_static_obstacle_grid_inputs(self, monkeypatch):
+        """Verify static map geometry is normalized once per reset, not every step.
+
+        This protects occupancy-grid step throughput while preserving reset-time cache refresh for
+        future map changes between episodes.
+        """
+        grid_config = _make_grid_config(width_m=7.0, height_m=7.0, resolution=0.2)
+        config = RobotSimulationConfig(
+            use_occupancy_grid=True,
+            grid_config=grid_config,
+            include_grid_in_observation=True,
+        )
+        normalize_calls = 0
+        original_normalize = RobotEnv._normalize_obstacles_for_grid
+
+        def counting_normalize(obstacles, bounds):
+            """Count normalization calls while preserving the production conversion."""
+            nonlocal normalize_calls
+            normalize_calls += 1
+            return original_normalize(obstacles, bounds)
+
+        monkeypatch.setattr(
+            RobotEnv,
+            "_normalize_obstacles_for_grid",
+            staticmethod(counting_normalize),
+        )
+
+        env = make_robot_env(config=config, seed=42)
+        try:
+            env.reset(seed=42)
+            assert normalize_calls == 1
+
+            for _ in range(3):
+                env.step(env.action_space.sample())
+
+            assert normalize_calls == 1
+
+            env.map_def.obstacles = list(env.map_def.obstacles)
+            env._get_static_grid_obstacles()
+            assert normalize_calls == 2
+
+            env.reset(seed=123)
+            assert normalize_calls == 3
+        finally:
+            env.close()
 
     def test_step_updates_grid_observation(self):
         """Verify step() updates occupancy grid each timestep."""


### PR DESCRIPTION
## Summary

- Caches RobotEnv occupancy-grid obstacle normalization so repeated environment observations can reuse static obstacle work.
- Adds Gymnasium occupancy regression coverage for the cache behavior.

Closes #1312.

## Validation

- Not rerun during this PR-body backfill.
- Branch includes `tests/test_occupancy_gymnasium.py` for the RobotEnv occupancy cache contract.

## Notes

- Body backfilled on 2026-05-18 because the original body only contained an automated CodeRabbit release-note block. No code changes were made as part of this metadata repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced redundant normalization of static obstacle geometry to improve step() execution efficiency.

* **Tests**
  * Added integration test verifying static obstacle grid caching behavior and cache invalidation on environment reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->