### PR TITLE
validation: add learned-policy eligibility helper

### DIFF
--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -96,6 +96,16 @@ concrete runnable Robot SF candidates with config pointers; source-only, monitor
 privileged-evaluation methods should stay in context notes until they have a runnable adapter
 contract.
 
+For repeatable checklist-input validation, record the candidate's learned-policy metadata as YAML or
+JSON and run:
+
+```bash
+uv run python scripts/validation/check_learned_policy_eligibility.py <candidate-spec.yaml>
+```
+
+This helper checks completeness and consistency of the eligibility inputs only. It does not turn a
+candidate into a benchmark-ready planner or replace adapter, smoke, or benchmark validation.
+
 ## Scope Boundary
 
 Local work may run smoke and narrow validation stages.

--- a/docs/context/policy_search/contracts/learned_local_policy_eligibility.md
+++ b/docs/context/policy_search/contracts/learned_local_policy_eligibility.md
@@ -12,11 +12,22 @@ candidate-registry entry, or benchmark evaluation. It extends the generic planne
 `robot_sf/benchmark/planner_command_contract.py` with learned-policy-specific leakage,
 observation, action, and logging gates.
 
-Treat this document as the docs-first `LearnedLocalPolicySpec`: a stable review contract for
-candidate intake until a later helper issue turns the checks into executable validation.
+Treat this document as the `LearnedLocalPolicySpec`: a stable review contract for candidate intake
+with an executable helper for validating structured checklist metadata.
 
 Passing this checklist means a candidate has an auditable local-policy contract. It is not
 performance evidence, baseline readiness, safety certification, or a paper-facing benchmark claim.
+
+For repeatable preflight checks, encode the candidate's checklist answers in a YAML or JSON mapping
+and run:
+
+```bash
+uv run python scripts/validation/check_learned_policy_eligibility.py <candidate-spec.yaml>
+```
+
+The helper validates that required verdict inputs are present and internally consistent. A passing
+helper result has the same boundary as this checklist: it means metadata completeness, not
+benchmark performance, adapter acceptance, or runtime safety proof.
 
 ## Required Verdict
 
@@ -154,3 +165,9 @@ BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
 
 Code changes that implement a candidate or helper must add targeted tests for the adapter path and
 then run the normal PR readiness gate.
+
+The executable preflight helper is:
+
+```bash
+uv run python scripts/validation/check_learned_policy_eligibility.py <candidate-spec.yaml>
+```

