### PR TITLE
fix: centralize ORCA preflight guard (#1527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the issue-1527 ORCA benchmark preflight gap by moving the `rvo2` fail-fast check into the
+  shared camera-ready campaign layer, so direct `prepare_campaign_preflight(...)`,
+  `run_campaign(...)`, and wrapper entrypoints such as `scripts/tools/run_benchmark_release.py`
+  cannot bypass the actionable `uv sync --extra orca` / `uv sync --all-extras` guidance for
+  enabled ORCA-dependent rows.
 * Fixed the README Zenodo DOI header by replacing the fragile badge image with a plain-text DOI
   link while preserving the canonical `https://doi.org/10.5281/zenodo.19563812` target.
 * Fixed the crowd-only Gymnasium environment contract so `CrowdSimEnv` keeps a stable

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -42,6 +42,7 @@ from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,
 )
+from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight
 from robot_sf.benchmark.runner import run_batch
 from robot_sf.benchmark.seed_variance import (
     build_seed_episode_rows,
@@ -2241,8 +2242,12 @@ def prepare_campaign_preflight(
 
     Returns:
         Paths and metadata required by preflight-only workflows and full runs.
+
+    Raises:
+        SystemExit: When enabled ORCA-dependent planners require ``rvo2`` but it is not importable.
     """
     _validate_campaign_config(cfg)
+    check_orca_rvo2_preflight(cfg)
     ensure_canonical_tree(categories=("benchmarks",))
     campaign_id = _resolve_campaign_id(cfg, label=label, campaign_id=campaign_id)
     base_dir = (
@@ -3128,12 +3133,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
 
     Returns:
         Campaign execution summary with output paths and high-level counters.
-    """
-    snqi_weights = load_optional_json(str(cfg.snqi_weights_path) if cfg.snqi_weights_path else None)
-    snqi_baseline = load_optional_json(
-        str(cfg.snqi_baseline_path) if cfg.snqi_baseline_path else None
-    )
 
+    Raises:
+        SystemExit: When enabled ORCA-dependent planners require ``rvo2`` but it is not importable.
+    """
     start = time.perf_counter()
     prepared = prepare_campaign_preflight(
         cfg,
@@ -3162,6 +3165,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     scenario_hash = str(prepared["scenario_hash"])
     git_meta = dict(prepared["git_meta"])
     config_hash = str(prepared["config_hash"])
+    snqi_weights = load_optional_json(str(cfg.snqi_weights_path) if cfg.snqi_weights_path else None)
+    snqi_baseline = load_optional_json(
+        str(cfg.snqi_baseline_path) if cfg.snqi_baseline_path else None
+    )
 
     runs_dir = campaign_root / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/tools/run_camera_ready_benchmark.py
+++ b/scripts/tools/run_camera_ready_benchmark.py
@@ -24,7 +24,6 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
 )
 from robot_sf.benchmark.fallback_policy import campaign_exit_code
-from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -92,7 +91,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger.add(sys.stderr, level=args.log_level)
 
     cfg = load_campaign_config(args.config)
-    check_orca_rvo2_preflight(cfg)
     invoked_command = shlex.join([sys.executable, str(Path(__file__)), *raw_argv])
     if args.mode == "preflight":
         prepared = prepare_campaign_preflight(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import sys
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ import pytest
 import yaml
 from loguru import logger
 
+import robot_sf.benchmark.camera_ready_campaign as camera_ready_campaign_module
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
 from robot_sf.benchmark.camera_ready_campaign import (
     DEFAULT_SEED_SETS_PATH,
@@ -2151,6 +2153,58 @@ def test_prepare_campaign_preflight_validates_campaign_config(tmp_path: Path) ->
     )
     with pytest.raises(ValueError, match="paper_profile_version"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="invalid")
+
+
+def test_prepare_campaign_preflight_checks_orca_rvo2_before_loading_scenarios(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Direct preflight calls fail before scenario loading when enabled ORCA rows lack rvo2."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    cfg = CampaignConfig(
+        name="orca_preflight_guard",
+        scenario_matrix_path=scenario_path,
+        planners=(PlannerSpec(key="orca", algo="orca"),),
+        seed_policy=SeedPolicy(),
+    )
+
+    monkeypatch.setitem(sys.modules, "rvo2", None)
+    monkeypatch.setattr(
+        camera_ready_campaign_module,
+        "_load_campaign_scenarios",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("_load_campaign_scenarios should not run before ORCA preflight")
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="rvo2"):
+        prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="orca")
+
+
+def test_run_campaign_checks_orca_rvo2_before_loading_optional_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Direct campaign runs fail before optional JSON loading when ORCA rows lack rvo2."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    cfg = CampaignConfig(
+        name="orca_run_guard",
+        scenario_matrix_path=scenario_path,
+        planners=(PlannerSpec(key="orca", algo="orca"),),
+        seed_policy=SeedPolicy(),
+    )
+
+    monkeypatch.setitem(sys.modules, "rvo2", None)
+    monkeypatch.setattr(
+        camera_ready_campaign_module,
+        "load_optional_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("load_optional_json should not run before ORCA preflight")
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="rvo2"):
+        run_campaign(cfg, output_root=tmp_path / "out", label="orca")
 
 
 def test_run_campaign_sanitizes_run_directory_keys(tmp_path: Path, monkeypatch) -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -2169,12 +2169,14 @@ def test_prepare_campaign_preflight_checks_orca_rvo2_before_loading_scenarios(
     )
 
     monkeypatch.setitem(sys.modules, "rvo2", None)
+
+    def fail_if_scenarios_load(*_args, **_kwargs):
+        raise AssertionError("_load_campaign_scenarios should not run before ORCA preflight")
+
     monkeypatch.setattr(
         camera_ready_campaign_module,
         "_load_campaign_scenarios",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("_load_campaign_scenarios should not run before ORCA preflight")
-        ),
+        fail_if_scenarios_load,
     )
 
     with pytest.raises(SystemExit, match="rvo2"):
@@ -2195,12 +2197,14 @@ def test_run_campaign_checks_orca_rvo2_before_loading_optional_artifacts(
     )
 
     monkeypatch.setitem(sys.modules, "rvo2", None)
+
+    def fail_if_optional_json_loads(*_args, **_kwargs):
+        raise AssertionError("load_optional_json should not run before ORCA preflight")
+
     monkeypatch.setattr(
         camera_ready_campaign_module,
         "load_optional_json",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("load_optional_json should not run before ORCA preflight")
-        ),
+        fail_if_optional_json_loads,
     )
 
     with pytest.raises(SystemExit, match="rvo2"):

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from robot_sf.benchmark.camera_ready_campaign import CampaignConfig, PlannerSpec, SeedPolicy
 from scripts.tools import run_benchmark_release
 
 
@@ -358,3 +362,39 @@ def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
     assert release_result["exit_code"] == 3
     assert release_result["release_status"] == "accepted_unavailable_only"
     assert release_result["release_exit_code"] == 3
+
+
+def test_release_preflight_fails_closed_when_orca_rvo2_missing(tmp_path: Path, monkeypatch) -> None:
+    """Preflight mode exits before execution when enabled ORCA planners lack rvo2."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    cfg = CampaignConfig(
+        name="orca_release_guard",
+        scenario_matrix_path=scenario_path,
+        planners=(PlannerSpec(key="orca", algo="orca"),),
+        seed_policy=SeedPolicy(),
+    )
+    manifest = SimpleNamespace(
+        canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml")
+    )
+
+    monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
+    monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: cfg)
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "validate_release_manifest",
+        lambda manifest, campaign_config=None: {
+            "status": "valid",
+            "problem_count": 0,
+            "problems": [],
+        },
+    )
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "build_resolved_release_manifest",
+        lambda manifest, campaign_config=None: {"release_id": "rid"},
+    )
+    monkeypatch.setitem(sys.modules, "rvo2", None)
+
+    with pytest.raises(SystemExit, match="rvo2"):
+        run_benchmark_release.main(["--manifest", "manifest.yaml", "--mode", "preflight"])

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -32,11 +32,6 @@ def _rvo2_missing() -> Generator[None, None, None]:
             sys.modules["rvo2"] = saved
 
 
