### PR TITLE
fix: fail closed optional planner preflights

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -100,6 +100,8 @@ knowledge, not every transient iteration detail.
   [issue_1167_predictive_obstacle_pipeline.md](issue_1167_predictive_obstacle_pipeline.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
+* Issue #1530 optional planner preflight audit:
+  [issue_1530_optional_preflight_audit.md](issue_1530_optional_preflight_audit.md)
 * Issue #1348 capability-aware map catalog design:
   [issue_1348_capability_map_catalog_design.md](issue_1348_capability_map_catalog_design.md)
 * Issue #1414 parser capability metadata:

--- a/docs/context/issue_1530_optional_preflight_audit.md
+++ b/docs/context/issue_1530_optional_preflight_audit.md
@@ -1,0 +1,62 @@
+# Issue #1530 Optional Planner Preflight Audit
+
+## Goal
+
+Audit benchmark-facing optional planner/runtime dependencies beyond the existing ORCA `rvo2`
+check, then add only the fail-closed guards that current `main` needs to keep benchmark evidence
+honest.
+
+## Scope And Anchors
+
+- Benchmark policy: `docs/context/issue_691_benchmark_fallback_policy.md`
+- Wrapper entrypoints:
+  `scripts/tools/run_camera_ready_benchmark.py`,
+  `scripts/tools/run_benchmark_release.py`
+- Benchmark preflight/runtime seam:
+  `robot_sf/benchmark/map_runner.py`
+- Planner families reviewed:
+  `robot_sf/planner/social_navigation_pyenvs_*.py`,
+  `robot_sf/planner/crowdnav_height.py`,
+  `robot_sf/planner/sonic_crowdnav.py`,
+  `robot_sf/planner/socnav.py`,
+  `robot_sf/baselines/{ppo,sac,drl_vo,dr_mpc,sicnav}.py`
+
+## Inventory And Classification
+
+| Surface | Optional dependency / asset | Current behavior on current `main` | Benchmark classification |
+| --- | --- | --- | --- |
+| `orca`, `social_navigation_pyenvs_orca` | `rvo2` | Camera-ready CLI already preflighted; release CLI bypassed that guard | **Guard added** in release wrapper |
+| `social_navigation_pyenvs_socialforce` | upstream checkout, `socialforce==0.2.3`, Torch-backed backend | Adapter constructor fails before episode work if checkout/runtime is missing or incompatible | Already fail-closed |
+| `social_navigation_pyenvs_sfm_helbing` | upstream checkout | Adapter constructor fails before episode work if checkout/runtime is missing | Already fail-closed |
+| `social_navigation_pyenvs_hsfm_new_guo` | upstream checkout | Adapter constructor fails before episode work if checkout/runtime is missing | Already fail-closed |
+| `crowdnav_height` | upstream checkout + extracted checkpoint bundle + Torch | Adapter constructor fails before episode work if checkout/checkpoint is missing | Already fail-closed |
+| `sonic_crowdnav`, `gensafenav_*` | upstream checkout + checkpoint + Torch | Adapter constructor fails before episode work if checkout/checkpoint/runtime is missing or incompatible | Already fail-closed |
+| `socnav_sampling`, `sacadrl`, `prediction_planner`, `socnav_bench`, hybrid SocNav wrappers | SocNavBench checkout, TensorFlow, checkpoints, `skfmm`, model assets | `map_runner._preflight_policy()` already marks `skip`/`fallback` explicitly via `socnav_missing_prereq_policy` | Already explicit, non-silent |
+| `sicnav`, `dr_mpc` | external upstream package / checkout | `_build_policy()` raises immediately when metadata reports missing dependency | Already fail-closed |
+| `ppo`, `sac`, `drl_vo` | SB3 / Torch / checkpoint resolution | Planner constructors could boot into internal goal-seeking fallback and preflight still returned `ok` | **Guard added** in benchmark preflight |
+
+## Changes Made
+
+1. `scripts/tools/run_benchmark_release.py` now runs `check_orca_rvo2_preflight(cfg)` immediately
+   after loading the canonical campaign config, matching the camera-ready CLI's existing
+   fail-fast behavior while preserving the release CLI's structured JSON exit contract.
+2. `robot_sf/benchmark/map_runner.py` now inspects planner metadata returned by `_build_policy()`
+   during preflight and converts `status="fallback"` into `preflight.status="skipped"` before any
+   episode jobs are scheduled. This closes the benchmark-strength evidence gap for learned
+   planners such as PPO, SAC, and DRL-VO when their optional runtime/checkpoint dependencies are
+   absent and they would otherwise silently goal-seek.
+
+## Why No Broader Guard Was Added
+
+Most other optional-dependency planners already fail early at adapter construction or are routed
+through the explicit SocNav prereq policy. Adding another wrapper-level inventory pass for those
+surfaces would duplicate constructor checks without changing benchmark semantics on current `main`.
+
+## Validation Path
+
+- `pytest tests/benchmark/test_map_runner_utils.py`
+- `pytest tests/benchmark/test_map_runner_preflight_profiles.py`
+- `pytest tests/tools/test_run_benchmark_release.py`
+- `scripts/dev/ruff_fix_format.sh`
+- `git diff --check origin/main...HEAD`
+- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -791,8 +791,12 @@ def _preflight_policy(  # noqa: C901, PLR0915
             f"'{missing_prereq_policy}'. Expected fail-fast|skip-with-warning|fallback.",
         )
 
-    def _build_and_close(cfg: dict[str, Any]) -> None:
-        """Instantiate then close a SocNav planner for dependency preflight."""
+    def _build_and_close(cfg: dict[str, Any]) -> dict[str, Any]:
+        """Instantiate then close one planner, returning any emitted benchmark metadata.
+
+        Returns:
+            dict[str, Any]: Planner metadata emitted during construction-time preflight.
+        """
         effective_kinematics = robot_kinematics
         if effective_kinematics is None:
             effective_kinematics = str(
@@ -832,6 +836,27 @@ def _preflight_policy(  # noqa: C901, PLR0915
         planner_close = getattr(policy_fn, "_planner_close", None)
         if callable(planner_close):
             planner_close()
+        return _meta if isinstance(_meta, dict) else {}
+
+    def _preflight_metadata_issue(meta: dict[str, Any]) -> str | None:
+        """Surface benchmark-blocking fallback metadata before any expensive episode work.
+
+        Returns:
+            str | None: Fail-closed reason when the planner initialized in fallback mode.
+        """
+        status = str(meta.get("status", "")).strip().lower()
+        if status != "fallback":
+            return None
+        fallback_reason = str(meta.get("fallback_reason", "")).strip()
+        algorithm_label = str(meta.get("algorithm") or algo).strip() or algo
+        if fallback_reason:
+            return (
+                f"Planner '{algorithm_label}' initialized in fallback mode during benchmark "
+                f"preflight ({fallback_reason})."
+            )
+        return (
+            f"Planner '{algorithm_label}' initialized in fallback mode during benchmark preflight."
+        )
 
     learned_contract = _evaluate_learned_policy_contract(
         algo=algo,
@@ -862,7 +887,17 @@ def _preflight_policy(  # noqa: C901, PLR0915
         )
 
     try:
-        _build_and_close(algo_config)
+        planner_meta = _build_and_close(algo_config)
+        metadata_issue = _preflight_metadata_issue(planner_meta)
+        if metadata_issue is not None:
+            logger.warning("{}", metadata_issue)
+            return dict(algo_config), {
+                "status": "skipped",
+                "error": metadata_issue,
+                "planner_metadata_status": str(planner_meta.get("status", "")),
+                "planner_metadata_fallback_reason": planner_meta.get("fallback_reason"),
+                "learned_policy_contract": learned_contract,
+            }
         return dict(algo_config), {
             "status": "ok",
             "learned_policy_contract": learned_contract,

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
+from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight
 from robot_sf.benchmark.release_protocol import (
     build_release_provenance,
     build_resolved_release_manifest,
@@ -149,6 +150,31 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     manifest = load_release_manifest(args.manifest)
     cfg = load_campaign_config(manifest.canonical_campaign_config_path)
+    try:
+        check_orca_rvo2_preflight(cfg)
+    except SystemExit as exc:
+        reason = str(exc)
+        result = {
+            "mode": args.mode,
+            "status": "orca_preflight_failed",
+            "status_reason": reason,
+            "benchmark_success": False,
+            "exit_code": 2,
+            "campaign_execution_status": "failed",
+            "evidence_status": "blocked",
+            "row_status_summary": {
+                "successful_evidence_rows": 0,
+                "accepted_unavailable_rows": 0,
+                "unexpected_failed_rows": 0,
+                "fallback_or_degraded_rows": 0,
+            },
+            "release_status": "orca_preflight_failed",
+            "release_status_reason": reason,
+            "release_benchmark_success": False,
+            "release_exit_code": 2,
+        }
+        print(json.dumps(result, indent=2))
+        return 2
     validation = validate_release_manifest(manifest, campaign_config=cfg)
 
     resolved_manifest = build_resolved_release_manifest(manifest, campaign_config=cfg)

--- a/tests/benchmark/test_map_runner_preflight_profiles.py
+++ b/tests/benchmark/test_map_runner_preflight_profiles.py
@@ -199,6 +199,54 @@ def test_socnav_fallback_policy_forces_allow_fallback(tmp_path: Path, monkeypatc
     assert summary["benchmark_availability"]["benchmark_success"] is False
 
 
+def test_learned_planner_fallback_metadata_skips_batch_fail_closed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Learned planners that only boot in fallback mode must skip before episode execution."""
+    _patch_lightweight_batch(monkeypatch)
+
+    def _fake_build_policy(
+        _algo,
+        _cfg,
+        *,
+        robot_kinematics=None,
+        robot_command_mode=None,
+        adapter_impact_eval=False,
+    ):
+        """Return fallback metadata without constructing the real planner."""
+        del robot_kinematics, robot_command_mode, adapter_impact_eval
+
+        def _policy(_obs):
+            """Return a dummy command that should never be used once preflight skips."""
+            return (0.0, 0.0)
+
+        return _policy, {
+            "algorithm": "ppo",
+            "status": "fallback",
+            "fallback_reason": "sb3_missing",
+        }
+
+    monkeypatch.setattr(map_runner, "_build_policy", _fake_build_policy)
+
+    summary = map_runner.run_map_batch(
+        [_scenario()],
+        tmp_path / "episodes.jsonl",
+        schema_path=SCHEMA_PATH,
+        algo="ppo",
+        benchmark_profile="experimental",
+        resume=False,
+    )
+
+    assert summary["written"] == 0
+    assert summary["total_jobs"] == 0
+    assert summary["preflight"]["status"] == "skipped"
+    assert summary["preflight"]["planner_metadata_status"] == "fallback"
+    assert summary["preflight"]["planner_metadata_fallback_reason"] == "sb3_missing"
+    assert summary["benchmark_availability"]["availability_status"] == "not_available"
+    assert summary["benchmark_availability"]["benchmark_success"] is False
+
+
 def test_testing_only_planner_requires_explicit_opt_in(tmp_path: Path, monkeypatch) -> None:
     """Experimental testing-only planners must fail closed unless explicitly enabled."""
     _patch_lightweight_batch(monkeypatch)

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -1855,6 +1855,49 @@ def test_preflight_policy_passes_robot_kinematics_to_build_policy(
     assert captured["robot_kinematics"] == "bicycle_drive"
 
 
+def test_preflight_policy_skips_non_socnav_planner_when_metadata_reports_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Benchmark preflight must fail closed when learned planners only boot in fallback mode."""
+
+    def _fake_build_policy(
+        algo,
+        cfg,
+        *,
+        robot_kinematics=None,
+        robot_command_mode=None,
+        adapter_impact_eval=False,
+    ):
+        """Return fallback metadata without needing the real learned-planner runtime."""
+        del cfg, robot_kinematics, robot_command_mode, adapter_impact_eval
+
+        def _policy(_obs):
+            """Return a dummy action for the metadata-only preflight test."""
+            return (0.0, 0.0)
+
+        return _policy, {
+            "algorithm": algo,
+            "status": "fallback",
+            "fallback_reason": "model_missing",
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._build_policy", _fake_build_policy)
+
+    cfg, preflight = _preflight_policy(
+        algo="ppo",
+        algo_config={"fallback_to_goal": True},
+        benchmark_profile="experimental",
+        missing_prereq_policy="fail-fast",
+        robot_kinematics="differential_drive",
+    )
+
+    assert cfg["fallback_to_goal"] is True
+    assert preflight["status"] == "skipped"
+    assert preflight["planner_metadata_status"] == "fallback"
+    assert preflight["planner_metadata_fallback_reason"] == "model_missing"
+    assert "fallback mode" in str(preflight["error"])
+
+
 def test_preflight_policy_treats_social_navigation_pyenvs_orca_as_socnav(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -68,9 +68,16 @@ def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_
         canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml")
     )
     sentinel_cfg = object()
+    called = {"orca_preflight": False}
+
+    def _fake_orca_preflight(cfg) -> None:
+        """Record that release preflight applies the ORCA runtime guard."""
+        assert cfg is sentinel_cfg
+        called["orca_preflight"] = True
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
     monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(run_benchmark_release, "check_orca_rvo2_preflight", _fake_orca_preflight)
     monkeypatch.setattr(
         run_benchmark_release,
         "validate_release_manifest",
@@ -111,6 +118,7 @@ def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_
     )
 
     assert exit_code == 0
+    assert called["orca_preflight"] is True
     payload = json.loads(capsys.readouterr().out)
     assert payload["manifest_validation"]["status"] == "valid"
     assert payload["campaign_id"] == "cid"
@@ -126,6 +134,7 @@ def test_release_run_fails_closed_on_invalid_manifest(monkeypatch, capsys) -> No
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
     monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(run_benchmark_release, "check_orca_rvo2_preflight", lambda cfg: None)
     monkeypatch.setattr(
         run_benchmark_release,
         "validate_release_manifest",
@@ -163,6 +172,58 @@ def test_release_run_fails_closed_on_invalid_manifest(monkeypatch, capsys) -> No
     }
 
 
+def test_release_run_reports_orca_preflight_failure_as_structured_json(
+    monkeypatch,
+    capsys,
+) -> None:
+    """ORCA runtime failures should keep the release CLI's structured exit contract."""
+    manifest = SimpleNamespace(
+        canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml")
+    )
+    sentinel_cfg = object()
+    called = {"validate": False, "run": False}
+
+    def _raise_orca_preflight(_cfg) -> None:
+        """Simulate the real missing-rvo2 preflight path."""
+        raise SystemExit("The required optional dependency 'rvo2' is not importable.")
+
+    monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
+    monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(run_benchmark_release, "check_orca_rvo2_preflight", _raise_orca_preflight)
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "validate_release_manifest",
+        lambda *args, **kwargs: called.__setitem__("validate", True),
+    )
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "run_campaign",
+        lambda *args, **kwargs: called.__setitem__("run", True),
+    )
+
+    exit_code = run_benchmark_release.main(["--manifest", "manifest.yaml"])
+
+    assert exit_code == 2
+    assert called == {"validate": False, "run": False}
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "run"
+    assert payload["status"] == "orca_preflight_failed"
+    assert payload["status_reason"] == payload["release_status_reason"]
+    assert payload["benchmark_success"] is False
+    assert payload["exit_code"] == 2
+    assert payload["campaign_execution_status"] == "failed"
+    assert payload["evidence_status"] == "blocked"
+    assert payload["row_status_summary"] == {
+        "successful_evidence_rows": 0,
+        "accepted_unavailable_rows": 0,
+        "unexpected_failed_rows": 0,
+        "fallback_or_degraded_rows": 0,
+    }
+    assert payload["release_status"] == "orca_preflight_failed"
+    assert payload["release_exit_code"] == 2
+    assert "rvo2" in payload["release_status_reason"]
+
+
 def test_release_run_exports_publication_only_after_benchmark_success(
     monkeypatch,
     capsys,
@@ -172,9 +233,16 @@ def test_release_run_exports_publication_only_after_benchmark_success(
     campaign_root = _make_campaign_tree(tmp_path)
     manifest = _manifest_fixture()
     sentinel_cfg = object()
+    called = {"orca_preflight": False}
+
+    def _fake_orca_preflight(cfg) -> None:
+        """Release runs should fail fast before campaign execution when ORCA is unavailable."""
+        assert cfg is sentinel_cfg
+        called["orca_preflight"] = True
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
     monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(run_benchmark_release, "check_orca_rvo2_preflight", _fake_orca_preflight)
     monkeypatch.setattr(
         run_benchmark_release,
         "validate_release_manifest",
@@ -237,6 +305,7 @@ def test_release_run_exports_publication_only_after_benchmark_success(
     exit_code = run_benchmark_release.main(["--manifest", "manifest.yaml"])
 
     assert exit_code == 0
+    assert called["orca_preflight"] is True
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "benchmark_success"
     assert payload["benchmark_success"] is True
@@ -268,6 +337,7 @@ def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
     monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
+    monkeypatch.setattr(run_benchmark_release, "check_orca_rvo2_preflight", lambda cfg: None)
     monkeypatch.setattr(
         run_benchmark_release,
         "validate_release_manifest",


### PR DESCRIPTION
## Summary

Closes #1530.

This PR audits optional benchmark-facing planner/runtime dependency preflights beyond the existing camera-ready ORCA guard and adds the current-main fail-closed gaps:

- runs the centralized ORCA `rvo2` preflight from `scripts/tools/run_benchmark_release.py` as well as the camera-ready wrapper
- preserves the release CLI JSON contract when ORCA preflight fails before campaign execution
- converts planner metadata `status="fallback"` into benchmark preflight `status="skipped"` before any episode jobs are scheduled
- documents the optional-dependency inventory in `docs/context/issue_1530_optional_preflight_audit.md`

## Validation

- `scripts/dev/ruff_fix_format.sh && pytest -q tests/tools/test_run_benchmark_release.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_orca_preflight.py tests/tools/test_run_camera_ready_benchmark.py && git --no-pager diff --check && BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - 143 passed
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - 4215 passed, 10 skipped, 8 warnings
  - changed-file coverage warning only: `robot_sf/benchmark/map_runner.py` 88.7%, above the hard threshold
- `uv run python scripts/dev/pr_ready_freshness.py write --base-ref origin/main && uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
  - fresh for `16afceb8faaf2dd4f3d5400f82692788033c497c`

## Delegation / Review

- Copilot gpt-5.4 xhigh implementation worker produced the initial patch.
- OpenCode Go review caught the release `SystemExit` JSON-contract gap.
- Copilot gpt-5.4 xhigh final review caught missing release JSON fields.
- Copilot gpt-5.4 xhigh blocker recheck caught the invalid `evidence_status="not_available"` value; fixed to `blocked`.

## Artifacts

Ignored `output/coverage/` and `output/validation/pr_ready/issue-1530-optional-preflight-audit.json` were generated by validation only and remain untracked.
