### PR TITLE
feat: add safety shield contract

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -94,6 +94,8 @@ knowledge, not every transient iteration detail.
   [issue_1240_scenario_coverage_entropy.md](issue_1240_scenario_coverage_entropy.md)
 * Issue #1255 open-issue dependency graph:
   [issue_1255_open_issue_dependency_graph.md](issue_1255_open_issue_dependency_graph.md)
+* Issue #1247 safety shield contract:
+  [issue_1247_safety_shield_contract.md](issue_1247_safety_shield_contract.md)
 * Issue #1287 force-gradient interpolation vectorization:
   [issue_1287_force_gradient_vectorization.md](issue_1287_force_gradient_vectorization.md)
 * Issue #1286 SNQI bootstrap stability:

--- a/docs/context/issue_1247_safety_shield_contract.md
+++ b/docs/context/issue_1247_safety_shield_contract.md
@@ -1,0 +1,47 @@
+# Issue #1247 Safety Shield Contract
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1247>
+
+## Goal
+
+Add a lightweight prediction-aware safety shield contract that separates policy actions, shield
+interventions, fallback recovery, and hard constraint violations from scalar rewards and headline
+benchmark metrics.
+
+## Implementation Boundary
+
+This slice adds benchmark instrumentation only:
+
+- `robot_sf.planner.safety_shield` defines `SafetyShield`, `ShieldDecision`, shield stats, and
+  scalar shield metric derivation.
+- `GuardedPPOAdapter` now exposes `choose_command_decision(...)` while preserving the legacy
+  `choose_command(...) -> (command, label)` API.
+- Guarded PPO and guarded GenSafeNav/SoNIC benchmark wrappers record `safety_shield_contract`,
+  `shield_stats`, and shield-derived metrics.
+- `episode.schema.v1.json` allows the new additive metadata and metrics.
+
+Out of scope:
+
+- no learned conformal predictor,
+- no CPO/PPO-Lagrangian/SAC-Lagrangian training,
+- no replacement of guarded PPO behavior,
+- no formal safety certification claim.
+
+## Validation Plan
+
+The focused proof covers:
+
+- red collection failure before `robot_sf.planner.safety_shield` existed,
+- shield decision serialization and stats/rate derivation,
+- guarded PPO fallback decisions with proposed/filtered action metadata,
+- guarded benchmark wrapper metadata integration.
+
+Full PR readiness should still be run after commit because the schema and map-runner surfaces are
+shared benchmark infrastructure.
+
+## Claim Boundary
+
+`shield_intervention_rate`, `shield_override_rate`, and
+`shield_hard_constraint_violation_rate` explain how often a shield changed or failed to fully
+protect a proposed action. They are diagnostic benchmark instrumentation, not a proof that a planner
+is safe in deployment.

--- a/docs/context/issue_602_guarded_ppo_profile.md
+++ b/docs/context/issue_602_guarded_ppo_profile.md
@@ -102,6 +102,8 @@ What `guarded_ppo` already covers:
 - benchmark-runnable internal safety-aware profile
 - clear fallback controller and threshold contract
 - practical evidence that the guard changes the policy behavior materially
+- additive `ShieldDecision`/`shield_stats` instrumentation for intervention, override, and
+  best-effort hard-constraint violation rates
 
 What it still lacks relative to a SoNIC-style method:
 - no learned uncertainty model
@@ -118,6 +120,9 @@ safety-aware benchmark representative.
 Treat `guarded_ppo` as an experimental documentation-backed safety-aware profile.
 
 It is not baseline-ready and should not be promoted as a headline benchmark row.
+
+The issue #1247 safety-shield instrumentation makes guard behavior easier to audit, but it does
+not change that claim boundary.
 
 ## Recommended Claim Boundary
 

--- a/docs/dev/safety_shield_contract.md
+++ b/docs/dev/safety_shield_contract.md
@@ -1,0 +1,41 @@
+# Safety Shield Contract
+
+The benchmark safety-shield contract records when a policy action is filtered by a runtime guard.
+It is an instrumentation layer, not a formal safety proof.
+
+## Core Types
+
+- `robot_sf.planner.safety_shield.SafetyShield`: protocol for filters that expose
+  `choose_command_decision(observation, proposed_command)`.
+- `robot_sf.planner.safety_shield.ShieldDecision`: JSON-serializable record containing the
+  proposed action, filtered action, decision label, violated constraints, prediction source,
+  uncertainty/calibration metadata, fallback-controller state, and selected-action evaluation.
+- `shield_metrics_from_stats`: converts per-step shield decisions into benchmark scalar metrics.
+
+## Benchmark Fields
+
+Guarded planners may add these fields under `algorithm_metadata`:
+
+- `safety_shield_contract`: stable description of the shield implementation, prediction source,
+  fallback policy, calibration status, and interpretation boundary.
+- `shield_stats`: per-episode counters and the last serialized `ShieldDecision`.
+
+Benchmark episode metrics may include:
+
+- `shield_decision_count`
+- `shield_intervention_count`
+- `shield_override_count`
+- `shield_hard_constraint_violation_count`
+- `shield_intervention_rate`
+- `shield_override_rate`
+- `shield_hard_constraint_violation_rate`
+
+These metrics stay separate from reward, success, collision count, and SNQI. A high intervention
+rate means the shield changed policy behavior often; it does not by itself prove a safer planner.
+
+## Current Implementation
+
+`GuardedPPOAdapter` is the first shield implementation. It uses a deterministic short-horizon
+rollout, not a learned or conformal predictor, and reports `calibration_status=not_calibrated`.
+Best-effort decisions such as `fallback_best_effort` or `stop_best_effort` are counted as hard
+constraint violations because no evaluated command satisfied the shield constraints.

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -120,6 +120,13 @@ from robot_sf.planner.safety_barrier import (
     SafetyBarrierPlannerAdapter,
     build_safety_barrier_config,
 )
