### PR TITLE
perf: cache static occupancy grid layers

### DIFF
--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -447,7 +447,7 @@ class OccupancyGrid:
 
         signature: list[Any] = []
         for polygon in obstacle_polygons:
-            if isinstance(polygon, _ShapelyPolygon | _ShapelyMultiPolygon):
+            if isinstance(polygon, (_ShapelyPolygon, _ShapelyMultiPolygon)):
                 signature.append(("shapely", polygon.wkb))
                 continue
             try:

--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -90,6 +90,7 @@ from robot_sf.nav import occupancy_grid_utils as grid_utils
 OCCUPANCY_FREE_THRESHOLD = 0.05
 _PYGAME_UNLOADED = object()
 pygame: Any = _PYGAME_UNLOADED
+_StaticObstacleLayerCacheKey = tuple[Any, ...]
 
 
 def _load_pygame():
@@ -397,6 +398,8 @@ class OccupancyGrid:
         self._last_use_ego_frame: bool = False
         self._prepared_obstacles: list[PreparedGeometry] | None = None
         self._obstacle_polygons: list[Any] = []
+        self._static_obstacle_layer_cache_key: _StaticObstacleLayerCacheKey | None = None
+        self._static_obstacle_layer_cache: np.ndarray | None = None
 
         logger.debug(
             f"OccupancyGrid initialized: "
@@ -416,6 +419,117 @@ class OccupancyGrid:
             ) from exc
 
         return float(x), float(y), float(theta)
