### PR TITLE
feat: add per-gpu telemetry samples

### DIFF
--- a/robot_sf/telemetry/gpu.py
+++ b/robot_sf/telemetry/gpu.py
@@ -21,12 +21,23 @@ else:  # pragma: no cover - runtime fallback since annotations are postponed
 
 
 @dataclass(slots=True)
+class GpuDeviceSample:
+    """Snapshot of one visible GPU device."""
+
+    index: int
+    util_percent: float
+    memory_used_mb: float
+    memory_total_mb: float
+
+
+@dataclass(slots=True)
 class GpuSample:
-    """Snapshot of aggregate GPU utilization across all visible devices."""
+    """Snapshot of GPU utilization across all visible devices."""
 
     util_percent: float | None = None
     memory_used_mb: float | None = None
     memory_total_mb: float | None = None
+    devices: tuple[GpuDeviceSample, ...] = ()
     notes: str | None = None
 
 
@@ -110,17 +121,32 @@ def collect_gpu_sample() -> GpuSample | None:
     total_util = 0.0
     total_memory_used = 0.0
     total_memory = 0.0
+    devices: list[GpuDeviceSample] = []
     for index in range(device_count):
         handle = pynvml.nvmlDeviceGetHandleByIndex(index)
         util = pynvml.nvmlDeviceGetUtilizationRates(handle)
         mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
-        total_util += float(util.gpu)
-        total_memory_used += float(mem.used)
-        total_memory += float(mem.total)
+        util_percent = float(util.gpu)
+        memory_used_mb = float(mem.used) / (1024**2)
+        memory_total_mb = float(mem.total) / (1024**2)
+        total_util += util_percent
+        total_memory_used += memory_used_mb
+        total_memory += memory_total_mb
+        devices.append(
+            GpuDeviceSample(
+                index=index,
+                util_percent=util_percent,
+                memory_used_mb=memory_used_mb,
+                memory_total_mb=memory_total_mb,
+            )
+        )
     avg_util = total_util / max(device_count, 1)
-    used_mb = total_memory_used / (1024**2)
-    total_mb = total_memory / (1024**2)
-    return GpuSample(util_percent=avg_util, memory_used_mb=used_mb, memory_total_mb=total_mb)
+    return GpuSample(
+        util_percent=avg_util,
+        memory_used_mb=total_memory_used,
+        memory_total_mb=total_memory,
+        devices=tuple(devices),
+    )
 
 
 def shutdown_gpu_telemetry() -> None:

--- a/robot_sf/telemetry/models.py
+++ b/robot_sf/telemetry/models.py
@@ -83,6 +83,7 @@ class TelemetrySnapshot:
     memory_rss_mb: float | None = None
     gpu_util_percent: float | None = None
     gpu_mem_used_mb: float | None = None
+    gpu_devices: tuple[dict[str, Any], ...] | None = None
     notes: str | None = None
 
 

--- a/robot_sf/telemetry/models.py
+++ b/robot_sf/telemetry/models.py
@@ -83,7 +83,7 @@ class TelemetrySnapshot:
     memory_rss_mb: float | None = None
     gpu_util_percent: float | None = None
     gpu_mem_used_mb: float | None = None
-    gpu_devices: tuple[dict[str, Any], ...] | None = None
+    gpu_devices: tuple[Any, ...] | None = None
     notes: str | None = None
 
 

--- a/robot_sf/telemetry/sampler.py
+++ b/robot_sf/telemetry/sampler.py
@@ -204,15 +204,7 @@ class TelemetrySampler:
             gpu_util = gpu_sample.util_percent
             gpu_mem_used = gpu_sample.memory_used_mb
             if gpu_sample.devices:
-                gpu_devices = tuple(
-                    {
-                        "index": device.index,
-                        "util_percent": device.util_percent,
-                        "memory_used_mb": device.memory_used_mb,
-                        "memory_total_mb": device.memory_total_mb,
-                    }
-                    for device in gpu_sample.devices
-                )
+                gpu_devices = gpu_sample.devices
             if gpu_sample.notes:
                 notes.add(gpu_sample.notes)
 

--- a/robot_sf/telemetry/sampler.py
+++ b/robot_sf/telemetry/sampler.py
@@ -199,9 +199,20 @@ class TelemetrySampler:
 
         gpu_sample = collect_gpu_sample()
         gpu_util = gpu_mem_used = None