+from robot_sf.planner.safety_shield import (
+    ShieldDecision,
+    new_shield_stats,
+    shield_contract_metadata,
+    shield_metrics_from_stats,
+    update_shield_stats,
+)
 from robot_sf.planner.social_navigation_pyenvs_force_model import (
     SocialNavigationPyEnvsForceModelAdapter,
     build_social_navigation_pyenvs_force_model_config,
@@ -1099,6 +1106,35 @@ class _GoalFallbackAdapter:
         return _goal_policy(observation, max_speed=self._max_speed)
 
 
+def _choose_shield_command(
+    shield: Any,
+    observation: dict[str, Any],
+    proposed_command: tuple[float, float],
+) -> ShieldDecision:
+    """Return a structured shield decision, adapting legacy guard implementations."""
+    decision_fn = getattr(shield, "choose_command_decision", None)
+    if callable(decision_fn):
+        decision = decision_fn(observation, proposed_command)
+        if isinstance(decision, ShieldDecision):
+            return decision
+        if hasattr(decision, "as_command_result"):
+            command, label = decision.as_command_result()
+            return ShieldDecision(
+                proposed_action=(float(proposed_command[0]), float(proposed_command[1])),
+                filtered_action=(float(command[0]), float(command[1])),
+                decision_label=str(label),
+                intervention_reason="legacy_structured_guard_decision",
+            )
+
+    command, label = shield.choose_command(observation, proposed_command)
+    return ShieldDecision(
+        proposed_action=(float(proposed_command[0]), float(proposed_command[1])),
+        filtered_action=(float(command[0]), float(command[1])),
+        decision_label=str(label),
+        intervention_reason="legacy_guard_decision",
+    )
+
+
 def _normalize_heading(value: float) -> float:
     """Normalize heading to [-pi, pi].
 
@@ -1757,6 +1793,12 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             "stop_best_effort": 0,
             "goal_reached": 0,
         }
+        meta["safety_shield_contract"] = shield_contract_metadata(
+            shield_name="GuardedPPOAdapter",
+            prediction_source="short_horizon_rollout",
+            fallback_policy=type(guard_adapter.fallback_adapter).__name__,
+        )
+        meta["shield_stats"] = new_shield_stats()
         planner_meta = meta.get("planner_kinematics")
         if isinstance(planner_meta, dict):
             planner_meta["planner_command_space"] = _default_robot_command_space(
@@ -1790,10 +1832,12 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 kinematics_model=ppo_kinematics_model,
                 project_command=False,
             )
-            chosen, decision = guard_adapter.choose_command(
+            shield_decision = _choose_shield_command(
+                guard_adapter,
                 obs,
                 (float(linear), float(angular)),
             )
+            chosen, decision = shield_decision.as_command_result()
             linear, angular = _project_with_feasibility(
                 model=ppo_kinematics_model,
                 command=(float(chosen[0]), float(chosen[1])),
@@ -1802,6 +1846,9 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             guard_stats = meta.get("guard_stats")
             if isinstance(guard_stats, dict):
                 guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
+            shield_stats = meta.get("shield_stats")
+            if isinstance(shield_stats, dict):
+                update_shield_stats(shield_stats, shield_decision)
             _update_adapter_impact_metrics(
                 meta,
                 conversion_mode,
@@ -1896,6 +1943,12 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             "stop_best_effort": 0,
             "goal_reached": 0,
         }
+        meta["safety_shield_contract"] = shield_contract_metadata(
+            shield_name="GuardedPPOAdapter",
+            prediction_source="short_horizon_rollout",
+            fallback_policy="goal",
+        )
+        meta["shield_stats"] = new_shield_stats()
         planner_meta = meta.get("planner_kinematics")
         if isinstance(planner_meta, dict):
             planner_meta["planner_command_space"] = _default_robot_command_space(
@@ -1918,10 +1971,12 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 tuple[float, float]: Guard-selected and projected command.
             """
             sonic_command = sonic_adapter.plan(obs)
-            chosen, decision = guard_adapter.choose_command(
+            shield_decision = _choose_shield_command(
+                guard_adapter,
                 obs,
                 (float(sonic_command[0]), float(sonic_command[1])),
             )
+            chosen, decision = shield_decision.as_command_result()
             linear, angular = _project_with_feasibility(
                 model=guarded_kinematics_model,
                 command=(float(chosen[0]), float(chosen[1])),
@@ -1930,6 +1985,9 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             guard_stats = meta.get("guard_stats")
             if isinstance(guard_stats, dict):
                 guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
+            shield_stats = meta.get("shield_stats")
+            if isinstance(shield_stats, dict):
+                update_shield_stats(shield_stats, shield_decision)
             _update_adapter_impact_metrics(
                 meta,
                 "adapter",
@@ -2904,6 +2962,9 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     visibility_settings = getattr(config, "observation_visibility", None)
     if visibility_settings is not None and hasattr(visibility_settings, "to_metadata"):
         algo_meta["observation_visibility"] = visibility_settings.to_metadata()
+    shield_stats = algo_meta.get("shield_stats")
+    if isinstance(shield_stats, dict):
+        metrics_raw.update(shield_metrics_from_stats(shield_stats))
     metrics = post_process_metrics(
         metrics_raw,
         snqi_weights=snqi_weights,

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2525,6 +2525,10 @@ def post_process_metrics(
         "ped_impact_turn_rate_delta_valid",
         "social_proxemic_ped_count",
         "social_proxemic_intrusion_steps",
+        "shield_decision_count",
+        "shield_intervention_count",
+        "shield_override_count",
+        "shield_hard_constraint_violation_count",
     ):
         if count_key in metrics and metrics[count_key] is not None:
             try:

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -305,6 +305,59 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "safety_shield_contract": {
+                    "type": "object",
+                    "description": "Benchmark-facing shield contract; not a formal safety certificate.",
+                    "properties": {
+                        "schema_version": {
+                            "const": "safety-shield-contract.v1"
+                        },
+                        "shield_name": {
+                            "type": "string"
+                        },
+                        "prediction_source": {
+                            "type": "string"
+                        },
+                        "fallback_policy": {
+                            "type": "string"
+                        },
+                        "calibration_status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "shield_stats": {
+                    "type": "object",
+                    "properties": {
+                        "schema_version": {
+                            "const": "safety-shield-stats.v1"
+                        },
+                        "decision_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "intervention_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "override_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "hard_constraint_violation_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "last_decision": {
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
                 }
             },
             "additionalProperties": true
@@ -364,6 +417,49 @@
                         "integer"
                     ],
                     "minimum": 0
+                },
+                "shield_decision_count": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "shield_intervention_count": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "shield_override_count": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "shield_hard_constraint_violation_count": {
+                    "type": [
+                        "number",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "shield_intervention_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "shield_override_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "shield_hard_constraint_violation_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
                 },
                 "pedestrian_impact": {
                     "type": "object",

--- a/robot_sf/planner/guarded_ppo.py
+++ b/robot_sf/planner/guarded_ppo.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 import numpy as np
 
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, _wrap_angle, build_risk_dwa_config
+from robot_sf.planner.safety_shield import ShieldDecision
 from robot_sf.planner.socnav import (
     OccupancyAwarePlannerMixin,
     ORCAPlannerAdapter,
@@ -301,7 +302,7 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
             "min_ttc": float(min_ttc),
         }
 
-    def choose_command(  # noqa: C901
+    def choose_command(
         self, observation: dict[str, Any], ppo_command: tuple[float, float]
     ) -> tuple[tuple[float, float], str]:
         """Choose between PPO, fallback planner, and stop.
@@ -309,9 +310,27 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
         Returns:
             tuple[tuple[float, float], str]: Selected command and decision label.
         """
+        return self.choose_command_decision(observation, ppo_command).as_command_result()
+
+    def choose_command_decision(  # noqa: C901
+        self, observation: dict[str, Any], ppo_command: tuple[float, float]
+    ) -> ShieldDecision:
+        """Choose a command and return structured safety-shield metadata.
+
+        Returns:
+            ShieldDecision: Proposed action, selected action, and shield decision metadata.
+        """
         robot_pos, _heading, goal, ped_pos, _ped_vel = self._extract_state(observation)
         if float(np.linalg.norm(goal - robot_pos)) <= float(self.config.goal_tolerance):
-            return (0.0, 0.0), "goal_reached"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(0.0, 0.0),
+                label="goal_reached",
+                reason="goal_within_tolerance",
+                ppo_eval={"safe": True},
+                selected_eval={"safe": True},
+                intervened=False,
+            )
 
         if ped_pos.size > 0:
             current_min_dist = float(np.min(np.linalg.norm(ped_pos - robot_pos[None, :], axis=1)))
@@ -330,34 +349,168 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
             blended_command = self._blend_commands(ppo_command, prior_command, prior_weight)
             blended_eval = self._evaluate_command(observation, blended_command)
             if self._blend_is_preferred(ppo_eval, blended_eval):
-                return blended_command, "prior_blend_safe"
+                return self._shield_decision(
+                    ppo_command=ppo_command,
+                    filtered_command=blended_command,
+                    label="prior_blend_safe",
+                    reason="prior_blend_improved_short_horizon_safety",
+                    ppo_eval=ppo_eval,
+                    selected_eval=blended_eval,
+                    fallback_policy=type(self.prior_adapter).__name__,
+                )
 
         if current_min_dist > float(self.config.near_field_distance) and bool(ppo_eval["safe"]):
-            return (float(ppo_command[0]), float(ppo_command[1])), "ppo_clear"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(float(ppo_command[0]), float(ppo_command[1])),
+                label="ppo_clear",
+                reason="proposed_action_clear_of_near_field",
+                ppo_eval=ppo_eval,
+                selected_eval=ppo_eval,
+                intervened=False,
+            )
         if bool(ppo_eval["safe"]):
-            return (float(ppo_command[0]), float(ppo_command[1])), "ppo_safe"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(float(ppo_command[0]), float(ppo_command[1])),
+                label="ppo_safe",
+                reason="proposed_action_satisfies_shield",
+                ppo_eval=ppo_eval,
+                selected_eval=ppo_eval,
+                intervened=False,
+            )
 
         if prior_command is not None:
             prior_eval = self._evaluate_command(observation, prior_command)
             if bool(prior_eval["safe"]):
-                return (float(prior_command[0]), float(prior_command[1])), "prior_safe"
+                return self._shield_decision(
+                    ppo_command=ppo_command,
+                    filtered_command=(float(prior_command[0]), float(prior_command[1])),
+                    label="prior_safe",
+                    reason="prior_command_satisfied_short_horizon_constraints",
+                    ppo_eval=ppo_eval,
+                    selected_eval=prior_eval,
+                    fallback_policy=type(self.prior_adapter).__name__,
+                )
 
         fallback_command = self.fallback_adapter.plan(observation)
         fallback_eval = self._evaluate_command(observation, fallback_command)
         if bool(fallback_eval["safe"]):
-            return (float(fallback_command[0]), float(fallback_command[1])), "fallback_safe"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(float(fallback_command[0]), float(fallback_command[1])),
+                label="fallback_safe",
+                reason="fallback_command_satisfied_short_horizon_constraints",
+                ppo_eval=ppo_eval,
+                selected_eval=fallback_eval,
+                fallback_policy=type(self.fallback_adapter).__name__,
+            )
 
         stop_eval = self._evaluate_command(observation, (0.0, 0.0))
         if bool(stop_eval["safe"]):
-            return (0.0, 0.0), "stop_safe"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(0.0, 0.0),
+                label="stop_safe",
+                reason="stop_command_satisfied_short_horizon_constraints",
+                ppo_eval=ppo_eval,
+                selected_eval=stop_eval,
+                fallback_policy="stop",
+            )
 
         if float(fallback_eval["min_ped_clear"]) > max(
             float(ppo_eval["min_ped_clear"]),
             float(stop_eval["min_ped_clear"]),
             float(prior_eval["min_ped_clear"]) if prior_eval is not None else float("-inf"),
         ):
-            return (float(fallback_command[0]), float(fallback_command[1])), "fallback_best_effort"
-        return (0.0, 0.0), "stop_best_effort"
+            return self._shield_decision(
+                ppo_command=ppo_command,
+                filtered_command=(float(fallback_command[0]), float(fallback_command[1])),
+                label="fallback_best_effort",
+                reason="no_safe_command_available_fallback_has_largest_clearance",
+                ppo_eval=ppo_eval,
+                selected_eval=fallback_eval,
+                fallback_policy=type(self.fallback_adapter).__name__,
+                hard_constraint_violation=True,
+            )
+        return self._shield_decision(
+            ppo_command=ppo_command,
+            filtered_command=(0.0, 0.0),
+            label="stop_best_effort",
+            reason="no_safe_command_available_stop_has_largest_clearance",
+            ppo_eval=ppo_eval,
+            selected_eval=stop_eval,
+            fallback_policy="stop",
+            hard_constraint_violation=True,
+        )
+
+    def _shield_decision(  # noqa: PLR0913
+        self,
+        *,
+        ppo_command: tuple[float, float],
+        filtered_command: tuple[float, float],
+        label: str,
+        reason: str,
+        ppo_eval: dict[str, float | bool],
+        selected_eval: dict[str, float | bool],
+        fallback_policy: str | None = None,
+        intervened: bool | None = None,
+        hard_constraint_violation: bool | None = None,
+    ) -> ShieldDecision:
+        """Build a structured shield decision for benchmark metadata.
+
+        Returns:
+            ShieldDecision: Serialized-ready action-filter decision.
+        """
+        explicit_intervened = (
+            label not in {"ppo_clear", "ppo_safe", "goal_reached"}
+            if intervened is None
+            else bool(intervened)
+        )
+        explicit_violation = (
+            bool(selected_eval.get("safe") is False)
+            if hard_constraint_violation is None
+            else bool(hard_constraint_violation)
+        )
+        return ShieldDecision(
+            proposed_action=(float(ppo_command[0]), float(ppo_command[1])),
+            filtered_action=(float(filtered_command[0]), float(filtered_command[1])),
+            decision_label=label,
+            intervention_reason=reason,
+            violated_constraints=self._violated_constraints(ppo_eval),
+            prediction_source="short_horizon_rollout",
+            prediction_horizon_steps=int(self.config.rollout_steps),
+            prediction_dt=float(self.config.rollout_dt),
+            uncertainty_metadata={"mode": "deterministic_rollout"},
+            calibration_metadata={"status": "not_calibrated"},
+            fallback_controller_state={
+                "policy": fallback_policy or type(self.fallback_adapter).__name__,
+                "prior_available": self.prior_adapter is not None,
+            },
+            proposed_evaluation=dict(ppo_eval),
+            selected_evaluation=dict(selected_eval),
+            intervened=explicit_intervened,
+            hard_constraint_violation=explicit_violation,
+        )
+
+    def _violated_constraints(self, evaluation: dict[str, float | bool]) -> tuple[str, ...]:
+        """Return hard constraints violated by an evaluated proposed command."""
+        if bool(evaluation.get("safe", True)):
+            return ()
+        violations: list[str] = []
+        min_ped_clear = float(evaluation.get("min_ped_clear", float("inf")))
+        first_ped_clear = float(evaluation.get("first_ped_clear", float("inf")))
+        min_obs_clear = float(evaluation.get("min_obs_clear", float("inf")))
+        min_ttc = float(evaluation.get("min_ttc", float("inf")))
+        if min_ped_clear < float(self.config.hard_ped_clearance):
+            violations.append("pedestrian_clearance")
+        if first_ped_clear < float(self.config.first_step_ped_clearance):
+            violations.append("first_step_pedestrian_clearance")
+        if min_obs_clear < float(self.config.hard_obstacle_clearance):
+            violations.append("obstacle_clearance")
+        if np.isfinite(min_ttc) and min_ttc < float(self.config.min_ttc):
+            violations.append("time_to_collision")
+        return tuple(violations)
 
 
 def build_guarded_ppo_config(cfg: dict[str, Any] | None) -> GuardedPPOConfig:

--- a/robot_sf/planner/safety_shield.py
+++ b/robot_sf/planner/safety_shield.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol
+
+import numpy as np
 
 ActionCommand = tuple[float, float]
 
@@ -39,6 +42,8 @@ class ShieldDecision:
     selected_evaluation: dict[str, Any] = field(default_factory=dict)
     intervened: bool | None = None
     hard_constraint_violation: bool | None = None
+    finished_at_utc: str | None = None
+    total_runtime: float | None = None
 
     @property
     def override_applied(self) -> bool:
@@ -69,27 +74,31 @@ class ShieldDecision:
 
     def to_metadata(self) -> dict[str, Any]:
         """Return a JSON-serializable shield decision payload."""
-        return {
-            "schema_version": "shield-decision.v1",
-            "decision_label": self.decision_label,
-            "proposed_action": [float(self.proposed_action[0]), float(self.proposed_action[1])],
-            "filtered_action": [float(self.filtered_action[0]), float(self.filtered_action[1])],
-            "intervened": self.is_intervention,
-            "override_applied": self.override_applied,
-            "hard_constraint_violation": self.final_constraint_violation,
-            "violated_constraints": list(self.violated_constraints),
-            "intervention_reason": self.intervention_reason,
-            "prediction": {
-                "source": self.prediction_source,
-                "horizon_steps": self.prediction_horizon_steps,
-                "dt": self.prediction_dt,
-                "uncertainty": _sanitize_payload(self.uncertainty_metadata),
-                "calibration": _sanitize_payload(self.calibration_metadata),
-            },
-            "fallback_controller_state": _sanitize_payload(self.fallback_controller_state),
-            "proposed_evaluation": _sanitize_payload(self.proposed_evaluation),
-            "selected_evaluation": _sanitize_payload(self.selected_evaluation),
-        }
+        return _sanitize_payload(
+            {
+                "schema_version": "shield-decision.v1",
+                "decision_label": self.decision_label,
+                "proposed_action": [float(self.proposed_action[0]), float(self.proposed_action[1])],
+                "filtered_action": [float(self.filtered_action[0]), float(self.filtered_action[1])],
+                "intervened": self.is_intervention,
+                "override_applied": self.override_applied,
+                "hard_constraint_violation": self.final_constraint_violation,
+                "violated_constraints": list(self.violated_constraints),
+                "intervention_reason": self.intervention_reason,
+                "prediction": {
+                    "source": self.prediction_source,
+                    "horizon_steps": self.prediction_horizon_steps,
+                    "dt": self.prediction_dt,
+                    "uncertainty": self.uncertainty_metadata,
+                    "calibration": self.calibration_metadata,
+                },
+                "fallback_controller_state": self.fallback_controller_state,
+                "proposed_evaluation": self.proposed_evaluation,
+                "selected_evaluation": self.selected_evaluation,
+                "finished_at_utc": self.finished_at_utc,
+                "total_runtime": self.total_runtime,
+            }
+        )
 
 
 def shield_contract_metadata(
@@ -190,14 +199,16 @@ def shield_metrics_from_stats(stats: dict[str, Any]) -> dict[str, float]:
 
 def _sanitize_payload(value: Any) -> Any:
     """Return a JSON-friendly payload without NaN or infinite numeric values."""
+    if isinstance(value, np.ndarray):
+        return _sanitize_payload(value.tolist())
+    if isinstance(value, np.generic):
+        return _sanitize_payload(value.item())
+    if isinstance(value, Path):
+        return str(value)
     if isinstance(value, dict):
-        return {
-            str(key): cleaned
-            for key, item in value.items()
-            if (cleaned := _sanitize_payload(item)) is not None
-        }
+        return {str(key): _sanitize_payload(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
-        return [cleaned for item in value if (cleaned := _sanitize_payload(item)) is not None]
+        return [_sanitize_payload(item) for item in value]
     if isinstance(value, float):
         return value if math.isfinite(value) else None
     return value

--- a/robot_sf/planner/safety_shield.py
+++ b/robot_sf/planner/safety_shield.py
@@ -1,0 +1,214 @@
+"""Prediction-aware safety shield contracts for benchmark instrumentation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+ActionCommand = tuple[float, float]
+
+
+class SafetyShield(Protocol):
+    """Protocol for action filters that expose structured shield decisions."""
+
+    def choose_command_decision(
+        self,
+        observation: dict[str, Any],
+        proposed_command: ActionCommand,
+    ) -> ShieldDecision:
+        """Return the filtered command plus benchmark-facing shield metadata."""
+
+
+@dataclass(frozen=True)
+class ShieldDecision:
+    """One action-filter decision emitted by a safety shield."""
+
+    proposed_action: ActionCommand
+    filtered_action: ActionCommand
+    decision_label: str
+    intervention_reason: str
+    violated_constraints: tuple[str, ...] = ()
+    prediction_source: str = "unknown"
+    prediction_horizon_steps: int | None = None
+    prediction_dt: float | None = None
+    uncertainty_metadata: dict[str, Any] = field(default_factory=dict)
+    calibration_metadata: dict[str, Any] = field(default_factory=dict)
+    fallback_controller_state: dict[str, Any] = field(default_factory=dict)
+    proposed_evaluation: dict[str, Any] = field(default_factory=dict)
+    selected_evaluation: dict[str, Any] = field(default_factory=dict)
+    intervened: bool | None = None
+    hard_constraint_violation: bool | None = None
+
+    @property
+    def override_applied(self) -> bool:
+        """Return whether the filtered command differs from the proposed command."""
+        return any(
+            not math.isclose(float(proposed), float(filtered), rel_tol=1e-9, abs_tol=1e-9)
+            for proposed, filtered in zip(self.proposed_action, self.filtered_action, strict=True)
+        )
+
+    @property
+    def is_intervention(self) -> bool:
+        """Return whether this decision represents shield intervention."""
+        if self.intervened is not None:
+            return bool(self.intervened)
+        return self.decision_label not in {"ppo_clear", "ppo_safe", "goal_reached"}
+
+    @property
+    def final_constraint_violation(self) -> bool:
+        """Return whether the selected action still violates hard shield constraints."""
+        if self.hard_constraint_violation is not None:
+            return bool(self.hard_constraint_violation)
+        safe = self.selected_evaluation.get("safe")
+        return bool(safe is False)
+
+    def as_command_result(self) -> tuple[ActionCommand, str]:
+        """Return the legacy ``(command, decision_label)`` pair."""
+        return self.filtered_action, self.decision_label
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable shield decision payload."""
+        return {
+            "schema_version": "shield-decision.v1",
+            "decision_label": self.decision_label,
+            "proposed_action": [float(self.proposed_action[0]), float(self.proposed_action[1])],
+            "filtered_action": [float(self.filtered_action[0]), float(self.filtered_action[1])],
+            "intervened": self.is_intervention,
+            "override_applied": self.override_applied,
+            "hard_constraint_violation": self.final_constraint_violation,
+            "violated_constraints": list(self.violated_constraints),
+            "intervention_reason": self.intervention_reason,
+            "prediction": {
+                "source": self.prediction_source,
+                "horizon_steps": self.prediction_horizon_steps,
+                "dt": self.prediction_dt,
+                "uncertainty": _sanitize_payload(self.uncertainty_metadata),
+                "calibration": _sanitize_payload(self.calibration_metadata),
+            },
+            "fallback_controller_state": _sanitize_payload(self.fallback_controller_state),
+            "proposed_evaluation": _sanitize_payload(self.proposed_evaluation),
+            "selected_evaluation": _sanitize_payload(self.selected_evaluation),
+        }
+
+
+def shield_contract_metadata(
+    *,
+    shield_name: str,
+    prediction_source: str,
+    fallback_policy: str,
+    calibration_status: str = "not_calibrated",
+) -> dict[str, Any]:
+    """Return stable benchmark metadata for a shield implementation."""
+    return {
+        "schema_version": "safety-shield-contract.v1",
+        "shield_name": shield_name,
+        "prediction_source": prediction_source,
+        "fallback_policy": fallback_policy,
+        "calibration_status": calibration_status,
+        "metrics": [
+            "shield_intervention_rate",
+            "shield_override_rate",
+            "shield_hard_constraint_violation_rate",
+        ],
+        "interpretation": (
+            "Benchmark instrumentation for action filtering; not a formal safety certificate."
+        ),
+    }
+
+
+def new_shield_stats() -> dict[str, Any]:
+    """Return an empty shield statistics accumulator."""
+    return {
+        "schema_version": "safety-shield-stats.v1",
+        "decision_count": 0,
+        "pass_through_count": 0,
+        "intervention_count": 0,
+        "override_count": 0,
+        "hard_constraint_violation_count": 0,
+        "decision_counts": {},
+        "violated_constraint_counts": {},
+        "last_decision": None,
+    }
+
+
+def update_shield_stats(stats: dict[str, Any], decision: ShieldDecision) -> dict[str, Any]:
+    """Update a shield statistics accumulator in place and return it.
+
+    Returns:
+        dict[str, Any]: The updated stats mapping.
+    """
+    if "schema_version" not in stats:
+        stats.update(new_shield_stats())
+
+    stats["decision_count"] = int(stats.get("decision_count", 0)) + 1
+    if decision.is_intervention:
+        stats["intervention_count"] = int(stats.get("intervention_count", 0)) + 1
+    else:
+        stats["pass_through_count"] = int(stats.get("pass_through_count", 0)) + 1
+    if decision.override_applied:
+        stats["override_count"] = int(stats.get("override_count", 0)) + 1
+    if decision.final_constraint_violation:
+        stats["hard_constraint_violation_count"] = (
+            int(stats.get("hard_constraint_violation_count", 0)) + 1
+        )
+
+    decision_counts = stats.setdefault("decision_counts", {})
+    if isinstance(decision_counts, dict):
+        decision_counts[decision.decision_label] = (
+            int(decision_counts.get(decision.decision_label, 0)) + 1
+        )
+
+    constraint_counts = stats.setdefault("violated_constraint_counts", {})
+    if isinstance(constraint_counts, dict):
+        for constraint in decision.violated_constraints:
+            constraint_counts[constraint] = int(constraint_counts.get(constraint, 0)) + 1
+
+    stats["last_decision"] = decision.to_metadata()
+    return stats
+
+
+def shield_metrics_from_stats(stats: dict[str, Any]) -> dict[str, float]:
+    """Return scalar benchmark metrics derived from shield statistics."""
+    decisions = int(stats.get("decision_count", 0) or 0)
+    interventions = int(stats.get("intervention_count", 0) or 0)
+    overrides = int(stats.get("override_count", 0) or 0)
+    violations = int(stats.get("hard_constraint_violation_count", 0) or 0)
+    denominator = float(decisions) if decisions > 0 else 1.0
+    return {
+        "shield_decision_count": float(decisions),
+        "shield_intervention_count": float(interventions),
+        "shield_override_count": float(overrides),
+        "shield_hard_constraint_violation_count": float(violations),
+        "shield_intervention_rate": float(interventions / denominator) if decisions else 0.0,
+        "shield_override_rate": float(overrides / denominator) if decisions else 0.0,
+        "shield_hard_constraint_violation_rate": (
+            float(violations / denominator) if decisions else 0.0
+        ),
+    }
+
+
+def _sanitize_payload(value: Any) -> Any:
+    """Return a JSON-friendly payload without NaN or infinite numeric values."""
+    if isinstance(value, dict):
+        return {
+            str(key): cleaned
+            for key, item in value.items()
+            if (cleaned := _sanitize_payload(item)) is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [cleaned for item in value if (cleaned := _sanitize_payload(item)) is not None]
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    return value
+
+
+__all__ = [
+    "ActionCommand",
+    "SafetyShield",
+    "ShieldDecision",
+    "new_shield_stats",
+    "shield_contract_metadata",
+    "shield_metrics_from_stats",
+    "update_shield_stats",
+]

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -825,6 +825,7 @@ def test_build_policy_gensafenav_ours_guarded_uses_guard_and_goal_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Guarded Ours_GST alias should wire guard decisions and expose mixed metadata."""
+    from robot_sf.planner.safety_shield import ShieldDecision
 
     planners: list[object] = []
 
@@ -852,8 +853,22 @@ def test_build_policy_gensafenav_ours_guarded_uses_guard_and_goal_fallback(
 
         def choose_command(self, observation, ppo_command):
             """Select the guard fallback command for the test."""
-            del ppo_command
-            return self.fallback_adapter.plan(observation), "fallback_safe"
+            return self.choose_command_decision(observation, ppo_command).as_command_result()
+
+        def choose_command_decision(self, observation, ppo_command):
+            """Select the guard fallback command with structured shield metadata."""
+            filtered = self.fallback_adapter.plan(observation)
+            return ShieldDecision(
+                proposed_action=(float(ppo_command[0]), float(ppo_command[1])),
+                filtered_action=(float(filtered[0]), float(filtered[1])),
+                decision_label="fallback_safe",
+                intervention_reason="ppo_action_violated_short_horizon_constraints",
+                violated_constraints=("pedestrian_clearance",),
+                prediction_source="short_horizon_rollout",
+                fallback_controller_state={"policy": "goal"},
+                proposed_evaluation={"safe": False},
+                selected_evaluation={"safe": True},
+            )
 
     monkeypatch.setattr("robot_sf.benchmark.map_runner.SonicCrowdNavAdapter", _DummyAdapter)
     monkeypatch.setattr("robot_sf.benchmark.map_runner.GuardedPPOAdapter", _DummyGuard)
@@ -881,6 +896,10 @@ def test_build_policy_gensafenav_ours_guarded_uses_guard_and_goal_fallback(
     assert meta["planner_kinematics"]["execution_mode"] == "mixed"
     assert meta["planner_kinematics"]["fallback_policy"] == "goal"
     assert meta["guard_stats"]["fallback_safe"] == 1
+    assert meta["shield_stats"]["decision_count"] == 1
+    assert meta["shield_stats"]["intervention_count"] == 1
+    assert meta["shield_stats"]["override_count"] == 1
+    assert meta["shield_stats"]["last_decision"]["decision_label"] == "fallback_safe"
     assert meta["adapter_impact"]["native_steps"] == 0
     assert meta["adapter_impact"]["adapted_steps"] == 1
 

--- a/tests/planner/test_guarded_ppo.py
+++ b/tests/planner/test_guarded_ppo.py
@@ -111,6 +111,34 @@ def test_guarded_ppo_uses_fallback_when_ppo_is_unsafe() -> None:
     assert decision == "fallback_safe"
 
 
+def test_guarded_ppo_exposes_structured_shield_decision_for_fallback() -> None:
+    """Guard decisions should preserve proposed, filtered, and constraint metadata."""
+    guard = GuardedPPOAdapter(
+        config=build_guarded_ppo_config(
+            {
+                "guard_near_field_distance": 2.5,
+                "guard_hard_ped_clearance": 0.45,
+                "guard_first_step_ped_clearance": 0.55,
+            }
+        ),
+        fallback_adapter=_FallbackAdapter((0.0, 1.0)),
+    )
+
+    decision = guard.choose_command_decision(
+        _obs(ped_positions=[(0.58, 0.0)], ped_velocities=[(0.0, 0.0)]),
+        (0.6, 0.0),
+    )
+
+    assert decision.decision_label == "fallback_safe"
+    assert decision.proposed_action == (0.6, 0.0)
+    assert decision.filtered_action == (0.0, 1.0)
+    assert decision.intervened is True
+    assert "pedestrian_clearance" in decision.violated_constraints
+    assert decision.prediction_source == "short_horizon_rollout"
+    assert decision.fallback_controller_state["policy"] == "_FallbackAdapter"
+    assert decision.hard_constraint_violation is False
+
+
 def test_guarded_ppo_blends_safe_orca_prior_in_near_field() -> None:
     """Near-field ORCA-prior blending should apply only when it remains safe."""
     guard = GuardedPPOAdapter(

--- a/tests/planner/test_safety_shield.py
+++ b/tests/planner/test_safety_shield.py
@@ -1,0 +1,82 @@
+"""Tests for benchmark-facing safety shield decision contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.planner.safety_shield import (
+    ShieldDecision,
+    shield_metrics_from_stats,
+    update_shield_stats,
+)
+
+
+def test_shield_decision_metadata_separates_proposed_filtered_and_prediction_fields() -> None:
+    """ShieldDecision should serialize action, constraint, fallback, and prediction details."""
+    decision = ShieldDecision(
+        proposed_action=(0.8, 0.0),
+        filtered_action=(0.0, 1.0),
+        decision_label="fallback_safe",
+        intervention_reason="ppo_action_violated_short_horizon_constraints",
+        violated_constraints=("pedestrian_clearance", "time_to_collision"),
+        prediction_source="short_horizon_rollout",
+        prediction_horizon_steps=6,
+        prediction_dt=0.2,
+        uncertainty_metadata={"mode": "deterministic"},
+        calibration_metadata={"status": "not_calibrated"},
+        fallback_controller_state={"policy": "RiskDWAPlannerAdapter"},
+        selected_evaluation={"safe": True, "min_ped_clear": 0.9},
+        proposed_evaluation={"safe": False, "min_ped_clear": 0.2},
+    )
+
+    metadata = decision.to_metadata()
+
+    assert metadata["schema_version"] == "shield-decision.v1"
+    assert metadata["proposed_action"] == [0.8, 0.0]
+    assert metadata["filtered_action"] == [0.0, 1.0]
+    assert metadata["intervened"] is True
+    assert metadata["override_applied"] is True
+    assert metadata["hard_constraint_violation"] is False
+    assert metadata["violated_constraints"] == ["pedestrian_clearance", "time_to_collision"]
+    assert metadata["prediction"]["source"] == "short_horizon_rollout"
+    assert metadata["prediction"]["calibration"]["status"] == "not_calibrated"
+
+
+def test_update_shield_stats_and_metrics_track_interventions_and_violations() -> None:
+    """Stats should expose benchmark rates without conflating them with reward/success."""
+    stats: dict[str, object] = {}
+    update_shield_stats(
+        stats,
+        ShieldDecision(
+            proposed_action=(0.4, 0.0),
+            filtered_action=(0.4, 0.0),
+            decision_label="ppo_safe",
+            intervention_reason="proposed_action_satisfies_shield",
+        ),
+    )
+    update_shield_stats(
+        stats,
+        ShieldDecision(
+            proposed_action=(0.8, 0.0),
+            filtered_action=(0.0, 0.0),
+            decision_label="stop_best_effort",
+            intervention_reason="no_safe_command_available",
+            violated_constraints=("pedestrian_clearance",),
+            selected_evaluation={"safe": False},
+            proposed_evaluation={"safe": False},
+        ),
+    )
+
+    assert stats["decision_count"] == 2
+    assert stats["pass_through_count"] == 1
+    assert stats["intervention_count"] == 1
+    assert stats["override_count"] == 1
+    assert stats["hard_constraint_violation_count"] == 1
+    assert stats["decision_counts"]["ppo_safe"] == 1
+    assert stats["decision_counts"]["stop_best_effort"] == 1
+
+    metrics = shield_metrics_from_stats(stats)
+    assert metrics["shield_decision_count"] == 2
+    assert metrics["shield_intervention_rate"] == pytest.approx(0.5)
+    assert metrics["shield_override_rate"] == pytest.approx(0.5)
+    assert metrics["shield_hard_constraint_violation_rate"] == pytest.approx(0.5)

--- a/tests/planner/test_safety_shield.py
+++ b/tests/planner/test_safety_shield.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import numpy as np
 import pytest
 
 from robot_sf.planner.safety_shield import (
@@ -40,6 +43,39 @@ def test_shield_decision_metadata_separates_proposed_filtered_and_prediction_fie
     assert metadata["violated_constraints"] == ["pedestrian_clearance", "time_to_collision"]
     assert metadata["prediction"]["source"] == "short_horizon_rollout"
     assert metadata["prediction"]["calibration"]["status"] == "not_calibrated"
+    assert metadata["finished_at_utc"] is None
+    assert metadata["total_runtime"] is None
+
+
+def test_shield_decision_metadata_sanitizes_complex_payloads_without_shape_drift() -> None:
+    """Serialization should preserve fixed-size containers while removing invalid numbers."""
+    decision = ShieldDecision(
+        proposed_action=(np.float32(0.8), np.float64("nan")),
+        filtered_action=(0.0, 1.0),
+        decision_label="fallback_safe",
+        intervention_reason="ppo_action_violated_short_horizon_constraints",
+        uncertainty_metadata={
+            "scores": np.array([0.2, np.inf], dtype=np.float32),
+            Path("path_key"): Path("evidence/shield.json"),
+        },
+        proposed_evaluation={"clearance": [np.nan, 0.5]},
+        selected_evaluation={"safe": np.bool_(True), "attempts": np.array([1, 2])},
+        finished_at_utc="2026-05-18T17:00:00Z",
+        total_runtime=np.float32(0.25),
+    )
+
+    metadata = decision.to_metadata()
+
+    assert metadata["proposed_action"] == [0.800000011920929, None]
+    scores = metadata["prediction"]["uncertainty"]["scores"]
+    assert scores[0] == pytest.approx(0.2)
+    assert scores[1] is None
+    assert metadata["prediction"]["uncertainty"]["path_key"] == "evidence/shield.json"
+    assert metadata["proposed_evaluation"]["clearance"] == [None, 0.5]
+    assert metadata["selected_evaluation"]["safe"] is True
+    assert metadata["selected_evaluation"]["attempts"] == [1, 2]
+    assert metadata["finished_at_utc"] == "2026-05-18T17:00:00Z"
+    assert metadata["total_runtime"] == pytest.approx(0.25)
 
 
 def test_update_shield_stats_and_metrics_track_interventions_and_violations() -> None:


### PR DESCRIPTION
## Summary

Closes #1247.

- Adds `robot_sf.planner.safety_shield` with `SafetyShield`, `ShieldDecision`, shield stats, and scalar shield metric derivation.
- Threads structured shield decisions through `GuardedPPOAdapter`, guarded PPO benchmark runs, and guarded GenSafeNav/SoNIC wrappers while preserving the legacy `choose_command(...)` API.
- Adds additive episode schema fields, benchmark metrics, tests, and docs for intervention, override, and hard-constraint violation rates.

## Validation

- Initial red proof: `uv run pytest tests/planner/test_safety_shield.py tests/planner/test_guarded_ppo.py::test_guarded_ppo_exposes_structured_shield_decision_for_fallback tests/benchmark/test_map_runner_utils.py::test_build_policy_gensafenav_ours_guarded_uses_guard_and_goal_fallback -q` failed because `robot_sf.planner.safety_shield` did not exist.
- Focused proof after implementation: same command -> `4 passed`.
- `uv run pytest tests/planner/test_safety_shield.py tests/planner/test_guarded_ppo.py tests/benchmark/test_map_runner_utils.py::test_build_policy_gensafenav_ours_guarded_uses_guard_and_goal_fallback tests/benchmark/test_map_runner_utils.py::test_build_policy_gensafenav_gst_predictor_rand_guarded_defaults_checkpoint -q` -> `20 passed`.
- `uv run pytest tests/planner/test_safety_shield.py tests/planner/test_guarded_ppo.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_preflight_profiles.py -q` -> `147 passed`.
- `uv run ruff check robot_sf/planner/safety_shield.py robot_sf/planner/guarded_ppo.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/metrics.py tests/planner/test_safety_shield.py tests/planner/test_guarded_ppo.py tests/benchmark/test_map_runner_utils.py` -> passed.
- `scripts/dev/check_docs_proof_consistency_diff.sh` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `3711 passed, 11 skipped, 6 warnings`.

Changed-file coverage warnings were above the required 80% floor: `map_runner.py` 88.5%, `metrics.py` 92.6%, `guarded_ppo.py` 90.0%, `safety_shield.py` 96.2%.

## Artifacts

- `output/coverage/` is ignored local validation output and is not required as a durable artifact.

## Delegation

- Used GPT-5.3-Codex-Spark for bounded read-only lookup of shield/benchmark integration surfaces; implementation, validation, push, and PR creation were handled locally.

## Claim Boundary

This adds benchmark instrumentation for shield behavior. It does not add learned conformal prediction, constrained-RL training, or formal safety certification.