--- a/scripts/validation/check_learned_policy_eligibility.py
+++ b/scripts/validation/check_learned_policy_eligibility.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Validate learned-local-policy eligibility metadata.
+
+This helper implements the checklist in
+``docs/context/policy_search/contracts/learned_local_policy_eligibility.md`` as
+a lightweight completeness preflight. A passing result means the candidate
+metadata records the required verdict inputs; it is not benchmark evidence,
+adapter readiness, or a safety claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ALLOWED_VERDICTS = {
+    "eligible_for_adapter",
+    "eligible_for_research_only",
+    "training_only_or_oracle",
+    "monitor_only",
+    "reject_for_benchmark",
+}
+
+ELIGIBLE_VERDICTS = {"eligible_for_adapter", "eligible_for_research_only"}
+
+ACTION_FAMILY_REQUIRED_FIELDS = {
+    "velocity_command": {
+        "frame",
+        "units",
+        "bounds",
+        "kinematics_compatibility",
+        "projection_policy",
+    },
+    "bounded_residual_command": {
+        "base_planner",
+        "residual_bounds",
+        "clamp_projection_order",
+        "fallback_behavior",
+    },
+    "waypoint_or_subgoal": {
+        "frame",
+        "horizon",
+        "goal_tolerance",
+        "local_planner",
+        "timeout_behavior",
+    },
+    "short_trajectory": {
+        "horizon",
+        "timestep",
+        "frame",
+        "feasibility_projection",
+        "collision_handling",
+        "first_action_extraction",
+    },
+    "motion_primitive_scores": {
+        "primitive_library",
+        "score_normalization",
+        "tie_breaking",
+        "selected_primitive_execution",
+        "fallback",
+    },
+}
+
+OBSERVATION_CLASSIFICATIONS = {
+    "deployment_observable",
+    "training_only",
+    "forbidden_evaluation_time",
+}
+
+PROVENANCE_FIELDS = {
+    "training_data_source",
+    "validation_split",
+    "test_split",
+    "checkpoint_or_model_provenance",
+    "privileged_training_inputs",
+    "privileged_training_inputs_enter_evaluation",
+    "normalization_statistics",
+    "normalization_statistics_fit_on_training_only",
+    "evidence_source",
+}
+
+LOGGING_FIELDS = {
+    "raw_model_action",
+    "adapted_action",
+    "post_guard_action",
+    "guard_applied",
+    "guard_or_fallback_reason",
+    "observation_level",
+    "planner_observation_mode",
+    "action_bounds",
+    "action_projection_metadata",
+}
+
+
+@dataclass(frozen=True)
+class EligibilityIssue:
+    """One checklist validation issue."""
+
+    path: str
+    message: str
+
+
+def _is_missing(value: Any) -> bool:
+    """Return whether a YAML value is absent for checklist purposes."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    """Return ``value`` when it is a mapping, otherwise an empty mapping."""
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Return ``value`` when it is a list, otherwise an empty list."""
+    return list(value) if isinstance(value, list) else []
+
+
+def _require_mapping(
+    issues: list[EligibilityIssue],
+    payload: dict[str, Any],
+    key: str,
+) -> dict[str, Any]:
+    """Require a top-level mapping and return it when present."""
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        issues.append(EligibilityIssue(key, "must be a non-empty mapping"))
+        return {}
+    if not value:
+        issues.append(EligibilityIssue(key, "must be a non-empty mapping"))
+    return dict(value)
+
+
+def _require_fields(
+    issues: list[EligibilityIssue],
+    mapping: dict[str, Any],
+    *,
+    prefix: str,
+    fields: set[str],
+) -> None:
+    """Require non-empty values for all fields in ``mapping``."""
+    for field in sorted(fields):
+        if _is_missing(mapping.get(field)):
+            issues.append(EligibilityIssue(f"{prefix}.{field}", "is required"))
+
+
+def _validate_verdict(payload: dict[str, Any], issues: list[EligibilityIssue]) -> str | None:
+    """Validate and return the top-level verdict."""
+    verdict = payload.get("verdict")
+    if not isinstance(verdict, str) or verdict not in ALLOWED_VERDICTS:
+        issues.append(
+            EligibilityIssue(
+                "verdict",
+                f"must be one of {', '.join(sorted(ALLOWED_VERDICTS))}",
+            )
+        )
+        return None
+    return verdict
+
+
+def _validate_observation_gate(
+    payload: dict[str, Any],
+    *,
+    verdict: str | None,
+    issues: list[EligibilityIssue],
+) -> None:
+    """Validate observation timing and input-field classifications."""
+    if _is_missing(payload.get("observation_t")):
+        issues.append(EligibilityIssue("observation_t", "is required"))
+
+    observation_fields = _require_mapping(issues, payload, "observation_fields")
+    for classification in sorted(OBSERVATION_CLASSIFICATIONS):
+        if classification not in observation_fields:
+            issues.append(
+                EligibilityIssue(
+                    f"observation_fields.{classification}",
+                    "must be present, even when the list is empty",
+                )
+            )
+        elif not isinstance(observation_fields[classification], list):
+            issues.append(
+                EligibilityIssue(
+                    f"observation_fields.{classification}",
+                    "must be a list",
+                )
+            )
+
+    deployment_fields = _as_list(observation_fields.get("deployment_observable"))
+    forbidden_fields = _as_list(observation_fields.get("forbidden_evaluation_time"))
+    if not deployment_fields:
+        issues.append(
+            EligibilityIssue(
+                "observation_fields.deployment_observable",
+                "must list at least one deployment-time input field",
+            )
+        )
+    if forbidden_fields and verdict in ELIGIBLE_VERDICTS:
+        issues.append(
+            EligibilityIssue(
+                "observation_fields.forbidden_evaluation_time",
+                "eligible verdicts cannot require forbidden evaluation-time fields",
+            )
+        )
+
+
+def _validate_split_provenance(
+    payload: dict[str, Any],
+    *,
+    verdict: str | None,
+    issues: list[EligibilityIssue],
+) -> None:
+    """Validate split, provenance, and leakage metadata."""
+    split_provenance = _require_mapping(issues, payload, "split_provenance")
+    _require_fields(
+        issues,
+        split_provenance,
+        prefix="split_provenance",
+        fields=PROVENANCE_FIELDS,
+    )
+    if (
+        split_provenance.get("privileged_training_inputs_enter_evaluation") is True
+        and verdict in ELIGIBLE_VERDICTS
+    ):
+        issues.append(
+            EligibilityIssue(
+                "split_provenance.privileged_training_inputs_enter_evaluation",
+                "eligible verdicts must keep privileged training inputs out of evaluation",
+            )
+        )
+    if (
+        split_provenance.get("normalization_statistics_fit_on_training_only") is False
+        and verdict in ELIGIBLE_VERDICTS
+    ):
+        issues.append(
+            EligibilityIssue(
+                "split_provenance.normalization_statistics_fit_on_training_only",
+                "eligible verdicts require normalization statistics fit on training data only",
+            )
+        )
+
+
+def _validate_action_contract(payload: dict[str, Any], issues: list[EligibilityIssue]) -> None:
+    """Validate the selected action-output family and adapter metadata."""
+    action_contract = _require_mapping(issues, payload, "action_contract")
+    output_family = action_contract.get("output_family")
+    if output_family not in ACTION_FAMILY_REQUIRED_FIELDS:
+        issues.append(
+            EligibilityIssue(
+                "action_contract.output_family",
+                f"must be one of {', '.join(sorted(ACTION_FAMILY_REQUIRED_FIELDS))}",
+            )
+        )
+    else:
+        _require_fields(
+            issues,
+            action_contract,
+            prefix="action_contract",
+            fields=ACTION_FAMILY_REQUIRED_FIELDS[output_family],
+        )
+    _require_fields(
+        issues,
+        action_contract,
+        prefix="action_contract",
+        fields={"raw_to_robot_sf_action", "guard_or_projection_policy"},
+    )
+
+
+def _validate_logging(payload: dict[str, Any], issues: list[EligibilityIssue]) -> None:
+    """Validate required per-step learned-policy diagnostics."""
+    logging = _require_mapping(issues, payload, "per_step_logging")
+    _require_fields(
+        issues,
+        logging,
+        prefix="per_step_logging",
+        fields=LOGGING_FIELDS,
+    )
+
+
+def _validate_registry_boundary(payload: dict[str, Any], issues: list[EligibilityIssue]) -> None:
+    """Validate registry-readiness fields when a registry entry is planned."""
+    registry = _as_mapping(payload.get("candidate_registry"))
+    if registry.get("entry_planned") is True:
+        _require_fields(
+            issues,
+            registry,
+            prefix="candidate_registry",
+            fields={
+                "candidate_config_path",
+                "adapter_path",
+                "smoke_or_validation_command",
+                "missing_checkpoint_policy",
+                "unsupported_observation_policy",
+                "guard_activation_policy",
+            },
+        )
+
+
+def validate_learned_policy_eligibility(payload: dict[str, Any]) -> list[EligibilityIssue]:
+    """Return checklist-completeness and consistency issues for one candidate spec."""
+    issues: list[EligibilityIssue] = []
+    verdict = _validate_verdict(payload, issues)
+    _validate_observation_gate(payload, verdict=verdict, issues=issues)
+    _validate_split_provenance(payload, verdict=verdict, issues=issues)
+    _validate_action_contract(payload, issues)
+    _validate_logging(payload, issues)
+    _validate_registry_boundary(payload, issues)
+    return issues
+
+
+def load_candidate_spec(path: Path) -> dict[str, Any]:
+    """Load one YAML or JSON learned-policy eligibility spec."""
+    if path.suffix.lower() == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected top-level mapping in {path}")
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("spec", nargs="+", type=Path, help="YAML/JSON eligibility spec files")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of text",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the learned-policy eligibility preflight."""
+    args = parse_args()
+    results: dict[str, list[dict[str, str]]] = {}
+
+    for spec_path in args.spec:
+        issues = validate_learned_policy_eligibility(load_candidate_spec(spec_path))
+        results[str(spec_path)] = [
+            {"path": issue.path, "message": issue.message} for issue in issues
+        ]
+
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        for spec_path, issues in results.items():
+            if not issues:
+                print(f"{spec_path}: PASS")
+                continue
+            print(f"{spec_path}: FAIL")
+            for issue in issues:
+                print(f"  - {issue['path']}: {issue['message']}")
+
+    return 1 if any(results.values()) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_learned_policy_eligibility.py
+++ b/scripts/validation/check_learned_policy_eligibility.py
@@ -319,12 +319,21 @@ def validate_learned_policy_eligibility(payload: dict[str, Any]) -> list[Eligibi
 
 def load_candidate_spec(path: Path) -> dict[str, Any]:
     """Load one YAML or JSON learned-policy eligibility spec."""
-    if path.suffix.lower() == ".json":
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    else:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        if path.suffix.lower() == ".json":
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"Error loading {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Error parsing {path} at line {exc.lineno}: {exc.msg}") from exc
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        line_text = f" at line {mark.line + 1}" if mark is not None else ""
+        raise ValueError(f"Error parsing {path}{line_text}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise TypeError(f"Expected top-level mapping in {path}")
+        raise ValueError(f"Expected top-level mapping in {path}")
     return payload
 
 

--- a/tests/validation/test_check_learned_policy_eligibility.py
+++ b/tests/validation/test_check_learned_policy_eligibility.py
@@ -1,0 +1,179 @@
+"""Tests for the learned-policy eligibility checklist helper."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from scripts.validation.check_learned_policy_eligibility import (
+    load_candidate_spec,
+    main,
+    validate_learned_policy_eligibility,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _eligible_spec() -> dict[str, object]:
+    """Return a complete learned-policy metadata spec."""
+    return {
+        "verdict": "eligible_for_adapter",
+        "observation_t": "decision step t before action selection",
+        "observation_fields": {
+            "deployment_observable": [
+                "robot pose",
+                "current goal",
+                "visible pedestrian positions and velocities",
+            ],
+            "training_only": ["expert demonstrations used for imitation loss"],
+            "forbidden_evaluation_time": [],
+        },
+        "split_provenance": {
+            "training_data_source": "synthetic training split",
+            "validation_split": "held-out maps validation_v1",
+            "test_split": "Robot SF benchmark test scenarios excluded from training",
+            "checkpoint_or_model_provenance": "wandb artifact candidate:v1",
+            "privileged_training_inputs": "critic-only future return labels",
+            "privileged_training_inputs_enter_evaluation": False,
+            "normalization_statistics": "fit on training episodes only",
+            "normalization_statistics_fit_on_training_only": True,
+            "evidence_source": "Robot SF local smoke command",
+        },
+        "action_contract": {
+            "output_family": "velocity_command",
+            "frame": "robot local frame",
+            "units": "m/s and rad/s",
+            "bounds": "linear <= 1.0 m/s, angular <= 1.5 rad/s",
+            "kinematics_compatibility": "differential-drive compatible",
+            "projection_policy": "clip to Robot SF planner command bounds",
+            "raw_to_robot_sf_action": "map raw velocity vector to action dictionary",
+            "guard_or_projection_policy": "log clipping and fallback separately",
+        },
+        "per_step_logging": {
+            "raw_model_action": "logged as candidate.raw_model_action",
+            "adapted_action": "logged as candidate.adapted_action",
+            "post_guard_action": "logged as candidate.post_guard_action",
+            "guard_applied": "boolean flag",
+            "guard_or_fallback_reason": "stable string or none",
+            "observation_level": "global observation level",
+            "planner_observation_mode": "candidate preprocessing mode",
+            "action_bounds": "bounds active for the step",
+            "action_projection_metadata": "clip/projection details",
+        },
+        "candidate_registry": {
+            "entry_planned": True,
+            "candidate_config_path": "configs/policy_search/candidates/example.yaml",
+            "adapter_path": "robot_sf/planner/example.py",
+            "smoke_or_validation_command": (
+                "uv run python scripts/validation/run_policy_search_candidate.py "
+                "--candidate example --stage smoke"
+            ),
+            "missing_checkpoint_policy": "fail closed with not_available",
+            "unsupported_observation_policy": "fail closed before benchmark run",
+            "guard_activation_policy": "report as caveat, not success evidence",
+        },
+    }
+
+
+def test_complete_eligible_spec_passes() -> None:
+    """A complete metadata spec should satisfy the checklist preflight."""
+    assert validate_learned_policy_eligibility(_eligible_spec()) == []
+
+
+def test_missing_fields_are_reported() -> None:
+    """The helper should flag absent checklist inputs with stable paths."""
+    spec = _eligible_spec()
+    spec["observation_t"] = ""
+    spec["observation_fields"] = {"deployment_observable": []}
+    spec["per_step_logging"] = {"raw_model_action": "yes"}
+
+    issues = validate_learned_policy_eligibility(spec)
+    paths = {issue.path for issue in issues}
+
+    assert "observation_t" in paths
+    assert "observation_fields.deployment_observable" in paths
+    assert "observation_fields.training_only" in paths
+    assert "observation_fields.forbidden_evaluation_time" in paths
+    assert "per_step_logging.post_guard_action" in paths
+    assert "per_step_logging.guard_or_fallback_reason" in paths
+
+
+def test_forbidden_evaluation_fields_block_eligible_verdict() -> None:
+    """Eligible verdicts must not depend on forbidden evaluation-time fields."""
+    spec = _eligible_spec()
+    spec["observation_fields"]["forbidden_evaluation_time"] = [
+        "future pedestrian trajectory",
+    ]
+
+    issues = validate_learned_policy_eligibility(spec)
+
+    assert any(
+        issue.path == "observation_fields.forbidden_evaluation_time"
+        and "eligible verdicts" in issue.message
+        for issue in issues
+    )
+
+
+def test_training_only_or_oracle_can_record_forbidden_fields() -> None:
+    """Oracle classifications should still record the forbidden inputs they need."""
+    spec = _eligible_spec()
+    spec["verdict"] = "training_only_or_oracle"
+    spec["observation_fields"]["forbidden_evaluation_time"] = [
+        "future collision label",
+    ]
+
+    assert validate_learned_policy_eligibility(spec) == []
+
+
+def test_missing_provenance_booleans_are_reported() -> None:
+    """Whether-style provenance checklist fields should be explicit."""
+    spec = _eligible_spec()
+    del spec["split_provenance"]["privileged_training_inputs_enter_evaluation"]
+    del spec["split_provenance"]["normalization_statistics_fit_on_training_only"]
+
+    issues = validate_learned_policy_eligibility(spec)
+    paths = {issue.path for issue in issues}
+
+    assert "split_provenance.privileged_training_inputs_enter_evaluation" in paths
+    assert "split_provenance.normalization_statistics_fit_on_training_only" in paths
+
+
+def test_cli_reports_json_and_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The command-line helper should return nonzero when any spec fails."""
+    valid = tmp_path / "valid.yaml"
+    invalid = tmp_path / "invalid.yaml"
+    valid.write_text(yaml.safe_dump(_eligible_spec()), encoding="utf-8")
+    invalid.write_text("verdict: eligible_for_adapter\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_learned_policy_eligibility.py",
+            "--json",
+            str(valid),
+            str(invalid),
+        ],
+    )
+
+    assert main() == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output[str(valid)] == []
+    assert any(issue["path"] == "observation_t" for issue in output[str(invalid)])
+    loaded = load_candidate_spec(valid)
+
+    assert loaded["verdict"] == "eligible_for_adapter"
+
+
+def test_json_spec_loading(tmp_path: Path) -> None:
+    """YAML and JSON specs should both be accepted by the loader."""
+    path = tmp_path / "candidate.json"
+    path.write_text(json.dumps(_eligible_spec()), encoding="utf-8")
+
+    assert load_candidate_spec(path)["action_contract"]["output_family"] == "velocity_command"

