### PR TITLE
feat: validate issue archetype metadata (#1513)

### DIFF
--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -28,6 +28,9 @@ writes when available.
 1. Read template contract files and run
    `uv run python scripts/tools/issue_template_audit.py` for bulk or targeted audits.
    - For batch routing, preserve `docs/context/issue_713_batch_first_issue_workflow.md`.
+   - Preserve the `## Archetype Metadata` YAML block from
+    `docs/context/issue_1512_issue_archetypes.md`; repair or flag missing keys and invalid
+    `archetype` / `evidence_tier` values conservatively instead of inventing replacements.
 2. Load issue body and metadata with GitHub MCP / GitHub app tools when available, or `gh issue view`.
 3. Compare required sections (problem statement, scope/non-goals, estimates, risks, acceptance, validation, metadata).
 4. If gaps are limited and obvious:
@@ -43,6 +46,8 @@ writes when available.
 
 - Preserve original issue content and decisions; avoid speculative rewrite.
 - Use `decision-required` instead of guessing when scope or problem statement is missing.
+- Preserve the metadata block even when values are incomplete; flag malformed YAML or invalid
+  canonical values instead of deleting or broad-rewriting the issue body.
 - Keep route/metadata cleanup separate from body repair.
 
 ## Output

--- a/.agents/skills/issue-contract-maintainer/SKILL.md
+++ b/.agents/skills/issue-contract-maintainer/SKILL.md
@@ -30,6 +30,11 @@ Use this skill when an issue needs contract maintenance before implementation: t
 - `clarify-ambiguity`: identify problem, scope, solution, or validation ambiguity and post concise options with pros/cons.
 - `apply-user-decision`: update issue text, labels, and Project #5 state after the user resolves a readiness question.
 
+For `audit-template-compliance`, treat the `## Archetype Metadata` YAML block as part of the issue
+contract. Preserve the block, validate `archetype` and `evidence_tier` against
+`docs/context/issue_1512_issue_archetypes.md`, require a `linked_policy` key to remain present, and
+flag malformed YAML or invalid values instead of inventing replacements.
+
 ## Workflow
 
 1. Read the issue, labels, linked PRs, recent comments, and Project #5 fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated the issue-template audit flow for issue-1513 so `scripts/tools/issue_template_audit.py`
+  now parses the `## Archetype Metadata` YAML block, flags invalid canonical `archetype` and
+  `evidence_tier` values plus malformed metadata, reports those findings alongside the existing
+  section audit, and aligns the issue-audit skill docs with the bounded metadata triage behavior.
 * Implemented the issue-1187 render-helper slice: `capture_frames()` now samples real RGB frame
   buffers or one direct render result, `generate_video_contact_sheet.py` writes deterministic PNG
   contact sheets from episode frame metadata, and the helper catalog documents the supported

--- a/scripts/tools/issue_template_audit.py
+++ b/scripts/tools/issue_template_audit.py
@@ -75,7 +75,10 @@ SECTION_PLACEHOLDERS: dict[str, str] = {
 
 HEADING_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$", re.MULTILINE)
 METADATA_SECTION_TITLE = "Archetype Metadata"
-METADATA_YAML_RE = re.compile(r"```yaml\s*\r?\n(?P<block>.*?)\r?\n```", re.DOTALL)
+METADATA_YAML_RE = re.compile(
+    r"^[ \t]*```ya?ml\s*\r?\n(?P<block>.*?)(?:\r?\n)?^[ \t]*```",
+    re.DOTALL | re.IGNORECASE | re.MULTILINE,
+)
 ARCHETYPE_METADATA_REQUIRED_KEYS: tuple[str, ...] = (
     "archetype",
     "evidence_tier",
@@ -125,7 +128,7 @@ class ArchetypeMetadataAuditResult:
     block_present: bool
     parsed_metadata: dict[str, object] | None
     missing_keys: tuple[str, ...]
-    invalid_values: dict[str, str]
+    invalid_values: dict[str, object]
     parse_error: str | None
 
     @property
@@ -245,21 +248,21 @@ def audit_archetype_metadata(body: str) -> ArchetypeMetadataAuditResult:
         )
 
     missing_keys = tuple(key for key in ARCHETYPE_METADATA_REQUIRED_KEYS if key not in parsed)
-    invalid_values: dict[str, str] = {}
+    invalid_values: dict[str, object] = {}
 
     if "archetype" in parsed:
         archetype_finding = _validate_canonical_value(
             "archetype", parsed.get("archetype"), VALID_ARCHETYPES
         )
         if archetype_finding is not None:
-            invalid_values["archetype"] = str(parsed.get("archetype"))
+            invalid_values["archetype"] = parsed.get("archetype")
 
     if "evidence_tier" in parsed:
         evidence_tier_finding = _validate_canonical_value(
             "evidence_tier", parsed.get("evidence_tier"), VALID_EVIDENCE_TIERS
         )
         if evidence_tier_finding is not None:
-            invalid_values["evidence_tier"] = str(parsed.get("evidence_tier"))
+            invalid_values["evidence_tier"] = parsed.get("evidence_tier")
 
     return ArchetypeMetadataAuditResult(
         heading_present=True,

--- a/scripts/tools/issue_template_audit.py
+++ b/scripts/tools/issue_template_audit.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -72,6 +74,37 @@ SECTION_PLACEHOLDERS: dict[str, str] = {
 }
 
 HEADING_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$", re.MULTILINE)
+METADATA_SECTION_TITLE = "Archetype Metadata"
+METADATA_YAML_RE = re.compile(r"```yaml\s*\r?\n(?P<block>.*?)\r?\n```", re.DOTALL)
+ARCHETYPE_METADATA_REQUIRED_KEYS: tuple[str, ...] = (
+    "archetype",
+    "evidence_tier",
+    "linked_policy",
+)
+VALID_ARCHETYPES: tuple[str, ...] = (
+    "blocked-asset",
+    "preflight",
+    "slurm-execution",
+    "analysis",
+    "synthesis",
+    "workflow",
+    "docs",
+    "benchmark-campaign",
+    "training-campaign",
+)
+VALID_EVIDENCE_TIERS: tuple[str, ...] = (
+    "idea",
+    "launch_packet",
+    "preflight_valid",
+    "smoke",
+    "nominal",
+    "stress",
+    "full_matrix",
+    "analysis_only",
+    "synthesis",
+    "paper_grade",
+    "blocked",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +114,38 @@ class IssueAuditResult:
     present_sections: tuple[str, ...]
     missing_sections: tuple[str, ...]
     repaired_body: str
+    metadata: ArchetypeMetadataAuditResult
+
+
+@dataclass(frozen=True, slots=True)
+class ArchetypeMetadataAuditResult:
+    """Structured output for the optional archetype metadata block."""
+
+    heading_present: bool
+    block_present: bool
+    parsed_metadata: dict[str, object] | None
+    missing_keys: tuple[str, ...]
+    invalid_values: dict[str, str]
+    parse_error: str | None
+
+    @property
+    def findings(self) -> tuple[str, ...]:
+        """Human-readable findings derived from the structural audit fields."""
+        if not self.heading_present:
+            return ("Missing '## Archetype Metadata' section.",)
+        if not self.block_present:
+            return ("Missing YAML code block under '## Archetype Metadata'.",)
+        if self.parse_error is not None:
+            return (f"Malformed archetype metadata YAML: {self.parse_error}",)
+        result: list[str] = []
+        if self.missing_keys:
+            result.append("Missing archetype metadata keys: " + ", ".join(self.missing_keys))
+        for key, value in self.invalid_values.items():
+            allowed = VALID_ARCHETYPES if key == "archetype" else VALID_EVIDENCE_TIERS
+            result.append(
+                f"Invalid {key!r} value {value!r}; expected one of: " + ", ".join(allowed)
+            )
+        return tuple(result)
 
 
 def normalize_section_title(raw_title: str) -> str:
@@ -106,6 +171,104 @@ def extract_present_sections(body: str) -> tuple[str, ...]:
             found.append(canonical)
             seen.add(canonical)
     return tuple(found)
+
+
+def _extract_named_section(body: str, expected_title: str) -> str | None:
+    """Return the raw content under a named `##` heading, if present."""
+
+    for match in HEADING_RE.finditer(body):
+        if normalize_section_title(match.group("title")) != expected_title:
+            continue
+        section_start = match.end()
+        next_heading = HEADING_RE.search(body, section_start)
+        section_end = next_heading.start() if next_heading is not None else len(body)
+        return body[section_start:section_end]
+    return None
+
+
+def _validate_canonical_value(
+    key: str, value: object, allowed_values: tuple[str, ...]
+) -> str | None:
+    """Return a finding when a metadata value is absent from the canonical set."""
+
+    if not isinstance(value, str) or value not in allowed_values:
+        return f"Invalid {key!r} value {value!r}; expected one of: " + ", ".join(allowed_values)
+    return None
+
+
+def audit_archetype_metadata(body: str) -> ArchetypeMetadataAuditResult:
+    """Audit the optional issue archetype metadata block near the top of the body."""
+
+    section = _extract_named_section(body, METADATA_SECTION_TITLE)
+    if section is None:
+        return ArchetypeMetadataAuditResult(
+            heading_present=False,
+            block_present=False,
+            parsed_metadata=None,
+            missing_keys=ARCHETYPE_METADATA_REQUIRED_KEYS,
+            invalid_values={},
+            parse_error=None,
+        )
+
+    block_match = METADATA_YAML_RE.search(section)
+    if block_match is None:
+        return ArchetypeMetadataAuditResult(
+            heading_present=True,
+            block_present=False,
+            parsed_metadata=None,
+            missing_keys=ARCHETYPE_METADATA_REQUIRED_KEYS,
+            invalid_values={},
+            parse_error=None,
+        )
+
+    try:
+        parsed = yaml.safe_load(block_match.group("block"))
+    except yaml.YAMLError as exc:
+        return ArchetypeMetadataAuditResult(
+            heading_present=True,
+            block_present=True,
+            parsed_metadata=None,
+            missing_keys=(),
+            invalid_values={},
+            parse_error=str(exc),
+        )
+
+    if not isinstance(parsed, dict):
+        message = "Archetype metadata YAML must decode to a mapping."
+        return ArchetypeMetadataAuditResult(
+            heading_present=True,
+            block_present=True,
+            parsed_metadata=None,
+            missing_keys=(),
+            invalid_values={},
+            parse_error=message,
+        )
+
+    missing_keys = tuple(key for key in ARCHETYPE_METADATA_REQUIRED_KEYS if key not in parsed)
+    invalid_values: dict[str, str] = {}
+
+    if "archetype" in parsed:
+        archetype_finding = _validate_canonical_value(
+            "archetype", parsed.get("archetype"), VALID_ARCHETYPES
+        )
+        if archetype_finding is not None:
+            invalid_values["archetype"] = str(parsed.get("archetype"))
+
+    if "evidence_tier" in parsed:
+        evidence_tier_finding = _validate_canonical_value(
+            "evidence_tier", parsed.get("evidence_tier"), VALID_EVIDENCE_TIERS
+        )
+        if evidence_tier_finding is not None:
+            invalid_values["evidence_tier"] = str(parsed.get("evidence_tier"))
+
+    return ArchetypeMetadataAuditResult(
+        heading_present=True,
+        block_present=True,
+        parsed_metadata=parsed,
+        missing_keys=missing_keys,
+        invalid_values=invalid_values,
+        parse_error=None,
+    )
 
 
 def missing_sections(
@@ -135,7 +298,10 @@ def audit_issue_body(body: str) -> IssueAuditResult:
     missing = missing_sections(body)
     repaired = build_repaired_body(body, missing)
     return IssueAuditResult(
-        present_sections=present, missing_sections=missing, repaired_body=repaired
+        present_sections=present,
+        missing_sections=missing,
+        repaired_body=repaired,
+        metadata=audit_archetype_metadata(body),
     )
 
 
@@ -166,6 +332,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         "present_sections": list(result.present_sections),
         "missing_sections": list(result.missing_sections),
         "repaired_body": result.repaired_body,
+        "metadata": {
+            "heading_present": result.metadata.heading_present,
+            "block_present": result.metadata.block_present,
+            "parsed_metadata": result.metadata.parsed_metadata,
+            "missing_keys": list(result.metadata.missing_keys),
+            "invalid_values": result.metadata.invalid_values,
+            "parse_error": result.metadata.parse_error,
+            "findings": list(result.metadata.findings),
+        },
     }
     print(json.dumps(payload, indent=2, ensure_ascii=False))
 

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -16,6 +16,7 @@ SKILL_FILES = [
     ROOT / ".agents" / "skills" / "gh-issue-creator" / "SKILL.md",
     ROOT / ".agents" / "skills" / "gh-issue-template-auditor" / "SKILL.md",
     ROOT / ".agents" / "skills" / "gh-issue-priority-assessor" / "SKILL.md",
+    ROOT / ".agents" / "skills" / "issue-contract-maintainer" / "SKILL.md",
 ]
 KNOWN_LABELS = {
     "agent",
@@ -120,7 +121,15 @@ def test_specialized_issue_templates_include_domain_specific_sections() -> None:
     """
 
     template_markers = {
-        "issue_default.md": ["## Goal / Problem", "Task type", "Entry points"],
+        "issue_default.md": [
+            "## Goal / Problem",
+            "## Archetype Metadata",
+            "archetype:",
+            "evidence_tier:",
+            "linked_policy:",
+            "Task type",
+            "Entry points",
+        ],
         "planner_integration.md": ["## Goal / Problem", "Planner", "Integration goal"],
         "benchmark_experiment.md": ["## Goal / Problem", "Scenario description", "Hypothesis"],
         "refactor.md": ["## Goal / Problem", "Objective", "Motivation"],
@@ -202,6 +211,8 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "gh issue view" in auditor_text
     assert "gh issue edit" in auditor_text
     assert "decision-required" in auditor_text
+    assert "Archetype Metadata" in auditor_text
+    assert "docs/context/issue_1512_issue_archetypes.md" in auditor_text
 
     assessor_text = SKILL_FILES[2].read_text(encoding="utf-8")
     assert "GitHub MCP / GitHub app tools" in assessor_text
@@ -212,6 +223,11 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "Priority Score" in assessor_text
     assert "Estimate Discussion" in assessor_text
     assert "plausibility" in assessor_text.lower()
+
+    maintainer_text = SKILL_FILES[3].read_text(encoding="utf-8")
+    assert "audit-template-compliance" in maintainer_text
+    assert "Archetype Metadata" in maintainer_text
+    assert "docs/context/issue_1512_issue_archetypes.md" in maintainer_text
 
     documentation_text = (TEMPLATE_DIR / "documentation.md").read_text(encoding="utf-8")
     assert "docs/README.md" in documentation_text

--- a/tests/tools/test_issue_template_audit.py
+++ b/tests/tools/test_issue_template_audit.py
@@ -193,6 +193,29 @@ linked_policy:
     }
 
 
+def test_issue_template_audit_accepts_yaml_fence_aliases() -> None:
+    """Verify metadata parsing accepts common YAML code-fence variants."""
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+  ```YML
+archetype: workflow
+evidence_tier: smoke
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+  ```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.block_present is True
+    assert result.metadata.findings == ()
+
+
 def test_issue_template_audit_flags_missing_metadata_block() -> None:
     """Verify the metadata section is reported when the YAML block is absent.
 
@@ -300,6 +323,31 @@ linked_policy:
 
     assert result.metadata.invalid_values == {"evidence_tier": "almost_done"}
     assert "Invalid 'evidence_tier' value 'almost_done'" in result.metadata.findings[0]
+
+
+def test_issue_template_audit_preserves_invalid_metadata_value_types() -> None:
+    """Verify invalid metadata values stay type-preserving in structured output."""
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: 7
+evidence_tier:
+  - smoke
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.invalid_values == {"archetype": 7, "evidence_tier": ["smoke"]}
+    assert "Invalid 'archetype' value 7" in result.metadata.findings[0]
+    assert "Invalid 'evidence_tier' value ['smoke']" in result.metadata.findings[1]
 
 
 def test_issue_template_audit_flags_malformed_metadata_yaml() -> None:

--- a/tests/tools/test_issue_template_audit.py
+++ b/tests/tools/test_issue_template_audit.py
@@ -40,6 +40,8 @@ Add a structured issue workflow.
     assert "## Added Value Estimation" in result.repaired_body
     assert "## Estimate Discussion" in result.repaired_body
     assert "## Definition of Done" in result.repaired_body
+    assert "## Archetype Metadata" not in result.repaired_body
+    assert result.metadata.findings == ("Missing '## Archetype Metadata' section.",)
     assert result.repaired_body.endswith("\n")
 
 
@@ -146,6 +148,186 @@ More legacy text.
     assert "## Goal / Problem" not in result.repaired_body
 
 
+def test_issue_template_audit_accepts_valid_archetype_metadata() -> None:
+    """Verify canonical archetype metadata parses without findings.
+
+    This matters because issue archetype triage should accept the documented
+    values without inventing repairs or blocking a valid issue contract.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: workflow
+evidence_tier: smoke
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+  - docs/context/artifact_evidence_vocabulary.md
+```
+
+## Scope
+
+- In scope:
+- Out of scope:
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.heading_present is True
+    assert result.metadata.block_present is True
+    assert result.metadata.missing_keys == ()
+    assert result.metadata.invalid_values == {}
+    assert result.metadata.parse_error is None
+    assert result.metadata.findings == ()
+    assert result.metadata.parsed_metadata == {
+        "archetype": "workflow",
+        "evidence_tier": "smoke",
+        "linked_policy": [
+            "docs/context/issue_1512_issue_archetypes.md",
+            "docs/context/artifact_evidence_vocabulary.md",
+        ],
+    }
+
+
+def test_issue_template_audit_flags_missing_metadata_block() -> None:
+    """Verify the metadata section is reported when the YAML block is absent.
+
+    This matters because the auditor should preserve the section heading while
+    still telling triage workflows that the structured metadata is incomplete.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+Metadata still needs to be filled in.
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.heading_present is True
+    assert result.metadata.block_present is False
+    assert result.metadata.missing_keys == (
+        "archetype",
+        "evidence_tier",
+        "linked_policy",
+    )
+    assert result.metadata.findings == ("Missing YAML code block under '## Archetype Metadata'.",)
+
+
+def test_issue_template_audit_flags_missing_metadata_keys() -> None:
+    """Verify missing metadata keys are surfaced without inventing defaults.
+
+    This matters because the issue archetype convention is opt-in metadata, so
+    the auditor must flag gaps instead of silently filling them.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: workflow
+```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.missing_keys == ("evidence_tier", "linked_policy")
+    assert result.metadata.invalid_values == {}
+    assert result.metadata.findings == (
+        "Missing archetype metadata keys: evidence_tier, linked_policy",
+    )
+
+
+def test_issue_template_audit_flags_invalid_archetype() -> None:
+    """Verify invalid archetype values are rejected against the canonical set.
+
+    This matters because issue triage should only emit the documented archetype
+    taxonomy from issue 1512.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: made-up
+evidence_tier: smoke
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.invalid_values == {"archetype": "made-up"}
+    assert "Invalid 'archetype' value 'made-up'" in result.metadata.findings[0]
+
+
+def test_issue_template_audit_flags_invalid_evidence_tier() -> None:
+    """Verify invalid evidence tiers are rejected against the canonical set.
+
+    This matters because the evidence tier controls how strongly an issue can
+    claim proof, so invalid values should be surfaced during audit.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: workflow
+evidence_tier: almost_done
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.invalid_values == {"evidence_tier": "almost_done"}
+    assert "Invalid 'evidence_tier' value 'almost_done'" in result.metadata.findings[0]
+
+
+def test_issue_template_audit_flags_malformed_metadata_yaml() -> None:
+    """Verify malformed metadata YAML is surfaced as an explicit parse failure.
+
+    This matters because triage workflows need a concrete repair signal when the
+    metadata block exists but cannot be parsed safely.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: workflow
+evidence_tier: smoke
+linked_policy: [docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+    result = audit_issue_body(body)
+
+    assert result.metadata.parse_error is not None
+    assert result.metadata.findings[0].startswith("Malformed archetype metadata YAML:")
+
+
 def test_issue_template_audit_cli_repairs_body(tmp_path: Path, capsys) -> None:
     """Verify the CLI wrapper can audit and repair a body file in place.
 
@@ -168,6 +350,7 @@ Repair the issue template body.
 
     assert exit_code == 0
     assert '"missing_sections": [' in captured.out
+    assert '"metadata": {' in captured.out
     assert repair_file.read_text(encoding="utf-8").startswith("## Goal / Problem")
     assert "## Validation / Testing" in repair_file.read_text(encoding="utf-8")
     assert "## Estimate Discussion" in repair_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Adds bounded machine-readable validation for issue archetype metadata in the existing issue-template audit tool, while preserving the current section repair behavior.

## Linked Issues
- Closes #1513
- Follow-up: #1532

## What Changed
- `scripts/tools/issue_template_audit.py` now parses the `## Archetype Metadata` YAML block and reports metadata findings alongside existing section audit output.
- Validates canonical `archetype` and `evidence_tier` values against the #1512 taxonomy, requires `linked_policy` to remain present, and flags malformed YAML without inventing replacements.
- Adds tests for valid metadata, missing blocks/keys, invalid values, malformed YAML, CLI JSON output, and default template metadata structure.
- Updates `gh-issue-template-auditor` and `issue-contract-maintainer` skill docs to preserve/flag metadata during triage workflows.
- Records the workflow-tooling change in `CHANGELOG.md`.

## Why It Matters
- Added value: issue triage can now check the #1512 metadata convention deterministically instead of relying on prose.
- Expected impact: future issue-audit and contract-maintenance passes can preserve metadata and flag invalid values without broad backlog rewrites.
- Why now: #1513 was ready, local, and unblocked after the #1512 convention landed.

## Validation / Proof
- `uv run pytest tests/tools/test_issue_template_audit.py tests/test_issue_templates.py -q` -> 15 passed.
- `scripts/dev/ruff_fix_format.sh && uv run pytest tests/tools/test_issue_template_audit.py tests/test_issue_templates.py tests/dev/test_check_skills.py` -> 19 passed.
- `uv run python scripts/dev/check_skills.py && uv run python scripts/tools/sync_ai_config.py --check` -> passed.
- `git diff --check origin/main...HEAD` -> passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4218 passed, 10 skipped, 9 warnings.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` -> fresh for `bcae06769671e939ebf0713052012a4e3767e0da`.

## Risks / Rollout
- Compatibility risks: CLI JSON output gains a `metadata` object; existing top-level section fields are preserved.
- Failure modes: metadata validation flags body issues but does not repair or migrate existing backlog metadata.
- Rollback or fallback plan: revert this single commit to restore section-only audit output.

## Docs / Provenance
- Updated docs: `.agents/skills/gh-issue-template-auditor/SKILL.md`, `.agents/skills/issue-contract-maintainer/SKILL.md`, `CHANGELOG.md`.
- Relevant design/provenance: canonical values remain anchored in `docs/context/issue_1512_issue_archetypes.md`.
- Artifact decision: generated `output/coverage/**` and `output/validation/pr_ready/**` are ignored disposable validation artifacts and are not committed.

## Follow-Up Issues
- #1532 decides whether body metadata should be mirrored into labels or Project #5 fields.

## Reviewer Notes
- Please check that body-only validation is the right first step and that the CLI JSON shape is acceptable for downstream issue-audit workflows.
- External Copilot implementation plus OpenCode Go review/cleanup were both locally validated before this PR.
