### PR TITLE
Refactor skills documentation for clarity and conciseness

### DIFF
--- a/.agents/skills/agentic-eval/SKILL.md
+++ b/.agents/skills/agentic-eval/SKILL.md
@@ -5,13 +5,10 @@ description: "Evaluate and improve AI workflow outputs with small goldens, rubri
 
 # Agentic Eval
 
-## Overview
+## When to use
 
-Use this skill when the thing being improved is an AI workflow artifact rather than ordinary
-application code.
-
-Good targets include skills, instructions, prompt-like text, issue bodies, review rubrics, and
-other generated artifacts that benefit from a small evaluation loop.
+Use this skill when the target is an AI workflow artifact (skills, prompts, rubrics, issue text,
+review guidance, etc.) rather than core product code.
 
 ## Read First
 
@@ -22,32 +19,40 @@ other generated artifacts that benefit from a small evaluation loop.
 
 ## Workflow
 
-1. Define the artifact
-   - Specify what output is being evaluated and what success looks like.
-   - Keep the evaluation set small and representative.
+1. Define the artifact and objective
+   - State the artifact, expected behavior, and what a pass/fail result looks like.
+   - Set a small representative evaluation set.
 
 2. Build a rubric
-   - Use a few concrete criteria.
-   - Separate required failures from softer quality preferences.
+   - Use 3–6 concrete criteria.
+   - Mark critical failures separately from quality preferences.
 
 3. Create a baseline
-   - Capture the current output against the rubric before changing anything.
+   - Score the current artifact against the rubric before editing.
 
 4. Improve one dimension at a time
    - Make a targeted change.
    - Re-run the same evaluation.
-   - Keep or discard the change based on the rubric result.
+   - Keep the change only if improvement is clear and reproducible.
 
-5. Record the result
-   - Summarize what improved, what regressed, and what remained hard to judge.
+5. Capture proof
+   - Compare baseline vs post-change with the same rubric and commands.
+   - Keep the result compact: what improved, what regressed, what remains unknown.
+
+## Proof and Guardrails
+
+- Always preserve baseline and post-change results.
+- Reuse the same corpus for all iterations.
+- If changes drift from the target behavior, revert and document the false regression.
+- Prefer `autoresearch` when the task has repeated measurable benchmarks.
+- If benchmark evidence is required, treat failed/invalid runs as inconclusive, not proof.
 
 ## Output
 
-Always report the artifact evaluated, the rubric used, the baseline result, the kept/discarded
-change, and remaining uncertainty.
+Report:
 
-## Guardrails
-
-- If the task has a strong measurable metric and needs repeated experiments, prefer `autoresearch`.
-- Keep the evaluation set small enough to rerun quickly.
-- Do not overfit to one example at the expense of general usefulness.
+- artifact inspected,
+- rubric and dataset,
+- baseline and final score,
+- keep/discard decision with rationale,
+- open questions.

--- a/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
+++ b/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
@@ -5,13 +5,17 @@ description: "Analyze a camera-ready benchmark campaign for consistency, runtime
 
 # Analyze Camera-Ready Benchmark
 
-## Overview
+## When to use
 
-Use this skill when reviewing benchmark outputs under:
+Use this skill when reviewing `*_policy_analysis*` or camera-ready campaign outputs and you need
+consistency, reproducibility, and fallback-mode visibility before claiming benchmark conclusions.
 
-- `output/benchmarks/camera_ready/<campaign_id>/`
+## Read First
 
-The skill runs the campaign analyzer, summarizes findings, and proposes next actions.
+- `docs/code_review.md`
+- `docs/benchmark_spec.md`
+- `docs/context/issue_691_benchmark_fallback_policy.md`
+- `docs/benchmark_camera_ready.md`
 
 ## Workflow
 
@@ -27,7 +31,7 @@ The skill runs the campaign analyzer, summarizes findings, and proposes next act
      - `reports/campaign_analysis.md`
 
 3. Validate core consistency
-   - Check for findings in `campaign_analysis.json`:
+   - Check `campaign_analysis.json` findings for:
      - episode count mismatches
      - summary-vs-episodes metric mismatches
      - adapter impact metadata mismatches
@@ -39,8 +43,8 @@ The skill runs the campaign analyzer, summarizes findings, and proposes next act
    - Note experimental planners running with fallback mode.
 
 5. Recommend actions
-   - If inconsistencies are found, provide concrete file-level follow-ups.
-   - If behavior is expected, document rationale and residual risk.
+   - If inconsistencies are found, propose concrete follow-ups in issue-facing wording.
+   - If behavior is expected, explicitly document rationale and residual risk.
 
 ## Typical Commands
 
@@ -57,3 +61,19 @@ uv run python scripts/tools/analyze_camera_ready_campaign.py \
   --output-json output/benchmarks/camera_ready/<campaign_id>/reports/custom_analysis.json \
   --output-md output/benchmarks/camera_ready/<campaign_id>/reports/custom_analysis.md
 ```
+
+## Proof and Guardrails
+
+- Classify each run mode as `native`, `adapter`, `fallback`, or `degraded`.
+- Fail-closed rule: do not treat fallback/degraded as successful benchmark evidence.
+- Require the produced JSON + markdown reports as proof artifacts before summarizing results.
+- Only report planner ranking where metrics and episode counts are internally consistent.
+
+## Output
+
+Provide a concise judgment with:
+- campaign id/path,
+- evidence list (`.json` + `.md`),
+- consistency status,
+- planner ranking by observed-mode,
+- concrete remediation steps or explicit pass conditions.

--- a/.agents/skills/analyze-latest-policy-sweep/SKILL.md
+++ b/.agents/skills/analyze-latest-policy-sweep/SKILL.md
@@ -5,12 +5,22 @@ description: Analyze latest policy analysis sweep runs (*_policy_analysis_*) by 
 
 # Analyze Latest Policy Sweep
 
-Use this skill when asked to compare recent `*_policy_analysis_*` benchmark runs (fast_pysf_planner, PPO, ORCA, etc.) and produce a summary report with diagnostics and video links.
+## When to use
+
+Use this skill when comparing recent `*_policy_analysis_*` runs and producing a compact, reproducible
+diagnostic summary with caveats.
+
+## Read First
+
+- `docs/code_review.md`
+- `docs/benchmark_spec.md`
+- `docs/context/issue_691_benchmark_fallback_policy.md`
 
 ## Quick start
-1) Confirm run directories exist and contain `episodes.jsonl` + `summary.json`.
-2) Load metrics from `episodes.jsonl` and aggregates from `summary.json`.
-3) Produce a report in `specs/409-planner-comparison/`.
+
+1. Confirm run directories contain `episodes.jsonl` and `summary.json`.
+2. Load per-episode metrics and summary aggregates.
+3. Write a report under `specs/409-planner-comparison/`.
 
 ## Required report contents
 - Aggregate metrics table (success rate, collision rate, time_to_goal_norm, avg_speed, near_misses, comfort_exposure, energy, jerk/curvature raw + filtered if present).
@@ -18,6 +28,14 @@ Use this skill when asked to compare recent `*_policy_analysis_*` benchmark runs
 - Lowest success scenarios (bottom 5) per run.
 - Top problem episodes (score = collisions*10 + comfort*2 + failure) with video paths.
 - Diagnostics: path_efficiency saturation, `shortest_path_len` presence, low-speed filter behavior (ε=0.1).
+
+## Workflow
+
+1. Load each run and validate required files.
+2. Compare `episodes.jsonl` and `summary.json` consistency.
+3. Compute and rank diagnostics.
+4. Attach video evidence for top problem episodes.
+5. Add explicit mode labeling (`native`/`adapter`/`fallback`/`degraded`) to any planner comparison.
 
 ## Optional
 - Extract frames (25/50/75% of duration) for top problem episodes using ffmpeg into `output/analysis/<report_id>/frames/` and list PNG paths in the report.
@@ -32,3 +50,19 @@ Use `specs/409-planner-comparison/analyze_latest_policy_sweep_prompt.md` as a te
 - **Path-efficiency saturation**: fraction with `path_efficiency >= 0.999` (clipped at 1.0).
 - **Shortest path presence**: ensure `shortest_path_len` is present in metrics when available.
 - **Low-speed filter**: report `low_speed_frac` and filtered metrics (`jerk_mean_eps0p1`, `curvature_mean_eps0p1` when present). Reason: curvature divides by |v|^3; near-zero speed inflates noise.
+
+## Proof and Guardrails
+
+- Treat mismatches between `episodes.jsonl` and `summary.json` as blocking.
+- Keep low-speed filtering explicit and report the method used.
+- Fail-closed: do not claim planner superiority when any planner is only partially valid.
+- Always include evidence location links in the final report.
+
+## Output
+
+Report:
+- run set,
+- consistency checks and pass/fail status,
+- ranking summary,
+- top failures/scenarios with links,
+- reproducibility note and open risks.

--- a/.agents/skills/auto-improvement/SKILL.md
+++ b/.agents/skills/auto-improvement/SKILL.md
@@ -5,13 +5,12 @@ description: "Focused measurement-aware refinement loop for Robot SF prompts, do
 
 # Auto Improvement
 
-## Overview
+## When to use
 
-Use this skill for small, iterative refinement work where the goal is to improve clarity, robustness,
-or validation coverage without starting a full experimentation campaign.
+Use this skill for small, iterative refinements that should improve clarity, robustness, or validation
+coverage without launching full experimentation campaigns.
 
-If the task has a strong measurable metric and needs repeated experiments, prefer `autoresearch`
-instead.
+If the task needs repeated measurable experiments, use `autoresearch` instead.
 
 ## Read First
 
@@ -23,19 +22,18 @@ instead.
 ## Workflow
 
 1. Identify the smallest measurable improvement target.
-2. Pick one validation signal.
+2. Pick one validation signal and one narrow change at a time.
 3. Limit scope to the named files.
-4. Make one improvement at a time.
-5. Keep the change if it improves the signal and stays simple.
-6. Revert the change if the gain is too small for the complexity cost.
-7. Repeat until the task is good enough or the user says stop.
+4. Apply one tweak; validate; keep or revert quickly.
+5. Stop when gain is too small for complexity or the user stops.
 
-## Repository Guardrails
+## Proof and Guardrails
 
-- Prefer repo-local scripts and docs as the source of truth.
-- Keep benchmark wording conservative.
-- Use `scripts/dev/` wrappers when validation is available there.
-- If the task is really a plain cleanup or formatting pass, use `clean-up`.
+- Keep changes small and reversible.
+- Keep benchmark/provenance wording conservative.
+- Prefer `scripts/dev/` wrappers for validation.
+- For tasks that are plain cleanup/formatting, use `clean-up`.
+- If validation shows no net gain, revert.
 
 ## Good Fits
 
@@ -45,7 +43,7 @@ instead.
 - adding a narrow regression test,
 - clarifying a workflow note.
 
-## Exit
+## Output
 
 Summarize:
 - what changed,

--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -5,13 +5,10 @@ description: "Autonomous iterative experimentation loop for measurable Robot SF 
 
 # Autoresearch
 
-## Overview
+## When to use
 
-Use this skill when the task has a measurable metric and the user wants an autonomous improvement
-loop rather than a single pass fix.
-
-This is the Agent-compatible version of the upstream `autoresearch` idea adapted to Robot SF's
-repo-local workflow, validation gates, and benchmark conservatism.
+Use this skill when the task has measurable goals and needs an iterative experiment loop (hypothesis,
+baseline, test, keep/discard decisions), not a single-pass edit.
 
 ## Read First
 
@@ -24,20 +21,18 @@ repo-local workflow, validation gates, and benchmark conservatism.
 ## Workflow
 
 1. Define the experiment contract
-   - Restate the goal, metric command, metric extraction method, scope, constraints, and stop
-     condition.
-   - If any of those are missing, ask for them or switch to a clarifying skill.
+   - Restate the goal, metric command, extraction method, scope, constraints, and stop condition.
+   - If any input is missing, ask for it or switch to a clarifying skill.
 
 2. Establish a baseline
    - Run the metric command on the current branch before changing code.
-   - Record the baseline in a short log under `output/ai/autoresearch/<slug>/results.tsv` or
-     another user-approved scratch location.
+   - Record baseline and metadata in `output/ai/autoresearch/<slug>/results.tsv` (or approved location).
 
 3. Iterate on one hypothesis at a time
    - Make the smallest useful edit.
-   - Commit the experiment before running it.
+   - Commit the experiment snapshot before running it.
    - Run the metric command and any repo-required validation gate.
-   - Keep the change only if it improves the metric without violating constraints.
+   - Keep only if metric improves and constraints are satisfied.
    - Revert the change if it regresses, stalls, or becomes too complex for the gain.
 
 4. Use repo-native validation
@@ -50,9 +45,19 @@ repo-local workflow, validation gates, and benchmark conservatism.
    - Summarize the baseline, best result, discarded attempts, and remaining risks.
    - Call out any assumption that stayed unresolved.
 
-## Guardrails
+## Proof and Guardrails
 
 - Do not add dependencies or change public contracts unless explicitly allowed.
 - Keep benchmark wording conservative.
 - Use one concept per experiment.
 - Stop when the user budget is reached or the metric stops improving.
+- If benchmark evidence is invalid or non-reproducible, stop and report that status as incomplete.
+
+## Output
+
+Summarize:
+
+- experiment contract,
+- baseline and best result,
+- discarded attempts and reasons,
+- unresolved assumptions and next risk.

--- a/.agents/skills/auxme-slurm-reliable-submit/SKILL.md
+++ b/.agents/skills/auxme-slurm-reliable-submit/SKILL.md
@@ -5,62 +5,40 @@ description: "Submit issue-791 style Auxme SLURM jobs with explicit config, live
 
 # Auxme SLURM Reliable Submit
 
-Use this skill for Auxme cluster submissions where reliability matters more than raw speed.
+## Purpose
 
-## Read First
-
-- `SLURM/AGENTS.md`
-- `SLURM/Auxme/README.md`
-- `docs/dev/slurm_submission.md`
-
-## Goals
-
-- avoid accidental stage1 fallback caused by missing config overrides,
-- choose partition/QoS using live availability and per-user slot headroom,
-- keep wall-time aligned with current partition policy.
+Submit Auxme jobs for issue-791-style training reliably and reproducibly.
+Use this when reliability, provenance, and correct config routing matter more than raw queue speed.
 
 ## Workflow
 
-1. Confirm the target config and intent
-   - Validate the YAML path exists under `configs/training/...`.
-   - Ensure horizon intent matches request (`32k`, `128k`, `1m`, `10m`, etc.).
-
-2. Snapshot partition pressure
-   - Run `scripts/dev/auxme_partition_status.sh`.
-   - Use free GPUs, pending depth, and per-user running slots as the primary signals.
-
-3. Submit through the reliable helper
-   - Run `scripts/dev/sbatch_auxme_issue791.sh` with explicit `--config`.
-   - Let it auto-select partition/QoS unless there is a deliberate override.
-
-4. Verify startup provenance
-   - Check job stdout startup summary for the exact config path and policy ID.
-   - Fail fast if wrapper-default config appears.
-
-5. Handle transient infra failures
-   - If stdout shows `Unable to confirm allocation ... Zero Bytes were transmitted or received`,
-     classify as transient and resubmit once with identical config.
-
-## Commands
-
-Status and recommendation:
-
-```bash
-scripts/dev/auxme_partition_status.sh
-scripts/dev/auxme_partition_status.sh --recommend
-```
-
-Reliable submit:
-
-```bash
-scripts/dev/sbatch_auxme_issue791.sh \
-  --config configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22.yaml \
-  --job-name robot-sf-issue791-reward-curriculum \
-  SLURM/Auxme/issue_791_reward_curriculum.sl
-```
+1. Read cluster-specific preflight:
+   - `SLURM/AGENTS.md`
+   - `SLURM/Auxme/README.md`
+   - `docs/dev/slurm_submission.md`
+2. Confirm target intent:
+   - Validate the `--config` path exists under `configs/training/...`.
+   - Verify requested training horizon (`32k`, `128k`, `1m`, `10m`) matches the user request.
+3. Check live capacity before submit:
+   - `scripts/dev/auxme_partition_status.sh`
+   - `scripts/dev/auxme_partition_status.sh --recommend`
+   - Use free GPUs, pending depth, and per-user running slots only from the live output.
+4. Submit with explicit config:
+   - `scripts/dev/sbatch_auxme_issue791.sh --config <path> --job-name <name> SLURM/Auxme/<script>.sl`
+5. Verify startup:
+   - Inspect stdout for exact config path and policy ID.
+   - Fail fast if wrapper-default config is used.
+6. Transient failure handling:
+   - If allocation handshake shows `Zero Bytes were transmitted or received`, retry once with identical arguments.
 
 ## Guardrails
 
-- Do not submit issue-791 wrappers without explicit `ISSUE791_TRAIN_CONFIG`.
-- Do not assume partition health from stale snapshots; always refresh right before submit.
-- Do not classify allocation-handshake failures as model regressions.
+- Never submit an issue-791 wrapper without explicit `ISSUE791_TRAIN_CONFIG`/`--config`.
+- Do not use stale partition status for a submission decision.
+- Do not interpret infrastructure handshake failures as training quality regressions.
+
+## Output
+
+- Chosen config path, partition/QoS decision, submit command.
+- Startup provenance (stdout markers) and whether a retry was triggered.
+- Final outcome (`submitted` / `blocked` / `retry suggested`) with exact reason.

--- a/.agents/skills/benchmark-overview/SKILL.md
+++ b/.agents/skills/benchmark-overview/SKILL.md
@@ -5,8 +5,10 @@ description: "Fast benchmark-faithful orientation for scenario splits, baselines
 
 # Benchmark Overview
 
-Use this skill when a task needs a fast, benchmark-faithful understanding of how this repository
-defines scenarios, seeds, baselines, metrics, and output artifacts.
+## When to use
+
+Use this skill when you need a fast, benchmark-faithful read of scenario definitions, seeds, baselines,
+metrics, and artifact layout before changing code or producing claims.
 
 ## Read First
 
@@ -15,18 +17,22 @@ defines scenarios, seeds, baselines, metrics, and output artifacts.
 - `docs/benchmark_planner_family_coverage.md`
 - `docs/benchmark_camera_ready.md` when the task is publication-facing
 
-## Focus
+## Workflow
 
-- canonical scenario/config entrypoints,
-- baseline readiness and category boundaries,
-- metric caveats,
-- reproducibility requirements,
-- artifact locations under `output/`.
+1. Identify the active benchmark contract for the request.
+2. Check scenario/config entrypoints and baseline family boundaries.
+3. Map required reproducibility artifacts and seeds.
+4. Return allowed conclusions and known caveats.
 
-## Output Expectations
+## Proof and Guardrails
 
-Summaries should call out:
+- Verify artifact provenance and contract mapping before interpretation.
+- Preserve fail-closed policy where fallback/degraded behavior exists.
+- Avoid implying success from runs with incomplete seeds, mismatched episodes, or missing metrics.
+- Use issue/context notes to capture non-obvious assumptions.
 
-- what benchmark contract applies,
-- why it matters for the requested task,
-- what uncertainty or limitation remains.
+## Output
+
+- benchmark contract and why it applies,
+- what evidence supports the interpretation,
+- known caveats and non-covered cases.

--- a/.agents/skills/clean-up/SKILL.md
+++ b/.agents/skills/clean-up/SKILL.md
@@ -5,55 +5,39 @@ description: "Clean up the current branch in the Robot SF repo by following docs
 
 # Clean Up
 
-## Overview
+## Purpose
 
-Clean and validate the current branch for the Robot SF repo by applying the dev guide
-workflow, running Ruff format/fix, and running parallel tests.
+Run the repo-standard cleanup pipeline for the current branch: formatting, automated checks,
+parallel tests, and diff-based quality gates.
 
-## Cleanup Workflow
+## Workflow
 
-1. Confirm repo and guidance
-   - Verify the working directory looks like the Robot SF repo (e.g., `.git`,
-     `docs/dev_guide.md`, `.specify/memory/constitution.md`, and
-     `.github/copilot-instructions.md` exist).
-   - Read `docs/dev_guide.md`, `.specify/memory/constitution.md`, and
-     `.github/copilot-instructions.md` to align with required rules.
+1. Confirm context:
+   - Check for repo markers (`.git`, `docs/dev_guide.md`, `.specify/memory/constitution.md`).
+   - Read `docs/dev_guide.md`, `.specify/memory/constitution.md`, and `.github/copilot-instructions.md`.
+2. Prepare environment:
+   - If `.venv` is present, use it.
+   - If missing, run `uv sync --all-extras`, `source .venv/bin/activate`, and `uv run pre-commit install`.
+3. Format and lint:
+   - `scripts/dev/ruff_fix_format.sh`
+   - Re-run until the script is clean.
+4. Run tests:
+   - `scripts/dev/run_tests_parallel.sh`
+   - Optional: `--new-first` or `--no-fast-fail` as needed.
+5. Run diff quality gates:
+   - `BASE_REF=origin/main scripts/dev/check_changed_coverage.sh`
+   - `BASE_REF=origin/main scripts/dev/check_docstring_todos_diff.sh`
+6. Report:
+   - Summarize passed/failed commands and any residual risk blocks (flaky or deferred tests).
 
-2. Ensure environment
-   - If `VIRTUAL_ENV` is empty and `.venv/bin/activate` exists, run
-     `source .venv/bin/activate`.
-   - If `.venv/bin/activate` is missing, follow dev guide setup:
-     `uv sync --all-extras`, `source .venv/bin/activate`, and
-     `uv run pre-commit install`.
+## Guardrails
 
-3. Run formatting and fixes first
-   - Use the shared script:
-     `scripts/dev/ruff_fix_format.sh`
-   - If Ruff reports issues, fix them and rerun until clean.
+- Fix failures with intent; do not silence value-heavy tests without explicit direction.
+- If touched tests were added, verify those new tests locally.
+- For rendering or benchmark-affecting work, keep GUI/benchmarks in follow-up if required and noted.
 
-4. Run tests in parallel
-   - Use the shared script:
-     `scripts/dev/run_tests_parallel.sh`
-   - Default behavior is fail-fast + failed-first ordering:
-     `pytest -n auto -x --failed-first`
-   - Optional ordering toggle:
-     `scripts/dev/run_tests_parallel.sh --new-first`
-   - To disable fail-fast when you need a full failure set:
-     `scripts/dev/run_tests_parallel.sh --no-fast-fail`
-   - If tests fail, evaluate test value first (Constitution Principle XIII /
-     dev guide testing strategy). Classify failures and decide whether to fix,
-     defer, or ask for direction before removing or relaxing tests.
+## Output
 
-5. Run diff-based quality gates and fix them.
-   - Run changed-files coverage check:
-     `BASE_REF=origin/main scripts/dev/check_changed_coverage.sh`
-     - If you changed any test files, run these new tests locally.
-   - Run touched-definition TODO docstring check:
-     `BASE_REF=origin/main scripts/dev/check_docstring_todos_diff.sh`
-
-6. Report and follow-ups
-   - Summarize commands run and results.
-   - Note remaining failures, flaky tests, or follow-up tasks (for example,
-     GUI tests if rendering changes were made, or CHANGELOG updates for
-     user-facing changes).
-  - Suggest commit batches and messages for any uncommited changes.
+- Commands executed and pass/fail status.
+- List of remaining failures and the decision (fix, defer, investigate).
+- Remaining follow-up tasks before merge-ready handoff.

--- a/.agents/skills/context-map/SKILL.md
+++ b/.agents/skills/context-map/SKILL.md
@@ -5,13 +5,11 @@ description: "Generate a focused repository context map before multi-file change
 
 # Context Map
 
-## Overview
+## When to use
 
-Use this skill before a non-trivial change when the main problem is finding the right repository
-surface to inspect.
+Use this skill before non-trivial work when the main risk is choosing the wrong files or commands.
 
-The goal is not to do the task yet. The goal is to produce a compact map of the files, commands,
-and checks that matter most so the next step is low-risk and well-scoped.
+The objective is a compact map that reduces wrong-surface edits, not execution.
 
 ## Read First
 
@@ -56,3 +54,8 @@ execution path.
 - Do not edit files in this skill.
 - Do not broaden scope while mapping context.
 - If the task is already well-scoped, switch to the appropriate execution skill.
+
+## Proof and Guardrails
+
+- Output should include `Primary`, `Adjacent`, `Validation`, `Risks`, and `Open questions`.
+- Do not include speculative recommendations beyond scoped evidence.

--- a/.agents/skills/context-note-maintainer/SKILL.md
+++ b/.agents/skills/context-note-maintainer/SKILL.md
@@ -5,13 +5,10 @@ description: "Create or refresh linked docs/context notes so reusable agent know
 
 # Context Note Maintainer
 
-## Overview
+## When to use
 
-Use this skill when work produces non-trivial reusable insights, decisions, reasoning, or
-validation context that should be preserved in Markdown, or when an existing `docs/context/` note
-has become stale, superseded, or hard to discover.
-
-This skill is for durable handoff knowledge, not transient scratch notes.
+Use this skill when reusable repo knowledge needs durable Markdown capture, or when `docs/context/` notes are
+stale, conflicting, or hard to discover.
 
 ## Read First
 
@@ -50,14 +47,21 @@ This skill is for durable handoff knowledge, not transient scratch notes.
    - Check that referenced paths and commands exist.
    - Run `uv run python scripts/dev/check_skills.py` if skill docs were changed.
 
+## Proof and Guardrails
+
+- Record what changed and why it is the canonical note.
+- Remove or clearly mark superseded claims.
+- Confirm links and commands resolve to existing files/entries.
+- For durable benchmark evidence, prefer a short manifest over raw logs in `output/`.
+- Run `uv run python scripts/dev/check_skills.py` only after finishing skill doc edits.
+
 ## Output
 
-Always report which note was updated or created, why that was the canonical surface, what stale
-content was cleaned up, and which entry points now link to it.
+Always report:
+- which note was created/updated,
+- why this surface is canonical,
+- stale content addressed,
+- updated discoverability links.
 
-## Guardrails
-
-- Do not create duplicate notes when an existing canonical note can be updated.
-- Do not leave touched stale content ambiguous.
-- Do not treat `docs/context/` as a scratchpad or dump of raw terminal output.
-- Do not rely on chat-only context for decisions that future agents will need to reuse.
+Also include:
+- confirmation that the note is durable handoff content, not a temporary scratchpad.

--- a/.agents/skills/experiment-context/SKILL.md
+++ b/.agents/skills/experiment-context/SKILL.md
@@ -5,8 +5,9 @@ description: "Find the canonical config-first training or evaluation path, artif
 
 # Experiment Context
 
-Use this skill when a task needs the current training/evaluation run context rather than generic
-benchmark theory.
+## When to use
+
+Use this skill when a specific training/evaluation task needs the canonical config-first command, artifact lineage, and validation gates before execution or interpretation.
 
 ## Read First
 
@@ -14,19 +15,27 @@ benchmark theory.
 - `docs/dev_guide.md`
 - relevant runbooks under `docs/training/`
 - relevant configs under `configs/training/` or `configs/benchmarks/`
+- `docs/context/issue_691_benchmark_fallback_policy.md` when benchmark runs are involved
 
-## Focus
+## Workflow
 
-- canonical command path,
-- config-first workflow,
-- artifact lineage,
-- host/runtime assumptions,
-- validation or promotion gates.
+1. Resolve the exact command or config entrypoint.
+2. Verify expected output roots and artifact layout.
+3. Capture host/runtime assumptions and dependencies.
+4. Identify required validation or promotion gates.
+5. Summarize the primary risk of deviating from canonical execution.
 
-## Output Expectations
+## Proof and Guardrails
+
+- Prefer tracked config and command paths over ad-hoc overrides.
+- If artifacts are missing or reproducibility assumptions are violated, classify the result as incomplete.
+- Keep benchmark conclusions conditional on provenance and fallback mode status.
+
+## Output
 
 Return:
 
-- the exact config or command path to use,
-- the artifact root that should contain outputs,
-- the main risk if the user deviates from the canonical path.
+- exact config/command path,
+- expected artifact root,
+- required checks,
+- the noncompliance risk if the canonical path is not used.

--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -1,168 +1,69 @@
 ---
 name: gh-issue-autopilot
-description: "Autonomous issue-to-PR workflow with GitHub MCP-first interaction and gh fallback for batch/project automation."
+description: "Autonomous issue-to-PR workflow from next eligible issue to draft PR with consistent metadata handling."
 ---
 
 # GH Issue Autopilot
 
-## Overview
+Use this when the user asks to "take the next issue" and execute through to draft PR.
 
-Use this skill when the user asks to "take the next issue" and execute end-to-end from issue
-selection to a draft PR, while keeping project metadata and follow-up tracking consistent.
+Primary integration is with repo project state and PR opening; details of branch validation and detailed
+issue creation are handled by child skills.
 
-Prefer GitHub MCP / GitHub app tools for interactive issue, PR, and project reads when available.
-Keep the concrete `gh` commands below as the deterministic fallback for project routing, scripted
-batch work, PR opening, and auth/debugging.
-
-Typical invocation:
-
-- `we have issues here, take the next most reasonable one, implement as you go until draft PR`
-
-## Defaults
+## Constants
 
 - Repository: `ll7/robot_sf_ll7`
 - Project: `ll7` Project `#5`
 - Base branch: `main`
