### PR TITLE
ci: include fast-pysf in canonical test phase (#1346)

### DIFF
--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -16,7 +16,7 @@ Run one or more canonical CI validation phases.
 Phases:
   lint             Ruff lint + format check
   typecheck        Ty type check (advisory, matches CI)
-  test             Main pytest suite
+  test             Main pytest suite (configured testpaths)
   smoke            Validation and benchmark smoke checks
   artifact-policy  Canonical artifact root policy guard
 
@@ -217,7 +217,7 @@ run_phase() {
       uvx ty check . --exit-zero
       ;;
     test)
-      "$SCRIPT_DIR/run_tests_parallel.sh" tests
+      "$SCRIPT_DIR/run_tests_parallel.sh"
       ;;
     smoke)
       run_smoke_phase "$event_name" "$github_ref"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
+PYPROJECT = ROOT / "pyproject.toml"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
 
 
@@ -23,11 +25,16 @@ def test_ci_driver_smoke_uses_runtime_schema_and_output_matrix_path() -> None:
 
 
 def test_ci_driver_test_phase_uses_shared_parallel_test_wrapper() -> None:
-    """Preserve the repo's platform-specific pytest wrapper in the CI driver."""
+    """Preserve the shared pytest wrapper and default testpaths in the CI driver."""
 
     script_text = CI_DRIVER.read_text(encoding="utf-8")
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    testpaths = pyproject["tool"]["pytest"]["ini_options"]["testpaths"]
 
-    assert '"$SCRIPT_DIR/run_tests_parallel.sh" tests' in script_text
+    assert '"$SCRIPT_DIR/run_tests_parallel.sh"' in script_text
+    assert '"$SCRIPT_DIR/run_tests_parallel.sh" tests' not in script_text
+    assert "tests" in testpaths
+    assert "fast-pysf/tests" in testpaths
     assert "uv run pytest -q -n auto --max-worker-restart=0" not in script_text
 
 


### PR DESCRIPTION
## Summary
Aligns the canonical CI/local `test` phase with pytest's configured `testpaths`, so
`fast-pysf/tests` runs with the rest of the unified suite.

## Linked Issues
- Closes #1346

## What Changed
- Updated `scripts/dev/ci_driver.sh test` to call the shared parallel pytest wrapper without a
  hard-coded `tests` path.
- Updated the CI script contract test to guard both the wrapper call and the configured pytest
  `testpaths` entries for `tests` and `fast-pysf/tests`.

## Why It Matters
- Added value: the canonical CI driver no longer bypasses the fast-pysf subtree.
- Expected impact: contributors and CI get a truer signal for pedestrian physics regressions.
- Why this is worth merging now: it removes a documented automation/docs mismatch with a tiny,
  low-risk script change.

## Validation / Proof
- `uv run pytest tests/test_ci_script_contract.py -q` -> 3 passed.
- `uv run pytest --collect-only -q tests` -> 3755 tests collected.
- `uv run pytest --collect-only -q` -> 3769 tests collected.
- `uv run pytest tests/test_ci_script_contract.py tests/test_ci_driver_contract.py -q` -> 11 passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after committing and
  syncing with latest `origin/main` -> 3775 passed, 11 skipped, 3 warnings.
- The committed readiness run printed `testpaths: tests, fast-pysf/tests` and collected 3786 items
  before marker/skip filtering.

## Risks / Rollout
- Compatibility risks: low; the change uses the existing pytest configuration as the source of
  truth.
- Failure modes: future edits to `pyproject.toml` `testpaths` will affect CI coverage directly.
  The updated contract test guards the expected entries.
- Rollback or fallback plan: revert the single commit to restore the explicit `tests` path.

## Docs / Provenance
- Updated docs: none; existing docs already describe the unified test suite.
- Relevant design or provenance notes: #1346 captured the observed mismatch and collect-only proof.
- Any assumptions that need to be preserved: `pyproject.toml` remains the canonical pytest discovery
  source for the unified suite.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that making `pyproject.toml` testpaths the CI-driver source of truth is the desired
  policy.
- Ignored `output/coverage/` files were generated by validation and are disposable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI contract tests now validate test target configuration at runtime against project settings instead of relying on inline expectations. The test suite also tightened assertions to confirm the parallel test runner is invoked without an explicit test list, ensuring alignment between CI behavior and project configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->