### PR TITLE
docs: clarify advisory typecheck policy (#1347)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,7 +74,7 @@
 		{
 			"label": "Check Code Quality (Ruff + advisory ty)",
 			"type": "shell",
-			"command": "uv run ruff check . && uv run ty check . --exit-zero",
+			"command": "uv run ruff check . && uvx ty check . --exit-zero",
 			"problemMatcher": [],
 			"group": "test"
 		},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,14 +72,14 @@
 			"group": "test"
 		},
 		{
-			"label": "Check Code Quality",
+			"label": "Check Code Quality (Ruff + advisory ty)",
 			"type": "shell",
 			"command": "uv run ruff check . && uv run ty check . --exit-zero",
 			"problemMatcher": [],
 			"group": "test"
 		},
 		{
-			"label": "Type Check",
+			"label": "Type Check (advisory)",
 			"type": "shell",
 			"command": "uvx ty check . --exit-zero",
 			"problemMatcher": [],

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -174,6 +174,9 @@ registry from training pipelines.
 uv run ruff check --fix . && uv run ruff format . && uvx ty check . --exit-zero && uv run pytest -n auto tests
 ```
 
+`ty` currently runs in advisory mode with `--exit-zero`: it reports findings, but the canonical
+typecheck phase is not a PR-readiness merge blocker by itself.
+
 ### Reusable dev scripts
 
 Prefer calling shared scripts from `scripts/dev/` so VS Code tasks, local shells, and Codex
@@ -521,7 +524,8 @@ from robot_sf.common import Vec2D, RobotPose, set_global_seed
   `reference_adapter` path before adding a new map-runner planner key.
 - Demos/trainings: keep runnable examples in `examples/` and scripts in `scripts/`. Place models in `model/`, maps in `maps/svg_maps/`, and write outputs under `output/`.
 - Tests: core in `tests/`; GUI in `test_pygame/` (headless: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy`). Physics-specific tests live in `fast-pysf/tests/`.
-- Quality gates (local): Install Dependencies → Ruff: Format and Fix → Check Code Quality → Type Check → Run Tests (see VS Code Tasks).
+- Quality gates (local): Install Dependencies → Ruff: Format and Fix → Check Code Quality (Ruff +
+  advisory ty) → Type Check (advisory) → Run Tests (see VS Code Tasks).
 
 ### Test style conventions
 
@@ -722,7 +726,8 @@ For coverage gap analysis, trend tracking, and CI integration, see `docs/coverag
 - [ ] Use factory env creators; do not instantiate env classes directly.
 - [ ] Set config via `robot_sf.gym_env.unified_config` before env creation; avoid ad‑hoc kwargs.
 - [ ] Keep lib code print-free; use logging from loguru for info and warnings.
-- [ ] Run VS Code Tasks: Install Dependencies, Ruff: Format and Fix, Check Code Quality, Type Check, Run Tests.
+- [ ] Run VS Code Tasks: Install Dependencies, Ruff: Format and Fix, Check Code Quality (Ruff +
+      advisory ty), Type Check (advisory), Run Tests.
 - [ ] Add a test or smoke (e.g., env reset/step) when you change public behavior.
 - [ ] For GUI-dependent tests, set headless env vars; avoid flaky display usage in CI.
 - [ ] Treat `fast-pysf/` as part of the repository, changes can be made.
@@ -842,19 +847,25 @@ Examples (copy‑ready):
 - Lint/format: Ruff
   - VS Code task “Ruff: Format and Fix” (keeps repo ruff‑clean with the expanded rule set; document exceptions with comments)
 - Type checking: ty
-  - VS Code task "Type Check" (uvx ty check . --exit-zero; runs type checking with exit-zero for current compatibility)
-  - **All type errors must be addressed before merging PRs**
-  - Warnings are allowed but should be triaged and gradually resolved
+  - VS Code task "Type Check (advisory)" (`uvx ty check . --exit-zero`; reports findings while
+    exiting zero for current compatibility)
+  - Type findings are useful quality signals and should be fixed when practical, especially in
+    substantially touched files or stable contracts such as public interfaces, benchmark schemas,
+    planner contracts, config parsing, map definitions, artifact metadata, and CLI boundaries.
+  - PRs are not blocked solely because the advisory `ty` phase reports findings. Reviewers may
+    still request typing fixes when findings affect changed code or stable contracts.
+  - A fail-closed typecheck gate, changed-files ratchet, or baseline-reduction workflow must be
+    proposed separately before becoming a merge requirement.
 - Tests: pytest
   - VS Code task “Run Tests” (default suite)
   - “Run Tests (Show All Warnings)” for diagnostics
   - “Run Tests (GUI)” for display‑dependent tests (headless via environment vars)
   - VS Code task “PR Ready Check” runs Ruff fix/format, full tests (incl. slow), changed‑files coverage gate, diff‑only TODO docstring warnings, and the TODO-docstring backlog ratchet
-- Code quality checks: VS Code task “Check Code Quality” (Ruff + ty errors‑only)
+- Code quality checks: VS Code task “Check Code Quality (Ruff + advisory ty)”
 - Diagrams: VS Code task “Generate UML”
 
 Quality gates to run locally before pushing:
-1) Install Dependencies → 2) Ruff: Format and Fix → 3) Check Code Quality → 4) Type Check → 5) Run Tests
+1) Install Dependencies → 2) Ruff: Format and Fix → 3) Check Code Quality (Ruff + advisory ty) → 4) Type Check (advisory) → 5) Run Tests
 
 Shortcuts (optional shell):
 - Break down complex problems into smaller, manageable tasks
@@ -1356,8 +1367,9 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
 - Requirements clarified (with options/assumptions recorded).
 - Design doc added/updated and linked (if non‑trivial).
 - Code implemented with tests (unit/integration; GUI when needed).
-- Ruff clean and “Check Code Quality” clean locally.
-- Type check clean (no type errors; warnings documented if present).
+- Ruff clean and “Check Code Quality (Ruff + advisory ty)” reviewed locally.
+- Advisory typecheck reviewed. Fix practical findings in touched files and stable contracts, and
+  document any meaningful remaining findings in the PR when they affect the change.
 - Docs updated (README in feature folder, diagrams if changed).
 - Feature branch synced with latest `origin/main` before PR creation, then validation scripts run
   and pass; optional benchmark if perf‑sensitive.
@@ -1413,12 +1425,16 @@ DISPLAY= MPLBACKEND=Agg uv run python scripts/benchmark02.py
 source .venv/bin/activate
 ```
 
