### PR TITLE
feat: add oracle imitation launch packet

### DIFF
--- a/configs/training/ppo_imitation/README.md
+++ b/configs/training/ppo_imitation/README.md
@@ -14,6 +14,9 @@ This directory hosts configuration files used by the expert-policy, trajectory c
   `ppo_finetune_issue_749_v10_warm_start.yaml` – Issue #749 BC warm-start PPO challenger launch
   packet; see `docs/context/issue_749_bc_preinit_ppo_launch_packet.md` for the dataset collection,
   artifact-persistence, and evaluation boundary.
+* `oracle_dataset_issue_1397_launch_packet.yaml` – pre-Slurm oracle-imitation dataset launch
+  packet. Validate with
+  `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json`.
 * Additional files describe scenario coverage manifests referenced by trajectory collection commands.
 
 ## Usage Notes

--- a/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+++ b/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
@@ -1,0 +1,81 @@
+schema_version: oracle-imitation-launch-packet.v1
+dataset_id: issue_1397_oracle_imitation_v1
+source_candidate: hybrid_rule_v3_static_margin0_waypoint2
+source_candidate_config: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
+source_report: docs/context/policy_search/reports/2026-04-30_best_non_learning_local_policy_report.md
+split_contract: docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+scenario_source: configs/policy_search/nominal_sanity_matrix.yaml
+scenario_ids:
+  - planner_sanity_simple
+  - classic_head_on_corridor_low
+  - classic_crossing_low
+  - classic_doorway_low
+  - classic_overtaking_low
+  - francis2023_following_human
+seed_set_refs:
+  manifest: configs/benchmarks/seed_sets_v1.yaml
+  validation: dev
+  evaluation: eval
+  train_excludes: paper_eval_s20
+seeds_by_split:
+  train: [201, 202, 203, 204, 205, 206]
+  validation: [101, 102, 103]
+  evaluation: [111, 112, 113]
+episode_ids_by_split:
+  train:
+    - train__planner_sanity_simple__seed201
+    - train__classic_head_on_corridor_low__seed202
+    - train__classic_crossing_low__seed203
+    - train__classic_doorway_low__seed204
+    - train__classic_overtaking_low__seed205
+    - train__francis2023_following_human__seed206
+  validation:
+    - validation__planner_sanity_simple__seed101
+    - validation__classic_crossing_low__seed102
+    - validation__classic_doorway_low__seed103
+  evaluation:
+    - evaluation__planner_sanity_simple__seed111
+    - evaluation__classic_crossing_low__seed112
+    - evaluation__classic_doorway_low__seed113
+hard_slice_assignment:
+  - slice_id: stress_slice
+    split: validation
+    predeclared_for_evaluation: false
+    reason: "Use stress-slice style failures for gate tuning, not final evaluation."
+  - slice_id: corridor_deadlock_recovery
+    split: train
+    predeclared_for_evaluation: false
+    reason: "Recovery relabeling examples belong to train unless a holdout slice is predeclared."
+relabeling_policy: null
+exclusion_rules:
+  - "Exclude every validation/evaluation seed from train, including paper_eval_s20."
+  - "Exclude hard-slice recovery examples from evaluation unless predeclared in this packet."
+provenance: >
+  Pre-Slurm launch packet for #1397. The selected oracle source is the best current
+  non-learning local policy from docs/context/policy_search/reports/
+  2026-04-30_best_non_learning_local_policy_report.md. This packet validates split,
+  artifact, checksum, and relabeling contracts only; it does not generate the full dataset.
+created_at: "2026-05-24T08:55:00+00:00"
+generating_commit: e14e2f8bc2058d9f0e071219629915dd5b5dd5a8
+artifact_paths:
+  dry_run_fixture: docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json
+  future_dataset_manifest_uri: wandb-artifact://robot-sf/oracle-imitation/issue_1397_oracle_imitation_v1_manifest:pending
+  future_dataset_npz_uri: wandb-artifact://robot-sf/oracle-imitation/issue_1397_oracle_imitation_v1_npz:pending
+checksums:
+  docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json: eb5ef938d15725ff29a013a196216d093dd549ae58ae805e642c98441777529f
+artifact_promotion_policy:
+  raw_outputs_are_durable: false
+  required_before_collection:
+    - "Replace :pending W&B artifact aliases with concrete aliases or run ids."
+    - "Record checksums for the generated dataset and manifest before imitation training starts."
+collection_command_shape: >
+  uv run python scripts/training/collect_expert_trajectories.py --dataset-id
+  issue_1397_oracle_imitation_v1 --policy-id hybrid_rule_v3_static_margin0_waypoint2
+  --scenario-config configs/policy_search/nominal_sanity_matrix.yaml --seeds 201 202 203
+  204 205 206
+local_preflight_command: >
+  uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config
+  configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json
+slurm_command_shape: >
+  Submit dataset collection only from a follow-up issue after local preflight passes and
+  concrete durable artifact aliases are assigned; do not submit Slurm from #1397.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -138,6 +138,8 @@ knowledge, not every transient iteration detail.
   [issue_1344_paired_amv_protocol_report.md](issue_1344_paired_amv_protocol_report.md)
 * SLURM issue batch status 2026-05-21:
   [slurm_issue_batch_status_2026-05-21.md](slurm_issue_batch_status_2026-05-21.md)
+* Issue #1397 Oracle Imitation Launch Packet:
+  [issue_1397_oracle_imitation_launch_packet.md](issue_1397_oracle_imitation_launch_packet.md)
 * Issue #1353 Broader AMV Baseline Preflight:
   [issue_1353_broader_amv_preflight.md](issue_1353_broader_amv_preflight.md)
 * Issue #1398 metric rollup reconciliation:
