### PR TITLE
docs: define oracle imitation split policy (#1443)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -426,6 +426,10 @@ knowledge, not every transient iteration detail.
   evaluation funnel, SLURM handoff notes, and the current
   [portfolio overview](./policy_search/portfolio_overview_2026-05-05.md) for the non-training
   policy-search workstream.
+* [Issue #1443 Oracle Imitation Dataset Split Policy](./policy_search/contracts/oracle_imitation_dataset_split.md)
+  defines the train/validation/evaluation seed-split contract, hard-slice assignment rules,
+  relabeling boundaries, and manifest schema required before any oracle-imitation dataset
+  generation begins.
 * [Issue #1357 Tentabot-Style Motion-Primitive Assessment](./policy_search/2026-05-20_tentabot_motion_primitive_assessment.md)
   records the source-backed verdict that Tentabot-style learned primitive-value scoring is a
   Robot SF-native spike candidate, not an upstream adapter or benchmark-ready planner.

--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -18,6 +18,7 @@ Use it for three things only:
   variants, DRL-VO, and source-side-only candidates. Check this before proposing a new follow-up.
 - `experiment_ledger.md`: compact execution log for implemented candidates.
 - `contracts/`: project contract, gates, taxonomy, and runbook.
+  - `oracle_imitation_dataset_split.md`: train/validation/evaluation seed-split policy, hard-slice assignment rules, relabeling boundaries, and manifest schema for oracle-imitation datasets (issue #1443).
 - `reasoning/`: bounded planning and design notes.
 - `reports/`: per-run markdown reports emitted by the policy-search runner.
 - `validation/`: local smoke or narrow validation notes.

--- a/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
+++ b/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
@@ -6,6 +6,12 @@ Generate a planner-oracle dataset from the strongest non-training candidate
 family and train a faster imitation-style policy that preserves the same safety
 guard semantics.
 
+## Gated Dependency
+
+This campaign is blocked on `contracts/oracle_imitation_dataset_split.md`.
+Dataset generation, hard-slice augmentation, and relabeling must wait until the
+split policy is committed and the manifest schema is populated. See issue #1397.
+
 ## Suggested Phases
 
 1. Collect trajectories from the best current model-based candidate.

--- a/docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+++ b/docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
@@ -1,4 +1,4 @@
-# Oracle Imitation Dataset Split Policy
+# Issue #1443 Oracle Imitation Dataset Split Policy (2026-05-22)
 
 ## Scope
 
@@ -14,9 +14,9 @@ feeds the policy-search imitation pipeline.
 - For the first #1397 dataset contract:
   - `validation_seeds`: `configs/benchmarks/seed_sets_v1.yaml` key `dev` (`101`, `102`, `103`).
   - `evaluation_seeds`: `configs/benchmarks/seed_sets_v1.yaml` key `eval` (`111`, `112`, `113`).
-  - `train_seeds`: predeclared collection seeds that exclude every seed in `dev`, `eval`,
-    `paper_eval_s5`, `paper_eval_s10`, and `paper_eval_s20`.
-- The three split fields, `train_seeds`, `validation_seeds`, and `evaluation_seeds`, must be
+  - `train_seeds`: predeclared collection seeds that exclude every seed in `dev` and
+    `paper_eval_s20`.
+- The three keys in `seeds_by_split` (`train`, `validation`, and `evaluation`) must be
   disjoint. No seed may appear in more than one split. A `no-overlap` invariant is mandatory.
 - The split assignment must be recorded before collection starts and must not be changed afterward.
 
@@ -72,5 +72,5 @@ Before training starts, verify:
 
 This policy is a prerequisite for the oracle-imitation dataset campaign. Do not begin trajectory
 collection or hard-slice augmentation until this split contract is in place and the manifest schema
-is populated. See the campaign note `SLURM/003_imitation_oracle_dataset_campaign.md` for the gated
+is populated. See the campaign note [SLURM/003_imitation_oracle_dataset_campaign.md](../SLURM/003_imitation_oracle_dataset_campaign.md) for the gated
 handoff.

--- a/docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+++ b/docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
@@ -1,0 +1,76 @@
+# Oracle Imitation Dataset Split Policy
+
+## Scope
+
+This contract governs how a planner-oracle dataset is partitioned into train, validation,
+and evaluation splits before any imitation-style policy training begins. It applies to
+all oracle-trajectory collection, hard-slice recovery augmentation, and relabeling that
+feeds the policy-search imitation pipeline.
+
+## Seed Split Rule
+
+- Use the repository canonical seed sets for validation and evaluation. Do not invent or
+  regenerate validation/evaluation seeds for this purpose.
+- For the first #1397 dataset contract:
+  - `validation_seeds`: `configs/benchmarks/seed_sets_v1.yaml` key `dev` (`101`, `102`, `103`).
+  - `evaluation_seeds`: `configs/benchmarks/seed_sets_v1.yaml` key `eval` (`111`, `112`, `113`).
+  - `train_seeds`: predeclared collection seeds that exclude every seed in `dev`, `eval`,
+    `paper_eval_s5`, `paper_eval_s10`, and `paper_eval_s20`.
+- The three split fields, `train_seeds`, `validation_seeds`, and `evaluation_seeds`, must be
+  disjoint. No seed may appear in more than one split. A `no-overlap` invariant is mandatory.
+- The split assignment must be recorded before collection starts and must not be changed afterward.
+
+## Hard-Slice Assignment
+
+- Hard-slice recovery examples (e.g., corridor-deadlock, static-escape, or scenario-specific
+  failure modes) are assigned to `train` or `validation` by default.
+- They may be assigned to `evaluation` only when a dedicated holdout eval slice is predeclared
+  in writing before collection begins.
+- If no holdout eval slice was predeclared, hard-slice recovery examples must be excluded from
+  `evaluation_seeds`.
+
+## Relabeling Policy
+
+- Relabeling of oracle actions or observations is permitted **only** on the `train` split.
+- Training-split relabeling must use a documented, deterministic rule and must name the source
+  oracle that produced the original label.
+- Relabeling on `validation` or `evaluation` is rejected except for metadata-only annotations
+  (e.g., tagging an episode with a failure mode label without changing actions or rewards).
+- Any relabeling applied to `train` must be declared in the manifest under `relabeling_policy`.
+
+## Manifest Schema
+
+Every generated oracle-imitation dataset must ship a manifest containing at least the following
+fields:
+
+| Field | Description |
+|-------|-------------|
+| `source_candidate` | Name of the planner-oracle candidate that generated the trajectories. |
+| `source_candidate_config` | Path or identifier of the config used for the source candidate. |
+| `scenario_ids` | List of scenario identifiers included in the dataset. |
+| `seeds_by_split` | Mapping with keys `train`, `validation`, `evaluation` listing the exact seeds per split. |
+| `episode_ids_by_split` | Mapping with keys `train`, `validation`, `evaluation` listing episode identifiers per split. |
+| `hard_slice_assignment` | Per-hard-slice record of which split it was assigned to and whether it was predeclared for evaluation. |
+| `relabeling_policy` | Null if no relabeling was performed; otherwise a deterministic rule description and source-oracle reference. |
+| `checksums` | Content checksums for the artifact files (e.g., SHA-256). |
+| `exclusion_rules` | Description of any episodes or seeds excluded from the dataset and why. |
+| `provenance` | Human-readable summary of how the dataset was produced. |
+| `created_at` | ISO-8601 timestamp of manifest creation. |
+| `generating_commit` | Git commit hash of the repository state used for collection. |
+| `artifact_paths` | Relative or absolute paths to the dataset artifacts this manifest describes. |
+
+## Validation Gate
+
+Before training starts, verify:
+
+1. `seeds_by_split` has no overlaps.
+2. `hard_slice_assignment` respects the predeclaration rule.
+3. If `relabeling_policy` is non-null, it references a training-split-only scope.
+4. `checksums` cover every file listed in `artifact_paths`.
+
+## Dependency
+
+This policy is a prerequisite for the oracle-imitation dataset campaign. Do not begin trajectory
+collection or hard-slice augmentation until this split contract is in place and the manifest schema
+is populated. See the campaign note `SLURM/003_imitation_oracle_dataset_campaign.md` for the gated
+handoff.


### PR DESCRIPTION
## Summary
Define the oracle-imitation dataset split and leakage policy required before #1397 can generate training data.

## Linked Issues
- Closes #1443
- Relates to #1397

## What Changed
- Added `docs/context/policy_search/contracts/oracle_imitation_dataset_split.md` with the split contract, hard-slice assignment rules, relabeling boundaries, manifest schema, and validation gate.
- Updated the #1397 SLURM campaign note to block dataset generation on the new policy.
- Linked the policy from the policy-search and context README indexes.

## Why It Matters
- Added value: prevents oracle-imitation data generation from leaking evaluation seeds or relabeled recovery examples into final evaluation.
- Expected impact: gives #1397 a concrete prerequisite contract before any dataset or checkpoint artifacts are produced.
- Why this is worth merging now: it is a small docs-only gate that de-risks the larger training campaign.

## Validation / Proof
- `git diff --check`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` (`OK docs/proof consistency check passed for 4 changed file(s).`)
- Required-term/path smoke check for the new contract and linked docs.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` (`3864 passed, 11 skipped, 8 warnings`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true` for `6c7c2b711e94b49a266195c4d52798665fb3dff0`)

## Risks / Rollout
- Compatibility risks: none expected; docs-only change.
- Failure modes: future dataset tooling still needs to enforce the manifest schema mechanically.
- Rollback or fallback plan: revert the docs commit if the split policy needs a different seed contract.

## Docs / Provenance
- Updated docs:
  - `docs/context/policy_search/contracts/oracle_imitation_dataset_split.md`
  - `docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md`
  - `docs/context/policy_search/README.md`
  - `docs/context/README.md`
- Generated artifacts: `output/coverage/*` and `output/validation/pr_ready/*` are ignored validation outputs and were not committed.
- Assumption: #1397 should not start dataset generation until this policy is merged and the concrete manifest is populated.

## Follow-Up Issues
- Deferred work: optional machine-readable JSON Schema/YAML template for the manifest if maintainers want enforcement before generation.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the split rule is conservative enough for the first #1397 dataset and that `dev`/`eval` seed assignments match the intended validation/evaluation boundary.
