### PR TITLE
docs: refresh README onboarding (#1482)

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -1,0 +1,43 @@
+# Acknowledgments and Upstream Work
+
+This repository builds on prior work in social robot navigation and pedestrian simulation. The
+references below preserve the provenance that previously lived in the root `README.md`.
+
+## Research lineage
+
+Caruso, Matteo, Enrico Regolin, Federico Julian Camerota Verdu, Stefano Alberto Russo, Luca
+Bortolussi, and Stefano Seriani. "Robot Navigation in Crowded Environments: A Reinforcement
+Learning Approach." *Machines* 11, no. 2 (2023): 268.
+<https://doi.org/10.3390/machines11020268>
+
+As stated in the paper's data-availability statement, related public material was made available in:
+
+- <https://github.com/EnricoReg/robot-sf>
+- <https://github.com/EnricoReg/asynch-rl>
+- <https://github.com/matteocaruso1993/crowd_nav_experimental>
+
+## Related upstream repositories
+
+Additional repositories referenced in this project's lineage and implementation context:
+
+- <https://github.com/Bonifatius94/robot-sf>
+- <https://github.com/yuxiang-gao/PySocialForce>
+- <https://github.com/Bonifatius94/PySocialForce>
+
+## fast-pysf / PySocialForce lineage
+
+The `fast-pysf/` subtree and surrounding pedestrian-simulation work acknowledge the upstream model
+and implementation lineage:
+
+- Based on Sven Kreiss's implementation of the vanilla Social Force model:
+  <https://github.com/svenkreiss/socialforce>
+- Force-implementation details also drew inspiration from:
+  <https://github.com/srl-freiburg/pedsim_ros>
+
+## Core references for the pedestrian model
+
+- Helbing, D., and P. Molnar. "Social force model for pedestrian dynamics." *Physical Review E* 51,
+  no. 5 (1995): 4282-4286. <https://doi.org/10.1103/PhysRevE.51.4282>
+- Moussaid, M., N. Perozo, S. Garnier, D. Helbing, and G. Theraulaz. "The walking behaviour of
+  pedestrian social groups and its impact on crowd dynamics." *PLoS ONE* 5, no. 4 (2010): 1-7.
+  <https://doi.org/10.1371/journal.pone.0010047>

--- a/README.md
+++ b/README.md
@@ -1,327 +1,92 @@
-# robot-sf
+# Robot SF
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19563812.svg)](https://doi.org/10.5281/zenodo.19563812)
 
-> 2025-09-16 Under Development. See <https://github.com/ll7/robot_sf_ll7/issues>.
+Gymnasium-based social navigation simulation and benchmarking for a robot moving through
+pedestrian-filled environments.
 
-<!-- This document is the first touchpoint for users and developers of the robot-sf project. Keep it very concise and focused on essential information. -->
+> **Status:** Active development. Start here for a quick first touch, then use the linked docs for
+> detailed workflows, benchmarks, and contributor guidance.
 
-## About
+![Robot SF demo](docs/video/demo_01.gif)
 
-This project provides a training environment for the simulation of a robot moving
-in a pedestrian-filled space.
+## Start here
 
-The project interfaces with Faram Foundations "Gymnasium" (successor to OpenAI Gym)
-to facilitate trainings with various
-SOTA reinforcement learning algorithms like e.g. StableBaselines3.
-For simulating the pedestrians, the SocialForce model is used via a dependency
-on a fork of PySocialForce.
+| I want to... | Go to |
+| --- | --- |
+| Understand the project quickly | [Why Robot SF?](#why-robot-sf) |
+| Install dependencies and run the first demos | [Quickstart](#quickstart) |
+| Browse runnable examples | [`examples/README.md`](examples/README.md) |
+| Find architecture, benchmark, and workflow docs | [`docs/README.md`](docs/README.md) |
+| Follow the contributor workflow | [`docs/dev_guide.md`](docs/dev_guide.md) |
+| Review repository conventions for agents and contributors | [`AGENTS.md`](AGENTS.md) |
+| See the public Zenodo-backed release artifact | [DOI 10.5281/zenodo.19563812](https://doi.org/10.5281/zenodo.19563812) |
+| Trace upstream lineage and citations | [`ACKNOWLEDGMENTS.md`](ACKNOWLEDGMENTS.md) |
 
-Following video outlines some training results where a robot with e-scooter
-kinematics is driving at the campus of University of Augsburg using real
-map data from OpenStreetMap.
+## Why Robot SF?
 
-![](./docs/video/demo_01.gif)
+- **Factory-based environments:** reusable Gymnasium entry points for robot and pedestrian
+  simulations.
+- **Curated examples:** quickstart, advanced, benchmark, and plotting workflows live in
+  [`examples/README.md`](examples/README.md).
+- **Benchmark-oriented tooling:** reproducible evaluation, metrics aggregation, and analysis docs are
+  indexed in [`docs/README.md`](docs/README.md).
+- **Repo-native contributor workflow:** setup, validation, and shared `scripts/dev/` entry points
+  are documented in [`docs/dev_guide.md`](docs/dev_guide.md).
 
-## Release Artifact
+## Quickstart
 
-The current Zenodo-backed release DOI for the public benchmark artifact is:
+The repository uses `uv` for dependency management and keeps generated artifacts under the
+git-ignored `output/` directory.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19563812.svg)](https://doi.org/10.5281/zenodo.19563812)
-
-- https://doi.org/10.5281/zenodo.19563812
-
-- [About](#about)
-- [Release Artifact](#release-artifact)
-- [Attribution and Upstream Work](#attribution-and-upstream-work)
-- [Development and Intallation](#development-and-intallation)
-  - [Prerequisites](#prerequisites)
-  - [Quick Start](#quick-start)
-  - [Examples Catalog](#examples-catalog)
-  - [Development Setup](#development-setup)
-  - [Artifact Outputs](#artifact-outputs)
-  - [Alternative Installation Methods](#alternative-installation-methods)
-    - [Manual dependency installation](#manual-dependency-installation)
-  - [System Dependencies](#system-dependencies)
-  - [Tests](#tests)
-    - [Unified Test Suite](#unified-test-suite)
-    - [Run Linter / Tests](#run-linter--tests)
-    - [GUI Tests](#gui-tests)
-  - [5. Run Visual Debugging of Pre-Trained Demo Models](#5-run-visual-debugging-of-pre-trained-demo-models)
-  - [6. Edit Maps](#6-edit-maps)
-  - [7. Extension: Pedestrian as Adversarial-Agent](#7-extension-pedestrian-as-adversarial-agent)
-- [📚 Documentation](#-documentation)
-  - [Core Documentation](#core-documentation)
-  - [Environment Architecture (New!)](#environment-architecture-new)
-  - [SNQI Weight Tooling (Benchmark Metrics)](#snqi-weight-tooling-benchmark-metrics)
-
-## Attribution and Upstream Work
-
-This project builds on prior work in social robot navigation, especially:
-
-Caruso, Matteo, Enrico Regolin, Federico Julian Camerota Verdu, Stefano Alberto Russo, Luca
-Bortolussi, and Stefano Seriani. "Robot Navigation in Crowded Environments: A Reinforcement
-Learning Approach." *Machines* 11, no. 2 (2023): 268.
-https://doi.org/10.3390/machines11020268
-
-As stated in the paper's Data Availability Statement, data/videos/samples/code were made
-publicly available in:
-
-- https://github.com/EnricoReg/robot-sf
-- https://github.com/EnricoReg/asynch-rl
-- https://github.com/matteocaruso1993/crowd_nav_experimental
-
-Additional related upstream repositories referenced in this project context:
-
-- https://github.com/Bonifatius94/robot-sf
-- https://github.com/yuxiang-gao/PySocialForce
-- https://github.com/Bonifatius94/PySocialForce
-
-For fast-pysf (PySocialForce), this project also acknowledges the upstream model and implementation
-lineage:
-
-- This project is based on Sven Kreiss's implementation of the vanilla social force model:
-  https://github.com/svenkreiss/socialforce
-- The implementation of forces drew inspiration from pedsim_ros:
-  https://github.com/srl-freiburg/pedsim_ros
-
-Main references for fast-pysf:
-
-- Helbing, D., and P. Molnar. "Social force model for pedestrian dynamics." *Physical Review E*
-  51, no. 5 (1995): 4282-4286. https://doi.org/10.1103/PhysRevE.51.4282
-- Moussaid, M., N. Perozo, S. Garnier, D. Helbing, and G. Theraulaz. "The walking behaviour of
-  pedestrian social groups and its impact on crowd dynamics." *PLoS ONE* 5, no. 4 (2010): 1-7.
-  https://doi.org/10.1371/journal.pone.0010047
-
-## Development and Intallation
-
-Refer to the [development guide](./docs/dev_guide.md) for contribution guidelines, code standards, and templates.
-
-This project now uses `uv` for modern Python dependency management and virtual environment handling.
-
-### Prerequisites
-
-Install Python 3.10+ (Python **3.12** is recommended) and `uv`:
-
-```sh
-# Install uv (the modern Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-# or
-pip install uv
-```
-
-### Quick Start
-
-```sh
-# Clone the repository with submodules
-git clone --recurse-submodules https://github.com/ll7/robot_sf_ll7
+```bash
+git clone https://github.com/ll7/robot_sf_ll7
 cd robot_sf_ll7
 
-# Install all dependencies and create virtual environment automatically
-uv sync
-
-# Activate the virtual environment
+scripts/dev/check_runtime_requirements.sh
+uv sync --all-extras
 source .venv/bin/activate
-
-# Install system dependencies (Linux/Ubuntu)
-sudo apt-get update && sudo apt-get install -y ffmpeg
-```
-
-### Examples Catalog
-
-Consult the curated [`examples/README.md`](./examples/README.md) for quickstart,
-advanced, benchmark, and plotting workflows. Each entry lists prerequisites,
-expected outputs, and CI status.
-
-### Development Setup
-
-For development work with additional tools:
-
-```sh
-# Install with development dependencies
-uv sync --extra dev
-
-# Install pre-commit hooks
 uv run pre-commit install
 
-# Run tests (unified suite: robot_sf + fast-pysf)
-uv run pytest  # → 893 tests total
-
-# Run only robot_sf tests
-uv run pytest tests  # → 881 tests
-
-# Run only fast-pysf tests
-uv run pytest fast-pysf/tests  # → 12 tests
-
-# Run linting and formatting
-uv run ruff check .
-uv run ruff format .
+uv run python examples/quickstart/01_basic_robot.py
+uv run python examples/quickstart/02_trained_model.py
+uv run python examples/quickstart/03_custom_map.py
 ```
 
-### Artifact Outputs
+These three scripts provide the fastest first-touch path:
 
-- Generated artifacts are routed into the canonical `output/` tree (`output/coverage/`, `output/benchmarks/`, `output/recordings/`, `output/wandb/`, `output/tmp/`).
-- After pulling new changes, run `uv run python scripts/tools/migrate_artifacts.py` (or `uv run robot-sf-migrate-artifacts`) to relocate any legacy `results/`, `recordings/`, or `htmlcov/` directories.
-- Use `uv run python scripts/tools/check_artifact_root.py` to verify the repository root stays clean; CI runs the same guard.
-- Set `ROBOT_SF_ARTIFACT_ROOT=/path/to/custom/output` before invoking scripts if you need to direct artifacts elsewhere—the helpers and guard respect the override.
-- Coverage HTML is available via `uv run python scripts/coverage/open_coverage_report.py`, which opens `output/coverage/htmlcov/index.html` cross-platform.
+1. `01_basic_robot.py` introduces the environment factory and a headless rollout.
+2. `02_trained_model.py` replays the bundled PPO benchmark example.
+3. `03_custom_map.py` shows how to load and simulate a custom SVG map.
 
-### Alternative Installation Methods
+For host packages, optional capabilities, and a fuller setup walkthrough, see
+[`docs/dev_guide.md`](docs/dev_guide.md) and [`docs/dev_runtime_requirements.md`](docs/dev_runtime_requirements.md).
 
-#### Manual dependency installation
+## Where to go next
 
-If you prefer more control over the installation:
+- **Examples:** [`examples/README.md`](examples/README.md) organizes the quickstart path plus
+  advanced features, benchmark runners, and plotting utilities.
+- **Documentation index:** [`docs/README.md`](docs/README.md) is the central map for architecture,
+  benchmarking, training, analysis, and context notes.
+- **Benchmark and artifact context:** the public release artifact is published at
+  [10.5281/zenodo.19563812](https://doi.org/10.5281/zenodo.19563812). For benchmark-specific
+  semantics and caveats, follow the benchmark docs linked from `docs/README.md`.
 
-```sh
-# Create virtual environment with specific Python version
-uv venv --python 3.12
+## Development workflow
 
-# Activate environment
+Use the development guide as the source of truth for contributor commands. The common local flow is:
+
+```bash
 source .venv/bin/activate
-
-# Install project in editable mode
-uv sync
-
-# Install development tools (optional)
-uv sync --group=dev
+scripts/dev/ruff_fix_format.sh
+scripts/dev/run_tests_parallel.sh
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 ```
 
-### System Dependencies
+If you are contributing through an agent workflow or want the repository-specific automation rules,
+start with [`AGENTS.md`](AGENTS.md).
 
-**FFMPEG** (required for video recording):
+## Acknowledgments and provenance
 
-```sh
-# Ubuntu/Debian
-sudo apt-get install -y ffmpeg
-
-# macOS
-brew install ffmpeg
-
-# Windows
-# Download from https://ffmpeg.org/download.html
-```
-
-### Tests
-
-#### Unified Test Suite
-
-The project uses a unified test suite that runs both robot_sf and fast-pysf tests via a single command:
-
-```sh
-# Run all tests (recommended)
-uv run pytest  # → 893 tests (881 robot_sf + 12 fast-pysf)
-
-# Run only robot_sf tests
-uv run pytest tests  # → 881 tests
-
-# Run only fast-pysf tests  
-uv run pytest fast-pysf/tests  # → 12 tests
-
-# Run with parallel execution (faster)
-uv run pytest -n auto
-```
-
-All tests should pass successfully. The test suite includes:
-- **robot_sf tests** (881): Unit, integration, baselines, benchmarks
-- **fast-pysf tests** (12): Force calculations, map loading, simulator functionality
-
-**Note**: The fast-pysf tests are now integrated into the main pytest configuration and no longer require running from the `fast-pysf/` directory or using `python -m pytest`.
-
-#### Run Linter / Tests
-
-```sh
-# Lint and format
-uv run ruff check --fix . && uv run ruff format .
-
-# Run all tests (unified suite)
-uv run pytest
-
-# Ruff linter
-uv run ruff check .
-```
-
-#### GUI Tests
-
-```sh
-pytest test_pygame
-```
-
-### 5. Run Visual Debugging of Pre-Trained Demo Models
-
-```sh
-uv run python examples/advanced/10_offensive_policy.py
-uv run python examples/advanced/09_defensive_policy.py
-# Classic interactions deterministic PPO visualization (Feature 128)
-uv run python examples/_archived/classic_interactions_pygame.py
-```
-
-[Visualization](./docs/SIM_VIEW.md)
-
-### 6. Edit Maps
-
-The preferred way to create maps: [SVG Editor](./docs/SVG_MAP_EDITOR.md)
-
-### 7. Extension: Pedestrian as Adversarial-Agent
-
-The pedestrian is an adversarial agent who tries to find weak points in the vehicle's policy.
-
-The Environment is built according to gymnasium rules, so that multiple RL algorithms can be used to train the pedestrian.
-
-It is important to know that the pedestrian always spawns near the robot.
-
-![demo_ped](./docs/video/demo_ped.gif)
-
-```sh
-uv run python examples/advanced/06_pedestrian_env_factory.py
-```
-
-[Visualization](./docs/SIM_VIEW.md)
-
-## 📚 Documentation
-
-**Comprehensive documentation is available in the [`docs/`](./docs/) directory.**
-
-For detailed guides on setup, development, benchmarking, and architecture, visit the **[Documentation Index](./docs/README.md)**.
-
-### Core Documentation
-- [Environment Refactoring](./docs/refactoring/) - **NEW**: Comprehensive guide to the refactored environment architecture
-- [Data Analysis](./docs/DATA_ANALYSIS.md) - Analysis tools and utilities
-- [Map Editor Usage](./docs/MAP_EDITOR_USAGE.md) - Creating and editing simulation maps
-- [SVG Map Editor](./docs/SVG_MAP_EDITOR.md) - SVG-based map creation
-- [Simulation View](./docs/SIM_VIEW.md) - Visualization and rendering
-- [UV Migration](./docs/UV_MIGRATION.md) - Migration to UV package manager
-- [Artifact Policy Quickstart](./specs/243-clean-output-dirs/quickstart.md) - Migration workflow, guard usage, and override instructions for the canonical `output/` tree
- - [Contributing Agents Guide](./AGENTS.md) – Repository structure, coding style, test workflow, and contributor conventions (start here if new!)
-
-### Environment Architecture (New!)
-The project has been refactored to provide a **consistent, extensible environment system**:
-
-```python
-# New factory pattern for environment creation
-from robot_sf.gym_env.environment_factory import (
-    make_robot_env,
-    make_image_robot_env, 
-    make_pedestrian_env
-)
-
-# Clean, consistent interface
-robot_env = make_robot_env(debug=True)
-image_env = make_image_robot_env(debug=True)
-ped_env = make_pedestrian_env(robot_model=model, debug=True)
-```
-
-**Key Benefits:**
-- ✅ **50% reduction** in code duplication
-- ✅ **Consistent interface** across all environment types
-- ✅ **Easy extensibility** for new environment types
-- ✅ **Backward compatibility** maintained
-
-📖 **[Read the full refactoring documentation →](./docs/refactoring/)**
-
-### SNQI Weight Tooling (Benchmark Metrics)
-
-Tools for recomputing, optimizing, and analyzing Social Navigation Quality Index (SNQI) weights are now available:
-
-- User Guide: [`docs/snqi-weight-tools/README.md`](./docs/snqi-weight-tools/README.md)
-- Design & architecture: [`docs/dev/issues/snqi-recomputation/DESIGN.md`](./docs/dev/issues/snqi-recomputation/DESIGN.md)
-- Headless usage (minimal deps): see [Headless mode](./docs/snqi-weight-tools/README.md#headless-mode-minimal-deps)
+The root README stays intentionally short. Upstream lineage, cited papers, and related repositories
+are preserved in [`ACKNOWLEDGMENTS.md`](ACKNOWLEDGMENTS.md).

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ cd robot_sf_ll7
 
 scripts/dev/check_runtime_requirements.sh
 uv sync --all-extras
-source .venv/bin/activate
-uv run pre-commit install
 
 uv run python examples/quickstart/01_basic_robot.py
 uv run python examples/quickstart/02_trained_model.py
@@ -77,7 +75,7 @@ For host packages, optional capabilities, and a fuller setup walkthrough, see
 Use the development guide as the source of truth for contributor commands. The common local flow is:
 
 ```bash
-source .venv/bin/activate
+uv run pre-commit install
 scripts/dev/ruff_fix_format.sh
 scripts/dev/run_tests_parallel.sh
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,6 +320,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[UV Migration Notes](./UV_MIGRATION.md)** - Migration to UV package manager
 * **[Repository Structure Analysis](./dev/issues/repository-structure-analysis.md)** - Comprehensive assessment of codebase organization and improvement roadmap
 * **[Agents & Contributor Onboarding](../AGENTS.md)** - High-level repository structure, coding/testing conventions, workflow tips
+* **[Acknowledgments & Upstream Work](../ACKNOWLEDGMENTS.md)** - Preserved provenance, cited papers, and upstream repository lineage for the project
 * **[Benchmark/Planner Review Guide](./code_review.md)** - Review checklist for benchmark semantics, normalization, scenario distributions, reproducibility, and provenance
 
 ### Simulation & UI


### PR DESCRIPTION
## Summary
Refreshes the root README into a shorter first-touch onboarding page and moves preserved upstream provenance into `ACKNOWLEDGMENTS.md`.

## Linked Issues
- Closes #1482

## What Changed
- Reworked `README.md` around a compact project summary, quick links, quickstart, and development workflow.
- Added `ACKNOWLEDGMENTS.md` for cited papers and upstream repository lineage.
- Linked the acknowledgments page from `docs/README.md`.

## Why It Matters
- Added value: makes the repository easier to scan for users, researchers, and contributors.
- Expected impact: reduces stale first-touch content while preserving provenance.
- Why this is worth merging now: #1482 calls out visible README drift, stale status language, and first-touch navigation gaps.

## Validation / Proof
- `git diff --check`
- `uv run ruff check README.md docs/README.md ACKNOWLEDGMENTS.md || true` (`ruff` reports no Python files, as expected)
- `uv run ruff format --preview --check README.md docs/README.md ACKNOWLEDGMENTS.md`
- Targeted README/ACK link sanity script for changed links and anchors
- `PYTEST_NUM_WORKERS=4 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed: 4147 passed, 11 skipped

## Risks / Rollout
- Compatibility risks: old deep links into the removed long README table of contents may no longer resolve.
- Failure modes: the demo GIF remains the existing `docs/video/demo_01.gif`; if GitHub rendering changes, a follow-up can replace it with a more reliable preview.
- Rollback or fallback plan: revert the docs-only commit.

## Docs / Provenance
- Updated docs: `README.md`, `docs/README.md`, `ACKNOWLEDGMENTS.md`.
- Relevant design or provenance notes: provenance content was preserved rather than deleted.
- Any assumptions that need to be preserved: root README should stay concise and point to detailed docs.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please review the first-screen README shape and whether contributor setup belongs in the quickstart.
- Generated `output/coverage/*` from validation is ignored/disposable and was not committed.