-def _nop_preflight(cfg: object) -> None:
-    """No-op replacement for check_orca_rvo2_preflight."""
-    del cfg
-
-
 def _write_config(path: Path, *, algo: str, key: str | None = None) -> None:
     """Write a minimal campaign config with a resolvable scenario matrix path."""
     (path.parent / "scenarios.yaml").write_text("scenarios: []\n", encoding="utf-8")
@@ -117,7 +112,6 @@ def test_main_preflight_mode_emits_preflight_payload(
     monkeypatch.setattr(
         run_camera_ready_benchmark, "load_campaign_config", _fake_load_campaign_config
     )
-    monkeypatch.setattr(run_camera_ready_benchmark, "check_orca_rvo2_preflight", _nop_preflight)
     monkeypatch.setattr(
         run_camera_ready_benchmark,
         "prepare_campaign_preflight",
@@ -201,7 +195,6 @@ def test_main_run_mode_uses_run_campaign(tmp_path: Path, monkeypatch, capsys) ->
     monkeypatch.setattr(
         run_camera_ready_benchmark, "load_campaign_config", _fake_load_campaign_config
     )
-    monkeypatch.setattr(run_camera_ready_benchmark, "check_orca_rvo2_preflight", _nop_preflight)
     monkeypatch.setattr(
         run_camera_ready_benchmark,
         "prepare_campaign_preflight",
@@ -236,7 +229,6 @@ def test_main_run_mode_returns_non_zero_for_non_success_campaign(
         "load_campaign_config",
         lambda path: sentinel_cfg if path == config_path else None,
     )
-    monkeypatch.setattr(run_camera_ready_benchmark, "check_orca_rvo2_preflight", _nop_preflight)
     monkeypatch.setattr(
         run_camera_ready_benchmark,
         "prepare_campaign_preflight",
@@ -289,7 +281,6 @@ def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaig
         "load_campaign_config",
         lambda path: sentinel_cfg if path == config_path else None,
     )
-    monkeypatch.setattr(run_camera_ready_benchmark, "check_orca_rvo2_preflight", _nop_preflight)
     monkeypatch.setattr(
         run_camera_ready_benchmark,
         "prepare_campaign_preflight",
@@ -341,29 +332,15 @@ def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaig
 class TestRunModeOrcaPreflightIntegration:
     """Integration tests that the CLI runner calls the ORCA-rvo2 preflight guard."""
 
-    def test_run_mode_aborts_when_orca_config_rvo2_missing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_run_mode_aborts_when_orca_config_rvo2_missing(self, tmp_path: Path) -> None:
         """Run mode aborts before run_campaign when ORCA config has rvo2 missing."""
         config_path = tmp_path / "config.yaml"
         _write_config(config_path, algo="orca")
-        run_called = False
-
-        def _fake_run_campaign(*args, **kwargs):
-            del args, kwargs
-            nonlocal run_called
-            run_called = True
-
-        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run_campaign)
-        monkeypatch.setattr(
-            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_run_campaign
-        )
 
         with _rvo2_missing():
             with pytest.raises(SystemExit) as exc_info:
                 run_camera_ready_benchmark.main(["--config", str(config_path)])
             assert "rvo2" in str(exc_info.value).lower()
-        assert not run_called
 
     def test_run_mode_passes_when_no_orca_in_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
Centralizes the ORCA/rvo2 preflight in the shared camera-ready campaign preflight layer so direct `prepare_campaign_preflight(...)`, `run_campaign(...)`, and release/CLI wrappers inherit the same fail-fast guard.

## Linked Issues
- Closes #1527
- Follow-up: #1530

## What Changed
- Imports `check_orca_rvo2_preflight` into `robot_sf.benchmark.camera_ready_campaign` and runs it from `prepare_campaign_preflight(...)` after structural config validation.
- Removes the duplicate CLI-level ORCA preflight call from `scripts/tools/run_camera_ready_benchmark.py`.
- Moves optional SNQI JSON loading until after shared preflight in `run_campaign(...)`, keeping ORCA dependency failures ahead of expensive or unrelated setup.
- Adds direct regression coverage for shared campaign APIs and release-wrapper preflight behavior when `rvo2` is missing.
- Records the issue-1527 fix in `CHANGELOG.md`.

## Why It Matters
- Added value: benchmark-facing ORCA rows can no longer bypass the dependency guard through lower-level campaign APIs.
- Expected impact: missing/broken `rvo2` fails closed with actionable `uv sync --extra orca` / `uv sync --all-extras` guidance before benchmark artifacts are produced.
- Why now: this closes the residual bypass risk left after the initial ORCA preflight helper landed.

## Validation / Proof
- `uv run pytest tests/benchmark/test_orca_preflight.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_camera_ready_benchmark.py tests/tools/test_run_benchmark_release.py` -> 118 passed.
- `git diff --check origin/main...HEAD` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4215 passed, 10 skipped, 8 warnings. Changed-file coverage warning only: `robot_sf/benchmark/camera_ready_campaign.py` at 90.4% vs the 100% goal.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` -> fresh for `87bdaac54f93cefdfb29fec3c7a34c22d6f4150d`.

## Risks / Rollout
- Compatibility risks: ORCA-enabled campaign preflight now requires `rvo2` from the shared API, not only named wrappers. This is intentional for benchmark-strength evidence.
- Failure modes: structurally invalid configs still fail validation before optional dependency checks; benchmark fallback/degraded ORCA execution remains non-success.
- Rollback or fallback plan: revert the single commit to restore wrapper-only preflight behavior.

## Docs / Provenance
- Updated docs: `CHANGELOG.md` and the `run_campaign` / `prepare_campaign_preflight` docstrings.
- Relevant design or provenance notes: delegated worker self-review note recorded locally under `.git/codex-agent-runs/notes/inbox/`.
- Artifact decision: generated `output/coverage/**` and `output/validation/pr_ready/**` files are ignored, disposable local validation artifacts and are not committed.

## Follow-Up Issues
- #1530 audits optional planner dependency preflights beyond ORCA/rvo2 without broadening this PR.

## Reviewer Notes
- Please check that centralizing the guard in `prepare_campaign_preflight(...)` is the desired API boundary for both preflight-only and full campaign runs.
- OpenCode Go independently reviewed the diff and found no blocking issues; its low-severity docstring/test suggestions are included in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ORCA benchmark dependency validation by consolidating preflight checks across all benchmark entry points. Users will now consistently receive guidance when required dependencies are missing, preventing accidental bypass of necessary setup instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## ORCA Entrypoint Inventory

- `scripts/tools/run_camera_ready_benchmark.py`: `guarded_by_camera_ready_runner`; it delegates to the shared campaign preflight and no longer needs a duplicate script-level guard.
- `scripts/tools/run_benchmark_release.py`: `guarded_by_camera_ready_runner`; release validation reaches `prepare_campaign_preflight(...)`, with regression coverage for missing `rvo2`.
- `robot_sf.benchmark.camera_ready_campaign.prepare_campaign_preflight(...)`: `needs_orca_preflight`; this PR centralizes the guard here for direct preflight callers.
- `robot_sf.benchmark.camera_ready_campaign.run_campaign(...)`: `guarded_by_camera_ready_runner`; it calls shared preflight before SNQI loading or campaign execution.
- Lower-level planner construction and exploratory probes: `non_benchmark_or_probe_only`; intentionally left to #1530 unless they load enabled ORCA benchmark rows.

This preserves the #1527 decision to guard evidence-producing campaign paths without moving optional dependency policy into low-level planner construction.
