### PR TITLE
Publish model registry release pointers

### DIFF
--- a/docs/model_registry_publication.md
+++ b/docs/model_registry_publication.md
@@ -1,0 +1,67 @@
+# Model Registry Publication
+
+The model registry supports a split public/provenance artifact policy.
+
+- `github_release` is the credential-free hydration path for public registry
+  entries. `resolve_model_path(..., allow_download=True)` downloads the release
+  asset and verifies the recorded SHA256 before returning it.
+- W&B metadata remains lineage/backfill metadata. It can identify the original
+  run or artifact, but public users should not need W&B credentials for canonical
+  registry assets.
+- `local_path` values under `output/model_cache/` are cache hints only. A fresh
+  checkout may not have those files.
+- Non-public entries should either be marked `local_only: true` with a
+  replacement hint or retain a clear private W&B/local-only boundary.
+
+## Current Public Release
+
+The current public bundle is:
+
+- Repository: `ll7/robot_sf_ll7`
+- Release tag: `artifact/models-2026-05-registry-v1`
+- Manifest assets: `manifest.json` and `SHA256SUMS`
+
+The release contains 11 registry-backed model assets: the canonical PPO
+benchmark checkpoint, seven historical/runner-up PPO checkpoints, and three
+predictive planner checkpoints. `model/registry.yaml` records each asset name,
+cache filename, SHA256, size, and metadata asset name under `github_release`.
+
+## Updating Pointers
+
+After staging or refreshing a release manifest, update the registry with:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py apply-manifest \
+  --manifest output/issue_1458_release/manifest.json \
+  --sha256s output/issue_1458_release/SHA256SUMS \
+  --write
+```
+
+Review the diff before committing. The helper inserts or replaces only
+`github_release` blocks for matching model IDs.
+
+To audit publication coverage without editing:
+
+```bash
+uv run python scripts/tools/publish_model_registry_release.py inventory \
+  --manifest output/issue_1458_release/manifest.json
+```
+
+## Verification
+
+Use a fresh cache directory when proving public access, for example:
+
+```bash
+uv run python - <<'PY'
+from robot_sf.models import resolve_model_path
+
+path = resolve_model_path(
+    "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417",
+    cache_dir="output/model_registry_public_smoke",
+)
+print(path)
+PY
+```
+
+The command should succeed without W&B credentials and should fail if the public
+asset is missing or its SHA256 differs from `model/registry.yaml`.

--- a/model/registry.md
+++ b/model/registry.md
@@ -19,6 +19,9 @@ notebooks to insert/update entries without manual YAML editing.
   otherwise use either `wandb_run_path` or `wandb_entity` + `wandb_project` +
   `wandb_run_id` so auto-download works.
 - `wandb_file`: file to download from the run (defaults to `model.zip`).
+- `github_release`: public GitHub release pointer used for credential-free
+  hydration. Include `repository`, `tag`, `asset_name`, `file_name`, `sha256`,
+  and `size_bytes`.
 - `local_only`: mark entries that are only valid when the recorded `local_path`
   exists on the current machine.
 - `replacement_model_id`: optional migration target surfaced in local-only
@@ -41,6 +44,13 @@ models:
     wandb_run_id: run_id
     wandb_file: model.zip
     wandb_artifact_path: entity/project/artifact_name:version
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: my_model_id-model.zip
+      file_name: model.zip
+      sha256: abc123...
+      size_bytes: 123456
     local_only: false
     replacement_model_id: my_model_id_v2
     tags: ["ppo", "socnav"]
@@ -60,14 +70,17 @@ path = resolve_model_path(
 )
 ```
 
-If the model is not present locally and W&B metadata is configured in
-`model/registry.yaml`, the helper will download the artifact into
-`output/model_cache/<model_id>/`.
+If the model is not present locally and `github_release` metadata is configured
+in `model/registry.yaml`, the helper downloads the public release asset into
+`output/model_cache/<model_id>/` and verifies the recorded SHA256 before returning
+the path. Entries without a public pointer can still use W&B metadata as a
+private/backfill provenance path.
 
 ### Durable vs local cache fields
 
