### PR TITLE
feat: publish registry models as release artifacts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[SLURM Multi-Worktree Branch Workflow](./context/slurm_multi_worktree_branch_workflow.md)** - Submit jobs from multiple active branches on one login node without branch-switch ambiguity
 * **[SLURM Resource Audit](./dev/slurm_resource_audit.md)** - Inspect Slurm allocations, query W&B system metrics correctly, and decide whether CPU, memory, or GPU requests are oversized
 * **[Model Registry](../model/registry.md)** - Track trained policies and load them on-demand via `robot_sf.models`
+* **[Model Registry Publication Workflow](./model_registry_publication.md)** - Preserve promoted/paper-facing policies as public GitHub release assets with checksums and registry pointers
 * **[Examples Catalog](../examples/README.md)** - Manifest-backed index of quickstart, advanced, benchmark, and plotting scripts with usage metadata
 * **[SocNav structured observation example](../examples/advanced/18_socnav_structured_observation.py)** - Run RobotEnv with SocNavBench-style observations and a simple planner adapter.
 * **[SocNav structured observation how-to](./dev/issues/socnav_structured_observation.md)** - Enable `ObservationMode.SOCNAV_STRUCT` and use planner adapters (lightweight + SocNavBench wrapper).

--- a/docs/model_registry_publication.md
+++ b/docs/model_registry_publication.md
@@ -1,0 +1,132 @@
+# Model Registry Publication Workflow
+
+This workflow preserves selected trained policies as public GitHub release assets while keeping W&B
+as private experiment-lineage provenance.
+
+## Why
+
+Training run data has not been published broadly. Public users should not need W&B or Hugging Face
+project credentials to load preserved Robot SF models from `model/registry.yaml`.
+
+For preserved models, the public source of truth is a curated GitHub release asset with checksum
+metadata. W&B fields may remain in the registry as provenance/backfill fields, but model hydration
+should prefer `github_release`.
+
+## When
+
+Run this workflow when a trained policy becomes one of:
+
+- promoted or canonical,
+- paper-facing,
+- needed by public examples or benchmark reproduction,
+- worth preserving beyond local `output/` and private W&B.
+
+Do not publish scratch runs, failed runs, broad training logs, or exploratory checkpoints unless a
+maintainer explicitly promotes them.
+
+## What
+
+For each selected W&B-backed registry entry, publish:
+
+- the model artifact, for example `model.zip` or `predictive_model.pt`,
+- `<model_id>-metadata.json` with registry provenance,
+- release-level `manifest.json`,
+- release-level `SHA256SUMS`.
+
+Then update the registry entry with:
+
+```yaml
+public_artifact_source: github_release
+github_release:
+  repo: ll7/robot_sf_ll7
+  tag: artifact/models-YYYY-MM-registry-v1
+  asset_name: <model_id>-model.zip
+  url: https://github.com/ll7/robot_sf_ll7/releases/download/<tag>/<asset>
+  sha256: <sha256>
+  size_bytes: <bytes>
+  metadata_asset: <model_id>-metadata.json
+```
+
+## How
+
+Inventory and stage the current W&B-backed entries without uploading:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py \
+  --tag artifact/models-YYYY-MM-registry-v1 \
+  --download-missing \
+  --output-json output/model_registry_release/plan.json
+```
+
+Publish a new release and update `model/registry.yaml`:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py \
+  --tag artifact/models-YYYY-MM-registry-v1 \
+  --download-missing \
+  --execute-upload \
+  --create-release \
+  --update-registry \
+  --output-json output/model_registry_release/published.json
+```
+
+Publish one model while testing the flow:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py \
+  --tag artifact/models-YYYY-MM-registry-v1 \
+  --model-id ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417 \
+  --download-missing \
+  --execute-upload \
+  --create-release \
+  --update-registry
+```
+
+If the release already exists, omit `--create-release`.
+
+## Agent Coding Contract
+
+An implementation agent should:
+
+1. Read `model/registry.yaml` and select W&B-backed entries.
+2. Resolve each selected model from existing `local_path` or hydrate it with `--download-missing`.
+3. Stage release assets under `output/model_registry_release/<tag>/`.
+4. Upload staged assets with `gh release upload`.
+5. Update `github_release` pointers in `model/registry.yaml`.
+6. Run targeted registry tests.
+7. Verify at least one fresh-cache download through `resolve_model_path`.
+
+Agents must not publish unselected scratch runs or training logs.
+
+## Verification
+
+After publication:
+
+```bash
+uv run pytest tests/models/test_registry.py tests/tools/test_publish_model_registry_release.py
+```
+
+Verify the release asset can be downloaded without using W&B:
+
+```bash
+rm -rf output/model_cache/<model_id>
+uv run python - <<'PY'
+from robot_sf.models import resolve_model_path
+path = resolve_model_path("<model_id>", allow_download=True)
+print(path)
+PY
+sha256sum output/model_cache/<model_id>/<asset_name>
+```
+
+The checksum must match `model/registry.yaml`.
+
+Also inspect:
+
+```bash
+gh release view artifact/models-YYYY-MM-registry-v1 --repo ll7/robot_sf_ll7
+gh release download artifact/models-YYYY-MM-registry-v1 \
+  --repo ll7/robot_sf_ll7 \
+  --pattern manifest.json \
+  --pattern SHA256SUMS \
+  --dir output/model_registry_release/verify
+```

--- a/model/registry.md
+++ b/model/registry.md
@@ -15,9 +15,11 @@ notebooks to insert/update entries without manual YAML editing.
 - `local_path`: local checkout path to the model file (if available).
 - `config_path`: training config used to produce the model.
 - `commit`: git commit hash for reproducibility.
-- W&B metadata (optional): prefer `wandb_artifact_path` for durable model artifacts;
-  otherwise use either `wandb_run_path` or `wandb_entity` + `wandb_project` +
-  `wandb_run_id` so auto-download works.
+- `github_release` metadata (optional): preferred public retrieval pointer for promoted or
+  preserved artifacts. Include `repo`, `tag`, `asset_name`, `url`, `sha256`, and `size_bytes`.
+- W&B metadata (optional): lineage and private/backfill provenance. Prefer `wandb_artifact_path`
+  when preserving W&B provenance; otherwise use either `wandb_run_path` or `wandb_entity` +
+  `wandb_project` + `wandb_run_id`.
 - `wandb_file`: file to download from the run (defaults to `model.zip`).
 - `local_only`: mark entries that are only valid when the recorded `local_path`
   exists on the current machine.
@@ -41,6 +43,13 @@ models:
     wandb_run_id: run_id
     wandb_file: model.zip
     wandb_artifact_path: entity/project/artifact_name:version
+    github_release:
+      repo: owner/repo
+      tag: artifact/models-YYYY-MM-registry-v1
+      asset_name: my_model_id-model.zip
+      url: https://github.com/owner/repo/releases/download/artifact/models-YYYY-MM-registry-v1/my_model_id-model.zip
+      sha256: ...
+      size_bytes: 123
     local_only: false
     replacement_model_id: my_model_id_v2
     tags: ["ppo", "socnav"]
@@ -60,17 +69,35 @@ path = resolve_model_path(
 )
 ```
 
-If the model is not present locally and W&B metadata is configured in
-`model/registry.yaml`, the helper will download the artifact into
-`output/model_cache/<model_id>/`.
+If the model is not present locally and `github_release` metadata is configured in
+`model/registry.yaml`, the helper downloads and verifies the public release asset into
+`output/model_cache/<model_id>/`. If no GitHub release pointer is available, W&B metadata remains a
+private/provenance fallback.
 
-### Durable vs local cache fields
+### Public artifacts vs provenance fields
 
-Treat `wandb_artifact_path` as the preferred durable checkpoint pointer. Treat
+Treat `github_release` as the preferred public checkpoint pointer for preserved/canonical models.
+Treat W&B fields as experiment-lineage provenance unless the entry is intentionally private. Treat
 `local_path` under `output/model_cache/` as a cache location that may be absent in a fresh checkout.
