### PR TITLE
ci: update setup-uv action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.11"
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.11"
 

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.11"
 

--- a/.github/workflows/pr-promoted-planner-smoke.yml
+++ b/.github/workflows/pr-promoted-planner-smoke.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.11"
 


### PR DESCRIPTION
## Summary

- update the pinned `astral-sh/setup-uv` action from the stale v3 SHA to v8.1.0
- apply the pin consistently across CI, PR promoted planner smoke, and nightly perf workflows
- keep the installed uv version pinned at `0.5.11`

## Context

Recent CI runs on `main` fail during GitHub Actions job setup before repository code runs because the runner cannot download `astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39`.

## Validation

Local gates intentionally skipped per maintainer request.

Lightweight checks already performed before opening this PR:

- confirmed no old `caf0cab7...` setup-uv pins remain in `.github/workflows`
- confirmed the replacement codeload URL for `08807647e7069bb48b6ef5acd8ec9567f424441b` returns `HTTP 200`
- ran `git diff --check`

CI on this PR is the proof path for the fix.