### PR TITLE
feat: enforce map catalog capabilities

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -98,6 +98,8 @@ knowledge, not every transient iteration detail.
   [issue_1414_parser_capability_metadata.md](issue_1414_parser_capability_metadata.md)
 * Issue #1413 map catalog schema and sync checker:
   [issue_1413_map_catalog_schema_sync.md](issue_1413_map_catalog_schema_sync.md)
+* Issue #1415 capability-aware map resolver:
+  [issue_1415_capability_map_resolver.md](issue_1415_capability_map_resolver.md)
 * Issue #1246 graded observation levels:
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
 * Issue #1239 human-model transfer robustness:

--- a/docs/context/issue_1415_capability_map_resolver.md
+++ b/docs/context/issue_1415_capability_map_resolver.md
@@ -1,0 +1,44 @@
+# Issue #1415 Capability-Aware Map Resolver
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1415>
+
+## Goal
+
+Issue #1415 adds fail-closed map capability checks to scenario `map_id` resolution while preserving
+legacy v1 registry behavior and direct `map_file` parser tests.
+
+## Implemented Contract
+
+`robot_sf/training/scenario_loader.py` now loads v2 catalog rows as resolved entries with:
+
+- local SVG path,
+- declared capabilities,
+- source hash,
+- role/profile,
+- limitations,
+- validation status.
+
+When a scenario references `map_id`, the loader defaults to requiring `robot_runtime`. Scenario or
+benchmark manifests can request another supported profile with `required_map_profile` or
+`map_profile`, including `benchmark_candidate`, `route_only`, `pedestrian_runtime`, or
+`obstacle_source`.
+
+Failure messages name the requested profile, missing capability, map path, validation status,
+role/profile, and limitations. If a v2 row has a stale `source_sha256`, resolution fails before the
+scenario is accepted.
+
+## Boundaries
+
+Generated converted-map cache loading remains out of scope. Legacy v1/simple registries do not
+provide capabilities and continue to resolve as path lookups for compatibility.
+
+## Validation
+
+Targeted proof for this slice:
+
+```bash
+uv run ruff check robot_sf/training/scenario_loader.py tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py
+uv run pytest tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py -q
+uv run pytest tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py tests/maps -q
+uv run python scripts/validation/check_docs_proof_consistency.py --base origin/issue-1413-map-catalog-schema-sync
+```

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 import os
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -32,9 +34,33 @@ from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
 
 _MAP_REGISTRY_ENV = "ROBOT_SF_MAP_REGISTRY"
 _MAP_REGISTRY_PATH = Path("maps/registry.yaml")
+_MAP_CATALOG_SCHEMA = "robot_sf.map_catalog.v2"
+_MAP_CATALOG_PARSER_VERSION = "parser-capability-metadata.v1"
+_DEFAULT_MAP_PROFILE = "robot_runtime"
+_MAP_PROFILE_CAPABILITIES = {
+    "robot_runtime": "robot_runtime",
+    "pedestrian_runtime": "pedestrian_runtime",
+    "route_only": "route_only",
+    "obstacle_source": "obstacle_source",
+    "benchmark_candidate": "benchmark_candidate",
+}
 _PLATFORM_SEMANTIC_STATUSES = {"metadata_only", "require_consumers"}
 _PLATFORM_SEMANTIC_KINDS = {"hazard", "keep_clear"}
 _PLATFORM_SEMANTIC_SHAPES = {"polygon", "bbox"}
+
+
+@dataclass(frozen=True)
+class _MapRegistryEntry:
+    """One map registry row resolved to local filesystem state."""
+
+    map_id: str
+    path: Path
+    capabilities: Mapping[str, bool] | None = None
+    source_sha256: str | None = None
+    role: str | None = None
+    profile: str | None = None
+    limitations: tuple[str, ...] = ()
+    validation_status: str | None = None
 
 
 def _load_yaml_documents(path: Path) -> Any:
@@ -530,11 +556,11 @@ def _resolve_map_registry_path() -> Path | None:
     return repo_root / _MAP_REGISTRY_PATH
 
 
