### PR TITLE
fix: enforce map definition invariants (#1348)

### DIFF
--- a/robot_sf/nav/map_config.py
+++ b/robot_sf/nav/map_config.py
@@ -337,11 +337,28 @@ class MapDefinition:
         """
         Validates the map definition and initializes the obstacles_pysf and
         robot_routes_by_spawn_id attributes.
-        Raises a ValueError if the width or height is less than 0,
+        Raises a ValueError if the width or height is non-positive,
         if the robot spawn zones or goal zones are empty,
         or if the bounds are not exactly 4.
         """
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(
+                "Map width and height must be positive. "
+                + f"Width: {self.width}, Height: {self.height}",
+            )
+
+        if not self.robot_spawn_zones:
+            raise ValueError("Robot spawn zones mustn't be empty!")
+
+        if not self.robot_goal_zones:
+            raise ValueError("Robot goal zones mustn't be empty!")
+
         self.bounds = _normalize_bounds(self.bounds)
+        if len(self.bounds) != 4:
+            raise ValueError(
+                "Invalid bounds! Expected exactly 4 bounds! " + f"Found {len(self.bounds)} bounds!",
+            )
+
         obstacle_lines = [line for obstacle in self.obstacles for line in obstacle.lines]
         self.obstacles_pysf = obstacle_lines + self.bounds
 
@@ -353,23 +370,6 @@ class MapDefinition:
                 self.robot_routes_by_spawn_id[route.spawn_id] = [route]
         if not self.robot_routes:
             logger.warning("MapDefinition has no robot routes; planners may synthesize defaults.")
-
-        if self.width <= 0 or self.height <= 0:
-            logger.critical(
-                "Map width and height mustn't be zero or negative! "
-                + f"Width: {self.width}, Height: {self.height}",
-            )
-
-        if not self.robot_spawn_zones:
-            logger.error("Robot spawn zones mustn't be empty!")
-
-        if not self.robot_goal_zones:
-            logger.error("Robot goal zones mustn't be empty!")
-
-        if len(self.bounds) != 4:
-            logger.critical(
-                "Invalid bounds! Expected exactly 4 bounds! " + f"Found {len(self.bounds)} bounds!",
-            )
 
         # Validate single pedestrians
         self._validate_single_pedestrians()
@@ -1054,16 +1054,35 @@ def _normalize_bounds(bounds: list[Line2D]) -> list[Line2D]:
         list[Line2D]: Bounds normalized into flat tuple format.
     """
     normalized: list[Line2D] = []
-    for bound in bounds:
-        if isinstance(bound, (tuple, list)) and len(bound) == 2:
+    for index, bound in enumerate(bounds):
+        if not isinstance(bound, (tuple, list)):
+            raise ValueError(
+                f"Invalid bound at index {index}: expected a 4-tuple or pair-of-points, got {bound!r}"
+            )
+
+        if len(bound) == 4:
+            try:
+                x_start, x_end, y_start, y_end = bound  # type: ignore[misc]
+                normalized.append((float(x_start), float(x_end), float(y_start), float(y_end)))
+                continue
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid bound at index {index}: failed to parse flat bound {bound!r}"
+                ) from exc
+
+        if len(bound) == 2:
             try:
                 (x1, y1), (x2, y2) = bound  # type: ignore[misc]
                 normalized.append((float(x1), float(x2), float(y1), float(y2)))
                 continue
-            except (TypeError, ValueError):
-                # Fall back to raw bound when unpacking fails.
-                pass
-        normalized.append(bound)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid bound at index {index}: failed to parse pair-of-points bound {bound!r}"
+                ) from exc
+
+        raise ValueError(
+            f"Invalid bound at index {index}: expected a 4-tuple or pair-of-points, got {bound!r}"
+        )
     return normalized
 
 

--- a/tests/test_map_definition_validation.py
+++ b/tests/test_map_definition_validation.py
@@ -1,0 +1,137 @@
+"""Regression tests for strict MapDefinition construction invariants."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.nav.map_config import MapDefinition
+
+
+def _valid_map_kwargs() -> dict:
+    """Return minimal valid MapDefinition kwargs for invariant tests."""
+
+    zone = ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0))
+    return {
+        "width": 10.0,
+        "height": 10.0,
+        "obstacles": [],
+        "robot_spawn_zones": [zone],
+        "ped_spawn_zones": [],
+        "robot_goal_zones": [zone],
+        "bounds": [
+            (0.0, 10.0, 0.0, 0.0),
+            (0.0, 10.0, 10.0, 10.0),
+            (0.0, 0.0, 0.0, 10.0),
+            (10.0, 10.0, 0.0, 10.0),
+        ],
+        "robot_routes": [],
+        "ped_goal_zones": [],
+        "ped_crowded_zones": [],
+        "ped_routes": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "message"),
+    [
+        ("width", 0.0, "Map width and height"),
+        ("width", -1.0, "Map width and height"),
+        ("height", 0.0, "Map width and height"),
+        ("height", -1.0, "Map width and height"),
+    ],
+)
+def test_map_definition_rejects_non_positive_dimensions(
+    field_name: str, value: float, message: str
+) -> None:
+    """Map dimensions are construction-time invariants, not logged degradations."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs[field_name] = value
+
+    with pytest.raises(ValueError, match=message):
+        MapDefinition(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "message"),
+    [
+        ("robot_spawn_zones", "Robot spawn zones"),
+        ("robot_goal_zones", "Robot goal zones"),
+    ],
+)
+def test_map_definition_rejects_missing_required_robot_zones(field_name: str, message: str) -> None:
+    """Robot spawn and goal zones must fail fast when absent."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs[field_name] = []
+
+    with pytest.raises(ValueError, match=message):
+        MapDefinition(**kwargs)
+
+
+def test_map_definition_rejects_wrong_bounds_count() -> None:
+    """A complete map boundary must contain exactly four bounds."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs["bounds"] = kwargs["bounds"][:3]
+
+    with pytest.raises(ValueError, match="Expected exactly 4 bounds"):
+        MapDefinition(**kwargs)
+
+
+def test_map_definition_rejects_malformed_pair_bounds() -> None:
+    """Malformed pair-of-point bounds should not survive normalization."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs["bounds"] = [
+        ((0.0, 0.0), (10.0,)),  # Missing y coordinate in second endpoint.
+        (0.0, 10.0, 10.0, 10.0),
+        (0.0, 0.0, 0.0, 10.0),
+        (10.0, 10.0, 0.0, 10.0),
+    ]
+
+    with pytest.raises(ValueError, match="Invalid bound"):
+        MapDefinition(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "bad_bound",
+    [
+        "skip-me",
+        (0.0, 10.0, "bad-y", 0.0),
+    ],
+)
+def test_map_definition_rejects_malformed_flat_bounds(bad_bound: object) -> None:
+    """Malformed flat bounds should fail before they reach simulation helpers."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs["bounds"] = [
+        bad_bound,
+        (0.0, 10.0, 10.0, 10.0),
+        (0.0, 0.0, 0.0, 10.0),
+        (10.0, 10.0, 0.0, 10.0),
+    ]
+
+    with pytest.raises(ValueError, match="Invalid bound"):
+        MapDefinition(**kwargs)
+
+
+def test_map_definition_normalizes_valid_pair_bounds() -> None:
+    """Valid pair-of-point bounds should normalize into flat pysf-compatible segments."""
+
+    kwargs = _valid_map_kwargs()
+    kwargs["bounds"] = [
+        ((0.0, 0.0), (10.0, 0.0)),
+        ((0.0, 10.0), (10.0, 10.0)),
+        ((0.0, 0.0), (0.0, 10.0)),
+        ((10.0, 0.0), (10.0, 10.0)),
+    ]
+
+    map_def = MapDefinition(**kwargs)
+
+    assert map_def.bounds == [
+        (0.0, 10.0, 0.0, 0.0),
+        (0.0, 10.0, 10.0, 10.0),
+        (0.0, 0.0, 0.0, 10.0),
+        (10.0, 10.0, 0.0, 10.0),
+    ]

--- a/tests/test_occupancy_additional.py
+++ b/tests/test_occupancy_additional.py
@@ -349,7 +349,12 @@ def test_check_quality_of_map_point_supports_flat_bounds_and_invalid_entries() -
         "skip-me",
         (0.0, 0.0, 0.0, 2.0),
     ]
-    map_def = _make_map(obstacles=[], bounds=flat_bounds)
+    map_def = SimpleNamespace(
+        width=2.0,
+        height=2.0,
+        obstacles=[],
+        bounds=flat_bounds,
+    )
 
     assert check_quality_of_map_point(map_def, (1.0, 1.0), radius=0.1) is True
     assert check_quality_of_map_point(map_def, (1.0, 0.0), radius=0.1) is False

--- a/tests/test_osm_map_builder.py
+++ b/tests/test_osm_map_builder.py
@@ -213,14 +213,15 @@ class TestBackwardCompat:
         self, pbf_fixture: str, tag_filters: OSMTagFilters
     ) -> None:
         """Test MapDefinition works with allowed_areas=None (legacy)."""
+        zone = ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0))
         # Create a legacy MapDefinition (without allowed_areas)
         legacy_map = MapDefinition(
             width=100.0,
             height=100.0,
             obstacles=[],
-            robot_spawn_zones=[],
+            robot_spawn_zones=[zone],
             ped_spawn_zones=[],
-            robot_goal_zones=[],
+            robot_goal_zones=[zone],
             ped_goal_zones=[],
             robot_routes=[],
             ped_crowded_zones=[],

--- a/tests/test_svg_classic_maps_format.py
+++ b/tests/test_svg_classic_maps_format.py
@@ -3,7 +3,7 @@
 These tests ensure each new classical interaction SVG map:
   * Parses without exception using SvgMapConverter
   * Produces a MapDefinition object
-  * Contains at least one robot spawn zone and goal zone (MapDefinition logs error otherwise)
+  * Contains at least one robot spawn zone and goal zone (MapDefinition rejects them otherwise)
   * Has width/height > 0
   * Contains obstacles (except explicitly documented minimal cases)
   * Ensures any route labels with indices reference existing spawn/goal zone indices

--- a/tests/test_svg_obstacle_self_intersection.py
+++ b/tests/test_svg_obstacle_self_intersection.py
@@ -158,6 +158,10 @@ def test_compound_obstacle_paths_preserve_detached_members(tmp_path: Path) -> No
               <path id="compound_obstacle"
                     inkscape:label="obstacle"
                     d="M 0 0 L 4 0 L 4 4 L 0 4 Z M 6 0 L 10 0 L 10 4 L 6 4 Z"/>
+              <rect id="spawn" inkscape:label="robot_spawn_zone"
+                    x="4.4" y="1" width="0.4" height="0.4"/>
+              <rect id="goal" inkscape:label="robot_goal_zone"
+                    x="10.6" y="1" width="0.4" height="0.4"/>
             </svg>
             """
         ).strip(),