-- Validation gate: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-- Batch-first workflow note: `docs/context/issue_713_batch_first_issue_workflow.md`
+- Readiness baseline: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+- Workflow note: `docs/context/issue_713_batch_first_issue_workflow.md`
 
-## Selection Policy: Next Best Issue
+## Selection Policy
 
-1. Prefer project-backed items with `Status` in this order:
-   - `Ready`
-   - `Todo`
-   - `Tracked`
-2. Within same status, prefer `Priority`:
-   - `Very High`, `High`, `Medium`, `Low`, `Very Low`
-3. Prefer issues without linked PRs and without blocker labels:
-   - `decision-required`, `blocked`, `wontfix`, `duplicate`
-4. Tie-breaker:
-   - lower issue number first (older work first).
+Choose the next issue in order:
+1. Project status `Ready`
+2. Project status `Todo`
+3. Project status `Tracked`
+4. Explicit user-requested issue
 
-Use GitHub MCP / GitHub app tools as the source of truth when available before falling back to
-`gh project item-list` and then plain `gh issue list`.
+Tie-breakers: no blocker labels, no linked PR, older open issue first, stronger evidence first.
 
 ## Workflow
 
-1. Sync and authenticate
-   - `gh auth status`
-   - `git fetch origin`
-   - `git switch main && git pull --ff-only`
+1. Refresh credentials and branch baseline (`gh auth status`, `git fetch origin`).
+2. Resolve queue candidate and re-check issue state.
+3. If issue statement is ambiguous:
+   - post a short decision options note,
+   - add `decision-required` (create if missing),
+   - set status back to `Tracked`,
+   - stop with blocker.
+4. Move the issue to `In progress` (optionally normalize priority).
+5. Create issue branch (`gh issue develop` preferred; fallback to git branch).
+6. Implement inside accepted scope.
+7. Run validation gate and rerun on failures only when fixable.
+8. Commit with conventional message; if long-running benchmark evidence appears, classify artifacts.
+9. Sync with latest `origin/main`, rerun readiness, and check artifact durability.
+10. Open draft PR using `gh-pr-opener`.
+11. For deferred important work, create follow-up issues and link them before final handoff.
 
-2. Resolve project/field IDs (needed for status and priority updates)
-   - `PROJECT_ID=$(gh project view 5 --owner ll7 --format json --jq .id)`
-   - `gh project field-list 5 --owner ll7 --format json`
-   - Extract:
-     - `Status` field ID and option IDs (`Tracked`, `Todo`, `Ready`, `In progress`, `Done`)
-     - `Priority` field ID and option IDs (`Very Low` .. `Very High`)
-   - Cache those IDs once per shell session when processing a batch, then reuse them for all
-     project writes.
+## Branch and State Safety
 
-3. Select next candidate issue
-   - Query project items:
-     - `gh project item-list 5 --owner ll7 --limit 200 --format json`
-   - Filter to open issue candidates and rank by policy above.
-   - Validate issue is still open:
-     - `gh issue view <number> --json state,title,body,labels,milestone,url`
+- One active issue branch by default.
+- Keep branch names stable and issue-linked.
+- Do not force-push, rewrite branch history, or merge unrelated issues into this branch.
+- If status/branch drift is detected mid-flow, pause and re-check before continuing.
 
-4. Ambiguity check before coding
-   - Verify problem statement, acceptance criteria, and boundaries are explicit.
-   - If ambiguous, write short options with:
-     - `Pros`
-     - `Cons`
-     - `Recommended option + rationale`
-   - If a decision is required from maintainers:
-     - ensure label exists:
-       - `gh label create "decision-required" --color B60205 --description "Needs maintainer decision" || true`
-     - add label: `gh issue edit <n> --add-label decision-required`
-     - set project status back to `Tracked`
-     - comment options via `scripts/dev/gh_comment.sh issue <n> <<'EOF' ... EOF`
-     - stop implementation and report blocking decision.
+## Anti-Loop Rules
 
-5. Move issue to active execution
-   - Set project `Status` to `In progress`.
-   - Optionally set or normalize `Priority` if obviously wrong.
+- Do not cycle between branch implementation and validation on unchanged failures.
+- If readiness/auth/project write fails twice, stop and report the blocker with minimal next action.
 
-6. Create and checkout issue branch
-   - Preferred:
-     - `gh issue develop <n> --base main --checkout --name "<n>-<slug>"`
-   - Fallback:
-     - `git switch -c <n>-<slug>`
+## Output
 
-7. Implement
-   - Keep scope tight to issue acceptance criteria.
-   - Add/adjust tests and docs with the code.
-   - If scope expands, split deferred work into follow-up issues (step 12).
-
-8. Validate with repository gates
-   - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-   - If failures occur, fix and rerun until green (or document justified exception).
-
-9. Commit the implementation
-   - Commit in logical batches with conventional messages.
-
-10. Sync with latest main before opening the PR
-   - `git fetch origin main`
-   - Merge or rebase the latest `origin/main` into the issue branch before PR creation.
-   - Run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after the sync; a readiness result
-     from before the sync is stale.
-
-11. Check local artifact persistence before PR handoff
-   - Inspect ignored/generated outputs:
-     - `git status --ignored --short -uall output`
-   - For likely durable artifacts, inspect size, timestamps, and hashes with `find output ...`,
-     `du -sh`, and `sha256sum`.
-   - Classify relevant artifacts as disposable, ignored cache, represented by a tracked
-     manifest/registry pointer, or requiring durable upload before PR handoff.
-   - Treat benchmark bundles, model checkpoints, W&B run outputs, policy-analysis reports, and
-     config dependencies under `output/model_cache` as durable-candidate artifacts.
-   - If code/config/docs rely on a local ignored artifact, persist the dependency first, preferably
-     through `model/registry.yaml` with W&B metadata such as `wandb_artifact_path`, a tracked
-     manifest, or another explicit durable source.
-   - Include the persistence decision in the PR body and any issue handoff comment.
-
-12. Run the first-pass self-review
-   - Use `docs/context/pr_first_pass_review_audit_2026-05-14.md` before pushing or opening the PR.
-   - For docs/context changes, verify index links and make validation statements match commands
-     actually run.
-   - For parser, schema, path, JSON, artifact, and public-helper changes, check malformed inputs,
-     missing values, empty collections, wrong shapes, non-finite numbers, path traversal, and
-     repository-relative path handling.
-   - For environment, benchmark, recording, and simulation-loop changes, check streaming behavior,
-     static Gymnasium spaces, random-state isolation, and per-step output size.
-   - For skill or workflow changes, read the changed text as executable instructions and make scope
-     boundaries, selected issue sets, and evidence destinations explicit.
-
-13. Push and open draft PR
-   - `git push -u origin "$(git branch --show-current)"`
-   - Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-   - Open draft PR linking issue:
-     - `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`
-
-14. Create follow-up issues when needed
-   - For deferred but important work, create dedicated issues:
-     - `gh issue create --title "<follow-up>" --body-file <body.md> --label "enhancement,technical-debt" --milestone "<milestone>"`
-   - Add to project:
-     - `gh project item-add 5 --owner ll7 --url <issue_url>`
-   - Set `Priority` + `Status` fields on follow-up issue item.
-   - Reference follow-up issue IDs in PR description and parent issue comment.
-   - If you are processing a larger batch, finish all issue cleanup before the project-write pass
-     and run score sync once at the end.
-
-15. Close loop metadata
-   - Parent issue:
-     - keep open while PR is draft; use closing keyword in PR body (`Closes #<n>`) when ready.
-   - Project:
-     - issue `Status`: keep `In progress` until merged (or `Done` only if team process wants pre-merge done).
-     - PR item `Status`: `In progress` / `Ready for review` if that convention is in use.
-
-## Output Requirements
-
-- Always report:
-  - selected issue number + why it was selected
-  - ambiguity decisions taken (or why none were needed)
-  - commands run for validation
-  - local artifact persistence decision for generated `output/` files
-  - first-pass self-review result
-  - follow-up issues created (if any) with labels/milestone/priority
-  - draft PR URL
+Emit:
+- selected issue + why,
+- branch and PR target,
+- commands run,
+- artifact classification decision,
+- follow-up issues created,
+- final PR URL or blocker reason.

--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -27,6 +27,8 @@ Choose the next issue in order:
 4. Explicit user-requested issue
 
 Tie-breakers: no blocker labels, no linked PR, older open issue first, stronger evidence first.
+Within the same status, prefer higher Project #5 Priority (`Very High`, `High`, `Medium`, `Low`,
+then `Very Low`) before the remaining tie-breakers.
 
 ## Workflow
 

--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -26,6 +26,8 @@ Choose the next issue in order:
 3. Project status `Tracked`
 4. Explicit user-requested issue
 
+Within the same status, prefer higher Project `Priority` (`Very High` to `Very Low`) before the
+remaining tie-breakers.
 Tie-breakers: no blocker labels, no linked PR, older open issue first, stronger evidence first.
 
 ## Workflow

--- a/.agents/skills/gh-issue-clarifier/SKILL.md
+++ b/.agents/skills/gh-issue-clarifier/SKILL.md
@@ -5,96 +5,36 @@ description: "Clarify ambiguous GitHub issues by tightening scope and acceptance
 
 # GH Issue Clarifier
 
-## Overview
+## Purpose
 
-Use this skill to make ambiguous issues implementation-ready with minimal churn and clear
-decision records.
+Turn unclear issues into executable tasks with explicit scope, acceptance criteria, and an auditable
+decision trail. Keep the issue small, stable, and ready for implementation.
 
-For larger issue batches, follow `docs/context/issue_713_batch_first_issue_workflow.md` so issue
-cleanup stays separate from Project #5 writes.
+## Workflow
 
