### PR TITLE
workflow: canonicalize feature extractor SLURM outputs

### DIFF
--- a/SLURM/feature_extractor_comparison/analyze_results.slurm
+++ b/SLURM/feature_extractor_comparison/analyze_results.slurm
@@ -46,10 +46,7 @@ combined_results = {
 }
 
 results_dir = Path('output/training/feature_extractors')
-individual_dirs = sorted({
-    *results_dir.glob('single_*'),
-    *results_dir.glob('single_extractor_*'),
-})
+individual_dirs = sorted(results_dir.glob('single_*'))
 
 print(f'Found {len(individual_dirs)} individual result directories')
 
@@ -99,7 +96,7 @@ if [ -f "$COMBINED_RESULTS" ]; then
     
     if [ $? -eq 0 ]; then
         echo "Analysis completed successfully!"
-        echo "Results available in: output/training/feature_extractors/combined_analysis/analysis/"
+        echo "Results available in: $(dirname "$COMBINED_RESULTS")/analysis/"
     else
         echo "Analysis failed!"
     fi

--- a/SLURM/feature_extractor_comparison/analyze_results.slurm
+++ b/SLURM/feature_extractor_comparison/analyze_results.slurm
@@ -6,8 +6,8 @@
 #SBATCH --cpus-per-task=4
 #SBATCH --mem=8G
 #SBATCH --time=2:00:00
-#SBATCH --output=slurm_logs/analyze_results_%j.out
-#SBATCH --error=slurm_logs/analyze_results_%j.err
+#SBATCH --output=output/slurm/%j-feature-extractor-analysis.out
+#SBATCH --error=output/slurm/%j-feature-extractor-analysis.err
 
 # SLURM script for analyzing feature extractor results
 # This runs after all training jobs complete
@@ -45,13 +45,20 @@ combined_results = {
     'results': {}
 }
 
-results_dir = Path('results')
-individual_dirs = list(results_dir.glob('single_extractor_*'))
+results_dir = Path('output/training/feature_extractors')
+individual_dirs = sorted({
+    *results_dir.glob('single_*'),
+    *results_dir.glob('single_extractor_*'),
+})
 
 print(f'Found {len(individual_dirs)} individual result directories')
 
 for individual_dir in individual_dirs:
-    extractor_name = individual_dir.name.replace('single_extractor_', '')
+    extractor_name = individual_dir.name
+    if extractor_name.startswith('single_extractor_'):
+        extractor_name = extractor_name.replace('single_extractor_', '', 1)
+    elif extractor_name.startswith('single_'):
+        extractor_name = extractor_name.replace('single_', '', 1)
     results_file = individual_dir / 'complete_results.json'
     
     if results_file.exists():
@@ -70,7 +77,7 @@ for individual_dir in individual_dirs:
 
 if combined_results['results']:
     # Save combined results
-    combined_dir = Path('results/combined_analysis')
+    combined_dir = Path('output/training/feature_extractors/combined_analysis')
     combined_dir.mkdir(parents=True, exist_ok=True)
     
     combined_file = combined_dir / 'complete_results.json'
@@ -85,14 +92,14 @@ else:
 "
 
 # Check if combination was successful
-COMBINED_RESULTS="results/combined_analysis/complete_results.json"
+COMBINED_RESULTS="output/training/feature_extractors/combined_analysis/complete_results.json"
 if [ -f "$COMBINED_RESULTS" ]; then
     echo "Running statistical analysis on combined results..."
     python scripts/analyze_feature_extractors.py "$COMBINED_RESULTS"
     
     if [ $? -eq 0 ]; then
         echo "Analysis completed successfully!"
-        echo "Results available in: results/combined_analysis/analysis/"
+        echo "Results available in: output/training/feature_extractors/combined_analysis/analysis/"
     else
         echo "Analysis failed!"
     fi

--- a/SLURM/feature_extractor_comparison/run_array.slurm
+++ b/SLURM/feature_extractor_comparison/run_array.slurm
@@ -7,8 +7,8 @@
 #SBATCH --mem=16G
 #SBATCH --gres=gpu:1
 #SBATCH --time=12:00:00
-#SBATCH --output=slurm_logs/feature_extractor_array_%A_%a.out
-#SBATCH --error=slurm_logs/feature_extractor_array_%A_%a.err
+#SBATCH --output=output/slurm/%A_%a-feature-extractor-array.out
+#SBATCH --error=output/slurm/%A_%a-feature-extractor-array.err
 
 # SLURM script for feature-extractor comparison jobs submitted as an array.
 # Each array task trains exactly one extractor and writes to the same
@@ -51,11 +51,11 @@ export DISPLAY=""
 export MPLBACKEND="Agg"
 export SDL_VIDEODRIVER="dummy"
 
-mkdir -p slurm_logs
+mkdir -p output/slurm
 
 echo "Starting training with $EXTRACTOR_NAME extractor..."
 
-OUTPUT_ROOT="results/single_extractor_${EXTRACTOR_NAME}"
+OUTPUT_ROOT="output/training/feature_extractors/single_${EXTRACTOR_NAME}"
 CONFIG_PATH="$OUTPUT_ROOT/single_extractor_config.yaml"
 
 mkdir -p "$OUTPUT_ROOT"