+        gpu_devices = None
         if gpu_sample:
             gpu_util = gpu_sample.util_percent
             gpu_mem_used = gpu_sample.memory_used_mb
+            if gpu_sample.devices:
+                gpu_devices = tuple(
+                    {
+                        "index": device.index,
+                        "util_percent": device.util_percent,
+                        "memory_used_mb": device.memory_used_mb,
+                        "memory_total_mb": device.memory_total_mb,
+                    }
+                    for device in gpu_sample.devices
+                )
             if gpu_sample.notes:
                 notes.add(gpu_sample.notes)
 
@@ -216,6 +227,7 @@ class TelemetrySampler:
             memory_rss_mb=memory_rss,
             gpu_util_percent=gpu_util,
             gpu_mem_used_mb=gpu_mem_used,
+            gpu_devices=gpu_devices,
             notes=", ".join(sorted(notes)) if notes else None,
         )
         return snapshot

--- a/tests/test_tracking/test_gpu_telemetry.py
+++ b/tests/test_tracking/test_gpu_telemetry.py
@@ -113,6 +113,7 @@ def test_sampler_serializes_per_device_gpu_metrics(monkeypatch: pytest.MonkeyPat
     assert writer.snapshots == [snapshot]
     assert snapshot.gpu_util_percent == pytest.approx(40.0)
     assert snapshot.gpu_mem_used_mb == pytest.approx(6.0)
+    assert snapshot.gpu_devices == sample.devices
     assert payload["gpu_devices"] == [
         {
             "index": 0,

--- a/tests/test_tracking/test_gpu_telemetry.py
+++ b/tests/test_tracking/test_gpu_telemetry.py
@@ -1,0 +1,129 @@
+"""Tests for GPU telemetry collection and serialization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.telemetry import gpu as gpu_module
+from robot_sf.telemetry.gpu import GpuDeviceSample, GpuSample
+from robot_sf.telemetry.models import serialize_payload
+from robot_sf.telemetry.sampler import TelemetrySampler
+
+
+class _Writer:
+    """Capture emitted telemetry snapshots."""
+
+    def __init__(self) -> None:
+        """Initialize empty snapshot storage."""
+        self.snapshots = []
+
+    def append_telemetry_snapshot(self, snapshot) -> None:
+        """Record one telemetry snapshot."""
+        self.snapshots.append(snapshot)
+
+
+class _FakeNvmlError(Exception):
+    """Fake NVML error type."""
+
+
+class _FakeNvml:
+    """Small NVML stand-in with two visible devices."""
+
+    NVMLError = _FakeNvmlError
+
+    def __init__(self) -> None:
+        """Initialize fake device metrics."""
+        mb = 1024**2
+        self.devices = (
+            SimpleNamespace(util=10.0, used=2 * mb, total=8 * mb),
+            SimpleNamespace(util=70.0, used=4 * mb, total=12 * mb),
+        )
+
+    def nvmlInit(self) -> None:
+        """Pretend NVML initialized successfully."""
+
+    def nvmlShutdown(self) -> None:
+        """Pretend NVML shut down successfully."""
+
+    def nvmlDeviceGetCount(self) -> int:
+        """Return fake device count."""
+        return len(self.devices)
+
+    def nvmlDeviceGetHandleByIndex(self, index: int) -> int:
+        """Use the index itself as the fake handle."""
+        return index
+
+    def nvmlDeviceGetUtilizationRates(self, handle: int) -> SimpleNamespace:
+        """Return fake utilization for a handle."""
+        return SimpleNamespace(gpu=self.devices[handle].util)
+
+    def nvmlDeviceGetMemoryInfo(self, handle: int) -> SimpleNamespace:
+        """Return fake memory info for a handle."""
+        device = self.devices[handle]
+        return SimpleNamespace(used=device.used, total=device.total)
+
+
+def test_collect_gpu_sample_includes_per_device_breakdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NVML collection keeps aggregate fields and exposes individual devices."""
+    monkeypatch.setattr(gpu_module, "_NVML_ERROR", None)
+    monkeypatch.setattr(gpu_module, "pynvml", _FakeNvml())
+    monkeypatch.setattr(gpu_module, "_NVML_HANDLE", gpu_module._NvmlHandle())
+
+    sample = gpu_module.collect_gpu_sample()
+
+    assert sample is not None
+    assert sample.util_percent == pytest.approx(40.0)
+    assert sample.memory_used_mb == pytest.approx(6.0)
+    assert sample.memory_total_mb == pytest.approx(20.0)
+    assert sample.devices == (
+        GpuDeviceSample(index=0, util_percent=10.0, memory_used_mb=2.0, memory_total_mb=8.0),
+        GpuDeviceSample(index=1, util_percent=70.0, memory_used_mb=4.0, memory_total_mb=12.0),
+    )
+
+
+def test_sampler_serializes_per_device_gpu_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Telemetry snapshots include a JSON-ready per-device breakdown."""
+    sample = GpuSample(
+        util_percent=40.0,
+        memory_used_mb=6.0,
+        memory_total_mb=20.0,
+        devices=(
+            GpuDeviceSample(index=0, util_percent=10.0, memory_used_mb=2.0, memory_total_mb=8.0),
+            GpuDeviceSample(index=1, util_percent=70.0, memory_used_mb=4.0, memory_total_mb=12.0),
+        ),
+    )
+    monkeypatch.setattr("robot_sf.telemetry.sampler.collect_gpu_sample", lambda: sample)
+
+    writer = _Writer()
+    sampler = TelemetrySampler(
+        writer=writer,
+        progress_tracker=None,
+        started_at=datetime.now(UTC),
+        step_rate_provider=lambda: None,
+    )
+
+    snapshot = sampler.emit_snapshot()
+    payload = serialize_payload(snapshot)
+
+    assert writer.snapshots == [snapshot]
+    assert snapshot.gpu_util_percent == pytest.approx(40.0)
+    assert snapshot.gpu_mem_used_mb == pytest.approx(6.0)
+    assert payload["gpu_devices"] == [
+        {
+            "index": 0,
+            "util_percent": 10.0,
+            "memory_used_mb": 2.0,
+            "memory_total_mb": 8.0,
+        },
+        {
+            "index": 1,
+            "util_percent": 70.0,
+            "memory_used_mb": 4.0,
+            "memory_total_mb": 12.0,
+        },
+    ]


### PR DESCRIPTION
## Summary
Adds per-device GPU telemetry while preserving the existing aggregate GPU utilization and memory fields.

## Linked Issues
- Closes #1314

## What Changed
- Added `GpuDeviceSample` and a `devices` tuple on `GpuSample`.
- Updated `collect_gpu_sample()` to populate both aggregate metrics and per-device utilization/memory snapshots.
- Added `TelemetrySnapshot.gpu_devices` and sampler plumbing so serialized telemetry JSON includes the per-device breakdown when available.
- Added fake-NVML unit tests for multi-GPU collection and JSON-ready snapshot serialization.

## Why It Matters
- Added value: multi-GPU runs can now expose skewed utilization instead of hiding it behind a single average.
- Expected impact: telemetry summaries remain backward compatible while gaining per-device diagnostic detail.
- Why this is worth merging now: the issue contract is small, concrete, and fully unit-testable without requiring a physical multi-GPU node.

## Validation / Proof
- `uv run pytest tests/test_tracking/test_gpu_telemetry.py tests/test_tracking/test_telemetry.py -q` -> 4 passed
- `uv run pytest tests/test_tracking -q` -> 12 passed
- `uv run ruff check robot_sf/telemetry/gpu.py robot_sf/telemetry/models.py robot_sf/telemetry/sampler.py tests/test_tracking/test_gpu_telemetry.py && uv run ruff format robot_sf/telemetry/gpu.py robot_sf/telemetry/models.py robot_sf/telemetry/sampler.py tests/test_tracking/test_gpu_telemetry.py` -> passed / unchanged
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3710 passed, 11 skipped, 6 warnings

## Risks / Rollout
- Compatibility risks: low; existing aggregate fields are unchanged.
- Failure modes: real multi-GPU node behavior still depends on NVML availability and permissions, but the fake-NVML test covers the collection contract.
- Rollback or fallback plan: revert the single commit.

## Docs / Provenance
- Updated docs: none; telemetry schema change is additive.
- Relevant design or provenance notes: per-device payload shape is covered in `tests/test_tracking/test_gpu_telemetry.py`.
- Artifact persistence: `output/coverage/` is ignored local validation output and is not required as a durable artifact.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the `gpu_devices` field name and JSON shape fit downstream telemetry consumers.
