### PR TITLE
Preserve worktree training artifacts and relax experimental planner success

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -92,6 +92,8 @@ knowledge, not every transient iteration detail.
   [open_issues_pr_split_strategy_2026-05-13.md](open_issues_pr_split_strategy_2026-05-13.md)
 * Thursday development review 2026-05-21:
   [thursday_development_review_2026-05-21.md](thursday_development_review_2026-05-21.md)
+* Worktree training preservation audit 2026-05-25:
+  [worktree_training_preservation_audit_2026-05-25.md](worktree_training_preservation_audit_2026-05-25.md)
 * Issue #1240 scenario coverage entropy:
   [issue_1240_scenario_coverage_entropy.md](issue_1240_scenario_coverage_entropy.md)
 * Issue #1167 predictive obstacle-feature pipeline:

--- a/docs/context/issue_1353_broader_amv_preflight.md
+++ b/docs/context/issue_1353_broader_amv_preflight.md
@@ -50,6 +50,13 @@ families from the all-planners camera-ready matrix:
 | `sacadrl` | broader row | `experimental` | Fallback SocNav prerequisite policy. |
 | `socnav_bench` | broader row | `experimental` | Fail-fast SocNav prerequisite policy. |
 
+2026-05-25 implementation update: campaign-level `benchmark_success` is now anchored on `core`
+planner rows whenever a campaign has explicit core rows. Experimental rows such as `socnav_bench`
+still report `not_available` when their external prerequisites are absent, and they remain visible
+in warnings/tables, but they no longer make an otherwise core-successful campaign exit as failed.
+Campaign summaries expose `benchmark_success_basis`, `core_successful_runs`, and `core_total_runs`
+so downstream reports can distinguish core success from all-row availability.
+
 ## Caveats
 
 - These configs lock the row list and preflight contract, but they do not prove planner execution.

