### PR TITLE
docs: add TEB runtime stall metrics

### DIFF
--- a/docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json
+++ b/docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json
@@ -4,7 +4,7 @@
   "scenario_slice": "configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml",
   "horizon": 600,
   "benchmark_profile": "experimental",
-  "command_reference": "docs/context/issue_1318_teb_corridor_deadlock_eval.md#reproduction",
+  "command_reference": "docs/context/issue_1318_teb_corridor_deadlock_eval.md#validation",
   "results": {
     "teb": {
       "classic_merging_low": {
@@ -70,6 +70,64 @@
         "avg_steps": 487.7,
         "total_collision_count": 1.0,
         "termination_reasons": {"collision": 1, "success": 2}
+      }
+    }
+  },
+  "runtime_and_stall_metrics": {
+    "source": "fresh #1389 rerun from the same tracked scenario slice and commands; raw JSONL artifacts are intentionally ignored and reproducible",
+    "stall_deadlock_definition": "explicit stall/deadlock count is the number of episodes ending by max_steps or timeout/low-progress rather than collision or success",
+    "teb": {
+      "classic_merging_low": {
+        "episodes": 2,
+        "total_steps": 495,
+        "wall_time_mean_sec": 15.298,
+        "wall_time_total_sec": 30.596,
+        "steps_per_second_aggregate": 16.179,
+        "explicit_stall_deadlock_count": 0
+      },
+      "classic_merging_medium": {
+        "episodes": 3,
+        "total_steps": 747,
+        "wall_time_mean_sec": 12.603,
+        "wall_time_total_sec": 37.81,
+        "steps_per_second_aggregate": 19.757,
+        "explicit_stall_deadlock_count": 0
+      }
+    },
+    "orca": {
+      "classic_merging_low": {
+        "episodes": 2,
+        "total_steps": 561,
+        "wall_time_mean_sec": 4.736,
+        "wall_time_total_sec": 9.473,
+        "steps_per_second_aggregate": 59.222,
+        "explicit_stall_deadlock_count": 0
+      },
+      "classic_merging_medium": {
+        "episodes": 3,
+        "total_steps": 921,
+        "wall_time_mean_sec": 1.76,
+        "wall_time_total_sec": 5.28,
+        "steps_per_second_aggregate": 174.43,
+        "explicit_stall_deadlock_count": 0
+      }
+    },
+    "hybrid_rule_local_planner": {
+      "classic_merging_low": {
+        "episodes": 2,
+        "total_steps": 854,
+        "wall_time_mean_sec": 31.616,
+        "wall_time_total_sec": 63.231,
+        "steps_per_second_aggregate": 13.506,
+        "explicit_stall_deadlock_count": 0
+      },
+      "classic_merging_medium": {
+        "episodes": 3,
+        "total_steps": 1463,
+        "wall_time_mean_sec": 31.621,
+        "wall_time_total_sec": 94.864,
+        "steps_per_second_aggregate": 15.422,
+        "explicit_stall_deadlock_count": 0
       }
     }
   },

