### PR TITLE
fix: add velocity-aware socnav personal space

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -130,6 +130,8 @@ knowledge, not every transient iteration detail.
   [issue_1111_carla_setup_smoke.md](issue_1111_carla_setup_smoke.md)
 * Issue #1322 SocNavBench device-placement cleanup:
   [issue_1322_socnavbench_device_placement_cleanup.md](issue_1322_socnavbench_device_placement_cleanup.md)
+* Issue #1323 SocNavBench personal-space velocity:
+  [issue_1323_socnavbench_personal_space_velocity.md](issue_1323_socnavbench_personal_space_velocity.md)
 * Issue #1319 task bundles:
   [issue_1319_task_bundles.md](issue_1319_task_bundles.md)
 * Issue #1245 Benchmark Claim Artifact:

--- a/docs/context/issue_1323_socnavbench_personal_space_velocity.md
+++ b/docs/context/issue_1323_socnavbench_personal_space_velocity.md
@@ -1,0 +1,56 @@
+# Issue #1323 SocNavBench Personal-Space Velocity
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1323>
+
+## Decision
+
+SocNavBench personal-space cost now has a default-off `use_agent_velocity` mode. The default path
+keeps the previous heading-derived unit vector, while enabled mode scales the heading vector by the
+agent's stored scalar speed when that speed is finite and above `min_agent_speed`.
+
+## Scope
+
+This change is limited to the SocNavBench objective implementation and its parameters. It does not
+make velocity-aware personal-space cost a benchmark default and does not claim planner-level
+performance impact.
+
+When speed is unavailable, zero, below threshold, or not finite, enabled mode falls back to the
+heading-derived unit vector so stationary or incomplete agent states preserve the old behavior.
+
+## Validation
+
+Validated on 2026-05-20 from the issue worktree:
+
+```bash
+uv run pytest tests/test_socnavbench_personal_space_cost.py -q
+```
+
+Result: 4 passed. The tests cover default-off equivalence, enabled positive-speed sensitivity,
+zero-speed fallback, and unavailable-speed fallback.
+
+```bash
+uv run python scripts/validation/run_issue_1323_socnav_personal_space_velocity_smoke.py
+```
+
+Result: passed. The synthetic sweep wrote:
+
+- `output/validation/issue_1323_socnav_personal_space_velocity/latest/summary.json`
+- `output/validation/issue_1323_socnav_personal_space_velocity/latest/summary.md`
+
+The smoke shows the disabled baseline and zero-speed enabled row match, while positive-speed
+enabled rows are sensitive to `agent_velocity_scale`. The local `output/` files are disposable;
+the reviewable values from the passing run were:
+
+| velocity_aware | agent_speed | velocity_scale | value | delta_from_default |
+| --- | ---: | ---: | ---: | ---: |
+| false | 2.000 | 1.000 | 0.135335 | 0.000000 |
+| true | 0.000 | 1.000 | 0.135335 | 0.000000 |
+| true | 2.000 | 0.500 | 0.135335 | 0.000000 |
+| true | 2.000 | 1.000 | 0.606531 | 0.471195 |
+| true | 2.000 | 2.000 | 0.882497 | 0.747162 |
+
+## Follow-Up Boundary
+
+The smoke is objective-level research evidence only. Planner-level SocNavBench benchmark claims
+would still need a separate scenario run with explicit asset readiness and fallback/degraded-mode
+reporting.