--- a/SLURM/feature_extractor_comparison/run_comparison.slurm
+++ b/SLURM/feature_extractor_comparison/run_comparison.slurm
@@ -7,8 +7,8 @@
 #SBATCH --mem=32G
 #SBATCH --gres=gpu:1
 #SBATCH --time=24:00:00
-#SBATCH --output=slurm_logs/feature_comparison_%j.out
-#SBATCH --error=slurm_logs/feature_comparison_%j.err
+#SBATCH --output=output/slurm/%j-feature-extractor-comparison.out
+#SBATCH --error=output/slurm/%j-feature-extractor-comparison.err
 
 # SLURM script for comprehensive feature extractor comparison
 # This script runs the complete comparison with all extractors
@@ -29,8 +29,8 @@ export PYTHONPATH="${SLURM_SUBMIT_DIR}:${PYTHONPATH}"
 export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES
 
 # Create output directories
-mkdir -p slurm_logs
-mkdir -p results/feature_extractor_comparison
+mkdir -p output/slurm
+mkdir -p output/training/feature_extractors/comparison
 
 # Change to project directory
 cd $SLURM_SUBMIT_DIR
@@ -49,7 +49,7 @@ export SDL_VIDEODRIVER="dummy"
 # Run the complete comparison
 echo "Starting multi-extractor training comparison..."
 
-OUTPUT_ROOT="results/feature_extractor_comparison"
+OUTPUT_ROOT="output/training/feature_extractors/comparison"
 CONFIG_PATH="configs/scenarios/multi_extractor_gpu.yaml"
 
 mkdir -p "$OUTPUT_ROOT"

--- a/SLURM/feature_extractor_comparison/single_extractor_template.slurm
+++ b/SLURM/feature_extractor_comparison/single_extractor_template.slurm
@@ -7,8 +7,8 @@
 #SBATCH --mem=16G
 #SBATCH --gres=gpu:1
 #SBATCH --time=12:00:00
-#SBATCH --output=slurm_logs/single_extractor_%EXTRACTOR_NAME%_%j.out
-#SBATCH --error=slurm_logs/single_extractor_%EXTRACTOR_NAME%_%j.err
+#SBATCH --output=output/slurm/%j-single-extractor-%EXTRACTOR_NAME%.out
+#SBATCH --error=output/slurm/%j-single-extractor-%EXTRACTOR_NAME%.err
 
 # SLURM script for training a single feature extractor
 # This template is used to submit individual extractor training jobs
@@ -30,8 +30,8 @@ export PYTHONPATH="${SLURM_SUBMIT_DIR}:${PYTHONPATH}"
 export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES
 
 # Create output directories
-mkdir -p slurm_logs
-mkdir -p results/single_extractor_%EXTRACTOR_NAME%
+mkdir -p output/slurm
+mkdir -p output/training/feature_extractors/single_%EXTRACTOR_NAME%
 
 # Change to project directory
 cd $SLURM_SUBMIT_DIR
@@ -47,7 +47,7 @@ export SDL_VIDEODRIVER="dummy"
 # Run single extractor training with the new CLI
 echo "Starting training with %EXTRACTOR_NAME% extractor..."
 
-OUTPUT_ROOT="results/single_extractor_%EXTRACTOR_NAME%"
+OUTPUT_ROOT="output/training/feature_extractors/single_%EXTRACTOR_NAME%"
 CONFIG_PATH="$OUTPUT_ROOT/single_extractor_config.yaml"
 
 mkdir -p "$OUTPUT_ROOT"

--- a/SLURM/feature_extractor_comparison/submit_parallel.sh
+++ b/SLURM/feature_extractor_comparison/submit_parallel.sh
@@ -18,7 +18,7 @@ echo "Extractors: ${EXTRACTORS[*]}"
 echo "Array concurrency cap: ${ARRAY_CONCURRENCY}"
 echo "============================================"
 
