### PR TITLE
perf: add socnavbench path ratio batching

### DIFF
--- a/tests/test_socnavbench_cost_functions.py
+++ b/tests/test_socnavbench_cost_functions.py
@@ -1,0 +1,80 @@
+"""Regression tests for vendored SocNavBench cost functions."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+def _load_cost_functions(monkeypatch: pytest.MonkeyPatch) -> Any:
+    socnavbench_root = Path(__file__).resolve().parents[1] / "third_party" / "socnavbench"
+    monkeypatch.syspath_prepend(str(socnavbench_root))
+    return importlib.import_module("metrics.cost_functions")
+
+
+def test_path_length_ratio_batch_matches_scalar_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batched path ratios preserve the existing per-trajectory scalar formula."""
+    cost_functions = _load_cost_functions(monkeypatch)
+    trajectories = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]],
+            [[0.0, 0.0], [0.0, 3.0], [4.0, 3.0]],
+        ],
+        dtype=float,
+    )
+    goals = np.array([[2.0, 0.0], [4.0, 3.0]], dtype=float)
+
+    batched = cost_functions.path_length_ratio_batch(trajectories, goals)
+    scalar = np.array(
+        [
+            cost_functions.path_length_ratio(trajectories[0], goals[0]),
+            cost_functions.path_length_ratio(trajectories[1], goals[1]),
+        ],
+        dtype=float,
+    )
+
+    assert batched == pytest.approx(scalar)
+
+
+def test_path_length_ratio_return_batch_keeps_scalar_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opt-in batch flag avoids changing the default scalar API."""
+    cost_functions = _load_cost_functions(monkeypatch)
+    trajectories = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0]],
+            [[0.0, 0.0], [0.0, 2.0]],
+        ],
+        dtype=float,
+    )
+
+    with pytest.raises(ValueError, match="single-trajectory batch"):
+        cost_functions.path_length_ratio(trajectories)
+
+    batched = cost_functions.path_length_ratio(trajectories, return_batch=True)
+    assert batched.shape == (2,)
+    assert batched == pytest.approx(np.array([1.0 / 1.00001, 2.0 / 2.00001]))
+
+
+def test_path_length_ratio_batch_broadcasts_single_goal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One goal config may be reused across a trajectory batch."""
+    cost_functions = _load_cost_functions(monkeypatch)
+    trajectories = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0]],
+            [[0.0, 1.0], [1.0, 1.0]],
+        ],
+        dtype=float,
+    )
+
+    batched = cost_functions.path_length_ratio_batch(trajectories, np.array([1.0, 0.0]))
+    assert batched == pytest.approx(np.array([1.0 / 1.00001, np.sqrt(2.0) / 1.00001]))

--- a/third_party/socnavbench/metrics/cost_functions.py
+++ b/third_party/socnavbench/metrics/cost_functions.py
@@ -57,9 +57,59 @@ def _coerce_traj_with_heading(trajectory: Trajectory | np.ndarray) -> np.ndarray
     return traj
 
 
+def _coerce_traj_batch_with_heading(trajectory: Trajectory | np.ndarray) -> np.ndarray:
+    """Return trajectory data as a ``(batch, steps, 3)`` array."""
+    if isinstance(trajectory, Trajectory):
+        traj = trajectory.position_and_heading_nk3()
+    else:
+        traj = np.asarray(trajectory)
+
+    if traj.ndim == 1:
+        traj = traj.reshape(1, 1, -1)
+    elif traj.ndim == 2:
+        traj = traj.reshape(1, *traj.shape)
+    elif traj.ndim != 3:
+        raise ValueError("path metrics expect trajectory shape (T,D) or (B,T,D).")
+
+    if traj.shape[-1] == 2:
+        if traj.shape[1] < 2:
+            headings = np.zeros((traj.shape[0], traj.shape[1]), dtype=float)
+        else:
+            diffs = traj[:, 1:, :] - traj[:, :-1, :]
+            headings = np.arctan2(diffs[:, :, 1], diffs[:, :, 0])
+            headings = np.concatenate([headings, headings[:, -1:]], axis=1)
+        traj = np.concatenate([traj, headings[..., None]], axis=2)
+    if traj.shape[-1] != 3:
+        raise ValueError("path metrics expect XY or XY-heading trajectories.")
+    return traj
+
+
 def _coerce_traj_xy(trajectory: Trajectory | np.ndarray) -> np.ndarray:
     traj = _coerce_traj_with_heading(trajectory)
     return traj[:, :2]