+
+    @staticmethod
+    def _line_cache_signature(obstacles: list[Line2D]) -> tuple[Any, ...]:
+        """Return a stable signature for obstacle line input."""
+
+        signature: list[Any] = []
+        for obstacle in obstacles:
+            try:
+                start, end = obstacle
+                signature.append(
+                    (
+                        (float(start[0]), float(start[1])),
+                        (float(end[0]), float(end[1])),
+                    )
+                )
+            except (TypeError, ValueError, IndexError):
+                signature.append(repr(obstacle))
+        return tuple(signature)
+
+    @staticmethod
+    def _polygon_cache_signature(obstacle_polygons: list[Any] | None) -> tuple[Any, ...]:
+        """Return a stable signature for optional filled obstacle geometry."""
+
+        if not obstacle_polygons:
+            return ()
+
+        signature: list[Any] = []
+        for polygon in obstacle_polygons:
+            if isinstance(polygon, _ShapelyPolygon | _ShapelyMultiPolygon):
+                signature.append(("shapely", polygon.wkb))
+                continue
+            try:
+                signature.append(tuple((float(vertex[0]), float(vertex[1])) for vertex in polygon))
+            except (TypeError, ValueError, IndexError):
+                signature.append(repr(polygon))
+        return tuple(signature)
+
+    def _build_static_obstacle_layer_cache_key(
+        self,
+        obstacles: list[Line2D],
+        obstacle_polygons: list[Any] | None,
+        grid_origin_x: float,
+        grid_origin_y: float,
+    ) -> _StaticObstacleLayerCacheKey:
+        """Build the cache key for fixed-origin world-frame obstacle layers.
+
+        Returns:
+            Tuple key describing grid geometry and static obstacle inputs.
+        """
+
+        return (
+            self.config.grid_height,
+            self.config.grid_width,
+            self.config.width,
+            self.config.height,
+            self.config.resolution,
+            np.dtype(self.config.dtype).str,
+            grid_origin_x,
+            grid_origin_y,
+            self._line_cache_signature(obstacles),
+            self._polygon_cache_signature(obstacle_polygons),
+        )
+
+    def _get_or_create_static_obstacle_layer(
+        self,
+        obstacles: list[Line2D],
+        obstacle_polygons: list[Any] | None,
+        grid_origin_x: float,
+        grid_origin_y: float,
+    ) -> np.ndarray:
+        """Return a cached fixed-origin obstacle layer, rasterizing on cache miss."""
+
+        cache_key = self._build_static_obstacle_layer_cache_key(
+            obstacles,
+            obstacle_polygons,
+            grid_origin_x,
+            grid_origin_y,
+        )
+        if (
+            self._static_obstacle_layer_cache_key == cache_key
+            and self._static_obstacle_layer_cache is not None
+        ):
+            logger.debug("Reused cached static obstacle layer")
+            return self._static_obstacle_layer_cache
+
+        layer = np.zeros((self.config.grid_height, self.config.grid_width), dtype=self.config.dtype)
+        num_rasterized = rasterization.rasterize_obstacles(
+            obstacles,
+            layer,
+            self.config,
+            grid_origin_x,
+            grid_origin_y,
+            value=1.0,
+        )
+        logger.debug(f"Rasterized {num_rasterized} obstacles")
+        if obstacle_polygons:
+            filled = 0
+            for polygon in obstacle_polygons:
+                filled += rasterization.rasterize_polygon(
+                    polygon,
+                    layer,
+                    self.config,
+                    grid_origin_x,
+                    grid_origin_y,
+                    value=1.0,
+                )
+            logger.debug("Filled %s obstacle cells via polygon rasterization", filled)
+
+        self._static_obstacle_layer_cache_key = cache_key
+        self._static_obstacle_layer_cache = layer
+        return layer
 
     def generate(  # noqa: C901,PLR0912,PLR0915
         self,
@@ -551,28 +665,36 @@ class OccupancyGrid:
                 continue
 
             if channel == GridChannel.OBSTACLES:
-                # Rasterize obstacles into this channel
-                num_rasterized = rasterization.rasterize_obstacles(
-                    transformed_obstacles,
-                    self._grid_data[channel_idx],
-                    self.config,
-                    grid_origin_x,
-                    grid_origin_y,
-                    value=1.0,
-                )
-                logger.debug(f"Rasterized {num_rasterized} obstacles")
-                if transformed_polygons:
-                    filled = 0
-                    for polygon in transformed_polygons:
-                        filled += rasterization.rasterize_polygon(
-                            polygon,
-                            self._grid_data[channel_idx],
-                            self.config,
-                            grid_origin_x,
-                            grid_origin_y,
-                            value=1.0,
-                        )
-                    logger.debug("Filled %s obstacle cells via polygon rasterization", filled)
+                if not use_ego_frame and not self.config.center_on_robot:
+                    self._grid_data[channel_idx] = self._get_or_create_static_obstacle_layer(
+                        transformed_obstacles,
+                        transformed_polygons,
+                        grid_origin_x,
+                        grid_origin_y,
+                    )
+                else:
+                    # Rasterize obstacles into this channel
+                    num_rasterized = rasterization.rasterize_obstacles(
+                        transformed_obstacles,
+                        self._grid_data[channel_idx],
+                        self.config,
+                        grid_origin_x,
+                        grid_origin_y,
+                        value=1.0,
+                    )
+                    logger.debug(f"Rasterized {num_rasterized} obstacles")
+                    if transformed_polygons:
+                        filled = 0
+                        for polygon in transformed_polygons:
+                            filled += rasterization.rasterize_polygon(
+                                polygon,
+                                self._grid_data[channel_idx],
+                                self.config,
+                                grid_origin_x,
+                                grid_origin_y,
+                                value=1.0,
+                            )
+                        logger.debug("Filled %s obstacle cells via polygon rasterization", filled)
 
             elif channel == GridChannel.PEDESTRIANS:
                 # Rasterize pedestrians into this channel

--- a/tests/test_occupancy_grid.py
+++ b/tests/test_occupancy_grid.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from robot_sf.nav import occupancy_grid_rasterization as rasterization
 from robot_sf.nav.occupancy_grid import GridChannel, GridConfig, OccupancyGrid
 
 
@@ -136,6 +137,132 @@ class TestGridGeneration:
         )
 
         assert grid_data.shape == occupancy_grid.shape