-Prefer GitHub MCP / GitHub app tools for interactive issue reads, linked-context inspection, and
-comment drafting when available. Keep the `gh` commands below as the deterministic fallback for
-labels, project status changes, and follow-up issue creation.
+1. Read issue state (`gh issue view`) and linked context (PRs, comments, labels, milestone).
+2. Classify ambiguity:
+   - Problem, scope, solution, or validation ambiguity.
+3. If multiple valid options exist, draft a minimal options set:
+   - approach, pros/cons, risk tradeoff, recommendation.
+4. Apply the chosen path:
+   - clarify issue body in-place (problem, in-scope/out-of-scope, acceptance criteria, tests),
+   - only add `decision-required` when maintainer choice is truly needed,
+   - create follow-up issues when scope remains too broad.
+5. Handle batching discipline:
+   - do issue text/label cleanup before Project #5 routing.
+   - use `docs/context/issue_713_batch_first_issue_workflow.md` for larger batches.
 
-## When To Use
+## Guardrails
 
-- Issue description is vague, contradictory, or missing acceptance criteria.
-- Multiple solution paths exist with meaningful tradeoffs.
-- Scope is too broad and needs decomposition.
+- Use MCP for interactive inspection when available; use `gh` as deterministic fallback.
+- Do not add assumptions that are not backed by issue context.
+- Keep decision comments structured and short (`Context`, `Options`, `Recommendation`, `Decision needed`).
+- Remove `decision-required` promptly once decision is recorded.
 
-## Clarification Workflow
+## Output
 
-1. Gather context
-   - `gh issue view <n> --comments --json title,body,labels,milestone,assignees,comments,url`
-   - Review linked PRs/commits if present.
-   - Inspect relevant code paths and tests before proposing changes.
-   - If this is part of a larger issue batch, keep issue cleanup separate from Project #5 writes.
-
-2. Detect ambiguity types
-   - Problem ambiguity: unclear bug or objective.
-   - Scope ambiguity: too broad for one PR.
-   - Solution ambiguity: multiple valid designs with different tradeoffs.
-   - Validation ambiguity: missing test or acceptance criteria.
-
-3. Produce option set (mandatory when ambiguity exists)
-   - For each option include:
-     - short approach name
-     - `Pros`
-     - `Cons`
-     - risk profile (speed vs reliability)
-   - Mark one `Recommended` option with concrete rationale.
-
-4. Decide path
-   - If a recommendation is clear and low risk:
-     - tighten issue body directly (problem, scope, acceptance criteria, test plan).
-     - keep/move project status to `Ready`.
-   - If maintainer decision is required:
-     - ensure label exists:
-       - `gh label create "decision-required" --color B60205 --description "Needs maintainer decision" || true`
-     - `gh issue edit <n> --add-label decision-required`
-     - move project status to `Tracked`
-     - post a structured decision comment with options and recommendation.
-
-5. Split follow-up work when needed
-   - Keep current issue narrowly implementable.
-   - Create follow-up issues for deferred scope:
-     - `gh issue create --title "<follow-up>" --body-file <body.md> --label "<labels>" --milestone "<milestone>"`
-   - Add follow-up items to project and assign `Priority`.
-   - Batch the project routing after the issue-body edits instead of interleaving the two passes.
-
-6. Finalize clarified issue contract
-   - Ensure issue contains:
-     - crisp problem statement
-     - in-scope / out-of-scope bullets
-     - acceptance criteria
-     - validation commands (tests/checks)
-     - links to follow-ups and dependencies
-
-## Comment Template (decision-required)
-
-Use `scripts/dev/gh_comment.sh issue <n> <<'EOF' ... EOF`:
-
-- `Context`
-- `Options`
-  - `Option A`: pros/cons
-  - `Option B`: pros/cons
-- `Recommendation`
-- `Decision needed from maintainer`
-- `Impact on timeline/risk`
-
-## Metadata Policy
-
-- Add or fix labels that improve routing (`bug`, `enhancement`, `validation`, `performance`, etc.).
-- Align milestone to roadmap when known.
-- Set project `Priority` explicitly for actionable issues.
-- Remove `decision-required` once a decision is made and move status to `Ready`.
-
-## Output Requirements
-
-- Report:
-  - what was ambiguous
-  - options evaluated
-  - recommended path
-  - metadata changes made
-  - follow-up issues created (if any)
+- What was ambiguous and the resolved contract.
+- Any option analysis and final recommendation.
+- Metadata edits (`labels`, project status/milestone where changed).
+- Follow-up issues created and reason for each.

--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -17,14 +17,19 @@ execution.
    - `docs/dev_guide.md`
    - `docs/context/issue_713_batch_first_issue_workflow.md` (for batch routing).
 2. Choose the narrowest matching template (`bug`, `enhancement`, `documentation`, `refactor`,
-   `research`, `planner_integration`, `benchmark_experiment`, fallback `issue_default`).
+   `research`, `planner_integration.md`, `benchmark_experiment.md`, fallback
+   `issue_default.md`).
 3. Normalize prompt into required fields:
    - goal, scope/non-scope, value/effort/complexity/risk, definition of done, success metrics,
      validation plan.
 4. Create issue:
    - `gh issue create --title "<title>" --body-file <body.md> --template <template> --label "<labels>"`
    - prefer existing labels; avoid inventing taxonomy.
+   - prefer GitHub MCP / GitHub app tools for interactive issue creation when available; keep `gh`
+     for scripted or fallback paths.
 5. Project routing:
+   - use `gh project item-add` when the CLI route is the active Project #5 write path.
+   - use `gh project item-edit` for explicit field updates when the CLI route is active.
    - add issue to Project #5 and update only expected fields (`Priority`, `Expected Duration in Hours`,
      `Reviewed`) using existing field/schema IDs.
 6. Batch discipline:

--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -17,14 +17,17 @@ execution.
    - `docs/dev_guide.md`
    - `docs/context/issue_713_batch_first_issue_workflow.md` (for batch routing).
 2. Choose the narrowest matching template (`bug`, `enhancement`, `documentation`, `refactor`,
-   `research`, `planner_integration`, `benchmark_experiment`, fallback `issue_default`).
+   `research`, `planner_integration.md`, `benchmark_experiment.md`, fallback `issue_default.md`).
 3. Normalize prompt into required fields:
    - goal, scope/non-scope, value/effort/complexity/risk, definition of done, success metrics,
      validation plan.
 4. Create issue:
+   - use GitHub MCP / GitHub app tools when available; use `gh` for deterministic fallback.
    - `gh issue create --title "<title>" --body-file <body.md> --template <template> --label "<labels>"`
    - prefer existing labels; avoid inventing taxonomy.
 5. Project routing:
+   - `gh project item-add` to add the issue to Project #5 when MCP coverage is unavailable.
+   - `gh project item-edit` to set expected fields after resolving project/item/field IDs.
    - add issue to Project #5 and update only expected fields (`Priority`, `Expected Duration in Hours`,
      `Reviewed`) using existing field/schema IDs.
 6. Batch discipline:

--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -5,101 +5,42 @@ description: "Create structured GitHub issues from vague prompts using repo temp
 
 # GH Issue Creator
 
-## Overview
+## Purpose
 
-Use this skill when the user wants a new issue created from a rough idea and needs it turned
-into a repo-ready issue body with the right template, labels, and project metadata.
-
-Prefer GitHub MCP / GitHub app tools for interactive issue/project inspection when available.
-Keep the `gh` commands below as the deterministic fallback for issue creation and batched Project
-`#5` routing.
-Use REST-backed issue operations and reserve GraphQL for Project #5 routing.
-
-## Read First
-
-- `.github/ISSUE_TEMPLATE/issue_default.md`
-- `.github/ISSUE_TEMPLATE/bug_report.md`
-- `.github/ISSUE_TEMPLATE/documentation.md`
-- `.github/ISSUE_TEMPLATE/enhancement.md`
-- `.github/ISSUE_TEMPLATE/refactor.md`
-- `.github/ISSUE_TEMPLATE/research.md`
-- `.github/ISSUE_TEMPLATE/planner_integration.md`
-- `.github/ISSUE_TEMPLATE/benchmark_experiment.md`
-- `docs/dev_guide.md`
-- `docs/context/issue_713_batch_first_issue_workflow.md`
-
-## Template Selection
-
-Pick the narrowest template that matches the prompt:
-
-- `bug_report.md` for crashes, regressions, incorrect behavior.
-- `documentation.md` for docs, guides, or examples.
-- `enhancement.md` for product or feature additions.
-- `refactor.md` for maintainability-only cleanup.
-- `research.md` for experiments or research questions.
-- `planner_integration.md` for external or local planner-family integration.
-- `benchmark_experiment.md` for benchmark comparisons or scenario work.
-- `issue_default.md` when the prompt is vague or mixed.
-
-If multiple templates are plausible, choose the one with the smallest viable scope and say what
-assumption you made.
+Create GitHub issues from rough prompts with minimal expansion and sufficient structure for agent
+execution.
 
 ## Workflow
 
-1. Normalize the prompt
-   - Extract the concrete goal, scope, likely files, and validation path.
-   - Keep assumptions explicit and conservative.
+1. Read required inputs:
+   - issue templates under `.github/ISSUE_TEMPLATE/`
+   - `docs/dev_guide.md`
+   - `docs/context/issue_713_batch_first_issue_workflow.md` (for batch routing).
+2. Choose the narrowest matching template (`bug`, `enhancement`, `documentation`, `refactor`,
+   `research`, `planner_integration`, `benchmark_experiment`, fallback `issue_default`).
+3. Normalize prompt into required fields:
+   - goal, scope/non-scope, value/effort/complexity/risk, definition of done, success metrics,
+     validation plan.
+4. Create issue:
+   - `gh issue create --title "<title>" --body-file <body.md> --template <template> --label "<labels>"`
+   - prefer existing labels; avoid inventing taxonomy.
+5. Project routing:
+   - add issue to Project #5 and update only expected fields (`Priority`, `Expected Duration in Hours`,
+     `Reviewed`) using existing field/schema IDs.
+6. Batch discipline:
+   - for multiple issues, perform body/label cleanup first, then bulk Project #5 writes, then one sync.
+   - if API is rate-limited, record pending project mutations and resume later.
 
-2. Draft the issue body
-   - Fill in the selected template.
-   - Include:
-     - added value estimation,
-     - effort estimate,
-     - complexity estimate,
-     - risk assessment,
-     - estimate discussion,
-     - definition of done,
-     - success metrics,
-     - validation/testing.
-   - Keep wording tight and executable.
+## Guardrails
 
-3. Create the issue with `gh`
-   - Use the template body as the starting point:
-     - `gh issue create --title "<title>" --body-file <body.md> --template <template-name> --label "<labels>"`
-   - Prefer labels that already exist in the repository.
-   - Avoid inventing new project taxonomy in the issue body.
+- Keep assumptions explicit and conservative.
+- If template fit is unclear, pick the smallest viable template and note the assumption.
+- Do not proceed with speculative follow-up links unless concrete and actionable.
+- Use REST for deterministic issue operations; use GraphQL/MCP only where useful for Project #5.
 
-4. Add project metadata
-   - Resolve the project and field IDs first, or reuse the local Project #5 cache
-     values if they were refreshed for the current batch:
-     - `gh project view 5 --owner ll7 --format json`
-     - `gh project field-list 5 --owner ll7 --format json`
-     - `gh project item-list 5 --owner ll7 --limit 200 --format json`
-   - Add the issue to Project #5:
-     - `gh project item-add 5 --owner ll7 --url <issue-url>`
-   - Update existing fields only:
-     - `Priority`
-     - `Expected Duration in Hours`
-     - `Reviewed`
-   - Edit the project item with the resolved IDs:
-     - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <field-id> --single-select-option-id <option-id>`
-     - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <field-id> --number <hours>`
-     - `gh project item-edit --id <item-id> --project-id <project-id> --field-id <field-id> --date <YYYY-MM-DD>`
-   - Use the current Project #5 schema; do not invent missing fields.
-   - When creating many issues, batch the project writes after the issue cleanup pass and run
-     score sync once at the end rather than after each issue.
-   - If GraphQL quota is exhausted, keep the issue created and report the pending Project #5
-     add/update with enough IDs to resume after reset.
+## Output
 
-5. Finalize the issue
-   - Link dependencies or follow-ups only when they are concrete.
-   - Keep the issue open and actionable.
-
-## Output Requirements
-
-- Report:
-  - template selected,
-  - assumptions made,
-  - labels applied,
-  - project fields updated,
-  - issue URL.
+- Template selected and why.
+- Issue URL.
+- Final labels, project fields touched, and any batch routing actions queued.
+- Explicit assumptions and unresolved metadata updates, if any.

--- a/.agents/skills/gh-issue-priority-assessor/SKILL.md
+++ b/.agents/skills/gh-issue-priority-assessor/SKILL.md
@@ -14,7 +14,9 @@ Assess Project #5 priority fields for plausibility using the canonical rubric, a
 
 1. Read rubric and issue context:
    - `docs/project_prioritization.md`
-   - issue body/metadata and current Project #5 field values.
+   - `docs/context/issue_713_batch_first_issue_workflow.md` for batch-first Project #5 writes.
+   - issue body/metadata from GitHub MCP / GitHub app tools or `gh issue view`.
+   - current Project #5 field values from MCP or `gh project item-list`.
 2. Evaluate five fields:
    - `Improvement`, `Success Probability`, `Time Criticality`, `Unlock Factor`,
      `Expected Duration in Hours`.
@@ -22,6 +24,7 @@ Assess Project #5 priority fields for plausibility using the canonical rubric, a
 4. If writeback is requested:
    - apply only fields with enough evidence,
    - batch updates for multiple issues,
+   - use `gh project item-edit` when a CLI fallback is needed,
    - run score sync once after the batch.
 5. Keep unresolved cases labeled as uncertain with a clear condition that would change the value.
 
@@ -34,7 +37,8 @@ Assess Project #5 priority fields for plausibility using the canonical rubric, a
 
 ## Output
 
-- Issue number and current vs proposed field values.
+- Issue number and current vs proposed field values, including `Priority Score` and
+  `Estimate Discussion` when present.
 - Field-by-field rationale and uncertainty.
 - Plausibility verdict and needed evidence to justify changes.
 - Whether writeback was applied.

--- a/.agents/skills/gh-issue-priority-assessor/SKILL.md
+++ b/.agents/skills/gh-issue-priority-assessor/SKILL.md
@@ -5,64 +5,36 @@ description: "LLM-backed review workflow for Project #5 priority inputs; assess 
 
 # GH Issue Priority Assessor
 
-## Overview
+## Purpose
 
-Use this skill when an issue needs a plausibility review for Project #5 priority
-inputs or when you want an LLM-backed estimate of the current issue fields.
-
-Prefer GitHub MCP / GitHub app tools for interactive issue/project reads when available. Keep
-the `gh` commands below as the deterministic fallback for scripted writeback and score-sync
-adjacent batching.
-
-## Read First
-
-- `docs/project_prioritization.md`
-- `docs/context/issue_713_batch_first_issue_workflow.md`
-- `.github/ISSUE_TEMPLATE/issue_default.md`
-- `.github/ISSUE_TEMPLATE/enhancement.md`
-- `.github/ISSUE_TEMPLATE/benchmark_experiment.md`
-- `scripts/tools/project_priority_score.py`
-- `.agents/skills/gh-issue-template-auditor/SKILL.md`
+Assess Project #5 priority fields for plausibility using the canonical rubric, and propose
+(or apply, when asked) minimal, evidence-grounded updates.
 
 ## Workflow
 
-1. Inspect the issue and current project values
-   - `gh issue view <n> --json title,body,labels,milestone,assignees,url`
-   - `gh project item-list 5 --owner ll7 --limit 400 --format json`
+1. Read rubric and issue context:
+   - `docs/project_prioritization.md`
+   - issue body/metadata and current Project #5 field values.
+2. Evaluate five fields:
+   - `Improvement`, `Success Probability`, `Time Criticality`, `Unlock Factor`,
+     `Expected Duration in Hours`.
+3. For each field, state whether current values are plausible, and why.
+4. If writeback is requested:
+   - apply only fields with enough evidence,
+   - batch updates for multiple issues,
+   - run score sync once after the batch.
+5. Keep unresolved cases labeled as uncertain with a clear condition that would change the value.
 
-2. Assess plausibility against the rubric
-   - Propose values for:
-     - `Improvement`
-     - `Success Probability`
-     - `Time Criticality`
-     - `Unlock Factor`
-     - `Expected Duration in Hours`
-   - Inspect the issue's `Estimate Discussion` section when present, and update
-     it with rationale and uncertainty if writeback is requested.
-   - Explain why each value is plausible or not.
-   - Note uncertainty and what evidence would move the estimate.
-   - Flag contradictions between the issue body and the current values.
+## Guardrails
 
-3. Keep review-first as the default
-   - Output proposed values and rationale without writing fields unless the
-     user explicitly asks to apply them.
-   - If writeback is requested, update the relevant Project #5 fields with
-     `gh project item-edit`.
-   - If you are reviewing multiple issues, batch the writebacks and run the
-     score sync helper once so `Priority Score` stays derived from the latest
-     values.
+- Use `docs/project_prioritization.md` as the only scale definition.
+- Do not invent new dimensions or Project #5 fields.
+- Default to review-only output; writeback only on explicit request.
+- Keep issues with contradictions marked for clarifier follow-up.
 
-4. Keep the rubric static
-   - Use `docs/project_prioritization.md` as the canonical reference for scales
-     and plausibility checks.
-   - Do not invent new score dimensions or new Project #5 fields.
+## Output
 
-## Output Requirements
-
-- Report:
-  - issue number,
-  - current values,
-  - proposed values,
-  - rationale and uncertainty,
-  - plausibility verdict,
-  - whether writeback was applied.
+- Issue number and current vs proposed field values.
+- Field-by-field rationale and uncertainty.
+- Plausibility verdict and needed evidence to justify changes.
+- Whether writeback was applied.

--- a/.agents/skills/gh-issue-priority-assessor/SKILL.md
+++ b/.agents/skills/gh-issue-priority-assessor/SKILL.md
@@ -8,12 +8,15 @@ description: "LLM-backed review workflow for Project #5 priority inputs; assess 
 ## Purpose
 
 Assess Project #5 priority fields for plausibility using the canonical rubric, and propose
-(or apply, when asked) minimal, evidence-grounded updates.
+(or apply, when asked) minimal, evidence-grounded updates. Prefer GitHub MCP / GitHub app tools for
+interactive reads when available.
 
 ## Workflow
 
 1. Read rubric and issue context:
    - `docs/project_prioritization.md`
+   - `gh issue view <issue>`
+   - `gh project item-list`
    - issue body/metadata and current Project #5 field values.
 2. Evaluate five fields:
    - `Improvement`, `Success Probability`, `Time Criticality`, `Unlock Factor`,
@@ -21,6 +24,7 @@ Assess Project #5 priority fields for plausibility using the canonical rubric, a
 3. For each field, state whether current values are plausible, and why.
 4. If writeback is requested:
    - apply only fields with enough evidence,
+   - use `gh project item-edit` for Project #5 field updates when using the CLI route,
    - batch updates for multiple issues,
    - run score sync once after the batch.
 5. Keep unresolved cases labeled as uncertain with a clear condition that would change the value.
@@ -34,7 +38,8 @@ Assess Project #5 priority fields for plausibility using the canonical rubric, a
 
 ## Output
 
-- Issue number and current vs proposed field values.
+- Issue number and current vs proposed field values, including `Priority Score` when available.
 - Field-by-field rationale and uncertainty.
-- Plausibility verdict and needed evidence to justify changes.
+- Plausibility verdict and needed evidence to justify changes, including `Estimate Discussion`
+  updates when relevant.
 - Whether writeback was applied.