--- a/docs/context/worktree_training_preservation_audit_2026-05-25.md
+++ b/docs/context/worktree_training_preservation_audit_2026-05-25.md
@@ -1,0 +1,172 @@
+# Worktree Training Preservation Audit, 2026-05-25
+
+## Goal
+
+Verify the active `robot_sf_ll7.worktrees/` checkouts for generated training outputs that should
+be preserved before any future cleanup, worktree pruning, or output compaction.
+
+This audit covers local worktree artifacts only. Files under `output/` remain cache/non-durable
+until promoted through the model registry, W&B artifact, GitHub release asset, or another explicit
+artifact store.
+
+## Live Queue Snapshot
+
+Checked on 2026-05-25 from the Auxme login node during the audit:
+
+```text
+12620|robot-sf-camera-ready-benchmark|RUNNING|l40s|started 2026-05-25T06:03:03
+```
+
+Follow-up check after artifact preservation:
+
+```text
+12620|robot-sf-camera-ready-benchmark|FAILED|2:0|00:21:29|2026-05-25T06:03:03|2026-05-25T06:24:32
+```
+
+Job `12620` is the issue #1353 stress benchmark follow-up, not a training run. It produced a
+campaign summary at
+`../robot_sf_ll7.worktrees/1353-broader-amv-row-contract/output/benchmarks/issue_1353/issue_1353_paired_stress_broader_baselines_issue1353-stress-rowcontract_20260525_060323/reports/campaign_summary.json`.
+The SLURM exit is failed because `socnav_bench` was recorded as `not_available` due missing
+SocNavBench `wayptnav_data`, matching the nominal job's row-contract failure mode.
+
+## Preserve Or Publish Candidates
+
+### Issue #1108 BC Warm-Start PPO
+
+Worktree: `../robot_sf_ll7.worktrees/1108-bc-warm-start-ppo`
+
+Preserved on 2026-05-25 as W&B artifact:
+
+* Artifact: `ll7/robot_sf/issue_1108_bc_warm_start_job12472:v0`
+* Aliases: `issue-1108`, `job-12472`, `preserved-20260525`
+* Size: `3,289,862,058` bytes
+* Preservation run: <https://wandb.ai/ll7/robot_sf/runs/19udjzki>
+
+Preserve the latest validated collection and BC checkpoint from job `12472`:
+
+| Artifact | Size | SHA256 | Decision |
+|---|---:|---|---|
+| `output/slurm/issue1108-bcppo-job-12472/benchmarks/expert_trajectories/issue_749_b60iopxt_v10_eval_trajectories.npz` | 3.25 GB | `fc62311e2dfb0cbc6742e745e7deb0ae876bda5c588a35101812d3297c902e81` | Preserve/publish if #1108 continues; validated 141-episode dataset. |
+| `output/slurm/issue1108-bcppo-job-12472/benchmarks/expert_policies/issue_749_bc_preinit_v10_policy.zip` | 41.4 MB | `c7ee44796f73c3e58dbf9ba7b006e56452b15d4a4d2dde1bc148f9ea2d826ac1` | Preserve/publish if #1108 continues; BC completed before PPO fine-tune timed out. |
+
+Evidence:
+
+* Dataset manifest reports `quality_status=validated`, `episode_count=141`, seeds
+  `[111, 112, 113]`, source policy
+  `ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200`, and scenario coverage
+  `classic_bottleneck_low: 141`.
+* `sacct -j 12472` reports collection step `12472.0` completed, BC step `12472.1` completed, and
+  PPO fine-tune step `12472.2` timed out after reaching about `7,454,720` timesteps with
+  `success_rate=0` near the tail.
+
+Important caveat: the four 3.25 GB dataset files from jobs `12462`, `12463`, `12471`, and `12472`
+are same-size but not byte-identical. Their hashes are:
+
+| Job | SHA256 |
+|---:|---|
+| 12472 | `fc62311e2dfb0cbc6742e745e7deb0ae876bda5c588a35101812d3297c902e81` |
+| 12471 | `da667464056e131dc0b5fc9fc17ee7c1f25d1e86fa071e08ad847f6cb2d6c6b5` |
+| 12463 | `c95fa10041eb61d284cda8f6fb9328ff81fc15c899dcfc32952db70cb17131c1` |
+| 12462 | `7a34468f9737f51c9075b0ea35e7a144e7cebfac2da34c50eb7df5b457d65509` |
+
+Do not delete the older three as "duplicates" unless their metadata differences are explicitly
+accepted as irrelevant. The local 21-byte/28-byte files under `output/benchmarks/expert_policies/`
+are not useful model artifacts.
+
+### Issue #1024 H500 PPO Retrain
+
+Worktree: `../robot_sf_ll7.worktrees/1024-retrain-learned-planners-h500`
+
+Preserved on 2026-05-25 as W&B artifact:
+
+* Artifact: `ll7/robot_sf/issue_1024_h500_best_checkpoints:v0`
+* Aliases: `issue-1024`, `h500`, `preserved-20260525`
+* Size: `190,619,004` bytes
+* Preservation run: <https://wandb.ai/ll7/robot_sf/runs/v4gaehbc>
+
+The final issue insight is already documented in
+`docs/context/issue_1024_h500_ppo_retrain.md`: the H500 retrain is useful evidence but not a
+promotion over the registered issue-791 leader. Preserve these only if future #1024/H500 analysis
+needs re-evaluation or warm-starting from the checkpoint; otherwise the metrics and W&B run are
+enough for the issue decision.
+
+| Artifact | Best eval | SHA256 | Decision |
+|---|---|---|---|
+| `output/slurm/issue791-reward-curriculum-job-12352/benchmarks/expert_policies/checkpoints/ppo_expert_issue_1024_all_available_h500_schedule_12m_env30_l40s/ppo_expert_issue_1024_all_available_h500_schedule_12m_env30_l40s_best.zip` | step 6,291,456; success `0.900`, collision `0.100`, SNQI `0.134` | `777a12c2f23dab9b4f980737018c880920a3cf3b97ff9bccb1e928c60897a8e4` | Conditional preserve; strongest #1024 checkpoint. |
+| `output/slurm/issue791-reward-curriculum-job-12350/benchmarks/expert_policies/checkpoints/ppo_expert_issue_1024_all_available_h500_schedule_12m_env22/ppo_expert_issue_1024_all_available_h500_schedule_12m_env22_best.zip` | step 7,340,032; success `0.900`, collision `0.100`, SNQI `0.088` | `0bb76a330c4ea5d66a1a3f0f397791dd35454e8470e5156074362aaf182439f5` | Lower priority preserve; useful hardware/env-count comparison. |
+
+The registered canonical PPO leader remains
+`ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417`, which is already a
+GitHub release asset under `artifact/models-2026-05-registry-v1`.
+
+### Older Issue #791 Policy-Search Worktree
+
+Worktree: `../robot_sf_ll7.worktrees/origin-2026-04-28-policy_search`
+
+Most large issue-791 policy outputs are superseded by the registered leader and published model
+registry artifacts. Do not preserve every intermediate checkpoint. If this worktree is cleaned,
+keep only explicit non-registry comparison candidates that still answer a live ablation question:
+
+| Artifact | Best eval | SHA256 | Decision |
+|---|---|---|---|
+| `output/slurm/issue791-asymmetric-critic-job-12221/benchmarks/expert_policies/checkpoints/ppo_expert_issue_791_asymmetric_critic_promotion_10m_env22_eval_aligned/ppo_expert_issue_791_asymmetric_critic_promotion_10m_env22_eval_aligned_best.zip` | step 9,961,472; success `0.857`, collision `0.143`, SNQI `0.100` | `d30f98f2c0a33515596043d54d87fa21d691c502eef255be8e43c702a0aef96f` | Conditional preserve only for ablation replay; below canonical leader. |
+| `output/slurm/issue791-attention-head-job-12209/benchmarks/expert_policies/checkpoints/ppo_expert_issue_791_attention_head_promotion_10m_env22/ppo_expert_issue_791_attention_head_promotion_10m_env22_best.zip` | step 5,242,880; success `0.486`, collision `0.514`, SNQI `-0.996` | `33d4839bb9ed7c7e257f68a3bb874ee9d9a67a869f064df063c07ccb782e3015` | Do not promote; preserve only if the failed attention-head ablation needs exact replay. |
+
+## Do Not Preserve As Training Artifacts
+
+### Issue #857 Horizon-Matched PPO
+
+Worktree: `../robot_sf_ll7.worktrees/857-ppo-horizon-matched`
+
+The horizon100 policy is an archived negative ablation, not a promotion candidate. The issue note
+explicitly rejects it after camera-ready evaluation collapsed to `success_mean=0.1489` with high
+timeout share. Keep the context note and compact campaign summaries; no model publication is
+recommended.
+
+For traceability, the best training-eval checkpoint hash is:
+
+```text
+c2a94b9e8c7cb3e916a8fd9564e8321179b20a627763484f847995d18fb75087
+output/slurm/issue791-reward-curriculum-job-12178/benchmarks/expert_policies/checkpoints/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_horizon100/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_horizon100_best.zip
+```
+
+### Predictive, Benchmark, And Workflow Worktrees
+
+These worktrees contain benchmark evidence, negative predictive comparisons, workflow outputs, or
+small smoke artifacts rather than training outputs requiring model preservation:
+
+* `../robot_sf_ll7.worktrees/1427-predictive-slurm-runs`: negative obstacle-feature comparison;
+  preserve compact summaries already used by the PR/issue, not model checkpoints.
+* `../robot_sf_ll7.worktrees/1353-broader-amv-row-contract`: current #1353 benchmark campaign
+  outputs and model-cache copies of already registered inputs; not new training.
+* `../robot_sf_ll7.worktrees/1391-1392-slurm-workflow`: #1344/#1354 benchmark campaign summaries;
+  not new training.
+* `../robot_sf_ll7.worktrees/1398-snqi-rollup`: metric rollup evidence; not training.
+* `../robot_sf_ll7.worktrees/1191-evaluate-ml-intern`: assistant/workflow smoke outputs; not
+  training.
+* `../robot_sf_ll7.worktrees/qwen-issue-1309-codex-smoke`: no relevant Robot SF training output.
+* `../robot_sf_ll7.worktrees/origin-codex-best-learning-policy`: no inspected new training
+  checkpoint that beats or replaces the registered policy.
+
+## Cleanup Guardrails
+
+Before deleting or pruning any worktree output:
+
+1. Preserve or publish the #1108 job `12472` dataset and BC checkpoint if #1108 remains active.
+2. Decide whether #1024 needs exact checkpoint replay; if yes, publish the env30 best checkpoint
+   and optionally the env22 comparison checkpoint.
+3. Treat older #791 policy-search checkpoints as superseded unless a specific ablation issue still
+   needs exact replay.
+4. Keep compact benchmark/report evidence under `docs/context/` or `docs/context/evidence/`, not
+   raw `output/` bundles.
+5. Re-check `squeue --me` and `sacct` before cleanup so running jobs are not disrupted.
+
+## Dirty Worktree Caution
+
+At audit time, several worktrees had local modifications or branch drift. Do not clean them with
+destructive Git commands:
+
+* `1108-bc-warm-start-ppo`: branch ahead/behind; contains the active #1108 artifacts above.
+* `origin-2026-04-28-policy_search`: modified SLURM scripts.
+* `origin-codex-best-learning-policy`: modified context note.
+* `qwen-issue-1309-codex-smoke`: modified docs and far behind main.

