### PR TITLE
workflow: distinguish accepted unavailable campaigns

### DIFF
--- a/docs/benchmark_release_protocol.md
+++ b/docs/benchmark_release_protocol.md
@@ -129,11 +129,32 @@ The entrypoint is intentionally a release wrapper, not a second benchmark
 execution engine.
 
 `release/release_result.json` preserves the wrapped campaign semantics in the
-top-level `status`, `status_reason`, `benchmark_success`, and `exit_code`
+top-level `status`, `status_reason`, `benchmark_success`, `exit_code`,
+`campaign_execution_status`, `evidence_status`, and `row_status_summary`
 fields. Release-wrapper state is recorded separately under
 `release_status`, `release_status_reason`, `release_benchmark_success`, and
 `release_exit_code`. Exit code `3` means the campaign finished as
 `accepted_unavailable_only`: still non-success and still fail-closed.
+
+`benchmark_success` now means the campaign produced fully valid benchmark
+evidence, not merely that the core planner subset completed. Accepted
+unavailable/excluded rows therefore keep `benchmark_success=false` even when
+the campaign execution finished cleanly. Distinguish the axes as follows:
+
+- `campaign_execution_status`
+  - `completed`: the campaign finished without unexpected row failures
+  - `failed`: malformed payloads or unexpected failed rows
+  - `interrupted`: unexpected failure with fewer executed rows than expected
+- `evidence_status`
+  - `valid`: every executed row produced benchmark-valid evidence
+  - `partial`: at least one successful evidence row plus accepted unavailable rows
+  - `blocked`: only accepted unavailable/excluded rows were produced
+  - `invalid`: unexpected failures or malformed payloads
+- `row_status_summary`
+  - `successful_evidence_rows`
+  - `accepted_unavailable_rows`
+  - `unexpected_failed_rows`
+  - `fallback_or_degraded_rows`
 
 ## Release Outputs
 

--- a/docs/benchmark_release_protocol.md
+++ b/docs/benchmark_release_protocol.md
@@ -128,6 +128,13 @@ The release entrypoint:
 The entrypoint is intentionally a release wrapper, not a second benchmark
 execution engine.
 
+`release/release_result.json` preserves the wrapped campaign semantics in the
+top-level `status`, `status_reason`, `benchmark_success`, and `exit_code`
+fields. Release-wrapper state is recorded separately under
+`release_status`, `release_status_reason`, `release_benchmark_success`, and
+`release_exit_code`. Exit code `3` means the campaign finished as
+`accepted_unavailable_only`: still non-success and still fail-closed.
+
 ## Release Outputs
 
 Each successful release writes:

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -32,6 +32,7 @@ from robot_sf.benchmark.fallback_policy import (
     classify_planner_row_status,
     summarize_benchmark_availability,
     summarize_campaign_outcome,
+    summarize_campaign_status_axes,
 )
 from robot_sf.benchmark.fallback_policy import (
     resolve_execution_mode as _resolve_benchmark_execution_mode,
@@ -2892,11 +2893,14 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
         f"- Runtime sec: `{campaign.get('runtime_sec', 0.0)}`",
         f"- Episodes/sec: `{campaign.get('episodes_per_second', 0.0)}`",
         f"- Campaign status: `{campaign.get('status', 'unknown')}`",
+        f"- Campaign execution status: `{campaign.get('campaign_execution_status', 'unknown')}`",
+        f"- Evidence status: `{campaign.get('evidence_status', 'unknown')}`",
         f"- Status reason: `{campaign.get('status_reason', 'unknown')}`",
         f"- Benchmark success: `{campaign.get('benchmark_success', False)}`",
         f"- Successful rows: `{campaign.get('successful_runs', 0)}` / `{campaign.get('total_runs', 0)}`",
         f"- Accepted unavailable/excluded rows: `{campaign.get('accepted_unavailable_runs', 0)}`",
         f"- Unexpected failed rows: `{campaign.get('unexpected_failed_runs', 0)}`",
+        (f"- Row status summary: `{campaign.get('row_status_summary', {})}`"),
         f"- Interpretation profile: `{campaign.get('paper_interpretation_profile', 'unknown')}`",
         f"- Command: `{campaign.get('invoked_command', 'unknown')}`",
         "",
@@ -3646,13 +3650,23 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         {"runs": run_entries, "planner_rows": planner_rows}
     )
     successful_runs = campaign_outcome.successful_runs
+    expected_total_runs = len([planner for planner in cfg.planners if planner.enabled]) * len(
+        kinematics_matrix
+    )
     expected_core_runs = sum(
         1 for planner in cfg.planners if planner.enabled and planner.planner_group == "core"
     )
+    campaign_status_axes = summarize_campaign_status_axes(
+        {"runs": run_entries, "planner_rows": planner_rows},
+        expected_total_runs=expected_total_runs,
+    )
+    row_status_summary = asdict(campaign_status_axes.row_status_summary)
     success_counters = _campaign_success_counters(
         run_entries, expected_core_runs=expected_core_runs * len(kinematics_matrix)
     )
-    benchmark_success = bool(success_counters["benchmark_success"])
+    benchmark_success = bool(
+        success_counters["benchmark_success"] and campaign_status_axes.evidence_status == "valid"
+    )
     confidence_settings = {
         "method": "bootstrap_mean_over_seed_means",
         "confidence": float(cfg.bootstrap_confidence),
@@ -3871,6 +3885,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "non_success_runs": campaign_outcome.non_success_runs,
             "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
             "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
+            "campaign_execution_status": campaign_status_axes.campaign_execution_status,
+            "evidence_status": campaign_status_axes.evidence_status,
+            "row_status_summary": row_status_summary,
             "benchmark_success": benchmark_success,
             "status": campaign_outcome.status,
             "status_reason": campaign_outcome.status_reason,
@@ -4147,6 +4164,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         "non_success_runs": campaign_outcome.non_success_runs,
         "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
         "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
+        "campaign_execution_status": campaign_status_axes.campaign_execution_status,
+        "evidence_status": campaign_status_axes.evidence_status,
+        "row_status_summary": row_status_summary,
         "benchmark_success": benchmark_success,
         "status": campaign_outcome.status,
         "status_reason": campaign_outcome.status_reason,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -30,6 +30,7 @@ from robot_sf.benchmark.artifact_publication import export_publication_bundle
 from robot_sf.benchmark.fallback_policy import (
     availability_payload,
     summarize_benchmark_availability,
+    summarize_campaign_outcome,
 )
 from robot_sf.benchmark.fallback_policy import (
     resolve_execution_mode as _resolve_benchmark_execution_mode,
@@ -2824,6 +2825,12 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
     campaign = payload.get("campaign", {})
     rows = payload.get("planner_rows", [])
     warnings = payload.get("warnings", [])
+    accepted_unavailable_rows = [
+        row for row in rows if str(row.get("status", "")).lower() in {"not_available", "excluded"}
+    ]
+    unexpected_failed_rows = [
+        row for row in rows if str(row.get("status", "")).lower() in {"failed", "partial-failure"}
+    ]
 
     lines = [
         "# Camera-Ready Benchmark Campaign Report",
@@ -2836,6 +2843,12 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
         f"- Git commit: `{campaign.get('git_hash', 'unknown')}`",
         f"- Runtime sec: `{campaign.get('runtime_sec', 0.0)}`",
         f"- Episodes/sec: `{campaign.get('episodes_per_second', 0.0)}`",
+        f"- Campaign status: `{campaign.get('status', 'unknown')}`",
+        f"- Status reason: `{campaign.get('status_reason', 'unknown')}`",
+        f"- Benchmark success: `{campaign.get('benchmark_success', False)}`",
+        f"- Successful rows: `{campaign.get('successful_runs', 0)}` / `{campaign.get('total_runs', 0)}`",
+        f"- Accepted unavailable/excluded rows: `{campaign.get('accepted_unavailable_runs', 0)}`",
+        f"- Unexpected failed rows: `{campaign.get('unexpected_failed_runs', 0)}`",
         f"- Interpretation profile: `{campaign.get('paper_interpretation_profile', 'unknown')}`",
         f"- Command: `{campaign.get('invoked_command', 'unknown')}`",
         "",
@@ -2998,23 +3011,25 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
         if isinstance(snqi_sensitivity, str):
             lines.append(f"- Sensitivity CSV: `{snqi_sensitivity}`")
 
-    lines.extend(["", "## Campaign Warnings", ""])
-    if warnings:
-        for warning in warnings:
-            lines.append(f"- {warning}")
+    lines.extend(["", "## Accepted Unavailable/Excluded Planners", ""])
+    if accepted_unavailable_rows:
+        lines.append("| planner | status | availability reason |")
+        lines.append("|---|---|---|")
+        for row in accepted_unavailable_rows:
+            lines.append(
+                "| "
+                f"{_escape_markdown_cell(row.get('planner_key'))} | "
+                f"{_escape_markdown_cell(row.get('status'))} | "
+                f"{_escape_markdown_cell(row.get('availability_reason') or row.get('most_likely_failure_reason') or 'unspecified')} |"
+            )
     else:
-        lines.append("- No campaign-level warnings.")
+        lines.append("- No accepted unavailable/excluded planners.")
 
-    failing_rows = [
-        row
-        for row in rows
-        if str(row.get("status", "")).lower() in {"failed", "partial-failure", "not_available"}
-    ]
-    lines.extend(["", "## Failed Planners And Likely Reasons", ""])
-    if failing_rows:
+    lines.extend(["", "## Unexpected Failed/Partial Planners", ""])
+    if unexpected_failed_rows:
         lines.append("| planner | status | most likely reason |")
         lines.append("|---|---|---|")
-        for row in failing_rows:
+        for row in unexpected_failed_rows:
             lines.append(
                 "| "
                 f"{_escape_markdown_cell(row.get('planner_key'))} | "
@@ -3022,7 +3037,14 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
                 f"{_escape_markdown_cell(row.get('most_likely_failure_reason') or row.get('availability_reason') or 'unspecified')} |"
             )
     else:
-        lines.append("- No failed/partial/not-available planners.")
+        lines.append("- No unexpected failed/partial planners.")
+
+    lines.extend(["", "## Campaign Warnings", ""])
+    if warnings:
+        for warning in warnings:
+            lines.append(f"- {warning}")
+    else:
+        lines.append("- No campaign-level warnings.")
 
     publication = payload.get("publication_bundle")
     if isinstance(publication, dict):
@@ -3250,12 +3272,19 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             )
             planner_rows.append(row)
 
-            if status in {"failed", "partial-failure", "not_available"}:
+            if status in {"failed", "partial-failure"}:
                 reason = str(row.get("most_likely_failure_reason", "")).strip() or "unspecified"
                 warnings.append(
                     "Planner failure recorded: "
                     f"planner='{planner.key}' kinematics='{kinematics}' status='{status}' "
                     f"most_likely_reason='{reason}'"
+                )
+            elif status == "not_available":
+                reason = str(row.get("availability_reason", "")).strip() or "unspecified"
+                warnings.append(
+                    "Accepted unavailable planner row recorded: "
+                    f"planner='{planner.key}' kinematics='{kinematics}' status='{status}' "
+                    f"availability_reason='{reason}'"
                 )
 
             run_entries.append(
@@ -3291,7 +3320,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                 },
             )
 
-            if status in {"failed", "partial-failure", "not_available"} and cfg.stop_on_failure:
+            if status in {"failed", "partial-failure"} and cfg.stop_on_failure:
                 logger.warning(
                     "Campaign stop_on_failure triggered: planner key={} kinematics={} status={} (halting remaining planners).",
                     planner.key,
@@ -3305,20 +3334,6 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                             f"'{planner.key}' ({kinematics}) had partial failures "
                             f"({int(summary.get('failed_jobs', 0))} failed jobs); "
                             "stop_on_failure=true"
-                        ),
-                    )
-                elif status == "not_available":
-                    availability_reason = (
-                        (summary.get("benchmark_availability") or {}).get("availability_reason")
-                        if isinstance(summary.get("benchmark_availability"), dict)
-                        else None
-                    )
-                    warnings.append(
-                        (
-                            "Campaign halted early: planner "
-                            f"'{planner.key}' ({kinematics}) was not available"
-                            + (f" ({availability_reason})" if availability_reason else "")
-                            + "; stop_on_failure=true"
                         ),
                     )
                 stop_requested = True