--- a/tests/validation/test_check_learned_policy_eligibility.py
+++ b/tests/validation/test_check_learned_policy_eligibility.py
@@ -177,3 +177,21 @@ def test_json_spec_loading(tmp_path: Path) -> None:
     path.write_text(json.dumps(_eligible_spec()), encoding="utf-8")
 
     assert load_candidate_spec(path)["action_contract"]["output_family"] == "velocity_command"
+
+
+def test_loader_errors_include_path_and_line(tmp_path: Path) -> None:
+    """Malformed specs should fail closed with actionable file context."""
+    path = tmp_path / "broken.json"
+    path.write_text('{\n  "verdict": "eligible_for_adapter",\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=rf"{path}.*line 3"):
+        load_candidate_spec(path)
+
+
+def test_loader_rejects_non_mapping_specs(tmp_path: Path) -> None:
+    """Top-level sequences should not be accepted as candidate metadata."""
+    path = tmp_path / "list.yaml"
+    path.write_text("- not\n- a mapping\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=rf"top-level mapping.*{path}"):
+        load_candidate_spec(path)


### PR DESCRIPTION
## Summary
Adds an executable learned-policy eligibility metadata preflight for the checklist created by #1363.

## Linked Issues
- Closes #1375
- Relates to #1363
- Relates to #1355
- Relates to #1359

## What Changed
- Added `scripts/validation/check_learned_policy_eligibility.py` to validate structured YAML/JSON learned-policy checklist metadata.
- Covered required verdict, `observation_t`, observation-field classifications, split/provenance, action-output contract, guard/projection, per-step logging, and registry-readiness fields.
- Added focused tests for eligible specs, missing fields, forbidden evaluation-time fields, oracle verdict handling, explicit provenance booleans, CLI JSON output, and JSON loading.
- Linked the helper from `docs/context/policy_search/README.md` and the checklist contract.

## Why It Matters
- Added value: learned-policy candidate screening now has a repeatable preflight instead of ad hoc checklist reading.
- Expected impact: future #1355/#1359-style candidate notes can cite helper output while preserving the checklist boundary.
- Why this is worth merging now: #1363 is on `origin/main`, so the stable checklist contract is available for executable validation.

## Validation / Proof
- `uv run ruff check scripts/validation/check_learned_policy_eligibility.py tests/validation/test_check_learned_policy_eligibility.py`
- `uv run pytest -q tests/validation/test_check_learned_policy_eligibility.py` -> 7 passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3820 passed, 11 skipped, 8 warnings

## Risks / Rollout
- Compatibility risks: low; this adds a standalone validation helper and docs links.
- Failure modes: candidate authors may treat a pass as benchmark readiness. The docs and helper module both state that passing means checklist metadata completeness only.
- Rollback or fallback plan: remove the helper and docs links if the structured metadata shape needs a different contract later.

## Docs / Provenance
- Updated docs: `docs/context/policy_search/contracts/learned_local_policy_eligibility.md`, `docs/context/policy_search/README.md`.
- Relevant design or provenance notes: the helper encodes the #1363 checklist as structured candidate metadata validation; it does not parse Markdown checklist prose.
- Assumption preserved: helper success is not performance evidence, adapter acceptance, runtime safety proof, or a paper-facing benchmark claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that the structured fields line up with the #1363 checklist boundary.
- Copilot read-only review caught a missing explicit-boolean requirement; fixed before handoff.