--- a/.agents/skills/gh-issue-sequencer/SKILL.md
+++ b/.agents/skills/gh-issue-sequencer/SKILL.md
@@ -5,71 +5,44 @@ description: "Maintain a clear next-work queue in GitHub Project #5 by normalizi
 
 # GH Issue Sequencer
 
-Use this skill when the user asks to order, triage, or normalize a batch of GitHub issues for
-Project #5 execution.
+## Purpose
 
-Prefer GitHub MCP / GitHub app tools for interactive issue and project reads when available. Use
-`gh` for deterministic batch project writes, score sync, and auth/debugging.
-
-## Read First
-
-- `docs/project_prioritization.md`
-- `docs/context/issue_713_batch_first_issue_workflow.md`
-- `scripts/tools/project_priority_score.py`
-- `.agents/skills/gh-issue-priority-assessor/SKILL.md`
-- `.agents/skills/gh-issue-clarifier/SKILL.md`
-
-## Batch-First Rule
-
-Follow `docs/context/issue_713_batch_first_issue_workflow.md`:
-
-1. Do issue text, label, and clarification cleanup first.
-2. Do Project #5 field routing second.
-3. Run derived score sync once at the end of the batch.
-4. Cache project and field IDs once per shell session or in the local Project #5 cache for
-   long-running/multi-agent work.
-5. Use REST/local `git` for non-project state and reserve GraphQL for Project #5 writes.
-
-Do not interleave body rewrites, status changes, and score sync issue-by-issue unless there is only
-one issue in scope.
+Maintain a clean Project #5 execution queue by separating clarification cleanup, readiness routing, and
+one-pass sequencing metadata writes.
 
 ## Workflow
 
-1. Inspect the queue
-   - Check `gh api rate_limit` before large queue work.
-   - `gh project item-list 5 --owner ll7 --limit 400 --format json`
-   - `gh project field-list 5 --owner ll7 --format json`
-   - Use REST (`gh api repos/ll7/robot_sf_ll7/issues?...`) for issue bodies and labels when
-     GraphQL quota is low.
+1. Prepare:
+   - read `docs/project_prioritization.md` and `docs/context/issue_713_batch_first_issue_workflow.md`,
+   - resolve project/field IDs once for the session,
+   - check `gh api rate_limit` when batch size is large.
+2. Inspect queue:
+   - list Project #5 items and issue metadata,
+   - use REST for issue fields when GraphQL is constrained.
+3. Resolve blockers first:
+   - route ambiguous issues to `gh-issue-clarifier`,
+   - route implausible priorities to `gh-issue-priority-assessor`,
+   - keep `decision-required`, `blocked`, `duplicate`, `wontfix` out of execution-ready ordering.
+4. Normalize issue status:
+   - `In progress` for the active item,
+   - `Ready` for actionable and unblocked work,
+   - `Tracked` for valid but deferred work,
+   - `Done` for merged/closed issues.
+5. Order and apply:
+   - sort by higher priority, lower uncertainty, unlock value, then oldest issue number,
+   - apply status/priority/duration edits in one write pass,
+   - run score sync once at batch end if inputs changed.
+6. If writes fail (rate limits or auth), stop writes and capture exact pending mutation details.
 
-2. Identify blockers before sequencing
-   - Mark ambiguous issues for `gh-issue-clarifier`.
-   - Mark implausible priority inputs for `gh-issue-priority-assessor`.
-   - Keep `decision-required`, `blocked`, `duplicate`, and `wontfix` out of the ready queue.
+## Guardrails
 
-3. Normalize execution status
-   - `In progress`: exactly the issue currently being executed.
-   - `Ready`: actionable issues with clear scope and validation path.
-   - `Tracked`: valid but not ready because they need sequencing, dependencies, or decisions.
-   - `Done`: merged/closed work only, unless the team explicitly uses pre-merge done.
+- Use MCP/interactive tools when available; use `gh` for deterministic sequencing mutations.
+- Do not interleave issue-body edits, project routing, and score sync issue-by-issue for multi-issue batches.
+- Use follow-up handoffs rather than retry loops when quotas are temporarily exhausted.
 
-4. Order the queue
-   - Prefer higher Project #5 priority and lower uncertainty.
-   - Prefer issues that unlock downstream work.
-   - Keep benchmark/paper-facing blockers ahead of speculative experiments.
-   - When priority ties, prefer older issue number first.
+## Output
 
-5. Apply project writes in one pass
-   - Resolve Project #5 and field option IDs once.
-   - Use `gh project item-edit` for status/priority/duration writeback.
-   - Run `uv run python scripts/tools/project_priority_score.py sync` once after the batch if
-     score inputs changed.
-   - If GraphQL is exhausted, leave a precise handoff with project ID, item ID, field ID, option ID,
-     and the reset time from `gh api rate_limit`.
-
-## Output Requirements
-
-- Report the ordered issue queue with one-line rationale per issue.
-- Report any issues moved to `Ready`, `Tracked`, or `In progress`.
-- Report whether score sync was run.
-- Report unresolved blockers and the next recommended issue to execute.
+- Ordered issue queue with one-line rationale per item.
+- Status and priority changes applied.
+- Unresolved blockers and next candidate issue.
+- Whether final score sync completed.

--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -12,8 +12,10 @@ agent-ready without changing intent.
 
 ## Workflow
 
-1. Read template contract files and `scripts/tools/issue_template_audit.py`.
-2. Load issue body and metadata with `gh issue view`.
+1. Read template contract files and run
+   `uv run python scripts/tools/issue_template_audit.py` for bulk or targeted audits.
+   - For batch routing, preserve `docs/context/issue_713_batch_first_issue_workflow.md`.
+2. Load issue body and metadata with GitHub MCP / GitHub app tools when available, or `gh issue view`.
 3. Compare required sections (problem statement, scope/non-goals, estimates, risks, acceptance, validation, metadata).
 4. If gaps are limited and obvious:
    - generate repaired body with missing sections,

--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -5,80 +5,33 @@ description: "Review existing GitHub issues against the repo's issue-template co
 
 # GH Issue Template Auditor
 
-## Overview
+## Purpose
 
-Use this skill when an existing issue should be checked against the repo's template contract and
-rewritten if it is missing the sections needed for agent-ready execution.
-
-Prefer GitHub MCP / GitHub app tools for interactive issue inspection when available. Keep the
-`gh` commands below as the deterministic fallback for issue edits, labels, and related project
-metadata cleanup.
-
-## Read First
-
-- `.github/ISSUE_TEMPLATE/issue_default.md`
-- `.github/ISSUE_TEMPLATE/bug_report.md`
-- `.github/ISSUE_TEMPLATE/documentation.md`
-- `.github/ISSUE_TEMPLATE/enhancement.md`
-- `.github/ISSUE_TEMPLATE/refactor.md`
-- `.github/ISSUE_TEMPLATE/research.md`
-- `.github/ISSUE_TEMPLATE/planner_integration.md`
-- `.github/ISSUE_TEMPLATE/benchmark_experiment.md`
-- `scripts/tools/issue_template_audit.py`
-- `.agents/skills/gh-issue-clarifier/SKILL.md`
-- `docs/context/issue_713_batch_first_issue_workflow.md`
-
-## What to Check
-
-An issue is template-ready only if it includes, at minimum:
-
-- goal or problem statement,
-- scope and non-goals,
-- added value estimate,
-- effort estimate,
-- complexity estimate,
-- risk assessment,
-- affected files or components,
-- definition of done,
-- success metrics,
-- validation or testing,
-- estimate discussion,
-- project metadata.
+Check issue bodies against the template contract and perform minimal, safe repairs so issues become
+agent-ready without changing intent.
 
 ## Workflow
 
-1. Inspect the issue
-   - `gh issue view <n> --json title,body,labels,milestone,url`
-   - Identify which template the issue should have used.
+1. Read template contract files and `scripts/tools/issue_template_audit.py`.
+2. Load issue body and metadata with `gh issue view`.
+3. Compare required sections (problem statement, scope/non-goals, estimates, risks, acceptance, validation, metadata).
+4. If gaps are limited and obvious:
+   - generate repaired body with missing sections,
+   - update with `gh issue edit --body-file`.
+5. If gaps are fundamental (unclear objective, wide ambiguity, contradictions):
+   - escalate with `decision-required`,
+   - keep issue in `Tracked`,
+   - add a short clarifying comment.
+6. Leave project field writes for the same issue to a separate batching pass.
 
-2. Audit the body
-   - Use `uv run python scripts/tools/issue_template_audit.py --body-file <body.md>` to identify missing
-     sections.
-   - If the issue is only missing headings or obvious placeholders, repair it.
+## Guardrails
 
-3. Repair when safe
-   - Rewrite the issue body with the missing sections filled in conservatively.
-   - Update the issue with:
-     - `gh issue edit <n> --body-file <repaired-body.md>`
-   - Keep the original substance intact.
+- Preserve original issue content and decisions; avoid speculative rewrite.
+- Use `decision-required` instead of guessing when scope or problem statement is missing.
+- Keep route/metadata cleanup separate from body repair.
 
-4. Escalate when not safe
-   - If the issue is too broad, contradictory, or missing the core problem statement, do not
-     guess.
-   - Add `decision-required` and move it to `Tracked` if project metadata is in use.
-   - Comment with the missing pieces and the narrowest recommended fix.
-   - Keep Project #5 updates in a separate pass after the body repair if the issue also needs
-     metadata cleanup.
+## Output
 
-5. Close the loop
-   - If the issue now fits the template contract, say which sections were added or corrected.
-   - If it could not be safely repaired, say why and what decision is needed.
-
-## Output Requirements
-
-- Report:
-  - issue number,
-  - template contract gaps,
-  - whether you repaired the body,
-  - whether `decision-required` was added,
-  - any follow-up recommendation.
+- Issue number and exact missing contract sections.
+- Whether repair was applied, skipped, or blocked.
+- Any required escalation and follow-up action.

--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -8,11 +8,12 @@ description: "Review existing GitHub issues against the repo's issue-template co
 ## Purpose
 
 Check issue bodies against the template contract and perform minimal, safe repairs so issues become
-agent-ready without changing intent.
+agent-ready without changing intent. Prefer GitHub MCP / GitHub app tools for interactive reads and
+writes when available.
 
 ## Workflow
 
-1. Read template contract files and `scripts/tools/issue_template_audit.py`.
+1. Read template contract files and `uv run python scripts/tools/issue_template_audit.py`.
 2. Load issue body and metadata with `gh issue view`.
 3. Compare required sections (problem statement, scope/non-goals, estimates, risks, acceptance, validation, metadata).
 4. If gaps are limited and obvious:

--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -1,90 +1,49 @@
 ---
 name: gh-pr-comment-fixer
-description: "Fix GitHub PR review comments using the gh CLI: fetch review threads, implement requested changes, run the full test suite, commit and push fixes, then resolve the review threads. Use when asked to address PR comments or review feedback on the current branch."
+description: "Fix GitHub PR review comments with branch-safe edits, validation, and explicit thread resolution."
 ---
 
 # Gh Pr Comment Fixer
 
-## Overview
+Use this on a writable PR branch when actionable review feedback exists.
 
-Use the gh CLI to retrieve PR review comments for the current branch, apply fixes, verify with
-the full test suite, and resolve the review threads after pushing.
+## Scope
+
+- Fetch PR context for current branch.
+- Collect review threads and top-level PR comments.
+- Apply only fixable-now items that stay inside PR scope.
+- Run proof at the tightest practical level, then push and resolve threads.
 
 ## Workflow
 
-1. Identify the PR for the current branch.
-   - Prefer `gh pr view --json number,headRefName` and confirm it matches the branch.
+1. Confirm PR for current branch and branch match.
+2. Pull requested comments and review threads; keep thread IDs for actionable items.
+3. Classify requests:
+   - fixable now,
+   - needs clarification (ask before editing),
+   - out-of-scope (defer).
+4. Apply minimal edits grouped by concern.
+5. Run appropriate validation (prefer targeted first; full suite only when needed by risk).
+6. Commit and push.
+7. Resolve only addressed threads using `resolveReviewThread` mutation inputs.
+8. Re-check thread state; report any unresolved items with blocker reason (permissions, rate limits, or
+   external dependency).
 
-2. Retrieve review threads and comments.
-   - Use GraphQL for review threads:
-     `gh api graphql -F owner=<owner> -F repo=<repo> -F number=<pr_number> -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{id body path line url}}}}}}}'`
-   - Keep the review thread `id` with each requested change. GitHub resolves review threads by
-     thread id, not by the inline comment id or a reply id.
-   - Use `gh pr view --json comments` for top-level discussion comments.
-   - Summarize the requested changes and note any questions or ambiguities.
+## Anti-Loop / Retry
 
-3. Evaluate each comment.
-   - Decide if it is reasonable, needs clarification, or should be declined.
-   - If clarification is needed, ask before changing code.
+- Do not rerun unchanged failing validation more than twice without code change or clarified input.
+- If a review request cannot be fixed safely, leave a precise blocker note and stop.
 
-4. Implement fixes.
-   - Make minimal, targeted edits.
-   - Add or update tests if the change warrants it.
-   - Keep commit scope aligned with a single comment or logical group.
+## Artifact and Race Rules
 
-5. Run the full test suite.
-   - Use the repo standard test command unless instructed otherwise.
-   - Report failures and decide whether to continue or request input.
+- Inspect `output/`-class artifacts before commit and document disposal/durability.
+- Verify PR head before applying fixes; avoid resolving threads not yet satisfied by code or commit.
+- Do not force-push or mutate thread state for unresolved/ambiguous feedback.
 
-6. Check local artifact persistence before committing or pushing.
-   - Inspect ignored/generated outputs:
-     - `git status --ignored --short -uall output`
-   - For likely durable artifacts, inspect size, timestamps, and hashes with `find output ...`,
-     `du -sh`, and `sha256sum`.
-   - Decide whether each relevant artifact is disposable, an ignored cache, represented by a
-     tracked manifest/registry entry, or must be uploaded to durable storage.
-   - Treat benchmark bundles, model checkpoints, W&B run outputs, policy-analysis reports, and
-     config dependencies under `output/model_cache` as durable-candidate artifacts.
-   - If the review fix introduces or discovers a dependency on an ignored local artifact, make it
-     persistent before pushing, preferably via `model/registry.yaml` with W&B artifact metadata or
-     another explicit durable reference.
-   - Mention the artifact persistence decision in the PR reply or follow-up comment.
+## Required Output
 
-7. Commit and push fixes.
-   - Use a conventional commit message.
-   - Mention which comments were addressed.
-
-8. Resolve review threads.
-   - Replying to a review thread is not the same as resolving it. After the fix is committed,
-     pushed, and validated, resolve each addressed review thread with GraphQL:
-
-     ```bash
-     gh api graphql \
-       -F thread_id=<review_thread_id> \
-       -f query='mutation($thread_id:ID!){resolveReviewThread(input:{threadId:$thread_id}){thread{id isResolved}}}'
-     ```
-
-   - Resolve only after the fix is pushed. Do not resolve threads that were merely acknowledged,
-     still need reviewer input, failed validation, or were converted into a follow-up issue without
-     satisfying the current PR.
-   - Re-query review threads after resolution and verify that each addressed thread reports
-     `isResolved: true` before saying the review comments are resolved:
-
-     ```bash
-     gh api graphql \
-       -F owner=<owner> \
-       -F repo=<repo> \
-       -F number=<pr_number> \
-       -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{id body path line url}}}}}}}'
-     ```
-
-   - If GraphQL auth, rate limits, or permissions block resolution, leave the PR comment or final
-     handoff explicit: fixes were pushed, but the named review thread ids remain unresolved.
-
-## Notes
-
-- Prefer `gh pr view` and `gh pr diff` over manual web browsing.
-- If no PR exists for the current branch, ask the user to open one or provide a PR number.
-- Post multiline comments using a body file, not escaped `\n`:
-  - Preferred helper: `scripts/dev/gh_comment.sh pr --current <<'EOF' ... EOF`
-  - Alternative: `gh pr comment <num> --body-file <file>`
+- Which comments were fixed,
+- validation command and result,
+- commit SHA pushed,
+- resolved thread IDs,
+- remaining open threads/blockers.

--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -25,7 +25,7 @@ Use this on a writable PR branch when actionable review feedback exists.
 4. Apply minimal edits grouped by concern.
 5. Run appropriate validation (prefer targeted first; full suite only when needed by risk).
 6. Commit and push.
-7. Resolve only addressed threads using `resolveReviewThread` mutation inputs.
+7. Resolve only addressed threads using the `resolveReviewThread` mutation via `gh api graphql`.
 8. Re-check thread state; report any unresolved items with blocker reason (permissions, rate limits, or
    external dependency).
 

--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -25,7 +25,8 @@ Use this on a writable PR branch when actionable review feedback exists.
 4. Apply minimal edits grouped by concern.
 5. Run appropriate validation (prefer targeted first; full suite only when needed by risk).
 6. Commit and push.
-7. Resolve only addressed threads using `resolveReviewThread` mutation inputs.
+7. Resolve only addressed threads using the `resolveReviewThread` mutation through
+   `gh api graphql`.
 8. Re-check thread state; report any unresolved items with blocker reason (permissions, rate limits, or
    external dependency).
 

--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -31,7 +31,8 @@ Freshness check:
 5. Classify generated artifacts from `output/` (discard/ignored/cache/durable evidence).
 6. Run the review audit checklist for changed workflow/skill area.
 7. Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-8. Open draft PR.
+8. Open draft PR using
+   `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`.
 9. Keep parent issue open unless repository policy indicates closure wording in PR description.
 
 ## Proof and Artifact Rules

--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -31,7 +31,8 @@ Freshness check:
 5. Classify generated artifacts from `output/` (discard/ignored/cache/durable evidence).
 6. Run the review audit checklist for changed workflow/skill area.
 7. Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-8. Open draft PR.
+8. Open draft PR:
+   `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`.
 9. Keep parent issue open unless repository policy indicates closure wording in PR description.
 
 ## Proof and Artifact Rules

--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -1,148 +1,58 @@
 ---
 name: gh-pr-opener
-description: "Open Robot SF PRs with MCP-first GitHub interaction, explicit issue-scope verification, and a conservative PR-readiness freshness gate."
+description: "Open a conservative Robot SF PR with scope verification, freshness checks, and artifact discipline."
 ---
 
 # GH PR Opener
 
-## Overview
+Use this when a branch is ready for PR handoff and must follow Repository-grade evidence rules.
 
-Use this skill when a branch is ready to be handed off as a GitHub PR and the repository wants a
-standard, conservative opening flow.
+## Key Guardrail
 
-Prefer GitHub MCP / GitHub app tools for interactive issue and PR inspection when available.
-Keep the concrete `gh` commands below as the deterministic fallback for PR creation, readiness
-verification, and metadata operations that still need CLI scripting.
+Fail-closed policy: do not open a PR until scope is implemented, proof is fresh, and artifacts are
+classified.
 
-This skill is fail-closed by design:
+## Preconditions
 
-- It does **not** open a PR until the linked issue scope appears implemented.
-- It does **not** trust old validation blindly.
-- It uses `.github/PULL_REQUEST_TEMPLATE/pr_default.md` as the PR body base.
+- Branch corresponds to a single clear issue scope.
+- Issue contract and PR diff match (or deferred work is captured by follow-up issues).
+- Current branch head differs from stale readiness stamps (freshness required).
 
-## Freshness Rule
-
-A prior readiness run counts as fresh only when all of the following are true:
-
-- the local stamp file for the current branch exists,
-- `status == "passed"`,
-- the stamped branch matches the current branch,
-- the stamped `head_sha` matches `git rev-parse HEAD`,
-- the stamped `base_ref` matches the intended PR base (default `origin/main`),
-- and the stamp is at most 24 hours old.
-
-Canonical helper:
-
+Freshness check:
 - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