+The `uvx ty check . --exit-zero` step is advisory: it should report findings without failing the
+command. Treat findings in touched code and stable contracts as reviewer-actionable even though the
+phase exits zero.
+
 ### TL;DR workflow checklist
 1) Clarify requirements (ask concise, optioned questions)
 2) Draft design doc under `docs/` (link issue, add test plan)
 3) Implement with small, reviewed commits
 4) Add/extend tests in `tests/` or `test_pygame/`
-5) Run quality gates via tasks: Install Dependencies → Ruff: Format and Fix → Check Code Quality → Type Check → Run Tests
+5) Run quality gates via tasks: Install Dependencies → Ruff: Format and Fix → Check Code Quality (Ruff + advisory ty) → Type Check (advisory) → Run Tests
 6) Update docs/diagrams; run “Generate UML” if classes changed
 7) Open PR with summary, risks, and links to docs/tests
 

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -15,7 +15,7 @@ Run one or more canonical CI validation phases.
 
 Phases:
   lint             Ruff lint + format check
-  typecheck        Ty type check (advisory, matches CI)
+  typecheck        Ty type check (advisory; reports findings but exits zero)
   test             Main pytest suite
   smoke            Validation and benchmark smoke checks
   artifact-policy  Canonical artifact root policy guard
@@ -214,6 +214,7 @@ run_phase() {
       uv run ruff format --check .
       ;;
     typecheck)
+      echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."
       uvx ty check . --exit-zero
       ;;
     test)

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -31,6 +31,17 @@ def test_ci_driver_test_phase_uses_shared_parallel_test_wrapper() -> None:
     assert "uv run pytest -q -n auto --max-worker-restart=0" not in script_text
 
 
+def test_ci_driver_typecheck_phase_is_explicitly_advisory() -> None:
+    """Typecheck phase should report findings without becoming a merge gate."""
+
+    script_text = CI_DRIVER.read_text(encoding="utf-8")
+
+    assert "Ty type check (advisory; reports findings but exits zero)" in script_text
+    assert "Running ty in advisory mode (--exit-zero)" in script_text
+    assert "findings are reported but do not fail this phase" in script_text
+    assert "uvx ty check . --exit-zero" in script_text
+
+
 def test_run_ci_local_loads_default_phases_from_ci_driver() -> None:
     """Avoid duplicating the canonical CI phase list in the local wrapper."""
 

