### PR TITLE
bench: stage predictive same-seed slurm handoff (#1427)

### DIFF
--- a/configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml
+++ b/configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml
@@ -1,0 +1,67 @@
+experiment:
+  run_id: predictive_br07_same_seed_issue_1427
+
+model_family: predictive_legacy_v1
+
+output:
+  root: output/tmp/predictive_planner/pipeline
+
+scenarios:
+  scenario_matrix: ../../scenarios/classic_interactions.yaml
+  hard_seed_manifest: ../../benchmarks/predictive_hard_seeds_v1.yaml
+  planner_grid: ../../benchmarks/predictive_sweep_planner_grid_v1.yaml
+
+base_collection:
+  seed_manifest: predictive_same_seed_issue_1427_base_seed_manifest.yaml
+  max_steps: 200
+  max_agents: 24
+  horizon_steps: 8
+  max_speed: 1.2
+
+hardcase_collection:
+  max_steps: 220
+  max_agents: 24
+  horizon_steps: 8
+  max_speed: 1.2
+
+mixing:
+  hardcase_repeat: 2
+  shuffle_seed: 42
+
+training:
+  model_id: predictive_br07_same_seed_issue_1427
+  model_family: predictive_legacy_v1
+  epochs: 40
+  batch_size: 128
+  lr: 0.0003
+  weight_decay: 0.00001
+  val_split: 0.2
+  seed: 42
+  hidden_dim: 128
+  message_passing_steps: 3
+  max_val_ade: 1.2
+  max_val_fde: 2.0
+  proxy_every_epochs: 5
+  proxy_horizon: 120
+  proxy_dt: 0.1
+  proxy_workers: 1
+
+wandb:
+  enabled: true
+  project: robot_sf
+  entity: ll7
+  group: predictive-same-seed-issue-1427
+  job_type: train
+  name: predictive_br07_same_seed_issue_1427
+  mode: online
+  tags:
+    - predictive
+    - baseline
+    - issue-1427
+    - same-seed
+
+evaluation:
+  workers: 1
+  campaign_workers: 2
+  horizon: 120
+  dt: 0.1

--- a/configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml
+++ b/configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml
@@ -1,0 +1,67 @@
+experiment:
+  run_id: predictive_obstacle_features_same_seed_issue_1427
+
+model_family: predictive_obstacle_features_v1
+
+output:
+  root: output/tmp/predictive_planner/pipeline
+
+scenarios:
+  scenario_matrix: ../../scenarios/classic_interactions.yaml
+  hard_seed_manifest: ../../benchmarks/predictive_hard_seeds_v1.yaml
+  planner_grid: ../../benchmarks/predictive_sweep_planner_grid_v1.yaml
+
+base_collection:
+  seed_manifest: predictive_same_seed_issue_1427_base_seed_manifest.yaml
+  max_steps: 200
+  max_agents: 24
+  horizon_steps: 8
+  max_speed: 1.2
+
+hardcase_collection:
+  max_steps: 220
+  max_agents: 24
+  horizon_steps: 8
+  max_speed: 1.2
+
+mixing:
+  hardcase_repeat: 2
+  shuffle_seed: 42
+
+training:
+  model_id: predictive_obstacle_features_same_seed_issue_1427
+  model_family: predictive_obstacle_features_v1
+  epochs: 40
+  batch_size: 128
+  lr: 0.0003
+  weight_decay: 0.00001
+  val_split: 0.2
+  seed: 42
+  hidden_dim: 128
+  message_passing_steps: 3
+  max_val_ade: 1.2
+  max_val_fde: 2.0
+  proxy_every_epochs: 5
+  proxy_horizon: 120
+  proxy_dt: 0.1
+  proxy_workers: 1
+
+wandb:
+  enabled: true
+  project: robot_sf
+  entity: ll7
+  group: predictive-same-seed-issue-1427
+  job_type: train
+  name: predictive_obstacle_features_same_seed_issue_1427
+  mode: online
+  tags:
+    - predictive
+    - obstacle-features
+    - issue-1427
+    - same-seed
+
+evaluation:
+  workers: 1
+  campaign_workers: 2
+  horizon: 120
+  dt: 0.1

--- a/configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml
+++ b/configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml
@@ -1,0 +1,115 @@
+classic_bottleneck_low:
+  - 11000
+  - 11001
+  - 11002
+  - 11003
+classic_bottleneck_medium:
+  - 111000
+  - 111001
+  - 111002
+  - 111003
+classic_bottleneck_high:
+  - 211000
+  - 211001
+  - 211002
+  - 211003
+classic_realworld_double_bottleneck_high:
+  - 311000
+  - 311001
+  - 311002
+  - 311003
+classic_station_platform_medium:
+  - 411000
+  - 411001
+  - 411002
+  - 411003
+classic_cross_trap_low:
+  - 511000
+  - 511001
+  - 511002
+  - 511003
+classic_cross_trap_medium:
+  - 611000
+  - 611001
+  - 611002
+  - 611003
+classic_cross_trap_high:
+  - 711000
+  - 711001
+  - 711002
+  - 711003
+classic_doorway_low:
+  - 811000
+  - 811001
+  - 811002
+  - 811003
+classic_doorway_medium:
+  - 911000
+  - 911001
+  - 911002
+  - 911003
+classic_doorway_high:
+  - 1011000
+  - 1011001
+  - 1011002
+  - 1011003
+classic_group_crossing_low:
+  - 1111000
+  - 1111001
+  - 1111002
+  - 1111003
+classic_group_crossing_medium:
+  - 1211000
+  - 1211001
+  - 1211002
+  - 1211003
+classic_group_crossing_high:
+  - 1311000
+  - 1311001
+  - 1311002
+  - 1311003
+classic_head_on_corridor_low:
+  - 1411000
+  - 1411001
+  - 1411002
+  - 1411003
+classic_head_on_corridor_medium:
+  - 1511000
+  - 1511001
+  - 1511002
+  - 1511003
+classic_merging_low:
+  - 1611000
+  - 1611001
+  - 1611002
+  - 1611003
+classic_merging_medium:
+  - 1711000
+  - 1711001
+  - 1711002
+  - 1711003
+classic_overtaking_low:
+  - 1811000
+  - 1811001
+  - 1811002
+  - 1811003
+classic_overtaking_medium:
+  - 1911000
+  - 1911001
+  - 1911002
+  - 1911003
+classic_t_intersection_low:
+  - 2011000
+  - 2011001
+  - 2011002
+  - 2011003
+classic_t_intersection_medium:
+  - 2111000
+  - 2111001
+  - 2111002
+  - 2111003
+classic_urban_crossing_medium:
+  - 2211000
+  - 2211001
+  - 2211002
+  - 2211003

--- a/docs/context/evidence/issue_1427_predictive_same_seed_handoff_2026-05-21/manifest.json
+++ b/docs/context/evidence/issue_1427_predictive_same_seed_handoff_2026-05-21/manifest.json
@@ -1,0 +1,27 @@
+{
+  "issue": 1427,
+  "artifact_role": "predictive_same_seed_handoff",
+  "generated_at": "2026-05-21",
+  "summary": "Prepared paired same-seed predictive baseline and obstacle-feature configs plus fail-closed obstacle-row preflight for external SLURM submission.",
+  "configs": {
+    "baseline": "configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml",
+    "obstacle": "configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml",
+    "shared_base_seed_manifest": "configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml",
+    "scenario_matrix": "configs/scenarios/classic_interactions.yaml",
+    "hard_seed_manifest": "configs/benchmarks/predictive_hard_seeds_v1.yaml",
+    "planner_grid": "configs/benchmarks/predictive_sweep_planner_grid_v1.yaml"
+  },
+  "commands": {
+    "baseline": "uv run python scripts/training/run_predictive_training_pipeline.py --config configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml",
+    "obstacle": "uv run python scripts/training/run_predictive_training_pipeline.py --config configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml"
+  },
+  "fail_closed_contract": {
+    "obstacle_preflight_report_pattern": "output/tmp/predictive_planner/pipeline/<run_id>/obstacle_feature_preflight.json",
+    "failure_condition": "The obstacle-feature pipeline aborts before training if either collected dataset has zero active non-sentinel obstacle rows.",
+    "same_seed_contract": "Both variants consume the same committed base seed manifest and the same hard-seed manifest."
+  },
+  "validation": {
+    "status": "prepared-not-submitted",
+    "note": "No SLURM job was submitted from this worktree. External submission should record job IDs, commit SHA, artifact roots, and downstream report paths."
+  }
+}

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -19,11 +19,17 @@ campaign can be submitted separately.
 - `scripts/training/run_predictive_training_pipeline.py` accepts `model_family` from the top-level
   config, collection config, or training config, then passes it to both collection stages and
   `train_predictive_planner.py`.
+- `scripts/training/run_predictive_training_pipeline.py` also accepts an optional committed
+  `base_collection.seed_manifest` and records the resolved base-seed manifest in the pipeline
+  summary so paired same-seed runs do not depend on regenerated output-local manifests.
 - `scripts/training/collect_predictive_hardcase_data.py` now supports
   `--model-family predictive_obstacle_features_v1`, emits `feature_schema_json`, and appends the
   same six map-derived obstacle features used by `collect_predictive_planner_data.py`.
 - `configs/training/predictive/predictive_obstacle_features_v1_issue_1167.yaml` records the
   canonical issue #1167 config-first command path.
+- Obstacle-feature pipeline runs now write `obstacle_feature_preflight.json` and fail before
+  training if either collected dataset contains only sentinel obstacle rows instead of any active
+  map-derived obstacle features.
 
 Canonical command:
 
@@ -81,9 +87,43 @@ uv run pytest -q tests/training/test_collect_predictive_hardcase_data.py \
 
 Observed targeted pytest result: `32 passed`.
 
+## Issue #1427 Same-Seed Handoff
+
+Issue #1427 needs runnable handoff surfaces for the actual bounded same-seed comparison, not a new
+pipeline design. The committed handoff set is:
+
+- shared base seed manifest:
+  `configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml`
+- baseline config:
+  `configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml`
+- obstacle-feature config:
+  `configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml`
+- compact evidence manifest:
+  `docs/context/evidence/issue_1427_predictive_same_seed_handoff_2026-05-21/manifest.json`
+
+Canonical command pair for external execution:
+
+```bash
+uv run python scripts/training/run_predictive_training_pipeline.py \
+  --config configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml
+
+uv run python scripts/training/run_predictive_training_pipeline.py \
+  --config configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml
+```
+
+Same-seed contract:
+
+- Both variants use the same committed base seed manifest and the same hard-seed manifest.
+- Training budget, scenario matrix, planner grid, and evaluation surface are identical between the
+  two configs.
+- The obstacle-feature run fails closed before training if the generated base or hardcase dataset
+  contains zero active non-sentinel obstacle rows. The preflight evidence is written to
+  `output/tmp/predictive_planner/pipeline/<run_id>/obstacle_feature_preflight.json`.
+
 ## Follow-Up Boundary
 
 Issue #1167 is not complete until the same-seed training/evaluation comparison reports ADE/FDE and
 downstream planner metrics. This patch removes the local pipeline blocker recorded during PR #1400
 triage and should be treated as the runnable setup for the campaign, not as benchmark-success
-evidence.
+evidence. Issue #1427 owns the actual SLURM submission, metric capture, and recommendation about
+whether obstacle features are worth further investment.

--- a/robot_sf/planner/obstacle_features.py
+++ b/robot_sf/planner/obstacle_features.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 PREDICTIVE_OBSTACLE_FEATURE_SCHEMA = "predictive_obstacle_features_v1"
 PREDICTIVE_OBSTACLE_FEATURE_DIM = 6
+PREDICTIVE_OBSTACLE_UNAVAILABLE_FEATURE_ROW = (50.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 PREDICTIVE_LEGACY_FEATURE_SCHEMA = "predictive_legacy_v1"
 PREDICTIVE_LEGACY_FEATURE_DIM = 4
 PREDICTIVE_EGO_FEATURE_SCHEMA = "predictive_ego_v1"
@@ -94,7 +95,7 @@ class LocalObstacleFeature:
 class LocalObstacleFeatureExtractor:
     """Extract deterministic nearest-line obstacle features."""
 
-    unavailable_distance: float = 50.0
+    unavailable_distance: float = PREDICTIVE_OBSTACLE_UNAVAILABLE_FEATURE_ROW[0]
 
     def __post_init__(self) -> None:
         """Validate unavailable-feature sentinel configuration."""

--- a/scripts/training/run_predictive_training_pipeline.py
+++ b/scripts/training/run_predictive_training_pipeline.py
@@ -22,7 +22,7 @@ from robot_sf.planner.obstacle_features import (
     PREDICTIVE_LEGACY_FEATURE_SCHEMA,
     PREDICTIVE_OBSTACLE_FEATURE_DIM,
     PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
-    infer_predictive_feature_schema,
+    PREDICTIVE_OBSTACLE_UNAVAILABLE_FEATURE_ROW,
 )
 from robot_sf.training.scenario_loader import load_scenarios
 
@@ -143,13 +143,13 @@ def _load_feature_schema_metadata(raw: Any) -> dict[str, Any]:
             payload = json.loads(raw_value)
             if isinstance(payload, dict):
                 return payload
-    return infer_predictive_feature_schema(int(np.asarray(raw["state"]).shape[2]))
+    raise ValueError("Missing or invalid feature_schema_json in dataset payload.")
 
 
 def _obstacle_feature_preflight(dataset_path: Path) -> dict[str, Any]:
     """Inspect one predictive dataset for active non-sentinel obstacle rows."""
     allowed_obstacle_sources = {"map_geometry"}
-    sentinel_row = np.asarray([50.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    sentinel_row = np.asarray(PREDICTIVE_OBSTACLE_UNAVAILABLE_FEATURE_ROW, dtype=np.float32)
     summary_path = dataset_path.with_suffix(".json")
     summary = _read_json(summary_path) if summary_path.exists() else {}
     with np.load(dataset_path) as raw:

--- a/scripts/training/run_predictive_training_pipeline.py
+++ b/scripts/training/run_predictive_training_pipeline.py
@@ -148,6 +148,7 @@ def _load_feature_schema_metadata(raw: Any) -> dict[str, Any]:
 
 def _obstacle_feature_preflight(dataset_path: Path) -> dict[str, Any]:
     """Inspect one predictive dataset for active non-sentinel obstacle rows."""
+    allowed_obstacle_sources = {"map_geometry"}
     sentinel_row = np.asarray([50.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
     summary_path = dataset_path.with_suffix(".json")
     summary = _read_json(summary_path) if summary_path.exists() else {}
@@ -170,7 +171,16 @@ def _obstacle_feature_preflight(dataset_path: Path) -> dict[str, Any]:
     if obstacle_feature_source is None:
         report["status"] = "failed"
         report["failure_reason"] = (
-            "Dataset summary is missing obstacle_feature_source; cannot prove real obstacle rows."
+            "Dataset obstacle_feature_source must be an explicit map-derived source; got None."
+        )
+        return report
+    obstacle_feature_source = str(obstacle_feature_source).strip()
+    report["obstacle_feature_source"] = obstacle_feature_source
+    if obstacle_feature_source not in allowed_obstacle_sources:
+        report["status"] = "failed"
+        report["failure_reason"] = (
+            "Dataset obstacle_feature_source must be an explicit map-derived source; got "
+            f"{obstacle_feature_source!r}."
         )
         return report
 

--- a/scripts/training/run_predictive_training_pipeline.py
+++ b/scripts/training/run_predictive_training_pipeline.py
@@ -18,7 +18,12 @@ import numpy as np
 import yaml
 from loguru import logger
 
-from robot_sf.planner.obstacle_features import PREDICTIVE_LEGACY_FEATURE_SCHEMA
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+    PREDICTIVE_OBSTACLE_FEATURE_DIM,
+    PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+    infer_predictive_feature_schema,
+)
 from robot_sf.training.scenario_loader import load_scenarios
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -39,6 +44,7 @@ class PipelinePaths:
     eval_dir: Path
     diagnostics_dir: Path
     campaign_dir: Path
+    obstacle_preflight_report: Path
     final_summary: Path
 
 
@@ -123,6 +129,130 @@ def _dataset_npz_diagnostics(path: Path) -> dict[str, Any]:
         "empty_agent_rows": int(np.count_nonzero(agent_rows <= 0.0)),
         "empty_target_rows": int(np.count_nonzero(target_rows <= 0.0)),
     }
+
+
+def _load_feature_schema_metadata(raw: Any) -> dict[str, Any]:
+    """Resolve predictive feature-schema metadata from dataset payloads."""
+    if "feature_schema_json" in raw:
+        raw_value = raw["feature_schema_json"]
+        if isinstance(raw_value, np.ndarray) and raw_value.shape == ():
+            raw_value = raw_value.item()
+        if isinstance(raw_value, bytes):
+            raw_value = raw_value.decode("utf-8")
+        if isinstance(raw_value, str):
+            payload = json.loads(raw_value)
+            if isinstance(payload, dict):
+                return payload
+    return infer_predictive_feature_schema(int(np.asarray(raw["state"]).shape[2]))
+
+
+def _obstacle_feature_preflight(dataset_path: Path) -> dict[str, Any]:
+    """Inspect one predictive dataset for active non-sentinel obstacle rows."""
+    sentinel_row = np.asarray([50.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    summary_path = dataset_path.with_suffix(".json")
+    summary = _read_json(summary_path) if summary_path.exists() else {}
+    with np.load(dataset_path) as raw:
+        state = np.asarray(raw["state"], dtype=np.float32)
+        mask = np.asarray(raw["mask"], dtype=np.float32)
+        feature_schema = _load_feature_schema_metadata(raw)
+    schema_name = str(feature_schema.get("name", "")).strip()
+    report: dict[str, Any] = {
+        "dataset_path": str(dataset_path),
+        "feature_schema": feature_schema,
+        "status": "not_applicable",
+    }
+    if schema_name != PREDICTIVE_OBSTACLE_FEATURE_SCHEMA:
+        return report
+    obstacle_feature_source = summary.get("obstacle_feature_source")
+    report["summary_path"] = str(summary_path)
+    report["obstacle_feature_source"] = obstacle_feature_source
+    report["obstacle_line_count"] = summary.get("obstacle_line_count")
+    if obstacle_feature_source is None:
+        report["status"] = "failed"
+        report["failure_reason"] = (
+            "Dataset summary is missing obstacle_feature_source; cannot prove real obstacle rows."
+        )
+        return report
+
+    base_feature_dim = int(feature_schema.get("base_feature_dim", -1))
+    if base_feature_dim < 0:
+        raise ValueError(
+            f"Obstacle-feature dataset is missing base_feature_dim metadata: {dataset_path}"
+        )
+    obstacle_rows = state[
+        :,
+        :,
+        base_feature_dim : base_feature_dim + PREDICTIVE_OBSTACLE_FEATURE_DIM,
+    ]
+    if obstacle_rows.shape[2] != PREDICTIVE_OBSTACLE_FEATURE_DIM:
+        raise ValueError(
+            "Obstacle-feature dataset does not include the expected obstacle-feature width: "
+            f"{dataset_path} shape={obstacle_rows.shape}"
+        )
+
+    active_rows = mask > 0.0
+    valid_rows = active_rows & (obstacle_rows[:, :, -1] > 0.5)
+    exact_sentinel_rows = active_rows & np.all(
+        np.isclose(obstacle_rows, sentinel_row[None, None, :], atol=1e-6),
+        axis=2,
+    )
+    active_row_count = int(np.count_nonzero(active_rows))
+    valid_row_count = int(np.count_nonzero(valid_rows))
+    sentinel_row_count = int(np.count_nonzero(exact_sentinel_rows))
+    invalid_row_count = int(np.count_nonzero(active_rows & ~valid_rows))
+    report.update(
+        {
+            "status": "ok" if valid_row_count > 0 else "failed",
+            "active_agent_rows": active_row_count,
+            "active_valid_obstacle_rows": valid_row_count,
+            "active_invalid_obstacle_rows": invalid_row_count,
+            "active_exact_sentinel_rows": sentinel_row_count,
+            "valid_row_ratio": (
+                float(valid_row_count / active_row_count) if active_row_count > 0 else 0.0
+            ),
+            "failure_reason": (
+                None
+                if valid_row_count > 0
+                else "Dataset contains no active non-sentinel obstacle rows."
+            ),
+        }
+    )
+    return report
+
+
+def _write_obstacle_preflight_report(
+    *,
+    report_path: Path,
+    run_id: str,
+    config_path: Path,
+    config_hash: str,
+    git_commit: str,
+    model_family: str,
+    datasets: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Write compact obstacle-row preflight evidence for pipeline handoff."""
+    status = "ok"
+    failing_datasets = [
+        role for role, payload in datasets.items() if str(payload.get("status")) == "failed"
+    ]
+    if failing_datasets:
+        status = "failed"
+    payload = {
+        "artifact_role": "predictive_obstacle_preflight",
+        "contract_version": _CONTRACT_VERSION,
+        "training_family": _TRAINING_FAMILY,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "run_id": run_id,
+        "config_path": str(config_path),
+        "config_hash": config_hash,
+        "git_commit": git_commit,
+        "model_family": model_family,
+        "status": status,
+        "datasets": datasets,
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_json(report_path, payload)
+    return payload
 
 
 def _write_dataset_manifest(
@@ -272,6 +402,7 @@ def _paths_from_config(
         eval_dir=eval_dir,
         diagnostics_dir=diagnostics_dir,
         campaign_dir=campaign_dir,
+        obstacle_preflight_report=run_root / "obstacle_feature_preflight.json",
         final_summary=run_root / "final_performance_summary.json",
     )
 
@@ -368,13 +499,23 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             f"base_collection/model_family={model_family!r} "
             f"hardcase_collection.model_family={hardcase_model_family!r}"
         )
-    base_manifest = paths.root / "base_random_seed_manifest.yaml"
-    _build_random_seed_manifest(
-        scenario_matrix=scenario_matrix,
-        seeds_per_scenario=int(base_collection.get("seeds_per_scenario", 4)),
-        random_seed_base=int(base_collection.get("random_seed_base", 11_000)),
-        output_path=base_manifest,
-    )
+    base_manifest_cfg = base_collection.get("seed_manifest")
+    if base_manifest_cfg:
+        base_manifest = _resolve(base_manifest_cfg, base=base_dir)
+        if not base_manifest.exists():
+            raise FileNotFoundError(
+                f"Configured base_collection.seed_manifest was not found: {base_manifest}"
+            )
+        base_manifest_generated = False
+    else:
+        base_manifest = paths.root / "base_random_seed_manifest.yaml"
+        _build_random_seed_manifest(
+            scenario_matrix=scenario_matrix,
+            seeds_per_scenario=int(base_collection.get("seeds_per_scenario", 4)),
+            random_seed_base=int(base_collection.get("random_seed_base", 11_000)),
+            output_path=base_manifest,
+        )
+        base_manifest_generated = True
 
     # 1) Collect base dataset over all scenarios with randomized seed manifest.
     _run(
@@ -411,6 +552,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         git_commit=git_commit,
         extra={
             "seed_manifest": str(base_manifest),
+            "seed_manifest_generated": base_manifest_generated,
             "ego_conditioning": bool(base_collection.get("ego_conditioning", False)),
             "model_family": model_family,
         },
@@ -465,6 +607,32 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             "model_family": hardcase_model_family,
         },
     )
+    obstacle_preflight_payload: dict[str, Any] | None = None
+    if model_family == PREDICTIVE_OBSTACLE_FEATURE_SCHEMA:
+        obstacle_preflight_payload = _write_obstacle_preflight_report(
+            report_path=paths.obstacle_preflight_report,
+            run_id=run_id,
+            config_path=config_path,
+            config_hash=config_hash,
+            git_commit=git_commit,
+            model_family=model_family,
+            datasets={
+                "base": _obstacle_feature_preflight(paths.base_dataset),
+                "hardcase": _obstacle_feature_preflight(paths.hardcase_dataset),
+            },
+        )
+        failing_datasets = [
+            role
+            for role, payload in obstacle_preflight_payload["datasets"].items()
+            if str(payload.get("status")) == "failed"
+        ]
+        if failing_datasets:
+            raise RuntimeError(
+                "Obstacle-feature pipeline preflight failed before training because "
+                "one or more collected datasets contain only sentinel obstacle rows: "
+                + ", ".join(sorted(failing_datasets))
+                + f". See {paths.obstacle_preflight_report}."
+            )
 
     # 3) Build mixed dataset.
     mixing_cfg = cfg.get("mixing", {})
@@ -736,9 +904,14 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "config_hash": config_hash,
         "git_commit": git_commit,
         "scenario_matrix": str(scenario_matrix),
+        "base_seed_manifest": str(base_manifest),
+        "base_seed_manifest_generated": base_manifest_generated,
         "hard_seed_manifest": str(hard_seed_manifest),
         "planner_grid": str(planner_grid),
         "model_family": model_family,
+        "obstacle_feature_preflight_report": (
+            str(paths.obstacle_preflight_report) if obstacle_preflight_payload is not None else None
+        ),
         "dataset_manifests": {
             "base": str(base_dataset_manifest),
             "hardcase": str(hardcase_dataset_manifest),

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -9,7 +9,10 @@ import numpy as np
 import pytest
 import yaml
 
-from robot_sf.planner.obstacle_features import PREDICTIVE_OBSTACLE_FEATURE_SCHEMA
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_OBSTACLE_FEATURE_DIM,
+    PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+)
 from scripts.training import run_predictive_training_pipeline as pipeline
 
 
@@ -305,14 +308,25 @@ def test_pipeline_passes_obstacle_model_family_to_collectors_and_training(
 
     def _fake_dataset(path: Path) -> None:
         """Write an obstacle-schema predictive dataset fixture."""
+        state = np.zeros((2, 3, 10), dtype=np.float32)
+        state[:, :, -1] = 1.0
         np.savez(
             path,
-            state=np.zeros((2, 3, 10), dtype=np.float32),
+            state=state,
             target=np.zeros((2, 3, 5, 2), dtype=np.float32),
             mask=np.ones((2, 3), dtype=np.float32),
             target_mask=np.ones((2, 3, 5), dtype=np.float32),
         )
-        path.with_suffix(".json").write_text(json.dumps({"num_samples": 2}), encoding="utf-8")
+        path.with_suffix(".json").write_text(
+            json.dumps(
+                {
+                    "num_samples": 2,
+                    "obstacle_feature_source": "map_geometry",
+                    "obstacle_line_count": 3,
+                }
+            ),
+            encoding="utf-8",
+        )
 
     def _fake_run(cmd: list[str], *, log_level: str) -> None:
         """Simulate pipeline commands and record schema-routing flags."""
@@ -377,6 +391,62 @@ def test_pipeline_passes_obstacle_model_family_to_collectors_and_training(
         for cmd in collector_cmds
     )
     assert train_cmd[train_cmd.index("--model-family") + 1] == PREDICTIVE_OBSTACLE_FEATURE_SCHEMA
+
+
+def test_obstacle_feature_preflight_reports_active_non_sentinel_rows(tmp_path: Path) -> None:
+    """Obstacle preflight should pass when active rows contain map-derived features."""
+    dataset_path = tmp_path / "predictive_rollouts_base.npz"
+    state = np.zeros((2, 2, 10), dtype=np.float32)
+    state[0, 0, 4 : 4 + PREDICTIVE_OBSTACLE_FEATURE_DIM] = np.asarray(
+        [2.5, 1.0, 0.0, 0.0, 1.0, 1.0],
+        dtype=np.float32,
+    )
+    np.savez(
+        dataset_path,
+        state=state,
+        target=np.zeros((2, 2, 5, 2), dtype=np.float32),
+        mask=np.ones((2, 2), dtype=np.float32),
+        target_mask=np.ones((2, 2, 5), dtype=np.float32),
+    )
+    dataset_path.with_suffix(".json").write_text(
+        json.dumps({"obstacle_feature_source": "map_geometry", "obstacle_line_count": 2}),
+        encoding="utf-8",
+    )
+
+    report = pipeline._obstacle_feature_preflight(dataset_path)
+
+    assert report["status"] == "ok"
+    assert report["active_agent_rows"] == 4
+    assert report["active_valid_obstacle_rows"] == 1
+    assert report["active_invalid_obstacle_rows"] == 3
+
+
+def test_obstacle_feature_preflight_fails_sentinel_only_rows(tmp_path: Path) -> None:
+    """Obstacle preflight should fail before training on sentinel-only obstacle rows."""
+    dataset_path = tmp_path / "predictive_rollouts_base.npz"
+    state = np.zeros((1, 3, 10), dtype=np.float32)
+    state[:, :, 4 : 4 + PREDICTIVE_OBSTACLE_FEATURE_DIM] = np.asarray(
+        [50.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        dtype=np.float32,
+    )
+    np.savez(
+        dataset_path,
+        state=state,
+        target=np.zeros((1, 3, 5, 2), dtype=np.float32),
+        mask=np.ones((1, 3), dtype=np.float32),
+        target_mask=np.ones((1, 3, 5), dtype=np.float32),
+    )
+    dataset_path.with_suffix(".json").write_text(
+        json.dumps({"obstacle_feature_source": "not_available", "obstacle_line_count": 0}),
+        encoding="utf-8",
+    )
+
+    report = pipeline._obstacle_feature_preflight(dataset_path)
+
+    assert report["status"] == "failed"
+    assert report["active_valid_obstacle_rows"] == 0
+    assert report["active_exact_sentinel_rows"] == 3
+    assert report["failure_reason"] == "Dataset contains no active non-sentinel obstacle rows."
 
 
 def test_pipeline_rejects_mismatched_collection_model_families(

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -437,7 +437,7 @@ def test_obstacle_feature_preflight_fails_sentinel_only_rows(tmp_path: Path) -> 
         target_mask=np.ones((1, 3, 5), dtype=np.float32),
     )
     dataset_path.with_suffix(".json").write_text(
-        json.dumps({"obstacle_feature_source": "not_available", "obstacle_line_count": 0}),
+        json.dumps({"obstacle_feature_source": "map_geometry", "obstacle_line_count": 0}),
         encoding="utf-8",
     )
 
@@ -447,6 +447,36 @@ def test_obstacle_feature_preflight_fails_sentinel_only_rows(tmp_path: Path) -> 
     assert report["active_valid_obstacle_rows"] == 0
     assert report["active_exact_sentinel_rows"] == 3
     assert report["failure_reason"] == "Dataset contains no active non-sentinel obstacle rows."
+
+
+def test_obstacle_feature_preflight_rejects_non_map_source_with_valid_rows(tmp_path: Path) -> None:
+    """Obstacle preflight should fail closed when the source is not explicitly map-derived."""
+    dataset_path = tmp_path / "predictive_rollouts_base.npz"
+    state = np.zeros((1, 2, 10), dtype=np.float32)
+    state[0, 0, 4 : 4 + PREDICTIVE_OBSTACLE_FEATURE_DIM] = np.asarray(
+        [2.5, 1.0, 0.0, 0.0, 1.0, 1.0],
+        dtype=np.float32,
+    )
+    np.savez(
+        dataset_path,
+        state=state,
+        target=np.zeros((1, 2, 5, 2), dtype=np.float32),
+        mask=np.ones((1, 2), dtype=np.float32),
+        target_mask=np.ones((1, 2, 5), dtype=np.float32),
+    )
+    dataset_path.with_suffix(".json").write_text(
+        json.dumps({"obstacle_feature_source": "not_available", "obstacle_line_count": 2}),
+        encoding="utf-8",
+    )
+
+    report = pipeline._obstacle_feature_preflight(dataset_path)
+
+    assert report["status"] == "failed"
+    assert report["obstacle_feature_source"] == "not_available"
+    assert report["failure_reason"] == (
+        "Dataset obstacle_feature_source must be an explicit map-derived source; got "
+        "'not_available'."
+    )
 
 
 def test_pipeline_rejects_mismatched_collection_model_families(
@@ -622,3 +652,131 @@ def test_pipeline_uses_resolved_model_id_and_fails_when_promotion_fails(
     assert final_summary["promoted_model"]["model_id"] == "predictive_explicit_model"
     assert final_summary["stage_status"]["promotion_ok"] is False
     assert final_summary["final_gate_results"]["all_ok"] is False
+
+
+def test_pipeline_uses_committed_base_seed_manifest_without_generating(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Pipeline should reuse a configured base seed manifest and record it as pre-existing."""
+    config_path = tmp_path / "predictive_existing_manifest.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "experiment": {"run_id": "predictive_existing_manifest"},
+                "output": {"root": "output/tmp/predictive_planner/pipeline"},
+                "scenarios": {
+                    "scenario_matrix": "scenarios.yaml",
+                    "hard_seed_manifest": "hard.yaml",
+                    "planner_grid": "grid.yaml",
+                },
+                "base_collection": {"seed_manifest": "base_manifest.yaml"},
+                "hardcase_collection": {},
+                "mixing": {},
+                "training": {"model_id": "predictive_existing_manifest"},
+                "wandb": {"enabled": False},
+                "evaluation": {},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "scenarios.yaml").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "hard.yaml").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "grid.yaml").write_text("{}\n", encoding="utf-8")
+    base_manifest = tmp_path / "base_manifest.yaml"
+    base_manifest.write_text("scenario: [7]\n", encoding="utf-8")
+
+    monkeypatch.setattr(pipeline, "_sha1_file", lambda _path: "cfghash")
+    monkeypatch.setattr(pipeline, "_git_hash", lambda: "deadbeef")
+
+    build_calls: list[dict[str, object]] = []
+
+    def _fake_build_seed_manifest(**kwargs) -> Path:
+        """Capture unexpected seed-manifest generation requests."""
+        build_calls.append(kwargs)
+        output_path = Path(kwargs["output_path"])
+        output_path.write_text("scenario: [1]\n", encoding="utf-8")
+        return output_path
+
+    monkeypatch.setattr(pipeline, "_build_random_seed_manifest", _fake_build_seed_manifest)
+
+    def _fake_dataset(path: Path) -> None:
+        """Write a default predictive dataset fixture."""
+        np.savez(
+            path,
+            state=np.zeros((2, 3, 4), dtype=np.float32),
+            target=np.zeros((2, 3, 5, 2), dtype=np.float32),
+            mask=np.ones((2, 3), dtype=np.float32),
+            target_mask=np.ones((2, 3, 5), dtype=np.float32),
+        )
+        path.with_suffix(".json").write_text(json.dumps({"num_samples": 2}), encoding="utf-8")
+
+    def _fake_run(cmd: list[str], *, log_level: str) -> None:
+        """Simulate pipeline commands and materialize expected artifacts."""
+        if any("collect_predictive_hardcase_data.py" in part for part in cmd):
+            output = Path(cmd[cmd.index("--output") + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            _fake_dataset(output)
+            return
+        if any("build_predictive_mixed_dataset.py" in part for part in cmd):
+            output = Path(cmd[cmd.index("--output") + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            _fake_dataset(output)
+            return
+        if any("train_predictive_planner.py" in part for part in cmd):
+            out_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "training_summary.json").write_text(
+                json.dumps(
+                    {"selection": {"selected_epoch": 1}, "selected_checkpoint_reason": "proxy"}
+                ),
+                encoding="utf-8",
+            )
+            (out_dir / "predictive_model.pt").write_text("stub", encoding="utf-8")
+            return
+        if any("run_predictive_success_campaign.py" in part for part in cmd):
+            output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / "campaign_summary.json").write_text(
+                json.dumps({"run_id": "predictive_existing_manifest", "status": "success"}),
+                encoding="utf-8",
+            )
+            return
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(pipeline, "_run", _fake_run)
+    monkeypatch.setattr(
+        pipeline,
+        "_run_capture_json",
+        lambda _cmd, **_kwargs: {"status": "ok", "return_code": 0},
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_parse_args",
+        lambda: pipeline.argparse.Namespace(
+            config=config_path,
+            run_id="predictive_existing_manifest",
+            log_level="INFO",
+        ),
+    )
+
+    resolved_paths = pipeline._paths_from_config(
+        yaml.safe_load(config_path.read_text(encoding="utf-8")),
+        run_id="predictive_existing_manifest",
+        base_dir=config_path.parent,
+        output_base_dir=pipeline._REPO_ROOT,
+    )
+
+    assert pipeline.main() == 0
+    assert build_calls == []
+
+    final_summary = json.loads(resolved_paths.final_summary.read_text(encoding="utf-8"))
+    assert final_summary["base_seed_manifest"] == str(base_manifest)
+    assert final_summary["base_seed_manifest_generated"] is False
+
+    base_dataset_manifest = json.loads(
+        Path(final_summary["dataset_manifests"]["base"]).read_text(encoding="utf-8")
+    )
+    assert base_dataset_manifest["extra"]["seed_manifest"] == str(base_manifest)
+    assert base_dataset_manifest["extra"]["seed_manifest_generated"] is False

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -16,6 +16,22 @@ from robot_sf.planner.obstacle_features import (
 from scripts.training import run_predictive_training_pipeline as pipeline
 
 
+def _obstacle_feature_schema_json(base_dim: int = 4) -> str:
+    """Return obstacle-feature schema metadata for predictive NPZ fixtures."""
+    return json.dumps(
+        {
+            "name": PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+            "base_schema": "predictive_legacy_v1",
+            "base_feature_dim": base_dim,
+            "obstacle_feature_schema": {
+                "name": PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+                "feature_dim": PREDICTIVE_OBSTACLE_FEATURE_DIM,
+            },
+            "input_dim": base_dim + PREDICTIVE_OBSTACLE_FEATURE_DIM,
+        }
+    )
+
+
 def test_paths_from_config_resolves_root_relative_to_output_base(tmp_path: Path) -> None:
     """Resolve output root relative to output base directory and run id."""
     cfg = {"output": {"root": "output/tmp/predictive_planner/pipeline"}}
@@ -316,6 +332,7 @@ def test_pipeline_passes_obstacle_model_family_to_collectors_and_training(
             target=np.zeros((2, 3, 5, 2), dtype=np.float32),
             mask=np.ones((2, 3), dtype=np.float32),
             target_mask=np.ones((2, 3, 5), dtype=np.float32),
+            feature_schema_json=np.asarray(_obstacle_feature_schema_json()),
         )
         path.with_suffix(".json").write_text(
             json.dumps(
@@ -407,6 +424,7 @@ def test_obstacle_feature_preflight_reports_active_non_sentinel_rows(tmp_path: P
         target=np.zeros((2, 2, 5, 2), dtype=np.float32),
         mask=np.ones((2, 2), dtype=np.float32),
         target_mask=np.ones((2, 2, 5), dtype=np.float32),
+        feature_schema_json=np.asarray(_obstacle_feature_schema_json()),
     )
     dataset_path.with_suffix(".json").write_text(
         json.dumps({"obstacle_feature_source": "map_geometry", "obstacle_line_count": 2}),
@@ -435,6 +453,7 @@ def test_obstacle_feature_preflight_fails_sentinel_only_rows(tmp_path: Path) -> 
         target=np.zeros((1, 3, 5, 2), dtype=np.float32),
         mask=np.ones((1, 3), dtype=np.float32),
         target_mask=np.ones((1, 3, 5), dtype=np.float32),
+        feature_schema_json=np.asarray(_obstacle_feature_schema_json()),
     )
     dataset_path.with_suffix(".json").write_text(
         json.dumps({"obstacle_feature_source": "map_geometry", "obstacle_line_count": 0}),
@@ -463,6 +482,7 @@ def test_obstacle_feature_preflight_rejects_non_map_source_with_valid_rows(tmp_p
         target=np.zeros((1, 2, 5, 2), dtype=np.float32),
         mask=np.ones((1, 2), dtype=np.float32),
         target_mask=np.ones((1, 2, 5), dtype=np.float32),
+        feature_schema_json=np.asarray(_obstacle_feature_schema_json()),
     )
     dataset_path.with_suffix(".json").write_text(
         json.dumps({"obstacle_feature_source": "not_available", "obstacle_line_count": 2}),


### PR DESCRIPTION
## Summary
- add paired same-seed predictive baseline and obstacle-feature configs for #1427
- teach the predictive training pipeline to consume a committed base seed manifest and record it in run summaries
- add fail-closed obstacle-feature preflight so sentinel-only obstacle rows abort before training
- document the SLURM handoff and compact evidence manifest for external submission

## Validation
- `uv run ruff check scripts/training/run_predictive_training_pipeline.py tests/training/test_run_predictive_training_pipeline.py`
- `uv run pytest -q tests/training/test_run_predictive_training_pipeline.py` (`11 passed`)
- YAML/JSON parse for both new configs, the shared seed manifest, and `docs/context/evidence/issue_1427_predictive_same_seed_handoff_2026-05-21/manifest.json`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` (`3860 passed, 11 skipped`)

## Artifact Classification
- No SLURM job submitted from this host; `local.machine.md` has `allow_slurm_submission: false`.
- Ignored test-generated `output/tmp/predictive_planner/pipeline/*` and `output/coverage/*` were removed after validation.
- Existing ignored local cache `output/model_cache/predictive_proxy_selected_v2_full/predictive_model.pt` remains local and is not part of this branch.
- External submitter should record SLURM job IDs, commit SHA, config paths, output roots, dataset/checkpoint paths, `final_performance_summary.*`, diagnostics, campaign summaries, and `obstacle_feature_preflight.json`.

## SLURM Handoff
Run on a SLURM-capable host:

```bash
uv run python scripts/training/run_predictive_training_pipeline.py \
  --config configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml

uv run python scripts/training/run_predictive_training_pipeline.py \
  --config configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml
```

Relates to #1427. This PR stages the same-seed handoff; issue #1427 should remain open until external SLURM run evidence is captured and interpreted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new predictive model training configurations for experimentation
  * Implemented preflight validation in the training pipeline for obstacle-feature models
  * Added base seed manifest configuration support for reproducible training

* **Documentation**
  * Updated training pipeline documentation with new workflow guidance

* **Tests**
  * Added validation tests for obstacle-feature preflight checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