-def _iter_registry_mapping(entries: Mapping[str, Any]) -> Iterable[tuple[str, str]]:
+def _iter_registry_mapping(entries: Mapping[str, Any]) -> Iterable[tuple[str, Mapping[str, Any]]]:
     """Yield map_id/path pairs from a mapping-form registry.
 
     Yields:
-        tuple[str, str]: Map id and path entries.
+        tuple[str, Mapping[str, Any]]: Map id and normalized row data.
     """
     for map_id, map_path in entries.items():
         if map_id == "version":
@@ -542,14 +568,14 @@ def _iter_registry_mapping(entries: Mapping[str, Any]) -> Iterable[tuple[str, st
         if not isinstance(map_path, str):
             logger.warning("Skipping map registry entry '{}' with non-string path.", map_id)
             continue
-        yield str(map_id), map_path
+        yield str(map_id), {"map_id": str(map_id), "path": map_path}
 
 
-def _iter_registry_list(entries: list[Any]) -> Iterable[tuple[str, str]]:
+def _iter_registry_list(entries: list[Any]) -> Iterable[tuple[str, Mapping[str, Any]]]:
     """Yield map_id/path pairs from a list-form registry.
 
     Yields:
-        tuple[str, str]: Map id and path entries.
+        tuple[str, Mapping[str, Any]]: Map id and normalized row data.
     """
     for entry in entries:
         if not isinstance(entry, Mapping):
@@ -560,18 +586,18 @@ def _iter_registry_list(entries: list[Any]) -> Iterable[tuple[str, str]]:
         if not isinstance(map_id, str) or not isinstance(map_path, str):
             logger.warning("Skipping invalid map registry entry: {}", entry)
             continue
-        yield map_id, map_path
+        yield map_id, entry
 
 
 def _iter_map_registry_entries(
     data: Mapping[str, Any],
     *,
     registry_path: Path,
-) -> Iterable[tuple[str, str]]:
+) -> Iterable[tuple[str, Mapping[str, Any]]]:
     """Yield map registry entries from the loaded registry data.
 
     Yields:
-        tuple[str, str]: Map id and path entries.
+        tuple[str, Mapping[str, Any]]: Map id and row entries.
     """
     entries = data.get("maps", data if "maps" not in data else None)
     if isinstance(entries, Mapping):
@@ -584,10 +610,10 @@ def _iter_map_registry_entries(
 
 
 def _register_map_entry(
-    registry: dict[str, Path],
+    registry: dict[str, _MapRegistryEntry],
     *,
     map_id: str,
-    map_path: str,
+    row: Mapping[str, Any],
     registry_path: Path,
 ) -> None:
     """Insert a map registry entry, resolving relative paths."""
@@ -596,18 +622,82 @@ def _register_map_entry(
         raise ValueError(f"Map registry entry in '{registry_path}' has empty map_id.")
     if key in registry:
         raise ValueError(f"Duplicate map_id '{key}' in map registry '{registry_path}'.")
+    map_path = row.get("path") or row.get("map_file")
+    if not isinstance(map_path, str):
+        raise ValueError(f"Map registry entry '{key}' in '{registry_path}' has invalid path.")
     candidate = Path(map_path)
     if not candidate.is_absolute():
         candidate = (registry_path.parent / candidate).resolve()
-    registry[key] = candidate
+    registry[key] = _MapRegistryEntry(
+        map_id=key,
+        path=candidate,
+        capabilities=_coerce_capabilities(row.get("capabilities")),
+        source_sha256=row.get("source_sha256")
+        if isinstance(row.get("source_sha256"), str)
+        else None,
+        role=row.get("role") if isinstance(row.get("role"), str) else None,
+        profile=row.get("profile") if isinstance(row.get("profile"), str) else None,
+        limitations=_coerce_limitations(row.get("limitations")),
+        validation_status=_coerce_validation_status(row.get("validation")),
+    )
+
+
+def _coerce_capabilities(raw: Any) -> Mapping[str, bool] | None:
+    """Return boolean capability fields from a registry row, if present."""
+    if not isinstance(raw, Mapping):
+        return None
+    return {
+        key: value for key, value in raw.items() if isinstance(key, str) and isinstance(value, bool)
+    }
+
+
+def _coerce_limitations(raw: Any) -> tuple[str, ...]:
+    """Return stable limitation labels from a registry row."""
+    if not isinstance(raw, list):
+        return ()
+    return tuple(str(item) for item in raw if isinstance(item, str))
+
+
+def _coerce_validation_status(raw: Any) -> str | None:
+    """Return the catalog validation status string, if present."""
+    if not isinstance(raw, Mapping):
+        return None
+    status = raw.get("status")
+    return status if isinstance(status, str) else None
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_catalog_header(data: Mapping[str, Any], *, registry_path: Path) -> None:
+    """Fail closed when a v2 catalog has stale schema/parser headers."""
+    version = data.get("version")
+    if version != 2:
+        return
+    if data.get("schema") != _MAP_CATALOG_SCHEMA:
+        raise ValueError(
+            f"Map registry '{registry_path}' has stale schema "
+            f"{data.get('schema')!r}; expected {_MAP_CATALOG_SCHEMA}."
+        )
+    if data.get("parser_version") != _MAP_CATALOG_PARSER_VERSION:
+        raise ValueError(
+            f"Map registry '{registry_path}' has stale parser_version "
+            f"{data.get('parser_version')!r}; expected {_MAP_CATALOG_PARSER_VERSION}."
+        )
 
 
 @lru_cache(maxsize=4)
-def _load_map_registry(path: Path | None = None) -> dict[str, Path]:
-    """Load map registry entries, returning map_id -> absolute path.
+def _load_map_registry(path: Path | None = None) -> dict[str, _MapRegistryEntry]:
+    """Load map registry entries, returning map_id -> catalog entry.
 
     Returns:
-        dict[str, Path]: Map registry map_id to absolute map file path.
+        dict[str, _MapRegistryEntry]: Map registry map_id to resolved catalog entries.
     """
     registry_path = path or _resolve_map_registry_path()
     if registry_path is None or not registry_path.exists():
@@ -615,12 +705,13 @@ def _load_map_registry(path: Path | None = None) -> dict[str, Path]:
     data = yaml.safe_load(registry_path.read_text(encoding="utf-8")) or {}
     if not isinstance(data, Mapping):
         raise ValueError(f"Map registry '{registry_path}' must contain a mapping.")
-    registry: dict[str, Path] = {}
-    for map_id, map_path in _iter_map_registry_entries(data, registry_path=registry_path):
+    _validate_catalog_header(data, registry_path=registry_path)
+    registry: dict[str, _MapRegistryEntry] = {}
+    for map_id, row in _iter_map_registry_entries(data, registry_path=registry_path):
         _register_map_entry(
             registry,
             map_id=map_id,
-            map_path=map_path,
+            row=row,
             registry_path=registry_path,
         )
     return registry
@@ -629,8 +720,9 @@ def _load_map_registry(path: Path | None = None) -> dict[str, Path]:
 def _resolve_map_id(
     map_id: str,
     *,
-    map_registry: Mapping[str, Path],
+    map_registry: Mapping[str, _MapRegistryEntry],
     source: Path,
+    required_profile: str = _DEFAULT_MAP_PROFILE,
 ) -> Path:
     """Resolve a map_id to a filesystem path using the registry.
 
@@ -643,10 +735,46 @@ def _resolve_map_id(
         )
     if map_id not in map_registry:
         raise ValueError(f"Unknown map_id '{map_id}' in '{source}'.")
-    resolved = map_registry[map_id]
-    if not resolved.exists():
-        raise ValueError(f"Map registry entry '{map_id}' points to missing file: {resolved}")
-    return resolved
+    entry = map_registry[map_id]
+    if not entry.path.exists():
+        raise ValueError(f"Map registry entry '{map_id}' points to missing file: {entry.path}")
+    _validate_map_catalog_entry(
+        entry,
+        source=source,
+        required_profile=required_profile,
+    )
+    return entry.path
+
+
+def _validate_map_catalog_entry(
+    entry: _MapRegistryEntry,
+    *,
+    source: Path,
+    required_profile: str,
+) -> None:
+    """Validate a resolved catalog entry for a requested map profile."""
+    if entry.source_sha256 is not None and _sha256_file(entry.path) != entry.source_sha256:
+        raise ValueError(
+            f"Scenario in '{source}' requested profile '{required_profile}' for map_id "
+            f"'{entry.map_id}', but registry source_sha256 is stale for {entry.path}."
+        )
+    if entry.capabilities is None:
+        return
+    required_capability = _MAP_PROFILE_CAPABILITIES.get(required_profile)
+    if required_capability is None:
+        raise ValueError(
+            f"Scenario in '{source}' requested unknown map profile '{required_profile}' "
+            f"for map_id '{entry.map_id}'."
+        )
+    if entry.capabilities.get(required_capability):
+        return
+    raise ValueError(
+        f"Scenario in '{source}' requested profile '{required_profile}' for map_id "
+        f"'{entry.map_id}', but missing capability '{required_capability}' for {entry.path}. "
+        f"catalog_status={entry.validation_status or 'unknown'}; "
+        f"role={entry.role or 'unknown'}; profile={entry.profile or 'unknown'}; "
+        f"limitations={list(entry.limitations)}"
+    )
 
 
 def _normalize_scenarios(
@@ -661,7 +789,7 @@ def _normalize_scenarios(
     Returns:
         list[Mapping[str, Any]]: Normalized scenario entries.
     """
-    map_registry: dict[str, Path] = {}
+    map_registry: dict[str, _MapRegistryEntry] = {}
     if any(isinstance(entry, Mapping) and entry.get("map_id") for entry in scenarios):
         map_registry = _load_map_registry()
     normalized: list[Mapping[str, Any]] = []
@@ -696,6 +824,7 @@ def _validate_scenario_entry(
         raise ValueError(f"Scenario name must be a string in '{source}' at index {index}.")
 
     _validate_map_reference(scenario, name=name, source=source, index=index)
+    _resolve_required_map_profile(scenario, source=source)
     _validate_optional_mapping(scenario, key="simulation_config", source=source, index=index)
     _validate_optional_mapping(scenario, key="robot_config", source=source, index=index)
     _validate_optional_mapping(scenario, key="observation_visibility", source=source, index=index)
@@ -730,13 +859,34 @@ def _validate_map_reference(
         )
 
 
+def _resolve_required_map_profile(
+    scenario: Mapping[str, Any],
+    *,
+    source: Path,
+) -> str:
+    """Resolve the capability profile a scenario requires from a map_id row.
+
+    Returns:
+        str: Required map capability profile.
+    """
+    raw = scenario.get("required_map_profile") or scenario.get("map_profile")
+    if raw is None:
+        return _DEFAULT_MAP_PROFILE
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"required_map_profile must be a non-empty string in '{source}'.")
+    profile = raw.strip()
+    if profile not in _MAP_PROFILE_CAPABILITIES:
+        raise ValueError(f"Unknown required_map_profile '{profile}' in '{source}'.")
+    return profile
+
+
 def _rebase_scenario_paths(
     scenario: Mapping[str, Any],
     *,
     source: Path,
     root: Path,
     map_search_paths: list[Path],
-    map_registry: Mapping[str, Path],
+    map_registry: Mapping[str, _MapRegistryEntry],
 ) -> Mapping[str, Any]:
     """Rewrite relative map paths to be relative to the root scenario file.
 
@@ -746,7 +896,12 @@ def _rebase_scenario_paths(
     search_root = root if root.is_dir() else root.parent
     map_id = scenario.get("map_id")
     if isinstance(map_id, str) and map_id.strip():
-        resolved = _resolve_map_id(map_id, map_registry=map_registry, source=source)
+        resolved = _resolve_map_id(
+            map_id,
+            map_registry=map_registry,
+            source=source,
+            required_profile=_resolve_required_map_profile(scenario, source=source),
+        )
         rel = os.path.relpath(resolved, search_root)
         updated = dict(scenario)
         updated["map_file"] = Path(rel).as_posix()

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,11 @@ from robot_sf.training.scenario_loader import (
 def _write_yaml(path: Path, content: str) -> None:
     """Write a YAML fixture file."""
     path.write_text(content, encoding="utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a fixture file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def test_load_scenarios_with_includes(tmp_path: Path) -> None:
@@ -656,6 +662,219 @@ scenarios:
     scenarios = load_scenarios(manifest, base_dir=manifest)
     scenario_loader._load_map_registry.cache_clear()
     assert scenarios[0]["map_file"] == "../maps/demo.svg"
+
+
+def test_map_id_enforces_robot_runtime_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scenario map_id resolution should fail closed on missing runtime capability."""
+    maps_dir = tmp_path / "maps"
+    maps_dir.mkdir()
+    map_path = maps_dir / "demo.svg"
+    map_path.write_text("<svg></svg>", encoding="utf-8")
+
+    registry_path = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry_path,
+        f"""
+version: 2
+schema: robot_sf.map_catalog.v2
+parser_version: parser-capability-metadata.v1
+maps:
+  - map_id: demo_map
+    path: maps/demo.svg
+    source_sha256: {_sha256_file(map_path)}
+    role: obstacle_only
+    profile: obstacle_only
+    capabilities:
+      robot_runtime: false
+      pedestrian_runtime: false
+      route_only: false
+      obstacle_source: true
+      benchmark_candidate: false
+    limitations:
+      - no_robot_routes
+    validation:
+      status: unchecked
+""",
+    )
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: demo
+    map_id: demo_map
+""",
+    )
+
+    monkeypatch.setenv("ROBOT_SF_MAP_REGISTRY", str(registry_path))
+    scenario_loader._load_map_registry.cache_clear()
+
+    with pytest.raises(ValueError, match="requested profile 'robot_runtime'.*no_robot_routes"):
+        load_scenarios(manifest, base_dir=manifest)
+    scenario_loader._load_map_registry.cache_clear()
+
+
+def test_map_id_allows_route_only_for_requested_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Route-only maps should pass only when callers request route-only capability."""
+    maps_dir = tmp_path / "maps"
+    maps_dir.mkdir()
+    map_path = maps_dir / "route_only.svg"
+    map_path.write_text("<svg></svg>", encoding="utf-8")
+
+    registry_path = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry_path,
+        f"""
+version: 2
+schema: robot_sf.map_catalog.v2
+parser_version: parser-capability-metadata.v1
+maps:
+  - map_id: route_only
+    path: maps/route_only.svg
+    source_sha256: {_sha256_file(map_path)}
+    role: route_only
+    profile: route_only
+    capabilities:
+      robot_runtime: false
+      pedestrian_runtime: false
+      route_only: true
+      obstacle_source: false
+      benchmark_candidate: false
+    limitations:
+      - route_derived_zones
+    validation:
+      status: unchecked
+""",
+    )
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: demo
+    map_id: route_only
+    required_map_profile: route_only
+""",
+    )
+
+    monkeypatch.setenv("ROBOT_SF_MAP_REGISTRY", str(registry_path))
+    scenario_loader._load_map_registry.cache_clear()
+
+    scenarios = load_scenarios(manifest, base_dir=manifest)
+
+    scenario_loader._load_map_registry.cache_clear()
+    assert scenarios[0]["map_file"] == "maps/route_only.svg"
+
+
+def test_map_id_allows_benchmark_candidate_for_requested_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Benchmark callers should be able to request benchmark_candidate rows."""
+    maps_dir = tmp_path / "maps"
+    maps_dir.mkdir()
+    map_path = maps_dir / "benchmark.svg"
+    map_path.write_text("<svg></svg>", encoding="utf-8")
+
+    registry_path = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry_path,
+        f"""
+version: 2
+schema: robot_sf.map_catalog.v2
+parser_version: parser-capability-metadata.v1
+maps:
+  - map_id: benchmark_map
+    path: maps/benchmark.svg
+    source_sha256: {_sha256_file(map_path)}
+    role: benchmark_candidate
+    profile: benchmark_candidate
+    capabilities:
+      robot_runtime: true
+      pedestrian_runtime: true
+      route_only: false
+      obstacle_source: true
+      benchmark_candidate: true
+    limitations: []
+    validation:
+      status: reviewed
+""",
+    )
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: benchmark
+    map_id: benchmark_map
+    required_map_profile: benchmark_candidate
+""",
+    )
+
+    monkeypatch.setenv("ROBOT_SF_MAP_REGISTRY", str(registry_path))
+    scenario_loader._load_map_registry.cache_clear()
+
+    scenarios = load_scenarios(manifest, base_dir=manifest)
+
+    scenario_loader._load_map_registry.cache_clear()
+    assert scenarios[0]["map_file"] == "maps/benchmark.svg"
+
+
+def test_map_id_rejects_stale_source_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog source hashes should fail closed when SVG files drift."""
+    maps_dir = tmp_path / "maps"
+    maps_dir.mkdir()
+    (maps_dir / "demo.svg").write_text("<svg></svg>", encoding="utf-8")
+
+    registry_path = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry_path,
+        """
+version: 2
+schema: robot_sf.map_catalog.v2
+parser_version: parser-capability-metadata.v1
+maps:
+  - map_id: demo_map
+    path: maps/demo.svg
+    source_sha256: stale
+    role: robot_runtime
+    profile: robot_runtime
+    capabilities:
+      robot_runtime: true
+      pedestrian_runtime: false
+      route_only: false
+      obstacle_source: false
+      benchmark_candidate: false
+    limitations: []
+    validation:
+      status: unchecked
+""",
+    )
+    manifest = tmp_path / "manifest.yaml"
+    _write_yaml(
+        manifest,
+        """
+scenarios:
+  - name: demo
+    map_id: demo_map
+""",
+    )
+
+    monkeypatch.setenv("ROBOT_SF_MAP_REGISTRY", str(registry_path))
+    scenario_loader._load_map_registry.cache_clear()
+
+    with pytest.raises(ValueError, match="source_sha256 is stale"):
+        load_scenarios(manifest, base_dir=manifest)
+    scenario_loader._load_map_registry.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/training/test_scenario_loader_additional.py
+++ b/tests/training/test_scenario_loader_additional.py
@@ -89,7 +89,9 @@ def test_load_map_definition_unsupported_extension(tmp_path: Path) -> None:
 def test_iter_registry_mapping_skips_version_and_bad_entries() -> None:
     """Registry mapping iterators should skip metadata and invalid paths."""
     entries = {"version": 1, "demo": "maps/demo.svg", "bad": 123}
-    assert list(scenario_loader._iter_registry_mapping(entries)) == [("demo", "maps/demo.svg")]
+    assert list(scenario_loader._iter_registry_mapping(entries)) == [
+        ("demo", {"map_id": "demo", "path": "maps/demo.svg"})
+    ]
 
 
 def test_iter_registry_list_handles_invalid_entries() -> None:
@@ -100,10 +102,11 @@ def test_iter_registry_list_handles_invalid_entries() -> None:
         {"map_id": 1, "path": "maps/other.svg"},
         {"id": "alt", "map_file": "maps/alt.svg"},
     ]
-    assert list(scenario_loader._iter_registry_list(entries)) == [
-        ("demo", "maps/demo.svg"),
-        ("alt", "maps/alt.svg"),
-    ]
+    rows = list(scenario_loader._iter_registry_list(entries))
+    assert rows[0][0] == "demo"
+    assert rows[0][1]["path"] == "maps/demo.svg"
+    assert rows[1][0] == "alt"
+    assert rows[1][1]["map_file"] == "maps/alt.svg"
 
 
 def test_iter_map_registry_entries_rejects_invalid_format(tmp_path: Path) -> None:
@@ -116,6 +119,25 @@ def test_iter_map_registry_entries_rejects_invalid_format(tmp_path: Path) -> Non
                 registry_path=tmp_path / "registry.yaml",
             )
         )
+
+
+def test_load_map_registry_rejects_stale_v2_headers(tmp_path: Path) -> None:
+    """V2 catalog schema and parser versions should fail closed when stale."""
+    registry = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry,
+        """
+version: 2
+schema: old.schema
+parser_version: parser-capability-metadata.v1
+maps: []
+""",
+    )
+
+    scenario_loader._load_map_registry.cache_clear()
+    with pytest.raises(ValueError, match="stale schema"):
+        scenario_loader._load_map_registry(registry)
+    scenario_loader._load_map_registry.cache_clear()
 
 
 @pytest.mark.parametrize("scenarios_value", ["", None, "{}"])
@@ -142,30 +164,30 @@ def test_load_scenarios_rejects_non_list_scenarios_key(
 
 def test_register_map_entry_resolves_relative_paths_and_duplicates(tmp_path: Path) -> None:
     """Registry entries should resolve relative paths and reject duplicates."""
-    registry: dict[str, Path] = {}
+    registry: dict[str, scenario_loader._MapRegistryEntry] = {}
     registry_path = tmp_path / "registry.yaml"
 
     with pytest.raises(ValueError, match="empty map_id"):
         scenario_loader._register_map_entry(
             registry,
             map_id=" ",
-            map_path="maps/demo.svg",
+            row={"path": "maps/demo.svg"},
             registry_path=registry_path,
         )
 
     scenario_loader._register_map_entry(
         registry,
         map_id="demo",
-        map_path="maps/demo.svg",
+        row={"path": "maps/demo.svg"},
         registry_path=registry_path,
     )
-    assert registry["demo"] == (registry_path.parent / "maps/demo.svg").resolve()
+    assert registry["demo"].path == (registry_path.parent / "maps/demo.svg").resolve()
 
     with pytest.raises(ValueError, match="Duplicate map_id"):
         scenario_loader._register_map_entry(
             registry,
             map_id="demo",
-            map_path="maps/other.svg",
+            row={"path": "maps/other.svg"},
             registry_path=registry_path,
         )
 


### PR DESCRIPTION
Closes #1415.

## Summary
- load v2 map catalog rows as capability-aware scenario registry entries
- enforce requested map profiles during `map_id` resolution, defaulting runtime scenarios to `robot_runtime`
- support `required_map_profile` / `map_profile` for benchmark and route-only callers
- fail closed on stale catalog source hashes, stale v2 schema/parser headers, and missing capabilities with actionable error details

## Scope Boundaries
- legacy v1/simple registries continue to resolve as path lookups for compatibility
- direct `map_file` loading and low-level parser tests are unchanged
- generated converted-map cache loading remains out of scope

## Validation
- `uv run ruff check robot_sf/training/scenario_loader.py tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py`
- `uv run pytest tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py -q` -> 44 passed
- `uv run pytest tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py tests/maps -q` -> 70 passed
- `uv run python scripts/validation/check_docs_proof_consistency.py --base origin/issue-1413-map-catalog-schema-sync`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/issue-1413-map-catalog-schema-sync scripts/dev/pr_ready_check.sh` -> 3826 passed, 11 skipped, 11 warnings; changed-file coverage warning for `robot_sf/training/scenario_loader.py` at 86.8%

## Delegation Notes
- Copilot high-effort review timed out without a final findings report; it reran the focused scenario-loader tests successfully in its transcript.
- The delegation run exposed a broken worktree-local `local.machine.md` symlink, which was fixed locally and recorded in the delegation observations note.