-
-If freshness cannot be proven, rerun:
-
-- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-
-After a successful rerun, record freshness evidence:
-
-- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
+- If stale/failing, rerun `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` and write freshness.
 
 ## Workflow
 
-1. Confirm branch + issue context
-   - `git branch --show-current`
-   - `gh issue view <n> --json number,title,body,url,state`
-   - Stop if the issue is closed, superseded, or the branch is unrelated.
+1. Confirm branch/issue alignment.
+2. Verify scope completion and linked issue status.
+3. Sync latest `origin/main`, then rebase/merge according to repo policy.
+4. Recheck readiness freshness post-sync.
+5. Classify generated artifacts from `output/` (discard/ignored/cache/durable evidence).
+6. Run the review audit checklist for changed workflow/skill area.
+7. Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
+8. Open draft PR.
+9. Keep parent issue open unless repository policy indicates closure wording in PR description.
 
-2. Verify the issue scope is actually implemented
-   - Read the issue goal, scope, acceptance criteria, and definition of done.
-   - Review `git diff origin/main...HEAD --stat` and targeted file diffs.
-   - Check that each in-scope requirement is either implemented now or explicitly deferred into a
-     linked follow-up issue.
-   - If the issue is only partially done, do not open the PR yet.
+## Proof and Artifact Rules
 
-3. Sync with latest main before opening the PR
-   - `git fetch origin main`
-   - Merge or rebase the latest `origin/main` into the feature branch before PR creation.
-   - Treat any readiness result from before the latest-main sync as stale.
+- PR body must state:
+  - implementation summary,
+  - validation evidence,
+  - artifact classification and provenance decision,
+  - follow-up issues, if any.
+- Do not commit large temporary artifacts from `output/`; use manifests or external artifact pointers.
 
-4. Check local artifact persistence before handoff
-   - Inspect ignored/generated outputs before PR creation:
-     - `git status --ignored --short -uall output`
-     - For likely durable artifacts, inspect size, timestamps, and hashes with `find output ...`,
-       `du -sh`, and `sha256sum`.
-   - Classify each relevant `output/` artifact as one of:
-     - disposable local byproduct,
-     - safe ignored cache,
-     - small reviewable evidence that should be copied under `docs/context/evidence/`,
-     - needs a tracked manifest/registry pointer,
-     - or must be uploaded to durable storage before PR handoff.
-   - Treat benchmark bundles, model checkpoints, W&B run outputs, policy-analysis reports, and
-     any config dependency under `output/model_cache` as durable-candidate artifacts.
-   - Promote only compact, reviewable evidence into git: selected `summary.json` files, Markdown
-     reports, small CSV/JSON tables, and checksums. Do not commit raw episode JSONL, videos, large
-     Slurm logs, coverage HTML, model caches, or checkpoints unless they are deliberately small
-     regression fixtures.
-   - If an ignored artifact is reproducible from tracked configs, seeds, commands, and commit SHAs,
-     document that it is safe to leave ignored or delete locally. Use external artifact storage
-     rather than git for large non-regenerable bundles, and track the manifest/pointer.
-   - Do not propose Git LFS by default. Use it only for deliberately versioned, non-regenerable
-     binary fixtures after an explicit maintainer decision.
-   - If code or configs depend on an ignored local model/checkpoint, make that dependency
-     persistent before opening the PR, preferably through `model/registry.yaml` with W&B metadata
-     such as `wandb_artifact_path`, or another explicit durable artifact reference.
-   - Record the persistence decision in the PR body or a linked `docs/context/` note.
+## Anti-Loop / Race Rules
 
-5. Verify readiness freshness after the sync
-   - Run:
-     - `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
-   - If the helper exits non-zero or returns non-fresh JSON, rerun:
-     - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-     - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main`
+- Never rely on stale validation after branch/head changes.
+- If issue/branch linkage changes mid-flow, stop and recompute handoff state.
+- Avoid force-push during PR open flow.
 
-6. Run the first-pass self-review
-   - Use `docs/context/pr_first_pass_review_audit_2026-05-14.md` as the reviewer-lens checklist.
-   - For docs/context changes, verify index links and make validation statements match commands
-     actually run.
-   - For parser, schema, path, JSON, artifact, and public-helper changes, check malformed inputs,
-     missing values, empty collections, wrong shapes, non-finite numbers, path traversal, and
-     repository-relative path handling.
-   - For environment, benchmark, recording, and simulation-loop changes, check streaming behavior,
-     static Gymnasium spaces, random-state isolation, and per-step output size.
-   - For skill or workflow changes, read the changed text as executable instructions and make scope
-     boundaries, selected issue sets, and evidence destinations explicit.
+## Required Output
 
-7. Build the PR body from the repository template
-   - Start from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-   - Fill sections with repository-specific evidence:
-     - summary of implementation,
-     - linked issue (`Closes #<n>` when appropriate),
-     - validation commands actually run,
-     - risks/limitations,
-     - artifact persistence decisions for generated `output/` files,
-     - docs/provenance references,
-     - follow-up issues if any.
-   - Do not remove sections; keep the template structure intact.
-
-8. Open the draft PR
-   - Preferred command:
-     - `gh pr create --draft --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`
-   - Use a conventional commit/PR title prefix such as `feat:`, `fix:`, or `docs:`.
-
-9. Close the loop
-   - Keep the parent issue open while the PR is draft unless repository policy says otherwise.
-   - Comment on the issue or PR when a follow-up item was intentionally deferred.
-
-## Required Evidence
-
-- Current issue scope reviewed against the actual branch diff.
-- Latest `origin/main` integrated into the feature branch before PR creation.
-- Ignored/generated `output/` artifacts inspected, classified, and either made durable or
-  documented as disposable/local-only.
-- First-pass self-review completed against `docs/context/pr_first_pass_review_audit_2026-05-14.md`.
-- Fresh readiness proof from either:
-  - a passing `pr_ready_freshness.py status`, or
-  - a new `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` run plus a new stamp.
-- PR body based on `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-
-## Notes
-
-- The readiness stamp is local branch evidence under `output/validation/pr_ready/`; this keeps the
-  rule explicit and reproducible without changing `scripts/dev/pr_ready_check.sh`.
-- Conservative behavior is preferred over skipping validation by mistake.
+- PR opened URL,
+- branch SHA at open time,
+- freshness evidence source,
+- artifact decision,
+- follow-up issues created.

--- a/.agents/skills/goal-issue-discovery/SKILL.md
+++ b/.agents/skills/goal-issue-discovery/SKILL.md
@@ -1,19 +1,34 @@
 ---
 name: goal-issue-discovery
-description: "Autonomous goal loop that scans Robot SF for improvement opportunities and opens evidence-graded GitHub issues."
+description: "Use for an autonomous Robot SF issue-discovery loop that finds bounded improvement opportunities and creates evidence-graded GitHub issues; not for implementation."
 ---
 
 # Goal Issue Discovery
 
-## Overview
+Use this skill when the user wants a bounded, low-noise issue discovery pass.
 
-Use this skill when the user wants an autonomous pass that finds possible bugs, performance gains,
-research ideas, feature opportunities, documentation gaps, or maintainability improvements and turns
-them into detailed GitHub issues.
+This skill orchestrates:
+- `gh-issue-creator`
+- `gh-issue-sequencer`
+- `gh-issue-priority-assessor`
+- `agentic-eval`
+- `auto-improvement`
+- `autoresearch`
+- `context-map`
 
-This is a goal-driven orchestration skill. It reuses `gh-issue-creator`, `gh-issue-sequencer`,
-`gh-issue-priority-assessor`, `context-map`, `agentic-eval`, `auto-improvement`, and
-`autoresearch` instead of replacing them.
+It does not implement issues. It defines scope, evidence quality, duplication control, and stop
+conditions.
+
+## Trigger Boundary
+
+Use this skill when the user asks to discover, scan, audit, or collect improvement opportunities and
+turn them into GitHub issues.
+
+Do not use it for:
+- implementing an existing issue,
+- reviewing or fixing a PR,
+- broad research synthesis without issue creation,
+- one-off issue drafting when `gh-issue-creator` is sufficient.
 
 ## Read First
 
@@ -24,87 +39,94 @@ This is a goal-driven orchestration skill. It reuses `gh-issue-creator`, `gh-iss
 - `.agents/skills/gh-issue-creator/SKILL.md`
 - `.agents/skills/gh-issue-sequencer/SKILL.md`
 - `.agents/skills/context-map/SKILL.md`
+- `scripts/dev/check_skills.py` (for local syntax/shape sanity)
 
-## Preflight
+## Preflight (required, once)
 
-At the start of each goal, state:
+State these items before discovery:
+- Scope: repo, benchmark, planner, docs, tests, performance, or explicit paths.
+- Lane policy: one bounded lane per pass unless user requests broad mode.
+- Write mode: issue creation + Project #5 updates allowed by default.
+- Stop condition set: time budget, blocker, API/auth failure, or user stop.
+- Exclusions: user-requested areas or explicit skip files.
 
-- discovery scope, such as whole repo, benchmark, planner, docs, tests, or performance,
-- write mode: autonomous GitHub issue creation and Project #5 routing are allowed by default,
-- stop condition: queue exhausted, explicit time budget reached, auth/API failure, or validation
-  blocker,
-- exclusions, if the user supplied any.
+Do not request additional confirmation for this preflight.
 
-Do not ask for confirmation after the preflight unless the user explicitly requests a gated run.
+## State Machine
 
-## Evidence Grades
+Each candidate is in exactly one state:
+- `candidate`
+- `duplicate`
+- `needs_more_evidence`
+- `issue_ready`
+- `issue_created`
+- `issue_updated`
+- `skipped`
 
-Every issue created by this loop must include one evidence grade in the issue body:
+Do not revisit `duplicate` or `skipped` in the same run unless new evidence appears.
 
-- `observed`: backed by a failing command, code path, stale doc, TODO, benchmark output, or other
-  directly inspected repo evidence.
-- `inferred`: supported by repository structure or repeated patterns, but not yet proven by an
-  executable failure.
-- `proposal`: a broad feature, research, or improvement idea that is useful enough to track even
-  without current failure evidence.
+## Evidence Grade (required)
 
-Do not present `proposal` issues as bugs or benchmark regressions.
+Choose one:
+- `observed`: backed by direct evidence (command output, failing tests, code path, benchmark output,
+  stale doc, TODO, trace).
+- `inferred`: likely pattern or gap from structure or repeated behavior.
+- `proposal`: valuable idea without immediate executable evidence.
+
+Use `proposal` for ideas only; do not frame as bugs/regressions.
+
+## Candidate Readiness
+
+Open or update only candidates with:
+- bounded scope and clear problem/opportunity statement,
+- affected area (files, docs, workflow, benchmark),
+- evidence grade,
+- falsification plan (how to prove it wrong),
+- explicit non-goals,
+- definition of done,
+- estimated value or risk.
+
+Split broad ideas before writing.
 
 ## Workflow
 
-1. Establish context
-   - Inspect `git status --short --branch`.
-   - Read local machine guidance if present before expensive checks.
-   - Pick one bounded discovery lane per pass unless the user explicitly asks for a broad scan.
+1. Establish lane and scan surface.
+2. Collect candidates from repo-native sources (TODOs, failed or disabled tests, context notes, issue
+   gaps, benchmark notes, docs staleness, API friction points).
+3. For each candidate:
+   - classify state,
+   - set evidence grade,
+   - record confidence (high if direct signal, medium if one-step derived, low if speculative).
+4. De-duplicate against open/closed issues before creation.
+5. Draft/update through `gh-issue-creator` only when state is `issue_ready`.
+6. Route Project #5 metadata in a single batch pass with score sync once at the end.
+7. Stop on no new candidates, budget/time expiry, or blocked writes.
 
-2. Search for candidates
-   - Prefer repo-native sources: open TODOs, failing or skipped tests, stale docs, complexity or
-     timing helpers, benchmark notes, issue-linked context notes, and recent PR/issue patterns.
-   - For benchmark or planner ideas, inspect the relevant context notes before making claims.
-   - Use Spark subagents only for bounded sidecar discovery, such as locating APIs or summarizing a
-     small directory. The main agent owns issue creation and final judgment.
+## Proof, Validation, and Artifact Rules
 
-3. De-duplicate before writing
-   - Search open and closed issues with REST-backed `gh api` calls when GraphQL quota is low; use
-     `gh issue list` and `gh issue search` only when available and affordable.
-   - If a related issue exists, update or comment on that issue instead of creating a duplicate.
-   - If the existing issue is too broad, create a child/follow-up issue and link both directions.
+- Do not use local `output/` contents as proof unless tracked or durably referenced.
+- Do not count fallback/degraded/fail-open benchmark runs as successful proof.
+- Benchmark/planner candidates must name scenario set, seeds/source evidence, and expected
+  reproduction command.
+- Any paper-facing statement from discovery evidence is forbidden.
 
-4. Draft issues through the repo template
-   - Use `.agents/skills/gh-issue-creator/SKILL.md`.
-   - Include: evidence grade, concise goal/problem, scope/non-goals, affected files, validation
-     path, risk, estimated value, and definition of done.
-   - Use existing labels only unless the discovery itself justifies a new label.
-   - Route Project #5 metadata in a separate batch pass.
+## Anti-Loop and Race Conditions
 
-5. Batch project metadata
-   - Follow `docs/context/issue_713_batch_first_issue_workflow.md`.
-   - Cache Project #5 IDs once per shell session or in the local Project #5 cache for
-     longer runs.
-   - Use REST/local `git` for non-project state; reserve GraphQL budget for Project #5 writes.
-   - Set status and priority conservatively, then run score sync once if score inputs changed.
+- Stop revisiting candidates already marked `issue_created`, `issue_updated`, `duplicate`, or `skipped`
+  unless new evidence arrives.
+- Before creating an issue, re-check open/closed state to avoid duplicate creation races.
+- Use a single lane by default.
 
-6. Stop and hand off
-   - Stop when no more credible candidates remain, the time budget is reached, or GitHub/project
-     writes fail.
-   - If stopped early, write a concise handoff note or issue comment listing scanned areas,
-     created/updated issues, skipped candidates, and the next recommended lane.
+If API/project writes fail repeatedly, emit a short handoff and stop.
 
-## Guardrails
-
-- Broad ideas are allowed, but issue bodies must make uncertainty explicit.
-- Do not rely on local `output/` artifacts as durable evidence unless they are promoted or linked
-  through an accepted artifact path.
-- Do not classify fallback or degraded benchmark execution as success evidence.
-- Do not create large umbrella issues when separate bounded issues would be more executable.
+For benchmark or planner issues, use `review-benchmark-change` semantics before claim-like wording.
+- Do not make paper-facing claims from discovery evidence alone.
 
 ## Output Requirements
 
-Report:
-
 - discovery scope and stop condition,
-- areas inspected,
-- issues created or updated, with evidence grade,
-- duplicates avoided,
-- Project #5 writes and score sync status,
-- remaining candidate areas or blockers.
+- candidates seen by state and confidence,
+- created/updated issues with grade + evidence,
+- duplicates intentionally avoided,
+- Project #5 writes + score-sync status,
+- deferred/blocked candidates and race failures.

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -1,110 +1,178 @@
 ---
 name: goal-issue-implementation
-description: "Autonomous goal loop that sequentially implements eligible open issues, validates, pushes, and opens PRs."
+description: "Use for an autonomous Robot SF issue-to-PR loop that selects eligible GitHub issues, implements one scoped issue at a time, validates, pushes, and opens PRs."
 ---
 
 # Goal Issue Implementation
 
-## Overview
+Use this skill when the user asks for goal-driven implementation of open issues.
 
-Use this skill when the user wants open issues implemented as a goal-driven queue. The default
-execution model is sequential: select one eligible issue, create one branch, implement, validate,
-push, open one PR, then move to the next eligible issue.
+It is an orchestrator over:
 
-This is an orchestration layer over `gh-issue-sequencer`, `gh-issue-autopilot`,
-`implementation-verification`, `pr-ready-check`, `gh-pr-opener`, and `context-note-maintainer`.
+- `gh-issue-sequencer`
+- `gh-issue-autopilot`
+- `implementation-verification`
+- `pr-ready-check`
+- `gh-pr-opener`
+- `gh-issue-creator`
+- `context-note-maintainer`
+
+It does not define subordinate command details; it standardizes queue policy, evidence and proof
+requirements, and loop boundaries.
+
+## Trigger Boundary
+
+Use this skill when the user asks to implement open issues through branches, validation, and PRs.
+
+Do not use it for:
+- ambiguous issues that need clarification before coding,
+- discovering new work without implementation,
+- reviewing existing PRs,
+- merging PRs or rewriting contributor history.
 
 ## Read First
 
 - `AGENTS.md`
 - `docs/dev_guide.md`
+- `docs/code_review.md`
 - `docs/context/goal_driven_agent_loops_2026-05-13.md`
 - `docs/context/issue_713_batch_first_issue_workflow.md`
-- `.agents/skills/gh-issue-sequencer/SKILL.md`
-- `.agents/skills/gh-issue-autopilot/SKILL.md`
 - `.agents/skills/implementation-verification/SKILL.md`
 - `.agents/skills/pr-ready-check/SKILL.md`
+- `.agents/skills/gh-pr-opener/SKILL.md`
+- `.agents/skills/context-note-maintainer/SKILL.md`
+- `.github/PULL_REQUEST_TEMPLATE/pr_default.md`
 
 ## Preflight
 
-At the start of each goal, state:
+Record at start:
+- Issue source: queue filter, explicit list, Project #5 lane, or open-issues sweep.
+- Write permissions: branch/commit/PR/project writes allowed by default.
+- Stop condition: queue exhausted, time budget reached, ambiguous issue contract, environment/auth blocker,
+  validation dead-end, user stop.
+- Exclusions: benchmarks blocked by environment, blocked/decision-required issues, external-only work.
 
-- queue source: Project #5, label/milestone filter, explicit issue list, or all open issues,
-- write mode: branch creation, issue/project updates, commits, pushes, PR creation, and follow-up
-  issues are allowed by default,
-- stop condition: eligible queue exhausted, optional time budget reached, unclear issue contract,
-  validation blocker, GitHub/auth failure, or user stop,
-- exclusions, such as benchmark runs, GPU-only work, blocked issues, or paper-facing claims.
+Do not ask for extra confirmation after this preflight.
 
-Do not ask for confirmation after this preflight unless the user requested a gated run.
+## State Machine
 
-## Eligibility Policy
+Each issue is in exactly one state during the loop:
+- `queued`
+- `ineligible`
+- `selected`
+- `implementing`
+- `validating`
+- `blocked`
+- `pr_opened`
+- `deferred_followup`
+- `skipped`
 
-An issue is eligible when:
+Allowed transitions:
+`queued -> selected -> implementing -> validating -> pr_opened` with terminal `blocked`, `deferred_followup`,
+or `skipped` exits.
 
-- it is open,
-- it is not labeled `blocked`, `decision-required`, `duplicate`, `wontfix`, or `invalid`,
-- it has no linked open PR that already covers the scope,
-- its problem, scope, acceptance criteria, and validation path are clear enough to implement,
-- its required execution environment is available or has a documented fallback that does not weaken
-  the issue contract.
+Do not revisit `blocked` or `skipped` issues in the same goal run unless one of these changed:
+- issue body/labels,
+- linked PR state,
+- required environment,
+- linked issue policy/baseline.
 
-If eligibility fails, route the issue through `issue-audit`, `gh-issue-clarifier`, or
-`gh-issue-template-auditor` instead of guessing.
+## Eligibility
 