--- a/tests/test_svg_zone_indices.py
+++ b/tests/test_svg_zone_indices.py
@@ -86,15 +86,14 @@ def test_zone_index_helpers_handle_duplicates_and_gaps() -> None:
     assert assembled[1] == second_zone
 
 
-def test_process_rects_supports_bounds_obstacles_and_fallback_routes(tmp_path: Path) -> None:
-    """Ensure rect parsing handles bounds/obstacles and id-based zone labels."""
+def test_process_rects_supports_obstacles_zones_and_fallback_routes(tmp_path: Path) -> None:
+    """Ensure rect parsing handles obstacles, id-based zones, and fallback routes."""
     svg = """
     <svg xmlns="http://www.w3.org/2000/svg"
          xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
          width="10" height="10">
       <rect id="robot_spawn_zone_0" x="1" y="1" width="1" height="1" />
       <rect id="robot_goal_zone_0" x="8" y="8" width="1" height="1" />
-      <rect id="extra_bound" inkscape:label="bound" x="0" y="0" width="10" height="1" />
       <rect id="wall" inkscape:label="obstacle" x="2" y="2" width="1" height="1" />
       <rect id="crowd" inkscape:label="ped_crowded_zone" x="3" y="3" width="1" height="1" />
       <rect id="decor" inkscape:label="decorative" x="4" y="4" width="1" height="1" />
@@ -109,6 +108,7 @@ def test_process_rects_supports_bounds_obstacles_and_fallback_routes(tmp_path: P
     assert len(map_def.ped_crowded_zones) == 1
     assert len(map_def.robot_spawn_zones) == 1
     assert len(map_def.robot_goal_zones) == 1
+    assert len(map_def.bounds) == 4
     assert map_def.robot_routes  # fallback route generated when none defined
 
 


### PR DESCRIPTION
## Summary
Makes `MapDefinition` enforce its documented construction invariants with clear `ValueError`s
instead of logging invalid maps and continuing.

## Linked Issues
- Related: #1348 (does not close the rewritten capability-aware map catalog/design issue)

## What Changed
- Added fail-fast validation for non-positive map dimensions, missing robot spawn/goal zones, wrong
  bounds counts, and malformed bound entries.
- Hardened bounds normalization so valid flat and pair-of-point bounds normalize to the fast-pysf
  format, while malformed bounds fail at construction time.
- Added focused regression tests for invalid dimensions, required robot zones, bounds counts,
  malformed bounds, and valid pair-of-point normalization.
- Updated coupled fixtures that were exercising unrelated behavior with now-invalid maps.

## Why It Matters
- Added value: map authoring and parser errors now fail near the loading boundary with actionable
  messages.
- Expected impact: invalid map definitions cannot silently enter planner, simulation, or benchmark
  paths and fail later with opaque errors.
- Why this is worth merging now: #1348 documented a direct contradiction between the constructor
  docstring and runtime behavior.

## Validation / Proof
- `uv run python - <<'PY' ... MapDefinition(width=0.0, robot_spawn_zones=[], robot_goal_zones=[], bounds=[]) ... PY`
  before the fix -> logged errors and printed `no_exception`.
- `uv run pytest tests/test_map_definition_validation.py -q` before implementation -> 6 expected
  failures proving the new tests caught the bug.
- `uv run ruff check robot_sf/nav/map_config.py tests/test_map_definition_validation.py tests/test_occupancy_additional.py tests/test_osm_map_builder.py tests/test_svg_classic_maps_format.py tests/test_svg_obstacle_self_intersection.py tests/test_svg_zone_indices.py`
  -> passed.
- `uv run pytest tests/test_svg_zone_indices.py::test_process_rects_supports_obstacles_zones_and_fallback_routes tests/test_svg_obstacle_self_intersection.py::test_compound_obstacle_paths_preserve_detached_members tests/test_map_definition_validation.py tests/test_occupancy_additional.py tests/test_osm_map_builder.py tests/test_map_selection.py tests/test_map_migration.py tests/test_svg_classic_maps_format.py -q`
  -> 94 passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after syncing with
  latest `origin/main` -> 3786 passed, 11 skipped, 3 warnings; changed-file coverage minimum passed
  with `robot_sf/nav/map_config.py` at 85.9% and a warning for missing the 100% goal.

## Risks / Rollout
- Compatibility risks: medium; code that intentionally constructed incomplete `MapDefinition`
  objects must now use valid minimal zones/bounds or a map-like test double when testing lower-level
  helper tolerance.
- Failure modes: previously tolerated malformed SVG/map fixtures now raise earlier.
- Rollback or fallback plan: revert the commit to restore log-only validation.

## Docs / Provenance
- Updated docs: no user docs changed; one test module comment was updated from "logs error" to
  "rejects".
- Relevant design or provenance notes: #1348 captures the observed gap and repro.
- Any assumptions that need to be preserved: exactly four map boundary segments remain the
  `MapDefinition` contract.

## Follow-Up Issues
- Deferred work: #1348 now tracks the capability-aware map catalog / validation-profile design and remains open.
- Issues opened for follow-up: none from this PR.

## Reviewer Notes
- Please verify that strict construction is the desired compatibility boundary for direct
  `MapDefinition` construction and SVG conversion.
- Ignored `output/coverage/` files were generated by validation and are disposable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map configuration validation is now stricter, raising errors for invalid dimensions, missing robot zones, or malformed boundaries instead of silently logging warnings. Invalid maps are caught earlier.

* **Tests**
  * Added comprehensive test coverage for map configuration validation scenarios, ensuring all validation rules are properly enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->