--- a/scripts/validation/run_issue_1323_socnav_personal_space_velocity_smoke.py
+++ b/scripts/validation/run_issue_1323_socnav_personal_space_velocity_smoke.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Run a synthetic SocNavBench personal-space velocity sensitivity smoke."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+SOCNAV_ROOT = ROOT / "third_party" / "socnavbench"
+DEFAULT_OUTPUT_DIR = ROOT / "output/validation/issue_1323_socnav_personal_space_velocity/latest"
+
+
+@dataclass(frozen=True)
+class SmokeRow:
+    """One synthetic personal-space cost evaluation."""
+
+    velocity_aware: bool
+    agent_speed: float
+    velocity_scale: float
+    value: float
+    delta_from_default: float
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--agent-speed",
+        type=float,
+        default=2.0,
+        help="Synthetic non-ego agent speed used for enabled-mode rows.",
+    )
+    parser.add_argument(
+        "--velocity-scale",
+        dest="velocity_scales",
+        action="append",
+        type=float,
+        default=None,
+        help="Velocity scale to evaluate. Repeat to override the default sweep.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for summary.json and summary.md outputs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _repo_relative(path: Path) -> str:
+    """Return a repository-relative path when possible."""
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _with_socnav_imports() -> None:
+    """Prepare upstream SocNavBench imports that depend on cwd-relative params."""
+    sys.path.insert(0, str(SOCNAV_ROOT))
+    os.chdir(SOCNAV_ROOT)
+
+
+def _trajectory_at(x: float, y: float):
+    """Create a one-step ego trajectory at ``(x, y)``."""
+    from trajectory.trajectory import Trajectory
+
+    return Trajectory.from_pos3_array(np.array([[[x, y, 0.0]]], dtype=np.float32))
+
+
+def _sim_state_for_agent(*, heading: float, speed: float):
+    """Create a one-agent SocNavBench sim state for synthetic objective evaluation."""
+    from simulators.sim_state import AgentState, SimState
+    from trajectory.trajectory import SystemConfig
+
+    agent = AgentState(
+        name="ped_0",
+        goal_config=None,
+        start_config=None,
+        current_config=SystemConfig.from_pos3([0.0, 0.0, heading], v=speed),
+    )
+    return SimState(environment=None, pedestrians={"ped_0": agent}, robots={})
+
+
+def _personal_space_value(
+    *,
+    velocity_aware: bool,
+    agent_speed: float,
+    velocity_scale: float,
+) -> float:
+    """Evaluate the objective at a fixed point beside the synthetic pedestrian."""
+    from dotmap import DotMap
+    from objectives.personal_space_cost import PersonalSpaceCost
+
+    objective = PersonalSpaceCost(
+        DotMap(
+            psc_scale=1.0,
+            use_agent_velocity=velocity_aware,
+            agent_velocity_scale=velocity_scale,
+            min_agent_speed=1e-3,
+        )
+    )
+    values = objective.evaluate_objective(
+        _trajectory_at(0.0, 1.0),
+        {0: _sim_state_for_agent(heading=0.0, speed=agent_speed)},
+    )
+    return float(values[0, 0])
+
+
+def _build_rows(agent_speed: float, velocity_scales: tuple[float, ...]) -> list[SmokeRow]:
+    """Build the default-off row, zero-speed fallback row, and enabled sweep rows."""
+    default_value = _personal_space_value(
+        velocity_aware=False,
+        agent_speed=agent_speed,
+        velocity_scale=1.0,
+    )
+    rows = [
+        SmokeRow(
+            velocity_aware=False,
+            agent_speed=agent_speed,
+            velocity_scale=1.0,
+            value=default_value,
+            delta_from_default=0.0,
+        )
+    ]
+
+    zero_value = _personal_space_value(
+        velocity_aware=True,
+        agent_speed=0.0,
+        velocity_scale=1.0,
+    )
+    rows.append(
+        SmokeRow(
+            velocity_aware=True,
+            agent_speed=0.0,
+            velocity_scale=1.0,
+            value=zero_value,
+            delta_from_default=zero_value - default_value,
+        )
+    )
+
+    for velocity_scale in velocity_scales:
+        value = _personal_space_value(
+            velocity_aware=True,
+            agent_speed=agent_speed,
+            velocity_scale=velocity_scale,
+        )
+        rows.append(
+            SmokeRow(
+                velocity_aware=True,
+                agent_speed=agent_speed,
+                velocity_scale=velocity_scale,
+                value=value,
+                delta_from_default=value - default_value,
+            )
+        )
+    return rows
+
+
+def _failures(rows: list[SmokeRow]) -> list[str]:
+    """Return smoke-gate failures for the synthetic sweep."""
+    default = rows[0].value
+    zero = rows[1].value
+    enabled_rows = sorted(rows[2:], key=lambda row: row.velocity_scale)
+    failures: list[str] = []
+    if not np.isclose(zero, default):
+        failures.append("zero-speed velocity-aware row did not fall back to default")
+    if not any(not np.isclose(row.value, default) for row in enabled_rows):
+        failures.append("enabled velocity-aware sweep did not differ from default")
+    for row in enabled_rows:
+        if not np.isfinite(row.value):
+            failures.append(
+                f"enabled velocity-aware row was not finite for scale={row.velocity_scale}"
+            )
+    return failures
+
+
+def _write_markdown(path: Path, rows: list[SmokeRow], failures: list[str]) -> None:
+    """Write a compact human-readable smoke summary."""
+    lines = [
+        "# Issue 1323 SocNavBench Personal-Space Velocity Smoke",
+        "",
+        "| velocity_aware | agent_speed | velocity_scale | value | delta_from_default |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        aware = str(row.velocity_aware).lower()
+        lines.append(
+            f"| {aware} | {row.agent_speed:.3f} | {row.velocity_scale:.3f} | "
+            f"{row.value:.6f} | {row.delta_from_default:.6f} |"
+        )
+    lines.extend(["", "## Result", ""])
+    if failures:
+        lines.extend(f"- FAIL: {failure}" for failure in failures)
+    else:
+        lines.append("- PASS: enabled positive-speed sweep contains finite, non-default rows.")
+        lines.append("- PASS: zero-speed enabled mode falls back to default behavior.")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the synthetic sweep and write summary artifacts."""
+    os.environ.setdefault("LOGURU_LEVEL", "WARNING")
+    args = _parse_args(argv)
+    velocity_scales = tuple(args.velocity_scales or (0.5, 1.0, 2.0))
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    original_cwd = Path.cwd()
+    try:
+        _with_socnav_imports()
+        rows = _build_rows(args.agent_speed, velocity_scales)
+    finally:
+        os.chdir(original_cwd)
+
+    failures = _failures(rows)
+    summary: dict[str, Any] = {
+        "passed": not failures,
+        "failures": failures,
+        "rows": [asdict(row) for row in rows],
+    }
+    summary_json = output_dir / "summary.json"
+    summary_md = output_dir / "summary.md"
+    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(summary_md, rows, failures)
+
+    print(json.dumps({**summary, "summary_json": _repo_relative(summary_json)}, sort_keys=True))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_socnavbench_personal_space_cost.py
+++ b/tests/test_socnavbench_personal_space_cost.py
@@ -1,0 +1,146 @@
+"""Tests for SocNavBench personal-space velocity handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SOCNAV_ROOT = ROOT / "third_party" / "socnavbench"
+
+
+@pytest.fixture(autouse=True)
+def _socnav_import_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.syspath_prepend(str(SOCNAV_ROOT))
+    monkeypatch.chdir(SOCNAV_ROOT)
+
+
+def _trajectory_at(x: float, y: float):
+    from trajectory.trajectory import Trajectory
+
+    return Trajectory.from_pos3_array(np.array([[[x, y, 0.0]]], dtype=np.float32))
+
+
+def _sim_state_for_agent(*, heading: float, speed: float = 0.0):
+    from simulators.sim_state import AgentState, SimState
+    from trajectory.trajectory import SystemConfig
+
+    agent = AgentState(
+        name="ped_0",
+        goal_config=None,
+        start_config=None,
+        current_config=SystemConfig.from_pos3([0.0, 0.0, heading], v=speed),
+    )
+    return SimState(environment=None, pedestrians={"ped_0": agent}, robots={})
+
+
+def _personal_space_value(
+    *,
+    heading: float,
+    speed: float = 0.0,
+    x: float = 0.0,
+    y: float = 1.0,
+    velocity_aware: bool = False,
+):
+    from dotmap import DotMap
+    from objectives.personal_space_cost import PersonalSpaceCost
+
+    params = DotMap(
+        psc_scale=1.0,
+        use_agent_velocity=velocity_aware,
+    )
+    objective = PersonalSpaceCost(params)
+    values = objective.evaluate_objective(
+        _trajectory_at(x, y),
+        {0: _sim_state_for_agent(heading=heading, speed=speed)},
+    )
+    return float(values[0, 0])
+
+
+def test_default_personal_space_uses_heading_derived_unit_vector() -> None:
+    """Default mode should ignore stored agent speed."""
+    default_value = _personal_space_value(
+        heading=0.0,
+        speed=2.0,
+        velocity_aware=False,
+    )
+    baseline_value = _personal_space_value(
+        heading=0.0,
+        speed=0.0,
+        velocity_aware=False,
+    )
+
+    assert default_value == pytest.approx(baseline_value)
+
+
+def test_velocity_aware_personal_space_uses_agent_speed() -> None:
+    """Enabled mode should scale the personal-space Gaussian by agent speed."""
+    from metrics.cost_functions import asym_gauss_from_vel
+
+    disabled_value = _personal_space_value(
+        heading=0.0,
+        speed=2.0,
+        velocity_aware=False,
+    )
+    enabled_value = _personal_space_value(
+        heading=0.0,
+        speed=2.0,
+        velocity_aware=True,
+    )
+    expected_enabled_value = float(
+        asym_gauss_from_vel(
+            x=0.0,
+            y=1.0,
+            velx=2.0,
+            vely=0.0,
+            xc=0.0,
+            yc=0.0,
+        )
+    )
+
+    assert enabled_value != pytest.approx(disabled_value)
+    assert enabled_value == pytest.approx(expected_enabled_value)
+
+
+def test_velocity_aware_personal_space_falls_back_for_zero_speed() -> None:
+    """Zero-speed agents should use the default heading-derived unit vector."""
+    disabled_value = _personal_space_value(
+        heading=0.0,
+        speed=0.0,
+        velocity_aware=False,
+    )
+    enabled_zero_value = _personal_space_value(
+        heading=0.0,
+        speed=0.0,
+        velocity_aware=True,
+    )
+
+    assert enabled_zero_value == pytest.approx(disabled_value)
+
+
+def test_velocity_aware_personal_space_falls_back_when_speed_unavailable() -> None:
+    """Missing speed tensors should preserve default behavior."""
+    from dotmap import DotMap
+    from objectives.personal_space_cost import PersonalSpaceCost
+    from simulators.sim_state import AgentState, SimState
+    from trajectory.trajectory import SystemConfig
+
+    agent = AgentState(
+        name="ped_0",
+        goal_config=None,
+        start_config=None,
+        current_config=SystemConfig.from_pos3([0.0, 0.0, 0.0]),
+    )
+    agent.current_config._speed_nk1 = None
+    objective = PersonalSpaceCost(DotMap(psc_scale=1.0, use_agent_velocity=True))
+
+    values = objective.evaluate_objective(
+        _trajectory_at(0.0, 1.0),
+        {0: SimState(environment=None, pedestrians={"ped_0": agent}, robots={})},
+    )
+
+    assert float(values[0, 0]) == pytest.approx(
+        _personal_space_value(heading=0.0, velocity_aware=False)
+    )

--- a/third_party/socnavbench/objectives/personal_space_cost.py
+++ b/third_party/socnavbench/objectives/personal_space_cost.py
@@ -1,7 +1,9 @@
 
+"""SocNavBench personal-space objective."""
+
 import numpy as np
 from dotmap import DotMap
-from metrics.cost_functions import *
+from metrics.cost_functions import asym_gauss_from_vel
 from objectives.objective_function import Objective
 from simulators.sim_state import AgentState, SimState
 from trajectory.trajectory import Trajectory
@@ -13,12 +15,45 @@ class PersonalSpaceCost(Objective):
     """
 
     def __init__(self, params: DotMap):
+        """Initialize the personal-space objective."""
         self.p: DotMap = params
         self.tag: str = "personal_space_cost_per_nonego_agent"
+
+    def _agent_velocity_from_config(
+        self, agent_vals: AgentState, theta: float
+    ) -> tuple[float, float]:
+        """Return the velocity vector used to orient and scale personal space."""
+        heading_velocity = (float(np.cos(theta)), float(np.sin(theta)))
+        if not self.p.get("use_agent_velocity", False):
+            return heading_velocity
+
+        current_config = agent_vals.get_current_config()
+        if current_config is None:
+            return heading_velocity
+
+        speed_nk1 = current_config.speed_nk1()
+        if speed_nk1 is None:
+            return heading_velocity
+
+        speed_values = np.asarray(speed_nk1, dtype=float).reshape(-1)
+        if speed_values.size == 0:
+            return heading_velocity
+
+        speed = float(speed_values[-1])
+        min_speed = float(self.p.get("min_agent_speed", 1e-3))
+        if not np.isfinite(speed) or abs(speed) <= min_speed:
+            return heading_velocity
+
+        velocity_scale = float(self.p.get("agent_velocity_scale", 1.0))
+        return (
+            float(velocity_scale * speed * np.cos(theta)),
+            float(velocity_scale * speed * np.sin(theta)),
+        )
 
     def evaluate_objective(
         self, trajectory: Trajectory, sim_state_hist: dict[int, SimState]
     ) -> np.ndarray:
+        """Evaluate personal-space cost along a candidate ego trajectory."""
         # get ego agent trajectory
         ego_traj = trajectory.position_and_heading_nk3()
 
@@ -36,16 +71,16 @@ class PersonalSpaceCost(Objective):
             # iterate through every non ego agent
             agents: dict[str, AgentState] = sim_state.get_all_agents()
 
-            for _, agent_vals in agents.items():
+            for agent_vals in agents.values():
                 agent_pos3 = agent_vals.get_pos3()  # (x,y,th)
                 theta = agent_pos3[2]
+                velx, vely = self._agent_velocity_from_config(agent_vals, theta)
                 # gaussian centered around the non ego agent
-                # TODO actually account for velocity here
                 personal_space_cost[0, i] += asym_gauss_from_vel(
                     x=ego_pos3[0],
                     y=ego_pos3[1],
-                    velx=np.cos(theta),
-                    vely=np.sin(theta),
+                    velx=velx,
+                    vely=vely,
                     xc=agent_pos3[0],
                     yc=agent_pos3[1],
                 )

--- a/third_party/socnavbench/objectives/personal_space_cost.py
+++ b/third_party/socnavbench/objectives/personal_space_cost.py
@@ -18,13 +18,16 @@ class PersonalSpaceCost(Objective):
         """Initialize the personal-space objective."""
         self.p: DotMap = params
         self.tag: str = "personal_space_cost_per_nonego_agent"
+        self._use_agent_velocity = bool(self.p.get("use_agent_velocity", False))
+        self._agent_velocity_scale = float(self.p.get("agent_velocity_scale", 1.0))
+        self._min_agent_speed = float(self.p.get("min_agent_speed", 1e-3))
 
     def _agent_velocity_from_config(
         self, agent_vals: AgentState, theta: float
     ) -> tuple[float, float]:
         """Return the velocity vector used to orient and scale personal space."""
         heading_velocity = (float(np.cos(theta)), float(np.sin(theta)))
-        if not self.p.get("use_agent_velocity", False):
+        if not self._use_agent_velocity:
             return heading_velocity
 
         current_config = agent_vals.get_current_config()
@@ -40,20 +43,22 @@ class PersonalSpaceCost(Objective):
             return heading_velocity
 
         speed = float(speed_values[-1])
-        min_speed = float(self.p.get("min_agent_speed", 1e-3))
-        if not np.isfinite(speed) or abs(speed) <= min_speed:
+        if not np.isfinite(speed) or abs(speed) <= self._min_agent_speed:
             return heading_velocity
 
-        velocity_scale = float(self.p.get("agent_velocity_scale", 1.0))
         return (
-            float(velocity_scale * speed * np.cos(theta)),
-            float(velocity_scale * speed * np.sin(theta)),
+            float(self._agent_velocity_scale * speed * np.cos(theta)),
+            float(self._agent_velocity_scale * speed * np.sin(theta)),
         )
 
     def evaluate_objective(
         self, trajectory: Trajectory, sim_state_hist: dict[int, SimState]
     ) -> np.ndarray:
-        """Evaluate personal-space cost along a candidate ego trajectory."""
+        """Evaluate personal-space cost along a candidate ego trajectory.
+
+        Returns:
+            Cost values for each batch item and trajectory step.
+        """
         # get ego agent trajectory
         ego_traj = trajectory.position_and_heading_nk3()
 

--- a/third_party/socnavbench/params/central_params.py
+++ b/third_party/socnavbench/params/central_params.py
@@ -455,7 +455,13 @@ def create_agent_params(
     )
 
     # Personal Space cost parameters
-    p.personal_space_objective = DotMap(power=1, psc_scale=10)
+    p.personal_space_objective = DotMap(
+        power=1,
+        psc_scale=10,
+        use_agent_velocity=False,
+        agent_velocity_scale=1.0,
+        min_agent_speed=1e-3,
+    )
 
     p.objective_fn_params = DotMap(obj_type=agent_p2.get("obj_type"))
     p.goal_margin = p.goal_distance_objective.goal_margin


### PR DESCRIPTION
## Summary
Adds a default-off SocNavBench personal-space mode that uses the non-ego agent's stored scalar speed when available, while preserving the previous heading-derived unit vector by default.

## Linked Issues
- Closes #1323

## What Changed
- Added `use_agent_velocity`, `agent_velocity_scale`, and `min_agent_speed` parameters to the SocNavBench personal-space objective config.
- Updated `PersonalSpaceCost` to use finite, non-stationary `AgentState.current_config.speed_nk1()` values when the new mode is enabled.
- Added direct objective tests for default-off equivalence, positive-speed behavior, zero-speed fallback, and unavailable-speed fallback.
- Added a synthetic validation smoke for the coefficient sweep and recorded the objective-level evidence in `docs/context/issue_1323_socnavbench_personal_space_velocity.md`.

## Why It Matters
- Added value: velocity-aware personal-space experiments can now use the pedestrian speed already present in SocNavBench state.
- Expected impact: no default benchmark behavior change; the new behavior is opt-in.
- Why this is worth merging now: the issue contract is narrow, tested, and documented without overclaiming planner-level performance.

## Validation / Proof
- `uv run pytest tests/test_socnavbench_personal_space_cost.py -q` — 4 passed.
- `uv run python scripts/validation/run_issue_1323_socnav_personal_space_velocity_smoke.py` — passed, wrote disposable local summaries under `output/validation/issue_1323_socnav_personal_space_velocity/latest/`.
- `uv run pytest tests/test_planner/test_socnav.py -q` — 15 passed, 1 skipped.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed for 6 changed files.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` before latest-main sync — 3779 passed, 11 skipped, 6 warnings.
- After merging latest `origin/main`: `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 3782 passed, 10 skipped, 3 warnings.

## Risks / Rollout
- Compatibility risks: default behavior remains disabled and uses the old heading-derived unit vector.
- Failure modes: if speed is missing, zero, near-zero, or non-finite, enabled mode falls back to default behavior.
- Rollback or fallback plan: disable `use_agent_velocity` or revert the objective/parameter changes.

## Docs / Provenance
- Updated docs: `docs/context/issue_1323_socnavbench_personal_space_velocity.md`, `docs/context/README.md`.
- Relevant design or provenance notes: the validation smoke is objective-level evidence only, not a SocNavBench planner benchmark claim.
- Assumptions: `AgentState.current_config.speed_nk1()` is the available SocNavBench scalar-speed source; vector direction is derived from heading.

## Follow-Up Issues
- Deferred work: planner-level SocNavBench benchmark evidence, if maintainers want this mode promoted beyond objective-level experiments.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that keeping `use_agent_velocity=False` by default is the desired rollout boundary.
- The branch includes a clean merge from latest `origin/main` before the final readiness run.