--- a/docs/context/worktree_training_preservation_audit_2026-05-25.md
+++ b/docs/context/worktree_training_preservation_audit_2026-05-25.md
@@ -26,7 +26,7 @@ Follow-up check after artifact preservation:
 Job `12620` is the issue #1353 stress benchmark follow-up, not a training run. It produced a
 campaign summary at
 `../robot_sf_ll7.worktrees/1353-broader-amv-row-contract/output/benchmarks/issue_1353/issue_1353_paired_stress_broader_baselines_issue1353-stress-rowcontract_20260525_060323/reports/campaign_summary.json`.
-The SLURM exit is failed because `socnav_bench` was recorded as `not_available` due missing
+The SLURM exit is failed because `socnav_bench` was recorded as `not_available` due to missing
 SocNavBench `wayptnav_data`, matching the nominal job's row-contract failure mode.
 
 ## Preserve Or Publish Candidates

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -119,19 +119,33 @@ _ROUTE_CLEARANCE_CERTIFICATION_STATUSES = {
 }
 
 
-def _campaign_success_counters(run_entries: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+def _campaign_success_counters(
+    run_entries: Sequence[Mapping[str, Any]], *, expected_core_runs: int | None = None
+) -> dict[str, Any]:
     """Return campaign success counters, anchoring success on core planners when present."""
-    total_runs = len(run_entries)
-    successful_runs = sum(1 for entry in run_entries if str(entry.get("status", "")) == "ok")
-    core_entries = [
-        entry
-        for entry in run_entries
-        if str((entry.get("planner") or {}).get("planner_group", "")).strip().lower() == "core"
-    ]
-    core_successful_runs = sum(1 for entry in core_entries if str(entry.get("status", "")) == "ok")
-    if core_entries:
+    total_runs = 0
+    successful_runs = 0
+    core_total_runs = 0
+    core_successful_runs = 0
+
+    for entry in run_entries:
+        total_runs += 1
+        is_ok = str(entry.get("status", "")) == "ok"
+        if is_ok:
+            successful_runs += 1
+
+        planner_group = str((entry.get("planner") or {}).get("planner_group", "")).strip().lower()
+        if planner_group == "core":
+            core_total_runs += 1
+            if is_ok:
+                core_successful_runs += 1
+
+    if expected_core_runs is None:
+        expected_core_runs = core_total_runs
+
+    if core_total_runs:
         success_basis = "core"
-        benchmark_success = core_successful_runs == len(core_entries)
+        benchmark_success = core_successful_runs == core_total_runs == expected_core_runs
     else:
         success_basis = "all"
         benchmark_success = total_runs > 0 and successful_runs == total_runs
@@ -141,7 +155,7 @@ def _campaign_success_counters(run_entries: Sequence[Mapping[str, Any]]) -> dict
         "successful_runs": successful_runs,
         "total_runs": total_runs,
         "core_successful_runs": core_successful_runs,
-        "core_total_runs": len(core_entries),
+        "core_total_runs": core_total_runs,
     }
 
 