+
+
+def _coerce_goal_xy_batch(
+    goal_config: SystemConfig | np.ndarray | None,
+    traj_batch: np.ndarray,
+) -> np.ndarray:
+    """Return goal XY rows compatible with ``traj_batch``."""
+    if goal_config is None:
+        return traj_batch[:, -1, :2]
+
+    if not isinstance(goal_config, Trajectory):
+        goal_arr = np.asarray(goal_config)
+        if goal_arr.ndim == 2 and goal_arr.shape[0] == traj_batch.shape[0]:
+            if goal_arr.shape[1] not in (2, 3):
+                raise ValueError("goal_config rows must contain XY or XY-heading values.")
+            return goal_arr[:, :2]
+
+    goal_batch = _coerce_traj_batch_with_heading(goal_config)[:, -1, :2]
+    if goal_batch.shape[0] == traj_batch.shape[0]:
+        return goal_batch
+    if goal_batch.shape[0] == 1:
+        return np.broadcast_to(goal_batch, (traj_batch.shape[0], 2))
+    raise ValueError("goal_config batch size must match trajectory batch size or contain one goal.")
 
 
 def asym_gauss(
@@ -111,15 +161,42 @@ def path_length(trajectory: Trajectory | np.ndarray) -> float:
     return distance
 
 
+def path_length_batch(trajectory: Trajectory | np.ndarray) -> np.ndarray:
+    """Return path length for each trajectory in a batch."""
+    traj_xy = _coerce_traj_batch_with_heading(trajectory)[:, :, :2]
+    distance_sq = np.sum(np.power(np.diff(traj_xy, axis=1), 2), axis=2)
+    return np.sum(np.sqrt(distance_sq), axis=1)
+
+
+def path_length_ratio_batch(
+    trajectory: Trajectory | np.ndarray,
+    goal_config: SystemConfig | np.ndarray | None = None,
+) -> np.ndarray:
+    """Return SocNavBench path length ratio for each trajectory in a batch."""
+    traj_batch = _coerce_traj_batch_with_heading(trajectory)
+    traj_xy = traj_batch[:, :, :2]
+    goal_xy = _coerce_goal_xy_batch(goal_config, traj_batch)
+
+    start_config = traj_xy[:, 0, :]
+    epsilon = 0.00001  # for numerical stability
+    distance = path_length_batch(traj_batch) + epsilon
+    displacement = np.linalg.norm(goal_xy - start_config, axis=1)
+    return displacement / distance
+
+
 def path_length_ratio(
-    trajectory: Trajectory | np.ndarray, goal_config: SystemConfig | np.ndarray | None = None
-) -> float:
+    trajectory: Trajectory | np.ndarray,
+    goal_config: SystemConfig | np.ndarray | None = None,
+    *,
+    return_batch: bool = False,
+) -> float | np.ndarray:
     """
     Returns displacement/distance -- displacement may be zero
     (Distance is an approximation based on the time resolution of stored trajectory)
     Higher should be better but also depends on your exact scenario
     """
-    # TODO: make this run in batch mode
+    if return_batch:
+        return path_length_ratio_batch(trajectory, goal_config)
 
     traj_xy = _coerce_traj_xy(trajectory)
 

--- a/third_party/socnavbench/metrics/cost_functions.py
+++ b/third_party/socnavbench/metrics/cost_functions.py
@@ -164,8 +164,7 @@ def path_length(trajectory: Trajectory | np.ndarray) -> float:
 def path_length_batch(trajectory: Trajectory | np.ndarray) -> np.ndarray:
     """Return path length for each trajectory in a batch."""
     traj_xy = _coerce_traj_batch_with_heading(trajectory)[:, :, :2]
-    distance_sq = np.sum(np.power(np.diff(traj_xy, axis=1), 2), axis=2)
-    return np.sum(np.sqrt(distance_sq), axis=1)
+    return np.sum(np.linalg.norm(np.diff(traj_xy, axis=1), axis=2), axis=1)
 
 
 def path_length_ratio_batch(


### PR DESCRIPTION
## Summary
Adds explicit batched SocNavBench path-ratio helpers while preserving the existing scalar `path_length_ratio(...)` behavior by default.

## Linked Issues
- Closes #1325

## What Changed
- Added `path_length_batch(...)` and `path_length_ratio_batch(...)` in `third_party/socnavbench/metrics/cost_functions.py`.
- Added an opt-in `return_batch=True` path to `path_length_ratio(...)`; default multi-trajectory input still follows the old scalar path and raises for non-single batches.
- Added parity tests proving batched ratios match existing scalar calls, preserve the scalar default contract, and broadcast a single goal across a trajectory batch.

## Why It Matters
- Added value: removes the explicit batch-mode TODO for the path-ratio cost helper.
- Expected impact: callers that evaluate candidate trajectory batches can compute path ratios without Python-side scalar loops.
- Why this is worth merging now: this is a conservative first slice of SocNavBench batching with behavior-preserving tests.

## Validation / Proof
- GPT-5.3-Codex-Spark read-only lookup identified `path_length_ratio` as the explicit batch-mode TODO and mapped relevant parity tests.
- `uv run pytest tests/test_socnavbench_cost_functions.py tests/test_metrics.py -k socnavbench -q` -> 6 passed, 63 deselected
- `uv run ruff check tests/test_socnavbench_cost_functions.py && uv run ruff format tests/test_socnavbench_cost_functions.py` -> passed / unchanged
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3712 passed, 10 skipped, 6 warnings

## Risks / Rollout
- Compatibility risks: low; scalar callers retain the previous default behavior.
- Failure modes: consumers must explicitly opt into the batched API; this PR does not rewrite optimizer call sites.
- Rollback or fallback plan: revert the single commit.

## Docs / Provenance
- Updated docs: none; no user-facing behavior changed.
- Relevant design or provenance notes: `tests/test_socnavbench_cost_functions.py` documents batch/scalar parity and goal broadcasting.
- Artifact persistence: `output/coverage/` is ignored local validation output and is not required as a durable artifact.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that keeping batch support opt-in is the right compatibility boundary for vendored SocNavBench code.
