### PR TITLE
bug: reject mismatched simulator action counts

### DIFF
--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -259,6 +259,18 @@ class Simulator:
         """Current (vx, vy) velocities of all pedestrians."""
         return self.pysf_state.ped_velocities
 
+    def _validate_robot_action_count(self, actions: list[RobotAction]) -> None:
+        """Raise when a simulator step receives the wrong number of robot actions."""
+
+        expected = len(self.robots)
+        actual = len(actions)
+        if actual != expected:
+            action_word = "action" if expected == 1 else "actions"
+            raise ValueError(
+                f"{type(self).__name__}.step_once expected {expected} robot "
+                f"{action_word}, got {actual}."
+            )
+
     def reset_state(self):
         """Reset robot navigation and spawn positions.
 
@@ -284,13 +296,14 @@ class Simulator:
         Args:
             actions: Control actions for each robot (velocity, angular velocity, etc.).
         """
+        self._validate_robot_action_count(actions)
         for behavior in self.peds_behaviors:
             behavior.step()
         ped_forces = self.pysf_sim.compute_forces()
         self.last_ped_forces = np.asarray(ped_forces, dtype=float)
         groups = self.groups.groups_as_lists
         self.pysf_sim.peds.step(ped_forces, groups)
-        for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=False):
+        for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=True):
             robot.apply_action(action, self.config.time_per_step_in_secs)
             nav.update_position(robot.pos)
 
@@ -551,13 +564,14 @@ class PedSimulator(Simulator):
             actions: Control actions for each robot.
             ego_ped_actions: Control actions for the ego pedestrian.
         """
+        self._validate_robot_action_count(actions)
         for behavior in self.peds_behaviors:
             behavior.step()
         ped_forces = self.pysf_sim.compute_forces()
         self.last_ped_forces = np.asarray(ped_forces, dtype=float)
         groups = self.groups.groups_as_lists
         self.pysf_sim.peds.step(ped_forces, groups)
-        for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=False):
+        for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=True):
             robot.apply_action(action, self.config.time_per_step_in_secs)
             nav.update_position(robot.pos)
 

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -421,6 +421,7 @@ class PedSimulator(Simulator):
             raise ValueError(
                 f"PedSimulator.step_once expected 1 ego pedestrian action, got {actual}."
             )
+
     spawn_near_robot: bool = True
 
     def __post_init__(self):

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -411,6 +411,16 @@ class PedSimulator(Simulator):
     """
 
     ego_ped: UnicycleDrivePedestrian
+
+    @staticmethod
+    def _validate_ego_ped_action_count(ego_ped_actions: list[UnicycleAction]) -> None:
+        """Raise when a pedestrian simulator step receives the wrong ego-ped action count."""
+
+        actual = len(ego_ped_actions)
+        if actual != 1:
+            raise ValueError(
+                f"PedSimulator.step_once expected 1 ego pedestrian action, got {actual}."
+            )
     spawn_near_robot: bool = True
 
     def __post_init__(self):
@@ -565,6 +575,7 @@ class PedSimulator(Simulator):
             ego_ped_actions: Control actions for the ego pedestrian.
         """
         self._validate_robot_action_count(actions)
+        self._validate_ego_ped_action_count(ego_ped_actions)
         for behavior in self.peds_behaviors:
             behavior.step()
         ped_forces = self.pysf_sim.compute_forces()

--- a/tests/sim/test_simulator_action_count.py
+++ b/tests/sim/test_simulator_action_count.py
@@ -84,3 +84,22 @@ def test_ped_simulator_step_once_rejects_mismatched_robot_action_count(actions):
 
     with pytest.raises(ValueError, match="expected 1 robot action"):
         simulator.step_once(actions, ego_ped_actions=[(0.0, 0.0)])
+
+
+@pytest.mark.parametrize("ego_ped_actions", [[], [(0.0, 0.0), (0.1, 0.0)]])
+def test_ped_simulator_step_once_rejects_mismatched_ego_ped_action_count(ego_ped_actions):
+    """PedSimulator should fail loudly when ego-ped action count is not exactly one."""
+    map_def = _minimal_map()
+    config = PedestrianSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.0]),
+    )
+    simulator = init_ped_simulators(
+        config,
+        map_def,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+    with pytest.raises(ValueError, match="expected 1 ego pedestrian action"):
+        simulator.step_once([(0.0, 0.0)], ego_ped_actions=ego_ped_actions)

--- a/tests/sim/test_simulator_action_count.py
+++ b/tests/sim/test_simulator_action_count.py
@@ -1,0 +1,86 @@
+"""Regression tests for simulator robot/action count validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.common.types import Line2D, Rect
+from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
+from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.sim.simulator import init_ped_simulators, init_simulators
+
+
+def _minimal_map() -> MapDefinition:
+    """Build a compact map with one deterministic robot route."""
+    width = 10.0
+    height = 10.0
+    spawn_zone: Rect = ((1.0, 1.0), (2.0, 1.0), (1.0, 2.0))
+    goal_zone: Rect = ((8.0, 8.0), (9.0, 8.0), (8.0, 9.0))
+    bounds: list[Line2D] = [
+        ((0.0, 0.0), (width, 0.0)),
+        ((width, 0.0), (width, height)),
+        ((width, height), (0.0, height)),
+        ((0.0, height), (0.0, 0.0)),
+    ]
+    route = GlobalRoute(
+        spawn_id=0,
+        goal_id=0,
+        waypoints=[(1.2, 1.2), (8.8, 8.8)],
+        spawn_zone=spawn_zone,
+        goal_zone=goal_zone,
+    )
+    return MapDefinition(
+        width=width,
+        height=height,
+        obstacles=[],
+        robot_spawn_zones=[spawn_zone],
+        ped_spawn_zones=[spawn_zone],
+        robot_goal_zones=[goal_zone],
+        bounds=bounds,
+        robot_routes=[route],
+        ped_goal_zones=[goal_zone],
+        ped_crowded_zones=[],
+        ped_routes=[route],
+        single_pedestrians=[],
+    )
+
+
+@pytest.mark.parametrize("actions", [[], [(0.0, 0.0), (0.1, 0.0)]])
+def test_simulator_step_once_rejects_mismatched_robot_action_count(actions):
+    """Simulator should fail loudly when action count does not match robots."""
+    map_def = _minimal_map()
+    config = RobotSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.0]),
+    )
+    simulator = init_simulators(
+        config,
+        map_def,
+        num_robots=1,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+    with pytest.raises(ValueError, match="expected 1 robot action"):
+        simulator.step_once(actions)
+
+
+@pytest.mark.parametrize("actions", [[], [(0.0, 0.0), (0.1, 0.0)]])
+def test_ped_simulator_step_once_rejects_mismatched_robot_action_count(actions):
+    """PedSimulator should share the same robot/action count contract."""
+    map_def = _minimal_map()
+    config = PedestrianSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.0]),
+    )
+    simulator = init_ped_simulators(
+        config,
+        map_def,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+    with pytest.raises(ValueError, match="expected 1 robot action"):
+        simulator.step_once(actions, ego_ped_actions=[(0.0, 0.0)])


### PR DESCRIPTION
## Summary

- Rejects mismatched simulator action counts instead of silently truncating robot/action pairs.
- Adds simulator action-count regression coverage.

Closes #1315.

## Validation

- Not rerun during this PR-body backfill.
- Branch includes `tests/sim/test_simulator_action_count.py` for the simulator mismatch contract.

## Notes

- Body backfilled on 2026-05-18 after an earlier PR creation path produced an empty body. No code changes were made as part of this metadata repair.