--- a/tests/test_typecheck_advisory_docs.py
+++ b/tests/test_typecheck_advisory_docs.py
@@ -1,0 +1,35 @@
+"""Contract tests for advisory ty/typecheck documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEV_GUIDE = ROOT / "docs" / "dev_guide.md"
+VSCODE_TASKS = ROOT / ".vscode" / "tasks.json"
+
+
+def test_dev_guide_documents_typecheck_as_advisory() -> None:
+    """Merge guidance should match the current exit-zero typecheck behavior."""
+    text = DEV_GUIDE.read_text(encoding="utf-8")
+
+    assert "not a PR-readiness merge blocker by itself" in text
+    assert "PRs are not blocked solely because the advisory `ty` phase reports findings" in text
+    assert (
+        "A fail-closed typecheck gate, changed-files ratchet, or baseline-reduction workflow"
+        in text
+    )
+    assert "**All type errors must be addressed before merging PRs**" not in text
+    assert "Type check clean (no type errors; warnings documented if present)" not in text
+
+
+def test_vscode_typecheck_tasks_are_labeled_advisory() -> None:
+    """VS Code task labels should not imply fail-closed typecheck behavior."""
+    text = VSCODE_TASKS.read_text(encoding="utf-8")
+
+    assert '"label": "Type Check (advisory)"' in text
+    assert '"command": "uvx ty check . --exit-zero"' in text
+    assert '"label": "Check Code Quality (Ruff + advisory ty)"' in text
+    assert '"command": "uv run ruff check . && uv run ty check . --exit-zero"' in text
+    assert '"label": "Type Check",' not in text
+    assert '"label": "Check Code Quality",' not in text

--- a/tests/test_typecheck_advisory_docs.py
+++ b/tests/test_typecheck_advisory_docs.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DEV_GUIDE = ROOT / "docs" / "dev_guide.md"
 VSCODE_TASKS = ROOT / ".vscode" / "tasks.json"
+
+
+def _load_vscode_tasks() -> dict[str, str]:
+    """Load VS Code tasks as structured data despite JSON-with-trailing-comma syntax."""
+    text = VSCODE_TASKS.read_text(encoding="utf-8")
+    normalized = re.sub(r",(\s*[}\]])", r"\1", text)
+    return {task["label"]: task["command"] for task in json.loads(normalized)["tasks"]}
 
 
 def test_dev_guide_documents_typecheck_as_advisory() -> None:
@@ -26,10 +35,12 @@ def test_dev_guide_documents_typecheck_as_advisory() -> None:
 def test_vscode_typecheck_tasks_are_labeled_advisory() -> None:
     """VS Code task labels should not imply fail-closed typecheck behavior."""
     text = VSCODE_TASKS.read_text(encoding="utf-8")
+    tasks = _load_vscode_tasks()
 
-    assert '"label": "Type Check (advisory)"' in text
-    assert '"command": "uvx ty check . --exit-zero"' in text
-    assert '"label": "Check Code Quality (Ruff + advisory ty)"' in text
-    assert '"command": "uv run ruff check . && uv run ty check . --exit-zero"' in text
+    assert tasks["Type Check (advisory)"] == "uvx ty check . --exit-zero"
+    assert (
+        tasks["Check Code Quality (Ruff + advisory ty)"]
+        == "uv run ruff check . && uvx ty check . --exit-zero"
+    )
     assert '"label": "Type Check",' not in text
     assert '"label": "Check Code Quality",' not in text


### PR DESCRIPTION
## Summary
Aligns repository docs, VS Code task labels, and CI-driver output with the current advisory
`ty --exit-zero` policy.

## Linked Issues
- Closes #1347

## What Changed
- Updated `scripts/dev/ci_driver.sh typecheck` help/output to say `ty` is advisory and exits zero
  while reporting findings.
- Renamed VS Code task labels to `Type Check (advisory)` and
  `Check Code Quality (Ruff + advisory ty)`.
- Replaced merge-blocking typecheck wording in `docs/dev_guide.md` with the maintainer decision:
  type findings are useful and reviewer-actionable for touched files/stable contracts, but the
  current PR-readiness gate is not blocked solely by advisory `ty` output.
- Added tests that guard the advisory command/help/docs/task-label contract.

## Why It Matters
- Added value: contributors can tell whether type findings block a PR.
- Expected impact: `ty` remains visible as a quality signal without contradicting the exit-zero
  automation.
- Why this is worth merging now: #1347 documented a direct mismatch between advisory automation and
  merge guidance.

## Validation / Proof
- `scripts/dev/ci_driver.sh --help` -> typecheck listed as advisory and exit-zero.
- `uv run pytest tests/test_ci_script_contract.py tests/test_typecheck_advisory_docs.py -q` -> 6
  passed.
- Scratch proof: `uvx ty check output/typecheck_scratch/bad_type.py --exit-zero` reported
  `invalid-assignment` and exited `0`.
- `scripts/dev/ci_driver.sh typecheck` -> printed the advisory banner, reported existing type
  findings, and exited `0`.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed for 5 changed
  files.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after syncing with
  latest `origin/main` and refreshing `uv sync --all-extras` -> 3779 passed, 10 skipped, 7 warnings.

## Risks / Rollout
- Compatibility risks: low; existing `--exit-zero` behavior is preserved.
- Failure modes: contributors may still treat advisory findings as ignorable; docs now call out
  reviewer-actionable areas such as changed files, public interfaces, benchmark schemas, planner
  contracts, map/config definitions, artifact metadata, and CLI boundaries.
- Rollback or fallback plan: revert this commit to restore the previous labels/docs/output.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`.
- Relevant design or provenance notes: #1347 records the maintainer decision to keep `ty` advisory
  for current PR readiness.
- Any assumptions that need to be preserved: strict fail-closed typecheck, changed-files ratchet, or
  baseline-reduction workflow should be proposed separately before becoming merge policy.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Ignored `output/coverage/` and `output/typecheck_scratch/ty_exit_zero.log` were generated by
  validation and are disposable.
