### PR TITLE
docs: require review thread resolution verification

### DIFF
--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -18,6 +18,8 @@ the full test suite, and resolve the review threads after pushing.
 2. Retrieve review threads and comments.
    - Use GraphQL for review threads:
      `gh api graphql -F owner=<owner> -F repo=<repo> -F number=<pr_number> -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:20){nodes{id body path line url}}}}}}}'`
+   - Keep the review thread `id` with each requested change. GitHub resolves review threads by
+     thread id, not by the inline comment id or a reply id.
    - Use `gh pr view --json comments` for top-level discussion comments.
    - Summarize the requested changes and note any questions or ambiguities.
 
@@ -53,8 +55,31 @@ the full test suite, and resolve the review threads after pushing.
    - Mention which comments were addressed.
 
 8. Resolve review threads.
-   - Use `gh pr review --comment` for replies and `gh api` or `gh pr review` to resolve threads.
-   - Resolve only after the fix is pushed.
+   - Replying to a review thread is not the same as resolving it. After the fix is committed,
+     pushed, and validated, resolve each addressed review thread with GraphQL:
+
+     ```bash
+     gh api graphql \
+       -F thread_id=<review_thread_id> \
+       -f query='mutation($thread_id:ID!){resolveReviewThread(input:{threadId:$thread_id}){thread{id isResolved}}}'
+     ```
+
+   - Resolve only after the fix is pushed. Do not resolve threads that were merely acknowledged,
+     still need reviewer input, failed validation, or were converted into a follow-up issue without
+     satisfying the current PR.
+   - Re-query review threads after resolution and verify that each addressed thread reports
+     `isResolved: true` before saying the review comments are resolved:
+
+     ```bash
+     gh api graphql \
+       -F owner=<owner> \
+       -F repo=<repo> \
+       -F number=<pr_number> \
+       -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:20){nodes{id body path line url}}}}}}}'
+     ```
+
+   - If GraphQL auth, rate limits, or permissions block resolution, leave the PR comment or final
+     handoff explicit: fixes were pushed, but the named review thread ids remain unresolved.
 
 ## Notes
 

--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -17,7 +17,7 @@ the full test suite, and resolve the review threads after pushing.
 
 2. Retrieve review threads and comments.
    - Use GraphQL for review threads:
-     `gh api graphql -F owner=<owner> -F repo=<repo> -F number=<pr_number> -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:20){nodes{id body path line url}}}}}}}'`
+     `gh api graphql -F owner=<owner> -F repo=<repo> -F number=<pr_number> -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{id body path line url}}}}}}}'`
    - Keep the review thread `id` with each requested change. GitHub resolves review threads by
      thread id, not by the inline comment id or a reply id.
    - Use `gh pr view --json comments` for top-level discussion comments.
@@ -75,7 +75,7 @@ the full test suite, and resolve the review threads after pushing.
        -F owner=<owner> \
        -F repo=<repo> \
        -F number=<pr_number> \