-mkdir -p slurm_logs
+mkdir -p output/slurm
 
 array_end=$(( ${#EXTRACTORS[@]} - 1 ))
 job_output=$(sbatch --array="0-${array_end}%${ARRAY_CONCURRENCY}" "$SCRIPT_DIR/run_array.slurm")
@@ -37,4 +37,4 @@ echo "Analysis will run after the array completes"
 
 echo "============================================"
 echo "Monitor jobs with: squeue -u $USER"
-echo "Check logs in: slurm_logs/"
+echo "Check logs in: output/slurm/"

--- a/docs/feature_extractors/README.md
+++ b/docs/feature_extractors/README.md
@@ -93,17 +93,17 @@ Run systematic comparison across all extractors:
 uv run python scripts/multi_extractor_training.py \
   --config configs/scenarios/multi_extractor_default.yaml \
   --run-id doc-demo \
-  --output-root results/feature_extractor_comparison
+  --output-root output/training/feature_extractors/comparison
 
 # Run the GPU/vectorized comparison (skips gracefully when CUDA is absent)
 uv run python scripts/multi_extractor_training.py \
   --config configs/scenarios/multi_extractor_gpu.yaml \
   --run-id doc-gpu \
-  --output-root results/feature_extractor_comparison
+  --output-root output/training/feature_extractors/comparison
 
 # Analyze any `complete_results.json` or `summary.json`
 uv run python scripts/analyze_feature_extractors.py \
-  results/feature_extractor_comparison/complete_results.json
+  output/training/feature_extractors/comparison/complete_results.json
 ```
 
 Each run writes:
@@ -116,11 +116,15 @@ For large-scale experiments on HPC clusters:
 
 ```bash
 # Submit complete comparison job
-sbatch SLURM/feature_extractor_comparison/run_comparison.slurm
+scripts/dev/sbatch_use_max_time.sh SLURM/feature_extractor_comparison/run_comparison.slurm
 
 # Or submit the comparison as a throttled Slurm job array
 ./SLURM/feature_extractor_comparison/submit_parallel.sh
 ```
+
+SLURM logs are written under `output/slurm/`. Training and analysis artifacts are written under
+`output/training/feature_extractors/`, which is ignored by git unless a small manifest or durable
+artifact pointer is intentionally promoted.
 
 ## Files and Structure
 

--- a/docs/feature_extractors/usage_guide.md
+++ b/docs/feature_extractors/usage_guide.md
@@ -149,7 +149,7 @@ if param_count < 100_000:  # Your budget
 uv run python scripts/multi_extractor_training.py \
   --config configs/scenarios/multi_extractor_default.yaml \
   --run-id study-default \
-  --output-root results/feature_extractor_comparison
+  --output-root output/training/feature_extractors/comparison
 ```
 
 This runs all extractors with the default hyperparameters and saves timestamped results for
@@ -208,7 +208,7 @@ config_path = Path("configs/scenarios/custom_multi_extractor.yaml")
 config_path.parent.mkdir(parents=True, exist_ok=True)
 config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
 
-output_root = Path("results/custom_multi_extractor")
+output_root = Path("output/training/feature_extractors/custom_multi_extractor")
 output_root.mkdir(parents=True, exist_ok=True)
 
 from scripts import multi_extractor_training
@@ -233,7 +233,7 @@ from pathlib import Path
 
 import yaml  # type: ignore
 
-study_root = Path("results/ablation_studies")
+study_root = Path("output/training/feature_extractors/ablation_studies")
 study_root.mkdir(parents=True, exist_ok=True)
 
 def run_ablation(run_label: str, extractor_names: list[str]) -> None:
@@ -363,7 +363,7 @@ finetune_model = PPO("MultiInputPolicy", env, policy_kwargs=finetune_config.get_
 
 ```bash
 # Submit complete comparison
-sbatch SLURM/feature_extractor_comparison/run_comparison.slurm
+scripts/dev/sbatch_use_max_time.sh SLURM/feature_extractor_comparison/run_comparison.slurm
 
 # Submit the extractor comparison as a Slurm job array
 ./SLURM/feature_extractor_comparison/submit_parallel.sh
@@ -372,7 +372,7 @@ sbatch SLURM/feature_extractor_comparison/run_comparison.slurm
 squeue -u $USER
 
 # Monitor logs
-tail -f slurm_logs/feature_comparison_*.out
+tail -f output/slurm/*-feature-extractor-comparison.out
 ```
 
 ### 2. Custom SLURM Jobs


### PR DESCRIPTION
## Summary

- Closes #1391.
- Moves feature-extractor SLURM logs from `slurm_logs/` to job-id-first files under `output/slurm/`.
- Moves feature-extractor training and analysis artifacts from `results/...` to `output/training/feature_extractors/...`.
- Updates the feature-extractor docs to use the canonical output roots and the shared `sbatch_use_max_time.sh` wrapper.

## Validation

- `bash -n SLURM/feature_extractor_comparison/run_comparison.slurm SLURM/feature_extractor_comparison/single_extractor_template.slurm SLURM/feature_extractor_comparison/run_array.slurm SLURM/feature_extractor_comparison/analyze_results.slurm SLURM/feature_extractor_comparison/submit_parallel.sh`
- Fake-`sbatch` dry run: `ARRAY_CONCURRENCY=1 bash SLURM/feature_extractor_comparison/submit_parallel.sh` with exported shell fake `sbatch` -> array + analysis submission commands built successfully.
- Legacy path scan: no remaining `slurm_logs`, `results/feature_extractor_comparison`, `results/single_extractor`, or `results/combined_analysis` references in `SLURM/feature_extractor_comparison` or `docs/feature_extractors`.
- `git diff --check && BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Copilot/OpenCode high-effort read-only review found a producer/consumer path mismatch in the analysis glob and one raw `sbatch` docs command; fixed.
- `uv sync --all-extras`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3813 passed, 11 skipped, 11 warnings.

## Artifact Boundary

- Only ignored coverage artifacts were generated under `output/`.
- No SLURM logs, training outputs, checkpoints, or analysis artifacts are promoted.