--- a/docs/context/issue_1318_teb_corridor_deadlock_eval.md
+++ b/docs/context/issue_1318_teb_corridor_deadlock_eval.md
@@ -67,6 +67,23 @@ experimental`, `--horizon 600`, `--workers 1`, `--no-resume`, `--no-video`, and
 | `hybrid_rule_local_planner` | `classic_merging_low` | 2 | 2 | 0 | 0 | 427.0 | `success=2` |
 | `hybrid_rule_local_planner` | `classic_merging_medium` | 3 | 2 | 1 | 0 | 487.7 | `collision=1`, `success=2` |
 
+Runtime and explicit stall/deadlock follow-up from #1389:
+
+| Algo | Scenario | Episodes | Total steps | Wall time mean (s) | Wall time total (s) | Aggregate steps/s | Explicit stall/deadlock |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `teb` | `classic_merging_low` | 2 | 495 | 15.298 | 30.596 | 16.179 | 0 |
+| `teb` | `classic_merging_medium` | 3 | 747 | 12.603 | 37.810 | 19.757 | 0 |
+| `orca` | `classic_merging_low` | 2 | 561 | 4.736 | 9.473 | 59.222 | 0 |
+| `orca` | `classic_merging_medium` | 3 | 921 | 1.760 | 5.280 | 174.430 | 0 |
+| `hybrid_rule_local_planner` | `classic_merging_low` | 2 | 854 | 31.616 | 63.231 | 13.506 | 0 |
+| `hybrid_rule_local_planner` | `classic_merging_medium` | 3 | 1463 | 31.621 | 94.864 | 15.422 | 0 |
+
+The explicit stall/deadlock count is zero for every row because all fresh #1389 episodes ended by
+`collision` or `success`; no episode reached `max_steps`, timeout, or low-progress termination.
+Wall time is local machine runtime from `wall_time_sec` in the fresh JSONL artifacts, so it is useful
+for relative overhead on this checkout, not a portable throughput benchmark. Aggregate steps/s is
+computed as total episode steps divided by total wall time for each row.
+
 Seed-level collision attribution:
 
 - TEB collisions are static obstacle collisions on all five selected seeds.
@@ -83,6 +100,11 @@ The useful #1318 outcome is therefore negative evidence plus a reusable scenario
 work should use this slice as a quick regression surface for corridor-commitment changes, but should
 not claim TEB improves the corridor-deadlock case without a new planner/config change and a rerun.
 
+The #1389 runtime/stall augmentation adds two practical details: TEB is slower than ORCA on this
+slice and still fails by early static collisions rather than explicit deadlock, while the
+hybrid-rule incumbent spends more wall time because its successful episodes run much longer before
+route completion.
+
 ## Validation
 
 Focused proof:
@@ -98,6 +120,10 @@ Benchmark evidence:
 LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo teb --algo-config configs/algos/teb_commitment_camera_ready.yaml --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1318_teb_corridor_deadlock_teb.jsonl --workers 1 --no-resume --no-video --structured-output json
 LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo orca --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1318_teb_corridor_deadlock_orca.jsonl --workers 1 --no-resume --no-video --structured-output json
 LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo hybrid_rule_local_planner --algo-config configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1318_teb_corridor_deadlock_hybrid.jsonl --workers 1 --no-resume --no-video --structured-output json
+
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo teb --algo-config configs/algos/teb_commitment_camera_ready.yaml --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1389_teb_runtime_stall_teb.jsonl --workers 1 --no-resume --no-video --structured-output json
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo orca --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1389_teb_runtime_stall_orca.jsonl --workers 1 --no-resume --no-video --structured-output json
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run robot_sf_bench run --matrix configs/scenarios/sets/issue_1318_teb_corridor_deadlock_slice.yaml --algo hybrid_rule_local_planner --algo-config configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml --benchmark-profile experimental --horizon 600 --out output/benchmarks/issue_1389_teb_runtime_stall_hybrid.jsonl --workers 1 --no-resume --no-video --structured-output json
 ```
 
 Artifact decision:


### PR DESCRIPTION
## Summary

- Closes #1389.
- Adds the missing runtime and explicit stall/deadlock metrics to the #1318 TEB corridor-deadlock evidence summary.
- Documents the fresh TEB, ORCA, and hybrid rerun commands plus a short interpretation of why TEB's failures are early static collisions rather than explicit stall/deadlock endings.

## Evidence

- `docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json`
- `docs/context/issue_1318_teb_corridor_deadlock_eval.md`

## Validation

- `python -m json.tool docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json >/dev/null && git diff --check && BASE_REF=pr-1384 scripts/dev/check_docs_proof_consistency_diff.sh`
- `PYTEST_NUM_WORKERS=8 BASE_REF=pr-1384 scripts/dev/pr_ready_check.sh` -> 3813 passed, 11 skipped, 10 warnings.
- After rebasing onto current `origin/main`: `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3813 passed, 11 skipped, 8 warnings.

## Artifact Boundary

- Raw rerun JSONL files remain ignored under `output/benchmarks/`:
  - `output/benchmarks/issue_1389_teb_runtime_stall_teb.jsonl`
  - `output/benchmarks/issue_1389_teb_runtime_stall_orca.jsonl`
  - `output/benchmarks/issue_1389_teb_runtime_stall_hybrid.jsonl`
- The compact tracked summary is the durable evidence for review.