-       -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:20){nodes{id body path line url}}}}}}}'
+       -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{id body path line url}}}}}}}'
      ```
 
    - If GraphQL auth, rate limits, or permissions block resolution, leave the PR comment or final

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -54,7 +54,8 @@ Apply `merge-ready` only when all are true:
 - tests, CI, or `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` provide adequate proof,
 - benchmark/planner changes have benchmark-safe evidence and do not count fallback/degraded
   execution as success,
-- unresolved review threads are handled, fixed, or converted into follow-up issues,
+- unresolved review threads are fixed and resolved on GitHub, converted into follow-up issues, or
+  left open with an explicit blocker that prevents safe resolution,
 - generated `output/` artifacts are classified and durable dependencies are represented,
 - deferred but important work has dedicated GitHub issues linked from the PR.
 
@@ -129,6 +130,11 @@ Do not duplicate those skills' detailed procedures here.
    - Remove stale `merge-ready` if a later review finds the proof bar no longer passes.
    - After any fix attempt, commit, push, and record the validation evidence before reassessing the
      label.
+   - Before applying `merge-ready`, re-query review threads and verify that every addressed thread
+     has `isResolved: true`. A PR reply or summary comment does not resolve a review thread by
+     itself; use `gh-pr-comment-fixer`'s `resolveReviewThread` GraphQL step for fixed threads.
+   - Do not apply `merge-ready` when a fixed review thread remains unresolved only because the
+     resolution mutation was skipped, blocked by GraphQL auth/rate limits, or not verified.
    - Leave a short PR comment summarizing the proof basis when applying the label.
    - Leave a "not merge-ready" comment only when attempted fixes are impossible, unsafe, blocked, or
      insufficient after validation.
@@ -141,7 +147,9 @@ Do not duplicate those skills' detailed procedures here.
 
 - Do not treat passing CI alone as enough for `merge-ready`.
 - Do not mark a PR merge-ready if linked issues remain semantically unresolved.
-- Do not ignore open review threads; resolve, answer, or convert them to follow-up issues.
+- Do not ignore open review threads; resolve fixed threads through GitHub's review-thread
+  resolution API, answer threads that need reviewer input, or convert out-of-scope work to
+  follow-up issues.
 - Do not make broad edits just to satisfy readiness; stay inside the issue/PR contract.
 - Do not rewrite contributor history or force-push unless the user explicitly authorizes it.
 - Do not merge PRs. This skill applies readiness signals only.

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -200,6 +200,20 @@ When comments arrive, use `gh-pr-comment-fixer` or the equivalent local edit flo
 4. Push the fix.
 5. Resolve the review thread only after the fix is landed.
 
+GitHub treats a reply and a resolution as separate actions. A reply such as "fixed in
+`<commit>`" leaves the conversation unresolved until the review-thread id is passed to the
+GraphQL `resolveReviewThread` mutation. Resolve fixed threads with:
+
+```bash
+gh api graphql \
+  -F thread_id=<review_thread_id> \
+  -f query='mutation($thread_id:ID!){resolveReviewThread(input:{threadId:$thread_id}){thread{id isResolved}}}'
+```
+
+Then re-query the PR's `reviewThreads` and verify that addressed threads report
+`isResolved: true`. If GraphQL auth, rate limits, or permissions prevent resolution, say that the
+fix was pushed but the named thread ids remain unresolved.
+
 ### 9. Close the loop
 
 When work is deferred, create a follow-up issue rather than leaving the remainder hidden in chat or PR text.


### PR DESCRIPTION
## Summary
Clarifies the PR review-fix workflow so replying to a review thread is not treated as resolving it. The skills now require the GitHub `resolveReviewThread` GraphQL mutation and a post-resolution `isResolved: true` verification before claiming review conversations are resolved.

## Linked Issues
- None. Fixes the observed `goal-pr-review` workflow behavior where addressed review threads could remain unresolved.

## What Changed
- Updated `.agents/skills/gh-pr-comment-fixer/SKILL.md` to preserve review-thread ids, resolve fixed threads through `resolveReviewThread`, and verify resolution afterward.
- Updated `.agents/skills/goal-pr-review/SKILL.md` so `merge-ready` requires fixed threads to be resolved on GitHub or explicitly blocked/deferred.
- Updated `docs/ai/ai-workflow.md` with the same reply-versus-resolution distinction and GraphQL command.

## Why It Matters
- Added value: prevents the agent from leaving GitHub review conversations open after pushing fixes.
- Expected impact: `goal-pr-review` and `gh-pr-comment-fixer` should now close the full review loop instead of only posting replies.
- Why this is worth merging now: it corrects a real workflow gap in the PR readiness path.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` before final main sync: 3796 passed, 11 skipped
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after rebasing onto latest `origin/main`: 3801 passed, 10 skipped
  - `git diff --check`
- Evidence that the change works here: skill validation, AI config link validation, docs/proof consistency, whitespace check, and the full repo readiness gate all passed on the rebased branch.
- Benchmarks or smoke tests, if applicable: not applicable; this is a docs/skill workflow correction.

## Risks / Rollout
- Compatibility risks: low; this changes workflow instructions and docs only.
- Failure modes: GraphQL auth, rate limits, or permissions may still prevent resolution; the skill now requires naming those unresolved thread ids explicitly.
- Rollback or fallback plan: revert the docs/skill commit if the workflow proves too strict.

## Docs / Provenance
- Updated docs: `.agents/skills/gh-pr-comment-fixer/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`, `docs/ai/ai-workflow.md`.
- Relevant design or provenance notes: GitHub review-thread resolution is a separate API action from replying to an inline review comment.
- Any assumptions that need to be preserved: resolve only threads that are actually fixed, validated, and pushed; do not resolve threads needing reviewer input or out-of-scope follow-up.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify the GraphQL query uses review thread ids, not review comment ids.
- Known limitation: this does not automate resolution itself; it makes the required workflow explicit for the skills.