@@ -3579,8 +3594,11 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         )
         for entry in run_entries
     )
-    successful_runs = sum(1 for entry in run_entries if str(entry.get("status", "")) == "ok")
-    benchmark_success = len(run_entries) > 0 and successful_runs == len(run_entries)
+    campaign_outcome = summarize_campaign_outcome(
+        {"runs": run_entries, "planner_rows": planner_rows}
+    )
+    successful_runs = campaign_outcome.successful_runs
+    benchmark_success = campaign_outcome.benchmark_success
     confidence_settings = {
         "method": "bootstrap_mean_over_seed_means",
         "confidence": float(cfg.bootstrap_confidence),
@@ -3796,7 +3814,13 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "total_episodes": total_episodes,
             "successful_runs": successful_runs,
             "total_runs": len(run_entries),
+            "non_success_runs": campaign_outcome.non_success_runs,
+            "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
+            "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
             "benchmark_success": benchmark_success,
+            "status": campaign_outcome.status,
+            "status_reason": campaign_outcome.status_reason,
+            "exit_code": campaign_outcome.exit_code,
             "paper_interpretation_profile": cfg.paper_interpretation_profile,
             "kinematics_matrix": list(kinematics_matrix),
             "holonomic_command_mode": cfg.holonomic_command_mode,
@@ -4063,7 +4087,13 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         "statistical_sufficiency_json": str(statistical_sufficiency_json_path),
         "total_runs": len(run_entries),
         "successful_runs": successful_runs,
+        "non_success_runs": campaign_outcome.non_success_runs,
+        "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
+        "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
         "benchmark_success": benchmark_success,
+        "status": campaign_outcome.status,
+        "status_reason": campaign_outcome.status_reason,
+        "exit_code": campaign_outcome.exit_code,
         "total_episodes": total_episodes,
         "runtime_sec": runtime_sec,
         "publication_bundle": publication_payload,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -29,6 +29,7 @@ from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
 from robot_sf.benchmark.artifact_publication import export_publication_bundle
 from robot_sf.benchmark.fallback_policy import (
     availability_payload,
+    classify_planner_row_status,
     summarize_benchmark_availability,
     summarize_campaign_outcome,
 )
@@ -2826,10 +2827,14 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
     rows = payload.get("planner_rows", [])
     warnings = payload.get("warnings", [])
     accepted_unavailable_rows = [
-        row for row in rows if str(row.get("status", "")).lower() in {"not_available", "excluded"}
+        row
+        for row in rows
+        if classify_planner_row_status(str(row.get("status", ""))) == "accepted_unavailable"
     ]
     unexpected_failed_rows = [
-        row for row in rows if str(row.get("status", "")).lower() in {"failed", "partial-failure"}
+        row
+        for row in rows
+        if classify_planner_row_status(str(row.get("status", ""))) == "unexpected_failure"
     ]
 
     lines = [
@@ -3279,7 +3284,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                     f"planner='{planner.key}' kinematics='{kinematics}' status='{status}' "
                     f"most_likely_reason='{reason}'"
                 )
-            elif status == "not_available":
+            elif classify_planner_row_status(status) == "accepted_unavailable":
                 reason = str(row.get("availability_reason", "")).strip() or "unspecified"
                 warnings.append(
                     "Accepted unavailable planner row recorded: "
@@ -3320,7 +3325,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                 },
             )
 
