### PR TITLE
docs: record GenSafeNav source harness blocker

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -386,6 +386,7 @@ knowledge, not every transient iteration detail.
 * [Issue #1368 NeuPAN Point-Obstacle Comparator Assessment (2026-05-20)](issue_1368_neupan_point_obstacle_assessment.md)
 * [Issue #1367 CrowdNav-Family Learned-Policy Verdict](./policy_search/issue_1367_crowdnav_family_verdict.md)
 * [Issue #1366 GenSafeNav / SoNIC Conformal Contract](./policy_search/issue_1366_gensafenav_sonic_conformal_contract.md)
+* [Issue #1393 GenSafeNav / SoNIC Source-Harness Reproduction](./policy_search/issue_1393_gensafenav_source_harness.md)
 * [Policy Search Context](./policy_search/README.md) - file-based candidate registry, staged local
   evaluation funnel, SLURM handoff notes, and the current
   [portfolio overview](./policy_search/portfolio_overview_2026-05-05.md) for the non-training

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -386,7 +386,7 @@ knowledge, not every transient iteration detail.
 * [Issue #1368 NeuPAN Point-Obstacle Comparator Assessment (2026-05-20)](issue_1368_neupan_point_obstacle_assessment.md)
 * [Issue #1367 CrowdNav-Family Learned-Policy Verdict](./policy_search/issue_1367_crowdnav_family_verdict.md)
 * [Issue #1366 GenSafeNav / SoNIC Conformal Contract](./policy_search/issue_1366_gensafenav_sonic_conformal_contract.md)
-* [Issue #1393 GenSafeNav / SoNIC Source-Harness Reproduction](./policy_search/issue_1393_gensafenav_source_harness.md)
+* [Issue #1393 GenSafeNav / SoNIC Source-Harness Reproduction (2026-05-20)](./policy_search/issue_1393_gensafenav_source_harness.md)
 * [Policy Search Context](./policy_search/README.md) - file-based candidate registry, staged local
   evaluation funnel, SLURM handoff notes, and the current
   [portfolio overview](./policy_search/portfolio_overview_2026-05-05.md) for the non-training

--- a/docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json
+++ b/docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json
@@ -1,12 +1,17 @@
 {
   "issue": 1393,
-  "date": "2026-05-20",
   "repo_remote_url": "https://github.com/tasl-lab/GenSafeNav",
-  "repo_commit": "01baf926a5c77c1a4ab28635658eb014ef4f1767",
+  "repo_root": "<GenSafeNav checkout at commit 01baf926a5c77c1a4ab28635658eb014ef4f1767>",
   "model_name": "Ours_GST",
   "checkpoint": "05207.pt",
-  "checkpoint_path": "trained_models/Ours_GST/checkpoints/05207.pt",
-  "command": "uv run python scripts/tools/probe_sonic_source_harness.py --issue 1393 --repo-remote-url https://github.com/tasl-lab/GenSafeNav --repo-root <GenSafeNav checkout> --model-name Ours_GST --checkpoint 05207.pt --timeout-seconds 30",
+  "command": [
+    "<python>",
+    "test.py",
+    "--model_dir",
+    "trained_models/Ours_GST",
+    "--test_model",
+    "05207.pt"
+  ],
   "docker_base_image": "pytorch/pytorch:2.3.1-cuda12.1-cudnn8-devel",
   "source_contract": {
     "robot_policy": "selfAttn_merge_srnn",
@@ -17,10 +22,15 @@
     "env_use_wrapper": true,
     "env_name": "CrowdSimPredRealGST-v0"
   },
+  "training_defaults": {},
+  "requirements_files": {},
   "verdict": "source harness blocked",
   "failure_stage": "source_entrypoint",
   "failure_summary": "missing python dependency: gym",
   "returncode": 1,
+  "stdout_tail": "",
+  "stderr_tail": "Traceback (most recent call last):\n  File \"<GenSafeNav checkout>/test.py\", line 9, in <module>\n    from rl.networks.envs import make_vec_envs\n  File \"<GenSafeNav checkout>/rl/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'",
   "timeout_seconds": 30,
-  "stderr_tail": "Traceback (most recent call last):\n  File \"<GenSafeNav checkout>/test.py\", line 9, in <module>\n    from rl.networks.envs import make_vec_envs\n  File \"<GenSafeNav checkout>/rl/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'"
+  "source_commit": "01baf926a5c77c1a4ab28635658eb014ef4f1767",
+  "checkpoint_path": "trained_models/Ours_GST/checkpoints/05207.pt"
 }

--- a/docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json
+++ b/docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json
@@ -1,0 +1,26 @@
+{
+  "issue": 1393,
+  "date": "2026-05-20",
+  "repo_remote_url": "https://github.com/tasl-lab/GenSafeNav",
+  "repo_commit": "01baf926a5c77c1a4ab28635658eb014ef4f1767",
+  "model_name": "Ours_GST",
+  "checkpoint": "05207.pt",
+  "checkpoint_path": "trained_models/Ours_GST/checkpoints/05207.pt",
+  "command": "uv run python scripts/tools/probe_sonic_source_harness.py --issue 1393 --repo-remote-url https://github.com/tasl-lab/GenSafeNav --repo-root <GenSafeNav checkout> --model-name Ours_GST --checkpoint 05207.pt --timeout-seconds 30",
+  "docker_base_image": "pytorch/pytorch:2.3.1-cuda12.1-cudnn8-devel",
+  "source_contract": {
+    "robot_policy": "selfAttn_merge_srnn",
+    "human_policy": "orca",
+    "robot_sensor": "coordinates",
+    "predict_method": "inferred",
+    "action_kinematics": "holonomic",
+    "env_use_wrapper": true,
+    "env_name": "CrowdSimPredRealGST-v0"
+  },
+  "verdict": "source harness blocked",
+  "failure_stage": "source_entrypoint",
+  "failure_summary": "missing python dependency: gym",
+  "returncode": 1,
+  "timeout_seconds": 30,
+  "stderr_tail": "Traceback (most recent call last):\n  File \"<GenSafeNav checkout>/test.py\", line 9, in <module>\n    from rl.networks.envs import make_vec_envs\n  File \"<GenSafeNav checkout>/rl/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'"
+}

--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -69,6 +69,8 @@ Use it for three things only:
   gates for each candidate land.
 - `issue_1366_gensafenav_sonic_conformal_contract.md`: GenSafeNav / SoNIC conformal uncertainty
   assessment; current verdict is source-side reproduction first before benchmark promotion.
+- `issue_1393_gensafenav_source_harness.md`: fresh GenSafeNav `Ours_GST` source-harness
+  reproduction record; current verdict remains blocked by the missing `gym` source dependency.
 - `../issue_769_drl_vo_assessment.md`: DRL-VO metadata history plus issue #1364 privileged-state
   audit verdict; current status is prototype-only/tracked-agent diagnostic, not main-table ready.
 - `2026-05-20_tentabot_motion_primitive_assessment.md`: issue #1357 assessment of Tentabot-style

--- a/docs/context/policy_search/issue_1366_gensafenav_sonic_conformal_contract.md
+++ b/docs/context/policy_search/issue_1366_gensafenav_sonic_conformal_contract.md
@@ -24,6 +24,8 @@ Primary external sources:
 * GenSafeNav paper: <https://arxiv.org/abs/2508.05634>
 * SoNIC repository: <https://github.com/tasl-lab/SoNIC-Social-Nav>
 * SoNIC paper: <https://arxiv.org/abs/2407.17460>
+* Issue #1393 source-harness rerun:
+  [issue_1393_gensafenav_source_harness.md](issue_1393_gensafenav_source_harness.md)
 
 Local source snapshot inspected in the ignored worktree output area:
 

--- a/docs/context/policy_search/issue_1393_gensafenav_source_harness.md
+++ b/docs/context/policy_search/issue_1393_gensafenav_source_harness.md
@@ -1,0 +1,110 @@
+# Issue #1393 GenSafeNav / SoNIC Source-Harness Reproduction
+
+Date: 2026-05-20
+
+Related issues:
+
+* <https://github.com/ll7/robot_sf_ll7/issues/1393>
+* [Issue #1366 GenSafeNav / SoNIC Conformal Contract](issue_1366_gensafenav_sonic_conformal_contract.md)
+* [Issue #626 SoNIC Source-Harness Reproduction Probe](../issue_626_sonic_source_harness_probe.md)
+* [Issue #627 SoNIC / GenSafeNav Model-Only Wrapper Follow-Up](../issue_627_sonic_wrapper_followup.md)
+* [Learned-Policy Eligibility Checklist](contracts/learned_local_policy_eligibility.md)
+
+## Goal
+
+Turn the GenSafeNav / SoNIC source-side-first verdict into a fresh executable record for #1393.
+The task is source-harness proof, not a Robot SF adapter and not a benchmark claim.
+
+## Source Snapshot
+
+External checkout:
+
+* Repository: <https://github.com/tasl-lab/GenSafeNav>
+* Local ignored checkout: `output/repos/GenSafeNav`
+* Commit: `01baf926a5c77c1a4ab28635658eb014ef4f1767`
+* Docker base image recorded by the source: `pytorch/pytorch:2.3.1-cuda12.1-cudnn8-devel`
+* Model: `trained_models/Ours_GST`
+* Checkpoint: `trained_models/Ours_GST/checkpoints/05207.pt`
+
+The checkout, model files, and generated probe logs remain ignored local artifacts. The compact
+tracked evidence summary is
+`docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json`.
+
+## Probe Command
+
+```bash
+git clone https://github.com/tasl-lab/GenSafeNav output/repos/GenSafeNav
+git -C output/repos/GenSafeNav checkout 01baf926a5c77c1a4ab28635658eb014ef4f1767
+git -C output/repos/GenSafeNav rev-parse HEAD
+uv run python scripts/tools/probe_sonic_source_harness.py \
+  --issue 1393 \
+  --repo-remote-url https://github.com/tasl-lab/GenSafeNav \
+  --repo-root output/repos/GenSafeNav \
+  --model-name Ours_GST \
+  --checkpoint 05207.pt \
+  --timeout-seconds 30 \
+  --output-json output/benchmarks/external/gensafenav_source_harness_probe_1393/report.json \
+  --output-md output/benchmarks/external/gensafenav_source_harness_probe_1393/report.md
+```
+
+The probe exits non-zero when the source harness is blocked. For this run that non-zero exit is the
+expected fail-closed result.
+
+## Result
+
+Verdict: `source harness blocked`.
+
+Observed blocker:
+
+```text
+Traceback (most recent call last):
+  File "output/repos/GenSafeNav/test.py", line 9, in <module>
+    from rl.networks.envs import make_vec_envs
+  File "output/repos/GenSafeNav/rl/networks/envs.py", line 3, in <module>
+    import gym
+ModuleNotFoundError: No module named 'gym'
+```
+
+The probe also extracted the source contract:
+
+* `robot_policy`: `selfAttn_merge_srnn`
+* `human_policy`: `orca`
+* `robot_sensor`: `coordinates`
+* `predict_method`: `inferred`
+* `action_kinematics`: `holonomic`
+* `env_use_wrapper`: `True`
+* default env: `CrowdSimPredRealGST-v0`
+
+## Field Classification
+
+This run does not advance the ACI/conformal fields beyond the #1366 assessment because the source
+entrypoint fails before an episode starts. The #1366 classification remains authoritative:
+
+* current robot and tracked pedestrian state: deployment-observable under the declared observation
+  level,
+* GST-predicted pedestrian trajectories: deployment-derived predictions only if generated from
+  current/past observations by a frozen predictor,
+* `conformity_scores`: allowed only as train/validation-calibrated or online-past-only state,
+* `conformal_intrusion_cost` and cost critic training state: training or diagnostic only,
+* source `human_future_traj` truth and evaluation-seed calibration: forbidden as policy inputs.
+
+## Verdict
+
+Status: `source harness blocked by runtime dependency`.
+
+The source harness has not reproduced a GenSafeNav `Ours_GST` checkpoint in the Robot SF runtime.
+This keeps GenSafeNav / SoNIC out of benchmark-ready and source-faithful adapter status. Model-only
+compatibility shims remain useful for metadata/prototype work, but they do not prove conformal,
+constrained-RL, or source simulator semantics.
+
+## Next Reopen Gate
+
+Revisit source-harness promotion only after a dedicated source environment can run:
+
+```bash
+python test.py --model_dir trained_models/Ours_GST --test_model 05207.pt
+```
+
+without local fallback, model-only shims, evaluation-seed calibration, or future-trajectory policy
+inputs. The next record should capture the pinned Python version, `gym`, `matplotlib`, Torch/CUDA
+stack, source commit, checkpoint checksum, and whether the run reaches at least one source episode.

--- a/docs/context/policy_search/reject_monitor_registry.md
+++ b/docs/context/policy_search/reject_monitor_registry.md
@@ -100,15 +100,18 @@ the repository-specific decision about benchmark fit, fairness, and reopen crite
 - Evidence grade: `observed`
 - Source-backed facts: SoNIC and GenSafeNav expose model/checkpoint assets that can be referenced by
   the Robot SF metadata layer. The source-harness probe found the upstream source environment
-  blocked in the current Robot SF environment, while model-only reuse is possible through explicit
+  blocked in the current Robot SF environment. Issue #1393 reran the GenSafeNav `Ours_GST`
+  checkpoint path at commit `01baf926a5c77c1a4ab28635658eb014ef4f1767` and reproduced
+  `ModuleNotFoundError: No module named 'gym'`; model-only reuse is possible through explicit
   compatibility shims.
 - Robot SF synthesis: Keep these as model-only prototypes or source-side-first safety/OOD
   candidates. Do not claim SoNIC/GenSafeNav benchmark parity or conformal-safety support until
   calibration, future-trajectory, and source-harness boundaries are proven.
-- Related Robot SF work: #601, #602, #626, #627, #1366,
+- Related Robot SF work: #601, #602, #626, #627, #1366, #1393,
   `docs/context/issue_626_sonic_source_harness_probe.md`,
   `docs/context/issue_627_sonic_wrapper_followup.md`,
-  `docs/context/issue_602_guarded_ppo_profile.md`.
+  `docs/context/issue_602_guarded_ppo_profile.md`,
+  `docs/context/policy_search/issue_1393_gensafenav_source_harness.md`.
 - Reopen if: the source harness becomes reproducible in a pinned environment and any uncertainty or
   calibration fields are classified as train-only, deployment-observable, oracle-only, or forbidden.
 

--- a/scripts/tools/probe_sonic_source_harness.py
+++ b/scripts/tools/probe_sonic_source_harness.py
@@ -177,7 +177,13 @@ class ProbeReport:
 
 
 def run_probe(
-    repo_root: Path, model_name: str, checkpoint: str | None, timeout_seconds: int
+    repo_root: Path,
+    model_name: str,
+    checkpoint: str | None,
+    timeout_seconds: int,
+    *,
+    issue: int = 626,
+    repo_remote_url: str = "https://github.com/tasl-lab/SoNIC-Social-Nav",
 ) -> ProbeReport:
     """Run a fail-fast probe against the upstream SoNIC source test entrypoint."""
     test_path = repo_root / "test.py"
@@ -202,8 +208,8 @@ def run_probe(
     missing = [str(path) for path in required_paths if not path.exists()]
     if missing:
         return ProbeReport(
-            issue=626,
-            repo_remote_url="https://github.com/tasl-lab/SoNIC-Social-Nav",
+            issue=issue,
+            repo_remote_url=repo_remote_url,
             repo_root=str(repo_root),
             model_name=model_name,
             checkpoint=checkpoint or "",
@@ -226,8 +232,8 @@ def run_probe(
             resolved_checkpoint = _default_checkpoint(checkpoints_dir)
         except FileNotFoundError:
             return ProbeReport(
-                issue=626,
-                repo_remote_url="https://github.com/tasl-lab/SoNIC-Social-Nav",
+                issue=issue,
+                repo_remote_url=repo_remote_url,
                 repo_root=str(repo_root),
                 model_name=model_name,
                 checkpoint="",
@@ -253,8 +259,8 @@ def run_probe(
     checkpoint_path = checkpoints_dir / resolved_checkpoint
     if not checkpoint_path.exists():
         return ProbeReport(
-            issue=626,
-            repo_remote_url="https://github.com/tasl-lab/SoNIC-Social-Nav",
+            issue=issue,
+            repo_remote_url=repo_remote_url,
             repo_root=str(repo_root),
             model_name=model_name,
             checkpoint=resolved_checkpoint,
@@ -309,8 +315,8 @@ def run_probe(
         stderr_tail = (exc.stderr or "")[-4000:]
 
     return ProbeReport(
-        issue=626,
-        repo_remote_url="https://github.com/tasl-lab/SoNIC-Social-Nav",
+        issue=issue,
+        repo_remote_url=repo_remote_url,
         repo_root=str(repo_root),
         model_name=model_name,
         checkpoint=resolved_checkpoint,
@@ -412,6 +418,17 @@ def main() -> int:
         default=30,
         help="Timeout for the source entrypoint probe.",
     )
+    parser.add_argument(
+        "--issue",
+        type=int,
+        default=626,
+        help="Issue number to record in generated reports.",
+    )
+    parser.add_argument(
+        "--repo-remote-url",
+        default="https://github.com/tasl-lab/SoNIC-Social-Nav",
+        help="Source repository URL to record in generated reports.",
+    )
     parser.add_argument("--output-json", type=Path, default=None, help="Optional JSON report path.")
     parser.add_argument(
         "--output-md", type=Path, default=None, help="Optional Markdown report path."
@@ -423,6 +440,8 @@ def main() -> int:
         model_name=args.model_name,
         checkpoint=args.checkpoint,
         timeout_seconds=args.timeout_seconds,
+        issue=args.issue,
+        repo_remote_url=args.repo_remote_url,
     )
     payload = asdict(report)
 

--- a/tests/tools/test_probe_sonic_source_harness.py
+++ b/tests/tools/test_probe_sonic_source_harness.py
@@ -86,6 +86,25 @@ def test_run_probe_captures_missing_dependency_from_entrypoint(tmp_path: Path) -
     assert report.training_defaults["env_name"] == "CrowdSimPredRealGST-v0"
 
 
+def test_run_probe_records_requested_issue_number(tmp_path: Path) -> None:
+    """Probe reports should be reusable for follow-up issues beyond the original source probe."""
+    repo_root = tmp_path / "repo"
+    _write_fake_repo(repo_root)
+    _write(repo_root / "test.py", "print('ok')\n")
+
+    report = run_probe(
+        repo_root,
+        model_name="SoNIC_GST",
+        checkpoint="05207.pt",
+        timeout_seconds=5,
+        issue=1393,
+        repo_remote_url="https://github.com/tasl-lab/GenSafeNav",
+    )
+
+    assert report.issue == 1393
+    assert report.repo_remote_url == "https://github.com/tasl-lab/GenSafeNav"
+
+
 def test_run_probe_blocks_cleanly_when_checkpoint_dir_is_empty(tmp_path: Path) -> None:
     """An empty checkpoints dir should produce a blocked report, not a traceback."""
     repo_root = tmp_path / "repo"


### PR DESCRIPTION
## Summary
Records a fresh GenSafeNav `Ours_GST` source-harness reproduction attempt for #1393 and keeps the verdict fail-closed: the source entrypoint is still blocked by the missing `gym` runtime dependency.

Also makes the reusable SoNIC/GenSafeNav probe accept explicit issue and source-repository metadata so follow-up reports do not inherit stale #626 / SoNIC attribution.

## Linked Issues
- Closes #1393

## What Changed
- Added `docs/context/policy_search/issue_1393_gensafenav_source_harness.md` with the pinned GenSafeNav checkout, command, source contract, blocker, and reopen gate.
- Added compact tracked evidence at `docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json`.
- Updated policy-search indexes and the reject/monitor registry to point at the #1393 proof.
- Extended `scripts/tools/probe_sonic_source_harness.py` with `--issue` and `--repo-remote-url` report metadata.

## Why It Matters
- Added value: converts the assessment-only source-side-first verdict into a rerunnable source-harness proof record.
- Expected impact: prevents GenSafeNav / SoNIC from being treated as benchmark-ready until the real source runtime runs.
- Why this is worth merging now: the blocker is concrete, reproducible, and documented without committing external repos or checkpoints.

## Validation / Proof
- `git clone https://github.com/tasl-lab/GenSafeNav output/repos/GenSafeNav`
- `git -C output/repos/GenSafeNav checkout 01baf926a5c77c1a4ab28635658eb014ef4f1767`
- `uv run python scripts/tools/probe_sonic_source_harness.py --issue 1393 --repo-remote-url https://github.com/tasl-lab/GenSafeNav --repo-root output/repos/GenSafeNav --model-name Ours_GST --checkpoint 05207.pt --timeout-seconds 30 --output-json output/benchmarks/external/gensafenav_source_harness_probe_1393/report.json --output-md output/benchmarks/external/gensafenav_source_harness_probe_1393/report.md` -> expected non-zero, `source harness blocked`, `missing python dependency: gym`
- `uv run ruff check scripts/tools/probe_sonic_source_harness.py tests/tools/test_probe_sonic_source_harness.py`
- `uv run pytest -q tests/tools/test_probe_sonic_source_harness.py` -> 6 passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 3816 passed, 9 skipped, 11 warnings

## Risks / Rollout
- Compatibility risks: probe metadata options are additive and default to the original #626 / SoNIC values.
- Failure modes: this PR intentionally records a blocked source harness; it does not make GenSafeNav runnable.
- Rollback or fallback plan: revert the docs/probe metadata extension; existing #626/#1366 notes still preserve the older assessment trail.

## Docs / Provenance
- Updated docs: policy-search README, context README, #1366 note, reject/monitor registry, new #1393 note.
- Relevant design or provenance notes: `docs/context/evidence/issue_1393_gensafenav_source_harness_2026-05-20/report.json`.
- Assumptions: external checkout and generated probe logs remain ignored local artifacts; only the compact summary is tracked.

## Follow-Up Issues
- Deferred work: build a dedicated source environment that can run `python test.py --model_dir trained_models/Ours_GST --test_model 05207.pt` without fallback or model-only shims.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the PR does not overclaim source reproduction: the verdict remains blocked.
- Please check source metadata: GenSafeNav repo, commit `01baf926a5c77c1a4ab28635658eb014ef4f1767`, model `Ours_GST`, checkpoint `05207.pt`.
