### PR TITLE
fix: fail closed on malformed benchmark jsonl (#1350)

### DIFF
--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from loguru import logger
 
-from robot_sf.benchmark.errors import AggregationMetadataError
+from robot_sf.benchmark.errors import AggregationMetadataError, EpisodeRecordInputError
 from robot_sf.benchmark.metrics import snqi as snqi_fn
 from robot_sf.benchmark.thresholds import validate_threshold_parameter_consistency
 
@@ -33,8 +33,43 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 
-def read_jsonl(paths: Sequence[str | Path] | str | Path) -> list[dict[str, Any]]:
+def _format_jsonl_input_error(
+    *,
+    missing_paths: list[Path],
+    malformed_lines: list[tuple[Path, int, str]],
+) -> str:
+    """Build an actionable JSONL input error message.
+
+    Returns:
+        Compact error message with counts and representative locations.
+    """
+    details = [
+        "Episode JSONL input is not suitable for benchmark aggregation",
+        f"missing_paths={len(missing_paths)}",
+        f"malformed_lines={len(malformed_lines)}",
+    ]
+    if missing_paths:
+        preview = ", ".join(str(path) for path in missing_paths[:5])
+        details.append(f"missing=[{preview}]")
+    if malformed_lines:
+        preview = "; ".join(
+            f"{path}:{line_number}: {message}" for path, line_number, message in malformed_lines[:5]
+        )
+        details.append(f"malformed=[{preview}]")
+    return "; ".join(details)
+
+
+def read_jsonl(
+    paths: Sequence[str | Path] | str | Path,
+    *,
+    strict: bool = True,
+) -> list[dict[str, Any]]:
     """Read one or more JSONL files into a list of records.
+
+    Args:
+        paths: One or more JSONL files.
+        strict: When true, fail closed on missing paths and malformed records. When false, skip
+            missing/malformed records for explicitly exploratory/advisory use.
 
     Returns:
         List of parsed episode records.
@@ -44,20 +79,33 @@ def read_jsonl(paths: Sequence[str | Path] | str | Path) -> list[dict[str, Any]]
     else:
         path_list = list(paths)  # type: ignore[arg-type]
     records: list[dict[str, Any]] = []
+    missing_paths: list[Path] = []
+    malformed_lines: list[tuple[Path, int, str]] = []
     for p in path_list:
         p = Path(p)
         if not p.exists():
+            if strict:
+                missing_paths.append(p)
             continue
         with p.open("r", encoding="utf-8") as f:
-            for line in f:
+            for line_number, line in enumerate(f, start=1):
                 line = line.strip()
                 if not line:
                     continue
                 try:
                     rec = json.loads(line)
-                except json.JSONDecodeError:
+                except json.JSONDecodeError as exc:
+                    if strict:
+                        malformed_lines.append((p, line_number, exc.msg))
                     continue
                 records.append(rec)
+    if missing_paths or malformed_lines:
+        raise EpisodeRecordInputError(
+            _format_jsonl_input_error(
+                missing_paths=missing_paths,
+                malformed_lines=malformed_lines,
+            )
+        )
     return records
 
 

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -427,7 +427,8 @@ def _handle_summary(args) -> int:
         except Exception:
             logging.debug("Logging 'Summary plots written' failed", exc_info=True)
         return 0
-    except Exception:  # pragma: no cover - error path
+    except Exception as exc:  # pragma: no cover - error path
+        logging.exception("Summary generation failed: %s", exc)
         return 2
 
 
@@ -480,7 +481,8 @@ def _handle_aggregate(args) -> int:
         except Exception:
             logging.debug("Logging 'Aggregated summary' failed", exc_info=True)
         return 0
-    except Exception:  # pragma: no cover - error path
+    except Exception as exc:  # pragma: no cover - error path
+        logging.exception("Aggregation failed: %s", exc)
         return 2
 
 

--- a/robot_sf/benchmark/errors.py
+++ b/robot_sf/benchmark/errors.py
@@ -44,4 +44,8 @@ class AggregationMetadataError(ValueError):
         return payload
 
 
-__all__ = ["AggregationMetadataError"]
+class EpisodeRecordInputError(ValueError):
+    """Raised when benchmark episode JSONL input is missing or malformed."""
+
+
+__all__ = ["AggregationMetadataError", "EpisodeRecordInputError"]

--- a/robot_sf/benchmark/summary.py
+++ b/robot_sf/benchmark/summary.py
@@ -17,36 +17,107 @@ import numpy as np
 mpl.use("Agg", force=True)
 import matplotlib.pyplot as plt
 
+from robot_sf.benchmark.errors import EpisodeRecordInputError
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
 
-def _iter_records(paths: Sequence[str | Path] | str | Path) -> Iterable[dict[str, Any]]:
-    """Iterate over JSONL episode records stored at one or more paths.
+def _path_list(paths: Sequence[str | Path] | str | Path) -> list[Path]:
+    """Normalize one or more path-like inputs into ``Path`` objects.
+
+    Returns:
+        List of paths to read.
+    """
+    if isinstance(paths, str | Path):
+        return [Path(paths)]
+    return [Path(path) for path in paths]  # type: ignore[arg-type]
+
+
+def _raise_record_input_error(
+    *,
+    missing_paths: list[Path],
+    malformed_lines: list[tuple[Path, int, str]],
+    fallback_errors: list[str] | None = None,
+) -> None:
+    """Raise a compact error summarizing benchmark input data-loss risks."""
+    fallback_errors = fallback_errors or []
+    if not missing_paths and not malformed_lines and not fallback_errors:
+        return
+    details: list[str] = [
+        "Episode JSONL input is not suitable for benchmark evidence",
+        f"missing_paths={len(missing_paths)}",
+        f"malformed_lines={len(malformed_lines)}",
+        f"fallback_derivation_errors={len(fallback_errors)}",
+    ]
+    if missing_paths:
+        preview = ", ".join(str(path) for path in missing_paths[:5])
+        details.append(f"missing=[{preview}]")
+    if malformed_lines:
+        preview = "; ".join(
+            f"{path}:{line_number}: {message}" for path, line_number, message in malformed_lines[:5]
+        )
+        details.append(f"malformed=[{preview}]")
+    if fallback_errors:
+        preview = "; ".join(fallback_errors[:5])
+        details.append(f"fallback_errors=[{preview}]")
+    raise EpisodeRecordInputError("; ".join(details))
+
+
+def load_episode_records(
+    paths: Sequence[str | Path] | str | Path,
+    *,
+    strict: bool = True,
+) -> list[dict[str, Any]]:
+    """Load episode records from JSONL paths.
 
     Args:
         paths: Single path or collection of JSONL file paths to scan.
+        strict: When true, fail closed on missing paths and malformed JSONL lines. When false,
+            skip malformed or missing inputs for explicitly exploratory/advisory use.
 
-    Yields:
-        dict[str, Any]: Parsed JSON record for each non-empty line across the provided files.
+    Returns:
+        Parsed episode records.
     """
-    if isinstance(paths, str | Path):
-        path_list = [paths]
-    else:
-        path_list = list(paths)  # type: ignore[arg-type]
-    for p in path_list:
-        p = Path(p)
-        if not p.exists():
+    records: list[dict[str, Any]] = []
+    missing_paths: list[Path] = []
+    malformed_lines: list[tuple[Path, int, str]] = []
+
+    for path in _path_list(paths):
+        if not path.exists():
+            if strict:
+                missing_paths.append(path)
             continue
-        with p.open("r", encoding="utf-8") as f:
-            for line in f:
+        with path.open("r", encoding="utf-8") as f:
+            for line_number, line in enumerate(f, start=1):
                 line = line.strip()
                 if not line:
                     continue
                 try:
-                    yield json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    if strict:
+                        malformed_lines.append((path, line_number, exc.msg))
+
+    _raise_record_input_error(missing_paths=missing_paths, malformed_lines=malformed_lines)
+    return records
+
+
+def _iter_records(
+    paths: Sequence[str | Path] | str | Path,
+    *,
+    strict: bool = True,
+) -> Iterable[dict[str, Any]]:
+    """Iterate over JSONL episode records stored at one or more paths.
+
+    Args:
+        paths: Single path or collection of JSONL file paths to scan.
+        strict: When true, fail closed on malformed or missing input.
+
+    Yields:
+        dict[str, Any]: Parsed JSON record for each non-empty line across the provided files.
+    """
+    yield from load_episode_records(paths, strict=strict)
 
 
 def _get_nested(d: dict[str, Any], path: str, default: Any = None) -> Any:
@@ -89,6 +160,8 @@ def _safe_number(x: Any) -> float | None:
 
 def collect_values(
     records: Iterable[dict[str, Any]],
+    *,
+    strict: bool = True,
 ) -> tuple[list[float], list[float]]:
     """Collect min_distance and avg_speed from episode records.
 
@@ -103,6 +176,7 @@ def collect_values(
     """
     mins: list[float] = []
     speeds: list[float] = []
+    fallback_errors: list[str] = []
     for rec in records:
         md = _get_nested(rec, "metrics.min_distance")
         mdv = _safe_number(md)
@@ -122,8 +196,15 @@ def collect_values(
                     s = np.linalg.norm(arr, axis=1).mean()
                     if np.isfinite(s):
                         speeds.append(float(s))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    if strict:
+                        record_id = rec.get("episode_id") or rec.get("scenario_id") or "<unknown>"
+                        fallback_errors.append(f"{record_id}: {exc}")
+    _raise_record_input_error(
+        missing_paths=[],
+        malformed_lines=[],
+        fallback_errors=fallback_errors,
+    )
     return mins, speeds
 
 
@@ -174,13 +255,18 @@ def plot_histograms(
     return out_paths
 
 
-def summarize_to_plots(paths: Sequence[str | Path] | str | Path, out_dir: str | Path) -> list[str]:
+def summarize_to_plots(
+    paths: Sequence[str | Path] | str | Path,
+    out_dir: str | Path,
+    *,
+    strict: bool = True,
+) -> list[str]:
     """Load episodes and write summary histogram plots.
 
     Returns:
         List of written image paths.
     """
-    mins, speeds = collect_values(_iter_records(paths))
+    mins, speeds = collect_values(_iter_records(paths, strict=strict), strict=strict)
     return plot_histograms(mins, speeds, out_dir)
 
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from robot_sf.benchmark.aggregate import (
     compute_aggregates,
     compute_aggregates_with_ci,
@@ -11,6 +13,7 @@ from robot_sf.benchmark.aggregate import (
     read_jsonl,
     write_episode_csv,
 )
+from robot_sf.benchmark.errors import AggregationMetadataError, EpisodeRecordInputError
 from robot_sf.benchmark.runner import run_batch
 
 SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
@@ -84,6 +87,88 @@ def test_read_and_flatten_and_write_csv(tmp_path: Path):
     assert Path(out).exists()
     text = Path(out).read_text(encoding="utf-8")
     assert text.splitlines()[0].startswith("episode_id,scenario_id,seed")
+
+
+def test_read_jsonl_fails_closed_on_malformed_line(tmp_path: Path) -> None:
+    """Aggregate input loading should not silently drop malformed benchmark records."""
+    path = tmp_path / "episodes_bad.jsonl"
+    path.write_text('{"episode_id":"ok","metrics":{}}\n{bad json\n', encoding="utf-8")
+
+    with pytest.raises(EpisodeRecordInputError) as excinfo:
+        read_jsonl(path)
+
+    message = str(excinfo.value)
+    assert "malformed_lines=1" in message
+    assert f"{path}:2" in message
+
+
+def test_read_jsonl_fails_closed_on_missing_path(tmp_path: Path) -> None:
+    """Aggregate input loading should report missing benchmark inputs by default."""
+    path = tmp_path / "missing.jsonl"
+
+    with pytest.raises(EpisodeRecordInputError) as excinfo:
+        read_jsonl(path)
+
+    message = str(excinfo.value)
+    assert "missing_paths=1" in message
+    assert str(path) in message
+
+
+def test_read_jsonl_best_effort_mode_is_explicit(tmp_path: Path) -> None:
+    """Exploratory aggregate callers can opt into partial parsing explicitly."""
+    path = tmp_path / "episodes_bad.jsonl"
+    path.write_text('{"episode_id":"ok","metrics":{}}\n{bad json\n', encoding="utf-8")
+
+    assert [record["episode_id"] for record in read_jsonl(path, strict=False)] == ["ok"]
+
+
+def test_aggregate_cli_reports_malformed_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The benchmark-facing aggregate command should fail closed with diagnostics."""
+    from robot_sf.benchmark import cli
+
+    src = tmp_path / "episodes_bad.jsonl"
+    src.write_text('{"episode_id":"ok","metrics":{}}\n{bad json\n', encoding="utf-8")
+    errors: list[str] = []
+
+    def _record_exception(message: str, *args: object, **_kwargs: object) -> None:
+        errors.append(message % args)
+
+    monkeypatch.setattr(cli.logging, "exception", _record_exception)
+
+    exit_code = cli.cli_main(
+        [
+            "aggregate",
+            "--in",
+            str(src),
+            "--out",
+            str(tmp_path / "summary.json"),
+        ]
+    )
+
+    assert exit_code == 2
+    assert errors
+    assert "malformed_lines=1" in errors[0]
+    assert f"{src}:2" in errors[0]
+
+
+def test_aggregation_metadata_error_to_dict_includes_optional_context() -> None:
+    """Structured aggregation errors should expose optional context fields."""
+    error = AggregationMetadataError(
+        "missing metadata",
+        episode_id="episode-1",
+        missing_fields=["scenario_params.algo", "algo"],
+        advice="add algorithm metadata",
+    )
+
+    assert error.to_dict() == {
+        "message": "missing metadata",
+        "episode_id": "episode-1",
+        "missing_fields": ["scenario_params.algo", "algo"],
+        "advice": "add algorithm metadata",
+    }
 
 
 def test_compute_aggregates_group_by_algo(tmp_path: Path):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from robot_sf.benchmark.summary import summarize_to_plots
+import pytest
+
+from robot_sf.benchmark.errors import EpisodeRecordInputError
+from robot_sf.benchmark.summary import (
+    aggregate_training_metrics_with_bootstrap,
+    bootstrap_metric_confidence,
+    collect_values,
+    load_episode_records,
+    summarize_to_plots,
+)
 
 
 def _write_sample_jsonl(path: Path) -> None:
@@ -47,3 +56,170 @@ def test_summary_creates_pngs(tmp_path: Path):
     assert len(outs) == 2
     for p in outs:
         assert Path(p).exists()
+
+
+def test_load_episode_records_fails_closed_on_malformed_jsonl(tmp_path: Path) -> None:
+    """Malformed JSONL should fail with path and line context by default."""
+    src = tmp_path / "episodes_bad.jsonl"
+    src.write_text(
+        "\n".join(
+            [
+                json.dumps({"metrics": {"min_distance": 0.4}}),
+                "{bad json",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EpisodeRecordInputError) as excinfo:
+        load_episode_records(src)
+
+    message = str(excinfo.value)
+    assert "malformed_lines=1" in message
+    assert f"{src}:2" in message
+
+
+def test_load_episode_records_fails_closed_on_missing_path(tmp_path: Path) -> None:
+    """Missing benchmark input paths should not be silently ignored."""
+    missing = tmp_path / "missing.jsonl"
+
+    with pytest.raises(EpisodeRecordInputError) as excinfo:
+        load_episode_records(missing)
+
+    assert "missing_paths=1" in str(excinfo.value)
+    assert str(missing) in str(excinfo.value)
+
+
+def test_load_episode_records_best_effort_is_explicit(tmp_path: Path) -> None:
+    """Exploratory callers may opt into best-effort parsing explicitly."""
+    src = tmp_path / "episodes_bad.jsonl"
+    src.write_text(
+        "\n".join(
+            [
+                json.dumps({"episode_id": "ok", "metrics": {"min_distance": 0.4}}),
+                "{bad json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    records = load_episode_records(src, strict=False)
+
+    assert [record["episode_id"] for record in records] == ["ok"]
+
+
+def test_load_episode_records_handles_multiple_paths_and_blank_lines(tmp_path: Path) -> None:
+    """Strict loading should accept multiple clean files and ignore empty lines."""
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    first.write_text(json.dumps({"episode_id": "a"}) + "\n\n", encoding="utf-8")
+    second.write_text(json.dumps({"episode_id": "b"}) + "\n", encoding="utf-8")
+
+    records = load_episode_records([first, second])
+
+    assert [record["episode_id"] for record in records] == ["a", "b"]
+
+
+def test_summarize_to_plots_best_effort_is_explicit_end_to_end(tmp_path: Path) -> None:
+    """Best-effort plotting should be opt-in and still process valid records."""
+    src = tmp_path / "episodes_bad.jsonl"
+    src.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "episode_id": "ok",
+                        "metrics": {"min_distance": 0.4, "avg_speed": 0.8},
+                    }
+                ),
+                "{bad json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    outputs = summarize_to_plots(src, tmp_path / "figs", strict=False)
+
+    assert len(outputs) == 2
+    assert all(Path(path).exists() for path in outputs)
+
+
+def test_collect_values_reports_malformed_trajectory_fallback() -> None:
+    """Invalid fallback velocity payloads should be visible in strict mode."""
+    records = [
+        {
+            "episode_id": "bad-speed",
+            "metrics": {"min_distance": 0.2},
+            "trajectory": {"robot_vel": [["not-a-number", 0.0]]},
+        }
+    ]
+
+    with pytest.raises(EpisodeRecordInputError) as excinfo:
+        collect_values(records)
+
+    assert "fallback_derivation_errors=1" in str(excinfo.value)
+    assert "bad-speed" in str(excinfo.value)
+
+
+def test_collect_values_derives_speed_from_valid_trajectory() -> None:
+    """Valid robot velocity fallback data should contribute average speed."""
+    mins, speeds = collect_values(
+        [
+            {
+                "metrics": {"min_distance": 0.3, "avg_speed": float("nan")},
+                "trajectory": {"robot_vel": [[3.0, 4.0], [0.0, 0.0]]},
+            }
+        ]
+    )
+
+    assert mins == [0.3]
+    assert speeds == [2.5]
+
+
+def test_training_metric_bootstrap_helpers_cover_empty_and_populated_inputs() -> None:
+    """Training summary helpers should provide deterministic bootstrap summaries."""
+    empty = bootstrap_metric_confidence([], n_samples=5, seed=1)
+    assert empty == {"mean": 0.0, "median": 0.0, "ci_low": 0.0, "ci_high": 0.0}
+
+    populated = bootstrap_metric_confidence([1.0, 2.0, 3.0], n_samples=20, seed=1)
+    assert populated["mean"] == pytest.approx(2.0)
+    assert populated["median"] == pytest.approx(2.0)
+    assert populated["ci_low"] <= populated["ci_high"]
+
+    aggregate = aggregate_training_metrics_with_bootstrap(
+        [
+            {"metrics": {"success_rate": 1.0}},
+            {"metrics": {"success_rate": 0.0}},
+            {"metrics": {"success_rate": "not-numeric"}},
+        ],
+        ["metrics.success_rate", "metrics.missing"],
+        n_samples=10,
+        seed=2,
+    )
+    assert aggregate["metrics.success_rate"]["mean"] == pytest.approx(0.5)
+    assert aggregate["metrics.missing"] == empty
+
+
+def test_summary_cli_reports_malformed_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The benchmark-facing summary command should fail closed with diagnostics."""
+    from robot_sf.benchmark import cli
+
+    src = tmp_path / "episodes_bad.jsonl"
+    src.write_text('{"metrics":{"min_distance":0.4}}\n{bad json\n', encoding="utf-8")
+    errors: list[str] = []
+
+    def _record_error(message: str, *args: object, **_kwargs: object) -> None:
+        errors.append(message % args)
+
+    monkeypatch.setattr(cli.logging, "error", _record_error)
+
+    exit_code = cli.cli_main(["summary", "--in", str(src), "--out-dir", str(tmp_path / "figs")])
+
+    assert exit_code == 2
+    assert errors
+    assert "malformed_lines=1" in errors[0]
+    assert f"{src}:2" in errors[0]


### PR DESCRIPTION
## Summary
Makes benchmark episode JSONL loading fail closed by default when source files are missing or
malformed, while preserving explicit best-effort modes for exploratory/advisory use.

## Linked Issues
- Closes #1350

## What Changed
- Added `EpisodeRecordInputError` for benchmark input-quality failures.
- Added strict `load_episode_records(...)` in `robot_sf.benchmark.summary` with missing-path and
  malformed-line counts plus path/line diagnostics.
- Made summary value collection report invalid trajectory-derived speed fallbacks instead of
  silently swallowing them.
- Added explicit `strict=False` best-effort behavior for summary plots and aggregate JSONL loading.
- Made aggregate JSONL loading fail closed by default on missing paths and malformed lines.
- Logged summary/aggregate CLI failures with the actionable input diagnostics.
- Added regression coverage for malformed JSONL, missing paths, best-effort mode, CLI diagnostics,
  and fallback-derived trajectory failures.

## Why It Matters
- Added value: corrupt or partial benchmark evidence can no longer silently shrink denominators.
- Expected impact: benchmark-facing summaries and aggregate reports stop with actionable data-quality
  errors unless the caller explicitly chooses advisory best-effort parsing.
- Why this is worth merging now: #1350 documented direct silent drops in `summary.py`, and the same
  pattern existed in aggregate loading used by benchmark/report scripts.

## Validation / Proof
- `uv run pytest tests/test_summary.py -q` before implementation -> failed at import because the new
  strict input API did not exist.
- `uv run pytest tests/test_summary.py tests/test_aggregate.py -q` -> 22 passed.
- `uv run ruff check robot_sf/benchmark/summary.py robot_sf/benchmark/aggregate.py robot_sf/benchmark/errors.py robot_sf/benchmark/cli.py tests/test_summary.py tests/test_aggregate.py`
  -> passed.
- `uv run python - <<'PY' ... load_episode_records/read_jsonl malformed input smoke ... PY` ->
  both strict loaders raised `EpisodeRecordInputError` with `malformed_lines=1`; both
  `strict=False` paths returned 1 valid record.
- `uv sync --all-extras && uv run pytest tests/test_summary.py tests/test_aggregate.py tests/test_generate_figures_summary_ci.py tests/test_generate_figures_summary_ci_missing_and_suffix.py tests/test_baseline_stats.py -q`
  -> 20 passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after syncing with
  latest `origin/main` -> 3790 passed, 10 skipped, 3 warnings; changed-file coverage minimum passed
  with `aggregate.py` 93.8%, `cli.py` 87.6%, `errors.py` 100.0%, and `summary.py` 96.2%.

## Risks / Rollout
- Compatibility risks: medium; public `read_jsonl(...)` and summary loading now fail closed by
  default where malformed or missing inputs were previously skipped. This is intentional for
  benchmark-facing evidence paths.
- Failure modes: exploratory scripts that truly want partial data must pass `strict=False`.
- Rollback or fallback plan: revert the commit to restore permissive parsing defaults.

## Docs / Provenance
- Updated docs: no standalone docs changed; test coverage documents strict/default vs best-effort
  contracts.
- Relevant design or provenance notes: #1350 captures the maintainer decision that benchmark-facing
  commands should fail closed by default and classify data loss as a limitation/failure.
- Any assumptions that need to be preserved: SNQI-specific loaders with explicit skipped-line
  reporting remain separate.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check whether any known exploratory caller should be switched to `strict=False`; I left
  default callers strict to match the #1350 benchmark-evidence policy.
- Ignored `output/coverage/` and `output/issue_1350_bad.jsonl` were generated by validation and are
  disposable.
