### PR TITLE
workflow: add predictive pipeline slurm launcher

### DIFF
--- a/SLURM/Auxme/camera_ready_benchmark.sl
+++ b/SLURM/Auxme/camera_ready_benchmark.sl
@@ -135,11 +135,11 @@ ensure_module_command() {
 }
 
 run_in_allocation() {
-  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
+  if [[ "${CAMERA_READY_BENCH_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
     log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores "$@"
   else
-    echo "[camera-ready-bench] srun unavailable, broken, or not in a Slurm allocation; running directly." >&2
+    echo "[camera-ready-bench] running directly inside the batch allocation; set CAMERA_READY_BENCH_USE_SRUN=1 to opt into srun." >&2
     "$@"
   fi
 }

--- a/SLURM/Auxme/camera_ready_benchmark.sl
+++ b/SLURM/Auxme/camera_ready_benchmark.sl
@@ -135,11 +135,11 @@ ensure_module_command() {
 }
 
 run_in_allocation() {
-  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
+  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
     log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores "$@"
   else
-    echo "[camera-ready-bench] srun unavailable or not in a Slurm allocation; running directly." >&2
+    echo "[camera-ready-bench] srun unavailable, broken, or not in a Slurm allocation; running directly." >&2
     "$@"
   fi
 }

--- a/SLURM/Auxme/predictive_training_pipeline.sl
+++ b/SLURM/Auxme/predictive_training_pipeline.sl
@@ -44,11 +44,11 @@ die() {
 }
 
 run_in_allocation() {
-  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
+  if [[ "${PREDICTIVE_PIPELINE_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
     log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores "$@"
   else
-    echo "[predictive-pipeline] srun unavailable, broken, or not in a Slurm allocation; running directly." >&2
+    echo "[predictive-pipeline] running directly inside the batch allocation; set PREDICTIVE_PIPELINE_USE_SRUN=1 to opt into srun." >&2
     "$@"
   fi
 }

--- a/SLURM/Auxme/predictive_training_pipeline.sl
+++ b/SLURM/Auxme/predictive_training_pipeline.sl
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=rsf-pred-pipe
+#SBATCH --account=mitarbeiter
+#SBATCH --partition=a30
+#SBATCH --qos=a30-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=96G
+#SBATCH --time=12:00:00
+#SBATCH --gres=gpu:1
+#SBATCH --output=output/slurm/%j-predictive-pipeline.out
+
+# Run one config-driven predictive-planner training/evaluation pipeline on Auxme.
+#
+# Required env vars:
+#   PREDICTIVE_PIPELINE_CONFIG  predictive pipeline YAML, relative to repo root or absolute
+#
+# Optional env vars:
+#   PREDICTIVE_PIPELINE_RUN_ID       run id override for stable artifact roots
+#   PREDICTIVE_PIPELINE_LOG_LEVEL    default: INFO
+#   PREDICTIVE_PIPELINE_RESULTS_DIR  final sync dir, default:
+#                                    output/slurm/predictive-pipeline-job-${SLURM_JOB_ID}
+set -euo pipefail
+
+PROJECT_ROOT=$(git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null || echo "${SLURM_SUBMIT_DIR:-$(pwd)}")
+LOCAL_OUTPUT_ROOT=${PROJECT_ROOT}/output/slurm
+RESULTS_ROOT=${PREDICTIVE_PIPELINE_RESULTS_DIR:-${LOCAL_OUTPUT_ROOT}/predictive-pipeline-job-${SLURM_JOB_ID:-local}}
+WORKDIR=${SLURM_TMPDIR:-/tmp/${USER}/predictive-pipeline-${SLURM_JOB_ID:-local}}
+PYTHON_BIN=${PROJECT_ROOT}/.venv/bin/python
+
+PIPELINE_CONFIG=${PREDICTIVE_PIPELINE_CONFIG:-}
+PIPELINE_RUN_ID=${PREDICTIVE_PIPELINE_RUN_ID:-}
+PIPELINE_LOG_LEVEL=${PREDICTIVE_PIPELINE_LOG_LEVEL:-INFO}
+RUN_OUTPUT_DIR=""
+
+log() {
+  echo "[predictive-pipeline] $*"
+}
+
+die() {
+  echo "[predictive-pipeline] $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "${RUN_OUTPUT_DIR}" && -d "${RUN_OUTPUT_DIR}" ]]; then
+    mkdir -p "${RESULTS_ROOT}"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --partial --prune-empty-dirs "${RUN_OUTPUT_DIR}/" "${RESULTS_ROOT}/" \
+        || echo "[predictive-pipeline] Warning: rsync failed to sync artifacts to ${RESULTS_ROOT}" >&2
+    else
+      cp -r "${RUN_OUTPUT_DIR}/." "${RESULTS_ROOT}/" \
+        || echo "[predictive-pipeline] Warning: cp failed to sync artifacts to ${RESULTS_ROOT}" >&2
+    fi
+  fi
+}
+trap cleanup EXIT
+
+if ! git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  die "PROJECT_ROOT is not inside a git work tree: ${PROJECT_ROOT}"
+fi
+
+if [[ -z "${PIPELINE_CONFIG}" ]]; then
+  die "PREDICTIVE_PIPELINE_CONFIG is required."
+fi
+
+if [[ "${PIPELINE_CONFIG}" = /* ]]; then
+  PIPELINE_CONFIG_PATH=${PIPELINE_CONFIG}
+else
+  PIPELINE_CONFIG_PATH=${PROJECT_ROOT}/${PIPELINE_CONFIG}
+fi
+
+if [[ ! -f "${PIPELINE_CONFIG_PATH}" ]]; then
+  die "Pipeline config not found: ${PIPELINE_CONFIG_PATH}"
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  die "Expected repo virtualenv python at ${PYTHON_BIN}"
+fi
+
+mkdir -p "${WORKDIR}" "${LOCAL_OUTPUT_ROOT}"
+export ROBOT_SF_ARTIFACT_ROOT=${WORKDIR}/results
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+export SDL_VIDEODRIVER=${SDL_VIDEODRIVER:-dummy}
+export MPLBACKEND=${MPLBACKEND:-Agg}
+export LOGURU_LEVEL=${LOGURU_LEVEL:-${PIPELINE_LOG_LEVEL}}
+mkdir -p "${ROBOT_SF_ARTIFACT_ROOT}"
+
+cd "${PROJECT_ROOT}"
+
+RUN_ID_ARG=()
+if [[ -n "${PIPELINE_RUN_ID}" ]]; then
+  RUN_ID_ARG=(--run-id "${PIPELINE_RUN_ID}")
+  RUN_OUTPUT_DIR=${PROJECT_ROOT}/output/tmp/predictive_planner/pipeline/${PIPELINE_RUN_ID}
+fi
+
+log "Starting predictive pipeline"
+log "Config: ${PIPELINE_CONFIG_PATH}"
+log "Run id: ${PIPELINE_RUN_ID:-<config timestamp default>}"
+log "Results sync dir: ${RESULTS_ROOT}"
+log "Node: ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}"
+
+"${PYTHON_BIN}" scripts/training/run_predictive_training_pipeline.py \
+  --config "${PIPELINE_CONFIG_PATH}" \
+  --log-level "${PIPELINE_LOG_LEVEL}" \
+  "${RUN_ID_ARG[@]}"
+
+if [[ -z "${RUN_OUTPUT_DIR}" ]]; then
+  RUN_OUTPUT_DIR=$(find "${PROJECT_ROOT}/output/tmp/predictive_planner/pipeline" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' \
+    | sort -nr | awk 'NR==1 {print $2}')
+fi
+
+log "Predictive pipeline completed. Artifacts will be synced to ${RESULTS_ROOT}"

--- a/SLURM/Auxme/predictive_training_pipeline.sl
+++ b/SLURM/Auxme/predictive_training_pipeline.sl
@@ -43,6 +43,16 @@ die() {
   exit 1
 }
 
+run_in_allocation() {
+  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
+    log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
+    srun --cpu_bind=cores "$@"
+  else
+    echo "[predictive-pipeline] srun unavailable, broken, or not in a Slurm allocation; running directly." >&2
+    "$@"
+  fi
+}
+
 cleanup() {
   if [[ -n "${RUN_OUTPUT_DIR}" && -d "${RUN_OUTPUT_DIR}" ]]; then
     mkdir -p "${RESULTS_ROOT}"
@@ -89,26 +99,22 @@ mkdir -p "${ROBOT_SF_ARTIFACT_ROOT}"
 
 cd "${PROJECT_ROOT}"
 
-RUN_ID_ARG=()
-if [[ -n "${PIPELINE_RUN_ID}" ]]; then
-  RUN_ID_ARG=(--run-id "${PIPELINE_RUN_ID}")
-  RUN_OUTPUT_DIR=${PROJECT_ROOT}/output/tmp/predictive_planner/pipeline/${PIPELINE_RUN_ID}
+if [[ -z "${PIPELINE_RUN_ID}" ]]; then
+  PIPELINE_RUN_ID="predictive_pipeline_${SLURM_JOB_ID:-local_${BASHPID}}_$(date -u +%Y%m%dT%H%M%SZ)"
 fi
+RUN_ID_ARG=(--run-id "${PIPELINE_RUN_ID}")
+RUN_OUTPUT_DIR=${PROJECT_ROOT}/output/tmp/predictive_planner/pipeline/${PIPELINE_RUN_ID}
 
 log "Starting predictive pipeline"
 log "Config: ${PIPELINE_CONFIG_PATH}"
-log "Run id: ${PIPELINE_RUN_ID:-<config timestamp default>}"
+log "Run id: ${PIPELINE_RUN_ID}"
+log "Run output dir: ${RUN_OUTPUT_DIR}"
 log "Results sync dir: ${RESULTS_ROOT}"
 log "Node: ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}"
 
-"${PYTHON_BIN}" scripts/training/run_predictive_training_pipeline.py \
+run_in_allocation "${PYTHON_BIN}" scripts/training/run_predictive_training_pipeline.py \
   --config "${PIPELINE_CONFIG_PATH}" \
   --log-level "${PIPELINE_LOG_LEVEL}" \
   "${RUN_ID_ARG[@]}"
-
-if [[ -z "${RUN_OUTPUT_DIR}" ]]; then
-  RUN_OUTPUT_DIR=$(find "${PROJECT_ROOT}/output/tmp/predictive_planner/pipeline" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' \
-    | sort -nr | awk 'NR==1 {print $2}')
-fi
 
 log "Predictive pipeline completed. Artifacts will be synced to ${RESULTS_ROOT}"

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -153,6 +153,26 @@ Later status: job `12612` exited `FAILED` with code `2:0` after
 whether missing predictive proxy/success-campaign JSONL should be fail-closed earlier or summarized
 as structured evidence caveats. Job `12611` was still running at the last handoff refresh.
 
+Update after #1481 hardening and schema propagation: commit `b0564463` teaches the predictive
+planner algo-config builder to read the checkpoint feature-schema metadata when a concrete
+checkpoint is supplied. This fixes the obstacle-feature rerun's earlier proxy-eval mismatch where
+`proxy_epoch_0005_algo.yaml` used `predictive_legacy_v1` for a
+`predictive_obstacle_features_v1` checkpoint.
+
+Fresh paired rerun from `b0564463`:
+
+- job `12617`, `pred1427-base4`, run id
+  `predictive_br07_same_seed_issue_1427_20260524T114637Z`
+- job `12618`, `pred1427-obs4`, run id
+  `predictive_obstacle_features_same_seed_issue_1427_20260524T114637Z`
+
+Both jobs started on `a30` node `auxme-imech172`. As of the 2026-05-24 14:20 CEST refresh, both
+were still `RUNNING`. Training completed for both, final eval summaries existed for both, and both
+jobs had entered `scripts/validation/run_predictive_success_campaign.py`. The obstacle-feature job
+proved the schema fix by writing nonempty proxy JSONL artifacts through epoch 40; its generated
+`training/proxy_eval/proxy_epoch_0005_algo.yaml` now contains
+`predictive_feature_schema_name: predictive_obstacle_features_v1`.
+
 Verification commands for the launcher branch:
 
 ```bash

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -146,6 +146,13 @@ exceptions for missing `training/proxy_eval/proxy_epoch_*.jsonl` files. The trai
 continued and passed the configured quality gates, but final interpretation should check whether
 missing proxy metrics should be a hard failure for this comparison.
 
+Later status: job `12612` exited `FAILED` with code `2:0` after
+`scripts/validation/run_predictive_success_campaign.py` could not read the expected
+`campaign/hard__baseline_like__predictive_model_00e46d73fe.jsonl` artifact. The pipeline wrote
+`final_performance_summary.json` and reported failing stage gates. Follow-up issue #1481 tracks
+whether missing predictive proxy/success-campaign JSONL should be fail-closed earlier or summarized
+as structured evidence caveats. Job `12611` was still running at the last handoff refresh.
+
 Verification commands for the launcher branch:
 
 ```bash

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -120,6 +120,42 @@ Same-seed contract:
   contains zero active non-sentinel obstacle rows. The preflight evidence is written to
   `output/tmp/predictive_planner/pipeline/<run_id>/obstacle_feature_preflight.json`.
 
+## Issue #1427 SLURM Launch Update, 2026-05-24
+
+PR #1480 added `SLURM/Auxme/predictive_training_pipeline.sl` as the Auxme launcher for the
+same-seed pair and hardened `SLURM/Auxme/camera_ready_benchmark.sl` against the broken `srun`
+symbol-error path observed in earlier campaign submissions.
+
+Submitted jobs from branch `issue-1427-predictive-slurm-runs`:
+
+- job `12611`, `pred1427-base`, config
+  `configs/training/predictive/predictive_br07_same_seed_issue_1427.yaml`, run id
+  `predictive_br07_same_seed_issue_1427_20260524T110529Z`
+- job `12612`, `pred1427-obs`, config
+  `configs/training/predictive/predictive_obstacle_features_same_seed_issue_1427.yaml`, run id
+  `predictive_obstacle_features_same_seed_issue_1427_20260524T110529Z`
+
+Both jobs started on `a30` node `auxme-imech172`. Early logs showed repeated node-side NVML
+`Driver/library version mismatch` warnings, but both jobs continued past startup. At the time of
+this handoff, both jobs had produced base, hardcase, and mixed rollout datasets plus
+`training/predictive_model.pt`. The obstacle-feature run also wrote `training/training_summary.json`,
+passed its ADE/FDE quality gates, and entered final `scripts/validation/evaluate_predictive_planner.py`.
+
+Observed caveat: proxy evaluation at training checkpoints logged non-fatal `FileNotFoundError`
+exceptions for missing `training/proxy_eval/proxy_epoch_*.jsonl` files. The training command
+continued and passed the configured quality gates, but final interpretation should check whether
+missing proxy metrics should be a hard failure for this comparison.
+
+Verification commands for the launcher branch:
+
+```bash
+bash -n SLURM/Auxme/predictive_training_pipeline.sl \
+  && bash -n SLURM/Auxme/camera_ready_benchmark.sl
+scripts/dev/sbatch_use_max_time.sh --time 12:00:00 --dry-run \
+  SLURM/Auxme/predictive_training_pipeline.sl
+git diff --check
+```
+
 ## Follow-Up Boundary
 
 Issue #1167 is not complete until the same-seed training/evaluation comparison reports ADE/FDE and

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -173,6 +173,36 @@ proved the schema fix by writing nonempty proxy JSONL artifacts through epoch 40
 `training/proxy_eval/proxy_epoch_0005_algo.yaml` now contains
 `predictive_feature_schema_name: predictive_obstacle_features_v1`.
 
+Final #1427 rerun result, refreshed 2026-05-25:
+
+- job `12617`, `pred1427-base4`, exited `FAILED` with code `2:0` after 1:23:32.
+- job `12618`, `pred1427-obs4`, exited `FAILED` with code `2:0` after 1:22:49.
+- Both jobs produced complete final-eval and success-campaign artifacts, including
+  `final_eval_summary.json`, `campaign/campaign_summary.json`, and
+  `final_performance_summary.json`.
+- Both failures were benchmark stage-gate failures, not missing-artifact failures:
+  `evaluation_ok: false`, `campaign_ok: true`, `hard_seed_diagnostics_ok: true`.
+
+Final eval metrics:
+
+| Variant | Success rate | Mean min distance | Final gate |
+| --- | ---: | ---: | --- |
+| Baseline predictive | 0.1304 | 2.1931 | failed success gate (`min_success_rate: 0.3`) |
+| Obstacle-feature predictive | 0.1014 | 2.2105 | failed success gate (`min_success_rate: 0.3`) |
+
+Campaign best variants:
+
+| Variant | Best planner grid row | Hard success | Global success | Global mean min distance |
+| --- | --- | ---: | ---: | ---: |
+| Baseline predictive | `risk_aware_adaptive` | 0.0000 | 0.1304 | 2.1931 |
+| Obstacle-feature predictive | `baseline_like` | 0.0000 | 0.1014 | 2.2081 |
+
+Interpretation: the obstacle-feature model improved validation forecast loss/clearance signals but did not
+improve downstream navigation on this same-seed run. Its global success rate was lower than the
+baseline, and hard-seed success remained zero. Treat this as evidence against promoting
+`predictive_obstacle_features_v1` as-is; future work should revise the planner/policy coupling or
+the training objective before spending on larger obstacle-feature campaigns.
+
 Verification commands for the launcher branch:
 
 ```bash
@@ -185,8 +215,6 @@ git diff --check
 
 ## Follow-Up Boundary
 
-Issue #1167 is not complete until the same-seed training/evaluation comparison reports ADE/FDE and
-downstream planner metrics. This patch removes the local pipeline blocker recorded during PR #1400
-triage and should be treated as the runnable setup for the campaign, not as benchmark-success
-evidence. Issue #1427 owns the actual SLURM submission, metric capture, and recommendation about
-whether obstacle features are worth further investment.
+Issue #1167's runnable same-seed surface has now produced a complete #1427 comparison. PR #1480
+should be treated as workflow/artifact-contract progress plus negative same-seed evidence for
+obstacle-feature promotion, not as a successful benchmark promotion.

--- a/robot_sf/benchmark/predictive_planner_config.py
+++ b/robot_sf/benchmark/predictive_planner_config.py
@@ -79,8 +79,8 @@ def build_predictive_planner_algo_config(
     if checkpoint_path is not None:
         config["predictive_checkpoint_path"] = str(checkpoint_path)
         config.pop("predictive_model_id", None)
-        feature_schema_name = feature_schema_name or infer_predictive_checkpoint_feature_schema_name(
-            checkpoint_path
+        feature_schema_name = (
+            feature_schema_name or infer_predictive_checkpoint_feature_schema_name(checkpoint_path)
         )
     if feature_schema_name is not None:
         config["predictive_feature_schema_name"] = str(feature_schema_name)

--- a/robot_sf/benchmark/predictive_planner_config.py
+++ b/robot_sf/benchmark/predictive_planner_config.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import torch
 import yaml
+
+from robot_sf.planner.obstacle_features import PREDICTIVE_LEGACY_FEATURE_SCHEMA
 
 _DEFAULT_CONFIG_PATH = (
     Path(__file__).resolve().parent.parent.parent
@@ -30,10 +33,40 @@ def load_predictive_planner_algo_config(
     return dict(payload)
 
 
+def infer_predictive_checkpoint_feature_schema_name(
+    checkpoint_path: str | Path,
+) -> str | None:
+    """Return the saved predictive feature schema name from a checkpoint when available."""
+    path = Path(checkpoint_path)
+    if not path.exists():
+        return None
+
+    try:
+        payload = torch.load(path, map_location="cpu", weights_only=True)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    feature_schema = payload.get("feature_schema")
+    if isinstance(feature_schema, dict):
+        name = str(feature_schema.get("name", "") or "").strip()
+        if name:
+            return name
+
+    config = payload.get("config")
+    if isinstance(config, dict):
+        name = str(config.get("feature_schema_name", "") or "").strip()
+        if name:
+            return name
+    return None
+
+
 def build_predictive_planner_algo_config(
     *,
     checkpoint_path: str | Path | None = None,
     device: str | None = "cpu",
+    feature_schema_name: str | None = None,
     overrides: dict[str, Any] | None = None,
     config_path: Path | None = None,
 ) -> dict[str, Any]:
@@ -46,8 +79,13 @@ def build_predictive_planner_algo_config(
     if checkpoint_path is not None:
         config["predictive_checkpoint_path"] = str(checkpoint_path)
         config.pop("predictive_model_id", None)
-    if "predictive_feature_schema_name" not in config:
-        config["predictive_feature_schema_name"] = "predictive_legacy_v1"
+        feature_schema_name = feature_schema_name or infer_predictive_checkpoint_feature_schema_name(
+            checkpoint_path
+        )
+    if feature_schema_name is not None:
+        config["predictive_feature_schema_name"] = str(feature_schema_name)
+    elif "predictive_feature_schema_name" not in config:
+        config["predictive_feature_schema_name"] = PREDICTIVE_LEGACY_FEATURE_SCHEMA
     if device is not None:
         config["predictive_device"] = str(device)
     if overrides:

--- a/scripts/training/run_predictive_training_pipeline.py
+++ b/scripts/training/run_predictive_training_pipeline.py
@@ -842,6 +842,11 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
     campaign_summary = {}
     if campaign_summary_path.exists():
         loaded_summary = json.loads(campaign_summary_path.read_text(encoding="utf-8"))
+        campaign_status["summary_path"] = str(campaign_summary_path)
+        if int(campaign_status.get("return_code", 1)) != 0:
+            campaign_status["summary_status"] = str(loaded_summary.get("status", ""))
+            if isinstance(loaded_summary.get("failure"), dict):
+                campaign_status["failure"] = loaded_summary["failure"]
         if (
             int(campaign_status.get("return_code", 1)) == 0
             and loaded_summary.get("run_id") == run_id

--- a/scripts/training/train_predictive_planner.py
+++ b/scripts/training/train_predictive_planner.py
@@ -276,13 +276,15 @@ def _run_proxy_eval(
         resume=False,
         benchmark_profile="experimental",
     )
+    if not jsonl_path.exists():
+        raise RuntimeError(f"Proxy evaluation expected JSONL was not created: {jsonl_path}")
     rows = [
         json.loads(line)
         for line in jsonl_path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
     if not rows:
-        raise RuntimeError("Proxy evaluation produced no episode rows.")
+        raise RuntimeError(f"Proxy evaluation produced no episode rows: {jsonl_path}")
     success_vals = [1.0 if _episode_success(row) else 0.0 for row in rows]
     min_dist_vals = [
         float(row.get("metrics", {}).get("min_distance"))
@@ -945,12 +947,17 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             )
             try:
                 proxy_metrics = _run_proxy_eval(checkpoint_path=epoch_ckpt, args=args, epoch=epoch)
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "Proxy evaluation failed at epoch={} checkpoint={}",
                     epoch,
                     epoch_ckpt,
                 )
+                if bool(args.select_by_proxy):
+                    raise RuntimeError(
+                        "Proxy evaluation is required when --select-by-proxy is enabled; "
+                        f"failed at epoch={epoch} checkpoint={epoch_ckpt}: {exc}"
+                    ) from exc
                 continue
             proxy_metrics["val_loss"] = float(val_loss)
             proxy_metrics["val_ade"] = float(val_ade)

--- a/scripts/validation/run_predictive_success_campaign.py
+++ b/scripts/validation/run_predictive_success_campaign.py
@@ -346,11 +346,14 @@ def main() -> int:
                         "ranking_key": list(_rank_key(hard_res, global_res)),
                     }
                 )
-    except Exception as exc:
+    except (Exception, SystemExit) as exc:
         if isinstance(exc, MissingCampaignArtifactError):
             failure = exc.to_failure_payload()
         else:
-            failure = {"type": type(exc).__name__, "message": str(exc)}
+            message = str(exc)
+            if isinstance(exc, SystemExit) and not message:
+                message = str(getattr(exc, "code", ""))
+            failure = {"type": type(exc).__name__, "message": message}
         failure_summary = {
             "contract_version": _CONTRACT_VERSION,
             "training_family": _TRAINING_FAMILY,

--- a/scripts/validation/run_predictive_success_campaign.py
+++ b/scripts/validation/run_predictive_success_campaign.py
@@ -38,6 +38,43 @@ class EvalResult:
     jsonl_path: str
 
 
+class MissingCampaignArtifactError(RuntimeError):
+    """Raised when a campaign stage does not produce its required JSONL artifact."""
+
+    def __init__(
+        self,
+        *,
+        jsonl_path: Path,
+        suite_name: str,
+        checkpoint: str,
+        variant_name: str,
+        reason: str,
+    ) -> None:
+        """Initialize the missing-artifact error with structured context."""
+        self.jsonl_path = jsonl_path
+        self.suite_name = suite_name
+        self.checkpoint = checkpoint
+        self.variant_name = variant_name
+        self.reason = reason
+        super().__init__(
+            "Predictive success campaign expected JSONL artifact was not usable: "
+            f"path={jsonl_path} suite={suite_name} variant={variant_name} "
+            f"checkpoint={checkpoint} reason={reason}"
+        )
+
+    def to_failure_payload(self) -> dict[str, str]:
+        """Return structured failure details for campaign summaries."""
+        return {
+            "type": type(self).__name__,
+            "message": str(self),
+            "jsonl_path": str(self.jsonl_path),
+            "suite": str(self.suite_name),
+            "checkpoint": str(self.checkpoint),
+            "variant": str(self.variant_name),
+            "reason": str(self.reason),
+        }
+
+
 def parse_args() -> argparse.Namespace:
     """Parse campaign CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -156,6 +193,14 @@ def _run_eval(
         resume=False,
         benchmark_profile="experimental",
     )
+    if not jsonl_path.exists():
+        raise MissingCampaignArtifactError(
+            jsonl_path=jsonl_path,
+            suite_name=suite_name,
+            checkpoint=checkpoint,
+            variant_name=variant_name,
+            reason="missing_jsonl",
+        )
 
     rows: list[dict] = []
     for line_number, line in enumerate(
@@ -171,6 +216,14 @@ def _run_eval(
             ) from exc
         if isinstance(payload, dict):
             rows.append(payload)
+    if not rows:
+        raise MissingCampaignArtifactError(
+            jsonl_path=jsonl_path,
+            suite_name=suite_name,
+            checkpoint=checkpoint,
+            variant_name=variant_name,
+            reason="empty_jsonl",
+        )
     success_vals = np.asarray([1.0 if _episode_success(row) else 0.0 for row in rows], dtype=float)
     min_dist_vals = np.asarray(
         [
@@ -257,41 +310,84 @@ def main() -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     results: list[dict] = []
 
-    for checkpoint in args.checkpoints:
-        if not Path(checkpoint).exists():
-            raise FileNotFoundError(f"Checkpoint not found: {checkpoint}")
-        for variant in variants:
-            name = str(variant["name"])
-            cfg = _base_algo_cfg(checkpoint)
-            cfg.update(dict(variant.get("params", {})))
-            hard_res = _run_eval(
-                scenarios_or_path=hard_scenarios,
-                suite_name="hard",
-                checkpoint=checkpoint,
-                variant_name=name,
-                algo_cfg=cfg,
-                args=args,
-                output_dir=args.output_dir,
+    try:
+        for checkpoint in args.checkpoints:
+            if not Path(checkpoint).exists():
+                raise FileNotFoundError(f"Checkpoint not found: {checkpoint}")
+            for variant in variants:
+                name = str(variant["name"])
+                cfg = _base_algo_cfg(checkpoint)
+                cfg.update(dict(variant.get("params", {})))
+                hard_res = _run_eval(
+                    scenarios_or_path=hard_scenarios,
+                    suite_name="hard",
+                    checkpoint=checkpoint,
+                    variant_name=name,
+                    algo_cfg=cfg,
+                    args=args,
+                    output_dir=args.output_dir,
+                )
+                global_res = _run_eval(
+                    scenarios_or_path=args.scenario_matrix,
+                    suite_name="global",
+                    checkpoint=checkpoint,
+                    variant_name=name,
+                    algo_cfg=cfg,
+                    args=args,
+                    output_dir=args.output_dir,
+                )
+                results.append(
+                    {
+                        "checkpoint": checkpoint,
+                        "variant": name,
+                        "config": cfg,
+                        "hard": hard_res.__dict__,
+                        "global": global_res.__dict__,
+                        "ranking_key": list(_rank_key(hard_res, global_res)),
+                    }
+                )
+    except Exception as exc:
+        if isinstance(exc, MissingCampaignArtifactError):
+            failure = exc.to_failure_payload()
+        else:
+            failure = {"type": type(exc).__name__, "message": str(exc)}
+        failure_summary = {
+            "contract_version": _CONTRACT_VERSION,
+            "training_family": _TRAINING_FAMILY,
+            "artifact_role": "predictive_success_campaign",
+            "status": "failed",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "scenario_matrix": str(args.scenario_matrix),
+            "hard_seed_manifest": str(args.hard_seed_manifest),
+            "planner_grid": str(args.planner_grid),
+            "horizon": int(args.horizon),
+            "dt": float(args.dt),
+            "workers": int(args.workers),
+            "partial_results": results,
+            "failure": failure,
+        }
+        json_path = args.output_dir / "campaign_summary.json"
+        json_path.write_text(
+            json.dumps(_nan_to_none(failure_summary), indent=2),
+            encoding="utf-8",
+        )
+        md_path = args.output_dir / "campaign_report.md"
+        md_path.write_text(
+            "\n".join(
+                [
+                    "# Predictive Success Campaign",
+                    "",
+                    "- Status: `failed`",
+                    f"- Failure type: `{failure['type']}`",
+                    f"- Failure: `{failure['message']}`",
+                    f"- JSON summary: `{json_path}`",
+                ]
             )
-            global_res = _run_eval(
-                scenarios_or_path=args.scenario_matrix,
-                suite_name="global",
-                checkpoint=checkpoint,
-                variant_name=name,
-                algo_cfg=cfg,
-                args=args,
-                output_dir=args.output_dir,
-            )
-            results.append(
-                {
-                    "checkpoint": checkpoint,
-                    "variant": name,
-                    "config": cfg,
-                    "hard": hard_res.__dict__,
-                    "global": global_res.__dict__,
-                    "ranking_key": list(_rank_key(hard_res, global_res)),
-                }
-            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps({"summary": str(json_path), "report": str(md_path)}, indent=2))
+        return 2
 
     ranked = sorted(
         results,

--- a/tests/benchmark/test_prediction_planner_audit_contract.py
+++ b/tests/benchmark/test_prediction_planner_audit_contract.py
@@ -16,6 +16,15 @@ from robot_sf.benchmark.predictive_planner_config import (
     build_predictive_planner_algo_config,
     load_predictive_planner_algo_config,
 )
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+    predictive_feature_schema_metadata,
+)
+from robot_sf.planner.predictive_model import (
+    PredictiveModelConfig,
+    PredictiveTrajectoryModel,
+    save_predictive_checkpoint,
+)
 
 
 def test_prediction_planner_readiness_is_experimental_and_checkpoint_dependent() -> None:
@@ -122,3 +131,30 @@ def test_build_predictive_planner_algo_config_prefers_explicit_checkpoint_overri
     assert config["predictive_device"] == "cpu"
     assert config["predictive_feature_schema_name"] == "predictive_legacy_v1"
     assert "predictive_model_id" not in config
+
+
+def test_build_predictive_planner_algo_config_uses_checkpoint_schema(tmp_path: Path) -> None:
+    """Runtime checkpoint overrides should carry the checkpoint's feature-schema contract."""
+    feature_schema = predictive_feature_schema_metadata(
+        model_family=PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+        ego_conditioning=False,
+    )
+    model = PredictiveTrajectoryModel(
+        PredictiveModelConfig(
+            input_dim=int(feature_schema["input_dim"]),
+            feature_schema_name=PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+        )
+    )
+    checkpoint = tmp_path / "obstacle_predictive_model.pt"
+    save_predictive_checkpoint(
+        checkpoint,
+        model=model,
+        optimizer=None,
+        epoch=1,
+        feature_schema_metadata=feature_schema,
+    )
+
+    config = build_predictive_planner_algo_config(checkpoint_path=checkpoint, device="cpu")
+
+    assert config["predictive_checkpoint_path"] == str(checkpoint)
+    assert config["predictive_feature_schema_name"] == PREDICTIVE_OBSTACLE_FEATURE_SCHEMA

--- a/tests/training/test_train_predictive_planner_dataset_diagnostics.py
+++ b/tests/training/test_train_predictive_planner_dataset_diagnostics.py
@@ -123,6 +123,31 @@ def test_should_update_val_loss_best_skips_after_proxy_selection() -> None:
     )
 
 
+def test_proxy_eval_fails_when_jsonl_artifact_missing(monkeypatch, tmp_path: Path) -> None:
+    """Proxy evaluation should fail closed when the benchmark runner writes no JSONL."""
+
+    def _fake_run_map_batch(*_args, **_kwargs) -> None:
+        """Simulate a runner failure that returns without materializing the JSONL."""
+        return None
+
+    monkeypatch.setattr(trainer, "run_map_batch", _fake_run_map_batch)
+    args = trainer.argparse.Namespace(
+        output_dir=tmp_path,
+        proxy_scenario_matrix=tmp_path / "scenarios.yaml",
+        proxy_seed_manifest=None,
+        proxy_horizon=12,
+        proxy_dt=0.1,
+        proxy_workers=1,
+    )
+
+    with pytest.raises(RuntimeError, match="Proxy evaluation expected JSONL was not created"):
+        trainer._run_proxy_eval(
+            checkpoint_path=tmp_path / "predictive_model.pt",
+            args=args,
+            epoch=5,
+        )
+
+
 def test_source_dataset_ids_prefers_manifest_dataset_id(tmp_path: Path) -> None:
     """Training provenance should use the sibling dataset manifest id when present."""
     dataset = tmp_path / "predictive_rollouts_mixed.npz"

--- a/tests/validation/test_predictive_success_campaign_tags.py
+++ b/tests/validation/test_predictive_success_campaign_tags.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
 from scripts.validation import run_predictive_success_campaign as campaign
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_checkpoint_token_is_path_sensitive() -> None:
@@ -65,3 +73,84 @@ def test_rank_key_prefers_global_success_before_clearance_when_hard_tied() -> No
         jsonl_path="b.jsonl",
     )
     assert campaign._rank_key(hard_b, global_b) > campaign._rank_key(hard_a, global_a)
+
+
+def test_run_eval_fails_when_jsonl_artifact_missing(monkeypatch, tmp_path: Path) -> None:
+    """Campaign evaluation should fail closed when no episode JSONL is produced."""
+
+    def _fake_run_map_batch(*_args, **_kwargs) -> None:
+        """Simulate a runner failure that returns without materializing the JSONL."""
+        return None
+
+    monkeypatch.setattr(campaign, "run_map_batch", _fake_run_map_batch)
+    args = campaign.argparse.Namespace(
+        horizon=12,
+        dt=0.1,
+        workers=1,
+        bootstrap_samples=10,
+        bootstrap_seed=1,
+    )
+
+    with pytest.raises(
+        campaign.MissingCampaignArtifactError,
+        match="expected JSONL artifact was not usable",
+    ):
+        campaign._run_eval(
+            scenarios_or_path=[],
+            suite_name="hard",
+            checkpoint=str(tmp_path / "predictive_model.pt"),
+            variant_name="baseline_like",
+            algo_cfg={},
+            args=args,
+            output_dir=tmp_path,
+        )
+
+
+def test_main_writes_failure_summary_for_missing_jsonl(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Campaign main should leave a structured failure summary before exiting nonzero."""
+
+    checkpoint = tmp_path / "predictive_model.pt"
+    checkpoint.write_text("stub", encoding="utf-8")
+    output_dir = tmp_path / "campaign"
+
+    def _fake_run_map_batch(*_args, **_kwargs) -> None:
+        """Simulate a runner failure that returns without materializing the JSONL."""
+        return None
+
+    monkeypatch.setattr(campaign, "run_map_batch", _fake_run_map_batch)
+    monkeypatch.setattr(
+        campaign,
+        "_load_planner_variants",
+        lambda _path: [{"name": "baseline_like", "params": {}}],
+    )
+    monkeypatch.setattr(campaign, "load_seed_manifest", lambda _path: {"scenario": [1]})
+    monkeypatch.setattr(
+        campaign,
+        "make_subset_scenarios",
+        lambda _matrix, _manifest: [{"name": "scenario"}],
+    )
+    monkeypatch.setattr(
+        campaign,
+        "parse_args",
+        lambda: campaign.argparse.Namespace(
+            checkpoints=[str(checkpoint)],
+            scenario_matrix=tmp_path / "scenarios.yaml",
+            hard_seed_manifest=tmp_path / "hard.yaml",
+            planner_grid=tmp_path / "grid.yaml",
+            horizon=12,
+            dt=0.1,
+            workers=1,
+            bootstrap_samples=10,
+            bootstrap_seed=1,
+            output_dir=output_dir,
+        ),
+    )
+
+    assert campaign.main() == 2
+    summary = json.loads((output_dir / "campaign_summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "failed"
+    assert summary["failure"]["type"] == "MissingCampaignArtifactError"
+    assert summary["failure"]["reason"] == "missing_jsonl"

--- a/tests/validation/test_predictive_success_campaign_tags.py
+++ b/tests/validation/test_predictive_success_campaign_tags.py
@@ -154,3 +154,53 @@ def test_main_writes_failure_summary_for_missing_jsonl(
     assert summary["status"] == "failed"
     assert summary["failure"]["type"] == "MissingCampaignArtifactError"
     assert summary["failure"]["reason"] == "missing_jsonl"
+
+
+def test_main_writes_failure_summary_for_malformed_jsonl(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Malformed runner JSONL should still leave a structured failure summary."""
+
+    checkpoint = tmp_path / "predictive_model.pt"
+    checkpoint.write_text("stub", encoding="utf-8")
+    output_dir = tmp_path / "campaign"
+
+    def _fake_run_map_batch(_scenarios_or_path, jsonl_path: Path, **_kwargs) -> None:
+        """Simulate a runner that leaves malformed JSONL before failing downstream."""
+        jsonl_path.write_text("{not-json}\n", encoding="utf-8")
+
+    monkeypatch.setattr(campaign, "run_map_batch", _fake_run_map_batch)
+    monkeypatch.setattr(
+        campaign,
+        "_load_planner_variants",
+        lambda _path: [{"name": "baseline_like", "params": {}}],
+    )
+    monkeypatch.setattr(campaign, "load_seed_manifest", lambda _path: {"scenario": [1]})
+    monkeypatch.setattr(
+        campaign,
+        "make_subset_scenarios",
+        lambda _matrix, _manifest: [{"name": "scenario"}],
+    )
+    monkeypatch.setattr(
+        campaign,
+        "parse_args",
+        lambda: campaign.argparse.Namespace(
+            checkpoints=[str(checkpoint)],
+            scenario_matrix=tmp_path / "scenarios.yaml",
+            hard_seed_manifest=tmp_path / "hard.yaml",
+            planner_grid=tmp_path / "grid.yaml",
+            horizon=12,
+            dt=0.1,
+            workers=1,
+            bootstrap_samples=10,
+            bootstrap_seed=1,
+            output_dir=output_dir,
+        ),
+    )
+
+    assert campaign.main() == 2
+    summary = json.loads((output_dir / "campaign_summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "failed"
+    assert summary["failure"]["type"] == "SystemExit"
+    assert "Malformed JSON" in summary["failure"]["message"]


### PR DESCRIPTION
## Summary
- add an Auxme SLURM launcher for config-driven predictive-planner pipeline runs
- make predictive proxy/success-campaign missing JSONL artifacts fail closed with structured evidence
- default Auxme predictive/camera-ready launchers to direct execution inside the batch allocation, with opt-in `srun`, because this cluster can pass `srun --version` but fail allocation confirmation at launch time
- propagate predictive checkpoint feature-schema metadata into runtime algo configs so obstacle-feature checkpoints do not silently evaluate as `predictive_legacy_v1`
- record local #1427 handoff and final outcome updates in `docs/context/issue_1167_predictive_obstacle_pipeline.md`

## Validation
- `bash -n SLURM/Auxme/predictive_training_pipeline.sl && bash -n SLURM/Auxme/camera_ready_benchmark.sl`
- `scripts/dev/sbatch_use_max_time.sh --time 12:00:00 --dry-run SLURM/Auxme/predictive_training_pipeline.sl`
- `uv run ruff check scripts/training/train_predictive_planner.py scripts/validation/run_predictive_success_campaign.py scripts/training/run_predictive_training_pipeline.py tests/training/test_train_predictive_planner_dataset_diagnostics.py tests/validation/test_predictive_success_campaign_tags.py`
- `uv run pytest -q tests/training/test_run_predictive_training_pipeline.py tests/training/test_train_predictive_planner_dataset_diagnostics.py::test_proxy_eval_fails_when_jsonl_artifact_missing tests/validation/test_predictive_success_campaign_tags.py`
- `uv run ruff check robot_sf/benchmark/predictive_planner_config.py tests/benchmark/test_prediction_planner_audit_contract.py scripts/training/train_predictive_planner.py scripts/validation/evaluate_predictive_planner.py scripts/validation/run_predictive_hard_seed_diagnostics.py scripts/validation/run_predictive_success_campaign.py`
- `uv run pytest -q tests/benchmark/test_prediction_planner_audit_contract.py tests/training/test_train_predictive_planner_dataset_diagnostics.py::test_proxy_eval_fails_when_jsonl_artifact_missing tests/validation/test_predictive_success_campaign_tags.py`
- `git diff --check`

## Slurm proof
Earlier attempts:
- `12611` / `pred1427-base`: cancelled as obsolete before clean rerun; it had passed training gates and entered later validation.
- `12612` / `pred1427-obs`: failed after training because `run_predictive_success_campaign.py` expected a missing campaign JSONL.
- `12613` and `12614`: failed immediately because launcher-side `srun` could not confirm the allocation on Auxme.
- `12615` / `pred1427-base3`: cancelled as obsolete when rerunning both sides from the schema-fix commit.
- `12616` / `pred1427-obs3`: correctly failed closed at epoch-5 proxy eval; generated config showed the root cause, a schema mismatch (`predictive_legacy_v1` for an obstacle-feature checkpoint).

Final fixed rerun from pushed head `9f6b8473`:
- `12617` / `pred1427-base4`: run id `predictive_br07_same_seed_issue_1427_20260524T114637Z`; exited `FAILED` with code `2:0` after 1:23:32.
- `12618` / `pred1427-obs4`: run id `predictive_obstacle_features_same_seed_issue_1427_20260524T114637Z`; exited `FAILED` with code `2:0` after 1:22:49.

Both final jobs started on `a30` node `auxme-imech172`, used direct batch-allocation execution rather than `srun`, completed training, final eval, hard-seed diagnostics, and success-campaign execution, and produced complete campaign artifacts. The failures are benchmark stage-gate failures, not missing-artifact failures: `campaign_ok: true`, `hard_seed_diagnostics_ok: true`, `evaluation_ok: false`.

Final eval:
- baseline predictive: success `0.1304`, mean min distance `2.1931`, failed `min_success_rate: 0.3`.
- obstacle-feature predictive: success `0.1014`, mean min distance `2.2105`, failed `min_success_rate: 0.3`.

Campaign best variants:
- baseline predictive: `risk_aware_adaptive`, hard success `0.0000`, global success `0.1304`, global mean min distance `2.1931`.
- obstacle-feature predictive: `baseline_like`, hard success `0.0000`, global success `0.1014`, global mean min distance `2.2081`.

Interpretation: #1427 now has complete same-seed evidence. The obstacle-feature model slightly improved clearance/forecast-loss signals but reduced downstream success and had zero hard-seed success. Do not promote `predictive_obstacle_features_v1` as-is; future work should revise the planner/policy coupling or objective before spending on larger obstacle-feature campaigns.

Refs #1427
Refs #1481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a config-driven predictive training pipeline with optional SLURM execution (opt-in via PREDICTIVE_PIPELINE_USE_SRUN) and automated artifact sync on completion.
  * Automatic checkpoint feature-schema detection and propagation into planner configs.

* **Bug Fixes**
  * Safer srun opt-in behavior (requires explicit env to use srun).
  * Improved, descriptive error handling and failure reporting for missing/empty evaluation artifacts.

* **Documentation**
  * Expanded SLURM launcher and artifact-handling notes.

* **Tests**
  * Added tests covering checkpoint schema propagation and missing-artifact failure paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->