-If a paper-facing registry entry still has `commit: null`, the W&B run or artifact pointer is the
-recoverable source, but the missing source commit should remain visible as a provenance caveat until
-it is repaired.
+If a paper-facing registry entry still has `commit: null`, keep the missing source commit visible as
+a provenance caveat until it is repaired.
+
+### Publishing preserved models
+
+Use `scripts/tools/publish_model_registry_release.py` to migrate W&B-backed model entries to GitHub
+release assets:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py \
+  --tag artifact/models-YYYY-MM-registry-v1 \
+  --download-missing \
+  --execute-upload \
+  --create-release \
+  --update-registry
+```
+
+The script stages model files, per-model metadata JSON, `manifest.json`, and `SHA256SUMS`; uploads
+them to the release; and writes `github_release` pointers back into `model/registry.yaml`.
 
 ## Notes
 

--- a/model/registry.yaml
+++ b/model/registry.yaml
@@ -1,393 +1,479 @@
 version: 1
 models:
-  - model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
-    display_name: PPO issue-791 leader, eval-aligned large-capacity grid_socnav
-      (2026-04-17, promoted)
-    local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/model.zip
-    config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml
-    commit: null
-    wandb_run_id: ibo3aqus
-    wandb_run_path: ll7/robot_sf/ibo3aqus
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    wandb_artifact_path: ll7/robot_sf/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity-best-success:v9
-    tags:
-      - ppo
-      - issue-791
-      - eval-aligned
-      - large-capacity
-      - grid-socnav
-      - reward-curriculum
-      - predictive-foresight
-      - promoted
-      - canonical-baseline
-    notes:
-      - Promoted on 2026-04-28 as the canonical PPO benchmark baseline; replaces
-        BR-06 v3 as the default for configs/baselines/ppo_15m_grid_socnav.yaml.
-      - Best eval (70 episodes, ppo_full_maintained_eval_v1) success_rate=0.929,
-        collision_rate=0.071, SNQI=0.353 at step 9,961,472 / 10,000,000.
-      - Source SLURM job 11724 (auxme-imech093, l40s, 8h04m).
-      - Caveat policy is in-distribution on the eval superset; reported as
-        benchmark-set performance, not OOD generalization.
-      - Promotion verdict
-        docs/context/issue_791_best_policy_verdict_2026_04_21.md
-      - Narrow paper claim
-        memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md
-      - Durable checkpoint source is the W&B artifact path above. The local_path
-        and best_summary references are cache paths under output/ and may be
-        absent in a fresh checkout.
-      - Best summary
-        output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/best_summary.json.
-  - model_id: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200
-    display_name: PPO BR-06 v3 all-maps randomized (2026-03-04, issue-576 closeout)
-    local_path: output/model_cache/ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200/model.zip
-    config_path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
-    commit: 9fb131b6d7ff062887caab33ca8713ae05167ebe
-    wandb_run_id: b60iopxt
-    wandb_run_path: ll7/robot_sf/b60iopxt
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - br06
-      - v3-semantics
-      - issue-576-closeout
-      - all-maps
-      - randomized-seeds
-    notes:
-      - Issue-576 closeout artifact; remains the historical pin for
-        configs/baselines/ppo_issue_576_br06_v2_15m.yaml.
-      - Replaced as the canonical PPO benchmark baseline by
-        ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
-        on 2026-04-28.
-      - Full 15M run finished under route-complete success semantics.
-      - Full policy sweep
-        output/benchmarks/20260304_184717_policy_analysis_ppo/report.md
-      - Analysis
-        model/ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200/training_analysis.md
-  - model_id: ppo_expert_br06_v2_15m_all_maps_20260302T152332
-    display_name: PPO expert BR-06 v2 all-maps (2026-03-02)
-    local_path: output/model_cache/ppo_expert_br06_v2_15m_all_maps_20260302T152332/model.zip
-    config_path: configs/training/ppo_imitation/expert_ppo.yaml
-    commit: null
-    wandb_run_id: asym0xo2
-    wandb_run_path: ll7/robot_sf/asym0xo2
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - br06
-      - v2-semantics
-      - deprecated
-      - all-maps
-      - diffdrive
-      - grid-obs
-    notes:
-      - Deprecated and replaced by
-        ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200.
-      - Run ended at ~7.1M steps (W&B state=killed), not full 15M budget.
-      - Training analysis: model/ppo_expert_br06_v2_15m_all_maps_20260302T152332/training_analysis.md
-  - model_id: ppo_expert_br06_v2_15m_all_maps_20260303T074433
-    display_name: PPO expert BR-06 v2 all-maps (2026-03-03 candidate)
-    local_path: output/model_cache/ppo_expert_br06_v2_15m_all_maps_20260303T074433/model.zip
-    config_path: configs/training/ppo/expert_ppo_issue_576_br06_v2_15m_all_maps.yaml
-    commit: 436368d78f351b7a30fcbe873fd82b380f0b30a8
-    wandb_run_id: c4s6142g
-    wandb_run_path: ll7/robot_sf/c4s6142g
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - br06
-      - v2-semantics
-      - candidate
-      - all-maps
-    notes:
-      - Full 15M run finished.
-      - Not promoted: high collision on classic scenarios and one
-          integrity-contradiction error episode.
-      - Analysis: model/ppo_expert_br06_v2_15m_all_maps_20260303T074433/training_analysis.md
-  - model_id: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311
-    display_name: PPO BR-06 v8 num_envs=8 benchmark best checkpoint (2026-03-11 candidate)
-    local_path: output/model_cache/ppo_num_envs_benchmark_candidates/08/model.zip
-    config_path: configs/training/ppo/benchmark_num_envs/expert_ppo_issue_576_br06_v8_num_envs_benchmark_08_1m.yaml
-    commit: 63853a635c521fc5f2d5c0995cfd8bd3d190b89d
-    wandb_run_id: mwmtrog8
-    wandb_run_path: ll7/robot_sf/mwmtrog8
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - br06
-      - v8-success-priority
-      - candidate
-      - benchmark-num-envs
-      - num-envs-8
-      - best-success
-    notes:
-      - Best intermediate checkpoint from the imech156-u num_envs benchmark run.
-      - W&B best-checkpoint summary: output/model_cache/ppo_num_envs_benchmark_candidates/08/best_checkpoint_summary.json
-      - Full policy sweep: output/benchmarks/20260311_policy_analysis_ppo_v8_numenv08_best/report.md
-      - Full 141-episode sweep slightly outperformed the promoted PPO v3
-        baseline on success and collision rate.
-  - model_id: ppo_expert_br06_v10_best_27dbe5xu_20260317
-    display_name: PPO BR-06 v10 best-success checkpoint (2026-03-17 carry-forward candidate)
-    local_path: output/model_cache/wandb_artifacts/27dbe5xu_best_success/model.zip
-    config_path: configs/training/ppo/expert_ppo_issue_576_br06_v10_predictive_foresight_success_priority_policy_analysis_select.yaml
-    commit: null
-    wandb_run_id: 27dbe5xu
-    wandb_run_path: ll7/robot_sf/27dbe5xu
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - br06
-      - v10-policy-analysis-select
-      - candidate
-      - best-success
-      - carry-forward
-    notes:
-      - Stronger benchmark-gate candidate than v11_best_j0m2cm0w on the
-        classic_interactions gate.
-      - Best-success artifact from W&B run 27dbe5xu.
-      - Benchmark gate with SNQI: output/benchmarks/20260317_benchmark_gate_compare_with_snqi/comparison.json
-      - Not promoted; full 141-episode benchmark is still too weak in absolute
-        terms because max_steps remains high.
-  - model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417
-    display_name: PPO issue-791 Wave-5 runner-up (eval-aligned + reward curriculum +
-      n_steps=4096, 2026-04-17)
-    local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_nsteps4096_20260417/model.zip
-    config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_nsteps4096.yaml
-    commit: null
-    wandb_run_id: lnxfp2gr
-    wandb_run_path: ll7/robot_sf/lnxfp2gr
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - issue-791
-      - eval-aligned
-      - reward-curriculum
-      - n_steps-4096
-      - candidate
-      - wave-5
-    notes:
-      - SLURM job 11723 on l40s, 7h33m wall.
-      - Best eval (70 episodes) success_rate=0.9143, collision_rate=0.0857 at
-        step 7,340,032.
-      - Same caveat - trained on eval superset; not OOD-validated.
-  - model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417
-    display_name: PPO issue-791 Wave-4 baseline (eval-aligned + reward curriculum,
-      default capacity, 2026-04-17)
-    local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_20260417/model.zip
-    config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned.yaml
-    commit: null
-    wandb_run_id: liisaa19
-    wandb_run_path: ll7/robot_sf/liisaa19
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: model.zip
-    tags:
-      - ppo
-      - issue-791
-      - eval-aligned
-      - reward-curriculum
-      - candidate
-      - wave-4
-    notes:
-      - SLURM job 11660 on a30, 15h10m wall.
-      - Best eval (70 episodes) success_rate=0.9000, collision_rate=0.1000 at
-        step 9,437,184.
-      - Default-capacity sibling of the Wave-5 leader; the +0.029 success delta
-        to 11724 isolates the capacity effect.
-  - model_id: ga3c_cadrl_iros18
-    display_name: GA3C-CADRL (IROS18) checkpoint
-    local_path: model/ga3c_cadrl/IROS18/network_01900000.meta
-    config_path: null
-    commit: null
-    wandb_run_id: null
-    wandb_run_path: null
-    wandb_entity: null
-    wandb_project: null
-    wandb_file: null
-    tags:
-      - sacadrl
-      - ga3c
-      - cadrl
-      - baseline
-    notes:
-      - "Checkpoint prefix: network_01900000 (see model/ga3c_cadrl/README.md)."
-      - "Source: gym-collision-avoidance (MIT ACL),
-        GA3C_CADRL/checkpoints/IROS18."
-  - model_id: predictive_rgl_v1
-    display_name: Predictive planner model (predictive_rgl_v1)
-    local_path: output/tmp/predictive_planner/training/predictive_rgl_v1_20260219/predictive_model.pt
-    config_path: null
-    commit: dfc4aea84e25cc83f9888c620286457bab3e1596
-    wandb_run_id: null
-    wandb_run_path: null
-    wandb_entity: null
-    wandb_project: null
-    wandb_file: null
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/datasets/predictive_rollouts_v1.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_rgl_full_v1
-    display_name: Predictive planner model (predictive_rgl_full_v1)
-    local_path: output/tmp/predictive_planner/training/predictive_rgl_full_v1/predictive_model.pt
-    config_path: null
-    commit: dfc4aea84e25cc83f9888c620286457bab3e1596
-    wandb_run_id: null
-    wandb_run_path: null
-    wandb_entity: null
-    wandb_project: null
-    wandb_file: null
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_rgl_sweep_h256_mp4_s42
-    display_name: Predictive planner model (predictive_rgl_sweep_h256_mp4_s42)
-    local_path: output/tmp/predictive_planner/training/sweep_h256_mp4_s42/predictive_model.pt
-    config_path: null
-    commit: dfc4aea84e25cc83f9888c620286457bab3e1596
-    wandb_run_id: null
-    wandb_run_path: null
-    wandb_entity: null
-    wandb_project: null
-    wandb_file: null
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_rgl_sweep_h192_mp3_s7_wd5e5
-    display_name: Predictive planner model (predictive_rgl_sweep_h192_mp3_s7_wd5e5)
-    local_path: output/tmp/predictive_planner/training/sweep_h192_mp3_s7_wd5e5/predictive_model.pt
-    config_path: null
-    commit: dfc4aea84e25cc83f9888c620286457bab3e1596
-    wandb_run_id: null
-    wandb_run_path: null
-    wandb_entity: null
-    wandb_project: null
-    wandb_file: null
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_proxy_selected_v1
-    display_name: Predictive planner model (predictive_proxy_selected_v1)
-    local_path: output/tmp/predictive_planner/training/predictive_proxy_selected_v1/predictive_model.pt
-    config_path: null
-    commit: dfc4aea84e25cc83f9888c620286457bab3e1596
-    wandb_run_id: geedo1po
-    wandb_run_path: ll7/robot_sf/geedo1po
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: predictive_model.pt
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/datasets/predictive_rollouts_mixed_v1.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-      - "W&B run URL: https://wandb.ai/ll7/robot_sf/runs/geedo1po"
-  - model_id: predictive_proxy_sanity_local
-    display_name: Predictive planner model (predictive_proxy_sanity_local)
-    local_path: output/tmp/predictive_planner/pipeline/predictive_sanity_local_20260305T122356Z/training/predictive_model.pt
-    config_path: ""
-    commit: cef93136b92ddca9b0c4436bc44049412461a2fd
-    wandb_run_id: ""
-    wandb_run_path: ""
-    wandb_entity: ""
-    wandb_project: ""
-    wandb_file: ""
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/pipeline/predictive_sanity_local_20260305T122356Z/datasets/predictive_rollouts_mixed.npz"
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_proxy_selected_v2_full
-    display_name: Predictive planner model (predictive_proxy_selected_v2_full)
-    local_path: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_full_20260305T123116Z/training/predictive_model.pt
-    config_path: configs/training/predictive/predictive_br07_all_maps_randomized_full.yaml
-    commit: cef93136b92ddca9b0c4436bc44049412461a2fd
-    wandb_run_id: u40parjb
-    wandb_run_path: ll7/robot_sf/u40parjb
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: predictive_model.pt
-    local_only: false
-    replacement_model_id: ""
-    tags:
-      - predictive
-      - rgl
-      - planner
-      - trajectory
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_full_20260305T123116Z/datasets/predictive_rollouts_mixed.npz"
-      - "Training summary:
-        output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomi\
-        zed_full_20260305T123116Z/training/training_summary.json"
-      - Portable W&B provenance repaired via model-file-upload run
-        ll7/robot_sf/u40parjb.
-      - Generated by scripts/training/train_predictive_planner.py
-  - model_id: predictive_proxy_selected_v2_xl_ego
-    display_name: Predictive planner model (predictive_proxy_selected_v2_xl_ego)
-    local_path: output/model_cache/predictive_proxy_selected_v2_xl_ego/predictive_model.pt
-    config_path: configs/training/predictive/predictive_br07_all_maps_randomized_xl_ego.yaml
-    commit: c2d07c6ed0e5e71738bf5729f54db1273a58ba38
-    wandb_run_id: i17pmely
-    wandb_run_path: ll7/robot_sf/i17pmely
-    wandb_entity: ll7
-    wandb_project: robot_sf
-    wandb_file: predictive_model.pt
-    tags:
-      - predictive
-      - br07
-      - all-maps
-      - randomized-seeds
-      - xl
-      - ego-conditioned
-      - promoted
-    notes:
-      - "Dataset:
-        output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomi\
-        zed_xl_ego_20260309T141432Z/datasets/predictive_rollouts_mixed.npz"
-      - "Training summary uploaded to W&B run file: training_summary.json"
-      - Generated by scripts/training/train_predictive_planner.py
+- model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
+  display_name: PPO issue-791 leader, eval-aligned large-capacity grid_socnav (2026-04-17,
+    promoted)
+  local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/model.zip
+  config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml
+  commit: null
+  wandb_run_id: ibo3aqus
+  wandb_run_path: ll7/robot_sf/ibo3aqus
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  wandb_artifact_path: ll7/robot_sf/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity-best-success:v9
+  tags:
+  - ppo
+  - issue-791
+  - eval-aligned
+  - large-capacity
+  - grid-socnav
+  - reward-curriculum
+  - predictive-foresight
+  - promoted
+  - canonical-baseline
+  notes:
+  - Promoted on 2026-04-28 as the canonical PPO benchmark baseline; replaces BR-06
+    v3 as the default for configs/baselines/ppo_15m_grid_socnav.yaml.
+  - Best eval (70 episodes, ppo_full_maintained_eval_v1) success_rate=0.929, collision_rate=0.071,
+    SNQI=0.353 at step 9,961,472 / 10,000,000.
+  - Source SLURM job 11724 (auxme-imech093, l40s, 8h04m).
+  - Caveat policy is in-distribution on the eval superset; reported as benchmark-set
+    performance, not OOD generalization.
+  - Promotion verdict docs/context/issue_791_best_policy_verdict_2026_04_21.md
+  - Narrow paper claim memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md
+  - Durable checkpoint source is the W&B artifact path above. The local_path and best_summary
+    references are cache paths under output/ and may be absent in a fresh checkout.
+  - Best summary output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/best_summary.json.
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-model.zip
+    sha256: 2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d
+    size_bytes: 93662266
+    metadata_asset: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200
+  display_name: PPO BR-06 v3 all-maps randomized (2026-03-04, issue-576 closeout)
+  local_path: output/model_cache/ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200/model.zip
+  config_path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+  commit: 9fb131b6d7ff062887caab33ca8713ae05167ebe
+  wandb_run_id: b60iopxt
+  wandb_run_path: ll7/robot_sf/b60iopxt
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - br06
+  - v3-semantics
+  - issue-576-closeout
+  - all-maps
+  - randomized-seeds
+  notes:
+  - Issue-576 closeout artifact; remains the historical pin for configs/baselines/ppo_issue_576_br06_v2_15m.yaml.
+  - Replaced as the canonical PPO benchmark baseline by ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
+    on 2026-04-28.
+  - Full 15M run finished under route-complete success semantics.
+  - Full policy sweep output/benchmarks/20260304_184717_policy_analysis_ppo/report.md
+  - Analysis model/ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200/training_analysis.md
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-model.zip
+    sha256: 8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09
+    size_bytes: 174820762
+    metadata_asset: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_br06_v2_15m_all_maps_20260302T152332
+  display_name: PPO expert BR-06 v2 all-maps (2026-03-02)
+  local_path: output/model_cache/ppo_expert_br06_v2_15m_all_maps_20260302T152332/model.zip
+  config_path: configs/training/ppo_imitation/expert_ppo.yaml
+  commit: null
+  wandb_run_id: asym0xo2
+  wandb_run_path: ll7/robot_sf/asym0xo2
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - br06
+  - v2-semantics
+  - deprecated
+  - all-maps
+  - diffdrive
+  - grid-obs
+  notes:
+  - Deprecated and replaced by ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200.
+  - Run ended at ~7.1M steps (W&B state=killed), not full 15M budget.
+  - Training analysis: model/ppo_expert_br06_v2_15m_all_maps_20260302T152332/training_analysis.md
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_br06_v2_15m_all_maps_20260302T152332-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_br06_v2_15m_all_maps_20260302T152332-model.zip
+    sha256: e9bf737760efffa238296096bb63078e421b3bf6fcba749a7fce382cee9a989e
+    size_bytes: 174821385
+    metadata_asset: ppo_expert_br06_v2_15m_all_maps_20260302T152332-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_br06_v2_15m_all_maps_20260303T074433
+  display_name: PPO expert BR-06 v2 all-maps (2026-03-03 candidate)
+  local_path: output/model_cache/ppo_expert_br06_v2_15m_all_maps_20260303T074433/model.zip
+  config_path: configs/training/ppo/expert_ppo_issue_576_br06_v2_15m_all_maps.yaml
+  commit: 436368d78f351b7a30fcbe873fd82b380f0b30a8
+  wandb_run_id: c4s6142g
+  wandb_run_path: ll7/robot_sf/c4s6142g
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - br06
+  - v2-semantics
+  - candidate
+  - all-maps
+  notes:
+  - Full 15M run finished.
+  - Not promoted: high collision on classic scenarios and one integrity-contradiction
+      error episode.
+  - Analysis: model/ppo_expert_br06_v2_15m_all_maps_20260303T074433/training_analysis.md
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_br06_v2_15m_all_maps_20260303T074433-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_br06_v2_15m_all_maps_20260303T074433-model.zip
+    sha256: 17d1c0467878bf828b45370bbb9dbfeebbdf6d078e77d11c9f7072bd6fffee9c
+    size_bytes: 174821327
+    metadata_asset: ppo_expert_br06_v2_15m_all_maps_20260303T074433-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311
+  display_name: PPO BR-06 v8 num_envs=8 benchmark best checkpoint (2026-03-11 candidate)
+  local_path: output/model_cache/ppo_num_envs_benchmark_candidates/08/model.zip
+  config_path: configs/training/ppo/benchmark_num_envs/expert_ppo_issue_576_br06_v8_num_envs_benchmark_08_1m.yaml
+  commit: 63853a635c521fc5f2d5c0995cfd8bd3d190b89d
+  wandb_run_id: mwmtrog8
+  wandb_run_path: ll7/robot_sf/mwmtrog8
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - br06
+  - v8-success-priority
+  - candidate
+  - benchmark-num-envs
+  - num-envs-8
+  - best-success
+  notes:
+  - Best intermediate checkpoint from the imech156-u num_envs benchmark run.
+  - W&B best-checkpoint summary: output/model_cache/ppo_num_envs_benchmark_candidates/08/best_checkpoint_summary.json
+  - Full policy sweep: output/benchmarks/20260311_policy_analysis_ppo_v8_numenv08_best/report.md
+  - Full 141-episode sweep slightly outperformed the promoted PPO v3 baseline on success
+    and collision rate.
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311-model.zip
+    sha256: ba9e1ef5dbd559f0af29ea9d88a61e698ef4a748bf54dc6c2217ace679580fce
+    size_bytes: 165359988
+    metadata_asset: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_br06_v10_best_27dbe5xu_20260317
+  display_name: PPO BR-06 v10 best-success checkpoint (2026-03-17 carry-forward candidate)
+  local_path: output/model_cache/wandb_artifacts/27dbe5xu_best_success/model.zip
+  config_path: configs/training/ppo/expert_ppo_issue_576_br06_v10_predictive_foresight_success_priority_policy_analysis_select.yaml
+  commit: null
+  wandb_run_id: 27dbe5xu
+  wandb_run_path: ll7/robot_sf/27dbe5xu
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - br06
+  - v10-policy-analysis-select
+  - candidate
+  - best-success
+  - carry-forward
+  notes:
+  - Stronger benchmark-gate candidate than v11_best_j0m2cm0w on the classic_interactions
+    gate.
+  - Best-success artifact from W&B run 27dbe5xu.
+  - Benchmark gate with SNQI: output/benchmarks/20260317_benchmark_gate_compare_with_snqi/comparison.json
+  - Not promoted; full 141-episode benchmark is still too weak in absolute terms because
+    max_steps remains high.
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_br06_v10_best_27dbe5xu_20260317-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_br06_v10_best_27dbe5xu_20260317-model.zip
+    sha256: 341e6b464bceba6cf0360c06a282bc9c100b0efc5d4400f855b90ea83ae7e78f
+    size_bytes: 171119983
+    metadata_asset: ppo_expert_br06_v10_best_27dbe5xu_20260317-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417
+  display_name: PPO issue-791 Wave-5 runner-up (eval-aligned + reward curriculum +
+    n_steps=4096, 2026-04-17)
+  local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_nsteps4096_20260417/model.zip
+  config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_nsteps4096.yaml
+  commit: null
+  wandb_run_id: lnxfp2gr
+  wandb_run_path: ll7/robot_sf/lnxfp2gr
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - issue-791
+  - eval-aligned
+  - reward-curriculum
+  - n_steps-4096
+  - candidate
+  - wave-5
+  notes:
+  - SLURM job 11723 on l40s, 7h33m wall.
+  - Best eval (70 episodes) success_rate=0.9143, collision_rate=0.0857 at step 7,340,032.
+  - Same caveat - trained on eval superset; not OOD-validated.
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417-model.zip
+    sha256: 723af98b8a7ca4e50cf12c18bcb2cbce15539514be6cb8e3bcd5189e3f4fed28
+    size_bytes: 51095030
+    metadata_asset: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417
+  display_name: PPO issue-791 Wave-4 baseline (eval-aligned + reward curriculum, default
+    capacity, 2026-04-17)
+  local_path: output/model_cache/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_20260417/model.zip
+  config_path: configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned.yaml
+  commit: null
+  wandb_run_id: liisaa19
+  wandb_run_path: ll7/robot_sf/liisaa19
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: model.zip
+  tags:
+  - ppo
+  - issue-791
+  - eval-aligned
+  - reward-curriculum
+  - candidate
+  - wave-4
+  notes:
+  - SLURM job 11660 on a30, 15h10m wall.
+  - Best eval (70 episodes) success_rate=0.9000, collision_rate=0.1000 at step 9,437,184.
+  - Default-capacity sibling of the Wave-5 leader; the +0.029 success delta to 11724
+    isolates the capacity effect.
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417-model.zip
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417-model.zip
+    sha256: 8e85553219d182930494a4876b4a3c16ab57f7b292e34fcb9b2e5b84570696a1
+    size_bytes: 51094878
+    metadata_asset: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: ga3c_cadrl_iros18
+  display_name: GA3C-CADRL (IROS18) checkpoint
+  local_path: model/ga3c_cadrl/IROS18/network_01900000.meta
+  config_path: null
+  commit: null
+  wandb_run_id: null
+  wandb_run_path: null
+  wandb_entity: null
+  wandb_project: null
+  wandb_file: null
+  tags:
+  - sacadrl
+  - ga3c
+  - cadrl
+  - baseline
+  notes:
+  - 'Checkpoint prefix: network_01900000 (see model/ga3c_cadrl/README.md).'
+  - 'Source: gym-collision-avoidance (MIT ACL), GA3C_CADRL/checkpoints/IROS18.'
+- model_id: predictive_rgl_v1
+  display_name: Predictive planner model (predictive_rgl_v1)
+  local_path: output/tmp/predictive_planner/training/predictive_rgl_v1_20260219/predictive_model.pt
+  config_path: null
+  commit: dfc4aea84e25cc83f9888c620286457bab3e1596
+  wandb_run_id: null
+  wandb_run_path: null
+  wandb_entity: null
+  wandb_project: null
+  wandb_file: null
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/datasets/predictive_rollouts_v1.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+- model_id: predictive_rgl_full_v1
+  display_name: Predictive planner model (predictive_rgl_full_v1)
+  local_path: output/tmp/predictive_planner/training/predictive_rgl_full_v1/predictive_model.pt
+  config_path: null
+  commit: dfc4aea84e25cc83f9888c620286457bab3e1596
+  wandb_run_id: null
+  wandb_run_path: null
+  wandb_entity: null
+  wandb_project: null
+  wandb_file: null
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+- model_id: predictive_rgl_sweep_h256_mp4_s42
+  display_name: Predictive planner model (predictive_rgl_sweep_h256_mp4_s42)
+  local_path: output/tmp/predictive_planner/training/sweep_h256_mp4_s42/predictive_model.pt
+  config_path: null
+  commit: dfc4aea84e25cc83f9888c620286457bab3e1596
+  wandb_run_id: null
+  wandb_run_path: null
+  wandb_entity: null
+  wandb_project: null
+  wandb_file: null
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+- model_id: predictive_rgl_sweep_h192_mp3_s7_wd5e5
+  display_name: Predictive planner model (predictive_rgl_sweep_h192_mp3_s7_wd5e5)
+  local_path: output/tmp/predictive_planner/training/sweep_h192_mp3_s7_wd5e5/predictive_model.pt
+  config_path: null
+  commit: dfc4aea84e25cc83f9888c620286457bab3e1596
+  wandb_run_id: null
+  wandb_run_path: null
+  wandb_entity: null
+  wandb_project: null
+  wandb_file: null
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/datasets/predictive_rollouts_full_v1.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+- model_id: predictive_proxy_selected_v1
+  display_name: Predictive planner model (predictive_proxy_selected_v1)
+  local_path: output/tmp/predictive_planner/training/predictive_proxy_selected_v1/predictive_model.pt
+  config_path: null
+  commit: dfc4aea84e25cc83f9888c620286457bab3e1596
+  wandb_run_id: geedo1po
+  wandb_run_path: ll7/robot_sf/geedo1po
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: predictive_model.pt
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/datasets/predictive_rollouts_mixed_v1.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+  - 'W&B run URL: https://wandb.ai/ll7/robot_sf/runs/geedo1po'
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: predictive_proxy_selected_v1-predictive_model.pt
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/predictive_proxy_selected_v1-predictive_model.pt
+    sha256: 0e7e775fd09509543761d8326237c4f85b0cc540fb24f98b3c5f8f7c0009fccc
+    size_bytes: 5034129
+    metadata_asset: predictive_proxy_selected_v1-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: predictive_proxy_sanity_local
+  display_name: Predictive planner model (predictive_proxy_sanity_local)
+  local_path: output/tmp/predictive_planner/pipeline/predictive_sanity_local_20260305T122356Z/training/predictive_model.pt
+  config_path: ''
+  commit: cef93136b92ddca9b0c4436bc44049412461a2fd
+  wandb_run_id: ''
+  wandb_run_path: ''
+  wandb_entity: ''
+  wandb_project: ''
+  wandb_file: ''
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/pipeline/predictive_sanity_local_20260305T122356Z/datasets/predictive_rollouts_mixed.npz'
+  - Generated by scripts/training/train_predictive_planner.py
+- model_id: predictive_proxy_selected_v2_full
+  display_name: Predictive planner model (predictive_proxy_selected_v2_full)
+  local_path: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_full_20260305T123116Z/training/predictive_model.pt
+  config_path: configs/training/predictive/predictive_br07_all_maps_randomized_full.yaml
+  commit: cef93136b92ddca9b0c4436bc44049412461a2fd
+  wandb_run_id: u40parjb
+  wandb_run_path: ll7/robot_sf/u40parjb
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: predictive_model.pt
+  local_only: false
+  replacement_model_id: ''
+  tags:
+  - predictive
+  - rgl
+  - planner
+  - trajectory
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_full_20260305T123116Z/datasets/predictive_rollouts_mixed.npz'
+  - 'Training summary: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_full_20260305T123116Z/training/training_summary.json'
+  - Portable W&B provenance repaired via model-file-upload run ll7/robot_sf/u40parjb.
+  - Generated by scripts/training/train_predictive_planner.py
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: predictive_proxy_selected_v2_full-predictive_model.pt
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/predictive_proxy_selected_v2_full-predictive_model.pt
+    sha256: a28aed6d6ad7e1ebf597277ade1cf908efa6da038d0a9fcfdf80c7c31d8d1be1
+    size_bytes: 4958329
+    metadata_asset: predictive_proxy_selected_v2_full-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release
+- model_id: predictive_proxy_selected_v2_xl_ego
+  display_name: Predictive planner model (predictive_proxy_selected_v2_xl_ego)
+  local_path: output/model_cache/predictive_proxy_selected_v2_xl_ego/predictive_model.pt
+  config_path: configs/training/predictive/predictive_br07_all_maps_randomized_xl_ego.yaml
+  commit: c2d07c6ed0e5e71738bf5729f54db1273a58ba38
+  wandb_run_id: i17pmely
+  wandb_run_path: ll7/robot_sf/i17pmely
+  wandb_entity: ll7
+  wandb_project: robot_sf
+  wandb_file: predictive_model.pt
+  tags:
+  - predictive
+  - br07
+  - all-maps
+  - randomized-seeds
+  - xl
+  - ego-conditioned
+  - promoted
+  notes:
+  - 'Dataset: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_xl_ego_20260309T141432Z/datasets/predictive_rollouts_mixed.npz'
+  - 'Training summary uploaded to W&B run file: training_summary.json'
+  - Generated by scripts/training/train_predictive_planner.py
+  github_release:
+    repo: ll7/robot_sf_ll7
+    tag: artifact/models-2026-05-registry-v1
+    asset_name: predictive_proxy_selected_v2_xl_ego-predictive_model.pt
+    url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models-2026-05-registry-v1/predictive_proxy_selected_v2_xl_ego-predictive_model.pt
+    sha256: 49deeeca98d44bcadb0eb845d9a9a5fd36cc2911a8fed8c414f7f988ec0a3a69
+    size_bytes: 11176729
+    metadata_asset: predictive_proxy_selected_v2_xl_ego-metadata.json
+    published_at_utc: '2026-05-24T05:32:03+00:00'
+  public_artifact_source: github_release

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import yaml
@@ -162,8 +163,12 @@ def _download_from_github_release(entry: dict[str, Any], *, cache_dir: str | Pat
     expected_sha256 = _github_release_expected_sha256(release)
     if not asset_name:
         raise ValueError(f"Registry entry '{model_id}' github_release.asset_name is required.")
+    _validate_github_release_asset_name(asset_name, model_id=model_id)
+    if not expected_sha256:
+        raise ValueError(f"Registry entry '{model_id}' github_release.sha256 is required.")
     if not url:
         url = _github_release_url(release, model_id=model_id, asset_name=asset_name)
+    _validate_github_release_url(url, model_id=model_id)
 
     cache_root = Path(cache_dir) if cache_dir is not None else Path("output/model_cache")
     cache_root = cache_root / model_id
@@ -214,6 +219,23 @@ def _github_release_url(
             f"Registry entry '{model_id}' needs github_release.url or repo/tag/asset_name."
         )
     return f"https://github.com/{repo}/releases/download/{tag}/{asset_name}"
+
+
+def _validate_github_release_asset_name(asset_name: str, *, model_id: str) -> None:
+    """Validate that a release asset name cannot escape the cache directory."""
+    if Path(asset_name).name != asset_name or asset_name in {".", ".."}:
+        raise ValueError(
+            f"Registry entry '{model_id}' github_release.asset_name must be a file name."
+        )
+
+
+def _validate_github_release_url(url: str, *, model_id: str) -> None:
+    """Validate that a release URL is an HTTPS GitHub URL."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        raise ValueError(
+            f"Registry entry '{model_id}' github_release.url must be an https://github.com URL."
+        )
 
 
 def _cached_release_path_is_valid(path: Path, expected_sha256: str) -> bool:

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 import yaml
 from loguru import logger
@@ -104,7 +107,7 @@ def resolve_model_path(
     allow_download: bool = True,
     cache_dir: str | Path | None = None,
 ) -> Path:
-    """Resolve a local model path, downloading from W&B if needed.
+    """Resolve a local model path, downloading from a public release or W&B if needed.
 
     Returns:
         Path: Local filesystem path to the model artifact.
@@ -128,7 +131,136 @@ def resolve_model_path(
     if not allow_download:
         raise FileNotFoundError(f"Model '{model_id}' not found locally and downloads are disabled.")
 
+    if entry.get("github_release"):
+        return _download_from_github_release(entry, cache_dir=cache_dir)
+
     return _download_from_wandb(entry, cache_dir=cache_dir)
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA256 digest for a local file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _download_from_github_release(entry: dict[str, Any], *, cache_dir: str | Path | None) -> Path:
+    """Download a model artifact from a GitHub release asset.
+
+    Returns:
+        Path: Local filesystem path to the downloaded artifact.
+    """
+    release = entry.get("github_release")
+    if not isinstance(release, dict):
+        raise ValueError("Registry entry github_release must be a mapping.")
+
+    model_id = str(entry.get("model_id", "unknown-model"))
+    asset_name = str(release.get("asset_name") or "").strip()
+    url = str(release.get("url") or "").strip()
+    expected_sha256 = _github_release_expected_sha256(release)
+    if not asset_name:
+        raise ValueError(f"Registry entry '{model_id}' github_release.asset_name is required.")
+    if not url:
+        url = _github_release_url(release, model_id=model_id, asset_name=asset_name)
+
+    cache_root = Path(cache_dir) if cache_dir is not None else Path("output/model_cache")
+    cache_root = cache_root / model_id
+    cache_root.mkdir(parents=True, exist_ok=True)
+    cached_path = cache_root / asset_name
+
+    if cached_path.exists() and _cached_release_path_is_valid(cached_path, expected_sha256):
+        return cached_path
+
+    logger.info("Downloading model artifact {} from GitHub release {}", asset_name, url)
+    try:
+        _stream_download_url(url, cached_path)
+    except (HTTPError, URLError, TimeoutError) as exc:
+        raise RuntimeError(
+            f"Could not download model '{model_id}' from GitHub release asset: {url}"
+        ) from exc
+
+    _verify_download_checksum(
+        cached_path,
+        expected_sha256=expected_sha256,
+        model_id=model_id,
+        asset_name=asset_name,
+    )
+    return cached_path
+
+
+def _github_release_expected_sha256(release: dict[str, Any]) -> str:
+    """Return normalized expected SHA256 while preserving non-null YAML scalars."""
+    raw_sha256 = release.get("sha256")
+    return "" if raw_sha256 is None else str(raw_sha256).strip().lower()
+
+
+def _github_release_url(
+    release: dict[str, Any],
+    *,
+    model_id: str,
+    asset_name: str,
+) -> str:
+    """Build a GitHub release asset URL from repo/tag/asset fields.
+
+    Returns:
+        str: Public GitHub release asset URL.
+    """
+    repo = str(release.get("repo") or "").strip()
+    tag = str(release.get("tag") or "").strip()
+    if not repo or not tag:
+        raise ValueError(
+            f"Registry entry '{model_id}' needs github_release.url or repo/tag/asset_name."
+        )
+    return f"https://github.com/{repo}/releases/download/{tag}/{asset_name}"
+
+
+def _cached_release_path_is_valid(path: Path, expected_sha256: str) -> bool:
+    """Return whether a cached release asset can be reused."""
+    if expected_sha256:
+        observed = _sha256(path)
+        if observed != expected_sha256:
+            logger.warning(
+                "Cached GitHub release model artifact checksum mismatch; redownloading: {}",
+                path,
+            )
+            path.unlink()
+            return False
+    resolved_cached_path = path.resolve()
+    if resolved_cached_path not in _LOGGED_CACHED_MODEL_ARTIFACTS:
+        _LOGGED_CACHED_MODEL_ARTIFACTS.add(resolved_cached_path)
+        logger.info("Using cached model artifact: {}", path)
+    return True
+
+
+def _stream_download_url(url: str, target_path: Path) -> None:
+    """Stream a URL to a local target path."""
+    with urlopen(url, timeout=60) as response, target_path.open("wb") as handle:
+        while True:
+            chunk = response.read(1024 * 1024)
+            if not chunk:
+                break
+            handle.write(chunk)
+
+
+def _verify_download_checksum(
+    path: Path,
+    *,
+    expected_sha256: str,
+    model_id: str,
+    asset_name: str,
+) -> None:
+    """Validate a downloaded artifact checksum."""
+    if not expected_sha256:
+        return
+    observed = _sha256(path)
+    if observed != expected_sha256:
+        path.unlink(missing_ok=True)
+        raise ValueError(
+            f"Checksum mismatch for model '{model_id}' from GitHub release asset "
+            f"{asset_name}: expected {expected_sha256}, observed {observed}."
+        )
 
 
 def resolve_latest_wandb_model(  # noqa: PLR0913

--- a/scripts/tools/publish_model_registry_release.py
+++ b/scripts/tools/publish_model_registry_release.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Stage and publish model-registry artifacts as GitHub release assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.models import registry as model_registry
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry-path", type=Path, default=Path("model/registry.yaml"))
+    parser.add_argument("--repo", default="ll7/robot_sf_ll7")
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="GitHub release tag, for example artifact/models-2026-05-registry-v1.",
+    )
+    parser.add_argument(
+        "--model-id",
+        action="append",
+        default=[],
+        help="Limit publication to one model id. May be repeated. Defaults to all W&B-backed rows.",
+    )
+    parser.add_argument(
+        "--staging-dir",
+        type=Path,
+        default=None,
+        help="Directory for staged model assets, metadata, manifest, and checksums.",
+    )
+    parser.add_argument(
+        "--download-missing",
+        action="store_true",
+        help="Use registry download metadata to hydrate missing local model files before staging.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("output/model_cache"),
+        help="Cache directory used when --download-missing needs to hydrate an artifact.",
+    )
+    parser.add_argument(
+        "--execute-upload",
+        action="store_true",
+        help="Run gh release upload after staging. Default is dry-run plan only.",
+    )
+    parser.add_argument(
+        "--create-release",
+        action="store_true",
+        help="Create the release before upload. Use with --execute-upload for a new tag.",
+    )
+    parser.add_argument(
+        "--update-registry",
+        action="store_true",
+        help="Write github_release pointers into the registry after staging/upload planning.",
+    )
+    parser.add_argument(
+        "--registry-output",
+        type=Path,
+        default=None,
+        help="Optional output path for the updated registry. Defaults to --registry-path.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path for the publication plan JSON.",
+    )
+    return parser
+
+
+def _load_registry_data(path: Path) -> dict[str, Any]:
+    """Load the raw registry YAML document."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected mapping in registry: {path}")
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise ValueError(f"Registry is missing a models list: {path}")
+    return payload
+
+
+def _has_wandb_reference(entry: dict[str, Any]) -> bool:
+    """Return whether a registry entry currently references W&B as a model source."""
+    return bool(
+        entry.get("wandb_artifact_path")
+        or entry.get("wandb_run_path")
+        or (entry.get("wandb_entity") and entry.get("wandb_project") and entry.get("wandb_run_id"))
+    )
+
+
+def _safe_component(value: str) -> str:
+    """Make a stable release-asset component from a model id or filename."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+    cleaned = cleaned.strip(".-")
+    if not cleaned:
+        raise ValueError(f"Could not build a safe release asset component from: {value!r}")
+    return cleaned
+
+
+def _asset_name_for(entry: dict[str, Any], source_path: Path) -> str:
+    """Return the model release asset name for one registry entry."""
+    model_id = _safe_component(str(entry["model_id"]))
+    file_name = _safe_component(str(entry.get("wandb_file") or source_path.name))
+    return f"{model_id}-{file_name}"
+
+
+def _sha256(path: Path) -> str:
+    """Return a SHA256 digest for a local file."""
+    return model_registry._sha256(path)
+
+
+def _source_path_for(
+    entry: dict[str, Any],
+    *,
+    registry_path: Path,
+    download_missing: bool,
+    cache_dir: Path,
+) -> tuple[Path | None, str | None]:
+    """Resolve the local source model path, optionally hydrating from registry metadata."""
+    local_path = entry.get("local_path")
+    if isinstance(local_path, str) and local_path.strip():
+        path = Path(local_path)
+        if not path.is_absolute():
+            path = get_repository_root() / path
+        if path.exists():
+            return path, None
+
+    if not download_missing:
+        return None, "missing local_path; rerun with --download-missing to hydrate from registry"
+
+    try:
+        path = model_registry.resolve_model_path(
+            str(entry["model_id"]),
+            registry_path=registry_path,
+            cache_dir=cache_dir,
+        )
+    except Exception as exc:
+        return None, f"download failed: {exc}"
+    return path, None
+
+
+def _copy_model_asset(source_path: Path, target_path: Path) -> None:
+    """Copy one model artifact into the release staging directory."""
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, target_path)
+
+
+def _model_metadata(
+    entry: dict[str, Any], *, asset_name: str, sha256: str, size_bytes: int
+) -> dict:
+    """Build a small per-model metadata payload for release publication."""
+    keep_keys = [
+        "model_id",
+        "display_name",
+        "config_path",
+        "commit",
+        "tags",
+        "notes",
+        "wandb_artifact_path",
+        "wandb_run_path",
+        "wandb_run_id",
+        "wandb_entity",
+        "wandb_project",
+        "wandb_file",
+    ]
+    metadata = {key: entry.get(key) for key in keep_keys if key in entry}
+    metadata["release_asset"] = {
+        "asset_name": asset_name,
+        "sha256": sha256,
+        "size_bytes": size_bytes,
+    }
+    return metadata
+
+
+def _release_url(repo: str, tag: str, asset_name: str) -> str:
+    """Return the public GitHub release asset URL."""
+    return f"https://github.com/{repo}/releases/download/{tag}/{asset_name}"
+
+
+def _write_text(path: Path, body: str) -> None:
+    """Write UTF-8 text, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _stage_assets(args: argparse.Namespace, registry_data: dict[str, Any]) -> dict[str, Any]:
+    """Stage model assets and return the publication plan."""
+    repo_root = get_repository_root()
+    staging_dir = args.staging_dir or repo_root / "output" / "model_registry_release" / args.tag
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    selected_ids = set(args.model_id)
+    models = [
+        entry
+        for entry in registry_data["models"]
+        if isinstance(entry, dict)
+        and (not selected_ids or entry.get("model_id") in selected_ids)
+        and (_has_wandb_reference(entry) or selected_ids)
+    ]
+    if selected_ids:
+        found = {str(entry.get("model_id")) for entry in models}
+        missing = sorted(selected_ids - found)
+        if missing:
+            raise KeyError(f"Requested model ids are not in the registry: {missing}")
+
+    now = datetime.now(UTC).isoformat(timespec="seconds")
+    published: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    checksum_lines: list[str] = []
+    upload_assets: list[str] = []
+    registry_updates: dict[str, dict[str, Any]] = {}
+
+    for entry in models:
+        model_id = str(entry["model_id"])
+        source_path, error = _source_path_for(
+            entry,
+            registry_path=args.registry_path,
+            download_missing=bool(args.download_missing),
+            cache_dir=args.cache_dir,
+        )
+        if source_path is None:
+            skipped.append({"model_id": model_id, "reason": str(error)})
+            continue
+
+        asset_name = _asset_name_for(entry, source_path)
+        staged_model = staging_dir / asset_name
+        _copy_model_asset(source_path, staged_model)
+        sha256 = _sha256(staged_model)
+        size_bytes = staged_model.stat().st_size
+        metadata_name = f"{_safe_component(model_id)}-metadata.json"
+        metadata_path = staging_dir / metadata_name
+        metadata = _model_metadata(
+            entry,
+            asset_name=asset_name,
+            sha256=sha256,
+            size_bytes=size_bytes,
+        )
+        _write_text(metadata_path, json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+        checksum_lines.append(f"{sha256}  {asset_name}")
+        checksum_lines.append(f"{_sha256(metadata_path)}  {metadata_name}")
+        upload_assets.extend([str(staged_model), str(metadata_path)])
+        release_pointer = {
+            "repo": args.repo,
+            "tag": args.tag,
+            "asset_name": asset_name,
+            "url": _release_url(args.repo, args.tag, asset_name),
+            "sha256": sha256,
+            "size_bytes": size_bytes,
+            "metadata_asset": metadata_name,
+            "published_at_utc": now,
+        }
+        registry_updates[model_id] = release_pointer
+        published.append(
+            {
+                "model_id": model_id,
+                "source_path": str(source_path),
+                "asset_name": asset_name,
+                "metadata_asset": metadata_name,
+                "sha256": sha256,
+                "size_bytes": size_bytes,
+                "release_asset_url": release_pointer["url"],
+            }
+        )
+
+    manifest = {
+        "schema_version": "robot-sf-model-registry-release.v1",
+        "created_at_utc": now,
+        "repo": args.repo,
+        "tag": args.tag,
+        "registry_path": str(args.registry_path),
+        "models": published,
+        "skipped": skipped,
+    }
+    manifest_path = staging_dir / "manifest.json"
+    checksums_path = staging_dir / "SHA256SUMS"
+    notes_path = staging_dir / "release_notes.md"
+    _write_text(manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    checksum_lines.append(f"{_sha256(manifest_path)}  manifest.json")
+    _write_text(checksums_path, "\n".join(checksum_lines) + ("\n" if checksum_lines else ""))
+    _write_text(
+        notes_path,
+        "\n".join(
+            [
+                "# Robot SF model registry artifacts",
+                "",
+                f"Registry source: `{args.registry_path}`",
+                f"Published models: {len(published)}",
+                "",
+                "This release contains curated model artifacts copied from the model registry, "
+                "per-model metadata JSON, `manifest.json`, and `SHA256SUMS`.",
+                "",
+            ]
+        ),
+    )
+    upload_assets.extend([str(manifest_path), str(checksums_path)])
+
+    upload_command = [
+        "gh",
+        "release",
+        "upload",
+        args.tag,
+        *upload_assets,
+        "--repo",
+        args.repo,
+        "--clobber",
+    ]
+    create_command = [
+        "gh",
+        "release",
+        "create",
+        args.tag,
+        "--repo",
+        args.repo,
+        "--title",
+        args.tag,
+        "--notes-file",
+        str(notes_path),
+    ]
+    return {
+        "staging_dir": str(staging_dir),
+        "manifest_path": str(manifest_path),
+        "checksums_path": str(checksums_path),
+        "release_notes_path": str(notes_path),
+        "published": published,
+        "skipped": skipped,
+        "registry_updates": registry_updates,
+        "create_release_command": create_command,
+        "upload_command": upload_command,
+    }
+
+
+def _apply_registry_updates(
+    registry_data: dict[str, Any],
+    updates: dict[str, dict[str, Any]],
+    *,
+    output_path: Path,
+) -> None:
+    """Write GitHub release pointers back into the model registry."""
+    for entry in registry_data["models"]:
+        if not isinstance(entry, dict):
+            continue
+        model_id = str(entry.get("model_id"))
+        if model_id in updates:
+            entry["github_release"] = updates[model_id]
+            entry["public_artifact_source"] = "github_release"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml.safe_dump(registry_data, sort_keys=False), encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the model registry publication workflow."""
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    args.registry_path = args.registry_path.resolve()
+    args.cache_dir = args.cache_dir.resolve()
+    registry_data = _load_registry_data(args.registry_path)
+    plan = _stage_assets(args, registry_data)
+
+    if args.execute_upload:
+        if args.create_release:
+            subprocess.run(plan["create_release_command"], check=True)
+        subprocess.run(plan["upload_command"], check=True)
+
+    if args.update_registry:
+        output_path = (args.registry_output or args.registry_path).resolve()
+        _apply_registry_updates(registry_data, plan["registry_updates"], output_path=output_path)
+        plan["updated_registry_path"] = str(output_path)
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+
+    print(json.dumps(plan, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/publish_model_registry_release.py
+++ b/scripts/tools/publish_model_registry_release.py
@@ -70,6 +70,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Write github_release pointers into the registry after staging/upload planning.",
     )
     parser.add_argument(
+        "--allow-registry-update-without-upload",
+        action="store_true",
+        help=(
+            "Allow --update-registry without --execute-upload for offline fixture generation. "
+            "Default is fail-closed so unpublished release pointers are not written."
+        ),
+    )
+    parser.add_argument(
         "--registry-output",
         type=Path,
         default=None,
@@ -367,6 +375,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run the model registry publication workflow."""
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
+    if (
+        args.update_registry
+        and not args.execute_upload
+        and not args.allow_registry_update_without_upload
+    ):
+        parser.error("--update-registry requires --execute-upload or explicit offline override.")
     args.registry_path = args.registry_path.resolve()
     args.cache_dir = args.cache_dir.resolve()
     registry_data = _load_registry_data(args.registry_path)

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -351,6 +351,83 @@ models:
         )
 
 
+def test_resolve_model_path_requires_github_release_checksum(tmp_path: Path) -> None:
+    """Release-backed registry rows must fail closed without an expected checksum."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        """
+version: 1
+models:
+  - model_id: public_model
+    local_path: missing/model.zip
+    github_release:
+      url: https://github.com/ll7/robot_sf_ll7/releases/download/tag/public_model-model.zip
+      asset_name: public_model-model.zip
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="github_release.sha256 is required"):
+        registry.resolve_model_path(
+            "public_model",
+            registry_path=registry_path,
+            cache_dir=tmp_path / "cache",
+        )
+
+
+def test_resolve_model_path_rejects_untrusted_github_release_url(tmp_path: Path) -> None:
+    """Release-backed downloads should only use trusted GitHub HTTPS URLs."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        """
+version: 1
+models:
+  - model_id: public_model
+    local_path: missing/model.zip
+    github_release:
+      url: https://example.com/ll7/robot_sf_ll7/releases/download/tag/public_model-model.zip
+      asset_name: public_model-model.zip
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="https://github.com URL"):
+        registry.resolve_model_path(
+            "public_model",
+            registry_path=registry_path,
+            cache_dir=tmp_path / "cache",
+        )
+
+
+def test_resolve_model_path_rejects_release_asset_path_traversal(tmp_path: Path) -> None:
+    """Release asset names should not be able to escape the model cache directory."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        """
+version: 1
+models:
+  - model_id: public_model
+    local_path: missing/model.zip
+    github_release:
+      url: https://github.com/ll7/robot_sf_ll7/releases/download/tag/public_model-model.zip
+      asset_name: ../public_model-model.zip
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="asset_name must be a file name"):
+        registry.resolve_model_path(
+            "public_model",
+            registry_path=registry_path,
+            cache_dir=tmp_path / "cache",
+        )
+
+
 def test_resolve_model_path_rejects_missing_local_path_when_download_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -229,6 +229,128 @@ def test_resolve_model_path_prefers_existing_local_path(tmp_path: Path) -> None:
     assert resolved == local_model
 
 
+def test_resolve_model_path_downloads_github_release_asset(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Public GitHub release assets should be preferred over W&B downloads."""
+    payload = b"checkpoint"
+    source = tmp_path / "source.zip"
+    source.write_bytes(payload)
+    expected_sha = registry._sha256(source)
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        f"""
+version: 1
+models:
+  - model_id: public_model
+    local_path: missing/model.zip
+    wandb_run_path: ll7/robot_sf/private
+    github_release:
+      repo: ll7/robot_sf_ll7
+      tag: artifact/models-test
+      asset_name: public_model-model.zip
+      sha256: {expected_sha}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class _Response:
+        """Context-manager response returning payload chunks."""
+
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+            self._offset = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def read(self, size: int) -> bytes:
+            chunk = self._data[self._offset : self._offset + size]
+            self._offset += len(chunk)
+            return chunk
+
+    urls: list[str] = []
+
+    def _fake_urlopen(url: str, timeout: int):
+        """Capture the release URL and return the fake payload."""
+        assert timeout == 60
+        urls.append(url)
+        return _Response(payload)
+
+    def _fail_wandb_download(entry, *, cache_dir):
+        """Fail if GitHub release resolution falls back to W&B."""
+        raise AssertionError(entry)
+
+    monkeypatch.setattr(registry, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(registry, "_download_from_wandb", _fail_wandb_download)
+
+    resolved = registry.resolve_model_path(
+        "public_model",
+        registry_path=registry_path,
+        cache_dir=tmp_path / "cache",
+    )
+
+    assert resolved == tmp_path / "cache" / "public_model" / "public_model-model.zip"
+    assert resolved.read_bytes() == payload
+    assert urls == [
+        "https://github.com/ll7/robot_sf_ll7/releases/download/"
+        "artifact/models-test/public_model-model.zip"
+    ]
+
+
+def test_resolve_model_path_rejects_bad_github_release_checksum(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Release downloads must match the registry checksum when one is recorded."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        """
+version: 1
+models:
+  - model_id: public_model
+    local_path: missing/model.zip
+    github_release:
+      url: https://github.com/ll7/robot_sf_ll7/releases/download/tag/public_model-model.zip
+      asset_name: public_model-model.zip
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class _Response:
+        """Context-manager response returning one invalid payload."""
+
+        def __init__(self) -> None:
+            self._done = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def read(self, size: int) -> bytes:
+            if self._done:
+                return b""
+            self._done = True
+            return b"wrong"
+
+    monkeypatch.setattr(registry, "urlopen", lambda url, timeout: _Response())
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        registry.resolve_model_path(
+            "public_model",
+            registry_path=registry_path,
+            cache_dir=tmp_path / "cache",
+        )
+
+
 def test_resolve_model_path_rejects_missing_local_path_when_download_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_publish_model_registry_release.py
+++ b/tests/tools/test_publish_model_registry_release.py
@@ -1,0 +1,155 @@
+"""Tests for model-registry GitHub release publication helper."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools import publish_model_registry_release
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, payload: bytes | str) -> None:
+    """Write a test fixture file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+
+
+def _registry_text(model_path: Path) -> str:
+    """Return a small registry containing one W&B-backed model."""
+    return (
+        f"""
+version: 1
+models:
+  - model_id: demo_model
+    display_name: Demo model
+    local_path: {model_path.as_posix()}
+    config_path: configs/training/demo.yaml
+    commit: abc123
+    wandb_run_id: run123
+    wandb_run_path: ll7/robot_sf/run123
+    wandb_entity: ll7
+    wandb_project: robot_sf
+    wandb_file: model.zip
+    tags:
+      - demo
+  - model_id: local_only_model
+    local_path: local/model.zip
+""".strip()
+        + "\n"
+    )
+
+
+def test_publish_model_registry_release_stages_assets_and_manifest(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Dry-run publication should stage model, metadata, manifest, and checksums."""
+    model_path = tmp_path / "output" / "model_cache" / "demo_model" / "model.zip"
+    _write(model_path, b"checkpoint")
+    registry_path = tmp_path / "model" / "registry.yaml"
+    _write(registry_path, _registry_text(model_path))
+    monkeypatch.setattr(publish_model_registry_release, "get_repository_root", lambda: tmp_path)
+
+    exit_code = publish_model_registry_release.main(
+        [
+            "--registry-path",
+            str(registry_path),
+            "--tag",
+            "artifact/models-test",
+            "--staging-dir",
+            str(tmp_path / "staging"),
+        ]
+    )
+
+    assert exit_code == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert [item["model_id"] for item in plan["published"]] == ["demo_model"]
+    asset_name = "demo_model-model.zip"
+    assert (tmp_path / "staging" / asset_name).read_bytes() == b"checkpoint"
+    assert (tmp_path / "staging" / "demo_model-metadata.json").exists()
+    manifest = json.loads((tmp_path / "staging" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "robot-sf-model-registry-release.v1"
+    assert manifest["models"][0]["release_asset_url"].endswith(
+        "/releases/download/artifact/models-test/demo_model-model.zip"
+    )
+    assert "demo_model-model.zip" in (tmp_path / "staging" / "SHA256SUMS").read_text(
+        encoding="utf-8"
+    )
+    assert plan["upload_command"][0:3] == ["gh", "release", "upload"]
+
+
+def test_publish_model_registry_release_updates_registry_output(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Update mode should write github_release pointers without removing W&B provenance."""
+    model_path = tmp_path / "output" / "model_cache" / "demo_model" / "model.zip"
+    _write(model_path, b"checkpoint")
+    registry_path = tmp_path / "model" / "registry.yaml"
+    output_path = tmp_path / "updated_registry.yaml"
+    _write(registry_path, _registry_text(model_path))
+    monkeypatch.setattr(publish_model_registry_release, "get_repository_root", lambda: tmp_path)
+
+    publish_model_registry_release.main(
+        [
+            "--registry-path",
+            str(registry_path),
+            "--tag",
+            "artifact/models-test",
+            "--staging-dir",
+            str(tmp_path / "staging"),
+            "--update-registry",
+            "--registry-output",
+            str(output_path),
+        ]
+    )
+    capsys.readouterr()
+
+    updated = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+    entry = updated["models"][0]
+    assert entry["model_id"] == "demo_model"
+    assert entry["public_artifact_source"] == "github_release"
+    assert entry["github_release"]["asset_name"] == "demo_model-model.zip"
+    assert entry["github_release"]["sha256"]
+    assert entry["wandb_run_path"] == "ll7/robot_sf/run123"
+
+
+def test_publish_model_registry_release_reports_missing_local_without_download(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Missing local artifacts should be reported instead of silently skipped."""
+    registry_path = tmp_path / "model" / "registry.yaml"
+    _write(registry_path, _registry_text(tmp_path / "missing" / "model.zip"))
+    monkeypatch.setattr(publish_model_registry_release, "get_repository_root", lambda: tmp_path)
+
+    publish_model_registry_release.main(
+        [
+            "--registry-path",
+            str(registry_path),
+            "--tag",
+            "artifact/models-test",
+            "--staging-dir",
+            str(tmp_path / "staging"),
+        ]
+    )
+    plan = json.loads(capsys.readouterr().out)
+
+    assert plan["published"] == []
+    assert plan["skipped"] == [
+        {
+            "model_id": "demo_model",
+            "reason": "missing local_path; rerun with --download-missing to hydrate from registry",
+        }
+    ]

--- a/tests/tools/test_publish_model_registry_release.py
+++ b/tests/tools/test_publish_model_registry_release.py
@@ -109,6 +109,7 @@ def test_publish_model_registry_release_updates_registry_output(
             "--staging-dir",
             str(tmp_path / "staging"),
             "--update-registry",
+            "--allow-registry-update-without-upload",
             "--registry-output",
             str(output_path),
         ]
@@ -153,3 +154,34 @@ def test_publish_model_registry_release_reports_missing_local_without_download(
             "reason": "missing local_path; rerun with --download-missing to hydrate from registry",
         }
     ]
+
+
+def test_publish_model_registry_release_requires_upload_before_registry_update(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Registry updates should not write unpublished release pointers by default."""
+    model_path = tmp_path / "output" / "model_cache" / "demo_model" / "model.zip"
+    _write(model_path, b"checkpoint")
+    registry_path = tmp_path / "model" / "registry.yaml"
+    _write(registry_path, _registry_text(model_path))
+    monkeypatch.setattr(publish_model_registry_release, "get_repository_root", lambda: tmp_path)
+
+    try:
+        publish_model_registry_release.main(
+            [
+                "--registry-path",
+                str(registry_path),
+                "--tag",
+                "artifact/models-test",
+                "--staging-dir",
+                str(tmp_path / "staging"),
+                "--update-registry",
+                "--registry-output",
+                str(tmp_path / "updated_registry.yaml"),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("--update-registry without upload did not fail closed")


### PR DESCRIPTION
## Summary

- publish all W&B-backed model-registry entries as curated GitHub release assets under `artifact/models-2026-05-registry-v1`
- add `github_release` registry pointers and make `resolve_model_path(..., allow_download=True)` prefer verified GitHub release downloads before W&B fallback
- add an automated model-registry publication script plus documentation for when/how/why to preserve future trained policies

Closes #1458

## Release Artifacts

- Release: https://github.com/ll7/robot_sf_ll7/releases/tag/artifact/models-2026-05-registry-v1
- Contents: 11 model assets, 11 per-model metadata JSON files, `manifest.json`, and `SHA256SUMS`
- W&B metadata remains in `model/registry.yaml` as provenance/backfill, not the preferred public hydration path

## Validation

- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `4109 passed, 8 skipped, 6 warnings in 243.29s`
  - changed-file coverage warning only: `robot_sf/models/registry.py` at `87.9%` versus 80% minimum / 100% goal
- Fresh-cache GitHub release download verified for `predictive_proxy_selected_v2_xl_ego`
  - SHA256 `49deeeca98d44bcadb0eb845d9a9a5fd36cc2911a8fed8c414f7f988ec0a3a69`
- Fresh-cache GitHub release download verified for canonical PPO `ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417`
  - SHA256 `2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Models can now be downloaded from GitHub releases without requiring external credentials for public access.
  * Selected trained policy models published as GitHub release assets.

* **Documentation**
  * Added Model Registry Publication Workflow documentation describing how to preserve and publish trained policies.
  * Updated registry documentation with GitHub release integration details and download procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->