### PR TITLE
fix: exclude simulation errors from adversarial archive (#1453)

### DIFF
--- a/robot_sf/adversarial/archive.py
+++ b/robot_sf/adversarial/archive.py
@@ -66,7 +66,7 @@ def curate_failure_archive(
             "source_manifests": [path.as_posix() for path in manifests],
             "selection": {
                 "failure_attribution.primary_failure": (
-                    "not null and not one of success, invalid_candidate"
+                    "not null and not one of success, invalid_candidate, simulation_error"
                 ),
             },
             "grouping": [
@@ -116,7 +116,12 @@ def _is_archivable_failure(candidate_payload: dict[str, Any]) -> bool:
         return False
     if str(attribution.get("status", "")).strip().lower() == "not_evaluated":
         return False
-    return str(primary).strip().lower() not in {"", "success", "invalid_candidate"}
+    return str(primary).strip().lower() not in {
+        "",
+        "success",
+        "invalid_candidate",
+        "simulation_error",
+    }
 
 
 def _archive_entry(

--- a/robot_sf/adversarial/archive.py
+++ b/robot_sf/adversarial/archive.py
@@ -22,6 +22,18 @@ _SCALAR_FIELDS = (
     ("pedestrian_delay_s", ("pedestrian_delay_s",)),
 )
 
+_EXCLUDED_PRIMARY_FAILURES = frozenset({"", "success", "invalid_candidate", "simulation_error"})
+
+
+def _build_selection_description() -> str:
+    """Return the selection metadata string derived from the filtering constants."""
+    excluded = _EXCLUDED_PRIMARY_FAILURES - {""}
+    excluded_list = ", ".join(sorted(excluded))
+    return (
+        "not null, not empty, status is not not_evaluated, "
+        f"and primary_failure is not one of {excluded_list}"
+    )
+
 
 def curate_failure_archive(
     manifest_paths: list[str | Path],
@@ -65,9 +77,7 @@ def curate_failure_archive(
         "config": {
             "source_manifests": [path.as_posix() for path in manifests],
             "selection": {
-                "failure_attribution.primary_failure": (
-                    "not null and not one of success, invalid_candidate, simulation_error"
-                ),
+                "failure_attribution.primary_failure": _build_selection_description(),
             },
             "grouping": [
                 "config.policy",
@@ -116,12 +126,7 @@ def _is_archivable_failure(candidate_payload: dict[str, Any]) -> bool:
         return False
     if str(attribution.get("status", "")).strip().lower() == "not_evaluated":
         return False
-    return str(primary).strip().lower() not in {
-        "",
-        "success",
-        "invalid_candidate",
-        "simulation_error",
-    }
+    return str(primary).strip().lower() not in _EXCLUDED_PRIMARY_FAILURES
 
 
 def _archive_entry(

--- a/tests/adversarial/test_failure_archive.py
+++ b/tests/adversarial/test_failure_archive.py
@@ -116,6 +116,20 @@ def _manifest(tmp_path: Path) -> Path:
                     "details": {},
                 },
             },
+            {
+                "candidate": _candidate(1.0, seed=10),
+                "objective_value": 99.0,
+                "bundle_path": "output/adversarial/run/candidate_0005",
+                "scenario_yaml_path": "output/adversarial/run/candidate_0005/scenario.yaml",
+                "failure_attribution": {
+                    "status": "evaluation_failed",
+                    "primary_failure": "simulation_error",
+                    "reasons": ["spawn collision or unreachable goal"],
+                    "details": {
+                        "termination_reason": "simulation_error",
+                    },
+                },
+            },
         ],
     }
     path = tmp_path / "manifest.json"
@@ -134,7 +148,7 @@ def test_curate_failure_archive_groups_and_selects_representatives(tmp_path: Pat
     assert archive["schema_version"] == "adversarial_failure_archive.v1"
     assert archive["summary"] == {
         "source_manifest_count": 1,
-        "source_candidate_count": 5,
+        "source_candidate_count": 6,
         "archived_failure_count": 3,
         "cluster_count": 2,
     }
@@ -164,6 +178,40 @@ def test_curate_failure_archive_is_deterministic(tmp_path: Path) -> None:
     left.pop("created_at")
     right.pop("created_at")
     assert left == right
+
+
+def test_simulation_error_candidates_excluded_from_archive(tmp_path: Path) -> None:
+    """simulation_error must not enter archive entries, clusters, or representatives."""
+    manifest_path = _manifest(tmp_path)
+    output_path = tmp_path / "archive.json"
+
+    archive = curate_failure_archive([manifest_path], output_path=output_path)
+
+    primary_failures_in_entries = {
+        entry["failure_attribution"]["primary_failure"] for entry in archive["entries"]
+    }
+    cluster_mechanisms = {
+        cluster["mechanism"]["primary_failure"] for cluster in archive["clusters"]
+    }
+    representative_ids = {cluster["representative_archive_id"] for cluster in archive["clusters"]}
+    representative_failures = {
+        entry["failure_attribution"]["primary_failure"]
+        for entry in archive["entries"]
+        if entry["archive_id"] in representative_ids
+    }
+
+    assert "simulation_error" not in primary_failures_in_entries, (
+        "simulation_error candidate should not appear in archive entries"
+    )
+    assert "simulation_error" not in cluster_mechanisms, (
+        "simulation_error candidate should not appear in cluster mechanisms"
+    )
+    assert "simulation_error" not in representative_failures, (
+        "simulation_error candidate should not appear in cluster representatives"
+    )
+    assert archive["summary"]["source_candidate_count"] == 6, (
+        "source_candidate_count must still count simulation_error for budget auditing"
+    )
 
 
 def test_curate_failure_archive_cli_writes_summary(


### PR DESCRIPTION
## Summary
Excludes `simulation_error` outcomes from `adversarial_failure_archive.v1` eligibility while keeping them counted in raw source manifest auditing.

## Linked Issues
- Closes #1453
- Relates to #1433

## What Changed
- Added `simulation_error` to the compact adversarial failure archive exclusion set.
- Added a targeted archive fixture/test proving a scored `simulation_error` candidate stays out of entries, clusters, and representatives while still contributing to `source_candidate_count`.

## Why It Matters
- Added value: keeps runtime/spawn exceptions visible for budget auditing without treating them as adversarial episode failures.
- Expected impact: downstream clustering and representative selection now match the accepted v1 archive contract.
- Why this is worth merging now: this is a small correctness fix before additional stress-test reporting work consumes archive outputs.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format robot_sf/adversarial/archive.py tests/adversarial/test_failure_archive.py`
  - `uv run ruff check robot_sf/adversarial/archive.py tests/adversarial/test_failure_archive.py`
  - `uv run pytest tests/adversarial/test_failure_archive.py -q` (4 passed)
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4087 passed, 11 skipped; changed-file coverage warning only for `robot_sf/adversarial/archive.py` at 88.7%)
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` and `status --base-ref origin/main` (fresh for `c8ca7fc282086ec95afa06d8f9dbd28805c12c65`)
- Evidence that the change works here: `test_simulation_error_candidates_excluded_from_archive` asserts `simulation_error` is absent from archive entries, cluster mechanisms, and representatives while `source_candidate_count` remains 6.
- Benchmarks or smoke tests, if applicable: not applicable; no benchmark run needed for this archive eligibility fix.

## Risks / Rollout
- Compatibility risks: low; archive schema stays the same and only eligibility narrows.
- Failure modes: existing consumers expecting `simulation_error` in compact archive outputs would stop seeing those entries, which is the intended contract correction.
- Rollback or fallback plan: revert the single eligibility/test commit if downstream review finds a contract mismatch.

## Docs / Provenance
- Updated docs: none; the existing contract in `docs/context/issue_1433_adversarial_edge_case_search_design.md` already says simulation errors remain only in raw manifests.
- Relevant design or provenance notes: issue #1453, PR #1451 / issue #1433 contract.
- Any assumptions that need to be preserved: raw manifest accounting remains represented by `source_candidate_count`; compact archive clustering is episode-failure-only.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the archive eligibility boundary in `robot_sf/adversarial/archive.py` and the scored simulation-error fixture in `tests/adversarial/test_failure_archive.py`.
- Known limitation: changed-file coverage check reported 88.7% for `robot_sf/adversarial/archive.py` against a 100% goal, but the repo gate treats that as a warning and the targeted regression path is covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive curation logic to exclude simulation error failures from being archived, alongside other non-archivable failure classifications.

* **Tests**
  * Added comprehensive test coverage to ensure simulation errors are properly excluded from archive entries and clusters while remaining tracked in audit summary counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->