-## Workflow
+Process only when all are true:
+- issue is open and not labeled blocked/invalid/duplicate/decision-required,
+- scope is clear and bounded,
+- acceptance criteria are inferable without changing intent,
+- proof path is available or has a documented fallback that preserves contract,
+- implementation can fit in one coherent PR.
 
-1. Sequence the queue
-   - Use `.agents/skills/gh-issue-sequencer/SKILL.md`.
-   - Prefer Project #5 `Ready`, then `Todo`, then `Tracked`, ordered by priority and uncertainty.
-   - Keep benchmark/paper-facing blockers ahead of speculative experiments when priorities tie.
+If not eligible:
+- send to `issue-audit` or `gh-issue-clarifier`,
+- or create follow-up issue via `gh-issue-creator`.
 
-2. Execute exactly one issue at a time
-   - Use `.agents/skills/gh-issue-autopilot/SKILL.md`.
-   - Sync with latest `origin/main` at the start of active work and before PR creation.
-   - Create an issue branch with `gh issue develop` when possible.
-   - Keep scope tied to the issue contract.
+## Queue Policy
 
-3. Implement and prove
-   - Add or update tests/docs with the implementation when needed.
-   - Run targeted proof first, then the repository readiness gate:
-     `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-   - For benchmark or planner changes, require real executable evidence and treat fallback or
-     degraded execution as a caveat, not success.
+Default order:
+1. Project `#5 Ready`
+2. Project `#5 Todo`
+3. Project `#5 Tracked`
+4. explicitly requested
+5. other eligible open issues
 
-4. Handoff through PR
-   - Inspect generated `output/` artifacts and classify them as disposable, ignored cache,
-     tracked manifest/pointer, or durable-upload required.
-   - Commit in logical conventional commits.
-   - Push and open a PR with `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
-   - Create follow-up issues for deferred scope before closing the loop.
+Prioritize by:
+- clearer contract,
+- lower validation cost,
+- smaller diff,
+- less semantic risk,
+- older queue age.
 
-5. Continue the queue
-   - After a PR is open, return to step 1 for the next eligible issue.
-   - If the stop condition fires, write a concise handoff with current branch, issue, validation
-     state, blockers, and next command.
+## Process
 
-## Subagent Policy
+1. Select one issue (`gh-issue-sequencer` output or explicit user target).
+2. Create/checkout isolated implementation branch.
+3. Implement only in-scope behavior and required tests/docs.
+4. Validate using the narrowest meaningful level first, then expand.
+5. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
+6. Prepare proof and branch handoff via `gh-pr-opener`.
+7. Open PR, then report and move to next queue item.
 
-Use `gpt-5.3-codex-spark` subagents only for bounded side tasks such as file/API lookup, small test
-failure summaries, or narrow mechanical edits with clear file ownership. The main agent owns issue
-selection, final integration, validation, push, PR creation, and final judgment.
+Never run unrelated refactors or paper-facing claims in this loop.
 
-## Guardrails
+## Validation Tiers
 
-- Do not process multiple implementation branches in parallel by default.
-- Do not close issues before the PR/merge process resolves them unless the issue is explicitly
-  obsolete or duplicated and the GitHub update records why.
-- Do not let readiness checks from before the latest-main sync count for PR creation.
-- Do not depend on worktree-local `output/` contents without a durable source.
+Use the minimum required tier for changed surfaces:
 
-## Output Requirements
+- Tier 0: documentation-only and metadata-only changes, small mechanical code.
+- Tier 1: CLI/runtime changes, interfaces, shared utility wiring.
+- Tier 2: benchmark mode, metric, or planner-sensitive behavior.
+- Tier 3: campaign-level or statistical evidence changes.
 
-Report:
+Before PR creation, rerun freshness gate after latest `origin/main` sync.
+Do not use stale validation as proof.
 
-- selected issue and why it was eligible,
-- branch and PR URL,
-- validation commands and results,
-- artifact persistence decision,
-- follow-up issues created,
-- stop condition if the loop ended before queue exhaustion.
+## Proof and Artifact Rules
+
+- Do not count benchmark fallback/degraded execution as success unless task scope explicitly says so.
+- Classify all generated outputs before commit:
+  - `discard`, `ignored-cache`, `tracked-manifest`, `durable-required`.
+- Benchmark artifacts must include command, config, seeds, commit SHA, and provenance before PR handoff.
+- If a durable dependency cannot be guaranteed locally, stop with a blocker.
+
+## Confidence
+
+Use one confidence level for final reporting:
+- `High`: proof completed and current for branch head.
+- `Medium`: evidence exists but depends on external CI or temporary constraints.
+- `Low`: required proof/auth/benchmark path unavailable.
+
+Never close an issue with `Low` proof without explicitly marking follow-up work.
+
+## Anti-Loop and Retry
+
+- Do not rerun identical failed validations more than twice without meaningful code/env change.
+- If a candidate fails the same gate with no new signal, move to `blocked` and record:
+  - failing command,
+  - last error,
+  - next minimal action.
+
+## Race-Condition / Multi-Agent Safety
+
+- Operate one implementation branch at a time by default.
+- Before pushing, verify branch state is expected and avoid rewriting branch history.
+- If remote branch changed unexpectedly:
+  - stop,
+  - inspect divergence,
+  - avoid force-push,
+  - hand off with blocker details.
+
+## Required Output
+
+For each issue completed or stopped, report:
+- issue number and eligibility decision,
+- current and next state,
+- branch name + head SHA,
+- validation commands and pass/fail results,
+- artifact decision,
+- PR URL when opened,
+- follow-up issues,
+- blocker and next action.

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -1,19 +1,33 @@
 ---
 name: goal-pr-review
-description: "Autonomous goal loop that reviews open PRs, fixes safe actionable gaps, and applies merge-ready after full proof."
+description: "Use for an autonomous Robot SF PR review loop that fixes scoped review gaps, validates proof, resolves review threads, and applies merge-ready; not for merging."
 ---
 
 # Goal PR Review
 
-## Overview
+Use this skill when the user wants a scoped loop over PRs, including fix-safe review actions and
+`merge-ready` gating.
 
-Use this skill when the user wants an autonomous review loop over open PRs. The loop reviews each PR
-against its linked issue contract, checks proof quality, fixes safe actionable gaps on writable PR
-branches, captures deferred work as follow-up issues, and applies `merge-ready` only when the full
-proof bar passes.
+It orchestrates:
 
-This skill reuses `implementation-verification`, `pr-ready-check`, `gh-pr-comment-fixer`,
-`review-benchmark-change`, `gh-issue-creator`, and `context-note-maintainer`.
+- `implementation-verification`
+- `pr-ready-check`
+- `gh-pr-comment-fixer`
+- `review-benchmark-change`
+- `gh-issue-creator`
+- `context-note-maintainer`
+
+Do not let this file absorb subordinate mechanics; keep it as the high-level review contract.
+
+## Trigger Boundary
+
+Use this skill when the user asks to review, fix, verify, or mark open PRs as merge-ready.
+
+Do not use it for:
+- implementing new issues from the queue,
+- broad repository discovery,
+- passive code review where no PR state may be changed,
+- merging PRs.
 
 ## Read First
 
@@ -23,144 +37,99 @@ This skill reuses `implementation-verification`, `pr-ready-check`, `gh-pr-commen
 - `docs/context/goal_driven_agent_loops_2026-05-13.md`
 - `.github/PULL_REQUEST_TEMPLATE/pr_default.md`
 - `.agents/skills/implementation-verification/SKILL.md`
-- `.agents/skills/pr-ready-check/SKILL.md`
 - `.agents/skills/gh-pr-comment-fixer/SKILL.md`
 - `.agents/skills/review-benchmark-change/SKILL.md`
-- `.agents/skills/gh-issue-creator/SKILL.md`
-- `.agents/skills/context-note-maintainer/SKILL.md`
 
 ## Preflight
 
-At the start of each goal, state:
+Declare at start:
+- PR set (all open, non-draft, filtered, or explicit numbers),
+- write mode (fix/comment/issue creation/`merge-ready` allowed by default),
+- exclusions (drafts, heavy benchmark PRs, external infra blockers),
+- stop condition.
 
-- PR set: all open PRs, non-draft PRs, a label/milestone filter, or explicit PR numbers,
-- write mode: PR branch fixes, commits, pushes, PR comments, issue comments, follow-up issue
-  creation, thread resolution when appropriate, Project #5 routing, and `merge-ready` labeling are
-  allowed by default,
-- stop condition: PR queue exhausted, optional time budget reached, validation blocker,
-  GitHub/auth failure, or user stop,
-- exclusions, such as drafts, PRs by a specific author, benchmark-heavy validation, or external CI
-  blockers.
+Create `merge-ready` label if absent before first successful application.
 
-Create the `merge-ready` label if it does not exist before the first successful application.
+## State Machine
 
-## Full Proof Bar
+Each PR is in one state:
+- `queued`
+- `under_review`
+- `fixing`
+- `awaiting_ci`
+- `awaiting_reviewer`
+- `blocked_external`
+- `deferred_scope`
+- `merge_ready`
+- `closed_out`
 
-Apply `merge-ready` only when all are true:
+Avoid loops:
+- do not bounce `fixing` ↔ `awaiting_ci` without changes affecting proof.
 
-- the PR links one or more issues or has an explicit standalone scope,
-- each linked issue contract is resolved or correctly narrowed,
-- the diff matches the stated scope and does not hide unrelated changes,
-- tests, CI, or `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` provide adequate proof,
-- benchmark/planner changes have benchmark-safe evidence and do not count fallback/degraded
-  execution as success,
-- unresolved review threads are fixed and resolved on GitHub, converted into follow-up issues, or
-  left open with an explicit blocker that prevents safe resolution,
-- generated `output/` artifacts are classified and durable dependencies are represented,
-- deferred but important work has dedicated GitHub issues linked from the PR.
+## Review Workflow
 
-If any item fails, leave a concise review comment or issue/PR follow-up and do not apply
-`merge-ready`.
+1. Build queue snapshot (labels, draft status, checks, last update time).
+2. Sort/prioritize queue (or follow explicit user order).
+3. For each PR:
+   - capture issue link and head SHA,
+   - run `implementation-verification` for contract alignment,
+   - classify findings as fixable now, deferred, or blocker.
+4. Fix actionable items on writable branches; commit and push.
+5. Validate per required tier.
+6. Resolve review threads only after push and verification.
+7. Update `merge-ready` only after full proof bar closes.
 
-Before leaving that comment, first try to fix every failing item that is safely fixable on the PR
-branch. A passive "not merge-ready" comment is the fallback only after fixes are impossible, unsafe,
-blocked, or still insufficient after validation.
+## Proof and Validation
 
-## Fix-First Decision Tree
+Apply minimum tier by change surface:
 
-Classify each unmet requirement before commenting:
+- Tier 0: documentation and formatting scope with targeted checks and lint.
+- Tier 1: integration and replay changes, CLI runtime smoke, PR readiness.
+- Tier 2: planner, metric, scenario, and benchmark behavior.
+- Tier 3: campaign-level statistical claims or paper-facing evidence.
 
-- Fixable now:
-  - the PR branch is checked out or can be checked out,
-  - the branch is writable and can be pushed without force-push or history rewrite,
-  - the fix stays inside the linked issue or explicit PR scope,
-  - the change is mechanical or evidence-backed, such as lint, formatting, missing docs, missing
-    validation note, generated-artifact classification, a small test adjustment, or a clear review
-    comment fix.
-- Deferred follow-up:
-  - the finding is real but outside the current PR contract,
-  - the fix would broaden scope or require separate design,
-  - the current PR can still satisfy its issue after a dedicated follow-up issue is created with
-    `gh-issue-creator`.
-- Handoff-only blocker:
-  - author intent is unclear,
-  - the issue contract is ambiguous,
-  - the branch is not writable,
-  - required proof depends on unavailable credentials, external services, unavailable CI, heavy
-    benchmark infrastructure, or maintainer decisions.
+`merge-ready` conditions:
+- linked issue contract satisfied or intentionally narrowed with follow-up issues,
+- scope matches contract and tests and CI proof are current for reviewed SHA,
+- unresolved review threads closed via GitHub review-thread resolution,
+- artifacts from `output/` are durably represented or explicitly excluded,
+- benchmark evidence no longer depends on fallback/degraded execution.
 
-For fixable-now gaps, edit the PR branch, run the narrowest relevant validation, commit, push, and
-then reassess the full proof bar. Use `gh-pr-comment-fixer` for review-thread/comment fixes,
-`implementation-verification` to map repaired claims back to code, docs, and tests,
-`pr-ready-check` when readiness proof is needed, and `gh-issue-creator` for deferred follow-ups.
-For missing-proof repairs not tied to review threads, use `implementation-verification` to identify
-the smallest code, test, or docs patch, then apply that patch directly on the writable PR branch.
-Do not duplicate those skills' detailed procedures here.
+If one condition fails, withhold label and emit a blocker comment/follow-up.
 
-## Workflow
+## Confidence
 
-1. Build the PR queue
-   - Inspect open PRs with labels, draft state, review decision, checks, linked issues, and update
-     time.
-   - Skip drafts unless the user includes them.
-   - Prefer PRs with no `merge-ready` label and older update time first, unless priority is clear.
+Only `High` confidence PRs can receive `merge-ready`.
 
-2. Review one PR at a time
-   - Read PR body, linked issues, changed files, CI/checks, review threads, and relevant context
-     notes.
-   - Use `implementation-verification` to map claims to code, docs, tests, and proof.
-   - Use `review-benchmark-change` for benchmark-sensitive PRs.
+Confidence meanings:
+- `High`: current proof for the reviewed head SHA with closed/blocked threads.
+- `Medium`: partial proof or heavy external dependency still open.
+- `Low`: missing proof, ambiguous contract, or unavailable environment.
 
-3. Resolve actionable gaps
-   - Check whether the PR branch is writable before editing. Prefer repository branches; treat fork
-     PRs as review-only unless the branch can be checked out and pushed through normal GitHub
-     permissions.
-   - Fix every fixable-now gap on the PR branch before leaving a "not merge-ready" comment.
-   - If review comments request fixes, use `gh-pr-comment-fixer` when the PR branch is checked out
-     and writable.
-   - If scope is deferred, create dedicated follow-up issues with `gh-issue-creator` and link them
-     from the PR.
-   - If evidence is missing but the proof can be produced locally, run the proof and update the PR
-     rather than asking the author to do it.
-   - If a blocker cannot be fixed safely, comment with the exact blocker and the smallest next
-     action needed.
+## Anti-Loop and Retry
 
-4. Apply or withhold `merge-ready`
-   - Apply `merge-ready` only after the full proof bar passes.
-   - Remove stale `merge-ready` if a later review finds the proof bar no longer passes.
-   - After any fix attempt, commit, push, and record the validation evidence before reassessing the
-     label.
-   - Before applying `merge-ready`, re-query review threads and verify that every addressed thread
-     has `isResolved: true`. A PR reply or summary comment does not resolve a review thread by
-     itself; use `gh-pr-comment-fixer`'s `resolveReviewThread` GraphQL step for fixed threads.
-   - Do not apply `merge-ready` when a fixed review thread remains unresolved only because the
-     resolution mutation was skipped, blocked by GraphQL auth/rate limits, or not verified.
-   - Leave a short PR comment summarizing the proof basis when applying the label.
-   - Leave a "not merge-ready" comment only when attempted fixes are impossible, unsafe, blocked, or
-     insufficient after validation.
+- Do not rerun the same failing validation twice without code/env change.
+- After two repeats, move to `blocked_external` or `awaiting_reviewer` with failure signature and next
+  action.
+- Do not repeat benchmark campaigns for docs-only or metadata-only PR changes.
 
-5. Continue or hand off
-   - Continue until the PR queue is exhausted or the stop condition fires.
-   - If stopped early, report reviewed PRs, labels changed, blockers, follow-up issues, and next PR.
+## Artifact and Race Rules
 
-## Guardrails
-
-- Do not treat passing CI alone as enough for `merge-ready`.
-- Do not mark a PR merge-ready if linked issues remain semantically unresolved.
-- Do not ignore open review threads; resolve fixed threads through GitHub's review-thread
-  resolution API, answer threads that need reviewer input, or convert out-of-scope work to
-  follow-up issues.
-- Do not make broad edits just to satisfy readiness; stay inside the issue/PR contract.
-- Do not rewrite contributor history or force-push unless the user explicitly authorizes it.
-- Do not merge PRs. This skill applies readiness signals only.
+- Before final handoff, inspect `output/` locally and classify generated artifacts as:
+  - discard
+  - ignored-cache
+  - evidence-manifest
+  - durable-required
+- For benchmark-heavy PRs, require scenario set, seed count, and provenance metadata.
+- Before pushing/fixing, verify remote PR head has not advanced unexpectedly.
+- Avoid force-push and concurrent mutation of the same branch.
 
 ## Output Requirements
 
-Report:
-
-- PRs reviewed,
-- fix commits pushed,
-- `merge-ready` labels applied or removed,
-- validation or CI evidence used,
-- follow-up issues created,
-- unresolved blockers and next recommended review target.
+For each reviewed PR, report:
+- PR number, head SHA, queue state transitions,
+- validation tier and executed commands,
+- fix commits,
+- `merge-ready` decision + confidence,
+- blockers and `follow-up` issues,
+- artifact classification decision.

--- a/.agents/skills/implementation-verification/SKILL.md
+++ b/.agents/skills/implementation-verification/SKILL.md
@@ -1,73 +1,39 @@
 ---
 name: implementation-verification
-description: "Verify current branch implementations against origin/main by mapping each claimed feature to code, docs, tests, and executable proof; use before PR handoff or after substantial changes when passing tests alone is not enough."
+description: "Verify branch changes against origin/main with claim-based evidence, not only test status."
 ---
 
 # Implementation Verification
 
-## Overview
+## Purpose
 
