### PR TITLE
fix: match camera-ready analyzer rows by kinematics

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -126,6 +126,8 @@ knowledge, not every transient iteration detail.
   [issue_1387_tentabot_value_scorer_spike.md](issue_1387_tentabot_value_scorer_spike.md)
 * Issue #1344 paired AMV primary protocol report:
   [issue_1344_paired_amv_protocol_report.md](issue_1344_paired_amv_protocol_report.md)
+* SLURM issue batch status 2026-05-21:
+  [slurm_issue_batch_status_2026-05-21.md](slurm_issue_batch_status_2026-05-21.md)
 * Issue #1294 seed-sensitivity perturbations:
   [issue_1294_seed_sensitivity_perturbations.md](issue_1294_seed_sensitivity_perturbations.md)
 * Artifact evidence vocabulary:

--- a/docs/context/slurm_issue_batch_status_2026-05-21.md
+++ b/docs/context/slurm_issue_batch_status_2026-05-21.md
@@ -10,25 +10,25 @@ by the #1398 analyzer fix.
 
 | Issue | Current state | Result |
 | --- | --- | --- |
-| #1391 | Closed | PR #1405 merged the feature-extractor SLURM output layout cleanup. |
-| #1392 | Closed | PR #1403 merged the generic camera-ready benchmark SLURM launcher. |
-| #1344 | Closed | PR #1399 merged the paired AMV primary-row protocol and compact evidence. |
-| #1354 | Open | Bounded cross-kinematics execution proof exists; paper-facing interpretation remains open. |
-| #1398 | In progress | This branch fixes false SNQI row mismatches for repeated planner keys across kinematics. |
-| #1167 | Closed | PR #1412 merged the obstacle-feature pipeline path; no SLURM comparison job was submitted in the 2026-05-20 batch. |
-| #1358 | Open | PR #1409 merged a residual guarded-PPO surface; a true learned residual training run still needs training lineage. |
+| Issue #1391 | Closed | PR #1405 merged the feature-extractor SLURM output layout cleanup. |
+| Issue #1392 | Closed | PR #1403 merged the generic camera-ready benchmark SLURM launcher. |
+| Issue #1344 | Closed | PR #1399 merged the paired AMV primary-row protocol and compact evidence. |
+| Issue #1354 | Open | Bounded cross-kinematics execution proof exists; paper-facing interpretation remains open. |
+| Issue #1398 | In progress | This branch fixes false SNQI row mismatches for repeated planner keys across kinematics. |
+| Issue #1167 | Closed | PR #1412 merged the obstacle-feature pipeline path; no SLURM comparison job was submitted in the 2026-05-20 batch. |
+| Issue #1358 | Open | PR #1409 merged a residual guarded-PPO surface; a true learned residual training run still needs training lineage. |
 
 No user SLURM jobs were queued when this note was written.
 
 ## Benchmark Evidence Carried Forward
 
-#1344 post-#1384 reruns completed cleanly and are recorded in
+Issue #1344 post-#1384 reruns completed cleanly and are recorded in
 `docs/context/issue_1344_paired_amv_protocol_report.md`:
 
 - nominal primary-row job `12572`: `COMPLETED 0:0`, `benchmark_success=true`
 - stress primary-row job `12574`: `COMPLETED 0:0`, `benchmark_success=true`
 
-#1354 has bounded compatibility proof for `goal`, `orca`, and `social_force` across
+Issue #1354 has bounded compatibility proof for `goal`, `orca`, and `social_force` across
 `differential_drive`, `bicycle_drive`, and `holonomic`:
 
 - initial job `12571`: `COMPLETED 0:0`, but analyzer reported row-level SNQI mismatches
@@ -55,17 +55,17 @@ manifests if the #1354 report is updated for paper-facing use.
 
 ## Remaining SLURM Decisions
 
-#1354 should not launch a larger fixed-spec AMV campaign until the #1398 analyzer fix is merged and
+Issue #1354 should not launch a larger fixed-spec AMV campaign until the #1398 analyzer fix is merged and
 the existing bounded proof is reinterpreted in the issue thread. After that, the next decision is
 whether the bounded three-planner cross-kinematics surface is enough for an outlook note, or whether
 to launch a broader #1353-dependent matrix.
 
