### PR TITLE
feat: add stress uncertainty coverage report builder (#1445)

### DIFF
--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -68,6 +68,11 @@ from robot_sf.benchmark.scenario_thumbnails import (
 from robot_sf.benchmark.seed_variance import (
     compute_seed_variance as _compute_seed_variance,
 )
+from robot_sf.benchmark.stress_uncertainty_coverage import (
+    build_stress_uncertainty_coverage_report_from_jsonl,
+    load_stress_uncertainty_coverage_payload,
+    write_stress_uncertainty_coverage_report,
+)
 from robot_sf.benchmark.summary import summarize_to_plots
 from robot_sf.common.seed import get_seed_state_sample as _seed_sample
 from robot_sf.common.seed import set_global_seed as _set_seed
@@ -524,6 +529,36 @@ def _handle_claim(args) -> int:
         return 2
     except Exception:  # pragma: no cover - error path
         logging.exception("Unexpected error during benchmark claim generation")
+        return 2
+
+
+def _handle_stress_coverage_report(args) -> int:
+    """Build or validate a stress/uncertainty coverage report.
+
+    Returns:
+        Exit code (0 success, 2 failure).
+    """
+    try:
+        if args.summary_json:
+            payload = load_stress_uncertainty_coverage_payload(args.summary_json)
+        else:
+            payload = build_stress_uncertainty_coverage_report_from_jsonl(
+                args.episodes_jsonl,
+                report_id=args.report_id,
+                campaign_config_hash=args.campaign_config_hash,
+                scenario_matrix_hash=args.scenario_matrix_hash,
+                schema_mode=args.schema_mode,
+                aggregate_mode=args.aggregate_mode,
+                availability_status=args.availability_status,
+                bootstrap_samples=args.bootstrap_samples,
+                bootstrap_confidence=args.bootstrap_confidence,
+                bootstrap_seed=args.bootstrap_seed,
+            )
+        out_path = write_stress_uncertainty_coverage_report(payload, args.out)
+        logging.info("Stress/uncertainty coverage report written to %s", out_path)
+        return 0
+    except Exception:
+        logging.exception("Stress/uncertainty coverage report failed")
         return 2
 
 
@@ -1586,6 +1621,49 @@ def _add_aggregate_subparser(
     p.set_defaults(cmd="aggregate")
 
 
+def _add_stress_coverage_report_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the stress-coverage-report subcommand parser."""
+    p = subparsers.add_parser(
+        "stress-coverage-report",
+        help="Build or validate a stress_uncertainty_coverage.v1 report.",
+    )
+    source = p.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--episodes-jsonl",
+        nargs="+",
+        help="Input episode JSONL path(s) used to build a v1 report.",
+    )
+    source.add_argument(
+        "--summary-json",
+        help="Existing v1 or legacy aggregate summary JSON to validate/normalize.",
+    )
+    p.add_argument("--out", required=True, help="Output report JSON path")
+    p.add_argument("--report-id", default="stress-coverage-report")
+    p.add_argument("--campaign-config-hash", default="unknown")
+    p.add_argument("--scenario-matrix-hash", default="unknown")
+    p.add_argument(
+        "--schema-mode",
+        choices=("required", "advisory", "diagnostic"),
+        default="required",
+    )
+    p.add_argument(
+        "--aggregate-mode",
+        choices=("mean", "median", "descriptive_only"),
+        default="mean",
+    )
+    p.add_argument(
+        "--availability-status",
+        choices=("available", "partial-failure", "failed", "not_available"),
+        default="available",
+    )
+    p.add_argument("--bootstrap-samples", type=int, default=0)
+    p.add_argument("--bootstrap-confidence", type=float, default=0.95)
+    p.add_argument("--bootstrap-seed", type=int, default=None)
+    p.set_defaults(cmd="stress-coverage-report")
+
+
 def _add_claim_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2023,6 +2101,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_run_subparser(subparsers)
     _add_summary_subparser(subparsers)
     _add_aggregate_subparser(subparsers)
+    _add_stress_coverage_report_subparser(subparsers)
     _add_claim_subparser(subparsers)
     _add_export_parquet_subparser(subparsers)
     _add_seed_variance_subparser(subparsers)
@@ -2473,6 +2552,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "run": _handle_run,
         "summary": _handle_summary,
         "aggregate": _handle_aggregate,
+        "stress-coverage-report": _handle_stress_coverage_report,
         "claim": _handle_claim,
         "export-parquet": _handle_export_parquet,
         "seed-variance": _handle_seed_variance,

--- a/robot_sf/benchmark/schemas/stress_uncertainty_coverage.schema.v1.json
+++ b/robot_sf/benchmark/schemas/stress_uncertainty_coverage.schema.v1.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/stress_uncertainty_coverage.schema.v1.json",
+  "title": "RobotSF Stress/Uncertainty Coverage Report (v1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "schema_mode",
+    "report_id",
+    "generated_at_utc",
+    "campaign_config_hash",
+    "scenario_matrix_hash",
+    "coverage_axes",
+    "metric_groups",
+    "aggregate_mode",
+    "availability_status"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "stress_uncertainty_coverage.v1"
+    },
+    "schema_mode": {
+      "enum": ["required", "advisory", "diagnostic"]
+    },
+    "report_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "campaign_config_hash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scenario_matrix_hash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "aggregate_mode": {
+      "enum": ["mean", "median", "descriptive_only"]
+    },
+    "availability_status": {
+      "enum": ["available", "partial-failure", "failed", "not_available"]
+    },
+    "missing_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coverage_axes": {
+      "type": "object",
+      "required": ["scenario_parameters", "failure_modes"],
+      "additionalProperties": true,
+      "properties": {
+        "scenario_parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["observed_values", "required_values", "coverage_status"],
+            "additionalProperties": true,
+            "properties": {
+              "observed_values": {
+                "type": "array"
+              },
+              "required_values": {
+                "type": "array"
+              },
+              "coverage_status": {
+                "enum": ["full", "partial", "missing"]
+              },
+              "entropy": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "failure_modes": {
+          "type": "object",
+          "required": ["collision", "near_miss", "timeout_without_progress"],
+          "additionalProperties": {
+            "type": "object",
+            "required": ["observed_episodes", "observed_fraction", "classification_source"],
+            "additionalProperties": true,
+            "properties": {
+              "observed_episodes": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "observed_fraction": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "scenario_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "classification_source": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "metric_groups": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "bootstrap_ci": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "samples": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "seed": {
+          "type": ["integer", "null"]
+        },
+        "lower": {
+          "type": ["number", "null"]
+        },
+        "upper": {
+          "type": ["number", "null"]
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/benchmark/stress_uncertainty_coverage.py
+++ b/robot_sf/benchmark/stress_uncertainty_coverage.py
@@ -264,6 +264,19 @@ def _mean(values: list[float]) -> float | None:
     return float(sum(values) / len(values)) if values else None
 
 
+def _success_values_relative_to_total(records: list[dict[str, Any]]) -> list[float]:
+    """Build one success value per episode, treating missing values as failures.
+
+    Returns:
+        Per-record success values with missing or non-finite success set to ``0.0``.
+    """
+    values: list[float] = []
+    for record in records:
+        success_val = _number_or_none(_nested_value(record, "metrics", "success"))
+        values.append(success_val if success_val is not None else 0.0)
+    return values
+
+
 def _count_collisions(records: list[dict[str, Any]]) -> int:
     """Count collision episodes from metrics first, then outcome flags.
 
@@ -325,15 +338,7 @@ def _build_metric_groups(
     near_misses = _count_near_misses(records)
     min_distance = _mean(_metric_values(records, "min_distance", "min_distance_m"))
     comfort_exposure = _mean(_metric_values(records, "comfort_exposure"))
-    success_values = _metric_values(records, "success")
-    if not success_values:
-        success_values = [
-            1.0
-            if bool(_nested_value(record, "outcome", "route_complete"))
-            and not bool(_nested_value(record, "outcome", "collision_event"))
-            else 0.0
-            for record in records
-        ]
+    success_values = _success_values_relative_to_total(records)
     time_to_goal_norm = _mean(_metric_values(records, "time_to_goal_norm"))
 
     if min_distance is None:
@@ -346,7 +351,7 @@ def _build_metric_groups(
     return {
         "safety": {
             "collisions": collisions,
-            "collision_rate": collisions / total,
+            "collision_rate": collisions / total if total else 0.0,
             "near_misses": near_misses,
             "min_distance": min_distance,
         },
@@ -354,7 +359,7 @@ def _build_metric_groups(
             "comfort_exposure": comfort_exposure,
         },
         "efficiency": {
-            "success": _mean(success_values),
+            "success": sum(success_values) / total if total else 0.0,
             "time_to_goal_norm": time_to_goal_norm,
         },
     }

--- a/robot_sf/benchmark/stress_uncertainty_coverage.py
+++ b/robot_sf/benchmark/stress_uncertainty_coverage.py
@@ -1,0 +1,469 @@
+"""Stress/uncertainty coverage report builder and validator."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.aggregate import read_jsonl
+
+SCHEMA_VERSION = "stress_uncertainty_coverage.v1"
+LEGACY_AGGREGATE_SCHEMA_VERSION = "aggregate.schema.v1"
+
+_SCHEMA_MODES = {"required", "advisory", "diagnostic"}
+_AGGREGATE_MODES = {"mean", "median", "descriptive_only"}
+_AVAILABILITY_STATUSES = {"available", "partial-failure", "failed", "not_available"}
+_REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "schema_mode",
+    "report_id",
+    "generated_at_utc",
+    "campaign_config_hash",
+    "scenario_matrix_hash",
+    "coverage_axes",
+    "metric_groups",
+    "aggregate_mode",
+    "availability_status",
+}
+_REQUIRED_FAILURE_MODES = ("collision", "near_miss", "timeout_without_progress")
+_SCENARIO_PARAMETER_KEYS = (
+    "archetype",
+    "density_label",
+    "ped_density_bucket",
+    "flow_type",
+    "map_name",
+    "kinematics_mode",
+    "horizon_steps",
+    "observation_level",
+    "optional_stress_marker",
+    "seed_count_bucket",
+)
+
+
+class StressUncertaintyCoverageError(ValueError):
+    """Raised when a stress/uncertainty coverage report fails closed."""
+
+
+def load_stress_uncertainty_coverage_payload(path: str | Path) -> dict[str, Any]:
+    """Load a v1 or legacy aggregate report payload.
+
+    Legacy ``aggregate.schema.v1`` reports remain parseable but explicitly return a
+    coverage-unavailable diagnostic wrapper so callers cannot mistake missing annotations for
+    evidence.
+
+    Returns:
+        Parsed v1 payload or a diagnostic wrapper for legacy aggregate summaries.
+    """
+    payload = _load_json_object(Path(path))
+    schema_version = payload.get("schema_version")
+    if schema_version == SCHEMA_VERSION:
+        return validate_stress_uncertainty_coverage_report(payload)
+    if (
+        schema_version is None
+        and payload.get("version") == "v1"
+        and isinstance(payload.get("groups"), dict)
+    ):
+        return {
+            "schema_version": LEGACY_AGGREGATE_SCHEMA_VERSION,
+            "schema_mode": "diagnostic",
+            "availability_status": "not_available",
+            "missing_fields": ["stress_uncertainty_coverage"],
+            "legacy_payload": payload,
+        }
+    raise StressUncertaintyCoverageError(
+        f"Unsupported stress/uncertainty coverage schema_version: {schema_version!r}"
+    )
+
+
+def build_stress_uncertainty_coverage_report(  # noqa: PLR0913
+    records: list[dict[str, Any]],
+    *,
+    report_id: str,
+    campaign_config_hash: str,
+    scenario_matrix_hash: str,
+    schema_mode: str = "required",
+    aggregate_mode: str = "mean",
+    availability_status: str = "available",
+    bootstrap_samples: int = 0,
+    bootstrap_confidence: float = 0.95,
+    bootstrap_seed: int | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a conservative v1 stress/uncertainty coverage report from episode records.
+
+    Returns:
+        A validated ``stress_uncertainty_coverage.v1`` payload.
+    """
+    if not records:
+        raise StressUncertaintyCoverageError("Cannot build coverage report from zero records")
+    missing_fields: list[str] = []
+    metric_groups = _build_metric_groups(records, missing_fields)
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "schema_mode": schema_mode,
+        "report_id": report_id,
+        "generated_at_utc": generated_at_utc or datetime.now(UTC).isoformat(),
+        "campaign_config_hash": campaign_config_hash,
+        "scenario_matrix_hash": scenario_matrix_hash,
+        "coverage_axes": _build_coverage_axes(records),
+        "metric_groups": metric_groups,
+        "aggregate_mode": aggregate_mode,
+        "availability_status": availability_status,
+        "missing_fields": missing_fields,
+    }
+    if bootstrap_samples > 0:
+        payload["bootstrap_ci"] = {
+            "samples": int(bootstrap_samples),
+            "confidence": float(bootstrap_confidence),
+            "seed": bootstrap_seed,
+            "lower": None,
+            "upper": None,
+        }
+    elif schema_mode != "required":
+        payload["missing_fields"].append("bootstrap_ci")
+    return validate_stress_uncertainty_coverage_report(payload)
+
+
+def build_stress_uncertainty_coverage_report_from_jsonl(
+    paths: list[str | Path] | str | Path,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build a v1 stress/uncertainty coverage report from episode JSONL paths.
+
+    Returns:
+        Validated report payload.
+    """
+    return build_stress_uncertainty_coverage_report(read_jsonl(paths), **kwargs)
+
+
+def validate_stress_uncertainty_coverage_report(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a v1 report and return a normalized payload.
+
+    Returns:
+        Normalized report payload.
+
+    Raises:
+        StressUncertaintyCoverageError: If required-mode validation fails.
+    """
+    if not isinstance(payload, dict):
+        raise StressUncertaintyCoverageError("Stress/uncertainty coverage report must be an object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise StressUncertaintyCoverageError(
+            f"Unsupported stress/uncertainty coverage schema_version: {payload.get('schema_version')!r}"
+        )
+    normalized = dict(payload)
+    normalized.setdefault("missing_fields", [])
+    missing = sorted(field for field in _REQUIRED_TOP_LEVEL if field not in normalized)
+    missing.extend(_missing_required_nested_fields(normalized))
+    missing = sorted(set(missing))
+    if normalized.get("schema_mode") not in _SCHEMA_MODES:
+        missing.append("schema_mode")
+    if normalized.get("aggregate_mode") not in _AGGREGATE_MODES:
+        missing.append("aggregate_mode")
+    if normalized.get("availability_status") not in _AVAILABILITY_STATUSES:
+        missing.append("availability_status")
+    existing_missing = [str(field) for field in normalized.get("missing_fields") or []]
+    all_missing = sorted(set(existing_missing + missing))
+    normalized["missing_fields"] = all_missing
+    if all_missing and normalized.get("schema_mode") == "required":
+        normalized["availability_status"] = "failed"
+        raise StressUncertaintyCoverageError(
+            "Missing required stress/uncertainty coverage fields: " + ", ".join(all_missing)
+        )
+    if all_missing and normalized.get("schema_mode") == "advisory":
+        normalized["availability_status"] = "partial-failure"
+    return normalized
+
+
+def write_stress_uncertainty_coverage_report(
+    payload: dict[str, Any],
+    output_path: str | Path,
+) -> Path:
+    """Validate and write a stress/uncertainty coverage report.
+
+    Returns:
+        Output path.
+    """
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    report = (
+        validate_stress_uncertainty_coverage_report(payload)
+        if payload.get("schema_version") == SCHEMA_VERSION
+        else payload
+    )
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Load a JSON object from disk.
+
+    Returns:
+        Parsed JSON object.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise StressUncertaintyCoverageError(f"Expected JSON object at {path}")
+    return payload
+
+
+def _nested_value(payload: dict[str, Any], *keys: str) -> Any:
+    """Read a nested value from a mapping.
+
+    Returns:
+        Nested value or None when unavailable.
+    """
+    cur: Any = payload
+    for key in keys:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def _number_or_none(value: Any) -> float | None:
+    """Normalize finite numeric values.
+
+    Returns:
+        Finite float value, or None when unavailable.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _metric_values(records: list[dict[str, Any]], *metric_names: str) -> list[float]:
+    """Collect finite metric values from episode records.
+
+    Returns:
+        Finite metric values in record order.
+    """
+    values: list[float] = []
+    for record in records:
+        metrics = record.get("metrics")
+        if not isinstance(metrics, dict):
+            continue
+        for name in metric_names:
+            number = _number_or_none(metrics.get(name))
+            if number is not None:
+                values.append(number)
+                break
+    return values
+
+
+def _mean(values: list[float]) -> float | None:
+    """Return the arithmetic mean for finite values."""
+    return float(sum(values) / len(values)) if values else None
+
+
+def _count_collisions(records: list[dict[str, Any]]) -> int:
+    """Count collision episodes from metrics first, then outcome flags.
+
+    Returns:
+        Number of collision episodes.
+    """
+    count = 0
+    for record in records:
+        metrics_collision = _number_or_none(_nested_value(record, "metrics", "collisions"))
+        if metrics_collision is not None:
+            count += int(metrics_collision > 0.0)
+            continue
+        outcome = record.get("outcome")
+        if isinstance(outcome, dict) and bool(
+            outcome.get("collision_event", outcome.get("collision"))
+        ):
+            count += 1
+    return count
+
+
+def _count_near_misses(records: list[dict[str, Any]]) -> int:
+    """Count near-miss episodes from known metric fields.
+
+    Returns:
+        Number of near-miss episodes.
+    """
+    values = _metric_values(records, "near_misses", "near_miss", "near_miss_count")
+    return int(sum(1 for value in values if value > 0.0))
+
+
+def _count_timeouts(records: list[dict[str, Any]]) -> int:
+    """Count timeout-without-progress episodes conservatively.
+
+    Returns:
+        Number of timeout-without-progress episodes.
+    """
+    count = 0
+    for record in records:
+        reason = str(record.get("termination_reason", "")).strip().lower()
+        outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+        timed_out = bool(outcome.get("timeout")) or reason in {"timeout", "max_steps", "time_limit"}
+        route_complete = bool(outcome.get("route_complete") or outcome.get("success"))
+        if timed_out and not route_complete:
+            count += 1
+    return count
+
+
+def _build_metric_groups(
+    records: list[dict[str, Any]],
+    missing_fields: list[str],
+) -> dict[str, Any]:
+    """Build conservative safety, comfort, and efficiency metric groups.
+
+    Returns:
+        Metric group payload.
+    """
+    total = len(records)
+    collisions = _count_collisions(records)
+    near_misses = _count_near_misses(records)
+    min_distance = _mean(_metric_values(records, "min_distance", "min_distance_m"))
+    comfort_exposure = _mean(_metric_values(records, "comfort_exposure"))
+    success_values = _metric_values(records, "success")
+    if not success_values:
+        success_values = [
+            1.0
+            if bool(_nested_value(record, "outcome", "route_complete"))
+            and not bool(_nested_value(record, "outcome", "collision_event"))
+            else 0.0
+            for record in records
+        ]
+    time_to_goal_norm = _mean(_metric_values(records, "time_to_goal_norm"))
+
+    if min_distance is None:
+        missing_fields.append("metric_groups.safety.min_distance")
+    if comfort_exposure is None:
+        missing_fields.append("metric_groups.comfort.comfort_exposure")
+    if time_to_goal_norm is None:
+        missing_fields.append("metric_groups.efficiency.time_to_goal_norm")
+
+    return {
+        "safety": {
+            "collisions": collisions,
+            "collision_rate": collisions / total,
+            "near_misses": near_misses,
+            "min_distance": min_distance,
+        },
+        "comfort": {
+            "comfort_exposure": comfort_exposure,
+        },
+        "efficiency": {
+            "success": _mean(success_values),
+            "time_to_goal_norm": time_to_goal_norm,
+        },
+    }
+
+
+def _build_coverage_axes(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build scenario-parameter and failure-mode coverage axes.
+
+    Returns:
+        Coverage axes payload.
+    """
+    total = len(records)
+    return {
+        "scenario_parameters": _scenario_parameter_coverage(records),
+        "failure_modes": {
+            "collision": _failure_mode_payload(
+                records, observed=_count_collisions(records), total=total
+            ),
+            "near_miss": _failure_mode_payload(
+                records, observed=_count_near_misses(records), total=total
+            ),
+            "timeout_without_progress": _failure_mode_payload(
+                records, observed=_count_timeouts(records), total=total
+            ),
+        },
+    }
+
+
+def _scenario_parameter_coverage(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return observed scenario-parameter coverage for canonical keys."""
+    observed: dict[str, set[str]] = defaultdict(set)
+    for record in records:
+        params = record.get("scenario_params")
+        if not isinstance(params, dict):
+            continue
+        for key in _SCENARIO_PARAMETER_KEYS:
+            value = params.get(key)
+            if value is not None:
+                observed[key].add(str(value))
+    coverage: dict[str, Any] = {}
+    for key in sorted(observed):
+        values = sorted(observed[key])
+        coverage[key] = {
+            "observed_values": values,
+            "required_values": values,
+            "coverage_status": "full" if values else "missing",
+        }
+    return coverage
+
+
+def _failure_mode_payload(
+    records: list[dict[str, Any]],
+    *,
+    observed: int,
+    total: int,
+) -> dict[str, Any]:
+    """Build one failure-mode coverage payload.
+
+    Returns:
+        Failure-mode coverage payload.
+    """
+    scenario_ids = sorted(
+        {
+            str(record.get("scenario_id"))
+            for record in records
+            if record.get("scenario_id") is not None
+        }
+    )
+    return {
+        "observed_episodes": int(observed),
+        "observed_fraction": float(observed / total) if total else 0.0,
+        "scenario_ids": scenario_ids,
+        "classification_source": "episode_metrics",
+    }
+
+
+def _missing_required_nested_fields(payload: dict[str, Any]) -> list[str]:
+    """Return missing nested required-field paths for v1 reports."""
+    missing: list[str] = []
+    coverage_axes = payload.get("coverage_axes")
+    if not isinstance(coverage_axes, dict):
+        return ["coverage_axes"]
+    failure_modes = coverage_axes.get("failure_modes")
+    if not isinstance(failure_modes, dict):
+        missing.append("coverage_axes.failure_modes")
+    else:
+        for mode in _REQUIRED_FAILURE_MODES:
+            entry = failure_modes.get(mode)
+            if not isinstance(entry, dict):
+                missing.append(f"coverage_axes.failure_modes.{mode}")
+                continue
+            for field in ("observed_episodes", "observed_fraction", "classification_source"):
+                if field not in entry:
+                    missing.append(f"coverage_axes.failure_modes.{mode}.{field}")
+    metric_groups = payload.get("metric_groups")
+    if not isinstance(metric_groups, dict):
+        missing.append("metric_groups")
+    elif not any(group in metric_groups for group in ("safety", "comfort", "efficiency")):
+        missing.append("metric_groups.safety|comfort|efficiency")
+    return missing
+
+
+__all__ = [
+    "LEGACY_AGGREGATE_SCHEMA_VERSION",
+    "SCHEMA_VERSION",
+    "StressUncertaintyCoverageError",
+    "build_stress_uncertainty_coverage_report",
+    "build_stress_uncertainty_coverage_report_from_jsonl",
+    "load_stress_uncertainty_coverage_payload",
+    "validate_stress_uncertainty_coverage_report",
+    "write_stress_uncertainty_coverage_report",
+]

--- a/tests/benchmark/test_stress_uncertainty_coverage.py
+++ b/tests/benchmark/test_stress_uncertainty_coverage.py
@@ -13,6 +13,7 @@ from robot_sf.benchmark.stress_uncertainty_coverage import (
     LEGACY_AGGREGATE_SCHEMA_VERSION,
     SCHEMA_VERSION,
     StressUncertaintyCoverageError,
+    _build_metric_groups,
     build_stress_uncertainty_coverage_report_from_jsonl,
     load_stress_uncertainty_coverage_payload,
 )
@@ -190,3 +191,58 @@ def test_stress_coverage_report_cli_writes_report(
     payload = json.loads(out_path.read_text(encoding="utf-8"))
     assert payload["schema_version"] == SCHEMA_VERSION
     assert payload["report_id"] == "cli-report"
+
+
+def test_missing_success_metric_counts_against_total_episodes(tmp_path: Path) -> None:
+    """Missing success metrics should count as 0.0, not disappear from the denominator."""
+    records = [
+        {
+            "episode_id": "has-success",
+            "scenario_id": "sc-a",
+            "scenario_params": {"density_label": "low"},
+            "outcome": {"route_complete": True, "collision_event": False},
+            "metrics": {
+                "collisions": 0,
+                "min_distance": 2.0,
+                "comfort_exposure": 0.1,
+                "success": 1,
+                "time_to_goal_norm": 0.5,
+            },
+        },
+        {
+            "episode_id": "missing-success",
+            "scenario_id": "sc-b",
+            "scenario_params": {"density_label": "low"},
+            "outcome": {"route_complete": True, "collision_event": False},
+            "metrics": {
+                "collisions": 0,
+                "min_distance": 1.5,
+                "comfort_exposure": 0.2,
+                "time_to_goal_norm": 0.7,
+            },
+        },
+    ]
+    jsonl_path = tmp_path / "mixed_success.jsonl"
+    jsonl_path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+    report = build_stress_uncertainty_coverage_report_from_jsonl(
+        jsonl_path,
+        report_id="mixed-success",
+        campaign_config_hash="cfg-sha256",
+        scenario_matrix_hash="matrix-sha256",
+    )
+
+    assert report["metric_groups"]["efficiency"]["success"] == pytest.approx(0.5)
+
+
+class TestCollisionRateZeroTotalSafety:
+    """Prove collision_rate is safe when total=0."""
+
+    def test_collision_rate_zero_total_returns_zero(self) -> None:
+        """_build_metric_groups should return collision_rate=0.0 when total=0."""
+        result = _build_metric_groups([], [])
+        assert result["safety"]["collision_rate"] == 0.0
+        assert result["safety"]["collisions"] == 0

--- a/tests/benchmark/test_stress_uncertainty_coverage.py
+++ b/tests/benchmark/test_stress_uncertainty_coverage.py
@@ -1,0 +1,192 @@
+"""Tests for stress/uncertainty coverage report building."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.benchmark.stress_uncertainty_coverage import (
+    LEGACY_AGGREGATE_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    StressUncertaintyCoverageError,
+    build_stress_uncertainty_coverage_report_from_jsonl,
+    load_stress_uncertainty_coverage_payload,
+)
+
+FIXTURE_DIR = Path("tests/fixtures/stress_uncertainty_coverage")
+
+
+def _write_episode_jsonl(path: Path) -> None:
+    """Write a compact synthetic campaign JSONL file."""
+    records = [
+        {
+            "episode_id": "episode-1",
+            "scenario_id": "scenario-a",
+            "scenario_params": {
+                "density_label": "low",
+                "flow_type": "crossing",
+                "horizon_steps": 100,
+            },
+            "termination_reason": "collision",
+            "outcome": {"collision_event": True, "route_complete": False},
+            "metrics": {
+                "collisions": 1,
+                "near_misses": 0,
+                "min_distance": 0.2,
+                "comfort_exposure": 0.2,
+                "success": 0,
+                "time_to_goal_norm": 1.0,
+            },
+        },
+        {
+            "episode_id": "episode-2",
+            "scenario_id": "scenario-b",
+            "scenario_params": {
+                "density_label": "low",
+                "flow_type": "crossing",
+                "horizon_steps": 100,
+            },
+            "termination_reason": "timeout",
+            "outcome": {"timeout": True, "route_complete": False},
+            "metrics": {
+                "collisions": 0,
+                "near_misses": 1,
+                "min_distance": 0.5,
+                "comfort_exposure": 0.0,
+                "success": 0,
+                "time_to_goal_norm": 1.0,
+            },
+        },
+    ]
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_build_stress_uncertainty_coverage_report_from_jsonl(tmp_path: Path) -> None:
+    """Builder should emit required uncertainty and coverage fields from campaign JSONL."""
+    jsonl_path = tmp_path / "episodes.jsonl"
+    _write_episode_jsonl(jsonl_path)
+
+    report = build_stress_uncertainty_coverage_report_from_jsonl(
+        jsonl_path,
+        report_id="test-report",
+        campaign_config_hash="cfg-sha256",
+        scenario_matrix_hash="matrix-sha256",
+        generated_at_utc="2026-05-22T00:00:00+00:00",
+    )
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["availability_status"] == "available"
+    assert report["coverage_axes"]["failure_modes"]["collision"]["observed_episodes"] == 1
+    assert report["coverage_axes"]["failure_modes"]["near_miss"]["observed_episodes"] == 1
+    assert (
+        report["coverage_axes"]["failure_modes"]["timeout_without_progress"]["observed_episodes"]
+        == 1
+    )
+    assert report["coverage_axes"]["scenario_parameters"]["density_label"] == {
+        "observed_values": ["low"],
+        "required_values": ["low"],
+        "coverage_status": "full",
+    }
+    assert report["metric_groups"]["safety"]["collision_rate"] == 0.5
+    assert report["metric_groups"]["comfort"]["comfort_exposure"] == 0.1
+    assert report["metric_groups"]["efficiency"]["time_to_goal_norm"] == 1.0
+
+
+def test_load_legacy_aggregate_summary_is_coverage_unavailable() -> None:
+    """Pre-v1 aggregate summaries should parse without becoming coverage evidence."""
+    payload = load_stress_uncertainty_coverage_payload(FIXTURE_DIR / "legacy_aggregate_v1.json")
+
+    assert payload["schema_version"] == LEGACY_AGGREGATE_SCHEMA_VERSION
+    assert payload["availability_status"] == "not_available"
+    assert payload["missing_fields"] == ["stress_uncertainty_coverage"]
+    assert "legacy_payload" in payload
+
+
+def test_load_valid_v1_fixture() -> None:
+    """Minimal v1 fixture should pass the typed loader."""
+    payload = load_stress_uncertainty_coverage_payload(FIXTURE_DIR / "minimal_valid_v1.json")
+
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["missing_fields"] == []
+
+
+def test_valid_v1_fixture_matches_json_schema() -> None:
+    """Minimal v1 fixture should validate against the canonical JSON Schema."""
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/stress_uncertainty_coverage.schema.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload = json.loads((FIXTURE_DIR / "minimal_valid_v1.json").read_text(encoding="utf-8"))
+
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_required_v1_missing_failure_modes_fails_closed() -> None:
+    """Required-mode v1 reports must reject missing failure-mode coverage."""
+    with pytest.raises(StressUncertaintyCoverageError, match="coverage_axes.failure_modes"):
+        load_stress_uncertainty_coverage_payload(FIXTURE_DIR / "malformed_required_v1.json")
+
+
+def test_required_jsonl_missing_required_metric_fails_closed(tmp_path: Path) -> None:
+    """Required-mode JSONL builds must reject missing required metric fields."""
+    jsonl_path = tmp_path / "episodes.jsonl"
+    jsonl_path.write_text(
+        json.dumps(
+            {
+                "episode_id": "episode-1",
+                "scenario_id": "scenario-a",
+                "scenario_params": {"density_label": "low"},
+                "outcome": {"route_complete": True},
+                "metrics": {"collisions": 0, "success": 1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(StressUncertaintyCoverageError, match="metric_groups.safety.min_distance"):
+        build_stress_uncertainty_coverage_report_from_jsonl(
+            jsonl_path,
+            report_id="missing-metric",
+            campaign_config_hash="cfg-sha256",
+            scenario_matrix_hash="matrix-sha256",
+        )
+
+
+def test_stress_coverage_report_cli_writes_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI should build and write the report from JSONL input."""
+    jsonl_path = tmp_path / "episodes.jsonl"
+    out_path = tmp_path / "stress_report.json"
+    _write_episode_jsonl(jsonl_path)
+
+    exit_code = cli_main(
+        [
+            "stress-coverage-report",
+            "--episodes-jsonl",
+            str(jsonl_path),
+            "--out",
+            str(out_path),
+            "--report-id",
+            "cli-report",
+            "--campaign-config-hash",
+            "cfg-sha256",
+            "--scenario-matrix-hash",
+            "matrix-sha256",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["report_id"] == "cli-report"

--- a/tests/fixtures/stress_uncertainty_coverage/legacy_aggregate_v1.json
+++ b/tests/fixtures/stress_uncertainty_coverage/legacy_aggregate_v1.json
@@ -1,0 +1,14 @@
+{
+  "groups": {
+    "planner-a": {
+      "metrics": {
+        "collisions": {
+          "mean": 0.0,
+          "median": 0.0,
+          "p95": 0.0
+        }
+      }
+    }
+  },
+  "version": "v1"
+}

--- a/tests/fixtures/stress_uncertainty_coverage/malformed_required_v1.json
+++ b/tests/fixtures/stress_uncertainty_coverage/malformed_required_v1.json
@@ -1,0 +1,21 @@
+{
+  "aggregate_mode": "mean",
+  "availability_status": "available",
+  "campaign_config_hash": "cfg-sha256",
+  "coverage_axes": {
+    "scenario_parameters": {}
+  },
+  "generated_at_utc": "2026-05-22T00:00:00+00:00",
+  "metric_groups": {
+    "safety": {
+      "collision_rate": 0.0,
+      "collisions": 0,
+      "min_distance": 1.0,
+      "near_misses": 0
+    }
+  },
+  "report_id": "fixture-malformed",
+  "scenario_matrix_hash": "matrix-sha256",
+  "schema_mode": "required",
+  "schema_version": "stress_uncertainty_coverage.v1"
+}

--- a/tests/fixtures/stress_uncertainty_coverage/minimal_valid_v1.json
+++ b/tests/fixtures/stress_uncertainty_coverage/minimal_valid_v1.json
@@ -1,0 +1,54 @@
+{
+  "aggregate_mode": "mean",
+  "availability_status": "available",
+  "campaign_config_hash": "cfg-sha256",
+  "coverage_axes": {
+    "failure_modes": {
+      "collision": {
+        "classification_source": "episode_metrics",
+        "observed_episodes": 1,
+        "observed_fraction": 0.5,
+        "scenario_ids": ["scenario-a", "scenario-b"]
+      },
+      "near_miss": {
+        "classification_source": "episode_metrics",
+        "observed_episodes": 0,
+        "observed_fraction": 0.0,
+        "scenario_ids": ["scenario-a", "scenario-b"]
+      },
+      "timeout_without_progress": {
+        "classification_source": "episode_metrics",
+        "observed_episodes": 1,
+        "observed_fraction": 0.5,
+        "scenario_ids": ["scenario-a", "scenario-b"]
+      }
+    },
+    "scenario_parameters": {
+      "density_label": {
+        "coverage_status": "full",
+        "observed_values": ["low"],
+        "required_values": ["low"]
+      }
+    }
+  },
+  "generated_at_utc": "2026-05-22T00:00:00+00:00",
+  "metric_groups": {
+    "comfort": {
+      "comfort_exposure": 0.1
+    },
+    "efficiency": {
+      "success": 0.0,
+      "time_to_goal_norm": 1.0
+    },
+    "safety": {
+      "collision_rate": 0.5,
+      "collisions": 1,
+      "min_distance": 0.2,
+      "near_misses": 0
+    }
+  },
+  "report_id": "fixture-valid",
+  "scenario_matrix_hash": "matrix-sha256",
+  "schema_mode": "required",
+  "schema_version": "stress_uncertainty_coverage.v1"
+}


### PR DESCRIPTION
## Summary
Adds a conservative `stress_uncertainty_coverage.v1` report builder, loader, JSON Schema, fixtures, and `robot_sf_bench stress-coverage-report` CLI command.

## Linked Issues
- Closes #1445
- Relates to #1434

## What Changed
- Added `robot_sf.benchmark.stress_uncertainty_coverage` for building v1 reports from episode JSONL, validating v1 payloads, and treating legacy aggregate summaries as coverage-unavailable diagnostics.
- Added canonical JSON Schema at `robot_sf/benchmark/schemas/stress_uncertainty_coverage.schema.v1.json`.
- Added `robot_sf_bench stress-coverage-report` for JSONL build and summary validation/normalization paths.
- Added synthetic fixtures for valid v1, legacy aggregate v1, and malformed required-mode v1 reports.

## Why It Matters
- Added value: implements the accepted #1434 stress/uncertainty/coverage schema without changing metric formulas or benchmark semantics.
- Expected impact: report consumers can fail closed on missing required fields and avoid mistaking legacy aggregate summaries for stress coverage evidence.
- Why this is worth merging now: #1445 is the runtime follow-up that unblocks stress-test report generation after the schema/design PR merged.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff check robot_sf/benchmark/stress_uncertainty_coverage.py robot_sf/benchmark/cli.py tests/benchmark/test_stress_uncertainty_coverage.py`
  - `uv run pytest tests/benchmark/test_stress_uncertainty_coverage.py tests/test_cli_aggregate.py tests/contract/test_aggregate_schema.py -q` (12 passed)
  - `uv run robot_sf_bench stress-coverage-report --help`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4093 passed, 11 skipped; changed-file coverage warnings only for `robot_sf/benchmark/cli.py` at 87.6% and `robot_sf/benchmark/stress_uncertainty_coverage.py` at 86.2%)
  - `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` and `status --base-ref origin/main` (fresh for `94a3a54297a329da22128f4834371519712ca37b`)
- Evidence that the change works here: tests cover JSONL build, v1 fixture JSON Schema validation, legacy aggregate non-crash/unavailable handling, malformed required-mode fail-closed handling, missing required metric fail-closed handling, and CLI report writing.
- Benchmarks or smoke tests, if applicable: no benchmark campaign run; this is schema/report-builder implementation only.

## Risks / Rollout
- Compatibility risks: low for existing aggregate users; the existing `aggregate` command behavior is unchanged.
- Failure modes: required-mode reports can fail closed when JSONL lacks required stress/report metrics, by design.
- Rollback or fallback plan: revert this additive report-builder commit; legacy aggregate behavior is otherwise untouched.

## Docs / Provenance
- Updated docs: none; #1434 documentation already links this follow-up and defines the schema contract.
- Relevant design or provenance notes: `docs/context/issue_1434_stress_uncertainty_coverage_schema.md`.
- Any assumptions that need to be preserved: this builder does not redefine SNQI, metric formulas, scenario adequacy, or benchmark-success interpretation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the fail-closed boundary in `validate_stress_uncertainty_coverage_report` and the conservative legacy aggregate wrapper.
- Known limitation: the JSONL builder derives required values from observed scenario parameters unless a richer matrix contract is added later; it should not be interpreted as scenario adequacy proof.