-            if status in {"failed", "partial-failure"} and cfg.stop_on_failure:
+            if classify_planner_row_status(status) == "unexpected_failure" and cfg.stop_on_failure:
                 logger.warning(
                     "Campaign stop_on_failure triggered: planner key={} kinematics={} status={} (halting remaining planners).",
                     planner.key,

--- a/robot_sf/benchmark/fallback_policy.py
+++ b/robot_sf/benchmark/fallback_policy.py
@@ -37,6 +37,7 @@ _UNEXPECTED_FAILURE_STATUSES = {"failed", "partial-failure"}
 _SUCCESS_CAMPAIGN_STATUSES = {"benchmark_success", "ok"}
 _ACCEPTED_UNAVAILABLE_CAMPAIGN_STATUSES = {"accepted_unavailable_only"}
 _UNEXPECTED_FAILURE_CAMPAIGN_STATUSES = {"unexpected_failure"}
+_CANONICAL_EXIT_CODES: set[int] = {0, 2, 3}
 
 
 def _int_field(result: dict[str, Any], key: str) -> int:
@@ -55,6 +56,9 @@ def _int_field(result: dict[str, Any], key: str) -> int:
 def _run_statuses_from_result(result: dict[str, Any]) -> list[str]:
     """Extract normalized planner/run statuses from a campaign payload.
 
+    planner_rows statuses are trusted only when every row has a non-empty status.
+    Otherwise the function falls back to ``runs`` entries or returns an empty list.
+
     Returns:
         Ordered planner/run status labels when available.
     """
@@ -66,6 +70,9 @@ def _run_statuses_from_result(result: dict[str, Any]) -> list[str]:
                 status = str(row.get("status", "")).strip().lower()
                 if status:
                     run_statuses.append(status)
+                else:
+                    run_statuses.clear()
+                    break
     if run_statuses:
         return run_statuses
 
@@ -438,12 +445,35 @@ def summarize_campaign_outcome(result: dict[str, Any] | None) -> CampaignOutcome
 
 
 def campaign_exit_code(result: dict[str, Any] | None) -> int:
-    """Return camera-ready campaign CLI exit code for a result payload."""
+    """Return camera-ready campaign CLI exit code for a result payload.
+
+    Only canonical integer (non-bool) exit codes {0, 2, 3} are trusted
+    from the payload.  Bool values and unknown integers fall through to
+    the summarised outcome.
+    """
     if isinstance(result, dict):
         explicit_exit_code = result.get("exit_code")
-        if isinstance(explicit_exit_code, int) and explicit_exit_code >= 0:
+        if (
+            isinstance(explicit_exit_code, int)
+            and not isinstance(explicit_exit_code, bool)
+            and explicit_exit_code in _CANONICAL_EXIT_CODES
+        ):
             return explicit_exit_code
     return summarize_campaign_outcome(result).exit_code
+
+
+def classify_planner_row_status(status: str) -> str:
+    """Classify a planner-row status label into a canonical outcome class.
+
+    Returns:
+        One of ``"ok"``, ``"accepted_unavailable"``, or ``"unexpected_failure"``.
+    """
+    normalized = str(status or "").strip().lower()
+    if normalized == "ok":
+        return "ok"
+    if normalized in _ACCEPTED_UNAVAILABLE_STATUSES:
+        return "accepted_unavailable"
+    return "unexpected_failure"
 
 
 __all__ = [
@@ -452,6 +482,7 @@ __all__ = [
     "availability_payload",
     "benchmark_run_exit_code",
     "campaign_exit_code",
+    "classify_planner_row_status",
     "resolve_execution_mode",
     "summarize_benchmark_availability",
     "summarize_campaign_outcome",

--- a/robot_sf/benchmark/fallback_policy.py
+++ b/robot_sf/benchmark/fallback_policy.py
@@ -32,6 +32,25 @@ class CampaignOutcome:
     exit_code: int
 
 
+@dataclass(frozen=True)
+class CampaignRowStatusSummary:
+    """Canonical planner-row status counters for one campaign payload."""
+
+    successful_evidence_rows: int
+    accepted_unavailable_rows: int
+    unexpected_failed_rows: int
+    fallback_or_degraded_rows: int
+
+
+@dataclass(frozen=True)
+class CampaignStatusAxes:
+    """Normalized execution/evidence axes for a camera-ready campaign."""
+
+    campaign_execution_status: str
+    evidence_status: str
+    row_status_summary: CampaignRowStatusSummary
+
+
 _ACCEPTED_UNAVAILABLE_STATUSES = {"not_available", "excluded"}
 _UNEXPECTED_FAILURE_STATUSES = {"failed", "partial-failure"}
 _SUCCESS_CAMPAIGN_STATUSES = {"benchmark_success", "ok"}
@@ -53,6 +72,14 @@ def _int_field(result: dict[str, Any], key: str) -> int:
         return 0
 
 
+def _status_from_row(row: Any) -> str | None:
+    """Return a normalized non-empty row status, or ``None`` for malformed rows."""
+    if not isinstance(row, dict):
+        return None
+    status = str(row.get("status", "")).strip().lower()
+    return status or None
+
+
 def _run_statuses_from_result(result: dict[str, Any]) -> list[str]:
     """Extract normalized planner/run statuses from a campaign payload.
 
@@ -65,24 +92,16 @@ def _run_statuses_from_result(result: dict[str, Any]) -> list[str]:
     run_statuses: list[str] = []
     planner_rows = result.get("planner_rows")
     if isinstance(planner_rows, list):
-        for row in planner_rows:
-            if isinstance(row, dict):
-                status = str(row.get("status", "")).strip().lower()
-                if status:
-                    run_statuses.append(status)
-                else:
-                    run_statuses.clear()
-                    break
-    if run_statuses:
-        return run_statuses
+        planner_statuses = [_status_from_row(row) for row in planner_rows]
+        if planner_statuses and all(status is not None for status in planner_statuses):
+            return [status for status in planner_statuses if status is not None]
 
     runs = result.get("runs")
     if isinstance(runs, list):
         for entry in runs:
-            if isinstance(entry, dict):
-                status = str(entry.get("status", "")).strip().lower()
-                if status:
-                    run_statuses.append(status)
+            status = _status_from_row(entry)
+            if status:
+                run_statuses.append(status)
     return run_statuses
 
 
@@ -97,19 +116,13 @@ def _campaign_outcome_from_explicit_fields(result: dict[str, Any]) -> CampaignOu
     )
     explicit_reason = str(result.get("status_reason", "")).strip()
     benchmark_success = result.get("benchmark_success") is True
-    successful_runs = _int_field(result, "successful_runs")
-    accepted_unavailable_runs = _int_field(result, "accepted_unavailable_runs")
-    unexpected_failed_runs = _int_field(result, "unexpected_failed_runs")
-    non_success_runs = _int_field(result, "non_success_runs")
-    total_runs = _int_field(result, "total_runs")
-
-    if total_runs <= 0:
-        total_runs = successful_runs + accepted_unavailable_runs + unexpected_failed_runs
-    if non_success_runs <= 0 and total_runs > 0:
-        non_success_runs = max(
-            total_runs - successful_runs,
-            accepted_unavailable_runs + unexpected_failed_runs,
-        )
+    (
+        successful_runs,
+        accepted_unavailable_runs,
+        unexpected_failed_runs,
+        non_success_runs,
+        total_runs,
+    ) = _explicit_campaign_counts(result)
 
     if unexpected_failed_runs > 0 or explicit_status in _UNEXPECTED_FAILURE_CAMPAIGN_STATUSES:
         resolved_unexpected_failed_runs = unexpected_failed_runs
@@ -257,6 +270,237 @@ def _campaign_outcome_from_run_statuses(run_statuses: list[str]) -> CampaignOutc
         total_runs=total_runs,
         exit_code=2,
     )
+
+
+def _explicit_campaign_counts(result: dict[str, Any]) -> tuple[int, int, int, int, int]:
+    """Resolve campaign run counters from explicit fields and row-summary metadata.
+
+    Returns:
+        ``successful_runs``, ``accepted_unavailable_runs``, ``unexpected_failed_runs``,
+        ``non_success_runs``, and ``total_runs`` counters.
+    """
+    explicit_row_status_summary = _normalized_row_status_summary(result.get("row_status_summary"))
+    successful_runs = _int_field(result, "successful_runs")
+    accepted_unavailable_runs = _int_field(result, "accepted_unavailable_runs")
+    unexpected_failed_runs = _int_field(result, "unexpected_failed_runs")
+    non_success_runs = _int_field(result, "non_success_runs")
+    total_runs = _int_field(result, "total_runs")
+
+    if explicit_row_status_summary is not None:
+        successful_runs = _explicit_or_summary_count(
+            result, "successful_runs", explicit_row_status_summary.successful_evidence_rows
+        )
+        accepted_unavailable_runs = _explicit_or_summary_count(
+            result,
+            "accepted_unavailable_runs",
+            explicit_row_status_summary.accepted_unavailable_rows,
+        )
+        unexpected_failed_runs = _explicit_or_summary_count(
+            result, "unexpected_failed_runs", explicit_row_status_summary.unexpected_failed_rows
+        )
+        non_success_runs = _explicit_or_summary_count(
+            result,
+            "non_success_runs",
+            explicit_row_status_summary.accepted_unavailable_rows
+            + explicit_row_status_summary.unexpected_failed_rows,
+        )
+        total_runs = _explicit_or_summary_count(
+            result,
+            "total_runs",
+            explicit_row_status_summary.successful_evidence_rows
+            + explicit_row_status_summary.accepted_unavailable_rows
+            + explicit_row_status_summary.unexpected_failed_rows,
+        )
+
+    if total_runs <= 0:
+        total_runs = successful_runs + accepted_unavailable_runs + unexpected_failed_runs
+    if non_success_runs <= 0 and total_runs > 0:
+        non_success_runs = max(
+            total_runs - successful_runs,
+            accepted_unavailable_runs + unexpected_failed_runs,
+        )
+    return (
+        successful_runs,
+        accepted_unavailable_runs,
+        unexpected_failed_runs,
+        non_success_runs,
+        total_runs,
+    )
+
+
+def _explicit_or_summary_count(result: dict[str, Any], key: str, summary_value: int) -> int:
+    """Return an explicit counter when present, otherwise the row-summary value.
+
+    Returns:
+        Non-negative integer counter.
+    """
+    if key in result:
+        return _int_field(result, key)
+    return summary_value
+
+
+def _normalized_row_status_summary(raw: Any) -> CampaignRowStatusSummary | None:
+    """Parse an explicit row-status summary mapping when present.
+
+    Returns:
+        Normalized row-status counters, or ``None`` when the payload is not a mapping.
+    """
+    if not isinstance(raw, dict):
+        return None
+    return CampaignRowStatusSummary(
+        successful_evidence_rows=_int_field(raw, "successful_evidence_rows"),
+        accepted_unavailable_rows=_int_field(raw, "accepted_unavailable_rows"),
+        unexpected_failed_rows=_int_field(raw, "unexpected_failed_rows"),
+        fallback_or_degraded_rows=_int_field(raw, "fallback_or_degraded_rows"),
+    )
+
+
+def _row_status_summary_from_run_statuses(
+    run_statuses: list[str], *, fallback_or_degraded_rows: int
+) -> CampaignRowStatusSummary:
+    """Build row-status counters from normalized planner/run statuses.
+
+    Returns:
+        Row-status counters for success, accepted-unavailable, unexpected failure, and fallback.
+    """
+    return CampaignRowStatusSummary(
+        successful_evidence_rows=sum(1 for status in run_statuses if status == "ok"),
+        accepted_unavailable_rows=sum(
+            1 for status in run_statuses if status in _ACCEPTED_UNAVAILABLE_STATUSES
+        ),
+        unexpected_failed_rows=sum(
+            1 for status in run_statuses if status not in {"ok"} | _ACCEPTED_UNAVAILABLE_STATUSES
+        ),
+        fallback_or_degraded_rows=fallback_or_degraded_rows,
+    )
+
+
+def _row_status_summary_from_planner_rows(rows: Any) -> CampaignRowStatusSummary | None:
+    """Build row-status counters from planner rows when every row is well formed.
+
+    Returns:
+        Row-status counters, or ``None`` when planner rows are absent or malformed.
+    """
+    if not isinstance(rows, list):
+        return None
+    planner_statuses = [_status_from_row(row) for row in rows]
+    if not planner_statuses or any(status is None for status in planner_statuses):
+        return None
+    fallback_or_degraded_rows = sum(
+        1
+        for row in rows
+        if isinstance(row, dict)
+        and str(row.get("readiness_status", "")).strip().lower() in {"fallback", "degraded"}
+    )
+    return _row_status_summary_from_run_statuses(
+        [status for status in planner_statuses if status is not None],
+        fallback_or_degraded_rows=fallback_or_degraded_rows,
+    )
+
+
+def _row_status_summary_from_runs(runs: Any) -> CampaignRowStatusSummary | None:
+    """Build row-status counters from run entries when every run supplies a status.
+
+    Returns:
+        Row-status counters, or ``None`` when run entries are absent or malformed.
+    """
+    if not isinstance(runs, list):
+        return None
+    run_statuses = [_status_from_row(entry) for entry in runs]
+    if not run_statuses or any(status is None for status in run_statuses):
+        return None
+
+    fallback_or_degraded_rows = 0
+    for entry in runs:
+        if not isinstance(entry, dict):
+            return None
+        summary = entry.get("summary")
+        if not isinstance(summary, dict):
+            summary = entry
+        if summarize_benchmark_availability(summary).readiness_status in {"fallback", "degraded"}:
+            fallback_or_degraded_rows += 1
+    return _row_status_summary_from_run_statuses(
+        [status for status in run_statuses if status is not None],
+        fallback_or_degraded_rows=fallback_or_degraded_rows,
+    )
+
+
+def summarize_row_status_summary(result: dict[str, Any] | None) -> CampaignRowStatusSummary:
+    """Return canonical planner-row counters for a campaign payload."""
+    if not isinstance(result, dict):
+        return CampaignRowStatusSummary(0, 0, 0, 0)
+
+    planner_rows_summary = _row_status_summary_from_planner_rows(result.get("planner_rows"))
+    if planner_rows_summary is not None:
+        return planner_rows_summary
+
+    runs_summary = _row_status_summary_from_runs(result.get("runs"))
+    if runs_summary is not None:
+        return runs_summary
+
+    explicit_summary = _normalized_row_status_summary(result.get("row_status_summary"))
+    if explicit_summary is not None:
+        return explicit_summary
+
+    return CampaignRowStatusSummary(
+        successful_evidence_rows=_int_field(result, "successful_runs"),
+        accepted_unavailable_rows=_int_field(result, "accepted_unavailable_runs"),
+        unexpected_failed_rows=_int_field(result, "unexpected_failed_runs"),
+        fallback_or_degraded_rows=_int_field(result, "fallback_or_degraded_rows"),
+    )
+
+
+def summarize_campaign_status_axes(
+    result: dict[str, Any] | None, *, expected_total_runs: int | None = None
+) -> CampaignStatusAxes:
+    """Return explicit execution/evidence axes for a campaign payload."""
+    row_status_summary = summarize_row_status_summary(result)
+    if not isinstance(result, dict):
+        return CampaignStatusAxes(
+            campaign_execution_status="failed",
+            evidence_status="invalid",
+            row_status_summary=row_status_summary,
+        )
+
+    outcome = summarize_campaign_outcome(result)
+    observed_total_runs = (
+        row_status_summary.successful_evidence_rows
+        + row_status_summary.accepted_unavailable_rows
+        + row_status_summary.unexpected_failed_rows
+    )
+    if expected_total_runs is None or expected_total_runs <= 0:
+        expected_total_runs = None
+    interrupted = (
+        expected_total_runs is not None
+        and observed_total_runs > 0
+        and observed_total_runs < expected_total_runs
+        and outcome.status in _UNEXPECTED_FAILURE_CAMPAIGN_STATUSES
+    )
+
+    if outcome.status in _UNEXPECTED_FAILURE_CAMPAIGN_STATUSES | {"malformed"}:
+        campaign_execution_status = "interrupted" if interrupted else "failed"
+        evidence_status = "invalid"
+    elif outcome.status in _SUCCESS_CAMPAIGN_STATUSES:
+        campaign_execution_status = "completed"
+        evidence_status = "valid"
+    else:
+        campaign_execution_status = "completed"
+        evidence_status = (
+            "partial" if row_status_summary.successful_evidence_rows > 0 else "blocked"
+        )
+
+    return CampaignStatusAxes(
+        campaign_execution_status=campaign_execution_status,
+        evidence_status=evidence_status,
+        row_status_summary=row_status_summary,
+    )
+
+
+def campaign_status_axes_payload(
+    result: dict[str, Any] | None, *, expected_total_runs: int | None = None
+) -> dict[str, Any]:
+    """Return JSON-serializable execution/evidence axes for campaign payloads."""
+    return asdict(summarize_campaign_status_axes(result, expected_total_runs=expected_total_runs))
 
 
 def resolve_execution_mode(algorithm_metadata_contract: Any) -> str:
@@ -479,11 +723,16 @@ def classify_planner_row_status(status: str) -> str:
 __all__ = [
     "BenchmarkAvailability",
     "CampaignOutcome",
+    "CampaignRowStatusSummary",
+    "CampaignStatusAxes",
     "availability_payload",
     "benchmark_run_exit_code",
     "campaign_exit_code",
+    "campaign_status_axes_payload",
     "classify_planner_row_status",
     "resolve_execution_mode",
     "summarize_benchmark_availability",
     "summarize_campaign_outcome",
+    "summarize_campaign_status_axes",
+    "summarize_row_status_summary",
 ]

--- a/robot_sf/benchmark/fallback_policy.py
+++ b/robot_sf/benchmark/fallback_policy.py
@@ -17,6 +17,241 @@ class BenchmarkAvailability:
     availability_reason: str | None = None
 
 
+@dataclass(frozen=True)
+class CampaignOutcome:
+    """Normalized camera-ready campaign outcome and exit semantics."""
+
+    status: str
+    benchmark_success: bool
+    status_reason: str
+    successful_runs: int
+    accepted_unavailable_runs: int
+    unexpected_failed_runs: int
+    non_success_runs: int
+    total_runs: int
+    exit_code: int
+
+
+_ACCEPTED_UNAVAILABLE_STATUSES = {"not_available", "excluded"}
+_UNEXPECTED_FAILURE_STATUSES = {"failed", "partial-failure"}
+_SUCCESS_CAMPAIGN_STATUSES = {"benchmark_success", "ok"}
+_ACCEPTED_UNAVAILABLE_CAMPAIGN_STATUSES = {"accepted_unavailable_only"}
+_UNEXPECTED_FAILURE_CAMPAIGN_STATUSES = {"unexpected_failure"}
+
+
+def _int_field(result: dict[str, Any], key: str) -> int:
+    """Read one integer-like explicit campaign field with a fail-closed default.
+
+    Returns:
+        Parsed integer value, or zero when the field is missing or malformed.
+    """
+    value = result.get(key, 0)
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _run_statuses_from_result(result: dict[str, Any]) -> list[str]:
+    """Extract normalized planner/run statuses from a campaign payload.
+
+    Returns:
+        Ordered planner/run status labels when available.
+    """
+    run_statuses: list[str] = []
+    planner_rows = result.get("planner_rows")
+    if isinstance(planner_rows, list):
+        for row in planner_rows:
+            if isinstance(row, dict):
+                status = str(row.get("status", "")).strip().lower()
+                if status:
+                    run_statuses.append(status)
+    if run_statuses:
+        return run_statuses
+
+    runs = result.get("runs")
+    if isinstance(runs, list):
+        for entry in runs:
+            if isinstance(entry, dict):
+                status = str(entry.get("status", "")).strip().lower()
+                if status:
+                    run_statuses.append(status)
+    return run_statuses
+
+
+def _campaign_outcome_from_explicit_fields(result: dict[str, Any]) -> CampaignOutcome:
+    """Resolve campaign outcome from explicit top-level fields when row statuses are absent.
+
+    Returns:
+        Campaign outcome derived from top-level status metadata.
+    """
+    explicit_status = (
+        str(result.get("status") or result.get("campaign_status") or "").strip().lower()
+    )
+    explicit_reason = str(result.get("status_reason", "")).strip()
+    benchmark_success = result.get("benchmark_success") is True
+    successful_runs = _int_field(result, "successful_runs")
+    accepted_unavailable_runs = _int_field(result, "accepted_unavailable_runs")
+    unexpected_failed_runs = _int_field(result, "unexpected_failed_runs")
+    non_success_runs = _int_field(result, "non_success_runs")
+    total_runs = _int_field(result, "total_runs")
+
+    if total_runs <= 0:
+        total_runs = successful_runs + accepted_unavailable_runs + unexpected_failed_runs
+    if non_success_runs <= 0 and total_runs > 0:
+        non_success_runs = max(
+            total_runs - successful_runs,
+            accepted_unavailable_runs + unexpected_failed_runs,
+        )
+
+    if unexpected_failed_runs > 0 or explicit_status in _UNEXPECTED_FAILURE_CAMPAIGN_STATUSES:
+        resolved_unexpected_failed_runs = unexpected_failed_runs
+        if resolved_unexpected_failed_runs <= 0:
+            resolved_unexpected_failed_runs = max(
+                non_success_runs - accepted_unavailable_runs,
+                total_runs - successful_runs - accepted_unavailable_runs,
+                0,
+            )
+        return CampaignOutcome(
+            status="unexpected_failure",
+            benchmark_success=False,
+            status_reason=explicit_reason
+            or "campaign contains unexpected failed or partially failed rows",
+            successful_runs=successful_runs,
+            accepted_unavailable_runs=accepted_unavailable_runs,
+            unexpected_failed_runs=resolved_unexpected_failed_runs,
+            non_success_runs=max(non_success_runs, resolved_unexpected_failed_runs),
+            total_runs=total_runs,
+            exit_code=2,
+        )
+    if (
+        total_runs > 0
+        and non_success_runs == 0
+        and (not explicit_status or explicit_status in _SUCCESS_CAMPAIGN_STATUSES)
+        and (
+            benchmark_success
+            or explicit_status in _SUCCESS_CAMPAIGN_STATUSES
+            or successful_runs >= total_runs
+        )
+    ):
+        return CampaignOutcome(
+            status="benchmark_success",
+            benchmark_success=True,
+            status_reason=explicit_reason or "all planner rows were benchmark-success",
+            successful_runs=total_runs or successful_runs,
+            accepted_unavailable_runs=0,
+            unexpected_failed_runs=0,
+            non_success_runs=0,
+            total_runs=total_runs,
+            exit_code=0,
+        )
+    if accepted_unavailable_runs > 0 or explicit_status in _ACCEPTED_UNAVAILABLE_CAMPAIGN_STATUSES:
+        resolved_non_success_runs = max(
+            non_success_runs,
+            accepted_unavailable_runs,
+            total_runs - successful_runs,
+            0,
+        )
+        resolved_total_runs = max(total_runs, successful_runs + resolved_non_success_runs)
+        resolved_accepted_runs = max(
+            accepted_unavailable_runs,
+            resolved_non_success_runs - unexpected_failed_runs,
+        )
+        return CampaignOutcome(
+            status="accepted_unavailable_only",
+            benchmark_success=False,
+            status_reason=explicit_reason
+            or "campaign contains accepted unavailable/excluded rows and no unexpected failed rows",
+            successful_runs=successful_runs,
+            accepted_unavailable_runs=resolved_accepted_runs,
+            unexpected_failed_runs=0,
+            non_success_runs=resolved_non_success_runs,
+            total_runs=resolved_total_runs,
+            exit_code=3,
+        )
+    return CampaignOutcome(
+        status="malformed",
+        benchmark_success=False,
+        status_reason=(
+            explicit_reason
+            or (
+                f"campaign result payload has unknown explicit status '{explicit_status}'"
+                if explicit_status
+                else "campaign result payload is missing planner row status information"
+            )
+        ),
+        successful_runs=successful_runs,
+        accepted_unavailable_runs=accepted_unavailable_runs,
+        unexpected_failed_runs=unexpected_failed_runs,
+        non_success_runs=non_success_runs,
+        total_runs=total_runs,
+        exit_code=2,
+    )
+
+
+def _campaign_outcome_from_run_statuses(run_statuses: list[str]) -> CampaignOutcome:
+    """Resolve campaign outcome from normalized planner/run statuses.
+
+    Returns:
+        Campaign outcome derived from planner/run status labels.
+    """
+    successful_runs = sum(1 for status in run_statuses if status == "ok")
+    accepted_unavailable_runs = sum(
+        1 for status in run_statuses if status in _ACCEPTED_UNAVAILABLE_STATUSES
+    )
+    unexpected_failed_runs = sum(
+        1 for status in run_statuses if status in _UNEXPECTED_FAILURE_STATUSES
+    )
+    unexpected_failed_runs += sum(
+        1
+        for status in run_statuses
+        if status not in {"ok"} | _ACCEPTED_UNAVAILABLE_STATUSES | _UNEXPECTED_FAILURE_STATUSES
+    )
+    total_runs = len(run_statuses)
+    non_success_runs = total_runs - successful_runs
+    if total_runs > 0 and non_success_runs == 0:
+        return CampaignOutcome(
+            status="benchmark_success",
+            benchmark_success=True,
+            status_reason="all planner rows were benchmark-success",
+            successful_runs=successful_runs,
+            accepted_unavailable_runs=0,
+            unexpected_failed_runs=0,
+            non_success_runs=0,
+            total_runs=total_runs,
+            exit_code=0,
+        )
+    if total_runs > 0 and accepted_unavailable_runs > 0 and unexpected_failed_runs == 0:
+        return CampaignOutcome(
+            status="accepted_unavailable_only",
+            benchmark_success=False,
+            status_reason=(
+                "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+            ),
+            successful_runs=successful_runs,
+            accepted_unavailable_runs=accepted_unavailable_runs,
+            unexpected_failed_runs=0,
+            non_success_runs=non_success_runs,
+            total_runs=total_runs,
+            exit_code=3,
+        )
+    return CampaignOutcome(
+        status="unexpected_failure",
+        benchmark_success=False,
+        status_reason=(
+            "campaign contains unexpected failed or partially failed rows"
+            if total_runs > 0
+            else "campaign produced no planner runs"
+        ),
+        successful_runs=successful_runs,
+        accepted_unavailable_runs=accepted_unavailable_runs,
+        unexpected_failed_runs=unexpected_failed_runs,
+        non_success_runs=non_success_runs,
+        total_runs=total_runs,
+        exit_code=2,
+    )
+
+
 def resolve_execution_mode(algorithm_metadata_contract: Any) -> str:
     """Resolve execution mode from algorithm metadata payload with legacy fallbacks.
 
@@ -181,19 +416,43 @@ def benchmark_run_exit_code(summary: dict[str, Any] | None) -> int:
     return 0 if availability.benchmark_success else 2
 
 
+def summarize_campaign_outcome(result: dict[str, Any] | None) -> CampaignOutcome:
+    """Return canonical campaign status for camera-ready benchmark results."""
+    if not isinstance(result, dict):
+        return CampaignOutcome(
+            status="malformed",
+            benchmark_success=False,
+            status_reason="campaign result payload is missing or not a mapping",
+            successful_runs=0,
+            accepted_unavailable_runs=0,
+            unexpected_failed_runs=0,
+            non_success_runs=0,
+            total_runs=0,
+            exit_code=2,
+        )
+
+    run_statuses = _run_statuses_from_result(result)
+    if not run_statuses:
+        return _campaign_outcome_from_explicit_fields(result)
+    return _campaign_outcome_from_run_statuses(run_statuses)
+
+
 def campaign_exit_code(result: dict[str, Any] | None) -> int:
     """Return camera-ready campaign CLI exit code for a result payload."""
-    if not isinstance(result, dict):
-        return 2
-    benchmark_success = result.get("benchmark_success")
-    return 0 if benchmark_success is True else 2
+    if isinstance(result, dict):
+        explicit_exit_code = result.get("exit_code")
+        if isinstance(explicit_exit_code, int) and explicit_exit_code >= 0:
+            return explicit_exit_code
+    return summarize_campaign_outcome(result).exit_code
 
 
 __all__ = [
     "BenchmarkAvailability",
+    "CampaignOutcome",
     "availability_payload",
     "benchmark_run_exit_code",
     "campaign_exit_code",
     "resolve_execution_mode",
     "summarize_benchmark_availability",
+    "summarize_campaign_outcome",
 ]

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run a benchmark release workflow on top of the camera-ready campaign stack."""
+"""Run a benchmark release workflow on top of the camera-ready campaign stack.
+
+Exit codes follow the wrapped campaign semantics for non-success benchmark outcomes:
+- 0: benchmark-success release
+- 2: unexpected failure or missing required release artifacts
+- 3: accepted-unavailable-only campaign outcome (non-success, fail-closed)
+"""
 
 from __future__ import annotations
 
@@ -18,7 +24,6 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
-from robot_sf.benchmark.fallback_policy import campaign_exit_code
 from robot_sf.benchmark.release_protocol import (
     build_release_provenance,
     build_resolved_release_manifest,
@@ -204,9 +209,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     release_dir = campaign_root / "release"
     _write_json(release_dir / "release_manifest.resolved.json", resolved_manifest)
 
-    benchmark_success = bool(run_payload.get("benchmark_success")) and not missing
-    result["benchmark_success"] = benchmark_success
-    if benchmark_success:
+    release_benchmark_success = bool(run_payload.get("benchmark_success")) and not missing
+    result["release_benchmark_success"] = release_benchmark_success
+    if release_benchmark_success:
         publication_payload = _build_publication_payload(
             campaign_root=campaign_root,
             release_tag=manifest.release_tag,
@@ -223,15 +228,31 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         result["publication_bundle"] = None
 
-    if missing:
-        result["status"] = "missing_required_artifacts"
-    release_status = result.get("status")
-    if not isinstance(release_status, str) or not release_status:
-        result["status"] = "ok" if benchmark_success else "benchmark_failed"
+    result["release_status"] = (
+        "missing_required_artifacts"
+        if missing
+        else (
+            "ok"
+            if release_benchmark_success
+            else str(run_payload.get("status", "benchmark_failed"))
+        )
+    )
+    result["release_status_reason"] = (
+        "release artifacts validated and benchmark campaign was benchmark-success"
+        if release_benchmark_success
+        else (
+            "release is missing required benchmark artifacts"
+            if missing
+            else str(run_payload.get("status_reason", "benchmark release did not succeed"))
+        )
+    )
+    result["release_exit_code"] = (
+        0 if release_benchmark_success else (2 if missing else int(run_payload.get("exit_code", 2)))
+    )
     _write_json(release_dir / "release_result.json", result)
 
     print(json.dumps(result, indent=2))
-    return campaign_exit_code(result)
+    return int(result["release_exit_code"])
 
 
 if __name__ == "__main__":

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -181,6 +181,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if validation["status"] != "valid":
         result["benchmark_success"] = False
         result["status"] = "invalid_manifest"
+        result["campaign_execution_status"] = "failed"
+        result["evidence_status"] = "invalid"
+        result["row_status_summary"] = {
+            "successful_evidence_rows": 0,
+            "accepted_unavailable_rows": 0,
+            "unexpected_failed_rows": 0,
+            "fallback_or_degraded_rows": 0,
+        }
         print(json.dumps(result, indent=2))
         return 2
 

--- a/scripts/tools/run_camera_ready_benchmark.py
+++ b/scripts/tools/run_camera_ready_benchmark.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run a config-driven camera-ready benchmark campaign."""
+"""Run a config-driven camera-ready benchmark campaign.
+
+Exit codes preserve fail-closed campaign semantics for non-success outcomes:
+- 0: benchmark-success campaign
+- 2: unexpected failure, malformed result, or mixed failed/partial-failure outcome
+- 3: accepted-unavailable-only campaign outcome (non-success, fail-closed)
+"""
 
 from __future__ import annotations
 

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1144,6 +1144,8 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     assert preview_payload["scenarios"] == []
     report_text = (campaign_root / "reports" / "campaign_report.md").read_text(encoding="utf-8")
     assert "Campaign status: `accepted_unavailable_only`" in report_text
+    assert "Campaign execution status: `completed`" in report_text
+    assert "Evidence status: `partial`" in report_text
     assert "Readiness & Degraded/Fallback Status" in report_text
     assert "SocNav Strict-vs-Fallback Disclosure" in report_text
     assert "## Accepted Unavailable/Excluded Planners" in report_text
@@ -1180,8 +1182,24 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
         "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
     )
     assert result["exit_code"] == 3
+    assert result["campaign_execution_status"] == "completed"
+    assert result["evidence_status"] == "partial"
+    assert result["row_status_summary"] == {
+        "successful_evidence_rows": 1,
+        "accepted_unavailable_rows": 1,
+        "unexpected_failed_rows": 0,
+        "fallback_or_degraded_rows": 1,
+    }
     assert summary_payload["campaign"]["benchmark_success"] is False
     assert summary_payload["campaign"]["status"] == "accepted_unavailable_only"
+    assert summary_payload["campaign"]["campaign_execution_status"] == "completed"
+    assert summary_payload["campaign"]["evidence_status"] == "partial"
+    assert summary_payload["campaign"]["row_status_summary"] == {
+        "successful_evidence_rows": 1,
+        "accepted_unavailable_rows": 1,
+        "unexpected_failed_rows": 0,
+        "fallback_or_degraded_rows": 1,
+    }
     assert summary_payload["campaign"]["status_reason"] == (
         "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
     )
@@ -2370,12 +2388,23 @@ def test_run_campaign_success_ignores_not_available_experimental_when_core_ok(
     assert summary_payload["campaign"]["core_successful_runs"] == 1
     assert summary_payload["campaign"]["core_total_runs"] == 1
     assert summary_payload["campaign"]["benchmark_success_basis"] == "core"
-    assert summary_payload["campaign"]["benchmark_success"] is True
+    assert summary_payload["campaign"]["benchmark_success"] is False
+    assert summary_payload["campaign"]["campaign_execution_status"] == "completed"
+    assert summary_payload["campaign"]["evidence_status"] == "partial"
+    assert summary_payload["campaign"]["row_status_summary"] == {
+        "successful_evidence_rows": 1,
+        "accepted_unavailable_rows": 1,
+        "unexpected_failed_rows": 0,
+        "fallback_or_degraded_rows": 1,
+    }
     assert "core_with_optional_experimental" in result["campaign_id"]
     assert result["benchmark_success_basis"] == "core"
     assert result["core_successful_runs"] == 1
     assert result["core_total_runs"] == 1
-    assert result["benchmark_success"] is True
+    assert result["benchmark_success"] is False
+    assert result["status"] == "accepted_unavailable_only"
+    assert result["campaign_execution_status"] == "completed"
+    assert result["evidence_status"] == "partial"
 
 
 def test_run_campaign_fails_if_core_run_is_unattempted_after_stop_on_failure(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1143,8 +1143,18 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     assert preview_payload["preview_limit"] == 0
     assert preview_payload["scenarios"] == []
     report_text = (campaign_root / "reports" / "campaign_report.md").read_text(encoding="utf-8")
+    assert "Campaign status: `accepted_unavailable_only`" in report_text
     assert "Readiness & Degraded/Fallback Status" in report_text
     assert "SocNav Strict-vs-Fallback Disclosure" in report_text
+    assert "## Accepted Unavailable/Excluded Planners" in report_text
+    assert "## Unexpected Failed/Partial Planners" in report_text
+    assert "No unexpected failed/partial planners." in report_text
+    assert report_text.index("## Accepted Unavailable/Excluded Planners") < report_text.index(
+        "## Campaign Warnings"
+    )
+    assert report_text.index("## Unexpected Failed/Partial Planners") < report_text.index(
+        "## Campaign Warnings"
+    )
     assert "fallback" in report_text
     assert "learned contract" in report_text
     table_md = (campaign_root / "reports" / "campaign_table.md").read_text(encoding="utf-8")
@@ -1165,7 +1175,20 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     summary_payload = json.loads(
         (campaign_root / "reports" / "campaign_summary.json").read_text(encoding="utf-8")
     )
+    assert result["status"] == "accepted_unavailable_only"
+    assert result["status_reason"] == (
+        "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+    )
+    assert result["exit_code"] == 3
     assert summary_payload["campaign"]["benchmark_success"] is False
+    assert summary_payload["campaign"]["status"] == "accepted_unavailable_only"
+    assert summary_payload["campaign"]["status_reason"] == (
+        "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+    )
+    assert summary_payload["campaign"]["accepted_unavailable_runs"] == 1
+    assert summary_payload["campaign"]["unexpected_failed_runs"] == 0
+    assert summary_payload["campaign"]["non_success_runs"] == 1
+    assert summary_payload["campaign"]["exit_code"] == 3
     ppo_row = next(row for row in summary_payload["planner_rows"] if row["algo"] == "ppo")
     assert ppo_row["status"] == "not_available"
     assert ppo_row["availability_status"] == "not_available"
@@ -1448,8 +1471,10 @@ def test_run_campaign_stops_on_partial_failure_when_configured(tmp_path: Path, m
     assert planner_rows[0]["status"] == "partial-failure"
 
 
-def test_run_campaign_stops_on_not_available_when_configured(tmp_path: Path, monkeypatch) -> None:
-    """Campaign should stop after the first not-available planner when stop_on_failure is enabled."""
+def test_run_campaign_continues_after_not_available_when_stop_enabled(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Accepted unavailable rows should not halt later planners even with stop_on_failure enabled."""
     scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
     scenario_abs = (tmp_path / scenario_rel).resolve()
     scenario_abs.parent.mkdir(parents=True, exist_ok=True)
@@ -1507,7 +1532,16 @@ def test_run_campaign_stops_on_not_available_when_configured(tmp_path: Path, mon
                     },
                 },
             }
-        raise AssertionError("run_batch must not be called for planners after not_available")
+        return {
+            "total_jobs": 1,
+            "written": 1,
+            "failed_jobs": 0,
+            "failures": [],
+            "preflight": {
+                "status": "ok",
+                "learned_policy_contract": {"status": "not_applicable"},
+            },
+        }
 
     monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
 
@@ -1515,11 +1549,16 @@ def test_run_campaign_stops_on_not_available_when_configured(tmp_path: Path, mon
     summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
     planner_rows = summary_payload["planner_rows"]
 
-    assert call_order == ["ppo"]
-    assert len(planner_rows) == 1
-    assert planner_rows[0]["planner_key"] == "ppo"
-    assert planner_rows[0]["status"] == "not_available"
+    assert call_order == ["ppo", "goal"]
+    assert len(planner_rows) == 2
+    assert planner_rows[0]["planner_key"] == "goal"
+    assert planner_rows[1]["planner_key"] == "ppo"
+    ppo_row = next(row for row in planner_rows if row["planner_key"] == "ppo")
+    goal_row = next(row for row in planner_rows if row["planner_key"] == "goal")
+    assert ppo_row["status"] == "not_available"
+    assert goal_row["status"] == "ok"
     assert any("obs_mode=image mismatch" in warning for warning in summary_payload["warnings"])
+    assert not any("Campaign halted early" in warning for warning in summary_payload["warnings"])
 
 
 def test_run_campaign_continues_after_failure_when_stop_disabled(
@@ -1604,6 +1643,11 @@ def test_run_campaign_continues_after_failure_when_stop_disabled(
     failed_row = next(row for row in planner_rows if row["planner_key"] == "prediction_planner")
     assert failed_row["status"] == "partial-failure"
     assert failed_row["most_likely_failure_reason"] == "worker crash"
+    assert result["status"] == "unexpected_failure"
+    assert result["exit_code"] == 2
+    assert summary_payload["campaign"]["status"] == "unexpected_failure"
+    assert summary_payload["campaign"]["accepted_unavailable_runs"] == 0
+    assert summary_payload["campaign"]["unexpected_failed_runs"] == 1
     assert any(
         "most_likely_reason='worker crash'" in warning for warning in summary_payload["warnings"]
     )
@@ -1729,8 +1773,53 @@ def test_write_campaign_report_escapes_markdown_cells(tmp_path: Path) -> None:
     assert "holonomic\\|vx_vy" in report_text
     assert "direct_holonomic_world_velocity" in report_text
     assert "world_velocity_passthrough" in report_text
-    assert "## Failed Planners And Likely Reasons" in report_text
-    assert "No failed/partial/not-available planners." in report_text
+    assert "## Accepted Unavailable/Excluded Planners" in report_text
+    assert "## Unexpected Failed/Partial Planners" in report_text
+    assert "No accepted unavailable/excluded planners." in report_text
+    assert "No unexpected failed/partial planners." in report_text
+
+
+@pytest.mark.parametrize("unexpected_status", ["failed", "partial-failure"])
+def test_write_campaign_report_routes_non_success_rows_to_expected_sections(
+    tmp_path: Path, unexpected_status: str
+) -> None:
+    """Report sections should separate accepted-unavailable rows from unexpected failures."""
+    report_path = tmp_path / "campaign_report.md"
+    payload = {
+        "campaign": {"campaign_id": "c1"},
+        "warnings": [],
+        "planner_rows": [
+            {
+                "planner_key": "accepted_row",
+                "algo": "goal",
+                "kinematics": "differential_drive",
+                "status": "not_available",
+                "availability_reason": "missing optional dependency",
+            },
+            {
+                "planner_key": "unexpected_row",
+                "algo": "goal",
+                "kinematics": "differential_drive",
+                "status": unexpected_status,
+                "most_likely_failure_reason": "worker crash",
+            },
+        ],
+    }
+
+    write_campaign_report(report_path, payload)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    accepted_section = report_text.split("## Accepted Unavailable/Excluded Planners", 1)[1].split(
+        "## Unexpected Failed/Partial Planners", 1
+    )[0]
+    unexpected_section = report_text.split("## Unexpected Failed/Partial Planners", 1)[1].split(
+        "## Campaign Warnings", 1
+    )[0]
+
+    assert "| accepted_row | not_available | missing optional dependency |" in accepted_section
+    assert "unexpected_row" not in accepted_section
+    assert f"| unexpected_row | {unexpected_status} | worker crash |" in unexpected_section
+    assert "accepted_row" not in unexpected_section
 
 
 def test_planner_report_row_uses_nested_planner_kinematics_execution_mode() -> None:

--- a/tests/benchmark/test_fallback_policy.py
+++ b/tests/benchmark/test_fallback_policy.py
@@ -94,6 +94,35 @@ def test_campaign_outcome_and_exit_code_distinguish_non_success_campaign_classes
     assert campaign_exit_code(None) == 2
 
 
+def test_campaign_outcome_ignores_partial_planner_rows_and_falls_back_to_runs() -> None:
+    """Planner-row status summaries are trusted only when every row supplies a status."""
+    outcome = summarize_campaign_outcome(
+        {
+            "planner_rows": [{"status": "ok"}, {}],
+            "runs": [{"status": "partial-failure"}],
+        }
+    )
+
+    assert outcome.status == "unexpected_failure"
+    assert outcome.unexpected_failed_runs == 1
+    assert outcome.exit_code == 2
+
+
+def test_campaign_exit_code_rejects_noncanonical_explicit_values() -> None:
+    """Only canonical integer, non-bool campaign exit codes should bypass summarization."""
+    success_payload = {"exit_code": True, "planner_rows": [{"status": "ok"}]}
+    accepted_unavailable_payload = {
+        "exit_code": 7,
+        "planner_rows": [{"status": "ok"}, {"status": "not_available"}],
+    }
+
+    assert (
+        campaign_exit_code({"exit_code": 0, "planner_rows": [{"status": "partial-failure"}]}) == 0
+    )
+    assert campaign_exit_code(success_payload) == 0
+    assert campaign_exit_code(accepted_unavailable_payload) == 3
+
+
 def test_campaign_outcome_accepts_all_ok_explicit_fields_without_rows() -> None:
     """Explicit campaign-success fields should preserve the benchmark-success class."""
     outcome = summarize_campaign_outcome(

--- a/tests/benchmark/test_fallback_policy.py
+++ b/tests/benchmark/test_fallback_policy.py
@@ -6,8 +6,10 @@ from robot_sf.benchmark.fallback_policy import (
     availability_payload,
     benchmark_run_exit_code,
     campaign_exit_code,
+    campaign_status_axes_payload,
     summarize_benchmark_availability,
     summarize_campaign_outcome,
+    summarize_campaign_status_axes,
 )
 
 
@@ -108,6 +110,20 @@ def test_campaign_outcome_ignores_partial_planner_rows_and_falls_back_to_runs() 
     assert outcome.exit_code == 2
 
 
+def test_campaign_outcome_ignores_malformed_planner_rows_and_falls_back_to_runs() -> None:
+    """Planner-row status summaries are ignored when any row is malformed."""
+    outcome = summarize_campaign_outcome(
+        {
+            "planner_rows": [{"status": "ok"}, None],
+            "runs": [{"status": "partial-failure"}],
+        }
+    )
+
+    assert outcome.status == "unexpected_failure"
+    assert outcome.unexpected_failed_runs == 1
+    assert outcome.exit_code == 2
+
+
 def test_campaign_exit_code_rejects_noncanonical_explicit_values() -> None:
     """Only canonical integer, non-bool campaign exit codes should bypass summarization."""
     success_payload = {"exit_code": True, "planner_rows": [{"status": "ok"}]}
@@ -164,6 +180,58 @@ def test_campaign_outcome_accepts_accepted_unavailable_explicit_fields_without_r
     assert outcome.accepted_unavailable_runs == 1
     assert outcome.unexpected_failed_runs == 0
     assert outcome.exit_code == 3
+
+
+def test_campaign_status_axes_distinguish_partial_evidence_from_execution_completion() -> None:
+    """Accepted unavailable rows should keep completed execution but partial evidence."""
+    status_axes = summarize_campaign_status_axes(
+        {
+            "planner_rows": [
+                {"status": "ok", "readiness_status": "native"},
+                {"status": "not_available", "readiness_status": "fallback"},
+            ]
+        },
+        expected_total_runs=2,
+    )
+
+    assert status_axes.campaign_execution_status == "completed"
+    assert status_axes.evidence_status == "partial"
+    assert status_axes.row_status_summary.successful_evidence_rows == 1
+    assert status_axes.row_status_summary.accepted_unavailable_rows == 1
+    assert status_axes.row_status_summary.unexpected_failed_rows == 0
+    assert status_axes.row_status_summary.fallback_or_degraded_rows == 1
+    assert campaign_status_axes_payload(
+        {
+            "planner_rows": [
+                {"status": "ok", "readiness_status": "native"},
+                {"status": "not_available", "readiness_status": "fallback"},
+            ]
+        },
+        expected_total_runs=2,
+    ) == {
+        "campaign_execution_status": "completed",
+        "evidence_status": "partial",
+        "row_status_summary": {
+            "successful_evidence_rows": 1,
+            "accepted_unavailable_rows": 1,
+            "unexpected_failed_rows": 0,
+            "fallback_or_degraded_rows": 1,
+        },
+    }
+
+
+def test_campaign_status_axes_mark_interrupted_unexpected_failure() -> None:
+    """Unexpected failures with missing expected rows should surface interruption explicitly."""
+    status_axes = summarize_campaign_status_axes(
+        {"planner_rows": [{"status": "ok"}, {"status": "partial-failure"}]},
+        expected_total_runs=3,
+    )
+
+    assert status_axes.campaign_execution_status == "interrupted"
+    assert status_axes.evidence_status == "invalid"
+    assert status_axes.row_status_summary.successful_evidence_rows == 1
+    assert status_axes.row_status_summary.accepted_unavailable_rows == 0
+    assert status_axes.row_status_summary.unexpected_failed_rows == 1
 
 
 def test_campaign_outcome_explicit_counts_prefer_unexpected_failure_over_accepted_unavailable() -> (

--- a/tests/benchmark/test_fallback_policy.py
+++ b/tests/benchmark/test_fallback_policy.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from robot_sf.benchmark.fallback_policy import (
+    availability_payload,
     benchmark_run_exit_code,
     campaign_exit_code,
     summarize_benchmark_availability,
+    summarize_campaign_outcome,
 )
 
 
@@ -29,6 +31,14 @@ def test_summarize_benchmark_availability_marks_fallback_as_not_available() -> N
     assert availability.availability_reason == "missing optional dep"
     assert benchmark_run_exit_code(summary) == 2
 
+    assert availability_payload(summary) == {
+        "execution_mode": "adapter",
+        "readiness_status": "fallback",
+        "availability_status": "not_available",
+        "benchmark_success": False,
+        "availability_reason": "missing optional dep",
+    }
+
 
 def test_summarize_benchmark_availability_marks_partial_failure() -> None:
     """Planner runs with failed jobs must be non-success even if some episodes were written."""
@@ -50,12 +60,125 @@ def test_summarize_benchmark_availability_marks_partial_failure() -> None:
     assert availability.availability_reason == "worker crash"
 
 
-def test_campaign_exit_code_uses_benchmark_success_flag() -> None:
-    """Campaign CLI should exit non-zero for non-success benchmark results."""
-    assert campaign_exit_code({"benchmark_success": True}) == 0
-    assert campaign_exit_code({"benchmark_success": False}) == 2
+def test_campaign_outcome_and_exit_code_distinguish_non_success_campaign_classes() -> None:
+    """Campaign exit semantics should separate accepted unavailable rows from true failures."""
+    success = summarize_campaign_outcome({"planner_rows": [{"status": "ok"}]})
+    accepted_unavailable = summarize_campaign_outcome(
+        {"planner_rows": [{"status": "ok"}, {"status": "not_available"}]}
+    )
+    unexpected_failure = summarize_campaign_outcome(
+        {"planner_rows": [{"status": "ok"}, {"status": "partial-failure"}]}
+    )
+
+    assert success.status == "benchmark_success"
+    assert success.exit_code == 0
+    assert campaign_exit_code({"planner_rows": [{"status": "ok"}]}) == 0
+
+    assert accepted_unavailable.status == "accepted_unavailable_only"
+    assert accepted_unavailable.accepted_unavailable_runs == 1
+    assert accepted_unavailable.unexpected_failed_runs == 0
+    assert accepted_unavailable.exit_code == 3
+    assert (
+        campaign_exit_code({"planner_rows": [{"status": "ok"}, {"status": "not_available"}]}) == 3
+    )
+
+    assert unexpected_failure.status == "unexpected_failure"
+    assert unexpected_failure.accepted_unavailable_runs == 0
+    assert unexpected_failure.unexpected_failed_runs == 1
+    assert unexpected_failure.exit_code == 2
+    assert (
+        campaign_exit_code({"planner_rows": [{"status": "ok"}, {"status": "partial-failure"}]}) == 2
+    )
+
     assert campaign_exit_code({}) == 2
     assert campaign_exit_code(None) == 2
+
+
+def test_campaign_outcome_accepts_all_ok_explicit_fields_without_rows() -> None:
+    """Explicit campaign-success fields should preserve the benchmark-success class."""
+    outcome = summarize_campaign_outcome(
+        {
+            "status": "benchmark_success",
+            "benchmark_success": True,
+            "status_reason": "all planner rows were benchmark-success",
+            "successful_runs": 2,
+            "accepted_unavailable_runs": 0,
+            "unexpected_failed_runs": 0,
+            "non_success_runs": 0,
+            "total_runs": 2,
+        }
+    )
+
+    assert outcome.status == "benchmark_success"
+    assert outcome.benchmark_success is True
+    assert outcome.successful_runs == 2
+    assert outcome.exit_code == 0
+
+
+def test_campaign_outcome_accepts_accepted_unavailable_explicit_fields_without_rows() -> None:
+    """Explicit accepted-unavailable fields should keep the distinct nonzero code."""
+    outcome = summarize_campaign_outcome(
+        {
+            "status": "accepted_unavailable_only",
+            "benchmark_success": False,
+            "status_reason": "campaign contains accepted unavailable/excluded rows and no unexpected failed rows",
+            "successful_runs": 1,
+            "accepted_unavailable_runs": 1,
+            "unexpected_failed_runs": 0,
+            "non_success_runs": 1,
+            "total_runs": 2,
+        }
+    )
+
+    assert outcome.status == "accepted_unavailable_only"
+    assert outcome.benchmark_success is False
+    assert outcome.accepted_unavailable_runs == 1
+    assert outcome.unexpected_failed_runs == 0
+    assert outcome.exit_code == 3
+
+
+def test_campaign_outcome_explicit_counts_prefer_unexpected_failure_over_accepted_unavailable() -> (
+    None
+):
+    """Unexpected failed rows must dominate mixed explicit non-success counters."""
+    outcome = summarize_campaign_outcome(
+        {
+            "status": "accepted_unavailable_only",
+            "benchmark_success": False,
+            "successful_runs": 1,
+            "accepted_unavailable_runs": 1,
+            "unexpected_failed_runs": 1,
+            "non_success_runs": 2,
+            "total_runs": 3,
+        }
+    )
+
+    assert outcome.status == "unexpected_failure"
+    assert outcome.accepted_unavailable_runs == 1
+    assert outcome.unexpected_failed_runs == 1
+    assert outcome.non_success_runs == 2
+    assert outcome.exit_code == 2
+
+
+def test_campaign_outcome_unknown_explicit_status_fails_closed() -> None:
+    """Unknown campaign status labels must not silently degrade into success."""
+    outcome = summarize_campaign_outcome(
+        {
+            "status": "mystery_status",
+            "benchmark_success": True,
+            "successful_runs": 2,
+            "non_success_runs": 0,
+            "total_runs": 2,
+        }
+    )
+
+    assert outcome.status == "malformed"
+    assert outcome.benchmark_success is False
+    assert (
+        outcome.status_reason
+        == "campaign result payload has unknown explicit status 'mystery_status'"
+    )
+    assert outcome.exit_code == 2
 
 
 def test_summarize_benchmark_availability_fails_closed_for_malformed_payload() -> None:

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -153,6 +153,14 @@ def test_release_run_fails_closed_on_invalid_manifest(monkeypatch, capsys) -> No
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "invalid_manifest"
     assert payload["benchmark_success"] is False
+    assert payload["campaign_execution_status"] == "failed"
+    assert payload["evidence_status"] == "invalid"
+    assert payload["row_status_summary"] == {
+        "successful_evidence_rows": 0,
+        "accepted_unavailable_rows": 0,
+        "unexpected_failed_rows": 0,
+        "fallback_or_degraded_rows": 0,
+    }
 
 
 def test_release_run_exports_publication_only_after_benchmark_success(
@@ -189,6 +197,14 @@ def test_release_run_exports_publication_only_after_benchmark_success(
             "campaign_root": str(campaign_root),
             "benchmark_success": True,
             "status": "benchmark_success",
+            "campaign_execution_status": "completed",
+            "evidence_status": "valid",
+            "row_status_summary": {
+                "successful_evidence_rows": 1,
+                "accepted_unavailable_rows": 0,
+                "unexpected_failed_rows": 0,
+                "fallback_or_degraded_rows": 0,
+            },
             "status_reason": "all planner rows were benchmark-success",
             "exit_code": 0,
         },
@@ -224,6 +240,8 @@ def test_release_run_exports_publication_only_after_benchmark_success(
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "benchmark_success"
     assert payload["benchmark_success"] is True
+    assert payload["campaign_execution_status"] == "completed"
+    assert payload["evidence_status"] == "valid"
     assert payload["exit_code"] == 0
     assert payload["release_status"] == "ok"
     assert payload["release_benchmark_success"] is True
@@ -272,6 +290,14 @@ def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
             "campaign_root": str(campaign_root),
             "benchmark_success": False,
             "status": "accepted_unavailable_only",
+            "campaign_execution_status": "completed",
+            "evidence_status": "partial",
+            "row_status_summary": {
+                "successful_evidence_rows": 1,
+                "accepted_unavailable_rows": 1,
+                "unexpected_failed_rows": 0,
+                "fallback_or_degraded_rows": 1,
+            },
             "status_reason": (
                 "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
             ),
@@ -319,6 +345,8 @@ def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
         "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
     )
     assert payload["benchmark_success"] is False
+    assert payload["campaign_execution_status"] == "completed"
+    assert payload["evidence_status"] == "partial"
     assert payload["exit_code"] == 3
     assert payload["release_status"] == "accepted_unavailable_only"
     assert payload["release_status_reason"] == (

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -40,6 +40,28 @@ def _make_campaign_tree(tmp_path: Path) -> Path:
     return campaign_root
 
 
+def _manifest_fixture() -> SimpleNamespace:
+    """Return a minimal valid release-manifest stub for CLI tests."""
+    return SimpleNamespace(
+        canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml"),
+        required_artifact_paths=(
+            "campaign_manifest.json",
+            "manifest.json",
+            "run_meta.json",
+            "preflight/validate_config.json",
+            "preflight/preview_scenarios.json",
+            "reports/campaign_summary.json",
+            "reports/campaign_report.md",
+            "reports/matrix_summary.json",
+            "reports/campaign_table.md",
+            "reports/snqi_diagnostics.json",
+        ),
+        release_tag="paper-benchmark-smoke-v0.1.0",
+        doi="10.5281/zenodo.<record-id>",
+        repository_url="https://github.com/ll7/robot_sf_ll7",
+    )
+
+
 def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_path: Path) -> None:
     """Preflight mode should validate the manifest and emit preflight artifact paths."""
     manifest = SimpleNamespace(
@@ -140,24 +162,7 @@ def test_release_run_exports_publication_only_after_benchmark_success(
 ) -> None:
     """Successful releases should export publication bundles after artifact checks pass."""
     campaign_root = _make_campaign_tree(tmp_path)
-    manifest = SimpleNamespace(
-        canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml"),
-        required_artifact_paths=(
-            "campaign_manifest.json",
-            "manifest.json",
-            "run_meta.json",
-            "preflight/validate_config.json",
-            "preflight/preview_scenarios.json",
-            "reports/campaign_summary.json",
-            "reports/campaign_report.md",
-            "reports/matrix_summary.json",
-            "reports/campaign_table.md",
-            "reports/snqi_diagnostics.json",
-        ),
-        release_tag="paper-benchmark-smoke-v0.1.0",
-        doi="10.5281/zenodo.<record-id>",
-        repository_url="https://github.com/ll7/robot_sf_ll7",
-    )
+    manifest = _manifest_fixture()
     sentinel_cfg = object()
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
@@ -183,7 +188,9 @@ def test_release_run_exports_publication_only_after_benchmark_success(
             "campaign_id": "campaign_release",
             "campaign_root": str(campaign_root),
             "benchmark_success": True,
-            "status": "ok",
+            "status": "benchmark_success",
+            "status_reason": "all planner rows were benchmark-success",
+            "exit_code": 0,
         },
     )
     monkeypatch.setattr(
@@ -215,7 +222,111 @@ def test_release_run_exports_publication_only_after_benchmark_success(
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "benchmark_success"
+    assert payload["benchmark_success"] is True
+    assert payload["exit_code"] == 0
+    assert payload["release_status"] == "ok"
+    assert payload["release_benchmark_success"] is True
+    assert payload["release_exit_code"] == 0
+    assert payload["release_status_reason"] == (
+        "release artifacts validated and benchmark campaign was benchmark-success"
+    )
     assert payload["benchmark_success"] is True
     assert payload["publication_bundle"]["archive_path"].endswith("bundle.tar.gz")
     assert (campaign_root / "release" / "release_result.json").exists()
     assert (campaign_root / "release" / "release_manifest.resolved.json").exists()
+
+
+def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    """Accepted-unavailable campaigns should keep campaign semantics in release_result.json."""
+    campaign_root = _make_campaign_tree(tmp_path)
+    manifest = _manifest_fixture()
+    sentinel_cfg = object()
+    publication_called = {"value": False}
+
+    monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
+    monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "validate_release_manifest",
+        lambda manifest, campaign_config=None: {
+            "status": "valid",
+            "problem_count": 0,
+            "problems": [],
+        },
+    )
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "build_resolved_release_manifest",
+        lambda manifest, campaign_config=None: {"release_id": "rid"},
+    )
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "run_campaign",
+        lambda cfg, **kwargs: {
+            "campaign_id": "campaign_release",
+            "campaign_root": str(campaign_root),
+            "benchmark_success": False,
+            "status": "accepted_unavailable_only",
+            "status_reason": (
+                "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+            ),
+            "exit_code": 3,
+            "successful_runs": 1,
+            "accepted_unavailable_runs": 1,
+            "unexpected_failed_runs": 0,
+            "non_success_runs": 1,
+            "total_runs": 2,
+        },
+    )
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "build_release_provenance",
+        lambda manifest, campaign_root, invoked_command: {
+            "benchmark_protocol_version": "0.1.0",
+            "release_id": "rid",
+            "release_tag": manifest.release_tag,
+            "manifest_path": "configs/benchmarks/releases/smoke.yaml",
+            "manifest_sha256": "abc",
+            "canonical_campaign_config": "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+        },
+    )
+
+    def _unexpected_publication(**kwargs) -> dict:
+        publication_called["value"] = True
+        raise AssertionError(
+            "publication bundle must not export for accepted-unavailable campaigns"
+        )
+
+    monkeypatch.setattr(
+        run_benchmark_release, "_build_publication_payload", _unexpected_publication
+    )
+
+    exit_code = run_benchmark_release.main(["--manifest", "manifest.yaml"])
+
+    assert exit_code == 3
+    payload = json.loads(capsys.readouterr().out)
+    release_result = json.loads(
+        (campaign_root / "release" / "release_result.json").read_text(encoding="utf-8")
+    )
+    assert publication_called["value"] is False
+    assert payload["status"] == "accepted_unavailable_only"
+    assert payload["status_reason"] == (
+        "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+    )
+    assert payload["benchmark_success"] is False
+    assert payload["exit_code"] == 3
+    assert payload["release_status"] == "accepted_unavailable_only"
+    assert payload["release_status_reason"] == (
+        "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+    )
+    assert payload["release_benchmark_success"] is False
+    assert payload["release_exit_code"] == 3
+    assert release_result["status"] == "accepted_unavailable_only"
+    assert release_result["exit_code"] == 3
+    assert release_result["release_status"] == "accepted_unavailable_only"
+    assert release_result["release_exit_code"] == 3

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -141,6 +141,13 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
             "campaign_id": "cid",
             "campaign_root": str(tmp_path / "out" / "cid"),
             "benchmark_success": True,
+            "status": "benchmark_success",
+            "status_reason": "all planner rows were benchmark-success",
+            "successful_runs": 1,
+            "accepted_unavailable_runs": 0,
+            "unexpected_failed_runs": 0,
+            "non_success_runs": 0,
+            "total_runs": 1,
         }
 
     monkeypatch.setattr(
@@ -202,4 +209,57 @@ def test_main_run_mode_returns_non_zero_for_non_success_campaign(
     exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
     assert exit_code == 2
     payload = json.loads(capsys.readouterr().out)
+    assert payload["benchmark_success"] is False
+
+
+def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaign(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Accepted-unavailable-only campaigns should stay non-success with exit code 3."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("name: test\n", encoding="utf-8")
+    sentinel_cfg = object()
+
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "load_campaign_config",
+        lambda path: sentinel_cfg if path == config_path else None,
+    )
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "prepare_campaign_preflight",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("prepare_campaign_preflight should not be called in run mode")
+        ),
+    )
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "run_campaign",
+        lambda cfg, **kwargs: (
+            {
+                "campaign_id": "cid",
+                "campaign_root": str(tmp_path / "out" / "cid"),
+                "benchmark_success": False,
+                "status": "accepted_unavailable_only",
+                "status_reason": (
+                    "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
+                ),
+                "successful_runs": 1,
+                "accepted_unavailable_runs": 1,
+                "unexpected_failed_runs": 0,
+                "non_success_runs": 1,
+                "total_runs": 2,
+            }
+            if cfg is sentinel_cfg and isinstance(kwargs.get("invoked_command"), str)
+            else {}
+        ),
+    )
+
+    exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+
+    assert exit_code == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "accepted_unavailable_only"
     assert payload["benchmark_success"] is False

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -142,6 +142,14 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
             "campaign_root": str(tmp_path / "out" / "cid"),
             "benchmark_success": True,
             "status": "benchmark_success",
+            "campaign_execution_status": "completed",
+            "evidence_status": "valid",
+            "row_status_summary": {
+                "successful_evidence_rows": 1,
+                "accepted_unavailable_rows": 0,
+                "unexpected_failed_rows": 0,
+                "fallback_or_degraded_rows": 0,
+            },
             "status_reason": "all planner rows were benchmark-success",
             "successful_runs": 1,
             "accepted_unavailable_runs": 0,
@@ -168,6 +176,8 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
     assert called["preflight"] is False
     payload = json.loads(capsys.readouterr().out)
     assert payload["campaign_id"] == "cid"
+    assert payload["campaign_execution_status"] == "completed"
+    assert payload["evidence_status"] == "valid"
 
 
 def test_main_run_mode_returns_non_zero_for_non_success_campaign(
@@ -200,6 +210,14 @@ def test_main_run_mode_returns_non_zero_for_non_success_campaign(
                 "campaign_id": "cid",
                 "campaign_root": str(tmp_path / "out" / "cid"),
                 "benchmark_success": False,
+                "campaign_execution_status": "failed",
+                "evidence_status": "invalid",
+                "row_status_summary": {
+                    "successful_evidence_rows": 0,
+                    "accepted_unavailable_rows": 0,
+                    "unexpected_failed_rows": 1,
+                    "fallback_or_degraded_rows": 0,
+                },
             }
             if cfg is sentinel_cfg and isinstance(kwargs.get("invoked_command"), str)
             else {}
@@ -210,6 +228,8 @@ def test_main_run_mode_returns_non_zero_for_non_success_campaign(
     assert exit_code == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["benchmark_success"] is False
+    assert payload["campaign_execution_status"] == "failed"
+    assert payload["evidence_status"] == "invalid"
 
 
 def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaign(
@@ -243,6 +263,14 @@ def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaig
                 "campaign_root": str(tmp_path / "out" / "cid"),
                 "benchmark_success": False,
                 "status": "accepted_unavailable_only",
+                "campaign_execution_status": "completed",
+                "evidence_status": "partial",
+                "row_status_summary": {
+                    "successful_evidence_rows": 1,
+                    "accepted_unavailable_rows": 1,
+                    "unexpected_failed_rows": 0,
+                    "fallback_or_degraded_rows": 1,
+                },
                 "status_reason": (
                     "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"
                 ),
@@ -263,3 +291,5 @@ def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaig
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "accepted_unavailable_only"
     assert payload["benchmark_success"] is False
+    assert payload["campaign_execution_status"] == "completed"
+    assert payload["evidence_status"] == "partial"


### PR DESCRIPTION
Closes #1487

## Summary
- add an explicit accepted-unavailable campaign outcome for planned `not_available` / `excluded` rows
- route accepted unavailable rows separately from unexpected failures in camera-ready reporting
- preserve release result campaign fields and expose wrapper status as `release_*` fields
- document and test exit code 3 as fail-closed non-success for accepted-unavailable-only campaigns

## Validation
- `uv run ruff check robot_sf/benchmark/fallback_policy.py robot_sf/benchmark/camera_ready_campaign.py scripts/tools/run_benchmark_release.py scripts/tools/run_camera_ready_benchmark.py tests/benchmark/test_fallback_policy.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py tests/tools/test_run_camera_ready_benchmark.py`
- `uv run ruff format --check robot_sf/benchmark/fallback_policy.py robot_sf/benchmark/camera_ready_campaign.py scripts/tools/run_benchmark_release.py scripts/tools/run_camera_ready_benchmark.py tests/benchmark/test_fallback_policy.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py tests/tools/test_run_camera_ready_benchmark.py`
- `uv run pytest tests/benchmark/test_fallback_policy.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py tests/tools/test_run_camera_ready_benchmark.py -q` - 90 passed
- `PYTEST_NUM_WORKERS=4 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` - 4160 passed, 11 skipped, 9 warnings

## Notes
- Changed-file coverage warnings remained for `robot_sf/benchmark/camera_ready_campaign.py` and `robot_sf/benchmark/fallback_policy.py`, both above the enforced 80% minimum.
- Readiness generated ignored `output/coverage/*`; inspected as disposable local output and left untracked.
- Exit code 3 is intentionally non-success so benchmark automation does not classify accepted unavailability as a successful benchmark run; unexpected failures still use exit code 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for campaign exit codes and status semantics, including how exit code 3 indicates accepted-unavailable-only campaigns.

* **Bug Fixes**
  * Fixed campaign halt behavior to only trigger on actual failures, not when planners are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->