@@ -3608,7 +3622,12 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         )
         for entry in run_entries
     )
-    success_counters = _campaign_success_counters(run_entries)
+    expected_core_runs = sum(
+        1 for planner in cfg.planners if planner.enabled and planner.planner_group == "core"
+    )
+    success_counters = _campaign_success_counters(
+        run_entries, expected_core_runs=expected_core_runs * len(kinematics_matrix)
+    )
     successful_runs = int(success_counters["successful_runs"])
     benchmark_success = bool(success_counters["benchmark_success"])
     confidence_settings = {

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 import yaml
@@ -75,6 +75,9 @@ from robot_sf.common.artifact_paths import (
 from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.training.scenario_loader import load_scenarios
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
 DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
@@ -114,6 +117,32 @@ _ROUTE_CLEARANCE_CERTIFICATION_STATUSES = {
     "excluded_from_planner_attribution",
     "repaired_geometry",
 }
+
+
+def _campaign_success_counters(run_entries: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return campaign success counters, anchoring success on core planners when present."""
+    total_runs = len(run_entries)
+    successful_runs = sum(1 for entry in run_entries if str(entry.get("status", "")) == "ok")
+    core_entries = [
+        entry
+        for entry in run_entries
+        if str((entry.get("planner") or {}).get("planner_group", "")).strip().lower() == "core"
+    ]
+    core_successful_runs = sum(1 for entry in core_entries if str(entry.get("status", "")) == "ok")
+    if core_entries:
+        success_basis = "core"
+        benchmark_success = core_successful_runs == len(core_entries)
+    else:
+        success_basis = "all"
+        benchmark_success = total_runs > 0 and successful_runs == total_runs
+    return {
+        "benchmark_success": benchmark_success,
+        "benchmark_success_basis": success_basis,
+        "successful_runs": successful_runs,
+        "total_runs": total_runs,
+        "core_successful_runs": core_successful_runs,
+        "core_total_runs": len(core_entries),
+    }
 
 
 def _normalize_observation_mode(raw: Any, *, label: str) -> str | None:
@@ -3579,8 +3608,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         )
         for entry in run_entries
     )
-    successful_runs = sum(1 for entry in run_entries if str(entry.get("status", "")) == "ok")
-    benchmark_success = len(run_entries) > 0 and successful_runs == len(run_entries)
+    success_counters = _campaign_success_counters(run_entries)
+    successful_runs = int(success_counters["successful_runs"])
+    benchmark_success = bool(success_counters["benchmark_success"])
     confidence_settings = {
         "method": "bootstrap_mean_over_seed_means",
         "confidence": float(cfg.bootstrap_confidence),
@@ -3797,6 +3827,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "successful_runs": successful_runs,
             "total_runs": len(run_entries),
             "benchmark_success": benchmark_success,
+            "benchmark_success_basis": success_counters["benchmark_success_basis"],
+            "core_successful_runs": success_counters["core_successful_runs"],
+            "core_total_runs": success_counters["core_total_runs"],
             "paper_interpretation_profile": cfg.paper_interpretation_profile,
             "kinematics_matrix": list(kinematics_matrix),
             "holonomic_command_mode": cfg.holonomic_command_mode,
@@ -4064,6 +4097,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         "total_runs": len(run_entries),
         "successful_runs": successful_runs,
         "benchmark_success": benchmark_success,
+        "benchmark_success_basis": success_counters["benchmark_success_basis"],
+        "core_successful_runs": success_counters["core_successful_runs"],
+        "core_total_runs": success_counters["core_total_runs"],
         "total_episodes": total_episodes,
         "runtime_sec": runtime_sec,
         "publication_bundle": publication_payload,

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -2282,7 +2282,108 @@ def test_run_campaign_success_ignores_not_available_experimental_when_core_ok(
     assert summary_payload["campaign"]["core_total_runs"] == 1
     assert summary_payload["campaign"]["benchmark_success_basis"] == "core"
     assert summary_payload["campaign"]["benchmark_success"] is True
+    assert "core_with_optional_experimental" in result["campaign_id"]
+    assert result["benchmark_success_basis"] == "core"
+    assert result["core_successful_runs"] == 1
+    assert result["core_total_runs"] == 1
     assert result["benchmark_success"] is True
+
+
+def test_run_campaign_fails_if_core_run_is_unattempted_after_stop_on_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Stop-on-failure should not mask unfinished core groups as successful."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign_core_stop.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: core_stop_unattempted",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                "stop_on_failure: true",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    planner_group: core",
+                "  - key: socnav_bench",
+                "    algo: socnav_bench",
+                "    planner_group: experimental",
+                "  - key: social_force",
+                "    algo: social_force",
+                "    planner_group: core",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+
+    call_order: list[str] = []
+
+    def _fake_run_batch(*args, **kwargs):
+        """Stop execution on experimental planner before all core planners run."""
+        del args
+        algo = kwargs["algo"]
+        call_order.append(algo)
+        if algo == "goal":
+            return {
+                "total_jobs": 1,
+                "written": 1,
+                "failed_jobs": 0,
+                "failures": [],
+                "preflight": {
+                    "status": "ok",
+                    "learned_policy_contract": {"status": "not_applicable"},
+                },
+                "algorithm_readiness": {
+                    "name": "goal",
+                    "tier": "baseline-ready",
+                    "profile": "baseline-safe",
+                },
+            }
+        if algo == "socnav_bench":
+            return {
+                "total_jobs": 0,
+                "written": 0,
+                "failed_jobs": 0,
+                "failures": [],
+                "preflight": {
+                    "status": "fallback",
+                    "learned_policy_contract": {"critical_mismatches": ["missing"]},
+                },
+                "algorithm_readiness": {
+                    "name": "socnav_bench",
+                    "tier": "experimental",
+                    "profile": "experimental",
+                },
+            }
+        pytest.fail("run_batch must not execute remaining planners after stop_on_failure")
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+    result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="core_stop")
+    summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
+
+    assert call_order == ["goal", "socnav_bench"]
+    assert summary_payload["campaign"]["total_runs"] == 2
+    assert summary_payload["campaign"]["successful_runs"] == 1
+    assert summary_payload["campaign"]["core_successful_runs"] == 1
+    assert summary_payload["campaign"]["core_total_runs"] == 1
+    assert summary_payload["campaign"]["benchmark_success_basis"] == "core"
+    assert summary_payload["campaign"]["benchmark_success"] is False
+    assert result["core_total_runs"] == 1
+    assert result["core_successful_runs"] == 1
+    assert result["benchmark_success"] is False
+    assert result["benchmark_success_basis"] == "core"
 
 
 def test_run_campaign_marks_empty_run_set_as_non_success(tmp_path: Path, monkeypatch) -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -2182,6 +2182,109 @@ def test_run_campaign_marks_skipped_preflight_as_not_available(tmp_path: Path, m
     assert result["benchmark_success"] is False
 
 
+def test_run_campaign_success_ignores_not_available_experimental_when_core_ok(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Optional experimental planners should not make a core-successful campaign fail."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign_core_with_optional_experimental.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: core_with_optional_experimental",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    planner_group: core",
+                "    benchmark_profile: baseline-safe",
+                "  - key: socnav_bench",
+                "    algo: socnav_bench",
+                "    planner_group: experimental",
+                "    benchmark_profile: experimental",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+
+    def _fake_run_batch(*args, **kwargs):
+        """Return one successful core run and one missing optional dependency."""
+        algo = kwargs["algo"]
+        out_path = kwargs["out_path"]
+        if algo == "goal":
+            Path(out_path).write_text(
+                json.dumps(
+                    {
+                        "episode_id": "e-goal-0",
+                        "scenario_id": "mock",
+                        "seed": 111,
+                        "scenario_params": {
+                            "algo": "goal",
+                            "metadata": {"archetype": "crossing"},
+                        },
+                        "metrics": {"success": 1.0, "collisions": 0.0, "near_misses": 0.0},
+                        "algorithm_metadata": {"algorithm": "goal", "status": "ok"},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            return {
+                "total_jobs": 1,
+                "written": 1,
+                "failed_jobs": 0,
+                "failures": [],
+                "algorithm_readiness": {
+                    "name": "goal",
+                    "tier": "baseline-ready",
+                    "profile": "baseline-safe",
+                },
+            }
+        return {
+            "total_jobs": 0,
+            "written": 0,
+            "failed_jobs": 0,
+            "failures": [],
+            "preflight": {
+                "status": "skipped",
+                "compatibility_reason": "SocNavBench assets are not installed",
+            },
+            "algorithm_readiness": {
+                "name": "socnav_bench",
+                "tier": "experimental",
+                "profile": "experimental",
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+    result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="core_optional")
+    summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
+    rows = {row["planner_key"]: row for row in summary_payload["planner_rows"]}
+
+    assert rows["goal"]["status"] == "ok"
+    assert rows["socnav_bench"]["status"] == "not_available"
+    assert rows["socnav_bench"]["planner_group"] == "experimental"
+    assert summary_payload["campaign"]["successful_runs"] == 1
+    assert summary_payload["campaign"]["total_runs"] == 2
+    assert summary_payload["campaign"]["core_successful_runs"] == 1
+    assert summary_payload["campaign"]["core_total_runs"] == 1
+    assert summary_payload["campaign"]["benchmark_success_basis"] == "core"
+    assert summary_payload["campaign"]["benchmark_success"] is True
+    assert result["benchmark_success"] is True
+
+
 def test_run_campaign_marks_empty_run_set_as_non_success(tmp_path: Path, monkeypatch) -> None:
     """Campaigns with zero run entries must fail closed at campaign level."""
     scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")


### PR DESCRIPTION
## Summary

- Record a durable worktree training preservation audit for generated artifacts under `robot_sf_ll7.worktrees/`.
- Preserve the #1108 job-12472 dataset/BC checkpoint and #1024 H500 best checkpoints as W&B artifacts, with links and hashes in the context note.
- Change camera-ready campaign success semantics so explicit `core` planner rows determine `benchmark_success` when present; experimental rows such as `socnav_bench` can remain `not_available` without failing an otherwise core-successful campaign.
- Add a regression test for a successful core planner plus unavailable experimental `socnav_bench` row.

## Durable artifact pointers

- `ll7/robot_sf/issue_1108_bc_warm_start_job12472:v0` — preservation run https://wandb.ai/ll7/robot_sf/runs/19udjzki
- `ll7/robot_sf/issue_1024_h500_best_checkpoints:v0` — preservation run https://wandb.ai/ll7/robot_sf/runs/v4gaehbc

## Validation

- `uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_success_ignores_not_available_experimental_when_core_ok tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_marks_skipped_preflight_as_not_available tests/benchmark/test_issue_1353_broader_amv_configs.py tests/benchmark/test_fallback_policy.py -q`
- `uv run ruff check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py`
- `uv run ruff format --check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py`
- `git diff --check`

## Notes

The per-planner `socnav_bench` row still fails closed as `not_available` when SocNavBench assets are missing. The changed behavior is only at campaign aggregation: when a matrix has explicit `core` rows, campaign-level success now reflects those core rows and separately records `benchmark_success_basis`, `core_successful_runs`, and `core_total_runs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaigns no longer fail when experimental features are unavailable if core planners succeed
  * Campaign reports now expose success basis and core run counters for granular visibility

* **Documentation**
  * Added worktree training preservation audit documentation
  * Updated campaign success semantics documentation with new reporting fields

* **Tests**
  * Added test for campaign success behavior with unavailable experimental planners

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->