### PR TITLE
docs: standardize issue archetype metadata (#1512)

### DIFF
--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -15,27 +15,32 @@ execution.
 1. Read required inputs:
    - issue templates under `.github/ISSUE_TEMPLATE/`
    - `docs/dev_guide.md`
-   - `docs/context/issue_713_batch_first_issue_workflow.md` (for batch routing).
+   - `docs/context/issue_713_batch_first_issue_workflow.md` (for batch routing)
+   - `docs/context/issue_1512_issue_archetypes.md` (for archetype and evidence-tier convention)
 2. Choose the narrowest matching template (`bug`, `enhancement`, `documentation`, `refactor`,
    `research`, `planner_integration.md`, `benchmark_experiment.md`, fallback
    `issue_default.md`).
 3. Normalize prompt into required fields:
    - goal, scope/non-scope, value/effort/complexity/risk, definition of done, success metrics,
      validation plan.
-4. Create issue:
-   - use GitHub MCP / GitHub app tools when available; use `gh` for deterministic fallback.
+4. Assign an archetype and evidence tier using the convention in
+   `docs/context/issue_1512_issue_archetypes.md`. Include the archetype metadata block in
+   the issue body. Use only the canonical values from that note. When the archetype is unclear,
+   default to `archetype: workflow` with `evidence_tier: idea` and note the assumption.
+5. Create issue:
+   - use GitHub MCP / GitHub app tools when available; use `gh` for deterministic fallback
    - `gh issue create --title "<title>" --body-file <body.md> --template <template> --label "<labels>"`
-   - prefer existing labels; avoid inventing taxonomy.
+   - prefer existing labels; avoid inventing taxonomy
    - prefer GitHub MCP / GitHub app tools for interactive issue creation when available; keep `gh`
-     for scripted or fallback paths.
-5. Project routing:
-   - use `gh project item-add` when the CLI route is the active Project #5 write path.
-   - use `gh project item-edit` for explicit field updates when the CLI route is active.
+     for scripted or fallback paths
+6. Project routing:
+   - use `gh project item-add` when the CLI route is the active Project #5 write path
+   - use `gh project item-edit` for explicit field updates when the CLI route is active
    - add issue to Project #5 and update only expected fields (`Priority`, `Expected Duration in Hours`,
-     `Reviewed`) using existing field/schema IDs.
-6. Batch discipline:
-   - for multiple issues, perform body/label cleanup first, then bulk Project #5 writes, then one sync.
-   - if API is rate-limited, record pending project mutations and resume later.
+     `Reviewed`) using existing field/schema IDs
+7. Batch discipline:
+   - for multiple issues, perform body/label cleanup first, then bulk Project #5 writes, then one sync
+   - if API is rate-limited, record pending project mutations and resume later
 
 ## Guardrails
 

--- a/.github/ISSUE_TEMPLATE/issue_default.md
+++ b/.github/ISSUE_TEMPLATE/issue_default.md
@@ -11,6 +11,15 @@ assignees: []
 **Task type**
 - bugfix / feature / refactor / experiment / docs / other
 
+## Archetype Metadata
+
+<!-- Allowed values: docs/context/issue_1512_issue_archetypes.md -->
+```yaml
+archetype:
+evidence_tier:
+linked_policy:
+```
+
 **Context**
 <!-- What should change and why -->
 

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -152,6 +152,8 @@ knowledge, not every transient iteration detail.
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
 * Issue #1294 seed-sensitivity perturbations:
   [issue_1294_seed_sensitivity_perturbations.md](issue_1294_seed_sensitivity_perturbations.md)
+* Issue archetypes and evidence tiers:
+  [issue_1512_issue_archetypes.md](issue_1512_issue_archetypes.md)
 * Artifact evidence vocabulary:
   [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md)
 * PR first-pass review audit:

--- a/docs/context/issue_1512_issue_archetypes.md
+++ b/docs/context/issue_1512_issue_archetypes.md
@@ -1,0 +1,116 @@
+# Issue #1512 Issue Archetypes and Evidence Tiers
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1512>
+
+## Goal
+
+Define a short canonical convention for issue metadata so Robot SF issues can declare what kind of
+work they represent and what evidence bar they target without repeating long policy text.
+
+This note is a **classification convention only**. It does not change benchmark semantics, metrics,
+seeds, Project fields, or priority labels.
+
+## Canonical Archetype Values
+
+Every issue should declare exactly one `archetype` from this set:
+
+| Archetype | Use when the issue is primarily about |
+|---|---|
+| `blocked-asset` | A missing model, dataset, checkpoint, map, credential-free dependency, or other prerequisite that blocks progress |
+| `preflight` | Freezing inputs, validating setup, or preparing a run before broader execution |
+| `slurm-execution` | Launching or tracking the actual scheduled run on SLURM |
+| `analysis` | Interpreting existing outputs, metrics, logs, or campaign artifacts |
+| `synthesis` | Producing a report, paper-facing summary, or cross-run conclusion |
+| `workflow` | Agent workflow, automation, scripting, CI, issue process, or repo tooling changes |
+| `docs` | Documentation-only contract or guidance updates |
+| `benchmark-campaign` | A benchmark campaign intended to produce benchmark evidence |
+| `training-campaign` | A training campaign intended to produce model or training evidence |
+
+## Canonical Evidence-Tier Values
+
+Every issue should declare exactly one `evidence_tier` from this set:
+
+| Evidence tier | Meaning |
+|---|---|
+| `idea` | Early proposal or scoping work with no execution evidence yet |
+| `launch_packet` | Inputs are frozen enough to hand off or submit, but this is not execution evidence |
+| `preflight_valid` | Preconditions were checked and passed for the intended next execution step |
+| `smoke` | Minimal local or targeted path proving the surface works at a basic level |
+| `nominal` | Standard execution evidence for the intended path |
+| `stress` | Evidence from harsher scenarios, uncertainty probes, or adversarial conditions |
+| `full_matrix` | Full planned scenario/config matrix completed |
+| `analysis_only` | Existing outputs were analyzed without producing new execution evidence |
+| `synthesis` | Evidence is a synthesis of prior durable inputs rather than a new run |
+| `paper_grade` | Paper-facing, benchmark-success, or release-grade evidence |
+| `blocked` | The requested evidence could not be produced because a prerequisite is missing or invalid |
+
+## Short Metadata Block
+
+Place this block near the top of the issue body:
+
+```yaml
+archetype: preflight
+evidence_tier: launch_packet
+linked_policy:
+  - docs/context/issue_691_benchmark_fallback_policy.md
+  - docs/context/artifact_evidence_vocabulary.md
+```
+
+Use repository-relative paths in `linked_policy`. Keep the block short; issue-specific details belong
+in the body sections below it.
+
+## Concise Issue Skeleton
+
+```markdown
+## Question / Goal
+## Current status
+## Preconditions
+## Frozen inputs
+## Execution or analysis task
+## Evidence outputs
+## Accept / revise / reject
+## Non-evidence / failure modes
+## Next issue unlocked
+```
+
+## Distinguishing Common Cases
+
+Use the requested evidence-tier values to separate commonly conflated issue types:
+
+| Situation | Archetype | Evidence tier | Interpretation |
+|---|---|---|---|
+| Launch packet prepared for later execution | `preflight` | `launch_packet` | Inputs are ready for handoff/submission, but no benchmark or training claim is established yet |
+| Smoke run or setup probe | `preflight` or `workflow` | `smoke` | Minimal path check only; useful for interface proof, not campaign-strength evidence |
+| Fallback or degraded row observed during review | `analysis` | `analysis_only` | Record the limitation explicitly; this is not nominal success evidence |
+| Execution blocked by missing dependency or asset | `blocked-asset` | `blocked` | The issue documents why evidence could not be produced yet |
+| Standard scheduled campaign run | `slurm-execution`, `benchmark-campaign`, or `training-campaign` | `nominal`, `stress`, or `full_matrix` | Execution evidence exists and should match the claimed campaign depth |
+| Paper-facing benchmark result or manuscript table | `benchmark-campaign` or `synthesis` | `paper_grade` | Durable evidence and fail-closed benchmark interpretation are required |
+
+Launch packets, smoke runs, fallback/degraded rows, and paper-grade claims must not share the same
+`evidence_tier` value. In particular, fallback or degraded outcomes are never `paper_grade`.
+
+## Linked Canonical Policies
+
+This convention links to, and does not replace, the canonical policy notes:
+
+- **Fail-closed benchmark fallback**:
+  [issue_691_benchmark_fallback_policy.md](issue_691_benchmark_fallback_policy.md)
+- **Durable artifact vocabulary**:
+  [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md)
+- **Durable artifact reference audit**:
+  [issue_1053_durable_artifact_references.md](issue_1053_durable_artifact_references.md)
+- **Evidence bundle policy**: [evidence/README.md](evidence/README.md)
+
+## Workflow Integration
+
+- `.agents/skills/gh-issue-creator/SKILL.md` should read this note and emit only the canonical
+  `archetype` and `evidence_tier` values above.
+- When the prompt is underspecified, default conservatively to `archetype: workflow` and
+  `evidence_tier: idea`, then state the assumption explicitly.
+
+## Scope Boundary
+
+- **In scope**: canonical enum-like values, metadata block, concise issue skeleton, links to
+  canonical policies, and issue-creation workflow integration.
+- **Out of scope**: rewriting old issues, changing benchmark semantics, modifying Project #5 fields,
+  or enforcing these values automatically in GitHub.


