### PR TITLE
feat: replay CARLA static geometry proxies (#1329)

### DIFF
--- a/docs/context/evidence/issue_1169_carla_live_replay_2026-05-18/README.md
+++ b/docs/context/evidence/issue_1169_carla_live_replay_2026-05-18/README.md
@@ -14,9 +14,14 @@ attempt on May 18, 2026.
 * `live_replay_no_pull_before_image.json` - `live-replay` without `--pull`, also failing closed on
   the missing pinned CARLA image.
 * `live_replay_static_boundary_fixed.json` - `live-replay` after pulling `carlasim/carla:0.9.16`;
-  the Python client connected to CARLA `0.9.16` on `Town10HD_Opt`, then replay failed closed
-  because the certified T0 payload includes four static obstacles and static-geometry replay is
-  not implemented.
+  the Python client connected to CARLA `0.9.16` on `Town10HD_Opt`, then replay failed closed under
+  the pre-#1329 implementation because the certified T0 payload includes four static obstacles and
+  static-geometry replay was not implemented.
+
+No #1329 live rerun is stored in this bundle yet. The #1329 branch updates the code and CARLA-free
+tests so rectangular static obstacles are no longer rejected, but the Docker-backed live replay
+command still needs to be rerun on a CARLA-capable host before this bundle gains a replacement live
+JSON summary.
 
 ## Checksums
 

--- a/docs/context/issue_1169_carla_live_replay.md
+++ b/docs/context/issue_1169_carla_live_replay.md
@@ -15,10 +15,11 @@ The command starts the pinned `carlasim/carla:0.9.16` server, waits for the host
 `carla==0.9.16` Python client to connect, selects one certified T0 export payload, and attempts to
 spawn/replay Robot-SF actors by oracle transforms before stopping the container.
 
-The live replay runner is deliberately fail-closed. It currently supports the first representable
-slice: one robot actor plus scripted pedestrian actors moved by oracle transforms. It rejects static
-geometry because the bridge does not yet create CARLA meshes, walls, props, or other obstacle actors
-from Robot-SF `static_geometry`.
+The live replay runner is deliberately fail-closed. The original #1169 slice supported one robot
+actor plus scripted pedestrian actors moved by oracle transforms and rejected all static geometry.
+The #1329 follow-up branch adds the first bounded static-geometry slice: axis-aligned rectangular
+polygon obstacles are spawned as CARLA static-prop proxy actors before the dynamic replay begins,
+while unsupported obstacle shapes still fail closed with explicit counts.
 
 ## Implemented Path
 
@@ -75,19 +76,30 @@ cleanup.returncode: 0
 This is live CARLA execution evidence and a concrete semantic boundary, not a Robot-SF/CARLA parity
 claim.
 
+## Issue #1329 Static-Geometry Update
+
+The #1329 implementation removes the blanket static-obstacle rejection for the rectangular polygon
+walls present in the #1111 `pr_promoted_planner_smoke` payload. The local proof is still CARLA-free:
+fake-CARLA tests verify that rectangular static obstacles are spawned before robot/pedestrian
+actors, unsupported static obstacle shapes fail closed before replay, and cleanup destroys static
+proxies together with dynamic actors.
+
+The required live host rerun has not been executed on this laptop. The next live proof must run the
+same Docker-backed command on a CARLA-capable Linux/NVIDIA host and confirm that the previous
+failure reason is no longer `T0 payload static obstacle replay is not implemented`.
+
 ## Boundary
 
 The live replay path does not yet provide:
 
-* static-geometry replay,
 * sensor/perception replay,
 * metric parity,
 * benchmark-strength CARLA transfer,
 * long-running campaign evidence.
 
-For now, fallback or unsupported static-geometry behavior must remain `failed`, not
-`oracle-replay`, because silently ignoring obstacles would weaken the certified T0 scenario
-contract. Follow-up #1329 tracks representing T0 static geometry in CARLA.
+Static geometry is currently limited to axis-aligned rectangular polygon proxies. Any unsupported
+or malformed static obstacle must remain `failed`, not `oracle-replay`, because silently ignoring
+obstacles would weaken the certified T0 scenario contract.
 
 ## Validation
 

--- a/robot_sf_carla_bridge/live_replay.py
+++ b/robot_sf_carla_bridge/live_replay.py
@@ -293,7 +293,7 @@ def _axis_aligned_rectangle_bounds(obstacle: dict[str, Any]) -> dict[str, float]
         return None
     try:
         points = [(float(vertex[0]), float(vertex[1])) for vertex in vertices]
-    except (TypeError, ValueError, IndexError):
+    except (TypeError, ValueError, IndexError, KeyError):
         return None
     xs = {point[0] for point in points}
     ys = {point[1] for point in points}

--- a/robot_sf_carla_bridge/live_replay.py
+++ b/robot_sf_carla_bridge/live_replay.py
@@ -64,8 +64,8 @@ def run_t1_oracle_live_replay_against_server(
 ) -> dict[str, Any]:
     """Replay one representable T0 payload against an already-running CARLA server.
 
-    The runner is deliberately conservative: it validates the T0 payload, rejects static geometry
-    that cannot yet be represented in CARLA, spawns only explicit robot/pedestrian actors, moves
+    The runner is deliberately conservative: it validates the T0 payload, replays only static
+    obstacle shapes that have a bounded CARLA proxy, spawns explicit robot/pedestrian actors, moves
     them by oracle transforms, and records that no metric parity claim is made.
 
     Returns:
@@ -117,10 +117,7 @@ def run_t1_oracle_live_replay_against_server(
                 "server_version": client.get_server_version(),
                 "map": getattr(carla_map, "name", None),
             },
-            "actors": {
-                "robot": 1,
-                "pedestrians": len(cast("list[dict[str, Any]]", payload["pedestrians"])),
-            },
+            "actors": _actor_counts(payload),
             "trajectory": trajectory,
             "boundary": _live_replay_boundary(),
         }
@@ -169,10 +166,15 @@ def _base_summary(
 def _unsupported_payload_reasons(payload: dict[str, Any]) -> dict[str, Any] | None:
     static_geometry = cast("dict[str, Any]", payload["static_geometry"])
     obstacles = cast("list[dict[str, Any]]", static_geometry.get("obstacles", []))
-    if obstacles:
+    unsupported = [
+        obstacle for obstacle in obstacles if _axis_aligned_rectangle_bounds(obstacle) is None
+    ]
+    if unsupported:
         return {
-            "reason": "T0 payload static obstacle replay is not implemented",
+            "reason": "T0 payload contains unsupported static obstacle geometry",
             "static_obstacle_count": len(obstacles),
+            "unsupported_static_obstacle_count": len(unsupported),
+            "supported_static_obstacle_count": len(obstacles) - len(unsupported),
             "boundary": _live_replay_boundary(),
         }
     return None
@@ -186,16 +188,20 @@ def _spawn_replay_actors(
     blueprints = world.get_blueprint_library()
     robot = cast("dict[str, Any]", payload["robot"])
     pedestrians = cast("list[dict[str, Any]]", payload["pedestrians"])
+    static_geometry = cast("dict[str, Any]", payload["static_geometry"])
+    obstacles = cast("list[dict[str, Any]]", static_geometry.get("obstacles", []))
 
-    robot_actor = _spawn_actor(
-        world,
-        _blueprint(blueprints, "vehicle.tesla.model3", "vehicle.*", role_name="robot_sf_robot"),
-        robot_sf_pose_to_carla_transform(carla_module, cast("dict[str, Any]", robot["start"])),
-        label="robot",
-    )
+    static_actors = _spawn_static_obstacle_actors(carla_module, world, blueprints, obstacles)
 
+    robot_actor: _Actor | None = None
     pedestrian_actors: list[_Actor] = []
     try:
+        robot_actor = _spawn_actor(
+            world,
+            _blueprint(blueprints, "vehicle.tesla.model3", "vehicle.*", role_name="robot_sf_robot"),
+            robot_sf_pose_to_carla_transform(carla_module, cast("dict[str, Any]", robot["start"])),
+            label="robot",
+        )
         for index, pedestrian in enumerate(pedestrians):
             pedestrian_actors.append(
                 _spawn_actor(
@@ -214,14 +220,95 @@ def _spawn_replay_actors(
                 )
             )
     except Exception:
-        _destroy_actors([robot_actor, *pedestrian_actors])
+        _destroy_actors([actor for actor in [robot_actor, *pedestrian_actors] if actor is not None])
+        _destroy_actors(static_actors)
         raise
 
+    if robot_actor is None:
+        raise RuntimeError("CARLA failed to initialize robot actor")
     return {
-        "_actors": [robot_actor, *pedestrian_actors],
+        "_actors": [*static_actors, robot_actor, *pedestrian_actors],
+        "static_obstacle_actors": static_actors,
         "robot_actor": robot_actor,
         "pedestrian_actors": pedestrian_actors,
     }
+
+
+def _actor_counts(payload: dict[str, Any]) -> dict[str, int]:
+    static_geometry = cast("dict[str, Any]", payload["static_geometry"])
+    obstacles = cast("list[dict[str, Any]]", static_geometry.get("obstacles", []))
+    pedestrians = cast("list[dict[str, Any]]", payload["pedestrians"])
+    return {
+        "static_obstacles": len(obstacles),
+        "robot": 1,
+        "pedestrians": len(pedestrians),
+    }
+
+
+def _spawn_static_obstacle_actors(
+    carla_module: Any,
+    world: Any,
+    blueprints: Any,
+    obstacles: list[dict[str, Any]],
+) -> list[_Actor]:
+    static_actors: list[_Actor] = []
+    try:
+        for index, obstacle in enumerate(obstacles):
+            bounds = _axis_aligned_rectangle_bounds(obstacle)
+            if bounds is None:
+                raise RuntimeError(f"Unsupported static obstacle geometry: {obstacle.get('id')}")
+            static_actors.append(
+                _spawn_actor(
+                    world,
+                    _blueprint(
+                        blueprints,
+                        "static.prop.box01",
+                        "static.prop.*",
+                        role_name=f"robot_sf_static_obstacle_{index}",
+                    ),
+                    _static_obstacle_transform(carla_module, bounds),
+                    label=f"static obstacle {obstacle.get('id', index)}",
+                )
+            )
+    except Exception:
+        _destroy_actors(static_actors)
+        raise
+    return static_actors
+
+
+def _static_obstacle_transform(carla_module: Any, bounds: dict[str, float]) -> Any:
+    center_x = (bounds["min_x"] + bounds["max_x"]) / 2.0
+    center_y = (bounds["min_y"] + bounds["max_y"]) / 2.0
+    return carla_module.Transform(
+        carla_module.Location(x=center_x, y=-center_y, z=_DEFAULT_ACTOR_Z),
+        carla_module.Rotation(yaw=0.0),
+    )
+
+
+def _axis_aligned_rectangle_bounds(obstacle: dict[str, Any]) -> dict[str, float] | None:
+    if obstacle.get("type") != "polygon":
+        return None
+    vertices = obstacle.get("vertices")
+    if not isinstance(vertices, list) or len(vertices) != 4:
+        return None
+    try:
+        points = [(float(vertex[0]), float(vertex[1])) for vertex in vertices]
+    except (TypeError, ValueError, IndexError):
+        return None
+    xs = {point[0] for point in points}
+    ys = {point[1] for point in points}
+    if len(xs) != 2 or len(ys) != 2:
+        return None
+    expected = {(x, y) for x in xs for y in ys}
+    if set(points) != expected:
+        return None
+    min_x = min(xs)
+    max_x = max(xs)
+    min_y = min(ys)
+    max_y = max(ys)
+    if min_x == max_x or min_y == max_y:
+        return None
+    return {"min_x": min_x, "max_x": max_x, "min_y": min_y, "max_y": max_y}
 
 
 def _blueprint(
@@ -364,9 +451,12 @@ def _live_replay_boundary() -> dict[str, bool | str]:
     return {
         "oracle_transform_replay": True,
         "scripted_pedestrian_playback": True,
-        "static_geometry_replay": False,
+        "static_geometry_replay": True,
         "full_metrics_parity": False,
         "sensor_perception": False,
         "long_running_benchmark": False,
-        "note": "live CARLA actor replay attempt; no Robot-SF/CARLA parity claim",
+        "note": (
+            "live CARLA actor replay attempt with axis-aligned static obstacle proxies; "
+            "no Robot-SF/CARLA parity claim"
+        ),
     }

--- a/tests/carla_bridge/test_docker_runtime.py
+++ b/tests/carla_bridge/test_docker_runtime.py
@@ -9,6 +9,14 @@ from types import SimpleNamespace
 import pytest
 
 
+def _pretend_linux_x86_64(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make preflight tests exercise Docker checks past the CARLA host-platform gate."""
+    from robot_sf_carla_bridge import docker_runtime
+
+    monkeypatch.setattr(docker_runtime.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(docker_runtime.platform, "machine", lambda: "x86_64")
+
+
 def test_carla_docker_runtime_uses_pinned_0_9_16_image() -> None:
     """The runtime contract should never default to CARLA latest."""
     from robot_sf_carla_bridge.docker_runtime import CARLA_DOCKER_IMAGE, validate_carla_image
@@ -137,6 +145,7 @@ def test_preflight_requires_50_gib_free_before_pull_when_image_absent(monkeypatc
     from robot_sf_carla_bridge import docker_runtime
     from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
 
+    _pretend_linux_x86_64(monkeypatch)
     responses = {
         ("docker", "version"): CommandResult(["docker", "version"], 0, '{"Server": {}}', ""),
         ("nvidia-smi", "--query-gpu=name,driver_version,memory.total", "--format=csv,noheader"): (
@@ -184,10 +193,11 @@ def test_preflight_requires_50_gib_free_before_pull_when_image_absent(monkeypatc
     assert status["docker_storage"]["free_gib"] == pytest.approx(49.0)
 
 
-def test_preflight_nvidia_container_check_does_not_pull_test_image() -> None:
+def test_preflight_nvidia_container_check_does_not_pull_test_image(monkeypatch) -> None:
     """NVIDIA runtime probing should not download CUDA images unless explicitly prepared."""
     from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
 
+    _pretend_linux_x86_64(monkeypatch)
     observed_commands: list[list[str]] = []
 
     def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
@@ -213,6 +223,7 @@ def test_preflight_fails_when_post_pull_image_inspect_fails(monkeypatch) -> None
     from robot_sf_carla_bridge import docker_runtime
     from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
 
+    _pretend_linux_x86_64(monkeypatch)
     image_inspect_count = 0
 
     def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
@@ -249,6 +260,8 @@ def test_preflight_requires_image_digest_and_size(monkeypatch) -> None:
     """Image metadata without digest or size should fail before runtime evidence is trusted."""
     from robot_sf_carla_bridge import docker_runtime
     from robot_sf_carla_bridge.docker_runtime import CommandResult, run_carla_docker_preflight
+
+    _pretend_linux_x86_64(monkeypatch)
 
     def fake_runner(command: list[str], *, timeout_s: float) -> CommandResult:
         if command[:2] == ["docker", "version"]:

--- a/tests/carla_bridge/test_t1_live_replay.py
+++ b/tests/carla_bridge/test_t1_live_replay.py
@@ -176,6 +176,31 @@ def test_live_replay_fails_closed_for_unsupported_static_geometry(tmp_path: Path
     assert world.actors == []
 
 
+def test_live_replay_fails_closed_for_malformed_static_geometry(tmp_path: Path) -> None:
+    """Malformed T0 static obstacle vertices should fail closed before CARLA replay."""
+    from robot_sf_carla_bridge.live_replay import run_t1_oracle_live_replay_against_server
+
+    world = _FakeWorld()
+    payload = _minimal_t0_payload()
+    payload["static_geometry"]["obstacles"] = [
+        {"id": "dict_vertices", "type": "polygon", "vertices": [{"x": 0, "y": 0}] * 4}
+    ]
+    manifest_path = _write_manifest(
+        tmp_path, [{"scenario_id": "unit_crossing", "payload": payload}]
+    )
+
+    summary = run_t1_oracle_live_replay_against_server(
+        manifest_path,
+        carla_module=_fake_carla_module(world),
+    )
+
+    assert summary["status"] == "failed"
+    assert summary["reason"] == "T0 payload contains unsupported static obstacle geometry"
+    assert summary["unsupported"]["static_obstacle_count"] == 1
+    assert summary["unsupported"]["unsupported_static_obstacle_count"] == 1
+    assert world.actors == []
+
+
 def test_live_replay_spawns_replays_and_cleans_up_actors(tmp_path: Path) -> None:
     """Representable payloads should run an oracle transform replay against a live world."""
     from robot_sf_carla_bridge.live_replay import run_t1_oracle_live_replay_against_server

--- a/tests/carla_bridge/test_t1_live_replay.py
+++ b/tests/carla_bridge/test_t1_live_replay.py
@@ -118,27 +118,62 @@ def _fake_carla_module(world: _FakeWorld):
     )
 
 
-def test_live_replay_fails_closed_for_static_geometry(tmp_path: Path) -> None:
-    """Live replay should not silently ignore Robot-SF static obstacles."""
+def test_live_replay_spawns_static_geometry_and_cleans_up(tmp_path: Path) -> None:
+    """Rectangular T0 static obstacles should be represented by CARLA proxy actors."""
     from robot_sf_carla_bridge.live_replay import run_t1_oracle_live_replay_against_server
 
+    world = _FakeWorld()
     payload = _minimal_t0_payload()
-    payload["static_geometry"]["obstacles"] = [{"id": "wall", "type": "polygon"}]
+    payload["static_geometry"]["obstacles"] = [
+        {"id": "wall", "type": "polygon", "vertices": [[0, 0], [2, 0], [2, 1], [0, 1]]}
+    ]
     manifest_path = _write_manifest(
         tmp_path, [{"scenario_id": "unit_crossing", "payload": payload}]
     )
 
     summary = run_t1_oracle_live_replay_against_server(
         manifest_path,
-        carla_module=_fake_carla_module(_FakeWorld()),
+        carla_module=_fake_carla_module(world),
+        max_steps=2,
+    )
+
+    assert summary["status"] == "oracle-replay"
+    assert summary["actors"] == {"static_obstacles": 1, "robot": 1, "pedestrians": 1}
+    assert summary["boundary"]["static_geometry_replay"] is True
+    assert len(world.actors) == 3
+    static_actor = world.actors[0]
+    assert static_actor.blueprint.id == "static.prop.box01"
+    assert static_actor.blueprint.attributes["role_name"] == "robot_sf_static_obstacle_0"
+    assert static_actor.transforms[0].location.x == pytest.approx(1.0)
+    assert static_actor.transforms[0].location.y == pytest.approx(-0.5)
+    assert all(actor.destroyed for actor in world.actors)
+
+
+def test_live_replay_fails_closed_for_unsupported_static_geometry(tmp_path: Path) -> None:
+    """Unsupported T0 static obstacle shapes should fail closed before CARLA replay."""
+    from robot_sf_carla_bridge.live_replay import run_t1_oracle_live_replay_against_server
+
+    world = _FakeWorld()
+    payload = _minimal_t0_payload()
+    payload["static_geometry"]["obstacles"] = [
+        {"id": "triangle", "type": "polygon", "vertices": [[0, 0], [1, 0], [0, 1]]}
+    ]
+    manifest_path = _write_manifest(
+        tmp_path, [{"scenario_id": "unit_crossing", "payload": payload}]
+    )
+
+    summary = run_t1_oracle_live_replay_against_server(
+        manifest_path,
+        carla_module=_fake_carla_module(world),
     )
 
     assert summary["status"] == "failed"
     assert summary["mode"] == "failed"
     assert summary["stage"] == "live-replay"
-    assert summary["reason"] == "T0 payload static obstacle replay is not implemented"
+    assert summary["reason"] == "T0 payload contains unsupported static obstacle geometry"
     assert summary["unsupported"]["static_obstacle_count"] == 1
-    assert summary["unsupported"]["boundary"]["static_geometry_replay"] is False
+    assert summary["unsupported"]["unsupported_static_obstacle_count"] == 1
+    assert world.actors == []
 
 
 def test_live_replay_spawns_replays_and_cleans_up_actors(tmp_path: Path) -> None:
@@ -164,7 +199,7 @@ def test_live_replay_spawns_replays_and_cleans_up_actors(tmp_path: Path) -> None
     assert summary["carla"]["client_version"] == "0.9.16"
     assert summary["carla"]["server_version"] == "0.9.16"
     assert summary["carla"]["map"] == "Town01"
-    assert summary["actors"] == {"robot": 1, "pedestrians": 1}
+    assert summary["actors"] == {"static_obstacles": 0, "robot": 1, "pedestrians": 1}
     assert summary["trajectory"]["steps"] == 3
     assert summary["trajectory"]["truncated_by_max_steps"] is True
     assert world.ticks == 3


### PR DESCRIPTION
## Summary
Adds the first bounded static-geometry replay slice for CARLA T1 live replay: axis-aligned rectangular T0 polygon obstacles are spawned as CARLA static-prop proxy actors before robot/pedestrian oracle replay. Unsupported static obstacle shapes still fail closed with explicit counts.

## Linked Issues
- Refs #1329
- Follow-up to #1169

## What Changed
- Replaced the blanket static-geometry rejection in `robot_sf_carla_bridge/live_replay.py` with rectangle validation and static-prop proxy actor spawning.
- Extended fake-CARLA tests to cover static obstacle spawning, unsupported shape fail-closed behavior, actor cleanup, and updated actor counts.
- Adjusted Docker preflight tests so Docker-specific branches mock a Linux x86_64 CARLA host instead of stopping at the macOS host-platform gate.
- Updated the #1169 context/evidence notes to record the #1329 local implementation boundary and the still-pending live host rerun.

## Why It Matters
- Added value: removes the first known blocker for replaying the certified #1111 payload without silently ignoring static obstacles.
- Expected impact: local replay code can now attempt rectangular static obstacle payloads instead of failing before CARLA actor setup.
- Why this is worth merging now: it preserves fail-closed semantics while narrowing the remaining issue to real CARLA-host validation.

## Validation / Proof
- `uv run ruff check robot_sf_carla_bridge/live_replay.py tests/carla_bridge/test_t1_live_replay.py tests/carla_bridge/test_docker_runtime.py` -> passed.
- `uv run pytest tests/carla_bridge/test_t1_live_replay.py -q` -> 5 passed.
- `uv run pytest tests/carla_bridge/test_t1_live_replay.py tests/carla_bridge/test_docker_runtime.py -q` -> 22 passed.
- `uv run pytest tests/carla_bridge -q` -> 86 passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed for 5 changed files.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after committing and syncing with `origin/main` -> 3762 passed, 8 skipped, 1 warning; TODO-docstring ratchet passed.

## Risks / Rollout
- Compatibility risks: low for CARLA-free paths; live CARLA behavior still needs host validation.
- Failure modes: CARLA may not have a suitable `static.prop.box01` blueprint on every map/runtime, or the fixed static prop may only be a proxy rather than exact wall geometry.
- Rollback or fallback plan: revert the commit; unsupported or failed static geometry remains fail-closed.

## Docs / Provenance
- Updated docs: `docs/context/issue_1169_carla_live_replay.md` and the linked evidence README.
- Relevant design or provenance notes: #1169 remains the canonical CARLA live replay boundary note; no duplicate #1329 note was created.
- Any assumptions that need to be preserved: this is not a Robot-SF/CARLA metric parity or benchmark-transfer claim.

## Follow-Up Issues
- Deferred work: rerun `robot-sf-carla-docker-runtime live-replay --manifest docs/context/evidence/issue_1111_carla_setup_smoke_2026-05-18/manifest.json --max-steps 10 --json` on a CARLA-capable Linux/NVIDIA host and record the replacement live JSON summary.
- Issues opened for follow-up: none; #1329 should remain open until that live proof is captured.

## Reviewer Notes
- Please verify that static-prop proxies are an acceptable first representation for the rectangular #1111 wall obstacles.
- Known limitation: this PR does not prove the Docker-backed live command on a CARLA host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CARLA live replay now supports spawning axis-aligned rectangular static obstacles as proxy actors with granular failure reporting for unsupported shapes.

* **Documentation**
  * Updated issue `#1169` documentation to reflect expanded static geometry replay capabilities and clarify support boundaries for obstacle proxy actors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->