-Treat `wandb_artifact_path` as the preferred durable checkpoint pointer. Treat
-`local_path` under `output/model_cache/` as a cache location that may be absent in a fresh checkout.
+Treat `github_release` as the preferred public checkpoint pointer when it is
+present. Treat `wandb_artifact_path` as the preferred lineage/backfill pointer.
+Treat `local_path` under `output/model_cache/` as a cache location that may be absent in a fresh checkout.
 If a paper-facing registry entry still has `commit: null`, the W&B run or artifact pointer is the
 recoverable source, but the missing source commit should remain visible as a provenance caveat until
 it is repaired.

--- a/model/registry.yaml
+++ b/model/registry.yaml
@@ -12,6 +12,14 @@ models:
     wandb_project: robot_sf
     wandb_file: model.zip
     wandb_artifact_path: ll7/robot_sf/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity-best-success:v9
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-model.zip
+      file_name: model.zip
+      sha256: 2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d
+      size_bytes: 93662266
+      metadata_asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-metadata.json
     tags:
       - ppo
       - issue-791
@@ -49,6 +57,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-model.zip
+      file_name: model.zip
+      sha256: 8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09
+      size_bytes: 174820762
+      metadata_asset_name: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-metadata.json
     tags:
       - ppo
       - br06
@@ -77,6 +93,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_br06_v2_15m_all_maps_20260302T152332-model.zip
+      file_name: model.zip
+      sha256: e9bf737760efffa238296096bb63078e421b3bf6fcba749a7fce382cee9a989e
+      size_bytes: 174821385
+      metadata_asset_name: ppo_expert_br06_v2_15m_all_maps_20260302T152332-metadata.json
     tags:
       - ppo
       - br06
@@ -100,6 +124,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_br06_v2_15m_all_maps_20260303T074433-model.zip
+      file_name: model.zip
+      sha256: 17d1c0467878bf828b45370bbb9dbfeebbdf6d078e77d11c9f7072bd6fffee9c
+      size_bytes: 174821327
+      metadata_asset_name: ppo_expert_br06_v2_15m_all_maps_20260303T074433-metadata.json
     tags:
       - ppo
       - br06
@@ -121,6 +153,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311-model.zip
+      file_name: model.zip
+      sha256: ba9e1ef5dbd559f0af29ea9d88a61e698ef4a748bf54dc6c2217ace679580fce
+      size_bytes: 165359988
+      metadata_asset_name: ppo_expert_br06_v8_num_envs_benchmark_08_1m_best_20260311-metadata.json
     tags:
       - ppo
       - br06
@@ -145,6 +185,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_br06_v10_best_27dbe5xu_20260317-model.zip
+      file_name: model.zip
+      sha256: 341e6b464bceba6cf0360c06a282bc9c100b0efc5d4400f855b90ea83ae7e78f
+      size_bytes: 171119983
+      metadata_asset_name: ppo_expert_br06_v10_best_27dbe5xu_20260317-metadata.json
     tags:
       - ppo
       - br06
@@ -170,6 +218,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417-model.zip
+      file_name: model.zip
+      sha256: 723af98b8a7ca4e50cf12c18bcb2cbce15539514be6cb8e3bcd5189e3f4fed28
+      size_bytes: 51095030
+      metadata_asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_nsteps4096_20260417-metadata.json
     tags:
       - ppo
       - issue-791
@@ -194,6 +250,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: model.zip
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417-model.zip
+      file_name: model.zip
+      sha256: 8e85553219d182930494a4876b4a3c16ab57f7b292e34fcb9b2e5b84570696a1
+      size_bytes: 51094878
+      metadata_asset_name: ppo_expert_issue_791_reward_curriculum_eval_aligned_20260417-metadata.json
     tags:
       - ppo
       - issue-791
@@ -312,6 +376,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: predictive_model.pt
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: predictive_proxy_selected_v1-predictive_model.pt
+      file_name: predictive_model.pt
+      sha256: 0e7e775fd09509543761d8326237c4f85b0cc540fb24f98b3c5f8f7c0009fccc
+      size_bytes: 5034129
+      metadata_asset_name: predictive_proxy_selected_v1-metadata.json
     tags:
       - predictive
       - rgl
@@ -353,6 +425,14 @@ models:
     wandb_file: predictive_model.pt
     local_only: false
     replacement_model_id: ""
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: predictive_proxy_selected_v2_full-predictive_model.pt
+      file_name: predictive_model.pt
+      sha256: a28aed6d6ad7e1ebf597277ade1cf908efa6da038d0a9fcfdf80c7c31d8d1be1
+      size_bytes: 4958329
+      metadata_asset_name: predictive_proxy_selected_v2_full-metadata.json
     tags:
       - predictive
       - rgl