### PR DESCRIPTION
## Summary
Adds the #1512 issue archetype and evidence-tier convention, then wires it into the default issue template and `gh-issue-creator` workflow.

## Linked Issues
- Closes #1512
- Relates to #1513

## What Changed
- Added `docs/context/issue_1512_issue_archetypes.md` with the canonical archetype values and `evidence_tier` values requested in #1512.
- Linked the convention from `docs/context/README.md` for discoverability.
- Added an `Archetype Metadata` skeleton to `.github/ISSUE_TEMPLATE/issue_default.md`.
- Updated `.agents/skills/gh-issue-creator/SKILL.md` to read the convention and emit only canonical metadata values.

## Why It Matters
- Added value: future benchmark, training, data, analysis, synthesis, workflow, and docs issues can declare their work/evidence class without repeating long policy prose.
- Expected impact: issue creation becomes more machine-readable while preserving current Project #5 labels and fields.
- Why this is worth merging now: several recent backlog issues already carry similar metadata informally; this gives agents and reviewers one short canonical surface.

## Validation / Proof
- `git diff --check origin/main...HEAD` — passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed for 4 changed files.
- `uv run python scripts/dev/check_skills.py` — validated 34 skills and README coverage.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed twice. Latest committed-head run: 4155 passed, 10 skipped, 8 warnings in 289.18s.
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main` then `status` — fresh for `0fcc5ee81e8ab24d2e4908d3b6e2f2b557dce5b5`.
- Independent delegated review passes: OpenCode Go implementation, Copilot contract repair, Gemini final diff review.

## Risks / Rollout
- Compatibility risks: low; docs/template/skill-only change, no benchmark semantics or Project #5 fields changed.
- Failure modes: contributors or agents may still omit metadata outside `issue_default.md` and `gh-issue-creator` until validation/triage workflows are extended.
- Rollback or fallback plan: revert the docs/template/skill commit; existing issue creation remains usable without the new metadata block.

## Docs / Provenance
- Updated docs: `docs/context/issue_1512_issue_archetypes.md`, `docs/context/README.md`.
- Relevant policy links: fail-closed benchmark fallback, durable artifact vocabulary, durable artifact references, evidence bundle policy.
- Artifact decision: `output/coverage/*` and `output/validation/pr_ready/*` are local ignored validation artifacts; no generated output is committed or required as durable evidence.

## Follow-Up Issues
- Deferred work: metadata enforcement/preservation across triage and validation workflows.
- Issues opened for follow-up: #1513.

## Reviewer Notes
- Verify that the canonical archetype and evidence-tier values match #1512 exactly.
- The branch intentionally does not rewrite existing issues or add machine-readable enforcement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized archetype and evidence-tier metadata fields to GitHub issues for improved categorization and classification.

* **Documentation**
  * Established canonical issue metadata conventions with predefined archetype values and evidence-tier classifications.
  * Updated issue creation workflow to enforce consistent metadata assignment with fallback defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->