### PR TITLE
Fix ORCA preflight API boundary

### DIFF
--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -2244,7 +2244,8 @@ def prepare_campaign_preflight(
         Paths and metadata required by preflight-only workflows and full runs.
 
     Raises:
-        SystemExit: When enabled ORCA-dependent planners require ``rvo2`` but it is not importable.
+        OrcaRvo2PreflightError: When enabled ORCA-dependent planners require ``rvo2`` but it is
+            not importable.
     """
     _validate_campaign_config(cfg)
     check_orca_rvo2_preflight(cfg)
@@ -3135,7 +3136,8 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         Campaign execution summary with output paths and high-level counters.
 
     Raises:
-        SystemExit: When enabled ORCA-dependent planners require ``rvo2`` but it is not importable.
+        OrcaRvo2PreflightError: When enabled ORCA-dependent planners require ``rvo2`` but it is
+            not importable.
     """
     start = time.perf_counter()
     prepared = prepare_campaign_preflight(

--- a/robot_sf/benchmark/orca_preflight.py
+++ b/robot_sf/benchmark/orca_preflight.py
@@ -20,6 +20,22 @@ _SYNC_COMMAND_EXTRA = "uv sync --extra orca"
 _SYNC_COMMAND_ALL = "uv sync --all-extras"
 
 
+class OrcaRvo2PreflightError(RuntimeError):
+    """Typed ORCA preflight failure for library-facing campaign callers."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        planner_keys: tuple[str, ...] = (),
+        error: Exception | None = None,
+    ) -> None:
+        """Store the actionable message plus optional planner/import context."""
+        super().__init__(message)
+        self.planner_keys = planner_keys
+        self.error = error
+
+
 def _missing_rvo2_message(
     *, planner_keys: list[str] | None = None, error: Exception | None = None
 ) -> str:
@@ -66,33 +82,42 @@ def _is_orca_dependent_planner(planner_spec: PlannerSpec) -> bool:
     return enabled and _has_orca_algo(algo)
 
 
+def _ensure_rvo2_importable(*, planner_keys: list[str] | None = None) -> None:
+    """Raise a typed preflight error when ``rvo2`` is unavailable."""
+    try:
+        import rvo2  # type: ignore[import-untyped,unused-ignore]  # noqa: F401, PLC0415
+    except Exception as exc:
+        message = _missing_rvo2_message(planner_keys=planner_keys, error=exc)
+        logger.error(message)
+        raise OrcaRvo2PreflightError(
+            message,
+            planner_keys=tuple(planner_keys or ()),
+            error=exc,
+        ) from None
+
+
 def check_rvo2_importable() -> None:
     """Check whether ``rvo2`` can be imported in the current interpreter.
 
     Raises:
-        SystemExit: When ``rvo2`` is not importable, with a message naming the
+        OrcaRvo2PreflightError: When ``rvo2`` is not importable, with a message naming the
             missing dependency and the exact sync commands.
     """
-    try:
-        import rvo2  # type: ignore[import-untyped,unused-ignore]  # noqa: F401, PLC0415
-    except Exception as exc:
-        message = _missing_rvo2_message(error=exc)
-        logger.error(message)
-        raise SystemExit(message) from None
+    _ensure_rvo2_importable()
 
 
 def check_orca_rvo2_preflight(cfg: CampaignConfig) -> None:
     """Validate that rvo2 is importable when a campaign config includes ORCA planners.
 
     When the config contains enabled ORCA planners and rvo2 is not importable, this
-    function raises ``SystemExit`` with an actionable error message naming the
+    function raises ``OrcaRvo2PreflightError`` with an actionable error message naming the
     ORCA planner keys, the missing dependency, and the exact sync commands.
 
     Args:
         cfg: A loaded camera-ready campaign config.
 
     Raises:
-        SystemExit: When ORCA planners are present and ``rvo2`` is not importable.
+        OrcaRvo2PreflightError: When ORCA planners are present and ``rvo2`` is not importable.
     """
     orca_specs = [p for p in cfg.planners if _is_orca_dependent_planner(p)]
     if not orca_specs:
@@ -105,12 +130,7 @@ def check_orca_rvo2_preflight(cfg: CampaignConfig) -> None:
         f"ORCA-dependent planner(s) detected: {orca_keys_str}. Checking rvo2 importability..."
     )
 
-    try:
-        import rvo2  # type: ignore[import-untyped,unused-ignore]  # noqa: F401, PLC0415
-    except Exception as exc:
-        message = _missing_rvo2_message(planner_keys=orca_keys, error=exc)
-        logger.error(message)
-        raise SystemExit(message) from None
+    _ensure_rvo2_importable(planner_keys=orca_keys)
 
     logger.info("rvo2 is importable; ORCA preflight passed.")
 
@@ -125,7 +145,7 @@ def check_orca_rvo2_preflight_from_config(config_path: Path) -> None:
         config_path: Path to a camera-ready campaign config YAML.
 
     Raises:
-        SystemExit: When ORCA planners are present and ``rvo2`` is not importable.
+        OrcaRvo2PreflightError: When ORCA planners are present and ``rvo2`` is not importable.
     """
     from robot_sf.benchmark.camera_ready_campaign import (  # noqa: PLC0415
         load_campaign_config,
@@ -136,6 +156,7 @@ def check_orca_rvo2_preflight_from_config(config_path: Path) -> None:
 
 
 __all__ = [
+    "OrcaRvo2PreflightError",
     "check_orca_rvo2_preflight",
     "check_orca_rvo2_preflight_from_config",
     "check_rvo2_importable",

--- a/scripts/tools/orca_rvo2_preflight.py
+++ b/scripts/tools/orca_rvo2_preflight.py
@@ -17,7 +17,10 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight_from_config
+from robot_sf.benchmark.orca_preflight import (
+    OrcaRvo2PreflightError,
+    check_orca_rvo2_preflight_from_config,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -47,8 +50,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         check_orca_rvo2_preflight_from_config(args.config.resolve())
-    except SystemExit as exc:
-        return exc.code if isinstance(exc.code, int) else 1
+    except OrcaRvo2PreflightError:
+        return 1
     except Exception as exc:
         logger.error(f"Failed to load or validate campaign config: {exc}")
         return 1

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -24,7 +24,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
-from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight
+from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError, check_orca_rvo2_preflight
 from robot_sf.benchmark.release_protocol import (
     build_release_provenance,
     build_resolved_release_manifest,
@@ -152,7 +152,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     cfg = load_campaign_config(manifest.canonical_campaign_config_path)
     try:
         check_orca_rvo2_preflight(cfg)
-    except SystemExit as exc:
+    except OrcaRvo2PreflightError as exc:
         reason = str(exc)
         result = {
             "mode": args.mode,

--- a/scripts/tools/run_camera_ready_benchmark.py
+++ b/scripts/tools/run_camera_ready_benchmark.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
 )
 from robot_sf.benchmark.fallback_policy import campaign_exit_code
+from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -92,45 +93,64 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     cfg = load_campaign_config(args.config)
     invoked_command = shlex.join([sys.executable, str(Path(__file__)), *raw_argv])
-    if args.mode == "preflight":
-        prepared = prepare_campaign_preflight(
-            cfg,
-            output_root=args.output_root,
-            label=args.label,
-            campaign_id=args.campaign_id,
-            invoked_command=invoked_command,
-        )
+    try:
+        if args.mode == "preflight":
+            prepared = prepare_campaign_preflight(
+                cfg,
+                output_root=args.output_root,
+                label=args.label,
+                campaign_id=args.campaign_id,
+                invoked_command=invoked_command,
+            )
+            result = {
+                "campaign_id": prepared["campaign_id"],
+                "campaign_root": str(prepared["campaign_root"]),
+                "validate_config_path": str(prepared["validate_config_path"]),
+                "preview_scenarios_path": str(prepared["preview_scenarios_path"]),
+                "matrix_summary_json": str(prepared["matrix_summary_json_path"]),
+                "matrix_summary_csv": str(prepared["matrix_summary_csv_path"]),
+                "amv_coverage_json": str(prepared["amv_coverage_json_path"]),
+                "amv_coverage_md": str(prepared["amv_coverage_md_path"]),
+                "comparability_json": (
+                    str(prepared["comparability_json_path"])
+                    if prepared.get("comparability_json_path") is not None
+                    else None
+                ),
+                "comparability_md": (
+                    str(prepared["comparability_md_path"])
+                    if prepared.get("comparability_md_path") is not None
+                    else None
+                ),
+            }
+        else:
+            result = run_campaign(
+                cfg,
+                output_root=args.output_root,
+                label=args.label,
+                campaign_id=args.campaign_id,
+                skip_publication_bundle=bool(args.skip_publication_bundle),
+                invoked_command=invoked_command,
+            )
+    except OrcaRvo2PreflightError as exc:
         result = {
-            "campaign_id": prepared["campaign_id"],
-            "campaign_root": str(prepared["campaign_root"]),
-            "validate_config_path": str(prepared["validate_config_path"]),
-            "preview_scenarios_path": str(prepared["preview_scenarios_path"]),
-            "matrix_summary_json": str(prepared["matrix_summary_json_path"]),
-            "matrix_summary_csv": str(prepared["matrix_summary_csv_path"]),
-            "amv_coverage_json": str(prepared["amv_coverage_json_path"]),
-            "amv_coverage_md": str(prepared["amv_coverage_md_path"]),
-            "comparability_json": (
-                str(prepared["comparability_json_path"])
-                if prepared.get("comparability_json_path") is not None
-                else None
-            ),
-            "comparability_md": (
-                str(prepared["comparability_md_path"])
-                if prepared.get("comparability_md_path") is not None
-                else None
-            ),
+            "mode": args.mode,
+            "status": "orca_preflight_failed",
+            "status_reason": str(exc),
+            "benchmark_success": False,
+            "exit_code": 2,
+            "campaign_execution_status": "failed",
+            "evidence_status": "blocked",
+            "row_status_summary": {
+                "successful_evidence_rows": 0,
+                "accepted_unavailable_rows": 0,
+                "unexpected_failed_rows": 0,
+                "fallback_or_degraded_rows": 0,
+            },
         }
-    else:
-        result = run_campaign(
-            cfg,
-            output_root=args.output_root,
-            label=args.label,
-            campaign_id=args.campaign_id,
-            skip_publication_bundle=bool(args.skip_publication_bundle),
-            invoked_command=invoked_command,
-        )
     print(json.dumps(result, indent=2))
-    return 0 if args.mode == "preflight" else campaign_exit_code(result)
+    if args.mode == "preflight" and result.get("status") != "orca_preflight_failed":
+        return 0
+    return campaign_exit_code(result)
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -35,6 +35,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
+from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
 from robot_sf.common.artifact_paths import get_repository_root
 
 
@@ -2158,7 +2159,7 @@ def test_prepare_campaign_preflight_validates_campaign_config(tmp_path: Path) ->
 def test_prepare_campaign_preflight_checks_orca_rvo2_before_loading_scenarios(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Direct preflight calls fail before scenario loading when enabled ORCA rows lack rvo2."""
+    """Direct preflight calls raise a typed error before scenario loading when ORCA lacks rvo2."""
     scenario_path = tmp_path / "scenarios.yaml"
     scenario_path.write_text("scenarios: []\n", encoding="utf-8")
     cfg = CampaignConfig(
@@ -2179,14 +2180,14 @@ def test_prepare_campaign_preflight_checks_orca_rvo2_before_loading_scenarios(
         fail_if_scenarios_load,
     )
 
-    with pytest.raises(SystemExit, match="rvo2"):
+    with pytest.raises(OrcaRvo2PreflightError, match="rvo2"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="orca")
 
 
 def test_run_campaign_checks_orca_rvo2_before_loading_optional_artifacts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Direct campaign runs fail before optional JSON loading when ORCA rows lack rvo2."""
+    """Direct campaign runs raise a typed error before optional JSON loading when ORCA lacks rvo2."""
     scenario_path = tmp_path / "scenarios.yaml"
     scenario_path.write_text("scenarios: []\n", encoding="utf-8")
     cfg = CampaignConfig(
@@ -2207,7 +2208,7 @@ def test_run_campaign_checks_orca_rvo2_before_loading_optional_artifacts(
         fail_if_optional_json_loads,
     )
 
-    with pytest.raises(SystemExit, match="rvo2"):
+    with pytest.raises(OrcaRvo2PreflightError, match="rvo2"):
         run_campaign(cfg, output_root=tmp_path / "out", label="orca")
 
 

--- a/tests/benchmark/test_orca_preflight.py
+++ b/tests/benchmark/test_orca_preflight.py
@@ -13,6 +13,7 @@ import pytest
 
 from robot_sf.benchmark.camera_ready_campaign import CampaignConfig, PlannerSpec, SeedPolicy
 from robot_sf.benchmark.orca_preflight import (
+    OrcaRvo2PreflightError,
     _has_orca_algo,
     _is_orca_dependent_planner,
     check_orca_rvo2_preflight,
@@ -147,9 +148,9 @@ class TestCheckRvo2Importable:
             check_rvo2_importable()
 
     def test_raises_when_rvo2_missing(self) -> None:
-        """Function raises SystemExit when rvo2 is not importable."""
+        """Function raises a typed preflight error when rvo2 is not importable."""
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_rvo2_importable()
             assert "rvo2" in str(exc_info.value).lower()
             assert "uv sync --extra orca" in str(exc_info.value)
@@ -158,7 +159,7 @@ class TestCheckRvo2Importable:
     def test_raises_when_native_extension_import_fails(self) -> None:
         """Native-extension import failures are reported with actionable sync commands."""
         with _rvo2_import_raises(OSError("libRVO.so: cannot open shared object file")):
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_rvo2_importable()
         message = str(exc_info.value)
         assert "rvo2" in message.lower()
@@ -182,10 +183,10 @@ class TestCheckOrcaRvo2Preflight:
             check_orca_rvo2_preflight(cfg)
 
     def test_orca_planner_with_rvo2_missing_fails(self) -> None:
-        """Preflight raises SystemExit when ORCA planners exist and rvo2 is missing."""
+        """Preflight raises a typed error when ORCA planners exist and rvo2 is missing."""
         cfg = _make_cfg(planners=(_planner("orca", "orca"),))
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight(cfg)
             assert "rvo2" in str(exc_info.value).lower()
 
@@ -204,7 +205,7 @@ class TestCheckOrcaRvo2Preflight:
             )
         )
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight(cfg)
             assert "rvo2" in str(exc_info.value).lower()
 
@@ -212,7 +213,7 @@ class TestCheckOrcaRvo2Preflight:
         """Preflight fails for social_navigation_pyenvs_orca when rvo2 is missing."""
         cfg = _make_cfg(planners=(_planner("social_nav_orca", "social_navigation_pyenvs_orca"),))
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight(cfg)
             message = str(exc_info.value)
             assert "social_nav_orca" in message
@@ -227,7 +228,7 @@ class TestCheckOrcaRvo2Preflight:
             )
         )
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight(cfg)
         message = str(exc_info.value)
         assert "orca" in message
@@ -240,14 +241,14 @@ class TestCheckOrcaRvo2Preflight:
         """hybrid_orca_sampler is detected as ORCA-dependent."""
         cfg = _make_cfg(planners=(_planner("hybrid_orca", "hybrid_orca_sampler"),))
         with _rvo2_missing():
-            with pytest.raises(SystemExit):
+            with pytest.raises(OrcaRvo2PreflightError):
                 check_orca_rvo2_preflight(cfg)
 
     def test_orca_native_extension_import_failure_names_sync_commands(self) -> None:
         """Campaign preflight treats native rvo2 load errors as actionable dependency failures."""
         cfg = _make_cfg(planners=(_planner("orca", "orca"),))
         with _rvo2_import_raises(OSError("libRVO.so: cannot open shared object file")):
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight(cfg)
         message = str(exc_info.value)
         assert "orca" in message
@@ -260,11 +261,11 @@ class TestCheckOrcaRvo2PreflightFromConfig:
     """Tests for the config-path-based entry point."""
 
     def test_loads_config_and_checks(self, tmp_path: Path) -> None:
-        """Config with ORCA planner triggers preflight failure when rvo2 is missing."""
+        """Config with ORCA planner triggers a typed preflight failure when rvo2 is missing."""
         config_path = tmp_path / "config.yaml"
         _write_config(config_path, algo="orca")
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(OrcaRvo2PreflightError) as exc_info:
                 check_orca_rvo2_preflight_from_config(config_path)
             assert "rvo2" in str(exc_info.value).lower()
 

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -7,9 +7,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 from robot_sf.benchmark.camera_ready_campaign import CampaignConfig, PlannerSpec, SeedPolicy
+from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
 from scripts.tools import run_benchmark_release
 
 
@@ -189,7 +188,7 @@ def test_release_run_reports_orca_preflight_failure_as_structured_json(
 
     def _raise_orca_preflight(_cfg) -> None:
         """Simulate the real missing-rvo2 preflight path."""
-        raise SystemExit("The required optional dependency 'rvo2' is not importable.")
+        raise OrcaRvo2PreflightError("The required optional dependency 'rvo2' is not importable.")
 
     monkeypatch.setattr(run_benchmark_release, "load_release_manifest", lambda path: manifest)
     monkeypatch.setattr(run_benchmark_release, "load_campaign_config", lambda path: sentinel_cfg)
@@ -434,8 +433,10 @@ def test_release_run_preserves_campaign_status_for_accepted_unavailable_only(
     assert release_result["release_exit_code"] == 3
 
 
-def test_release_preflight_fails_closed_when_orca_rvo2_missing(tmp_path: Path, monkeypatch) -> None:
-    """Preflight mode exits before execution when enabled ORCA planners lack rvo2."""
+def test_release_preflight_fails_closed_when_orca_rvo2_missing(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Preflight mode should emit fail-closed JSON when enabled ORCA planners lack rvo2."""
     scenario_path = tmp_path / "scenarios.yaml"
     scenario_path.write_text("scenarios: []\n", encoding="utf-8")
     cfg = CampaignConfig(
@@ -466,5 +467,17 @@ def test_release_preflight_fails_closed_when_orca_rvo2_missing(tmp_path: Path, m
     )
     monkeypatch.setitem(sys.modules, "rvo2", None)
 
-    with pytest.raises(SystemExit, match="rvo2"):
-        run_benchmark_release.main(["--manifest", "manifest.yaml", "--mode", "preflight"])
+    exit_code = run_benchmark_release.main(["--manifest", "manifest.yaml", "--mode", "preflight"])
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "preflight"
+    assert payload["status"] == "orca_preflight_failed"
+    assert payload["status_reason"] == payload["release_status_reason"]
+    assert payload["benchmark_success"] is False
+    assert payload["campaign_execution_status"] == "failed"
+    assert payload["evidence_status"] == "blocked"
+    assert payload["exit_code"] == 2
+    assert payload["release_status"] == "orca_preflight_failed"
+    assert payload["release_exit_code"] == 2
+    assert "uv sync --extra orca" in payload["release_status_reason"]

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -332,15 +332,47 @@ def test_main_run_mode_returns_exit_code_3_for_accepted_unavailable_only_campaig
 class TestRunModeOrcaPreflightIntegration:
     """Integration tests that the CLI runner calls the ORCA-rvo2 preflight guard."""
 
-    def test_run_mode_aborts_when_orca_config_rvo2_missing(self, tmp_path: Path) -> None:
-        """Run mode aborts before run_campaign when ORCA config has rvo2 missing."""
+    def test_run_mode_emits_fail_closed_payload_when_orca_config_rvo2_missing(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Run mode should translate typed ORCA preflight failures into structured JSON."""
         config_path = tmp_path / "config.yaml"
         _write_config(config_path, algo="orca")
 
         with _rvo2_missing():
-            with pytest.raises(SystemExit) as exc_info:
-                run_camera_ready_benchmark.main(["--config", str(config_path)])
-            assert "rvo2" in str(exc_info.value).lower()
+            exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+
+        assert exit_code == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mode"] == "run"
+        assert payload["status"] == "orca_preflight_failed"
+        assert payload["benchmark_success"] is False
+        assert payload["campaign_execution_status"] == "failed"
+        assert payload["evidence_status"] == "blocked"
+        assert payload["exit_code"] == 2
+        assert "rvo2" in payload["status_reason"].lower()
+
+    def test_preflight_mode_emits_fail_closed_payload_when_orca_config_rvo2_missing(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Preflight mode should also stay fail-closed with actionable ORCA guidance."""
+        config_path = tmp_path / "config.yaml"
+        _write_config(config_path, algo="orca")
+
+        with _rvo2_missing():
+            exit_code = run_camera_ready_benchmark.main(
+                ["--config", str(config_path), "--mode", "preflight"]
+            )
+
+        assert exit_code == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mode"] == "preflight"
+        assert payload["status"] == "orca_preflight_failed"
+        assert payload["benchmark_success"] is False
+        assert payload["campaign_execution_status"] == "failed"
+        assert payload["evidence_status"] == "blocked"
+        assert payload["exit_code"] == 2
+        assert "uv sync --extra orca" in payload["status_reason"]
 
     def test_run_mode_passes_when_no_orca_in_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- Introduce `OrcaRvo2PreflightError` so library-facing ORCA/rvo2 preflight helpers fail with a typed exception instead of `SystemExit`.
- Keep CLI wrappers fail-closed by translating the typed error into actionable JSON/exit-code behavior.
- Update benchmark and tool tests for direct library callers, release CLI, camera-ready CLI, and standalone ORCA preflight CLI behavior.

Closes #1539.

## Validation
- `uv run ruff format --check robot_sf/benchmark/orca_preflight.py robot_sf/benchmark/camera_ready_campaign.py scripts/tools/orca_rvo2_preflight.py scripts/tools/run_benchmark_release.py scripts/tools/run_camera_ready_benchmark.py tests/benchmark/test_orca_preflight.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py tests/tools/test_run_camera_ready_benchmark.py`
- `uv run ruff check robot_sf/benchmark/orca_preflight.py robot_sf/benchmark/camera_ready_campaign.py scripts/tools/orca_rvo2_preflight.py scripts/tools/run_benchmark_release.py scripts/tools/run_camera_ready_benchmark.py tests/benchmark/test_orca_preflight.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py tests/tools/test_run_camera_ready_benchmark.py`
- `uv run pytest -q tests/benchmark/test_orca_preflight.py tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_camera_ready_benchmark.py tests/tools/test_run_benchmark_release.py` (`120 passed`)
- Copilot review pass: no issues found; ran `pytest -q tests/benchmark/test_orca_preflight.py tests/benchmark/test_camera_ready_campaign.py -k "orca or preflight"` (`39 passed, 62 deselected`) and `pytest -q tests/tools/test_run_camera_ready_benchmark.py tests/tools/test_run_benchmark_release.py -k "orca or preflight"` (`13 passed, 6 deselected`)
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` before commit (`4246 passed, 10 skipped`)
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after commit (`4246 passed, 10 skipped`; changed file coverage check: `robot_sf/benchmark/orca_preflight.py: 100.0%`)

## Notes
- Generated `output/coverage/*` artifacts were inspected as ignored validation output and not committed.
- Follow-up issue not opened: no additional bounded defect or deferred scope emerged from implementation or review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for ORCA/RVO2 dependency checks with clearer, actionable error messages.

* **Refactor**
  * Replaced generic system exit exceptions with typed exception handling in preflight validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->