### PR TITLE
fix: enforce policy step timeout boundary (#1349)

### DIFF
--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -15,10 +15,11 @@ multi-processing are future work.
 from __future__ import annotations
 
 import json
+import multiprocessing as mp
 import os
 import platform
 import time
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import (
     UTC,  # type: ignore[attr-defined]
@@ -150,6 +151,126 @@ FINAL_SPEED_CLAMP: float = 2.0  # m/s cap to prevent unrealistic velocities
 _episode_identity_hash = episode_identity_hash
 
 
+def _planner_step_worker(conn: Any, planner: Any) -> None:
+    """Run planner steps in an isolated child process."""
+    try:
+        while True:
+            try:
+                command, payload = conn.recv()
+            except EOFError:
+                break
+            if command == "close":
+                break
+            if command != "step":
+                conn.send(("error", ("RuntimeError", f"unknown command: {command!r}")))
+                continue
+            try:
+                conn.send(("ok", planner.step(payload)))
+            except Exception as exc:  # pragma: no cover - defensive child-process path
+                conn.send(("error", (type(exc).__name__, str(exc))))
+    finally:
+        conn.close()
+
+
+class _PlannerStepProcess:
+    """Persistent process boundary for planner.step with hard timeout cleanup."""
+
+    def __init__(self, planner: Any, *, timeout_s: float) -> None:
+        if "fork" not in mp.get_all_start_methods():
+            raise RuntimeError(
+                "planner step timeout isolation requires multiprocessing fork support"
+            )
+        self._planner = planner
+        self._timeout_s = timeout_s
+        self._ctx = mp.get_context("fork")
+        self._process: mp.Process | None = None
+        self._conn: Any | None = None
+
+    def step(self, obs: Any) -> Any:
+        """Run one planner step or raise when timeout/isolation fails.
+
+        Returns:
+            Planner action payload returned by the worker process.
+        """
+        self._ensure_worker()
+        assert self._conn is not None
+        assert self._process is not None
+        try:
+            self._conn.send(("step", obs))
+        except (BrokenPipeError, EOFError, OSError) as exc:
+            self.close()
+            raise RuntimeError("planner step worker was unavailable") from exc
+
+        deadline = time.monotonic() + self._timeout_s
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._terminate_worker()
+                raise FuturesTimeoutError()
+            if self._conn.poll(min(remaining, 0.01)):
+                status, payload = self._conn.recv()
+                if status == "ok":
+                    return payload
+                error_type, message = payload
+                raise RuntimeError(f"Planner step failed in worker ({error_type}: {message})")
+            if not self._process.is_alive():
+                self._process.join(timeout=0)
+                self.close()
+                raise RuntimeError("planner step worker exited without returning an action")
+
+    def close(self) -> None:
+        """Close the worker process and IPC handle."""
+        conn = self._conn
+        process = self._process
+        self._conn = None
+        self._process = None
+
+        if conn is not None:
+            try:
+                if process is not None and process.is_alive():
+                    conn.send(("close", None))
+            except (BrokenPipeError, EOFError, OSError):
+                pass
+            conn.close()
+        if process is not None:
+            process.join(timeout=0.1)
+            if process.is_alive():
+                self._terminate_process(process)
+
+    def _ensure_worker(self) -> None:
+        """Start the persistent worker process if needed."""
+        if self._process is not None and self._process.is_alive() and self._conn is not None:
+            return
+        self.close()
+        parent_conn, child_conn = self._ctx.Pipe(duplex=True)
+        process = self._ctx.Process(target=_planner_step_worker, args=(child_conn, self._planner))
+        process.start()
+        child_conn.close()
+        self._process = process
+        self._conn = parent_conn
+
+    def _terminate_worker(self) -> None:
+        """Terminate the current worker after a timeout."""
+        process = self._process
+        conn = self._conn
+        self._process = None
+        self._conn = None
+        if conn is not None:
+            conn.close()
+        if process is not None:
+            self._terminate_process(process)
+
+    @staticmethod
+    def _terminate_process(process: mp.Process) -> None:
+        """Terminate, then kill if necessary, and reap a worker process."""
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=0.1)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=0.1)
+
+
 def load_scenario_matrix(path: str | Path) -> list[dict[str, Any]]:
     """Load a scenario matrix from YAML (stream, list, or dict with scenarios).
 
@@ -270,7 +391,7 @@ def _build_episode_data(  # noqa: PLR0913
     )
 
 
-def _create_robot_policy(algo: str, algo_config_path: str | None, seed: int):  # noqa: C901
+def _create_robot_policy(algo: str, algo_config_path: str | None, seed: int):  # noqa: C901, PLR0915
     """Create a robot policy function based on the specified algorithm.
 
     Returns:
@@ -372,6 +493,24 @@ def _create_robot_policy(algo: str, algo_config_path: str | None, seed: int):  #
             return _clamp_speed(vel)
         raise ValueError(f"Invalid action format from {algo}: {action}")
 
+    metadata = planner.get_metadata() if hasattr(planner, "get_metadata") else {"algorithm": algo}
+    timeout_metadata: dict[str, Any] = {
+        "isolation": "process",
+        "step_timeout_s": POLICY_STEP_TIMEOUT_SECS,
+        "step_timeouts": 0,
+        "worker_errors": 0,
+        "fallback_actions": 0,
+    }
+    step_runner: _PlannerStepProcess | None
+    try:
+        step_runner = _PlannerStepProcess(planner, timeout_s=POLICY_STEP_TIMEOUT_SECS)
+    except RuntimeError as exc:
+        step_runner = None
+        timeout_metadata["isolation"] = "unavailable"
+        timeout_metadata["error"] = str(exc)
+        metadata["status"] = "policy_step_isolation_unavailable"
+        metadata["fallback_reason"] = "policy_step_isolation_unavailable"
+
     def policy_fn(
         robot_pos: np.ndarray,
         robot_vel: np.ndarray,
@@ -386,37 +525,36 @@ def _create_robot_policy(algo: str, algo_config_path: str | None, seed: int):  #
         """
         obs = _build_observation(Observation, robot_pos, robot_vel, robot_goal, ped_positions, dt)
 
-        # Execute planner.step with a small timeout to avoid stalls
-        def _do_step():
-            """Execute planner step in thread pool.
-
-            Returns:
-                Action dict from planner.
-            """
-            return planner.step(obs)
-
         try:
-            with ThreadPoolExecutor(max_workers=1) as ex:
-                fut = ex.submit(_do_step)
-                action = fut.result(timeout=POLICY_STEP_TIMEOUT_SECS)
+            if step_runner is None:
+                raise RuntimeError("policy step isolation unavailable")
+            action = step_runner.step(obs)
         except FuturesTimeoutError:
-            # Safe fallback: zero action in current space
-            # Prefer preserving action-space contract when possible
+            timeout_metadata["step_timeouts"] += 1
+            timeout_metadata["fallback_actions"] += 1
+            metadata["status"] = "policy_step_timeout_fallback"
+            metadata["fallback_reason"] = "policy_step_timeout"
             action = {"vx": 0.0, "vy": 0.0}
         except (RuntimeError, TypeError, ValueError) as exc:
-            # Any unexpected planner errors -> fallback but log for diagnostics
+            timeout_metadata["worker_errors"] += 1
+            timeout_metadata["fallback_actions"] += 1
+            metadata["status"] = "policy_step_error_fallback"
+            metadata["fallback_reason"] = "policy_step_error"
+            timeout_metadata["last_error"] = str(exc)
             logger.warning("Planner step failed unexpectedly: %s", exc)
             action = {"vx": 0.0, "vy": 0.0}
 
         # Convert action to velocity (handle both action spaces)
         return _action_to_velocity(action, robot_pos, robot_vel, robot_goal)
 
-    metadata = planner.get_metadata() if hasattr(planner, "get_metadata") else {"algorithm": algo}
+    if step_runner is not None:
+        policy_fn.close = step_runner.close  # type: ignore[attr-defined]
     # Ensure consistent metadata schema
     metadata.setdefault("algorithm", algo)
     metadata["config"] = algo_config
     metadata["config_hash"] = _config_hash(algo_config)
     metadata.setdefault("status", "ok")
+    metadata["policy_step_timeout"] = timeout_metadata
     metadata = enrich_algorithm_metadata(
         algo=algo,
         metadata=metadata,
@@ -424,6 +562,13 @@ def _create_robot_policy(algo: str, algo_config_path: str | None, seed: int):  #
     )
 
     return policy_fn, metadata
+
+
+def _close_robot_policy(policy: Any) -> None:
+    """Close optional policy resources after an episode."""
+    close_fn = getattr(policy, "close", None)
+    if callable(close_fn):
+        close_fn()
 
 
 def _append_video_skip_note(record: dict[str, Any], note: str) -> None:
@@ -965,16 +1110,19 @@ def run_episode(  # noqa: PLR0913
     robot_policy, algo_metadata = _create_robot_policy(algo, algo_config_path, seed)
 
     # Simulate episode
-    trajectories = _simulate_episode_with_policy(
-        scenario_params,
-        seed,
-        robot_policy,
-        horizon,
-        dt,
-        robot_start,
-        robot_goal,
-        record_forces,
-    )
+    try:
+        trajectories = _simulate_episode_with_policy(
+            scenario_params,
+            seed,
+            robot_policy,
+            horizon,
+            dt,
+            robot_start,
+            robot_goal,
+            record_forces,
+        )
+    finally:
+        _close_robot_policy(robot_policy)
     (
         robot_pos_traj,
         robot_vel_traj,

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -208,7 +208,13 @@ class _PlannerStepProcess:
                 self._terminate_worker()
                 raise FuturesTimeoutError()
             if self._conn.poll(min(remaining, 0.01)):
-                status, payload = self._conn.recv()
+                try:
+                    status, payload = self._conn.recv()
+                except EOFError as exc:
+                    self.close()
+                    raise RuntimeError(
+                        "planner step worker exited before returning an action"
+                    ) from exc
                 if status == "ok":
                     return payload
                 error_type, message = payload

--- a/tests/test_runner_policy_timeout.py
+++ b/tests/test_runner_policy_timeout.py
@@ -1,0 +1,56 @@
+"""Regression tests for benchmark runner planner-step timeouts."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+from robot_sf import baselines
+from robot_sf.benchmark import runner
+
+
+class _SlowPlanner:
+    """Planner stub whose step call exceeds the benchmark timeout budget."""
+
+    def __init__(self, _config: dict[str, Any], *, seed: int) -> None:
+        self.seed = seed
+
+    def step(self, _obs: Any) -> dict[str, float]:
+        time.sleep(0.75)
+        return {"vx": 1.0, "vy": 0.0}
+
+    def get_metadata(self) -> dict[str, Any]:
+        return {"algorithm": "random", "status": "ok", "seed": self.seed}
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
+def test_planner_step_timeout_fails_fast_and_reports_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow planner step should not block until the worker completes."""
+    monkeypatch.setitem(baselines.BASELINES, "random", _SlowPlanner)
+    monkeypatch.setattr(runner, "POLICY_STEP_TIMEOUT_SECS", 0.05)
+    policy, metadata = runner._create_robot_policy("random", None, seed=123)
+
+    start = time.monotonic()
+    velocity = policy(
+        np.array([0.0, 0.0]),
+        np.array([0.0, 0.0]),
+        np.array([1.0, 0.0]),
+        np.empty((0, 2)),
+        0.1,
+    )
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5
+    assert velocity == pytest.approx(np.array([0.0, 0.0]))
+    assert metadata["status"] == "policy_step_timeout_fallback"
+    timeout_metadata = metadata["policy_step_timeout"]
+    assert timeout_metadata["isolation"] == "process"
+    assert timeout_metadata["step_timeout_s"] == 0.05
+    assert timeout_metadata["step_timeouts"] == 1
+    assert timeout_metadata["fallback_actions"] == 1

--- a/tests/test_runner_policy_timeout.py
+++ b/tests/test_runner_policy_timeout.py
@@ -27,6 +27,41 @@ class _SlowPlanner:
         return {"algorithm": "random", "status": "ok", "seed": self.seed}
 
 
+class _EOFConn:
+    """Pipe stand-in that simulates a worker closing before sending a payload."""
+
+    def send(self, _payload: Any) -> None:
+        """Accept parent commands without raising."""
+
+    def poll(self, _timeout: float) -> bool:
+        """Report a ready pipe so the parent immediately calls recv."""
+        return True
+
+    def recv(self) -> object:
+        """Simulate the child process disappearing before a response is available."""
+        raise EOFError
+
+    def close(self) -> None:
+        """Close hook used by the runner cleanup path."""
+
+
+class _AliveProcess:
+    """Process stand-in that keeps _PlannerStepProcess on the recv path."""
+
+    def is_alive(self) -> bool:
+        """Return true so the runner treats the worker as active before recv."""
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        """Join hook used by the runner cleanup path."""
+
+    def terminate(self) -> None:
+        """Terminate hook used by the runner cleanup path."""
+
+    def kill(self) -> None:
+        """Kill hook used by the runner cleanup path."""
+
+
 @pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
 def test_planner_step_timeout_fails_fast_and_reports_metadata(
     monkeypatch: pytest.MonkeyPatch,
@@ -54,3 +89,14 @@ def test_planner_step_timeout_fails_fast_and_reports_metadata(
     assert timeout_metadata["step_timeout_s"] == 0.05
     assert timeout_metadata["step_timeouts"] == 1
     assert timeout_metadata["fallback_actions"] == 1
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
+def test_planner_step_process_reports_eof_between_poll_and_recv() -> None:
+    """A closed worker pipe should fail closed instead of leaking EOFError."""
+    step_process = runner._PlannerStepProcess(object(), timeout_s=0.5)
+    step_process._conn = _EOFConn()
+    step_process._process = _AliveProcess()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="exited before returning an action"):
+        step_process.step({"obs": "value"})


### PR DESCRIPTION
## Summary
Replaces the benchmark runner's thread-based `planner.step` timeout with a process-backed boundary
that can actually terminate a slow planner step instead of waiting for the worker to finish.

## Linked Issues
- Closes #1349

## What Changed
- Added a persistent forked worker for non-`simple_policy` runner planner steps, with hard timeout
  termination and cleanup.
- Preserved parent-side action validation and zero-action fallback for timeout/error cases.
- Added explicit `algorithm_metadata.policy_step_timeout` counters and fallback status/reason fields
  when a planner step times out or the worker fails.
- Added a wall-clock regression test proving a slow planner step returns near the timeout budget.

## Why It Matters
- Added value: benchmark episodes no longer silently wait for a slow planner after the timeout fires.
- Expected impact: timeout fallback metadata is honest and visible in episode records.
- Why this is worth merging now: #1349 documented that the old `ThreadPoolExecutor` context manager
  made the timeout guard misleading for benchmark runtime protection.

## Validation / Proof
- `uv run pytest tests/test_runner_policy_timeout.py -q` before the fix -> failed with a 0.75s call
  against a 0.05s timeout budget.
- `uv run pytest tests/test_runner_policy_timeout.py -q` after the fix -> 1 passed; timed call was
  about 0.08-0.09s.
- `uv run python - <<'PY' ... run_episode(... algo="random") and run_batch(... workers=2, algo="random") ... PY`
  -> episode metadata reported `status=ok`, `isolation=process`; batch summary wrote 2/2 with 0
  failures.
- `uv run pytest tests/test_runner_policy_timeout.py tests/test_runner_smoke.py tests/test_runner_batch.py tests/unit/test_runner_helper_coverage.py -q`
  -> 13 passed, 1 warning.
- `uv run ruff check robot_sf/benchmark/runner.py tests/test_runner_policy_timeout.py` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after syncing with
  latest `origin/main` -> 3776 passed, 11 skipped, 11 warnings; changed-file coverage minimum
  passed with `robot_sf/benchmark/runner.py` at 85.3% and a warning for missing the 100% goal.
- After amending formatter output, `uv run pytest tests/test_runner_policy_timeout.py -q` -> 1
  passed, 1 warning.

## Risks / Rollout
- Compatibility risks: medium; this uses `multiprocessing` fork isolation for the synthetic
  benchmark runner policy adapter path. On platforms without fork support, planner steps fail closed
  to zero-action fallback with `policy_step_isolation_unavailable` metadata instead of running
  unbounded.
- Failure modes: Python emits a multi-threaded `fork()` deprecation warning in some tests because
  the process already has imported threaded libraries. The warning is visible in validation output.
- Rollback or fallback plan: revert the commit to restore the previous thread-backed timeout guard.

## Docs / Provenance
- Updated docs: no user docs changed.
- Relevant design or provenance notes: #1349 captures the observed timeout/shutdown bug and the
  maintainer decision that benchmark-facing timeout correctness needs a real isolation boundary.
- Any assumptions that need to be preserved: this PR addresses `robot_sf/benchmark/runner.py`, not
  the separate `map_runner.py` policy-call surface.

## Follow-Up Issues
- Deferred work: none for #1349.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please scrutinize the fork-isolation tradeoff. It satisfies the fail-fast requirement on this
  Linux worker, while making unsupported isolation fail closed rather than silently running
  unbounded.
- Ignored `output/coverage/` and `output/issue_1349_random_batch_smoke.jsonl` were generated by
  validation and are disposable.