+
+
+class TestGridStaticObstacleLayerCache:
+    """Regression tests for fixed-origin static obstacle-layer reuse."""
+
+    def test_world_frame_reuses_static_obstacle_layer(self, monkeypatch):
+        """Avoid rerasterizing unchanged static obstacles while preserving dynamic output."""
+        config = GridConfig(
+            resolution=0.1,
+            width=6.0,
+            height=6.0,
+            channels=[
+                GridChannel.OBSTACLES,
+                GridChannel.PEDESTRIANS,
+                GridChannel.COMBINED,
+            ],
+        )
+        obstacles = [
+            ((0.5, 0.5), (5.5, 0.5)),
+            ((5.5, 0.5), (5.5, 5.5)),
+            ((5.5, 5.5), (0.5, 5.5)),
+            ((0.5, 5.5), (0.5, 0.5)),
+        ]
+        robot_pose = ((3.0, 3.0), 0.0)
+        rasterize_calls = 0
+        original_rasterize = rasterization.rasterize_obstacles
+
+        def counting_rasterize(*args, **kwargs):
+            """Count obstacle rasterization calls while preserving behavior."""
+            nonlocal rasterize_calls
+            rasterize_calls += 1
+            return original_rasterize(*args, **kwargs)
+
+        monkeypatch.setattr(rasterization, "rasterize_obstacles", counting_rasterize)
+
+        grid = OccupancyGrid(config=config)
+        first = grid.generate(
+            obstacles=obstacles,
+            pedestrians=[((2.0, 2.0), 0.25)],
+            robot_pose=robot_pose,
+        ).copy()
+        assert rasterize_calls == 1
+
+        second = grid.generate(
+            obstacles=obstacles,
+            pedestrians=[((4.0, 4.0), 0.25)],
+            robot_pose=robot_pose,
+        ).copy()
+        assert rasterize_calls == 1
+
+        expected = OccupancyGrid(config=config).generate(
+            obstacles=obstacles,
+            pedestrians=[((4.0, 4.0), 0.25)],
+            robot_pose=robot_pose,
+        )
+        np.testing.assert_array_equal(second, expected)
+        np.testing.assert_array_equal(second[0], first[0])
+        assert not np.array_equal(second[1], first[1])
+
+    def test_world_frame_cache_refreshes_when_obstacles_change(self, monkeypatch):
+        """Obstacle input changes must refresh the cached static layer."""
+        config = GridConfig(
+            resolution=0.1,
+            width=6.0,
+            height=6.0,
+            channels=[GridChannel.OBSTACLES],
+        )
+        obstacles = [((0.5, 0.5), (5.5, 0.5))]
+        changed_obstacles = [*obstacles, ((0.5, 5.5), (5.5, 5.5))]
+        robot_pose = ((3.0, 3.0), 0.0)
+        rasterize_calls = 0
+        original_rasterize = rasterization.rasterize_obstacles
+
+        def counting_rasterize(*args, **kwargs):
+            """Count obstacle rasterization calls while preserving behavior."""
+            nonlocal rasterize_calls
+            rasterize_calls += 1
+            return original_rasterize(*args, **kwargs)
+
+        monkeypatch.setattr(rasterization, "rasterize_obstacles", counting_rasterize)
+
+        grid = OccupancyGrid(config=config)
+        grid.generate(obstacles=obstacles, pedestrians=[], robot_pose=robot_pose)
+        grid.generate(obstacles=obstacles, pedestrians=[], robot_pose=robot_pose)
+        assert rasterize_calls == 1
+
+        changed = grid.generate(
+            obstacles=changed_obstacles,
+            pedestrians=[],
+            robot_pose=robot_pose,
+        ).copy()
+        assert rasterize_calls == 2
+
+        expected = OccupancyGrid(config=config).generate(
+            obstacles=changed_obstacles,
+            pedestrians=[],
+            robot_pose=robot_pose,
+        )
+        np.testing.assert_array_equal(changed, expected)
+
+    def test_centered_world_frame_does_not_reuse_static_obstacle_layer(self, monkeypatch):
+        """Moving-origin grids cannot reuse a fixed obstacle layer."""
+        config = GridConfig(
+            resolution=0.1,
+            width=6.0,
+            height=6.0,
+            channels=[GridChannel.OBSTACLES],
+            center_on_robot=True,
+        )
+        obstacles = [((0.5, 0.5), (5.5, 0.5))]
+        rasterize_calls = 0
+        original_rasterize = rasterization.rasterize_obstacles
+
+        def counting_rasterize(*args, **kwargs):
+            """Count obstacle rasterization calls while preserving behavior."""
+            nonlocal rasterize_calls
+            rasterize_calls += 1
+            return original_rasterize(*args, **kwargs)
+
+        monkeypatch.setattr(rasterization, "rasterize_obstacles", counting_rasterize)
+
+        grid = OccupancyGrid(config=config)
+        grid.generate(obstacles=obstacles, pedestrians=[], robot_pose=((2.0, 2.0), 0.0))
+        grid.generate(obstacles=obstacles, pedestrians=[], robot_pose=((3.0, 3.0), 0.0))
+
+        assert rasterize_calls == 2
 
 
 class TestGridChannels:


### PR DESCRIPTION
## Summary

- Caches static occupancy-grid layers to avoid recomputing map geometry across repeated grid builds.
- Adds occupancy-grid regression coverage for cache reuse and static-layer behavior.

Closes #1313.

## Validation

- Not rerun during this PR-body backfill.
- Branch includes `tests/test_occupancy_grid.py` for the occupancy-grid cache contract.

## Notes

- Body backfilled on 2026-05-18 after an earlier PR creation path produced an empty body. No code changes were made as part of this metadata repair.