-Use this skill when the task is to prove that the current branch actually implements the intended
-features compared to `origin/main`, not merely that the repository test suite passes.
-
-Good triggers:
-- "verify this branch against main"
-- "check whether every feature works as designed"
-- "audit implementation proof before PR"
-- "compare current implementation to issue/PR claims"
-
-This skill complements `pr-ready-check`. Run readiness gates, but also inspect whether each changed
-behavior has direct evidence.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/code_review.md`
-- `docs/dev_guide.md`
-- `.specify/memory/constitution.md`
-- `.agent/PLANS.md` when the branch changes benchmark, training, or public workflow semantics
+Prove that branch changes implement the stated claims versus `origin/main`, with evidence per behavior
+rather than only a global test pass signal.
 
 ## Workflow
 
-1. Establish the comparison base
-   - Default to `origin/main`.
-   - Run `git status --short --branch`.
-   - Inspect `git diff --stat origin/main...HEAD` and `git diff --name-only origin/main...HEAD`.
-
-2. Extract implementation claims
-   - Read the issue, PR body, changelog entries, new docs, and test names.
-   - Convert claims into a short checklist of expected features or behavior changes.
-   - Separate intended behavior from incidental refactors.
-
-3. Map claims to evidence
-   - For each claim, identify the exact code path, docs/config surface, and tests or commands that
-     should prove it.
-   - Prefer repo-native entry points under `scripts/dev/`, committed configs, and targeted tests.
-   - If a feature has no direct proof path, mark it as a gap before running broad tests.
-
-4. Verify behavior
-   - Run the smallest targeted check for each feature first.
-   - Then run the appropriate broader gate, usually:
-     `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-   - For benchmark/planner changes, require benchmark-safe evidence and do not count fallback or
-     degraded execution as success unless that fallback is the explicit subject.
-
-5. Report an evidence matrix
-   - Include one row per claimed feature:
-     `Claim | Evidence surface | Validation command/artifact | Result | Residual risk`
-   - Distinguish observed evidence from inference.
-   - State any features that were changed but not proven, and create or recommend follow-up issues
-     when proof is out of scope.
-
-Example:
-
-| Claim | Evidence surface | Validation command/artifact | Result | Residual risk |
-| --- | --- | --- | --- | --- |
-| Legacy entrypoint fails closed | `scripts/training_ppo.py`, contract test | `uv run pytest tests/training/test_train_expert_ppo_contract.py` | Observed pass | External docs may still mention old command |
+1. Set baseline:
+   - `git status --short --branch`
+   - `git diff --stat origin/main...HEAD`
+   - `git diff --name-only origin/main...HEAD`
+2. Extract claims from issue/PR body, docs, and changed code/docs.
+3. Map each claim to a concrete evidence surface:
+   - scripts, configs, tests, CLI commands, or artifacts.
+4. Validate claim by claim:
+   - run minimal targeted checks first,
+   - then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` when broader validation is required.
+5. Include benchmark safety checks when relevant:
+   - explicitly classify fallback/degraded execution as a limitation, never as success.
+6. Record residual gaps where no direct proof path exists.
 
 ## Guardrails
 
-- Do not treat "tests pass" as sufficient unless the tests directly exercise the claimed behavior.
-- Do not broaden implementation scope while verifying; open follow-up issues for unrelated gaps.
-- Do not revert or rewrite user changes discovered during the diff review.
-- If `origin/main` is stale or unavailable, state the alternate base and why it was used.
+- Do not treat a passing test suite as sufficient if it does not exercise the claim.
+- Do not edit unrelated code while proving current claims.
+- If `origin/main` is unavailable, switch to an explicit documented base and note why.
+
+## Output
+
+- Evidence matrix (`claim`, `proof`, `command/artifact`, `result`, `residual risk`).
+- Items proven vs unresolved.
+- Recommended follow-up tickets for unproven claims.

--- a/.agents/skills/issue-audit/SKILL.md
+++ b/.agents/skills/issue-audit/SKILL.md
@@ -1,112 +1,42 @@
 ---
 name: issue-audit
-description: "User-in-the-loop open-issue audit that asks one readiness-blocking question at a time and updates GitHub issues as decisions are made."
+description: "User-in-the-loop open-issue audit that asks one readiness-blocking question at a time and updates issues as decisions are made."
 ---
 
 # Issue Audit
 
-## Overview
+## Purpose
 
-Use this skill when the user wants to refine open issues through a discussion loop. This is not a
-default `/goal` loop: it keeps the user in the loop, asks one question at a time, and updates issues
-as decisions crystallize.
-
-This skill combines a one-question-at-a-time interview pattern, document-grounded challenge and
-terminology checks, and the repository workflows in `gh-issue-template-auditor`,
-`gh-issue-clarifier`, `gh-issue-sequencer`, and `gh-issue-creator`. The interview pattern is
-described here directly so the skill does not depend on locally installed helper skills.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/dev_guide.md`
-- `docs/context/goal_driven_agent_loops_2026-05-13.md`
-- `docs/context/issue_713_batch_first_issue_workflow.md`
-- `.agents/skills/gh-issue-template-auditor/SKILL.md`
-- `.agents/skills/gh-issue-clarifier/SKILL.md`
-- `.agents/skills/gh-issue-sequencer/SKILL.md`
-
-## Preflight
-
-At the start of the audit, state:
-
-- issue set, such as all open issues, a label, a milestone, a Project #5 slice, or a numbered list,
-- write mode: issue edits, comments, labels, project routing, issue splits, and consolidation are
-  allowed after each user decision,
-- ordering: `decision-required` blockers first; if none exist, continue through all open issues by
-  Project #5 priority and look for refinements,
-- stop condition: all selected issues are ready/tracked/blocked with a reason, the user stops, or
-  an optional time budget is reached.
-
-## Ordering Policy
-
-Prioritize the next question by readiness impact:
-
-1. `decision-required`, contradictory, or missing core problem statement.
-2. Missing acceptance criteria, validation path, or scope/non-goals.
-3. Duplicate, consolidation, split, or parent/child ambiguity.
-4. `blocked` issues whose unblock condition is unclear.
-5. Stale issues whose body conflicts with current repo state.
-6. Lower-risk template cleanup and metadata normalization.
-
-When no open issue has a `decision-required` label, do not stop the audit. Continue across all open
-issues, starting with the highest Project #5 priority and then the strongest issue-level priority
-signals, and look for refinements that would make the issue more executable, better scoped, less
-duplicative, or easier to validate. Do not spend user attention on already-actionable issues until
-readiness blockers are exhausted.
+Refine open issues through a guided loop: one blocking question at a time, immediate edits on confirmed
+decisions, and clear handoff state.
 
 ## Workflow
 
-1. Gather issue state
-   - Inspect open issues and Project #5 items.
-   - Prefer REST issue reads (`gh api repos/ll7/robot_sf_ll7/issues/...`) when GraphQL quota is
-     low; reserve GraphQL/`gh project` calls for Project #5 state.
-   - Cache Project #5 IDs once per session or use the local Project #5 cache
-     described in `docs/context/issue_713_batch_first_issue_workflow.md`.
-   - Check for `decision-required` issues first. If none exist, build a priority-ordered open-issue
-     queue and audit it for refinement opportunities instead of stopping.
-   - Run or use `scripts/tools/issue_template_audit.py` where issue body readiness is unclear.
-   - Inspect linked PRs, context notes, and relevant files before asking questions that repo
-     exploration can answer.
-
-2. Select one blocking question
-   - Ask exactly one question at a time.
-   - Include the recommended answer and why it is the safest default.
-   - The question must materially affect scope, acceptance criteria, sequencing, split/merge
-     decisions, blocked state, or validation.
-
-3. Apply the decision immediately
-   - Update the issue body, title, labels, comments, and Project #5 routing as needed.
-   - Remove `decision-required` once the decision is resolved.
-   - Create follow-up issues when the decision splits scope.
-   - Mark duplicates or superseded work clearly and link the canonical issue.
-
-4. Maintain batch discipline
-   - Do issue text, label, and comment cleanup first.
-   - Do Project #5 field routing second.
-   - Run derived score sync once at the end of a batch if score inputs changed.
-   - If GraphQL is exhausted, finish REST issue cleanup and report the exact pending Project #5
-     mutation instead of retry-looping.
-
-5. Continue or hand off
-   - Continue with the next readiness blocker.
-   - If stopped early, report the last completed issue, pending question, issues changed, project
-     writes still pending, and next recommended issue.
+1. Set scope and ordering:
+   - define issue set,
+   - start with `decision-required`/contradictory issues,
+   - if none, move by Project #5 priority.
+2. Gather readiness context:
+   - issue states, labels, linked PRs, templates/contracts, and related files.
+3. Ask exactly one question at a time focused on scope, acceptance, or priority tradeoff.
+4. Apply the decision immediately:
+   - edit issue body/labels as needed,
+   - remove `decision-required` when resolved,
+   - create follow-up issues for bounded splits.
+5. Keep batch discipline:
+   - issue/body cleanup first,
+   - routing/Project #5 updates second,
+   - one score-sync batch at the end if needed.
 
 ## Guardrails
 
-- Ask the user only about product, priority, scope, or tradeoff decisions that cannot be discovered
-  from the repository.
-- Do not ask multi-question bundles.
-- Do not preserve stale issue text if the decision makes it wrong; update or mark it superseded.
-- Do not create broad new issues when a bounded follow-up issue is enough.
+- Ask questions only for decisions not discoverable from repo artifacts.
+- Never ask bundled multi-part questions.
+- Do not preserve stale issue statements once a decision invalidates them.
 
-## Output Requirements
+## Output
 
-Report after each decision or audit batch:
-
-- issue number and readiness blocker,
-- question asked and selected answer,
-- issue/project changes made,
-- follow-up or consolidation issues created,
-- next readiness blocker.
+- Issue and blocker addressed.
+- Question asked and answer applied.
+- Changes made (body/labels/project state) and follow-up issues.
+- Next blocker and optional stop reason if interrupted.

--- a/.agents/skills/paper-facing-docs/SKILL.md
+++ b/.agents/skills/paper-facing-docs/SKILL.md
@@ -5,8 +5,10 @@ description: "Draft or review benchmark and manuscript-support docs conservative
 
 # Paper-Facing Docs
 
-Use this skill for docs that influence benchmark interpretation, manuscript support, or public
-artifact/provenance claims.
+## When to use
+
+Use this skill for any documentation that can affect benchmark interpretation, manuscript claims, or
+public-facing provenance statements.
 
 ## Read First
 
@@ -14,18 +16,26 @@ artifact/provenance claims.
 - `docs/benchmark_camera_ready.md`
 - `docs/benchmark_artifact_publication.md`
 - relevant issue execution notes under `docs/context/`
+- `docs/benchmark_spec.md`
 
-## Focus
+## Workflow
 
-- conservative wording,
-- provenance-preserving claims,
-- exact reproducible commands/configs,
-- explicit separation between observed evidence and future work.
+1. Validate the claim surface against existing benchmark definitions.
+2. Check reproducibility breadcrumbs (config, command, seed policy, artifact path).
+3. Mark caveats with plain-language risk language.
+4. Review wording for unsupported causality or overclaim.
+5. Add explicit provenance pointers before handoff.
 
-## Output Expectations
+## Proof and Guardrails
+
+- Preserve fail-closed semantics: do not present fallback/degraded runs as success.
+- Any claim must point to concrete reproducible artifacts.
+- Prefer tracked canonical documents and execution notes for evidence.
+
+## Output
 
 Paper-facing docs should:
 
-- cite the canonical benchmark/config surfaces,
+- cite canonical benchmark/config surfaces,
 - avoid overstating planner support,
 - name remaining caveats in plain language.

--- a/.agents/skills/planner-integration/SKILL.md
+++ b/.agents/skills/planner-integration/SKILL.md
@@ -5,7 +5,10 @@ description: "Assess planner-family integration feasibility, adapter burden, pro
 
 # Planner Integration
 
-Use this skill when evaluating, wrapping, or documenting a planner family for benchmark use.
+## When to use
+
+Use this skill when assessing whether a planner family can be integrated safely for benchmark and
+documentation use.
 
 ## Read First
 
@@ -13,19 +16,26 @@ Use this skill when evaluating, wrapping, or documenting a planner family for be
 - `docs/context/issue_601_crowdnav_feasibility_note.md`
 - `docs/context/issue_629_planner_zoo_research_prompt.md`
 - `docs/benchmark_planner_quality_audit.md`
+- `docs/context/issue_691_benchmark_fallback_policy.md`
 
-## Focus
+## Workflow
 
-- observation contract and adapter burden,
-- action space and kinematics compatibility,
-- upstream provenance and license safety,
-- benchmark readiness vs experimental-only status,
-- what would break paper-facing faithfulness.
+1. Validate observation/action contract and compatibility assumptions.
+2. Assess adapter burden and failure modes.
+3. Check upstream provenance, licenses, and distribution constraints.
+4. Classify benchmark readiness vs research-only usage.
+5. Define required validation and deprecation conditions.
 
-## Output Expectations
+## Proof and Guardrails
+
+- Do not claim paper-ready support if benchmark mode is degraded or fallback-only.
+- Require a reproducible harness for any wrapper-friendly claim.
+- Preserve conservative wording until adapter contracts are validated.
+
+## Output
 
 State clearly:
 
 - whether the planner is wrapper-friendly, model-only, or research-only,
-- what source-harness validation is required first,
-- what claim the repository can safely make after integration.
+- required first-step validation and evidence,
+- safe claim boundary after integration.

--- a/.agents/skills/pr-ready-check/SKILL.md
+++ b/.agents/skills/pr-ready-check/SKILL.md
@@ -1,53 +1,31 @@
 ---
 name: pr-ready-check
-description: "Run the repository PR readiness pipeline using shared scripts/dev entry points (ruff fix/format, parallel tests, changed-files coverage, and docstring TODO checks)."
+description: "Run the repository PR readiness pipeline using shared scripts/dev entry points (ruff fix/format, parallel tests, coverage, and docstring checks)."
 ---
 
 # PR Ready Check
 
-## Overview
+## Purpose
 
-Run the same PR validation pipeline used by local VS Code tasks, but via reusable
-`scripts/dev` commands that are stable for Agent automation.
+Run the canonical local readiness gates that mirror repo PR policy before handoff or review.
 
 ## Workflow
 
-1. Confirm repo + guidance
-   - Ensure you are in the Robot SF repo root.
-   - Review `docs/dev_guide.md`, `.specify/memory/constitution.md`, and
-     `.github/copilot-instructions.md` when context is needed.
+1. Confirm repo guidance (`docs/dev_guide.md`, `.specify/memory/constitution.md`) when uncertain.
+2. Ensure environment has `.venv` loaded or `source .venv/bin/activate` is available.
+3. Run: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
+4. If needed, use overrides, e.g. `MIN_COVERAGE`, `GOAL_COVERAGE`.
+5. Fix failures and rerun the same command until stable green.
+6. If benchmark outputs or model artifacts are involved, check artifact persistence policy before handoff.
 
-2. Ensure environment
-   - Prefer running from repo root with `.venv` present.
-   - Scripts source `.venv/bin/activate` when available.
+## Guardrails
 
-3. Run PR readiness checks
-   - Default command:
-     `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
-   - Optional overrides:
-     `BASE_REF=<ref> MIN_COVERAGE=80 GOAL_COVERAGE=100 scripts/dev/pr_ready_check.sh`
+- This skill runs validation; it does not perform PR creation or issue edits on its own.
+- Do not stop at lint green: ensure parallel tests and diff gates are also clean.
+- Treat benchmark fallback execution as unresolved unless explicitly scoped.
 
-4. If checks fail
-   - Fix issues directly in code/tests/docs.
-   - Re-run the same command until green.
-   - Apply test-value evaluation (Constitution Principle XIII) for failing tests.
+## Output
 
-5. Report result
-   - Summarize which checks ran and whether each passed:
-     - Ruff fix/format/lint stats
-     - Parallel pytest (`-n auto -x --failed-first` by default via `scripts/dev/run_tests_parallel.sh`)
-     - Changed-files coverage gate
-     - Touched-definition docstring TODO gate
-
-6. Commit and PR
-   - Once all checks pass, commit your changes with a clear message.
-   - Verify the issue addressed is actually resolved by the changes.
-   - Before push/PR handoff, inspect ignored/generated artifacts:
-     - `git status --ignored --short -uall output`
-   - For any benchmark bundle, model checkpoint, W&B output, policy-analysis report, or
-     `output/model_cache` dependency, decide whether it is disposable, an ignored cache, covered by
-     a tracked manifest/registry pointer, or needs durable upload.
-   - Make required artifacts persistent before handoff, preferably through W&B artifact metadata,
-     `model/registry.yaml`, a tracked manifest, or another explicit durable source.
-   - Record the artifact persistence decision in the PR body or linked context note.
-   - Push to your branch and create/update the PR referencing related issues.
+- Readiness command and result summary.
+- Which checks failed/succeeded (ruff, parallel tests, changed coverage, docstring TODO diff gate).
+- Any residual risks and required artifact persistence actions.

--- a/.agents/skills/quality-playbook/SKILL.md
+++ b/.agents/skills/quality-playbook/SKILL.md
@@ -1,59 +1,36 @@
 ---
 name: quality-playbook
-description: "Repo-wide proof-first workflow for non-trivial changes; use when a task needs context, risk assessment, validation planning, and documented follow-through."
+description: "Repo-wide proof-first workflow for non-trivial changes with context, risk, validation, and follow-through."
 ---
 
 # Quality Playbook
 
-## Overview
+## Purpose
 
-Use this skill for changes that need more than a quick edit: multi-file fixes, behavior changes,
-documentation shifts, or work that could regress a contract if handled casually.
-
-The playbook is intentionally conservative. It focuses on understanding the change surface, choosing
-the right proof, and making the result easy to review.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/code_review.md`
-- `docs/dev_guide.md`
-- `.specify/memory/constitution.md`
-- `.agent/PLANS.md` for larger tasks
+Provide a minimal, reusable structure for higher-risk changes that need stronger validation and explicit
+risk accounting.
 
 ## Workflow
 
-1. Restate the objective
-   - Define the change, non-goals, and affected contracts.
-   - Note whether the work is code, docs, benchmark, or AI-workflow related.
-
-2. Classify the risk
-   - Identify whether the change touches:
-     - runtime behavior,
-     - benchmark semantics,
-     - public docs,
-     - reproducibility,
-     - AI workflow surfaces.
-
-3. Choose proof
-   - Pick the smallest validation that demonstrates the intended contract here.
-   - Prefer repo-native scripts, targeted tests, or canonical commands.
-
-4. Make the smallest safe change
-   - Keep the scope narrow.
-   - Avoid unrelated cleanup unless it is needed to preserve correctness.
-
-5. Validate and document
-   - Run the selected checks.
-   - Record what passed, what remains uncertain, and any follow-up issue needed.
-
-## Output
-
-Always report objective, risk class, proof chosen, validation result, and residual risk or
-follow-up issue.
+1. Restate objective, in-scope boundaries, and affected contracts.
+2. Classify risk:
+   - behavior, benchmark, docs, reproducibility, AI-workflow.
+3. Pick the smallest proving approach:
+   - targeted tests, canonical scripts, and representative sample runs.
+4. Make the minimal safe change set.
+5. Execute checks and document:
+   - what passed,
+   - what remains uncertain,
+   - any required follow-up issue.
 
 ## Guardrails
 
-- Do not treat fallback or degraded behavior as a success unless the task explicitly measures it.
-- Do not widen scope while improving quality.
-- Prefer follow-up issues for deferred work instead of silent expansion.
+- Avoid scope expansion and broad refactors during proof-first tasks.
+- Do not count fallback/degraded operation as success unless explicitly requested.
+- Keep follow-up work as explicit backlog items, not silent omissions.
+
+## Output
+
+- Objective + risk class.
+- Proof strategy and validation results.
+- Residual risk and next required step.

--- a/.agents/skills/review-and-refactor/SKILL.md
+++ b/.agents/skills/review-and-refactor/SKILL.md
@@ -7,8 +7,8 @@ description: "Surgical review-then-refactor workflow for small code or docs chan
 
 ## Purpose
 
-Avoid broad rewrites: review a small surface first, then apply the smallest safe refactor needed to fix the
-identified issue.
+Avoid broad rewrites: review a small surface first, then surgically apply the smallest safe refactor
+needed to fix the identified issue.
 
 ## Workflow
 

--- a/.agents/skills/review-and-refactor/SKILL.md
+++ b/.agents/skills/review-and-refactor/SKILL.md
@@ -5,46 +5,26 @@ description: "Surgical review-then-refactor workflow for small code or docs chan
 
 # Review And Refactor
 
-## Overview
+## Purpose
 