@@ -377,6 +457,14 @@ models:
     wandb_entity: ll7
     wandb_project: robot_sf
     wandb_file: predictive_model.pt
+    github_release:
+      repository: ll7/robot_sf_ll7
+      tag: artifact/models-2026-05-registry-v1
+      asset_name: predictive_proxy_selected_v2_xl_ego-predictive_model.pt
+      file_name: predictive_model.pt
+      sha256: 49deeeca98d44bcadb0eb845d9a9a5fd36cc2911a8fed8c414f7f988ec0a3a69
+      size_bytes: 11176729
+      metadata_asset_name: predictive_proxy_selected_v2_xl_ego-metadata.json
     tags:
       - predictive
       - br07

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import shutil
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -104,7 +110,7 @@ def resolve_model_path(
     allow_download: bool = True,
     cache_dir: str | Path | None = None,
 ) -> Path:
-    """Resolve a local model path, downloading from W&B if needed.
+    """Resolve a local model path, downloading from a public release or W&B if needed.
 
     Returns:
         Path: Local filesystem path to the model artifact.
@@ -128,7 +134,115 @@ def resolve_model_path(
     if not allow_download:
         raise FileNotFoundError(f"Model '{model_id}' not found locally and downloads are disabled.")
 
+    if entry.get("github_release"):
+        return _download_from_github_release(entry, cache_dir=cache_dir)
+
     return _download_from_wandb(entry, cache_dir=cache_dir)
+
+
+def _cache_root_for_entry(entry: dict[str, Any], *, cache_dir: str | Path | None) -> Path:
+    """Return the per-model artifact cache directory for a registry entry."""
+    model_id = str(entry.get("model_id", "unknown-model"))
+    cache_root = Path(cache_dir) if cache_dir is not None else Path("output/model_cache")
+    cache_root = cache_root / model_id
+    cache_root.mkdir(parents=True, exist_ok=True)
+    return cache_root
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _github_release_download_url(release_pointer: dict[str, Any]) -> str:
+    """Build the public GitHub release asset URL from a registry pointer.
+
+    Returns:
+        str: Public release-asset download URL.
+    """
+    repository = str(release_pointer.get("repository", "") or "").strip()
+    tag = str(release_pointer.get("tag", "") or "").strip()
+    asset_name = str(release_pointer.get("asset_name", "") or "").strip()
+    if not repository or not tag or not asset_name:
+        raise ValueError("github_release pointer must include repository, tag, and asset_name.")
+    quoted_tag = urllib.parse.quote(tag, safe="/")
+    quoted_asset = urllib.parse.quote(asset_name, safe="")
+    return f"https://github.com/{repository}/releases/download/{quoted_tag}/{quoted_asset}"
+
+
+def _download_from_github_release(
+    entry: dict[str, Any],
+    *,
+    cache_dir: str | Path | None,
+) -> Path:
+    """Download and verify a model artifact from a public GitHub release.
+
+    Returns:
+        Path: Local filesystem path to the verified artifact.
+    """
+    release_pointer = entry.get("github_release")
+    if not isinstance(release_pointer, dict):
+        raise ValueError("Registry entry github_release pointer must be a mapping.")
+
+    expected_sha256 = str(release_pointer.get("sha256", "") or "").strip().lower()
+    if not expected_sha256:
+        raise ValueError("github_release pointer must include sha256.")
+
+    file_name = str(
+        release_pointer.get("file_name")
+        or entry.get("wandb_file")
+        or release_pointer.get("asset_name")
+        or "model.zip"
+    )
+    model_id = str(entry.get("model_id", "unknown-model"))
+    cache_root = _cache_root_for_entry(entry, cache_dir=cache_dir)
+    cached_path = cache_root / file_name
+    if cached_path.exists():
+        actual_sha256 = _sha256_file(cached_path)
+        if actual_sha256 == expected_sha256:
+            resolved_cached_path = cached_path.resolve()
+            if resolved_cached_path not in _LOGGED_CACHED_MODEL_ARTIFACTS:
+                _LOGGED_CACHED_MODEL_ARTIFACTS.add(resolved_cached_path)
+                logger.info("Using cached model artifact: {}", cached_path)
+            return cached_path
+        logger.warning(
+            "Cached model artifact {} has sha256 {}; expected {}; redownloading.",
+            cached_path,
+            actual_sha256,
+            expected_sha256,
+        )
+
+    url = str(release_pointer.get("url") or "").strip() or _github_release_download_url(
+        release_pointer
+    )
+    logger.info("Downloading model artifact {} from {}", file_name, url)
+    try:
+        with tempfile.NamedTemporaryFile(dir=cache_root, delete=False) as handle:
+            tmp_path = Path(handle.name)
+            with urllib.request.urlopen(url) as response:
+                shutil.copyfileobj(response, handle)
+    except urllib.error.URLError as exc:
+        raise FileNotFoundError(
+            f"Public GitHub release asset for model '{model_id}' is unavailable at {url}. "
+            "Publish the asset or mark the registry entry non-public/local-only."
+        ) from exc
+
+    try:
+        actual_sha256 = _sha256_file(tmp_path)
+        if actual_sha256 != expected_sha256:
+            raise ValueError(
+                f"Downloaded model '{model_id}' from {url} has sha256 {actual_sha256}; "
+                f"expected {expected_sha256}."
+            )
+        tmp_path.replace(cached_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    return cached_path
 
 
 def resolve_latest_wandb_model(  # noqa: PLR0913
@@ -257,10 +371,7 @@ def _download_from_wandb(entry: dict[str, Any], *, cache_dir: str | Path | None)
         raise RuntimeError("W&B not available; cannot download model artifact.")
 
     file_name = entry.get("wandb_file", "model.zip")
-    model_id = entry.get("model_id", "unknown-model")
-    cache_root = Path(cache_dir) if cache_dir is not None else Path("output/model_cache")
-    cache_root = cache_root / model_id
-    cache_root.mkdir(parents=True, exist_ok=True)
+    cache_root = _cache_root_for_entry(entry, cache_dir=cache_dir)
 
     cached_path = cache_root / file_name
     if cached_path.exists():

--- a/scripts/tools/publish_model_registry_release.py
+++ b/scripts/tools/publish_model_registry_release.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Prepare public GitHub release pointers for model registry entries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load YAML as a mapping."""
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    """Write YAML using the repository's registry style."""
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False, width=88)
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    """Load and validate the release manifest."""
+    with path.open("r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    if not isinstance(manifest, dict):
+        raise ValueError(f"Expected manifest mapping in {path}")
+    models = manifest.get("models")
+    if not isinstance(models, list):
+        raise ValueError(f"Manifest {path} must contain a models list")
+    return manifest
+
+
+def _load_sha256s(path: Path) -> dict[str, str]:
+    """Load a SHA256SUMS file keyed by asset name."""
+    checksums: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        digest, asset_name = stripped.split(maxsplit=1)
+        checksums[asset_name.lstrip("*")] = digest
+    return checksums
+
+
+def _manifest_model_index(
+    manifest: dict[str, Any],
+    *,
+    sha256s: dict[str, str],
+) -> dict[str, dict[str, Any]]:
+    """Return manifest rows indexed by model id, with checksum consistency checked."""
+    indexed: dict[str, dict[str, Any]] = {}
+    for item in manifest["models"]:
+        if not isinstance(item, dict):
+            raise ValueError(f"Invalid manifest model row: {item!r}")
+        model_id = str(item.get("model_id", "") or "").strip()
+        asset_name = str(item.get("asset_name", "") or "").strip()
+        sha256 = str(item.get("sha256", "") or "").strip().lower()
+        if not model_id or not asset_name or not sha256:
+            raise ValueError(f"Manifest row missing model_id, asset_name, or sha256: {item!r}")
+        checksum_sha256 = sha256s.get(asset_name)
+        if checksum_sha256 is not None and checksum_sha256.lower() != sha256:
+            raise ValueError(
+                f"Checksum mismatch for {asset_name}: manifest={sha256} "
+                f"SHA256SUMS={checksum_sha256}"
+            )
+        indexed[model_id] = item
+    return indexed
+
+
+def _cache_file_name(entry: dict[str, Any], manifest_row: dict[str, Any]) -> str:
+    """Return the cache filename expected by resolve_model_path."""
+    if entry.get("wandb_file"):
+        return str(entry["wandb_file"])
+    asset_name = str(manifest_row["asset_name"])
+    model_id = str(manifest_row["model_id"])
+    prefix = f"{model_id}-"
+    return asset_name.removeprefix(prefix) if asset_name.startswith(prefix) else asset_name
+
+
+def _public_pointer(
+    entry: dict[str, Any],
+    manifest_row: dict[str, Any],
+    *,
+    repository: str,
+    tag: str,
+) -> dict[str, Any]:
+    """Build the github_release pointer for a registry entry."""
+    pointer: dict[str, Any] = {
+        "repository": repository,
+        "tag": tag,
+        "asset_name": manifest_row["asset_name"],
+        "file_name": _cache_file_name(entry, manifest_row),
+        "sha256": str(manifest_row["sha256"]).lower(),
+        "size_bytes": manifest_row["size_bytes"],
+    }
+    metadata_asset = manifest_row.get("metadata_asset")
+    if metadata_asset:
+        pointer["metadata_asset_name"] = metadata_asset
+    return pointer
+
+
+def _pointer_yaml_lines(pointer: dict[str, Any]) -> list[str]:
+    """Return a github_release block formatted like model/registry.yaml."""
+    lines = ["    github_release:"]
+    for key, value in pointer.items():
+        lines.append(f"      {key}: {value}")
+    return lines
+
+
+def _insert_pointers_preserving_registry_text(  # noqa: C901
+    *,
+    registry_path: Path,
+    manifest_models: dict[str, dict[str, Any]],
+    pointers: dict[str, dict[str, Any]],
+) -> None:
+    """Insert public pointers without reserializing the whole YAML registry."""
+    original = registry_path.read_text(encoding="utf-8")
+    lines = original.splitlines()
+    output: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        if line.startswith("  - model_id: "):
+            model_id = line.split(": ", 1)[1]
+            pointer = pointers.get(model_id)
+            if pointer is not None:
+                scan_index = index + 1
+                insert_at = None
+                existing_pointer_start = None
+                existing_pointer_end = None
+                while scan_index < len(lines) and not lines[scan_index].startswith(
+                    "  - model_id: "
+                ):
+                    if lines[scan_index].startswith("    github_release:"):
+                        existing_pointer_start = scan_index
+                        existing_pointer_end = scan_index + 1
+                        while existing_pointer_end < len(lines) and lines[
+                            existing_pointer_end
+                        ].startswith("      "):
+                            existing_pointer_end += 1
+                    if lines[scan_index].startswith("    tags:") or lines[scan_index].startswith(
+                        "    notes:"
+                    ):
+                        insert_at = scan_index
+                        break
+                    scan_index += 1
+                if insert_at is None:
+                    insert_at = scan_index
+                while index + 1 < insert_at:
+                    index += 1
+                    if existing_pointer_start is not None and (
+                        existing_pointer_start <= index < existing_pointer_end
+                    ):
+                        continue
+                    output.append(lines[index])
+                output.extend(_pointer_yaml_lines(pointer))
+                index = insert_at - 1
+            manifest_models.pop(model_id, None)
+        index += 1
+    registry_path.write_text("\n".join(output) + "\n", encoding="utf-8")
+
+
+def apply_manifest(
+    *,
+    registry_path: Path,
+    manifest_path: Path,
+    sha256s_path: Path,
+    output_path: Path | None,
+    write: bool,
+) -> dict[str, Any]:
+    """Apply release pointers from a manifest to matching registry entries."""
+    registry = _load_yaml(registry_path)
+    manifest = _load_manifest(manifest_path)
+    manifest_models = _manifest_model_index(manifest, sha256s=_load_sha256s(sha256s_path))
+    repository = str(manifest.get("repo", "") or "").strip()
+    tag = str(manifest.get("tag", "") or "").strip()
+    if not repository or not tag:
+        raise ValueError("Manifest must include repo and tag")
+
+    models = registry.get("models")
+    if not isinstance(models, list):
+        raise ValueError(f"Registry {registry_path} must contain a models list")
+
+    updated: list[str] = []
+    missing_from_registry = set(manifest_models)
+    pointers: dict[str, dict[str, Any]] = {}
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        model_id = str(entry.get("model_id", "") or "").strip()
+        manifest_row = manifest_models.get(model_id)
+        if manifest_row is None:
+            continue
+        entry["github_release"] = _public_pointer(
+            entry,
+            manifest_row,
+            repository=repository,
+            tag=tag,
+        )
+        pointers[model_id] = entry["github_release"]
+        updated.append(model_id)
+        missing_from_registry.discard(model_id)
+
+    result = {
+        "registry_path": str(registry_path),
+        "manifest_path": str(manifest_path),
+        "updated": updated,
+        "missing_from_registry": sorted(missing_from_registry),
+    }
+    destination = output_path if output_path is not None else registry_path
+    if output_path is not None:
+        _write_yaml(destination, registry)
+    elif write:
+        _insert_pointers_preserving_registry_text(
+            registry_path=registry_path,
+            manifest_models=dict(manifest_models),
+            pointers=pointers,
+        )
+    return result
+
+
+def inventory(*, registry_path: Path, manifest_path: Path | None) -> dict[str, Any]:
+    """Return a compact publication inventory for registry review."""
+    registry = _load_yaml(registry_path)
+    models = registry.get("models")
+    if not isinstance(models, list):
+        raise ValueError(f"Registry {registry_path} must contain a models list")
+    manifest_ids: set[str] = set()
+    if manifest_path is not None:
+        manifest = _load_manifest(manifest_path)
+        manifest_ids = {
+            str(item.get("model_id"))
+            for item in manifest["models"]
+            if isinstance(item, dict) and item.get("model_id")
+        }
+    rows = []
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        model_id = str(entry.get("model_id", "") or "")
+        rows.append(
+            {
+                "model_id": model_id,
+                "has_github_release": isinstance(entry.get("github_release"), dict),
+                "has_wandb_pointer": bool(
+                    entry.get("wandb_artifact_path")
+                    or entry.get("wandb_run_path")
+                    or (
+                        entry.get("wandb_entity")
+                        and entry.get("wandb_project")
+                        and entry.get("wandb_run_id")
+                    )
+                ),
+                "local_only": bool(entry.get("local_only")),
+                "in_manifest": model_id in manifest_ids if manifest_path is not None else None,
+            }
+        )
+    return {"registry_path": str(registry_path), "models": rows}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apply_parser = subparsers.add_parser(
+        "apply-manifest",
+        help="Apply github_release pointers from a release manifest.",
+    )
+    apply_parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
+    apply_parser.add_argument("--manifest", type=Path, required=True)
+    apply_parser.add_argument("--sha256s", type=Path, required=True)
+    apply_parser.add_argument("--output", type=Path)
+    apply_parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Update the registry in place. Without --write, only JSON summary is emitted.",
+    )
+
+    inventory_parser = subparsers.add_parser(
+        "inventory",
+        help="Summarize registry publication state.",
+    )
+    inventory_parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
+    inventory_parser.add_argument("--manifest", type=Path)
+    return parser
+
+
+def main() -> None:
+    """Run the CLI."""
+    args = build_parser().parse_args()
+    if args.command == "apply-manifest":
+        result = apply_manifest(
+            registry_path=args.registry,
+            manifest_path=args.manifest,
+            sha256s_path=args.sha256s,
+            output_path=args.output,
+            write=args.write,
+        )
+    else:
+        result = inventory(registry_path=args.registry, manifest_path=args.manifest)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -206,6 +207,27 @@ models:
         registry.load_registry(registry_path)
 
 
+def test_canonical_registry_entry_has_public_release_pointer() -> None:
+    """The canonical PPO benchmark checkpoint should be publicly hydratable."""
+    entry = registry.get_registry_entry(
+        "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417"
+    )
+    assert entry["github_release"] == {
+        "repository": "ll7/robot_sf_ll7",
+        "tag": "artifact/models-2026-05-registry-v1",
+        "asset_name": (
+            "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-model.zip"
+        ),
+        "file_name": "model.zip",
+        "sha256": "2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d",
+        "size_bytes": 93662266,
+        "metadata_asset_name": (
+            "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417"
+            "-metadata.json"
+        ),
+    }
+
+
 def test_get_registry_entry_raises_for_unknown_model(tmp_path: Path) -> None:
     """Unknown model ids should raise a clear KeyError."""
     registry_path = tmp_path / "registry.yaml"
@@ -266,6 +288,132 @@ def test_resolve_model_path_rejects_missing_local_only_entry_with_migration_guid
         registry.resolve_model_path(
             "predictive_proxy_selected_v2_full",
             registry_path=registry_path,
+        )
+
+
+def test_resolve_model_path_downloads_github_release_before_wandb(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Public GitHub release pointers should hydrate without requiring W&B credentials."""
+    payload = b"public checkpoint"
+    expected_sha256 = registry.hashlib.sha256(payload).hexdigest()
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        (
+            "version: 1\nmodels:\n"
+            "  - model_id: public_model\n"
+            "    local_path: missing/model.zip\n"
+            "    wandb_run_path: ll7/robot_sf/private\n"
+            "    wandb_file: model.zip\n"
+            "    github_release:\n"
+            "      repository: ll7/robot_sf_ll7\n"
+            "      tag: artifact/models-2026-05-registry-v1\n"
+            "      asset_name: public_model-model.zip\n"
+            "      file_name: model.zip\n"
+            f"      sha256: {expected_sha256}\n"
+        ),
+        encoding="utf-8",
+    )
+    opened_urls: list[str] = []
+
+    class _Response(io.BytesIO):
+        """Context-manager byte stream returned by fake urlopen."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            self.close()
+
+    def _fake_urlopen(url: str):
+        opened_urls.append(url)
+        return _Response(payload)
+
+    monkeypatch.setattr(registry.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(registry, "wandb", None)
+
+    resolved = registry.resolve_model_path(
+        "public_model",
+        registry_path=registry_path,
+        cache_dir=tmp_path / "cache",
+    )
+
+    assert resolved == tmp_path / "cache" / "public_model" / "model.zip"
+    assert resolved.read_bytes() == payload
+    assert opened_urls == [
+        "https://github.com/ll7/robot_sf_ll7/releases/download/"
+        "artifact/models-2026-05-registry-v1/public_model-model.zip"
+    ]
+
+
+def test_download_from_github_release_reuses_valid_cached_file(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A cached public artifact should be reused only when its checksum matches."""
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
+    cache_dir = tmp_path / "cache"
+    cached = cache_dir / "public_model" / "model.zip"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"public checkpoint")
+
+    def _fail_urlopen(url: str):  # pragma: no cover - should not be reached
+        raise AssertionError(url)
+
+    monkeypatch.setattr(registry.urllib.request, "urlopen", _fail_urlopen)
+    resolved = registry._download_from_github_release(
+        {
+            "model_id": "public_model",
+            "github_release": {
+                "repository": "ll7/robot_sf_ll7",
+                "tag": "artifact/models-2026-05-registry-v1",
+                "asset_name": "public_model-model.zip",
+                "file_name": "model.zip",
+                "sha256": registry.hashlib.sha256(b"public checkpoint").hexdigest(),
+            },
+        },
+        cache_dir=cache_dir,
+    )
+
+    assert resolved == cached
+    registry._LOGGED_CACHED_MODEL_ARTIFACTS.clear()
+
+
+def test_download_from_github_release_rejects_checksum_mismatch(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Downloaded public artifacts should be immutable through SHA256 verification."""
+
+    class _Response(io.BytesIO):
+        """Context-manager byte stream returned by fake urlopen."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            self.close()
+
+    monkeypatch.setattr(
+        registry.urllib.request,
+        "urlopen",
+        lambda url: _Response(b"tampered checkpoint"),
+    )
+
+    with pytest.raises(ValueError, match="expected 0000"):
+        registry._download_from_github_release(
+            {
+                "model_id": "public_model",
+                "github_release": {
+                    "repository": "ll7/robot_sf_ll7",
+                    "tag": "artifact/models-2026-05-registry-v1",
+                    "asset_name": "public_model-model.zip",
+                    "file_name": "model.zip",
+                    "sha256": "0000",
+                },
+            },
+            cache_dir=tmp_path / "cache",
         )
 
 

--- a/tests/tools/test_publish_model_registry_release.py
+++ b/tests/tools/test_publish_model_registry_release.py
@@ -1,0 +1,115 @@
+"""Tests for the model-registry release publication helper."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools.publish_model_registry_release import apply_manifest, inventory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_apply_manifest_adds_public_release_pointer(tmp_path: Path) -> None:
+    """Manifest application should add verified GitHub release pointers."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        (
+            "version: 1\nmodels:\n"
+            "  - model_id: public_model\n"
+            "    local_path: output/model_cache/public_model/model.zip\n"
+            "    wandb_file: model.zip\n"
+            "  - model_id: local_model\n"
+            "    local_path: model/local/model.zip\n"
+        ),
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "robot-sf-model-registry-release.v1",
+                "repo": "ll7/robot_sf_ll7",
+                "tag": "artifact/models-2026-05-registry-v1",
+                "models": [
+                    {
+                        "model_id": "public_model",
+                        "asset_name": "public_model-model.zip",
+                        "metadata_asset": "public_model-metadata.json",
+                        "sha256": "abc123",
+                        "size_bytes": 12,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    sha256s_path = tmp_path / "SHA256SUMS"
+    sha256s_path.write_text("abc123  public_model-model.zip\n", encoding="utf-8")
+
+    result = apply_manifest(
+        registry_path=registry_path,
+        manifest_path=manifest_path,
+        sha256s_path=sha256s_path,
+        output_path=None,
+        write=True,
+    )
+
+    assert result["updated"] == ["public_model"]
+    data = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    assert data["models"][0]["github_release"] == {
+        "repository": "ll7/robot_sf_ll7",
+        "tag": "artifact/models-2026-05-registry-v1",
+        "asset_name": "public_model-model.zip",
+        "file_name": "model.zip",
+        "sha256": "abc123",
+        "size_bytes": 12,
+        "metadata_asset_name": "public_model-metadata.json",
+    }
+    assert "github_release" not in data["models"][1]
+
+
+def test_inventory_reports_publication_state(tmp_path: Path) -> None:
+    """Inventory should identify public, W&B-backed, and local-only registry rows."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        (
+            "version: 1\nmodels:\n"
+            "  - model_id: public_model\n"
+            "    github_release:\n"
+            "      repository: ll7/robot_sf_ll7\n"
+            "    wandb_run_path: ll7/robot_sf/run\n"
+            "  - model_id: local_model\n"
+            "    local_only: true\n"
+        ),
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {"repo": "ll7/robot_sf_ll7", "tag": "v1", "models": [{"model_id": "public_model"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    result = inventory(registry_path=registry_path, manifest_path=manifest_path)
+
+    assert result["models"] == [
+        {
+            "model_id": "public_model",
+            "has_github_release": True,
+            "has_wandb_pointer": True,
+            "local_only": False,
+            "in_manifest": True,
+        },
+        {
+            "model_id": "local_model",
+            "has_github_release": False,
+            "has_wandb_pointer": False,
+            "local_only": True,
+            "in_manifest": False,
+        },
+    ]


### PR DESCRIPTION
## Summary
- add `github_release` model-registry pointers for the 11 assets published in `artifact/models-2026-05-registry-v1`
- teach `resolve_model_path(..., allow_download=True)` to hydrate public GitHub release assets with SHA256 verification before falling back to W&B-only paths
- add a release-manifest helper plus docs for public registry publication and verification

Closes #1458

## Validation
- `uv run ruff format robot_sf/models/registry.py scripts/tools/publish_model_registry_release.py tests/models/test_registry.py tests/tools/test_publish_model_registry_release.py`
- `uv run ruff check robot_sf/models/registry.py scripts/tools/publish_model_registry_release.py tests/models/test_registry.py tests/tools/test_publish_model_registry_release.py`
- `uv run pytest -q tests/models/test_registry.py tests/tools/test_publish_model_registry_release.py` -> 22 passed
- `uv run python scripts/tools/publish_model_registry_release.py apply-manifest --manifest output/issue_1458_release/manifest.json --sha256s output/issue_1458_release/SHA256SUMS --write` -> idempotent staged diff
- public canonical PPO smoke: `resolve_model_path("ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417", cache_dir="output/issue_1458_public_smoke_cache")` -> 93,662,266 bytes, SHA256 `2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d`
- public predictive smoke: `resolve_model_path("predictive_proxy_selected_v2_xl_ego", cache_dir="output/issue_1458_public_smoke_cache")` -> 11,176,729 bytes, SHA256 `49deeeca98d44bcadb0eb845d9a9a5fd36cc2911a8fed8c414f7f988ec0a3a69`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4107 passed, 11 skipped, 9 warnings in 293.73s

## Notes
- W&B remains lineage/backfill metadata; `github_release` is the credential-free hydration path for published registry assets.
- `output/issue_1458_release/`, `output/issue_1458_public_smoke_cache/`, and coverage outputs are local ignored proof artifacts only.
