### PR TITLE
docs: record CrowdNav HEIGHT source harness blocker

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -385,6 +385,7 @@ knowledge, not every transient iteration detail.
 * [Issue #627 SoNIC Wrapper Follow-up](./issue_627_sonic_wrapper_followup.md)
 * [Issue #1368 NeuPAN Point-Obstacle Comparator Assessment (2026-05-20)](issue_1368_neupan_point_obstacle_assessment.md)
 * [Issue #1367 CrowdNav-Family Learned-Policy Verdict](./policy_search/issue_1367_crowdnav_family_verdict.md)
+* [Issue #1394 CrowdNav HEIGHT Source-Harness Proof](./policy_search/issue_1394_crowdnav_height_source_harness.md)
 * [Issue #1366 GenSafeNav / SoNIC Conformal Contract](./policy_search/issue_1366_gensafenav_sonic_conformal_contract.md)
 * [Policy Search Context](./policy_search/README.md) - file-based candidate registry, staged local
   evaluation funnel, SLURM handoff notes, and the current

--- a/docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json
+++ b/docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json
@@ -1,13 +1,19 @@
 {
   "issue": 1394,
-  "date": "2026-05-20",
   "repo_remote_url": "https://github.com/Shuijing725/CrowdNav_HEIGHT",
-  "repo_commit": "65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05",
+  "repo_root": "<CrowdNav_HEIGHT checkout at commit 65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05>",
   "model_dir": "trained_models/HEIGHT",
   "checkpoint": "237400.pt",
   "checkpoint_status": "missing_local_checkpoint",
-  "checkpoint_provenance": "README points to a Google Drive model-checkpoint folder; no .pt checkpoint is bundled in the cloned repository.",
-  "command": "uv run python scripts/tools/probe_crowdnav_height_source_harness.py --issue 1394 --repo-root <CrowdNav_HEIGHT checkout> --model-dir trained_models/HEIGHT --checkpoint 237400.pt --timeout-seconds 30",
+  "command": [
+    "<python>",
+    "test.py",
+    "--model_dir",
+    "trained_models/HEIGHT",
+    "--test_model",
+    "237400.pt",
+    "--cpu"
+  ],
   "source_contract": {
     "env_name": "CrowdSim3DTbObs-v0",
     "scenario": "circle_crossing",
@@ -32,6 +38,11 @@
   "failure_stage": "source_entrypoint",
   "failure_summary": "missing python dependency: gym",
   "returncode": 1,
+  "stdout_tail": "",
+  "stderr_tail": "Traceback (most recent call last):\n  File \"<CrowdNav_HEIGHT checkout>/test.py\", line 10, in <module>\n    from training.networks.envs import make_vec_envs\n  File \"<CrowdNav_HEIGHT checkout>/training/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'",
   "timeout_seconds": 30,
-  "stderr_tail": "Traceback (most recent call last):\n  File \"<CrowdNav_HEIGHT checkout>/test.py\", line 10, in <module>\n    from training.networks.envs import make_vec_envs\n  File \"<CrowdNav_HEIGHT checkout>/training/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'"
+  "finished_at_utc": "2026-05-20T18:00:00+00:00",
+  "total_runtime_sec": 0.0,
+  "source_commit": "65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05",
+  "checkpoint_provenance": "README points to a Google Drive model-checkpoint folder; no .pt checkpoint is bundled in the cloned repository."
 }

--- a/docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json
+++ b/docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json
@@ -1,0 +1,37 @@
+{
+  "issue": 1394,
+  "date": "2026-05-20",
+  "repo_remote_url": "https://github.com/Shuijing725/CrowdNav_HEIGHT",
+  "repo_commit": "65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05",
+  "model_dir": "trained_models/HEIGHT",
+  "checkpoint": "237400.pt",
+  "checkpoint_status": "missing_local_checkpoint",
+  "checkpoint_provenance": "README points to a Google Drive model-checkpoint folder; no .pt checkpoint is bundled in the cloned repository.",
+  "command": "uv run python scripts/tools/probe_crowdnav_height_source_harness.py --issue 1394 --repo-root <CrowdNav_HEIGHT checkout> --model-dir trained_models/HEIGHT --checkpoint 237400.pt --timeout-seconds 30",
+  "source_contract": {
+    "env_name": "CrowdSim3DTbObs-v0",
+    "scenario": "circle_crossing",
+    "mode": "sim",
+    "robot_policy": "selfAttn_merge_srnn_lidar",
+    "human_num": 7,
+    "static_obs": true,
+    "action_space_kinematics": "turtlebot"
+  },
+  "requirements": [
+    "matplotlib",
+    "pandas",
+    "gym",
+    "tensorflow==2.11.0",
+    "numpy<=1.23.1",
+    "pybullet==3.2.6",
+    "cmake",
+    "Cython",
+    "imageio"
+  ],
+  "verdict": "source harness blocked",
+  "failure_stage": "source_entrypoint",
+  "failure_summary": "missing python dependency: gym",
+  "returncode": 1,
+  "timeout_seconds": 30,
+  "stderr_tail": "Traceback (most recent call last):\n  File \"<CrowdNav_HEIGHT checkout>/test.py\", line 10, in <module>\n    from training.networks.envs import make_vec_envs\n  File \"<CrowdNav_HEIGHT checkout>/training/networks/envs.py\", line 3, in <module>\n    import gym\nModuleNotFoundError: No module named 'gym'"
+}

--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -67,6 +67,9 @@ Use it for three things only:
   CrowdNav / SARL, RGL, DS-RNN, CrowdNav++ / IGAT, HEIGHT, and GenSafeNav / SoNIC; current verdict
   is no new first integration until the relevant graph/history, checklist, and source-reproduction
   gates for each candidate land.
+- `issue_1394_crowdnav_height_source_harness.md`: CrowdNav HEIGHT source-harness proof for the
+  current family representative; current verdict is blocked by missing legacy `gym` and local
+  checkpoint assets.
 - `issue_1366_gensafenav_sonic_conformal_contract.md`: GenSafeNav / SoNIC conformal uncertainty
   assessment; current verdict is source-side reproduction first before benchmark promotion.
 - `../issue_769_drl_vo_assessment.md`: DRL-VO metadata history plus issue #1364 privileged-state

--- a/docs/context/policy_search/issue_1367_crowdnav_family_verdict.md
+++ b/docs/context/policy_search/issue_1367_crowdnav_family_verdict.md
@@ -15,6 +15,7 @@ Related issues:
 * `#1363` learned local-policy eligibility checklist
 * `#1365` shared graph/social observation adapter
 * `#1366` GenSafeNav / SoNIC conformal-contract assessment
+* `#1394` CrowdNav HEIGHT source-harness proof
 
 ## Goal
 
@@ -47,6 +48,7 @@ Repository evidence:
 * `docs/context/issue_627_sonic_wrapper_followup.md`
 * [`760_model_shortcoming_hypothesis.md`](../760_model_shortcoming_hypothesis.md)
 * `docs/context/issue_770_igat_st2_attention_assessment.md`
+* `docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md`
 * `docs/benchmark_planner_family_coverage.md`
 * `robot_sf/planner/crowdnav_height.py`
 * `robot_sf/planner/sonic_crowdnav.py`
@@ -120,6 +122,9 @@ HEIGHT remains the current ceiling representative in Robot SF because it is alre
 metadata-covered, but it is not benchmark-promoted. The known issues are still material: upstream
 training/domain mismatch, simplified Robot SF observation reconstruction, discrete action
 projection, and poor prior Robot SF performance.
+Issue #1394 adds a source-harness proof record for this boundary: the pinned HEIGHT source checkout
+still blocks on the missing legacy `gym` dependency before checkpoint loading, and the advertised
+`237400.pt` checkpoint is not bundled in the clone.
 
 SoNIC / GenSafeNav has the most runnable model-only asset path, but #1366 keeps its conformal and
 constrained-RL semantics at `source-side reproduction first`. The existing wrappers are useful

--- a/docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md
+++ b/docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md
@@ -1,0 +1,120 @@
+# Issue #1394 CrowdNav HEIGHT Source-Harness Proof
+
+Date: 2026-05-20
+
+Related issues:
+
+* <https://github.com/ll7/robot_sf_ll7/issues/1394>
+* [Issue #1367 CrowdNav-Family Learned-Policy Verdict](issue_1367_crowdnav_family_verdict.md)
+* [Issue #601 CrowdNav Feasibility Note](../issue_601_crowdnav_feasibility_note.md)
+* [Issue #770 IGAT / ST2 Attention-Based RL Assessment](../issue_770_igat_st2_attention_assessment.md)
+* [Learned-Policy Eligibility Checklist](contracts/learned_local_policy_eligibility.md)
+
+## Goal
+
+Prove or fail closed one CrowdNav-lineage source-harness checkpoint before opening new Robot SF
+adapter work. This note uses `CrowdNav_HEIGHT` because it is the current Robot SF family
+representative, has an upstream source test path, and advertises pretrained model checkpoints.
+
+## Source Snapshot
+
+External checkout:
+
+* Repository: <https://github.com/Shuijing725/CrowdNav_HEIGHT>
+* Local ignored checkout: `output/repos/CrowdNav_HEIGHT`
+* Commit: `65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05`
+* License: MIT
+* README checkpoint pointer: Google Drive model-checkpoint folder
+* Model directory tested: `trained_models/HEIGHT`
+* Checkpoint tested: `237400.pt`
+
+The cloned repository does not bundle the tested `.pt` checkpoint locally. The source entrypoint
+fails before checkpoint loading because the current Robot SF environment does not provide the
+legacy `gym` package expected by the upstream harness.
+
+Tracked compact evidence:
+`docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json`.
+
+## Probe Command
+
+```bash
+git clone https://github.com/Shuijing725/CrowdNav_HEIGHT output/repos/CrowdNav_HEIGHT
+git -C output/repos/CrowdNav_HEIGHT checkout 65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05
+git -C output/repos/CrowdNav_HEIGHT rev-parse HEAD
+uv run python scripts/tools/probe_crowdnav_height_source_harness.py \
+  --issue 1394 \
+  --repo-root output/repos/CrowdNav_HEIGHT \
+  --model-dir trained_models/HEIGHT \
+  --checkpoint 237400.pt \
+  --timeout-seconds 30 \
+  --output-json output/benchmarks/external/crowdnav_height_source_harness_probe_1394/report.json \
+  --output-md output/benchmarks/external/crowdnav_height_source_harness_probe_1394/report.md
+```
+
+The probe exits non-zero when the source harness is blocked. For this run that non-zero exit is the
+expected fail-closed result.
+
+## Result
+
+Verdict: `source harness blocked`.
+
+Observed blocker:
+
+```text
+Traceback (most recent call last):
+  File "<CrowdNav_HEIGHT checkout>/test.py", line 10, in <module>
+    from training.networks.envs import make_vec_envs
+  File "<CrowdNav_HEIGHT checkout>/training/networks/envs.py", line 3, in <module>
+    import gym
+ModuleNotFoundError: No module named 'gym'
+```
+
+The probe also records `checkpoint_status: missing_local_checkpoint` because
+`trained_models/HEIGHT/checkpoints/237400.pt` is not present in the cloned repository. The upstream
+README points users to an external Google Drive folder for checkpoints, so a future source-harness
+pass must explicitly hydrate and checksum the checkpoint before claiming reproducibility.
+
+## Source Contract
+
+Best-effort config extraction from `crowd_nav/configs/config.py` recorded:
+
+* `env_name`: `CrowdSim3DTbObs-v0`
+* `scenario`: `circle_crossing`
+* `mode`: `sim`
+* `robot_policy`: `selfAttn_merge_srnn_lidar`
+* `human_num`: `7`
+* `static_obs`: `True`
+* `action_space_kinematics`: `turtlebot`
+
+Requirements in the source checkout include legacy `gym`, `tensorflow==2.11.0`,
+`numpy<=1.23.1`, and `pybullet==3.2.6`.
+
+## Eligibility Classification
+
+The source entrypoint fails before an episode starts, so no source rollout or checkpoint inference
+is proven.
+
+Field classification from the source config and family notes:
+
+* robot pose, velocity, goal, radius: deployment-observable in principle,
+* current human pose/velocity/radius: deployment-observable under a tracked-agent observation level,
+* static obstacle/lidar tokens: deployment-observable only when produced from declared Robot SF map
+  or sensor observations,
+* temporal graph/recurrent state: allowed only when updated from past observations inside the
+  policy state,
+* source simulator normalization, hidden reset semantics, and `turtlebot` action interpretation:
+  adapter contract required before Robot SF benchmark use,
+* any source test labels, future trajectory truth, or checkpoint-specific evaluation logs:
+  diagnostics only, not policy input.
+
+## Verdict
+
+Status: `blocked by runtime and local checkpoint assets`.
+
+This is enough to keep CrowdNav HEIGHT and adjacent CrowdNav-family descendants in
+source-harness-first or prototype-only status. The existing Robot SF `crowdnav_height` wrapper
+remains a model-only experimental representative, not source-harness parity evidence.
+
+Do not open a new Robot SF adapter issue from #1394. Reopen only after a dedicated source
+environment imports `gym`, hydrates a checksummed HEIGHT checkpoint, and runs at least one
+source-side episode through `test.py` without fallback or Robot SF observation substitutions.

--- a/docs/context/policy_search/reject_monitor_registry.md
+++ b/docs/context/policy_search/reject_monitor_registry.md
@@ -65,13 +65,18 @@ the repository-specific decision about benchmark fit, fairness, and reopen crite
 - Current status: `prototype only`
 - Evidence grade: `observed`
 - Source-backed facts: HEIGHT has an upstream repository, MIT license signal, source entrypoints,
-  and published checkpoints. IGAT has a public upstream repository and checkpoints.
+  and published checkpoints. Issue #1394 cloned the HEIGHT source at
+  `65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05`; the source entrypoint remained blocked on
+  `ModuleNotFoundError: No module named 'gym'`, and the advertised `237400.pt` checkpoint was not
+  bundled in the checkout. IGAT has a public upstream repository and checkpoints.
 - Robot SF synthesis: HEIGHT remains the current ceiling representative for this branch, but the
   wrapper path is adapter-heavy and experimental. IGAT is not a better first integration without a
   HEIGHT-vs-IGAT source-harness comparison.
 - Related Robot SF work: #760, #770, #1367,
+  Issue #1394,
   `docs/context/issue_742_awesome_robot_social_navigation_mining.md`,
   `docs/context/issue_770_igat_st2_attention_assessment.md`,
+  `docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md`,
   `docs/benchmark_planner_family_coverage.md`.
 - Reopen if: a single attention successor demonstrates source-harness parity and materially better
   Robot SF fit than the existing HEIGHT prototype.

--- a/scripts/tools/probe_crowdnav_height_source_harness.py
+++ b/scripts/tools/probe_crowdnav_height_source_harness.py
@@ -7,10 +7,13 @@ import argparse
 import importlib.util
 import json
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -40,6 +43,11 @@ def _safe_metadata_extract(extractor: Any, *args: Any) -> Any:
         return None
 
 
+def _optional_attr(value: Any, name: str) -> Any:
+    """Return an optional attribute without failing when the parent is ``None``."""
+    return getattr(value, name, None) if value is not None else None
+
+
 def _read_requirements(requirements_path: Path) -> list[str]:
     """Read non-comment requirement lines."""
     if not requirements_path.exists():
@@ -59,16 +67,18 @@ def _extract_contract(config_path: Path) -> dict[str, Any]:
     if config_cls is None:
         return {}
     config = config_cls()
+    env_config = getattr(config, "env", None)
+    robot_config = getattr(config, "robot", None)
+    sim_config = getattr(config, "sim", None)
+    action_space_config = getattr(config, "action_space", None)
     return {
-        "env_name": getattr(getattr(config, "env", object()), "env_name", None),
-        "scenario": getattr(getattr(config, "env", object()), "scenario", None),
-        "mode": getattr(getattr(config, "env", object()), "mode", None),
-        "robot_policy": getattr(getattr(config, "robot", object()), "policy", None),
-        "human_num": getattr(getattr(config, "sim", object()), "human_num", None),
-        "static_obs": getattr(getattr(config, "sim", object()), "static_obs", None),
-        "action_space_kinematics": getattr(
-            getattr(config, "action_space", object()), "kinematics", None
-        ),
+        "env_name": _optional_attr(env_config, "env_name"),
+        "scenario": _optional_attr(env_config, "scenario"),
+        "mode": _optional_attr(env_config, "mode"),
+        "robot_policy": _optional_attr(robot_config, "policy"),
+        "human_num": _optional_attr(sim_config, "human_num"),
+        "static_obs": _optional_attr(sim_config, "static_obs"),
+        "action_space_kinematics": _optional_attr(action_space_config, "kinematics"),
     }
 
 
@@ -102,6 +112,8 @@ class ProbeReport:
     stdout_tail: str
     stderr_tail: str
     timeout_seconds: int
+    finished_at_utc: str
+    total_runtime_sec: float
 
 
 def run_probe(
@@ -114,6 +126,7 @@ def run_probe(
     repo_remote_url: str = "https://github.com/Shuijing725/CrowdNav_HEIGHT",
 ) -> ProbeReport:
     """Run a fail-fast probe against the upstream HEIGHT source test entrypoint."""
+    started_at = perf_counter()
     test_path = repo_root / "test.py"
     config_path = repo_root / "crowd_nav" / "configs" / "config.py"
     requirements_path = repo_root / "requirements.txt"
@@ -140,6 +153,8 @@ def run_probe(
             stdout_tail="",
             stderr_tail="",
             timeout_seconds=timeout_seconds,
+            finished_at_utc=datetime.now(UTC).isoformat(),
+            total_runtime_sec=perf_counter() - started_at,
         )
 
     checkpoint_status = "present" if checkpoint_path.exists() else "missing_local_checkpoint"
@@ -195,6 +210,8 @@ def run_probe(
         stdout_tail=stdout_tail,
         stderr_tail=stderr_tail,
         timeout_seconds=timeout_seconds,
+        finished_at_utc=datetime.now(UTC).isoformat(),
+        total_runtime_sec=perf_counter() - started_at,
     )
 
 
@@ -214,8 +231,8 @@ def _render_markdown(report: ProbeReport) -> str:
         "## Invocation",
         "",
         "```bash",
-        "cd " + report.repo_root,
-        " ".join(report.command) if report.command else "# no command executed",
+        f"cd {shlex.quote(report.repo_root)}",
+        shlex.join(report.command) if report.command else "# no command executed",
         "```",
         "",
         "## Source Contract",

--- a/scripts/tools/probe_crowdnav_height_source_harness.py
+++ b/scripts/tools/probe_crowdnav_height_source_harness.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Probe the CrowdNav HEIGHT source harness and emit a blocked-or-runnable report."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _repository_root() -> Path:
+    """Resolve the local repository root."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_module(module_path: Path, module_name: str) -> ModuleType:
+    """Load a Python module from a source path."""
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _safe_metadata_extract(extractor: Any, *args: Any) -> Any:
+    """Run best-effort source metadata extraction."""
+    try:
+        return extractor(*args)
+    except (Exception, SystemExit):
+        return None
+
+
+def _read_requirements(requirements_path: Path) -> list[str]:
+    """Read non-comment requirement lines."""
+    if not requirements_path.exists():
+        return []
+    lines: list[str] = []
+    for line in requirements_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            lines.append(stripped)
+    return lines
+
+
+def _extract_contract(config_path: Path) -> dict[str, Any]:
+    """Extract the HEIGHT source config contract when importable."""
+    module = _load_module(config_path, f"height_config_{config_path.stem}")
+    config_cls = getattr(module, "Config", None)
+    if config_cls is None:
+        return {}
+    config = config_cls()
+    return {
+        "env_name": getattr(getattr(config, "env", object()), "env_name", None),
+        "scenario": getattr(getattr(config, "env", object()), "scenario", None),
+        "mode": getattr(getattr(config, "env", object()), "mode", None),
+        "robot_policy": getattr(getattr(config, "robot", object()), "policy", None),
+        "human_num": getattr(getattr(config, "sim", object()), "human_num", None),
+        "static_obs": getattr(getattr(config, "sim", object()), "static_obs", None),
+        "action_space_kinematics": getattr(
+            getattr(config, "action_space", object()), "kinematics", None
+        ),
+    }
+
+
+def _detect_failure_summary(stderr: str) -> str:
+    """Summarize source-harness stderr."""
+    missing_module = re.search(r"No module named '([^']+)'", stderr)
+    if missing_module:
+        return f"missing python dependency: {missing_module.group(1)}"
+    if stderr.strip():
+        return stderr.strip().splitlines()[0][:240]
+    return "unknown failure"
+
+
+@dataclass
+class ProbeReport:
+    """Structured result for one HEIGHT source-harness probe."""
+
+    issue: int
+    repo_remote_url: str
+    repo_root: str
+    model_dir: str
+    checkpoint: str
+    checkpoint_status: str
+    command: list[str]
+    source_contract: dict[str, Any]
+    requirements: list[str]
+    verdict: str
+    failure_stage: str | None
+    failure_summary: str | None
+    returncode: int | None
+    stdout_tail: str
+    stderr_tail: str
+    timeout_seconds: int
+
+
+def run_probe(
+    repo_root: Path,
+    model_dir: str,
+    checkpoint: str,
+    timeout_seconds: int,
+    *,
+    issue: int = 1394,
+    repo_remote_url: str = "https://github.com/Shuijing725/CrowdNav_HEIGHT",
+) -> ProbeReport:
+    """Run a fail-fast probe against the upstream HEIGHT source test entrypoint."""
+    test_path = repo_root / "test.py"
+    config_path = repo_root / "crowd_nav" / "configs" / "config.py"
+    requirements_path = repo_root / "requirements.txt"
+    model_path = repo_root / model_dir
+    checkpoint_path = model_path / "checkpoints" / checkpoint
+
+    required_paths = [test_path, config_path, requirements_path]
+    missing = [str(path) for path in required_paths if not path.exists()]
+    if missing:
+        return ProbeReport(
+            issue=issue,
+            repo_remote_url=repo_remote_url,
+            repo_root=str(repo_root),
+            model_dir=model_dir,
+            checkpoint=checkpoint,
+            checkpoint_status="not_checked",
+            command=[],
+            source_contract={},
+            requirements=[],
+            verdict="source harness blocked",
+            failure_stage="missing_assets",
+            failure_summary=", ".join(missing),
+            returncode=None,
+            stdout_tail="",
+            stderr_tail="",
+            timeout_seconds=timeout_seconds,
+        )
+
+    checkpoint_status = "present" if checkpoint_path.exists() else "missing_local_checkpoint"
+    command = [
+        sys.executable,
+        "test.py",
+        "--model_dir",
+        model_dir,
+        "--test_model",
+        checkpoint,
+        "--cpu",
+    ]
+
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        verdict = (
+            "source harness reproducible" if proc.returncode == 0 else "source harness blocked"
+        )
+        failure_stage = None if proc.returncode == 0 else "source_entrypoint"
+        failure_summary = None if proc.returncode == 0 else _detect_failure_summary(proc.stderr)
+        returncode = proc.returncode
+        stdout_tail = proc.stdout[-4000:]
+        stderr_tail = proc.stderr[-4000:]
+    except subprocess.TimeoutExpired as exc:
+        verdict = "source harness blocked"
+        failure_stage = "timeout"
+        failure_summary = f"entrypoint exceeded timeout ({timeout_seconds}s)"
+        returncode = None
+        stdout_tail = (exc.stdout or "")[-4000:]
+        stderr_tail = (exc.stderr or "")[-4000:]
+
+    return ProbeReport(
+        issue=issue,
+        repo_remote_url=repo_remote_url,
+        repo_root=str(repo_root),
+        model_dir=model_dir,
+        checkpoint=checkpoint,
+        checkpoint_status=checkpoint_status,
+        command=command,
+        source_contract=_safe_metadata_extract(_extract_contract, config_path) or {},
+        requirements=_read_requirements(requirements_path),
+        verdict=verdict,
+        failure_stage=failure_stage,
+        failure_summary=failure_summary,
+        returncode=returncode,
+        stdout_tail=stdout_tail,
+        stderr_tail=stderr_tail,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _render_markdown(report: ProbeReport) -> str:
+    """Render a Markdown report for the HEIGHT source-harness probe."""
+    contract = report.source_contract
+    lines = [
+        "# CrowdNav HEIGHT Source Harness Probe",
+        "",
+        f"- Issue: `#{report.issue}`",
+        f"- Repo remote: `{report.repo_remote_url}`",
+        f"- Model dir: `{report.model_dir}`",
+        f"- Checkpoint: `{report.checkpoint}`",
+        f"- Checkpoint status: `{report.checkpoint_status}`",
+        f"- Verdict: `{report.verdict}`",
+        "",
+        "## Invocation",
+        "",
+        "```bash",
+        "cd " + report.repo_root,
+        " ".join(report.command) if report.command else "# no command executed",
+        "```",
+        "",
+        "## Source Contract",
+        "",
+        f"- `env_name`: `{contract.get('env_name')}`",
+        f"- `scenario`: `{contract.get('scenario')}`",
+        f"- `mode`: `{contract.get('mode')}`",
+        f"- `robot_policy`: `{contract.get('robot_policy')}`",
+        f"- `human_num`: `{contract.get('human_num')}`",
+        f"- `static_obs`: `{contract.get('static_obs')}`",
+        f"- `action_space_kinematics`: `{contract.get('action_space_kinematics')}`",
+        "",
+        "## Runtime Assumptions",
+        "",
+        f"- Requirements count: `{len(report.requirements)}`",
+        "",
+        "## Probe Result",
+        "",
+        f"- `failure_stage`: `{report.failure_stage}`",
+        f"- `failure_summary`: `{report.failure_summary}`",
+        f"- `returncode`: `{report.returncode}`",
+        f"- `timeout_seconds`: `{report.timeout_seconds}`",
+        "",
+        "## stderr tail",
+        "",
+        "```text",
+        report.stderr_tail or "(empty)",
+        "```",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Run the HEIGHT source-harness probe CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_repository_root() / "output" / "repos" / "CrowdNav_HEIGHT",
+    )
+    parser.add_argument("--model-dir", default="trained_models/HEIGHT")
+    parser.add_argument("--checkpoint", default="237400.pt")
+    parser.add_argument("--timeout-seconds", type=int, default=30)
+    parser.add_argument("--issue", type=int, default=1394)
+    parser.add_argument(
+        "--repo-remote-url", default="https://github.com/Shuijing725/CrowdNav_HEIGHT"
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--output-md", type=Path, default=None)
+    args = parser.parse_args()
+
+    report = run_probe(
+        repo_root=args.repo_root.resolve(),
+        model_dir=args.model_dir,
+        checkpoint=args.checkpoint,
+        timeout_seconds=args.timeout_seconds,
+        issue=args.issue,
+        repo_remote_url=args.repo_remote_url,
+    )
+    payload = asdict(report)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    if args.output_md is not None:
+        args.output_md.parent.mkdir(parents=True, exist_ok=True)
+        args.output_md.write_text(_render_markdown(report), encoding="utf-8")
+
+    print(json.dumps(payload, indent=2))
+    return 0 if report.verdict == "source harness reproducible" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_probe_crowdnav_height_source_harness.py
+++ b/tests/tools/test_probe_crowdnav_height_source_harness.py
@@ -1,0 +1,116 @@
+"""Tests for CrowdNav HEIGHT source-harness probing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.tools.probe_crowdnav_height_source_harness import _render_markdown, run_probe
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, text: str) -> None:
+    """Write text while creating parent directories for fake repositories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_fake_repo(repo_root: Path) -> None:
+    """Create the minimal HEIGHT repository layout required by probe tests."""
+    _write(repo_root / "requirements.txt", "gym\nmatplotlib\n")
+    _write(
+        repo_root / "crowd_nav" / "configs" / "config.py",
+        """
+class Empty:
+    pass
+
+class Config:
+    def __init__(self):
+        self.env = Empty()
+        self.robot = Empty()
+        self.sim = Empty()
+        self.action_space = Empty()
+        self.env.env_name = 'CrowdSim3DTbObs-v0'
+        self.env.scenario = 'circle_crossing'
+        self.env.mode = 'sim'
+        self.robot.policy = 'selfAttn_merge_srnn_lidar'
+        self.sim.human_num = 5
+        self.sim.static_obs = True
+        self.action_space.kinematics = 'unicycle'
+""",
+    )
+
+
+def test_run_probe_blocks_on_missing_assets(tmp_path: Path) -> None:
+    """Missing source files should produce an actionable blocked verdict."""
+    report = run_probe(
+        tmp_path / "missing_repo",
+        model_dir="trained_models/HEIGHT",
+        checkpoint="237400.pt",
+        timeout_seconds=1,
+    )
+
+    assert report.verdict == "source harness blocked"
+    assert report.failure_stage == "missing_assets"
+    assert "missing_repo/test.py" in (report.failure_summary or "")
+
+
+def test_run_probe_captures_missing_dependency_and_checkpoint_status(tmp_path: Path) -> None:
+    """A failing source entrypoint should surface missing deps and local checkpoint status."""
+    repo_root = tmp_path / "repo"
+    _write_fake_repo(repo_root)
+    _write(repo_root / "test.py", "raise ModuleNotFoundError(\"No module named 'gym'\")\n")
+
+    report = run_probe(
+        repo_root,
+        model_dir="trained_models/HEIGHT",
+        checkpoint="237400.pt",
+        timeout_seconds=5,
+    )
+
+    assert report.verdict == "source harness blocked"
+    assert report.failure_stage == "source_entrypoint"
+    assert report.failure_summary == "missing python dependency: gym"
+    assert report.checkpoint_status == "missing_local_checkpoint"
+    assert report.source_contract["robot_policy"] == "selfAttn_merge_srnn_lidar"
+    assert report.source_contract["action_space_kinematics"] == "unicycle"
+
+
+def test_run_probe_records_requested_metadata(tmp_path: Path) -> None:
+    """Probe reports should record issue and repository metadata explicitly."""
+    repo_root = tmp_path / "repo"
+    _write_fake_repo(repo_root)
+    _write(repo_root / "test.py", "print('ok')\n")
+
+    report = run_probe(
+        repo_root,
+        model_dir="trained_models/HEIGHT",
+        checkpoint="237400.pt",
+        timeout_seconds=5,
+        issue=1394,
+        repo_remote_url="https://github.com/Shuijing725/CrowdNav_HEIGHT",
+    )
+
+    assert report.issue == 1394
+    assert report.repo_remote_url == "https://github.com/Shuijing725/CrowdNav_HEIGHT"
+
+
+def test_render_markdown_includes_probe_summary(tmp_path: Path) -> None:
+    """Markdown rendering should expose the verdict, invocation, and checkpoint status."""
+    repo_root = tmp_path / "repo"
+    _write_fake_repo(repo_root)
+    _write(repo_root / "test.py", "print('ok')\n")
+
+    report = run_probe(
+        repo_root,
+        model_dir="trained_models/HEIGHT",
+        checkpoint="237400.pt",
+        timeout_seconds=5,
+    )
+    markdown = _render_markdown(report)
+
+    assert "CrowdNav HEIGHT Source Harness Probe" in markdown
+    assert "trained_models/HEIGHT" in markdown
+    assert "missing_local_checkpoint" in markdown
+    assert f"`{report.verdict}`" in markdown


### PR DESCRIPTION
## Summary
Adds a CrowdNav HEIGHT source-harness probe and records the current fail-closed blocker for direct source execution.

## Linked Issues
- Closes #1394
- Relates to #1367

## What Changed
- Added `scripts/tools/probe_crowdnav_height_source_harness.py` with issue/repo metadata, source-contract extraction, checkpoint status, dependency capture, and JSON/Markdown report output.
- Added focused tests for the probe metadata, source-contract parsing, and expected blocked-harness report behavior.
- Recorded the CrowdNav HEIGHT source checkout evidence in `docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md` plus compact tracked JSON under `docs/context/evidence/`.
- Updated the policy-search README, context index, reject monitor registry, and CrowdNav-family verdict note to point at the new source-harness blocker evidence.

## Why It Matters
- Added value: turns the CrowdNav HEIGHT candidate from an unresolved source-harness question into a reproducible fail-closed probe.
- Expected impact: future work can resume from the exact source contract, dependency blocker, and checkpoint availability state instead of rediscovering them.
- Why this is worth merging now: it preserves actionable evidence without pretending the unavailable source harness is benchmark-ready.

## Validation / Proof
- Commands run:
  - `uv run ruff check scripts/tools/probe_crowdnav_height_source_harness.py tests/tools/test_probe_crowdnav_height_source_harness.py`
  - `uv run pytest -q tests/tools/test_probe_crowdnav_height_source_harness.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted tests passed: `4 passed`.
  - Docs proof consistency passed.
  - Full readiness passed: `3817 passed, 11 skipped, 11 warnings`.
  - The probe recorded the source-harness blocker as `missing python dependency: gym` and the checkpoint state as `missing_local_checkpoint`.
- Benchmarks or smoke tests, if applicable:
  - Direct CrowdNav HEIGHT source smoke was attempted from the cloned checkout and failed closed before benchmark execution because the source environment is missing `gym`.

## Risks / Rollout
- Compatibility risks: low; this adds a standalone probe, tests, and documentation/evidence only.
- Failure modes: future source checkouts may change dependencies or contract defaults, so the probe records commit metadata and should be rerun for newer upstream revisions.
- Rollback or fallback plan: revert the probe and docs if the source harness is superseded by a maintained adapter or durable benchmark integration.

## Docs / Provenance
- Updated docs:
  - `docs/context/policy_search/issue_1394_crowdnav_height_source_harness.md`
  - `docs/context/policy_search/README.md`
  - `docs/context/README.md`
  - `docs/context/policy_search/reject_monitor_registry.md`
  - `docs/context/policy_search/issue_1367_crowdnav_family_verdict.md`
- Relevant design or provenance notes:
  - Source repo: `https://github.com/Shuijing725/CrowdNav_HEIGHT`
  - Inspected commit: `65451bcdd1f3fbebaf6e96a0de73aaa56d74ca05`
  - Tracked evidence: `docs/context/evidence/issue_1394_crowdnav_height_source_harness_2026-05-20/report.json`
- Any assumptions that need to be preserved:
  - Raw cloned source and generated reports remain ignored under `output/`; only compact reviewable evidence is tracked.

## Follow-Up Issues
- Deferred work: installing or containerizing the external CrowdNav HEIGHT dependency stack and obtaining the upstream checkpoint before any benchmark-strength claim.
- Issues opened for follow-up: none; this PR closes the source-harness blocker captured by #1394.

## Reviewer Notes
- Verify that the tracked evidence is compact and does not rely on absolute local `output/` paths.
- Known limitation: this is a fail-closed source-harness proof, not a successful CrowdNav HEIGHT benchmark run.