-#1358 should not submit a generic PPO or policy-search smoke as the training run. PR #1409 gives the
+Issue #1358 should not submit a generic PPO or policy-search smoke as the training run. PR #1409 gives the
 bounded residual adapter and diagnostics surface, but the issue still asks for a learned residual
 policy with explicit training config, checkpoint lineage, residual contribution diagnostics, and
 nominal gate evidence.
 
-#1167 is closed after PR #1412 made the config-first obstacle-feature pipeline runnable. If the
+Issue #1167 is closed after PR #1412 made the config-first obstacle-feature pipeline runnable. If the
 actual same-seed training/evaluation comparison is still desired, open or reuse a follow-up issue
 that submits the canonical config from `docs/context/issue_1167_predictive_obstacle_pipeline.md`
 and reports ADE/FDE plus downstream planner metrics.

--- a/docs/context/slurm_issue_batch_status_2026-05-21.md
+++ b/docs/context/slurm_issue_batch_status_2026-05-21.md
@@ -1,0 +1,71 @@
+# SLURM Issue Batch Status 2026-05-21
+
+Related issues: #1167, #1344, #1354, #1358, #1391, #1392, #1398.
+
+## Current Status
+
+The 2026-05-20 batch was split after PR #1400 was closed without merge. The durable workflow
+pieces landed through smaller PRs, while the remaining benchmark interpretation blocker is handled
+by the #1398 analyzer fix.
+
+| Issue | Current state | Result |
+| --- | --- | --- |
+| #1391 | Closed | PR #1405 merged the feature-extractor SLURM output layout cleanup. |
+| #1392 | Closed | PR #1403 merged the generic camera-ready benchmark SLURM launcher. |
+| #1344 | Closed | PR #1399 merged the paired AMV primary-row protocol and compact evidence. |
+| #1354 | Open | Bounded cross-kinematics execution proof exists; paper-facing interpretation remains open. |
+| #1398 | In progress | This branch fixes false SNQI row mismatches for repeated planner keys across kinematics. |
+| #1167 | Closed | PR #1412 merged the obstacle-feature pipeline path; no SLURM comparison job was submitted in the 2026-05-20 batch. |
+| #1358 | Open | PR #1409 merged a residual guarded-PPO surface; a true learned residual training run still needs training lineage. |
+
+No user SLURM jobs were queued when this note was written.
+
+## Benchmark Evidence Carried Forward
+
+#1344 post-#1384 reruns completed cleanly and are recorded in
+`docs/context/issue_1344_paired_amv_protocol_report.md`:
+
+- nominal primary-row job `12572`: `COMPLETED 0:0`, `benchmark_success=true`
+- stress primary-row job `12574`: `COMPLETED 0:0`, `benchmark_success=true`
+
+#1354 has bounded compatibility proof for `goal`, `orca`, and `social_force` across
+`differential_drive`, `bicycle_drive`, and `holonomic`:
+
+- initial job `12571`: `COMPLETED 0:0`, but analyzer reported row-level SNQI mismatches
+- post-#1384 job `12575`: `COMPLETED 0:0`, no campaign warnings, but the old analyzer still
+  reported row-level SNQI mismatches
+
+The #1398 fix reinterprets the #1354 post-#1384 artifact by matching summary rows on
+`(planner_key, kinematics)` instead of only `planner_key`. On the local job `12575` artifact, the
+patched analyzer reports no automated inconsistencies.
+
+Validation command for that reinterpretation:
+
+```bash
+RAW_ISSUE_1354_ROOT=output/benchmarks/issue_1354_post1384/cross_kinematics_v1_issue1354-cross-post1384_20260520_170814
+uv run python scripts/tools/analyze_camera_ready_campaign.py \
+  --campaign-root "$RAW_ISSUE_1354_ROOT" \
+  --output-json output/validation/issue_1398_cross_kinematics_analysis.json \
+  --output-md output/validation/issue_1398_cross_kinematics_analysis.md
+```
+
+The raw campaign output remains local and ignored; set `RAW_ISSUE_1354_ROOT` to the checkout that
+owns the generated `output/` tree before rerunning the command. Promote only compact summaries or
+manifests if the #1354 report is updated for paper-facing use.
+
+## Remaining SLURM Decisions
+
+#1354 should not launch a larger fixed-spec AMV campaign until the #1398 analyzer fix is merged and
+the existing bounded proof is reinterpreted in the issue thread. After that, the next decision is
+whether the bounded three-planner cross-kinematics surface is enough for an outlook note, or whether
+to launch a broader #1353-dependent matrix.
+
+#1358 should not submit a generic PPO or policy-search smoke as the training run. PR #1409 gives the
+bounded residual adapter and diagnostics surface, but the issue still asks for a learned residual
+policy with explicit training config, checkpoint lineage, residual contribution diagnostics, and
+nominal gate evidence.
+
+#1167 is closed after PR #1412 made the config-first obstacle-feature pipeline runnable. If the
+actual same-seed training/evaluation comparison is still desired, open or reuse a follow-up issue
+that submits the canonical config from `docs/context/issue_1167_predictive_obstacle_pipeline.md`
+and reports ADE/FDE plus downstream planner metrics.