@@ -204,6 +206,7 @@ knowledge, not every transient iteration detail.
   [issue 1023 scenario-horizon preflight](evidence/issue_1023_scenario_horizons_preflight_2026-05-06/README.md),
   [issue 1023 local full campaign](evidence/issue_1023_scenario_horizons_local_full_2026-05-06/README.md),
   [issue 1045 h500 solvability mechanisms](evidence/issue_1045_h500_solvability_mechanisms_2026-05-07/README.md),
+  [issue 1397 oracle imitation launch packet](evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/README.md),
   [issue 1113 continuous h500 promotion evidence](evidence/issue_1113_continuous_h500_2026-05-10/README.md),
   [Issue #1111 CARLA Setup-Only Smoke Evidence](evidence/issue_1111_carla_setup_smoke_2026-05-18/README.md),
   [Issue #1239 Human-Model Transfer Evidence](evidence/issue_1239_human_model_transfer_2026-05-18/README.md),

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -54,6 +54,8 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_1454_s10_h500_candidates_2026-05-23/`: compact exploratory S10 scenario-horizon h500
   evidence for the seven functioning Stage A rows plus local policy-search candidate rows, with a
   pointer to the non-package GitHub artifact release for the raw campaign archive.
+- `issue_1397_oracle_imitation_launch_packet_2026-05-24/`: dry-run fixture and checksum evidence
+  for the pre-Slurm oracle-imitation launch-packet validator.
 - `issue_1318_teb_corridor_deadlock_2026-05-20/`: compact TEB/ORCA/hybrid-rule
   classic-merging corridor-deadlock comparison summary for issue #1318.
 - `camera_ready_all_planners_2026-05-04/`: compact camera-ready all-planners campaign summaries and

--- a/docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/README.md
+++ b/docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/README.md
@@ -1,0 +1,16 @@
+# Issue #1397 Oracle Imitation Launch Packet Evidence
+
+This directory contains the small tracked dry-run fixture used by the #1397 launch-packet
+validator. It is not a trajectory dataset and must not be used for imitation training.
+
+Files:
+
+- `dry_run_dataset_stub.json`: minimal fixture referenced by
+  `configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml`
+  so checksum coverage and artifact-path validation can run before Slurm collection.
+
+Checksum:
+
+```text
+eb5ef938d15725ff29a013a196216d093dd549ae58ae805e642c98441777529f  dry_run_dataset_stub.json
+```

--- a/docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json
+++ b/docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json
@@ -1,0 +1,29 @@
+{
+  "dataset_id": "issue_1397_oracle_imitation_v1",
+  "fixture_role": "pre_slurm_manifest_preflight",
+  "source_candidate": "hybrid_rule_v3_static_margin0_waypoint2",
+  "episodes": [
+    {
+      "episode_id": "train__classic_doorway_low__seed201",
+      "scenario_id": "classic_doorway_low",
+      "seed": 201,
+      "split": "train"
+    },
+    {
+      "episode_id": "validation__classic_crossing_low__seed101",
+      "scenario_id": "classic_crossing_low",
+      "seed": 101,
+      "split": "validation"
+    },
+    {
+      "episode_id": "evaluation__planner_sanity_simple__seed111",
+      "scenario_id": "planner_sanity_simple",
+      "seed": 111,
+      "split": "evaluation"
+    }
+  ],
+  "notes": [
+    "Small tracked fixture only; it is not an oracle trajectory dataset.",
+    "Full collection remains a later Slurm follow-up after this launch packet is merged."
+  ]
+}

--- a/docs/context/issue_1397_oracle_imitation_launch_packet.md
+++ b/docs/context/issue_1397_oracle_imitation_launch_packet.md
@@ -1,0 +1,62 @@
+# Issue #1397 Oracle Imitation Launch Packet
+
+Date: 2026-05-24
+
+## Scope
+
+This note records the pre-Slurm launch packet for the oracle-imitation dataset campaign.
+It does not generate the full dataset, augment hard slices, train an imitation policy, or
+submit Slurm jobs.
+
+## Launch Packet
+
+- Config: `configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml`
+- Validator: `scripts/validation/validate_oracle_imitation_launch_packet.py`
+- Split contract: `docs/context/policy_search/contracts/oracle_imitation_dataset_split.md`
+- Source oracle candidate: `hybrid_rule_v3_static_margin0_waypoint2`
+- Source report: `docs/context/policy_search/reports/2026-04-30_best_non_learning_local_policy_report.md`
+- Evidence fixture:
+  `docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json`
+
+The source oracle is the best current non-learning local policy identified by the policy-search
+report. It is still an experimental, timeout-limited candidate; the launch packet uses it as an
+oracle source for a later dataset collection campaign, not as a promoted benchmark replacement.
+
+## Contract Enforced
+
+The new validator fails closed when:
+
+- train/validation/evaluation seeds overlap,
+- validation or evaluation seeds drift from `configs/benchmarks/seed_sets_v1.yaml`,
+- train seeds overlap `paper_eval_s20`,
+- hard-slice examples enter evaluation without predeclaration,
+- relabeling is configured outside the train split,
+- `generating_commit` is missing or not a Git SHA,
+- local artifact files are missing or have checksum mismatches,
+- artifact paths depend on worktree-local `output/`, or
+- no durable artifact URI is present.
+
+## Validation
+
+Executed locally:
+
+```bash
+uv run python scripts/validation/validate_oracle_imitation_launch_packet.py \
+  --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json
+```
+
+Result: `status=valid`, `dataset_id=issue_1397_oracle_imitation_v1`, six scenarios, and
+twelve planned manifest episode identifiers across train/validation/evaluation.
+
+Targeted tests:
+
+```bash
+uv run pytest -q tests/training/test_oracle_imitation_launch_packet.py
+```
+
+## Follow-Up Boundary
+
+The later dataset-collection issue should use this branch/commit, config path, validator command,
+source candidate, split manifest, hard-slice rules, and durable artifact URI policy. It should
+replace the `:pending` W&B artifact aliases with concrete aliases or run ids before collection
+starts, then record generated dataset checksums before any imitation training issue begins.

--- a/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
+++ b/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
@@ -6,11 +6,18 @@ Generate a planner-oracle dataset from the strongest non-training candidate
 family and train a faster imitation-style policy that preserves the same safety
 guard semantics.
 
-## Gated Dependency
+## Launch Packet
 
-This campaign is blocked on `contracts/oracle_imitation_dataset_split.md`.
-Dataset generation, hard-slice augmentation, and relabeling must wait until the
-split policy is committed and the manifest schema is populated. See issue #1397.
+Issue #1397 adds the pre-Slurm launch packet:
+
+- `configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml`
+- `scripts/validation/validate_oracle_imitation_launch_packet.py`
+- `docs/context/issue_1397_oracle_imitation_launch_packet.md`
+
+Dataset generation, hard-slice augmentation, and relabeling must still wait for a
+dedicated follow-up Slurm issue. That issue should first validate the launch packet,
+replace pending durable artifact aliases with concrete W&B aliases or run ids, then
+record generated dataset checksums before imitation training starts.
 
 ## Suggested Phases
 

--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -186,18 +186,16 @@ def _validate_seed_refs(
     seed_manifest = refs.get("manifest")
     if isinstance(seed_manifest, str) and seed_manifest.strip():
         manifest_path = _resolve_path(seed_manifest, repo_root)
+        if not manifest_path.is_file():
+            errors.append(f"seed_set_refs.manifest is not a regular file: {seed_manifest}")
+            return
         seed_payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
         if not isinstance(seed_payload, dict):
             errors.append("seed_set_refs.manifest must point to a mapping YAML file")
             return
         _validate_seed_ref("validation", refs.get("validation"), seed_payload, split_sets, errors)
         _validate_seed_ref("evaluation", refs.get("evaluation"), seed_payload, split_sets, errors)
-        excluded_ref = refs.get("train_excludes")
-        if isinstance(excluded_ref, str):
-            excluded = {int(seed) for seed in seed_payload.get(excluded_ref, [])}
-            overlap = sorted(split_sets.get("train", set()) & excluded)
-            if overlap:
-                errors.append(f"train seeds overlap excluded seed set {excluded_ref}: {overlap}")
+        _validate_train_excludes(refs, seed_payload, split_sets, errors)
 
 
 def _validate_seed_ref(
@@ -209,10 +207,52 @@ def _validate_seed_ref(
 ) -> None:
     if not isinstance(ref_name, str) or not ref_name.strip():
         return
-    expected = {int(seed) for seed in seed_payload.get(ref_name, [])}
+    ref_value = seed_payload.get(ref_name)
+    if not isinstance(ref_value, list):
+        errors.append(
+            f"seed_set_refs manifest key {ref_name!r} must be a list, got {type(ref_value).__name__}"
+        )
+        return
+    expected: set[int] = set()
+    for seed in ref_value:
+        if not isinstance(seed, int):
+            errors.append(
+                f"seed_set_refs manifest key {ref_name!r} contains non-integer entry: {seed!r}"
+            )
+            return
+        expected.add(seed)
     actual = split_sets.get(split, set())
     if expected != actual:
         errors.append(f"seeds_by_split.{split} must match seed set {ref_name}: {sorted(expected)}")
+
+
+def _validate_train_excludes(
+    refs: dict[str, Any],
+    seed_payload: dict[str, Any],
+    split_sets: dict[str, set[int]],
+    errors: list[str],
+) -> None:
+    excluded_ref = refs.get("train_excludes")
+    if not isinstance(excluded_ref, str):
+        return
+    excluded_value = seed_payload.get(excluded_ref)
+    if not isinstance(excluded_value, list):
+        errors.append(
+            f"seed_set_refs manifest key {excluded_ref!r} must be a list, "
+            f"got {type(excluded_value).__name__}"
+        )
+        return
+    excluded: set[int] = set()
+    for seed in excluded_value:
+        if not isinstance(seed, int):
+            errors.append(
+                f"seed_set_refs manifest key {excluded_ref!r} contains non-integer entry: {seed!r}"
+            )
+            return
+        excluded.add(seed)
+    overlap = sorted(split_sets.get("train", set()) & excluded)
+    if overlap:
+        errors.append(f"train seeds overlap excluded seed set {excluded_ref}: {overlap}")
 
 
 def _validate_episodes(packet: dict[str, Any], errors: list[str]) -> None:
@@ -315,7 +355,8 @@ def _artifact_path_text(name: str, raw_path: Any, errors: list[str]) -> str | No
         errors.append(f"artifact_paths.{name} must be a non-empty string")
         return None
     path_text = raw_path.strip()
-    if path_text.startswith("output/") or "/output/" in path_text:
+    _path_parts = Path(path_text).parts
+    if "output" in _path_parts:
         errors.append(
             f"artifact_paths.{name} must not depend on worktree-local output: {path_text}"
         )
@@ -341,9 +382,17 @@ def _validate_local_artifact(
     if not isinstance(expected, str) or not expected.strip():
         errors.append(f"checksums missing SHA-256 entry for {path_text}")
         return
-    actual = hashlib.sha256(local_path.read_bytes()).hexdigest()
+    actual = _sha256_hex_digest(local_path)
     if actual != expected.strip().lower():
         errors.append(f"checksum mismatch for {path_text}: expected {expected}, got {actual}")
+
+
+def _sha256_hex_digest(path: Path, chunk_size: int = 65536) -> str:
+    sha = hashlib.sha256()
+    with path.open("rb") as f:
+        while chunk := f.read(chunk_size):
+            sha.update(chunk)
+    return sha.hexdigest()
 
 
 __all__ = ["LaunchPacketError", "load_launch_packet", "validate_launch_packet"]

--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -1,0 +1,349 @@
+"""Validation helpers for oracle-imitation dataset launch packets."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_SCHEMA_VERSION = "oracle-imitation-launch-packet.v1"
+_SPLITS = ("train", "validation", "evaluation")
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_DURABLE_URI_PREFIXES = ("wandb-artifact://", "artifact://", "s3://", "gs://", "https://")
+
+
+class LaunchPacketError(ValueError):
+    """Raised when an oracle-imitation launch packet fails validation."""
+
+
+def load_launch_packet(config_path: Path) -> dict[str, Any]:
+    """Load a YAML oracle-imitation launch packet.
+
+    Args:
+        config_path: YAML file to load.
+
+    Returns:
+        Parsed mapping.
+
+    Raises:
+        LaunchPacketError: If the file is missing or does not contain a mapping.
+    """
+    if not config_path.is_file():
+        raise LaunchPacketError(f"launch packet is not a file: {config_path}")
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise LaunchPacketError("launch packet must be a YAML mapping")
+    return payload
+
+
+def validate_launch_packet(
+    config_path: Path,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Validate an oracle-imitation launch packet and return a compact report.
+
+    Args:
+        config_path: YAML launch-packet path.
+        repo_root: Repository root. Defaults to the current working directory.
+
+    Returns:
+        Validation report with status, checked fields, and artifact paths.
+
+    Raises:
+        LaunchPacketError: If any fail-closed launch-packet invariant is violated.
+    """
+    root = (repo_root or Path.cwd()).resolve()
+    config_path = _resolve_path(config_path, root)
+    packet = load_launch_packet(config_path)
+    errors: list[str] = []
+
+    if packet.get("schema_version") != _SCHEMA_VERSION:
+        errors.append(f"schema_version must be {_SCHEMA_VERSION!r}")
+
+    _require_non_empty_string(packet, "dataset_id", errors)
+    _require_non_empty_string(packet, "source_candidate", errors)
+    _require_existing_path(packet, "source_candidate_config", root, errors)
+    _require_existing_path(packet, "source_report", root, errors)
+    _require_existing_path(packet, "split_contract", root, errors)
+    _require_existing_path(packet, "scenario_source", root, errors)
+    _validate_scenarios(packet, errors)
+    _validate_seed_sets(packet, root, errors)
+    _validate_episodes(packet, errors)
+    _validate_hard_slices(packet, errors)
+    _validate_relabeling(packet, errors)
+    _validate_generating_commit(packet, errors)
+    artifact_paths = _validate_artifacts(packet, root, errors)
+
+    if errors:
+        joined = "\n- ".join(errors)
+        raise LaunchPacketError(f"oracle-imitation launch packet failed validation:\n- {joined}")
+
+    return {
+        "status": "valid",
+        "schema_version": packet["schema_version"],
+        "dataset_id": packet["dataset_id"],
+        "source_candidate": packet["source_candidate"],
+        "scenario_count": len(packet["scenario_ids"]),
+        "episode_count": sum(len(packet["episode_ids_by_split"][split]) for split in _SPLITS),
+        "seeds_by_split": {split: list(packet["seeds_by_split"][split]) for split in _SPLITS},
+        "artifact_paths": artifact_paths,
+    }
+
+
+def _resolve_path(path: Path | str, repo_root: Path) -> Path:
+    candidate = Path(path)
+    return candidate.resolve() if candidate.is_absolute() else (repo_root / candidate).resolve()
+
+
+def _require_non_empty_string(packet: dict[str, Any], key: str, errors: list[str]) -> None:
+    value = packet.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{key} must be a non-empty string")
+
+
+def _require_existing_path(
+    packet: dict[str, Any],
+    key: str,
+    repo_root: Path,
+    errors: list[str],
+) -> None:
+    value = packet.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{key} must be a non-empty path string")
+        return
+    path = _resolve_path(value, repo_root)
+    if not path.exists():
+        errors.append(f"{key} does not exist: {value}")
+
+
+def _validate_scenarios(packet: dict[str, Any], errors: list[str]) -> None:
+    scenario_ids = packet.get("scenario_ids")
+    if not isinstance(scenario_ids, list) or not scenario_ids:
+        errors.append("scenario_ids must be a non-empty list")
+        return
+    normalized: list[str] = []
+    for raw in scenario_ids:
+        if not isinstance(raw, str) or not raw.strip():
+            errors.append("scenario_ids entries must be non-empty strings")
+            return
+        normalized.append(raw.strip())
+    if len(set(normalized)) != len(normalized):
+        errors.append("scenario_ids must not contain duplicates")
+
+
+def _validate_seed_sets(packet: dict[str, Any], repo_root: Path, errors: list[str]) -> None:
+    seeds_by_split = packet.get("seeds_by_split")
+    if not isinstance(seeds_by_split, dict):
+        errors.append("seeds_by_split must be a mapping")
+        return
+
+    split_sets = _split_seed_sets(seeds_by_split, errors)
+    _validate_seed_overlap(split_sets, errors)
+    _validate_seed_refs(packet, repo_root, split_sets, errors)
+
+
+def _split_seed_sets(
+    seeds_by_split: dict[str, Any],
+    errors: list[str],
+) -> dict[str, set[int]]:
+    split_sets: dict[str, set[int]] = {}
+    for split in _SPLITS:
+        raw_seeds = seeds_by_split.get(split)
+        if not isinstance(raw_seeds, list) or not raw_seeds:
+            errors.append(f"seeds_by_split.{split} must be a non-empty list")
+            continue
+        try:
+            split_sets[split] = {int(seed) for seed in raw_seeds}
+        except (TypeError, ValueError):
+            errors.append(f"seeds_by_split.{split} must contain integer seeds")
+    return split_sets
+
+
+def _validate_seed_overlap(split_sets: dict[str, set[int]], errors: list[str]) -> None:
+    for index, left in enumerate(_SPLITS):
+        for right in _SPLITS[index + 1 :]:
+            overlap = sorted(split_sets.get(left, set()) & split_sets.get(right, set()))
+            if overlap:
+                errors.append(f"seed overlap between {left} and {right}: {overlap}")
+
+
+def _validate_seed_refs(
+    packet: dict[str, Any],
+    repo_root: Path,
+    split_sets: dict[str, set[int]],
+    errors: list[str],
+) -> None:
+    refs = packet.get("seed_set_refs", {})
+    if refs is None:
+        refs = {}
+    if not isinstance(refs, dict):
+        errors.append("seed_set_refs must be a mapping when provided")
+        return
+    seed_manifest = refs.get("manifest")
+    if isinstance(seed_manifest, str) and seed_manifest.strip():
+        manifest_path = _resolve_path(seed_manifest, repo_root)
+        seed_payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(seed_payload, dict):
+            errors.append("seed_set_refs.manifest must point to a mapping YAML file")
+            return
+        _validate_seed_ref("validation", refs.get("validation"), seed_payload, split_sets, errors)
+        _validate_seed_ref("evaluation", refs.get("evaluation"), seed_payload, split_sets, errors)
+        excluded_ref = refs.get("train_excludes")
+        if isinstance(excluded_ref, str):
+            excluded = {int(seed) for seed in seed_payload.get(excluded_ref, [])}
+            overlap = sorted(split_sets.get("train", set()) & excluded)
+            if overlap:
+                errors.append(f"train seeds overlap excluded seed set {excluded_ref}: {overlap}")
+
+
+def _validate_seed_ref(
+    split: str,
+    ref_name: Any,
+    seed_payload: dict[str, Any],
+    split_sets: dict[str, set[int]],
+    errors: list[str],
+) -> None:
+    if not isinstance(ref_name, str) or not ref_name.strip():
+        return
+    expected = {int(seed) for seed in seed_payload.get(ref_name, [])}
+    actual = split_sets.get(split, set())
+    if expected != actual:
+        errors.append(f"seeds_by_split.{split} must match seed set {ref_name}: {sorted(expected)}")
+
+
+def _validate_episodes(packet: dict[str, Any], errors: list[str]) -> None:
+    episodes = packet.get("episode_ids_by_split")
+    if not isinstance(episodes, dict):
+        errors.append("episode_ids_by_split must be a mapping")
+        return
+    all_ids: list[str] = []
+    for split in _SPLITS:
+        split_ids = episodes.get(split)
+        if not isinstance(split_ids, list) or not split_ids:
+            errors.append(f"episode_ids_by_split.{split} must be a non-empty list")
+            continue
+        for episode_id in split_ids:
+            if not isinstance(episode_id, str) or not episode_id.strip():
+                errors.append(f"episode_ids_by_split.{split} entries must be non-empty strings")
+                continue
+            all_ids.append(episode_id.strip())
+    if len(set(all_ids)) != len(all_ids):
+        errors.append("episode_ids_by_split must not contain duplicate episode ids")
+
+
+def _validate_hard_slices(packet: dict[str, Any], errors: list[str]) -> None:
+    assignments = packet.get("hard_slice_assignment")
+    if not isinstance(assignments, list):
+        errors.append("hard_slice_assignment must be a list")
+        return
+    for index, assignment in enumerate(assignments):
+        if not isinstance(assignment, dict):
+            errors.append(f"hard_slice_assignment[{index}] must be a mapping")
+            continue
+        split = assignment.get("split")
+        if split not in _SPLITS:
+            errors.append(f"hard_slice_assignment[{index}].split must be one of {_SPLITS}")
+        predeclared = bool(assignment.get("predeclared_for_evaluation", False))
+        if split == "evaluation" and not predeclared:
+            errors.append(
+                f"hard_slice_assignment[{index}] assigns evaluation without predeclaration"
+            )
+
+
+def _validate_relabeling(packet: dict[str, Any], errors: list[str]) -> None:
+    policy = packet.get("relabeling_policy")
+    if policy is None:
+        return
+    if not isinstance(policy, dict):
+        errors.append("relabeling_policy must be null or a mapping")
+        return
+    scope = policy.get("scope")
+    if scope != "train":
+        errors.append("relabeling_policy.scope must be 'train' when relabeling is enabled")
+    _require_non_empty_string(policy, "source_oracle", errors)
+    _require_non_empty_string(policy, "rule", errors)
+
+
+def _validate_generating_commit(packet: dict[str, Any], errors: list[str]) -> None:
+    commit = packet.get("generating_commit")
+    if not isinstance(commit, str) or not _GIT_SHA_RE.match(commit.strip()):
+        errors.append("generating_commit must be a 40-character git SHA")
+
+
+def _validate_artifacts(
+    packet: dict[str, Any],
+    repo_root: Path,
+    errors: list[str],
+) -> dict[str, str]:
+    artifact_paths = packet.get("artifact_paths")
+    checksums = packet.get("checksums")
+    if not isinstance(artifact_paths, dict) or not artifact_paths:
+        errors.append("artifact_paths must be a non-empty mapping")
+        return {}
+    if not isinstance(checksums, dict):
+        errors.append("checksums must be a mapping")
+        checksums = {}
+
+    normalized_paths: dict[str, str] = {}
+    local_paths: list[str] = []
+    durable_count = 0
+    for name, raw_path in sorted(artifact_paths.items()):
+        path_text = _artifact_path_text(str(name), raw_path, errors)
+        if path_text is None:
+            continue
+        normalized_paths[str(name)] = path_text
+        if _is_durable_uri(path_text):
+            durable_count += 1
+            continue
+        local_paths.append(path_text)
+        _validate_local_artifact(str(name), path_text, checksums, repo_root, errors)
+
+    for checksum_path in checksums:
+        if checksum_path not in local_paths:
+            errors.append(f"checksums contains path not listed in artifact_paths: {checksum_path}")
+    if durable_count == 0:
+        errors.append("artifact_paths must include at least one durable artifact URI")
+    return normalized_paths
+
+
+def _artifact_path_text(name: str, raw_path: Any, errors: list[str]) -> str | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append(f"artifact_paths.{name} must be a non-empty string")
+        return None
+    path_text = raw_path.strip()
+    if path_text.startswith("output/") or "/output/" in path_text:
+        errors.append(
+            f"artifact_paths.{name} must not depend on worktree-local output: {path_text}"
+        )
+    return path_text
+
+
+def _is_durable_uri(path_text: str) -> bool:
+    return path_text.startswith(_DURABLE_URI_PREFIXES)
+
+
+def _validate_local_artifact(
+    name: str,
+    path_text: str,
+    checksums: dict[str, Any],
+    repo_root: Path,
+    errors: list[str],
+) -> None:
+    local_path = _resolve_path(path_text, repo_root)
+    if not local_path.is_file():
+        errors.append(f"artifact_paths.{name} local artifact is missing: {path_text}")
+        return
+    expected = checksums.get(path_text)
+    if not isinstance(expected, str) or not expected.strip():
+        errors.append(f"checksums missing SHA-256 entry for {path_text}")
+        return
+    actual = hashlib.sha256(local_path.read_bytes()).hexdigest()
+    if actual != expected.strip().lower():
+        errors.append(f"checksum mismatch for {path_text}: expected {expected}, got {actual}")
+
+
+__all__ = ["LaunchPacketError", "load_launch_packet", "validate_launch_packet"]

--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -33,7 +33,10 @@ def load_launch_packet(config_path: Path) -> dict[str, Any]:
     """
     if not config_path.is_file():
         raise LaunchPacketError(f"launch packet is not a file: {config_path}")
-    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise LaunchPacketError(f"failed to load launch packet YAML: {config_path}") from exc
     if not isinstance(payload, dict):
         raise LaunchPacketError("launch packet must be a YAML mapping")
     return payload
@@ -184,18 +187,26 @@ def _validate_seed_refs(
         errors.append("seed_set_refs must be a mapping when provided")
         return
     seed_manifest = refs.get("manifest")
-    if isinstance(seed_manifest, str) and seed_manifest.strip():
-        manifest_path = _resolve_path(seed_manifest, repo_root)
-        if not manifest_path.is_file():
-            errors.append(f"seed_set_refs.manifest is not a regular file: {seed_manifest}")
-            return
+    if seed_manifest is None:
+        return
+    if not isinstance(seed_manifest, str) or not seed_manifest.strip():
+        errors.append("seed_set_refs.manifest must be a non-empty path string when provided")
+        return
+    manifest_path = _resolve_path(seed_manifest, repo_root)
+    if not manifest_path.is_file():
+        errors.append(f"seed_set_refs.manifest is not a regular file: {seed_manifest}")
+        return
+    try:
         seed_payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-        if not isinstance(seed_payload, dict):
-            errors.append("seed_set_refs.manifest must point to a mapping YAML file")
-            return
-        _validate_seed_ref("validation", refs.get("validation"), seed_payload, split_sets, errors)
-        _validate_seed_ref("evaluation", refs.get("evaluation"), seed_payload, split_sets, errors)
-        _validate_train_excludes(refs, seed_payload, split_sets, errors)
+    except (OSError, yaml.YAMLError) as exc:
+        errors.append(f"seed_set_refs.manifest could not be loaded: {exc}")
+        return
+    if not isinstance(seed_payload, dict):
+        errors.append("seed_set_refs.manifest must point to a mapping YAML file")
+        return
+    _validate_seed_ref("validation", refs.get("validation"), seed_payload, split_sets, errors)
+    _validate_seed_ref("evaluation", refs.get("evaluation"), seed_payload, split_sets, errors)
+    _validate_train_excludes(refs, seed_payload, split_sets, errors)
 
 
 def _validate_seed_ref(

--- a/scripts/validation/validate_oracle_imitation_launch_packet.py
+++ b/scripts/validation/validate_oracle_imitation_launch_packet.py
@@ -1,0 +1,54 @@
+"""Validate oracle-imitation dataset launch packets before Slurm collection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.training.oracle_imitation_launch_packet import (
+    LaunchPacketError,
+    validate_launch_packet,
+)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Validate a pre-Slurm oracle-imitation dataset launch packet."
+    )
+    parser.add_argument("--config", required=True, type=Path, help="Launch-packet YAML path.")
+    parser.add_argument(
+        "--repo-root",
+        default=Path.cwd(),
+        type=Path,
+        help="Repository root used to resolve relative paths.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate a launch packet and return a shell-friendly exit code."""
+    args = build_arg_parser().parse_args(argv)
+    try:
+        report = validate_launch_packet(args.config, repo_root=args.repo_root)
+    except LaunchPacketError as exc:
+        if args.json:
+            print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(str(exc))
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "oracle-imitation launch packet valid: "
+            f"{report['dataset_id']} ({report['episode_count']} planned episodes)"
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -131,3 +131,89 @@ def test_validate_launch_packet_cli_reports_json() -> None:
     )
 
     assert exit_code == 0
+
+
+def test_seed_manifest_missing_file_fails_closed(tmp_path: Path) -> None:
+    """A seed manifest that does not exist must fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["seed_set_refs"]["manifest"] = "nonexistent/manifest.yaml"
+
+    with pytest.raises(LaunchPacketError, match="not a regular file"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_seed_manifest_directory_fails_closed(tmp_path: Path) -> None:
+    """A seed manifest that is a directory must fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["seed_set_refs"]["manifest"] = str(tmp_path)
+
+    with pytest.raises(LaunchPacketError, match="not a regular file"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_seed_ref_non_list_fails_closed(tmp_path: Path) -> None:
+    """A seed set in the manifest that is not a list must fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken_manifest = tmp_path / "bad_manifest.yaml"
+    broken_manifest.write_text(
+        yaml.safe_dump({"dev": 42, "eval": [111, 112, 113]}), encoding="utf-8"
+    )
+    broken["seed_set_refs"]["manifest"] = str(broken_manifest)
+
+    with pytest.raises(LaunchPacketError, match="must be a list"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_seed_ref_non_integer_entry_fails_closed(tmp_path: Path) -> None:
+    """A seed set containing a non-integer entry must fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken_manifest = tmp_path / "bad_manifest.yaml"
+    broken_manifest.write_text(
+        yaml.safe_dump({"dev": [101, "bad", 103], "eval": [111, 112, 113]}),
+        encoding="utf-8",
+    )
+    broken["seed_set_refs"]["manifest"] = str(broken_manifest)
+
+    with pytest.raises(LaunchPacketError, match="non-integer entry"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_train_excludes_non_list_fails_closed(tmp_path: Path) -> None:
+    """A train_excludes set that is not a list must fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken_manifest = tmp_path / "bad_manifest.yaml"
+    broken_manifest.write_text(
+        yaml.safe_dump({"dev": [101, 102, 103], "eval": [111, 112, 113], "paper_eval_s20": "bad"}),
+        encoding="utf-8",
+    )
+    broken["seed_set_refs"]["manifest"] = str(broken_manifest)
+
+    with pytest.raises(LaunchPacketError, match="must be a list"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_output_component_in_path_rejected(tmp_path: Path) -> None:
+    """A path with 'output' as a directory component must be rejected."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["artifact_paths"]["dry_run_fixture"] = "output/subdir/local-only.json"
+    broken["checksums"] = {"output/subdir/local-only.json": "0" * 64}
+
+    with pytest.raises(LaunchPacketError, match="worktree-local output"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_output_substring_not_in_component_allowed(tmp_path: Path) -> None:
+    """A path containing 'output' only as a substring of another name is NOT rejected."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["artifact_paths"]["dry_run_fixture"] = "docs/my_output_config/stub.json"
+    broken["checksums"] = {"docs/my_output_config/stub.json": "0" * 64}
+
+    with pytest.raises(LaunchPacketError, match="local artifact is missing"):
+        validate_launch_packet(_write_packet(tmp_path, broken))

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -1,0 +1,133 @@
+"""Tests for oracle-imitation launch-packet validation."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.training.oracle_imitation_launch_packet import (
+    LaunchPacketError,
+    validate_launch_packet,
+)
+from scripts.validation.validate_oracle_imitation_launch_packet import main as validate_cli_main
+
+
+def _write_packet(tmp_path: Path, packet: dict[str, object]) -> Path:
+    path = tmp_path / "packet.yaml"
+    path.write_text(yaml.safe_dump(packet, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _valid_packet(tmp_path: Path) -> dict[str, object]:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text('{"status": "dry-run"}\n', encoding="utf-8")
+    digest = hashlib.sha256(fixture.read_bytes()).hexdigest()
+    return {
+        "schema_version": "oracle-imitation-launch-packet.v1",
+        "dataset_id": "demo_oracle_imitation",
+        "source_candidate": "hybrid_rule_v3_static_margin0_waypoint2",
+        "source_candidate_config": "configs/policy_search/candidates/"
+        "hybrid_rule_v3_static_margin0_waypoint2.yaml",
+        "source_report": "docs/context/policy_search/reports/"
+        "2026-04-30_best_non_learning_local_policy_report.md",
+        "split_contract": "docs/context/policy_search/contracts/oracle_imitation_dataset_split.md",
+        "scenario_source": "configs/policy_search/nominal_sanity_matrix.yaml",
+        "scenario_ids": ["planner_sanity_simple", "classic_crossing_low"],
+        "seed_set_refs": {
+            "manifest": "configs/benchmarks/seed_sets_v1.yaml",
+            "validation": "dev",
+            "evaluation": "eval",
+            "train_excludes": "paper_eval_s20",
+        },
+        "seeds_by_split": {
+            "train": [201, 202],
+            "validation": [101, 102, 103],
+            "evaluation": [111, 112, 113],
+        },
+        "episode_ids_by_split": {
+            "train": ["train__planner_sanity_simple__seed201"],
+            "validation": ["validation__planner_sanity_simple__seed101"],
+            "evaluation": ["evaluation__planner_sanity_simple__seed111"],
+        },
+        "hard_slice_assignment": [
+            {
+                "slice_id": "stress_slice",
+                "split": "validation",
+                "predeclared_for_evaluation": False,
+            }
+        ],
+        "relabeling_policy": None,
+        "exclusion_rules": ["exclude eval seeds from train"],
+        "provenance": "unit-test fixture",
+        "created_at": "2026-05-24T08:55:00+00:00",
+        "generating_commit": "e14e2f8bc2058d9f0e071219629915dd5b5dd5a8",
+        "artifact_paths": {
+            "dry_run_fixture": str(fixture),
+            "future_dataset_npz_uri": "wandb-artifact://robot-sf/demo:pending",
+        },
+        "checksums": {str(fixture): digest},
+    }
+
+
+def test_issue_1397_launch_packet_validates() -> None:
+    """The checked-in #1397 launch packet should pass the fail-closed preflight."""
+    report = validate_launch_packet(
+        Path("configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml")
+    )
+
+    assert report["status"] == "valid"
+    assert report["dataset_id"] == "issue_1397_oracle_imitation_v1"
+    assert report["source_candidate"] == "hybrid_rule_v3_static_margin0_waypoint2"
+    assert report["scenario_count"] == 6
+
+
+def test_validate_launch_packet_rejects_seed_overlap(tmp_path: Path) -> None:
+    """Seed overlap across train/validation/evaluation should fail closed."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["seeds_by_split"]["train"] = [101]
+
+    with pytest.raises(LaunchPacketError, match="seed overlap"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_validate_launch_packet_rejects_unpredeclared_evaluation_hard_slice(
+    tmp_path: Path,
+) -> None:
+    """Hard-slice examples cannot enter evaluation unless predeclared."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["hard_slice_assignment"] = [
+        {"slice_id": "stress_slice", "split": "evaluation", "predeclared_for_evaluation": False}
+    ]
+
+    with pytest.raises(LaunchPacketError, match="assigns evaluation without predeclaration"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_validate_launch_packet_rejects_output_artifact_paths(tmp_path: Path) -> None:
+    """Launch packets must not depend on worktree-local output artifacts."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["artifact_paths"]["dry_run_fixture"] = "output/local-only.json"
+    broken["checksums"] = {"output/local-only.json": "0" * 64}
+
+    with pytest.raises(LaunchPacketError, match="worktree-local output"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_validate_launch_packet_cli_reports_json() -> None:
+    """The CLI should expose the same validation report for automation."""
+    exit_code = validate_cli_main(
+        [
+            "--config",
+            "configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -11,6 +11,7 @@ import yaml
 
 from robot_sf.training.oracle_imitation_launch_packet import (
     LaunchPacketError,
+    load_launch_packet,
     validate_launch_packet,
 )
 from scripts.validation.validate_oracle_imitation_launch_packet import main as validate_cli_main
@@ -151,6 +152,27 @@ def test_seed_manifest_directory_fails_closed(tmp_path: Path) -> None:
 
     with pytest.raises(LaunchPacketError, match="not a regular file"):
         validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_seed_manifest_malformed_yaml_fails_closed(tmp_path: Path) -> None:
+    """A malformed seed manifest must become a validation error, not an escaped YAML error."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken_manifest = tmp_path / "bad_manifest.yaml"
+    broken_manifest.write_text("dev: [101, 102\n", encoding="utf-8")
+    broken["seed_set_refs"]["manifest"] = str(broken_manifest)
+
+    with pytest.raises(LaunchPacketError, match="manifest could not be loaded"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_load_launch_packet_malformed_yaml_raises_launch_packet_error(tmp_path: Path) -> None:
+    """Malformed launch-packet YAML should preserve the validator's public exception type."""
+    malformed = tmp_path / "packet.yaml"
+    malformed.write_text("schema_version: [broken\n", encoding="utf-8")
+
+    with pytest.raises(LaunchPacketError, match="failed to load launch packet YAML"):
+        load_launch_packet(malformed)
 
 
 def test_seed_ref_non_list_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1397.

## Summary
- add a versioned pre-Slurm oracle-imitation launch packet for `issue_1397_oracle_imitation_v1`
- add a fail-closed validator CLI for split, hard-slice, relabeling, commit, checksum, and durable artifact URI checks
- add targeted tests for the checked-in packet plus seed-overlap, hard-slice leakage, and worktree-local `output/` artifact failures
- document the launch boundary and preserve a tiny tracked dry-run fixture with checksum evidence

## Validation
- `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json` (`status=valid`, 6 scenarios, 12 planned episode ids)
- `uv run ruff format robot_sf/training/oracle_imitation_launch_packet.py scripts/validation/validate_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py`
- `uv run ruff check robot_sf/training/oracle_imitation_launch_packet.py scripts/validation/validate_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py`
- `uv run pytest -q tests/training/test_oracle_imitation_launch_packet.py --no-cov` (`5 passed`)
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4106 passed, 11 skipped, 11 warnings`)

## Artifact Decision
- Full datasets, checkpoints, raw logs, and Slurm outputs remain out of git.
- The only tracked evidence is the small dry-run fixture under `docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/`.
- The launch packet includes pending W&B artifact URI shapes for the future dataset manifest and NPZ; the follow-up Slurm issue must replace those pending aliases before collection starts.

## Boundary
This PR prepares the local launch packet and validation contract only. It does not collect the full oracle dataset, add hard-slice recovery examples, train imitation policies, or submit Slurm jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a validation system for oracle imitation training configurations with a command-line tool.
  * Added comprehensive configuration schema with support for dataset definitions, seed management, and artifact tracking.

* **Documentation**
  * Added configuration guide and validation instructions for oracle imitation workflows.
  * Included example fixture and evidence documentation for reference implementations.

* **Tests**
  * Added validation test coverage for configuration integrity, seed overlap detection, and artifact verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->