-Use this skill when you want to inspect a small change surface, identify the real issue, and make a
-targeted improvement without turning the task into a broad cleanup.
-
-This is a tighter workflow than a general refactor: review first, then change only what the review
-justified.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/code_review.md`
-- `docs/dev_guide.md`
-- `.specify/memory/constitution.md`
+Avoid broad rewrites: review a small surface first, then apply the smallest safe refactor needed to fix the
+identified issue.
 
 ## Workflow
 
-1. Inspect the local contract
-   - Read the relevant files and nearby tests.
-   - Identify the specific behavior or wording that needs adjustment.
-
-2. Review before editing
-   - Look for correctness risks, duplicated logic, naming drift, or docs mismatch.
-   - Prefer the smallest refactor that resolves the identified issue.
-
-3. Refactor surgically
-   - Keep behavior stable unless the task explicitly requires behavior change.
-   - Change one concern at a time.
-
-4. Verify the result
-   - Run the smallest meaningful validation first.
-   - Expand only if the change surface demands it.
-
-## Output
-
-Always report the reviewed surface, the specific issue found, the narrow change made, and the
-validation command/result.
+1. Read the local contract (AGENTS, docs, related tests) for the target surface.
+2. Review for concrete gap (correctness, drift, duplication, naming mismatch).
+3. Apply one focused change only.
+4. Validate immediately with targeted checks; expand only if needed.
 
 ## Guardrails
 
-- If the task is pure cleanup, use `clean-up`.
-- If the task is benchmark-sensitive, use `review-benchmark-change` or `benchmark-overview` first.
-- Do not replace one problem with a wider refactor.
+- Preserve behavior unless the task explicitly requests change.
+- Do not switch this into a general cleanup flow.
+- For benchmark-sensitive edits, route through benchmark-specific workflows first.
+
+## Output
+
+- Issue found, files touched, and exact narrow fix.
+- Validation command(s) and outcome.
+- Any risk introduced or deferred.

--- a/.agents/skills/review-and-refactor/SKILL.md
+++ b/.agents/skills/review-and-refactor/SKILL.md
@@ -7,8 +7,8 @@ description: "Surgical review-then-refactor workflow for small code or docs chan
 
 ## Purpose
 
-Avoid broad rewrites: review a small surface first, then apply the smallest safe refactor needed to fix the
-identified issue.
+Avoid broad rewrites: review a small surface first, then surgically apply the smallest safe
+refactor needed to fix the identified issue.
 
 ## Workflow
 

--- a/.agents/skills/review-benchmark-change/SKILL.md
+++ b/.agents/skills/review-benchmark-change/SKILL.md
@@ -5,8 +5,10 @@ description: "Review benchmark-sensitive code or docs changes for semantic regre
 
 # Review Benchmark Change
 
-Use this skill when reviewing a PR, patch, or doc change that could alter benchmark outcomes or
-their interpretation.
+## When to use
+
+Use this skill when reviewing PRs, patches, or docs that can change benchmark semantics,
+interpretation, or reproducibility.
 
 ## Read First
 
@@ -14,6 +16,15 @@ their interpretation.
 - `docs/benchmark_spec.md`
 - `docs/dev/observation_contract.md`
 - `docs/benchmark_planner_family_coverage.md`
+- `docs/context/issue_691_benchmark_fallback_policy.md`
+
+## Workflow
+
+1. Confirm the claimed benchmark contract and changed contract surface.
+2. Validate observation/normalization contract compatibility.
+3. Check seed/scenario policy and artifact reproducibility entries.
+4. Verify provenance and readiness labels match implementation status.
+5. Assess whether changes are intentional or regressions and document severity.
 
 ## Review Checklist
 
@@ -23,12 +34,17 @@ their interpretation.
 - reproducibility path still exists,
 - upstream provenance and benchmark-readiness labels remain accurate.
 
-## Output Expectations
+## Proof and Guardrails
 
-Review findings should prioritize:
+- Apply fail-closed logic if any changed path lacks reproducible evidence.
+- Do not accept fallback-degraded execution as a benchmark success.
+- Keep any claim in sync with `benchmark` contract source files.
 
-1. incorrect benchmark semantics,
-2. broken learned-policy contract or normalization,
-3. provenance overclaim,
-4. missing reproducibility hooks,
-5. missing tests/docs for changed public behavior.
+## Output
+
+- findings should prioritize:
+  1. incorrect benchmark semantics,
+  2. broken learned-policy contract or normalization,
+  3. provenance overclaim,
+  4. missing reproducibility hooks,
+  5. missing tests/docs for changed public behavior.

--- a/.agents/skills/skill-picker/SKILL.md
+++ b/.agents/skills/skill-picker/SKILL.md
@@ -1,62 +1,33 @@
 ---
 name: skill-picker
-description: "Choose the most appropriate repo-local skill for an ambiguous task by consulting .agents/skills/README.md; use when the user asks which skill to use, does not know the right skill, or explicitly asks for skill routing."
+description: "Choose the most appropriate repo-local skill for an ambiguous task by consulting .agents/skills/README.md."
 ---
 
 # Skill Picker
 
-## Overview
+## Purpose
 
-Use this skill when the user wants help choosing a repo-local skill before executing a task.
-
-Good triggers:
-- "which skill should I use?"
-- "pick the right skill"
-- "use the skill picker"
-- "I do not know which skill applies"
-
-Do not use this skill as a mandatory pre-step for ordinary tasks. If the user already named a
-specific skill, use that skill directly unless the request asks you to reconsider the choice or the
-named skill is clearly not the best fit for the task.
-
-When the user explicitly asks for skill routing, prioritize the task over the user's tentative skill
-choice: select the best matching skill, briefly state why it overrides the mentioned skill if
-needed, and proceed with the task. Do not stop to ask for confirmation unless the task itself is
-unsafe or missing required information.
+Select the smallest useful repo-local skill stack when the user request is ambiguous.
 
 ## Workflow
 
-1. Read the skill index
-   - Open `.agents/skills/README.md`.
-   - Use it as the routing overview before reading individual `SKILL.md` files.
+1. Read `.agents/skills/README.md`.
+2. Classify request type (issue, PR/review, verification, benchmark, docs, cleanup).
+3. Choose one primary skill; add secondary skills only when phases are distinct.
+4. If a specific user choice conflicts and is clearly wrong, override with rationale.
+5. Report selected skills and continue execution if requested.
 
-2. Classify the task
-   - Identify the task type: issue workflow, PR/review, implementation verification, benchmark
-     review, docs sync, context discovery, experimentation, or cleanup.
-   - Note whether the user requested execution now or only skill selection advice.
+## Guardrails
 
-3. Select the smallest useful skill set
-   - Prefer one specific skill over a broad stack.
-   - Override a user-mentioned skill when another skill clearly fits better.
-   - Combine skills only for distinct phases, for example:
-     `context-map` -> `implementation-verification` -> `pr-ready-check`.
-   - Avoid selecting skills that duplicate the same phase.
-
-4. Report and proceed
-   - State selected skill(s) and why.
-   - Briefly state obvious alternatives skipped when the choice is non-obvious.
-   - If the user asked you to proceed, load the selected skill's `SKILL.md` and continue.
+- Do not treat skill-picker as mandatory pre-step for explicit single-skill requests.
+- Avoid proposing overly broad bundles that overlap the same phase.
+- Use exact repository-specific terminology from AGENTS/skills docs.
 
 ## Output
 
-Use a compact routing note:
+Compact routing note:
 
-```md
-Selected: `skill-name`
-Why: <one sentence>
-Skipped: `<alternative>` because <one sentence>
-Override: `<user-mentioned-skill>` because <one sentence>  # omit when not needed
-Next: <what I will do>
-```
-
-If no skill fits, say that directly and continue with the normal repository workflow.
+- Selected skill(s)
+- Why they fit
+- Skipped alternatives
+- Next action

--- a/.agents/skills/svg-inspection/SKILL.md
+++ b/.agents/skills/svg-inspection/SKILL.md
@@ -1,43 +1,33 @@
 ---
 name: svg-inspection
-description: "Inspect and debug SVG maps for parser-facing issues (route-only mode, zone index mismatches, risky path commands, and obstacle-crossing routes) using reusable Robot SF helpers."
+description: "Inspect and debug SVG maps for parser-facing issues using reusable Robot SF helpers."
 ---
 
 # SVG Inspection
 
-## Overview
+## Purpose
 
-Use this skill when SVG maps behave unexpectedly at runtime or emit map parser
-warnings. The workflow combines fast text inspection, semantic checks via a
-dedicated CLI helper, and targeted follow-up tests.
+Diagnose map parse/runtime mismatches in `maps/svg_maps/` and produce a short, reproducible finding.
 
-## Procedure
+## Workflow
 
-1. Quick label scan
-   - Run:
+1. Inspect labels quickly:
    - `rg -n "ped_route|robot_route|spawn_zone|goal_zone|obstacle" maps/svg_maps/<map>.svg`
-
-2. Run semantic inspection helper
-   - Single map:
-   - `uv run python scripts/validation/svg_inspect.py maps/svg_maps/<map>.svg --show-routes`
-   - Batch:
-   - `uv run python scripts/validation/svg_inspect.py maps/svg_maps --pattern "classic_*.svg" --strict warning`
-
-3. Export machine-readable report when needed
+2. Run semantic inspection:
+   - `uv run python scripts/validation/svg_inspect.py <map>.svg --show-routes`
+   - batch mode: `uv run python scripts/validation/svg_inspect.py maps/svg_maps --pattern "classic_*.svg" --strict warning`
+3. Generate machine report if needed:
    - `uv run python scripts/validation/svg_inspect.py maps/svg_maps --json output/validation/svg_inspection.json`
+4. Cross-check with map verification helper if route/zone behavior is suspicious.
 
-4. Follow-up verification
-   - `uv run python scripts/validation/verify_maps.py --scope all --mode local`
+## Guardrails
 
-5. Fix and lock behavior
-   - Prefer explicit `*_spawn_zone*` and `*_goal_zone*` on canonical maps.
-   - If route-only mode is intentional, keep route labels consistent and add/update tests.
-   - Add tests in `tests/maps/` or `tests/test_svg_classic_maps_format.py`.
+- Canonical maps should prefer explicit `spawn_zone` and `goal_zone` labels; avoid route-only assumptions.
+- Preserve reproducibility: route-only mode only when intentional and documented.
+- Keep parser/runtime caveats explicit in the issue or follow-up.
 
-## Notes
+## Output
 
-- Reusable API lives in `robot_sf.maps.verification.svg_inspection`.
-- The parser is regex-based for path coordinates; commands like `H/V` and curves
-  can produce mismatches between editor rendering and runtime geometry.
-- Route-only mode is supported, but canonical benchmark maps should prefer
-  explicit zones for reproducibility.
+- Findings (warnings/errors), map(s) checked, helper output path.
+- Whether additional follow-up tests or label edits are required.
+- Recommendation for safe remediation.

--- a/.agents/skills/update-docs-on-code-change/SKILL.md
+++ b/.agents/skills/update-docs-on-code-change/SKILL.md
@@ -1,51 +1,31 @@
 ---
 name: update-docs-on-code-change
-description: "Keep docs aligned with code changes that affect workflows, commands, contracts, or user-facing behavior."
+description: "Keep docs aligned with code changes that affect workflows, contracts, or user-facing behavior."
 ---
 
 # Update Docs On Code Change
 
-## Overview
+## Purpose
 
-Use this skill whenever a code change would leave the repository documentation stale unless the docs
-are updated at the same time.
-
-The goal is to keep docs discoverable, concise, and accurate rather than to rewrite them broadly.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/dev_guide.md`
-- `docs/README.md`
-- `docs/ai/repo_overview.md`
-- `.github/copilot-instructions.md`
+Keep repository docs accurate when code, commands, or contracts change. Focus on minimal, discoverable
+updates, not broad documentation rewrites.
 
 ## Workflow
 
-1. Identify the doc surfaces
-   - Decide which docs actually describe the changed behavior.
-   - Prefer the smallest set of existing docs that users already read.
-
-2. Sync terminology
-   - Reuse the repo's existing names for commands, files, and workflows.
-   - Avoid introducing parallel wording for the same concept.
-
-3. Update the concrete instructions
-   - Update commands, paths, caveats, examples, and links.
-   - Keep the text short and executable.
-
-4. Validate the docs
-   - Check that referenced files and commands still exist.
-   - If the change affects discoverability, add or update a test.
-
-## Output
-
-Always report the code behavior that changed, docs updated, references verified, and any docs risk
-left out of scope.
+1. Identify affected docs from the change surface (workflows, commands, contracts).
+2. Apply only minimal corrections in existing docs.
+3. Keep terminology aligned with existing repo naming.
+4. Validate references and examples point to existing files/commands.
+5. For discoverability-impacting updates, add or update relevant docs tests/checks if present.
 
 ## Guardrails
 
-- Do not add a new doc when an existing doc can be corrected.
-- Do not describe code that no longer exists.
-- Do not leave workflow docs stale after a code change.
-- If the change is user-facing, make sure the docs reflect the new behavior in the same change.
+- Prefer updating existing docs over creating new documents.
+- Do not document behavior that no longer exists.
+- For user-facing behavior changes, update docs in the same change set.
+
+## Output
+
+- Updated docs list and specific sections changed.
+- Reference validation result.
+- Remaining documentation risks not yet covered.

--- a/.agents/skills/update-docs-on-code-change/SKILL.md
+++ b/.agents/skills/update-docs-on-code-change/SKILL.md
@@ -7,8 +7,9 @@ description: "Keep docs aligned with code changes that affect workflows, contrac
 
 ## Purpose
 
-Keep repository docs accurate when code, commands, or contracts change. Focus on minimal, discoverable
-updates, not broad documentation rewrites.
+Keep repository docs accurate when code, commands, or contracts change so docs stale against the
+implementation are repaired. Focus on minimal, discoverable workflow docs updates, not broad
+documentation rewrites.
 
 ## Workflow
 

--- a/.agents/skills/update-docs-on-code-change/SKILL.md
+++ b/.agents/skills/update-docs-on-code-change/SKILL.md
@@ -7,8 +7,8 @@ description: "Keep docs aligned with code changes that affect workflows, contrac
 
 ## Purpose
 
-Keep repository docs accurate when code, commands, or contracts change. Focus on minimal, discoverable
-updates, not broad documentation rewrites.
+Keep repository docs accurate when code, commands, or contracts change so docs stale risks do not
+hide workflow docs drift. Focus on minimal, discoverable updates, not broad documentation rewrites.
 
 ## Workflow
 

--- a/.agents/skills/what-context-needed/SKILL.md
+++ b/.agents/skills/what-context-needed/SKILL.md
@@ -1,52 +1,32 @@
 ---
 name: what-context-needed
-description: "Ask for the minimum repository context needed to answer or implement a task safely; use when the task is underspecified or missing required files."
+description: "Ask for the minimum repository context needed to answer or implement a task safely."
 ---
 
 # What Context Needed
 
-## Overview
+## Purpose
 
-Use this skill when the current task cannot be answered safely without additional repository
-context.
-
-The output should be a short, direct request for the missing files, commands, or decisions. Keep it
-minimal and action-oriented.
-
-## Read First
-
-- `AGENTS.md`
-- `docs/dev_guide.md`
-- `docs/code_review.md`
-- `.specify/memory/constitution.md`
+Request only the missing inputs required to avoid speculative or unsafe work.
 
 ## Workflow
 
-1. State what is already known
-   - Summarize the task in one or two sentences.
-   - Mention the files or signals already available.
-
-2. Identify the blockers
-   - Group blockers into:
-     - missing files,
-     - missing decision,
-     - missing validation path,
-     - ambiguous scope.
-
-3. Ask for the minimum needed
-   - Ask up to three short questions.
-   - Prefer exact file paths, issue numbers, or commands over open-ended requests.
-
-4. Offer the next step
-   - Say which skill or workflow would apply once the missing context is provided.
-
-## Output
-
-Ask for the smallest missing set of files, commands, artifacts, or decisions, and explain what each
-item will unblock.
+1. Restate the task in one sentence.
+2. Group blockers into:
+   - missing files/artifacts,
+   - missing decisions,
+   - missing validation path,
+   - ambiguous scope.
+3. Ask up to three precise unblockers (file paths, issue IDs, expected command, or decision).
+4. Move to execution workflow once missing context is provided.
 
 ## Guardrails
 
-- Do not invent missing facts.
-- Do not ask broad multi-part questions when one precise question is enough.
-- If the task becomes clear after the clarification, proceed with the appropriate execution skill.
+- Ask the smallest set of questions that changes uncertainty.
+- Do not invent missing facts or default assumptions.
+- Do not reuse this skill once required context is available.
+
+## Output
+
+- Minimal missing context checklist and why each item is required.
+- The first executable workflow to run next.

--- a/.agents/skills/what-context-needed/SKILL.md
+++ b/.agents/skills/what-context-needed/SKILL.md
@@ -17,7 +17,8 @@ Request only the missing inputs required to avoid speculative or unsafe work.
    - missing decisions,
    - missing validation path,
    - ambiguous scope.
-3. Ask up to three precise unblockers (file paths, issue IDs, expected command, or decision).
+3. Ask up to three short questions for precise unblockers (file paths, issue IDs, expected command,
+   or decision).
 4. Move to execution workflow once missing context is provided.
 
 ## Guardrails

--- a/.agents/skills/what-context-needed/SKILL.md
+++ b/.agents/skills/what-context-needed/SKILL.md
@@ -17,7 +17,8 @@ Request only the missing inputs required to avoid speculative or unsafe work.
    - missing decisions,
    - missing validation path,
    - ambiguous scope.
-3. Ask up to three precise unblockers (file paths, issue IDs, expected command, or decision).
+3. Ask up to three short questions for precise unblockers (file paths, issue IDs, expected
+   command, or decision).
 4. Move to execution workflow once missing context is provided.
 
 ## Guardrails


### PR DESCRIPTION
## Summary
Refactors the repo-local skill documents for clearer purpose/workflow/guardrail/output structure while keeping critical executable workflow details in place.

## Linked Issues
- Standalone docs/skill hygiene update; no tracking issue.

## What Changed
- Standardized wording across 34 `.agents/skills/*/SKILL.md` files.
- Restored actionable workflow details for issue priority ordering, draft PR creation, review-thread resolution, issue-template routing, batch-first Project #5 links, and protected prompt-surface phrases.
- Merged latest `origin/main` into the PR branch before final validation.

## Why It Matters
- Added value: makes skill entrypoints easier to scan without dropping the commands and queue semantics agents need during execution.
- Expected impact: lower context load for future agent sessions while preserving Project #5 and GitHub workflow behavior.
- Why this is worth merging now: these skills are used by the autonomous issue/PR loops and should remain concise but operational.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `uv run pytest tests/test_issue_workflow_batching.py::test_batch_first_workflow_note_is_linked_from_repo_guidance tests/test_ai_prompt_surfaces.py::test_ai_skill_files_contain_expected_language tests/test_issue_templates.py::test_issue_template_docs_and_skills_reference_real_paths -q`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - `check_skills.py` validated 34 skills and README coverage.
  - AI config link check validated 7 symlinks.
  - Docs/proof consistency passed for 34 changed files.
  - Targeted contract tests passed: 3 passed.
  - Full readiness gate passed: 3836 passed, 11 skipped, 8 warnings.
- Benchmarks or smoke tests, if applicable: not applicable; docs/skill-only update.

## Risks / Rollout
- Compatibility risks: skill wording changes can affect agent behavior.
- Failure modes: over-condensed instructions may hide operational details; the review and contract-test fixes restored concrete command and routing details.
- Rollback or fallback plan: revert this docs-only branch if a workflow skill proves less executable.

## Docs / Provenance
- Updated docs: `.agents/skills/*/SKILL.md`.
- Relevant design or provenance notes: `docs/context/goal_driven_agent_loops_2026-05-13.md` remains the loop contract.
- Any assumptions that need to be preserved: concise skills must still retain concrete commands when they define repo workflow behavior.

## Follow-Up Issues
- Deferred work: none identified in this review pass.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review threads from `gemini-code-assist` were addressed and are resolved.
- Generated artifacts: `output/coverage/*` was produced by validation and remains ignored/disposable; no durable artifact is required.