--- a/scripts/tools/analyze_camera_ready_campaign.py
+++ b/scripts/tools/analyze_camera_ready_campaign.py
@@ -27,6 +27,7 @@ class PlannerDiagnostics:
 
     planner_key: str
     algo: str
+    kinematics: str
     episodes_summary: int
     episodes_file: int
     success_mean_episodes: float
@@ -184,23 +185,52 @@ def _infer_campaign_repository_root(campaign_root: Path) -> Path:
     return resolved.parent.resolve()
 
 
-def _planner_row_index(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Index planner summary rows by planner key.
+def _planner_row_identity(planner_key: str, kinematics: str) -> tuple[str, str]:
+    """Return normalized planner row identity."""
+    return (planner_key.strip(), kinematics.strip())
+
+
+def _planner_row_index(payload: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    """Index planner summary rows by planner key and kinematics.
 
     Returns:
-        Mapping from planner key to planner row payload.
+        Mapping from ``(planner_key, kinematics)`` to planner row payload.
     """
     rows = payload.get("planner_rows")
     if not isinstance(rows, list):
         return {}
-    out: dict[str, dict[str, Any]] = {}
+    out: dict[tuple[str, str], dict[str, Any]] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
         key = row.get("planner_key")
         if isinstance(key, str) and key:
-            out[key] = row
+            kinematics = str(row.get("kinematics", "") or "")
+            out[_planner_row_identity(key, kinematics)] = row
     return out
+
+
+def _lookup_planner_row(
+    row_map: dict[tuple[str, str], dict[str, Any]],
+    *,
+    planner_key: str,
+    kinematics: str,
+) -> dict[str, Any] | None:
+    """Find the summary row matching a run entry.
+
+    Legacy single-kinematics summaries may omit ``kinematics``. In that case, fall back only when
+    there is exactly one row for the planner key.
+    """
+    exact = row_map.get(_planner_row_identity(planner_key, kinematics))
+    if exact is not None:
+        return exact
+    legacy = row_map.get(_planner_row_identity(planner_key, ""))
+    if legacy is not None:
+        return legacy
+    matches = [row for (key, _), row in row_map.items() if key == planner_key]
+    if len(matches) == 1:
+        return matches[0]
+    return None
 
 
 def _resolve_safe_campaign_path(campaign_root: Path, raw_path: str, *, label: str) -> Path:
@@ -355,6 +385,7 @@ def _analyze_planner(  # noqa: C901, PLR0915
     planner_key = str(planner.get("key", "unknown"))
     algo = str(planner.get("algo", "unknown"))
     summary = run_entry.get("summary", {}) if isinstance(run_entry, dict) else {}
+    kinematics = str(planner.get("kinematics", summary.get("kinematics", "unknown")) or "unknown")
     summary_written = int(summary.get("written", 0))
     preflight_status = str((summary.get("preflight") or {}).get("status", "unknown"))
     adapter_summary_status = (
@@ -472,6 +503,7 @@ def _analyze_planner(  # noqa: C901, PLR0915
     return PlannerDiagnostics(
         planner_key=planner_key,
         algo=algo,
+        kinematics=kinematics,
         episodes_summary=summary_written,
         episodes_file=episodes_n,
         success_mean_episodes=success_mean,
@@ -655,15 +687,16 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
         "## Planner Diagnostics",
         "",
         (
-            "| planner | algo | preflight | episodes | success(ep) | collision(ep) | snqi(ep) | "
-            "abs map paths | runtime(s) | eps/s |"
+            "| planner | algo | kinematics | preflight | episodes | success(ep) | collision(ep) | "
+            "snqi(ep) | abs map paths | runtime(s) | eps/s |"
         ),
-        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
+        "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for planner in planners:
         lines.append(
             "| "
-            f"{planner.get('planner_key')} | {planner.get('algo')} | {planner.get('preflight_status')} | "
+            f"{planner.get('planner_key')} | {planner.get('algo')} | {planner.get('kinematics')} | "
+            f"{planner.get('preflight_status')} | "
             f"{planner.get('episodes_file')} | {planner.get('success_mean_episodes'):.4f} | "
             f"{planner.get('collision_mean_episodes'):.4f} | "
             f"{planner.get('snqi_mean_episodes') if planner.get('snqi_mean_episodes') is not None else 'nan'} | "
@@ -679,7 +712,8 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
         for item in slowest_planners:
             lines.append(
                 "| "
-                f"{item.get('planner_key')} | {float(item.get('runtime_sec', 0.0)):.4f} | "
+                f"{item.get('planner_key')} ({item.get('kinematics')}) | "
+                f"{float(item.get('runtime_sec', 0.0)):.4f} | "
                 f"{float(item.get('wall_time_mean_sec', 0.0)):.4f} | "
                 f"{float(item.get('wall_time_p95_sec', 0.0)):.4f} |"
             )
@@ -688,7 +722,9 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
             top_scenarios = item.get("top_scenarios", [])
             if not top_scenarios:
                 continue
-            lines.append(f"- `{item.get('planner_key')}` top slow scenarios:")
+            lines.append(
+                f"- `{item.get('planner_key')}` ({item.get('kinematics')}) top slow scenarios:"
+            )
             for scenario in top_scenarios:
                 lines.append(
                     "  - "
@@ -730,23 +766,31 @@ def analyze_campaign(
     for entry in run_entries:
         if not isinstance(entry, dict):
             continue
-        planner_key = str((entry.get("planner") or {}).get("key", "unknown"))
+        planner = entry.get("planner") or {}
+        summary = entry.get("summary") or {}
+        planner_key = str(planner.get("key", "unknown"))
+        kinematics = str(
+            planner.get("kinematics", summary.get("kinematics", "unknown")) or "unknown"
+        )
         diag = _analyze_planner(
             entry,
-            row_map.get(planner_key),
+            _lookup_planner_row(row_map, planner_key=planner_key, kinematics=kinematics),
             campaign_root,
             tolerance=tolerance,
         )
         diagnostics.append(diag)
+        finding_prefix = f"{planner_key} ({kinematics})"
         for finding in diag.findings:
-            findings.append(f"{planner_key}: {finding}")
+            findings.append(f"{finding_prefix}: {finding}")
         if diag.preflight_status == "fallback":
             findings.append(
-                f"{planner_key}: preflight status is fallback (experimental degraded mode)",
+                f"{finding_prefix}: preflight status is fallback (experimental degraded mode)",
             )
 
     diagnostics_payload = [diag.__dict__ for diag in diagnostics]
-    diagnostics_payload.sort(key=lambda item: str(item.get("planner_key", "")))
+    diagnostics_payload.sort(
+        key=lambda item: (str(item.get("planner_key", "")), str(item.get("kinematics", "")))
+    )
     findings.sort()
     slowest_planners = []
     for item in sorted(
@@ -755,6 +799,7 @@ def analyze_campaign(
         slowest_planners.append(
             {
                 "planner_key": item.get("planner_key"),
+                "kinematics": item.get("kinematics"),
                 "runtime_sec": float(item.get("runtime_sec", 0.0)),
                 "wall_time_mean_sec": float(item.get("wall_time_mean_sec", 0.0)),
                 "wall_time_p95_sec": float(item.get("wall_time_p95_sec", 0.0)),

--- a/scripts/tools/analyze_camera_ready_campaign.py
+++ b/scripts/tools/analyze_camera_ready_campaign.py
@@ -227,7 +227,8 @@ def _lookup_planner_row(
     legacy = row_map.get(_planner_row_identity(planner_key, ""))
     if legacy is not None:
         return legacy
-    matches = [row for (key, _), row in row_map.items() if key == planner_key]
+    normalized_planner_key = planner_key.strip()
+    matches = [row for (key, _), row in row_map.items() if key == normalized_planner_key]
     if len(matches) == 1:
         return matches[0]
     return None
@@ -382,7 +383,7 @@ def _analyze_planner(  # noqa: C901, PLR0915
         Planner diagnostics with consistency findings and runtime hotspots.
     """
     planner = run_entry.get("planner", {}) if isinstance(run_entry, dict) else {}
-    planner_key = str(planner.get("key", "unknown"))
+    planner_key = str(planner.get("key", "unknown")).strip()
     algo = str(planner.get("algo", "unknown"))
     summary = run_entry.get("summary", {}) if isinstance(run_entry, dict) else {}
     kinematics = str(planner.get("kinematics", summary.get("kinematics", "unknown")) or "unknown")
@@ -768,7 +769,7 @@ def analyze_campaign(
             continue
         planner = entry.get("planner") or {}
         summary = entry.get("summary") or {}
-        planner_key = str(planner.get("key", "unknown"))
+        planner_key = str(planner.get("key", "unknown")).strip()
         kinematics = str(
             planner.get("kinematics", summary.get("kinematics", "unknown")) or "unknown"
         )

--- a/tests/tools/test_analyze_camera_ready_campaign.py
+++ b/tests/tools/test_analyze_camera_ready_campaign.py
@@ -425,6 +425,102 @@ def test_analyze_campaign_no_findings_on_consistent_payload(tmp_path: Path) -> N
     assert analysis["runtime_hotspots"]["slowest_planners"][0]["planner_key"] == "goal"
 
 
+def test_analyze_campaign_matches_rows_by_planner_and_kinematics(tmp_path: Path) -> None:
+    """Cross-kinematics rows should compare against their matching run only."""
+    campaign_root = tmp_path / "campaign"
+    summary_path = campaign_root / "reports" / "campaign_summary.json"
+    diff_episodes_path = campaign_root / "runs" / "goal__differential_drive" / "episodes.jsonl"
+    holo_episodes_path = campaign_root / "runs" / "goal__holonomic" / "episodes.jsonl"
+
+    base_episode = {
+        "status": "failure",
+        "termination_reason": "timeout",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+        "algorithm_metadata": {"adapter_impact": {"status": "disabled"}},
+    }
+    _write_jsonl(
+        diff_episodes_path,
+        [{**base_episode, "metrics": {"success": False, "collisions": 0, "snqi": -0.4}}],
+    )
+    _write_jsonl(
+        holo_episodes_path,
+        [{**base_episode, "metrics": {"success": False, "collisions": 0, "snqi": -0.1}}],
+    )
+    _write_json(
+        summary_path,
+        {
+            "campaign": {
+                "campaign_id": "cross_kinematics",
+                "runtime_sec": 2.0,
+                "episodes_per_second": 1.0,
+            },
+            "planner_rows": [
+                {
+                    "planner_key": "goal",
+                    "kinematics": "differential_drive",
+                    "planner_group": "core",
+                    "status": "ok",
+                    "preflight_status": "ok",
+                    "benchmark_success": "true",
+                    "success_mean": "0.0000",
+                    "collisions_mean": "0.0000",
+                    "snqi_mean": "-0.4000",
+                },
+                {
+                    "planner_key": "goal",
+                    "kinematics": "holonomic",
+                    "planner_group": "core",
+                    "status": "ok",
+                    "preflight_status": "ok",
+                    "benchmark_success": "true",
+                    "success_mean": "0.0000",
+                    "collisions_mean": "0.0000",
+                    "snqi_mean": "-0.1000",
+                },
+            ],
+            "runs": [
+                {
+                    "planner": {"key": "goal", "algo": "goal", "kinematics": "differential_drive"},
+                    "runtime_sec": 1.0,
+                    "episodes_path": "runs/goal__differential_drive/episodes.jsonl",
+                    "summary": {
+                        "written": 1,
+                        "episodes_per_second": 1.0,
+                        "preflight": {"status": "ok"},
+                        "kinematics": "differential_drive",
+                        "algorithm_metadata_contract": {"adapter_impact": {"status": "disabled"}},
+                    },
+                },
+                {
+                    "planner": {"key": "goal", "algo": "goal", "kinematics": "holonomic"},
+                    "runtime_sec": 1.0,
+                    "episodes_path": "runs/goal__holonomic/episodes.jsonl",
+                    "summary": {
+                        "written": 1,
+                        "episodes_per_second": 1.0,
+                        "preflight": {"status": "ok"},
+                        "kinematics": "holonomic",
+                        "algorithm_metadata_contract": {"adapter_impact": {"status": "disabled"}},
+                    },
+                },
+            ],
+        },
+    )
+
+    analysis = analyze_campaign(campaign_root)
+
+    assert analysis["findings"] == []
+    assert {(item["planner_key"], item["kinematics"]) for item in analysis["planners"]} == {
+        ("goal", "differential_drive"),
+        ("goal", "holonomic"),
+    }
+
+
 def test_analyze_campaign_accepts_repo_relative_paths_from_campaign_checkout(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_analyze_camera_ready_campaign.py
+++ b/tests/tools/test_analyze_camera_ready_campaign.py
@@ -485,7 +485,11 @@ def test_analyze_campaign_matches_rows_by_planner_and_kinematics(tmp_path: Path)
             ],
             "runs": [
                 {
-                    "planner": {"key": "goal", "algo": "goal", "kinematics": "differential_drive"},
+                    "planner": {
+                        "key": " goal ",
+                        "algo": "goal",
+                        "kinematics": "differential_drive",
+                    },
                     "runtime_sec": 1.0,
                     "episodes_path": "runs/goal__differential_drive/episodes.jsonl",
                     "summary": {


### PR DESCRIPTION
## Summary

- Fix `analyze_camera_ready_campaign.py` so planner summary rows are matched by `(planner_key, kinematics)` instead of only `planner_key`.
- Add a regression test for repeated planner keys across cross-kinematics rows.
- Add a compact SLURM batch status note for the #1391/#1392/#1344/#1354/#1398/#1167/#1358 follow-up state.

Closes #1398.
Relates #1354.

## Validation

- `uv run ruff format --check scripts/tools/analyze_camera_ready_campaign.py tests/tools/test_analyze_camera_ready_campaign.py`
- `uv run ruff check scripts/tools/analyze_camera_ready_campaign.py tests/tools/test_analyze_camera_ready_campaign.py`
- `uv run pytest tests/tools/test_analyze_camera_ready_campaign.py -q` (`14 passed`)
- `RAW_ISSUE_1354_ROOT=output/benchmarks/issue_1354_post1384/cross_kinematics_v1_issue1354-cross-post1384_20260520_170814 uv run python scripts/tools/analyze_camera_ready_campaign.py --campaign-root "$RAW_ISSUE_1354_ROOT" --output-json output/validation/issue_1398_cross_kinematics_analysis.json --output-md output/validation/issue_1398_cross_kinematics_analysis.md` (`No inconsistencies detected by automated checks`; raw artifact is local/ignored)
- `uv run python scripts/tools/sync_ai_config.py --check`
- `git diff --check origin/main...HEAD`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` (`3841 passed, 12 skipped`)

## Notes

The raw #1354 campaign artifact is local and ignored under `output/`; this PR only changes the analyzer contract and records the current batch interpretation boundary.