### PR TITLE
ci: trigger docker repro smoke on pinned matrix (#1351)

### DIFF
--- a/.github/workflows/benchmark-docker-repro-smoke.yml
+++ b/.github/workflows/benchmark-docker-repro-smoke.yml
@@ -8,6 +8,7 @@ on:
       - "docker/benchmark-repro.Dockerfile"
       - "scripts/repro/**"
       - "tests/repro/**"
+      - "configs/scenarios/planner_sanity_matrix_v1.yaml"
       - "docs/benchmark_docker_repro.md"
       - "docs/context/issue_1086_docker_reproduction_path.md"
 

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -14,6 +14,7 @@ CONTEXT_NOTE = ROOT / "docs" / "context" / "issue_1086_docker_reproduction_path.
 DOCS_README = ROOT / "docs" / "README.md"
 RELEASE_REPRO_DOC = ROOT / "docs" / "benchmark_release_reproducibility.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "benchmark-docker-repro-smoke.yml"
+PINNED_REPRO_MATRIX = "configs/scenarios/planner_sanity_matrix_v1.yaml"
 
 
 def _read_text_file(path: Path) -> str:
@@ -46,7 +47,7 @@ def test_benchmark_repro_scripts_define_one_command_smoke_contract() -> None:
 
     assert SMOKE_SCRIPT.stat().st_mode & stat.S_IXUSR
     assert WRAPPER_SCRIPT.stat().st_mode & stat.S_IXUSR
-    assert "configs/scenarios/planner_sanity_matrix_v1.yaml" in smoke
+    assert PINNED_REPRO_MATRIX in smoke
     assert "robot_sf_bench validate-config" in smoke
     assert "robot_sf_bench preview-scenarios" in smoke
     assert "robot_sf_bench --quiet run" in smoke
@@ -95,6 +96,7 @@ def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
         "workflow_dispatch:",
         "pull_request:",
         "paths:",
+        PINNED_REPRO_MATRIX,
         "docker version --format",
         "docker info --format",
         "nvidia-smi",
@@ -108,3 +110,4 @@ def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
 
     assert "docker_daemon_available" in workflow
     assert "nvidia_docker_available" in workflow
+    assert "configs/scenarios/**" not in workflow

--- a/tests/repro/test_benchmark_docker_repro_contract.py
+++ b/tests/repro/test_benchmark_docker_repro_contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import stat
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = ROOT / "docker" / "benchmark-repro.Dockerfile"
 SMOKE_SCRIPT = ROOT / "scripts" / "repro" / "benchmark_bundle_smoke.sh"
@@ -22,6 +24,16 @@ def _read_text_file(path: Path) -> str:
     if not path.is_file():
         raise FileNotFoundError(f"Expected file does not exist: {path}")
     return path.read_text(encoding="utf-8")
+
+
+def _read_workflow(path: Path) -> dict:
+    """Read a GitHub Actions workflow as structured YAML."""
+    return yaml.safe_load(_read_text_file(path))
+
+
+def _workflow_on(workflow_config: dict) -> dict:
+    """Return the GitHub Actions on block despite YAML 1.1 boolean parsing."""
+    return workflow_config.get("on") or workflow_config[True]
 
 
 def test_benchmark_repro_dockerfile_is_pinned_and_uses_frozen_uv_sync() -> None:
@@ -91,6 +103,8 @@ def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
     """Docker CI proof should record runner capabilities before running the smoke."""
 
     workflow = _read_text_file(WORKFLOW)
+    workflow_config = _read_workflow(WORKFLOW)
+    pull_request_paths = _workflow_on(workflow_config)["pull_request"]["paths"]
 
     for fragment in [
         "workflow_dispatch:",
@@ -110,4 +124,5 @@ def test_benchmark_repro_workflow_qualifies_runner_before_smoke() -> None:
 
     assert "docker_daemon_available" in workflow
     assert "nvidia_docker_available" in workflow
-    assert "configs/scenarios/**" not in workflow
+    assert PINNED_REPRO_MATRIX in pull_request_paths
+    assert "configs/scenarios/**" not in pull_request_paths


### PR DESCRIPTION
## Summary

- Add the exact pinned repro matrix path to the Docker benchmark smoke workflow `pull_request.paths`.
- Extend the Docker repro contract test so the workflow must include the pinned matrix path and must not broaden to `configs/scenarios/**`.

Closes #1351.

## Validation

- RED: `uv run pytest tests/repro/test_benchmark_docker_repro_contract.py -q` failed on missing `configs/scenarios/planner_sanity_matrix_v1.yaml` in the workflow.
- `uv run pytest tests/repro/test_benchmark_docker_repro_contract.py -q` -> 4 passed.
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY` -> workflow YAML parsed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3776 passed, 10 skipped, 6 warnings.

## Artifacts

- `output/coverage/` was generated by local validation and remains ignored/disposable.

## Delegation

- Spark queue triage selected #1351 as the safest next bounded issue.
- Copilot CLI read-only review (`gpt-5.3-codex --effort high`) reported no correctness findings; it could not run tests due plan-mode command permissions, so validation above was local.
