### PR TITLE
Add strict hybrid evidence SHA provenance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Extended the issue-1515 hybrid-evidence matrix validator with an opt-in git-history proof path:
+  default validation still only checks `commit_artifact` shape plus provenance pointers, while
+  `scripts/validation/validate_hybrid_evidence_matrix.py --check-git-history` now additionally fails
+  closed on unknown local commit SHAs before issue-1489 synthesis consumes stress/full-matrix rows.
 * Updated the issue-1519 predictive ego-feature contract so ego-conditioned schema metadata now
   records a machine-readable motion-channel producer key for same-seed/runtime vs standalone
   collection, and runtime inference rejects explicit standalone-producer checkpoints instead of

--- a/docs/context/issue_1499_hybrid_evidence_matrix_schema.md
+++ b/docs/context/issue_1499_hybrid_evidence_matrix_schema.md
@@ -184,6 +184,11 @@ Validation surface:
 - validates required fields, enums, nullability, and rate bounds,
 - checks `commit_artifact` as a comma- or newline-separated string containing a git SHA token plus
   one or more provenance tokens,
+- defaults to **format-only** `commit_artifact` validation so local row checks stay lightweight and
+  deterministic even when a SHA-looking token has not yet been proven against repository history,
+- supports an opt-in **history-backed** proof path via
+  `--check-git-history`, which additionally requires each git SHA token to resolve in the selected
+  local repository history before a row can pass,
 - requires repository-local provenance tokens to be repository-root-relative, present in the
   checkout, and outside `output/`,
 - enforces fail-closed fallback/degraded semantics for success-like evidence tiers,
@@ -194,6 +199,12 @@ Validation surface:
 
 The validator is intentionally conservative: it does not synthesize results, resolve remote artifact
 availability, or upgrade local `output/` paths into durable evidence.
+
+Use the default validator path while drafting rows, launch packets, and local schema fixes. Before
+issue [#1489](https://github.com/ll7/robot_sf_ll7/issues/1489) treats a `stress` or `full_matrix`
+row as synthesis input, rerun the same file with `--check-git-history` from a checkout whose git
+history includes the cited commit(s). That stricter pass separates shape validation from local
+repository-history proof without downgrading launch-packet rows or durable remote artifact pointers.
 
 ## Known Gaps
 
@@ -230,5 +241,8 @@ Run the targeted validator proof and the standard readiness gate:
 uv run pytest tests/benchmark/test_hybrid_evidence_matrix.py
 uv run python scripts/validation/validate_hybrid_evidence_matrix.py \
   --input tests/fixtures/hybrid_evidence_matrix/v1/valid_rows.yaml
+uv run python scripts/validation/validate_hybrid_evidence_matrix.py \
+  --input path/to/hybrid_evidence_rows.yaml \
+  --check-git-history
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 ```

--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -108,6 +109,7 @@ def validate_hybrid_evidence_file(
     path: Path,
     *,
     repo_root: Path | None = None,
+    check_git_history: bool = False,
 ) -> dict[str, Any]:
     """Load and validate a hybrid evidence matrix file.
 
@@ -115,7 +117,11 @@ def validate_hybrid_evidence_file(
         Structured validation report with per-row status, errors, and warnings.
     """
     input_format, rows = load_hybrid_evidence_input(path)
-    report = validate_hybrid_evidence_rows(rows, repo_root=repo_root)
+    report = validate_hybrid_evidence_rows(
+        rows,
+        repo_root=repo_root,
+        check_git_history=check_git_history,
+    )
     report["input_format"] = input_format
     report["input_path"] = _repo_relative_or_absolute(
         path.resolve(), root=(repo_root or get_repository_root())
@@ -127,6 +133,7 @@ def validate_hybrid_evidence_rows(
     rows: list[dict[str, Any]],
     *,
     repo_root: Path | None = None,
+    check_git_history: bool = False,
 ) -> dict[str, Any]:
     """Validate one or more hybrid evidence matrix rows.
 
@@ -134,12 +141,22 @@ def validate_hybrid_evidence_rows(
         Structured validation report with aggregate counts and per-row details.
     """
     root = (repo_root or get_repository_root()).resolve()
+    provenance_validation = "git_history" if check_git_history else "format_only"
+    git_commit_cache: dict[str, bool] = {}
     row_reports = [
-        _validate_row(row, index=index, repo_root=root) for index, row in enumerate(rows)
+        _validate_row(
+            row,
+            index=index,
+            repo_root=root,
+            provenance_validation=provenance_validation,
+            git_commit_cache=git_commit_cache,
+        )
+        for index, row in enumerate(rows)
     ]
     invalid_row_count = sum(1 for row in row_reports if row["status"] == "invalid")
     return {
         "status": "valid" if invalid_row_count == 0 else "invalid",
+        "provenance_validation": provenance_validation,
         "row_count": len(row_reports),
         "valid_row_count": len(row_reports) - invalid_row_count,
         "invalid_row_count": invalid_row_count,
@@ -147,7 +164,14 @@ def validate_hybrid_evidence_rows(
     }
 
 
-def _validate_row(row: object, *, index: int, repo_root: Path) -> dict[str, Any]:
+def _validate_row(
+    row: object,
+    *,
+    index: int,
+    repo_root: Path,
+    provenance_validation: str,
+    git_commit_cache: dict[str, bool],
+) -> dict[str, Any]:
     errors: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
     if not isinstance(row, dict):
@@ -185,6 +209,8 @@ def _validate_row(row: object, *, index: int, repo_root: Path) -> dict[str, Any]
         field="commit_artifact",
         repo_root=repo_root,
         synthesis_candidate=synthesis_candidate,
+        provenance_validation=provenance_validation,
+        git_commit_cache=git_commit_cache,
         errors=errors,
     )
     guard = _validate_guard_authority(row.get("guard_authority"), errors)
@@ -586,6 +612,8 @@ def _validate_commit_artifact(
     field: str,
     repo_root: Path,
     synthesis_candidate: bool,
+    provenance_validation: str,
+    git_commit_cache: dict[str, bool],
     errors: list[dict[str, str]],
 ) -> None:
     if not isinstance(value, str) or not value.strip():
@@ -601,10 +629,12 @@ def _validate_commit_artifact(
         return
     has_git_sha = False
     has_provenance_token = False
+    git_sha_tokens: list[str] = []
     for token in tokens:
         normalized = token.lower()
         if _GIT_SHA_RE.fullmatch(normalized):
             has_git_sha = True
+            git_sha_tokens.append(normalized)
             continue
         has_provenance_token = True
         _validate_reference_token(token, field, repo_root=repo_root, errors=errors)
@@ -612,6 +642,30 @@ def _validate_commit_artifact(
         _append_problem(errors, field, "must include a 7-40 character git SHA token")
     if not has_provenance_token:
         _append_problem(errors, field, "must include at least one provenance pointer token")
+    if provenance_validation == "git_history":
+        for sha in git_sha_tokens:
+            if _git_commit_exists(sha, repo_root=repo_root, cache=git_commit_cache):
+                continue
+            _append_problem(
+                errors,
+                field,
+                f"references unknown git commit SHA in repository history: {sha!r}",
+            )
+
+
+def _git_commit_exists(sha: str, *, repo_root: Path, cache: dict[str, bool]) -> bool:
+    cached = cache.get(sha)
+    if cached is not None:
+        return cached
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    exists = result.returncode == 0
+    cache[sha] = exists
+    return exists
 
 
 def _validate_reference_token(

--- a/scripts/validation/validate_hybrid_evidence_matrix.py
+++ b/scripts/validation/validate_hybrid_evidence_matrix.py
@@ -28,6 +28,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Repository root used to resolve repository-relative provenance paths.",
     )
+    parser.add_argument(
+        "--check-git-history",
+        action="store_true",
+        help=(
+            "Also verify that each git SHA token in commit_artifact resolves to a commit in the "
+            "local repository history. Default validation remains format-only."
+        ),
+    )
     return parser
 
 
@@ -35,7 +43,11 @@ def main(argv: list[str] | None = None) -> int:
     """Validate a matrix file and return a shell-friendly exit code."""
     args = build_arg_parser().parse_args(argv)
     try:
-        report = validate_hybrid_evidence_file(args.input, repo_root=args.repo_root)
+        report = validate_hybrid_evidence_file(
+            args.input,
+            repo_root=args.repo_root,
+            check_git_history=args.check_git_history,
+        )
     except HybridEvidenceMatrixValidationError as exc:
         print(json.dumps({"status": "error", "error": str(exc)}, indent=2, sort_keys=True))
         return 1

--- a/tests/benchmark/test_hybrid_evidence_matrix.py
+++ b/tests/benchmark/test_hybrid_evidence_matrix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 from pathlib import Path
 
 from robot_sf.benchmark.hybrid_evidence_matrix import (
@@ -21,6 +22,7 @@ def test_valid_rows_validate_and_preserve_launch_packet_rows() -> None:
     report = validate_hybrid_evidence_file(FIXTURE_ROOT / "valid_rows.yaml")
 
     assert report["status"] == "valid"
+    assert report["provenance_validation"] == "format_only"
     assert report["row_count"] == 2
     assert report["valid_row_count"] == 2
     assert report["rows"][0]["component"] == "learned_risk_model_v1"
@@ -130,5 +132,171 @@ def test_cli_emits_json_for_invalid_input(capsys) -> None:
     assert exit_code == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "invalid"
+    assert payload["provenance_validation"] == "format_only"
     assert payload["row_count"] == 1
     assert payload["rows"][0]["errors"][0]["field"]
+
+
+def test_format_only_validation_keeps_unknown_git_sha_lightweight(tmp_path: Path) -> None:
+    """Default validation must remain format-only so unknown SHAs do not fail local schema checks."""
+    repo_root, _known_sha = _create_temp_git_repo(tmp_path)
+    row = _make_repo_backed_row()
+    row["commit_artifact"] = "deadbeef, docs/context/proof.json"
+
+    report = validate_hybrid_evidence_rows([row], repo_root=repo_root)
+
+    assert report["status"] == "valid"
+    assert report["provenance_validation"] == "format_only"
+
+
+def test_git_history_validation_rejects_unknown_git_sha(tmp_path: Path) -> None:
+    """Strict provenance mode must fail closed when a commit SHA is not in repository history."""
+    repo_root, _known_sha = _create_temp_git_repo(tmp_path)
+    row = _make_repo_backed_row()
+    row["commit_artifact"] = "deadbeef, docs/context/proof.json"
+
+    report = validate_hybrid_evidence_rows([row], repo_root=repo_root, check_git_history=True)
+
+    assert report["status"] == "invalid"
+    assert report["provenance_validation"] == "git_history"
+    messages = {
+        error["message"]
+        for error in report["rows"][0]["errors"]
+        if error["field"] == "commit_artifact"
+    }
+    assert "references unknown git commit SHA in repository history: 'deadbeef'" in messages
+
+
+def test_git_history_validation_accepts_known_sha_launch_packet_and_remote_pointer(
+    tmp_path: Path,
+) -> None:
+    """Strict provenance must still accept known SHAs for launch packets and durable remote pointers."""
+    repo_root, known_sha = _create_temp_git_repo(tmp_path)
+    executed_row = _make_repo_backed_row()
+    executed_row["commit_artifact"] = f"{known_sha}, wandb://robot-sf/hybrid-evidence/run-1472"
+
+    launch_packet_row = _make_repo_backed_row()
+    launch_packet_row["component"] = "oracle_imitation_v1"
+    launch_packet_row["source_issue"] = "#1470"
+    launch_packet_row["commit_artifact"] = f"{known_sha}, docs/context/launch_packet.md"
+    launch_packet_row["evaluation_slice"] = "not_run"
+    launch_packet_row["guard_authority"]["active"] = False
+    launch_packet_row["guard_authority"]["veto_rate"] = None
+    launch_packet_row["learned_component_contribution"]["contribution_type"] = (
+        "warm_start_initialisation"
+    )
+    launch_packet_row["learned_component_contribution"]["bound"] = "oracle dataset only"
+    launch_packet_row["learned_component_contribution"]["active_rate"] = None
+    launch_packet_row["intervention_fallback_rates"] = {
+        "guard_veto_rate": None,
+        "fallback_rate": None,
+        "degraded_rate": None,
+    }
+    launch_packet_row["outcomes"] = {
+        "success_rate": None,
+        "collision_rate": None,
+        "near_miss_rate": None,
+        "low_progress_rate": None,
+        "timeout_rate": None,
+    }
+    launch_packet_row["evidence_tier"] = "launch_packet"
+    launch_packet_row["verdict"] = "pending"
+
+    report = validate_hybrid_evidence_rows(
+        [executed_row, launch_packet_row],
+        repo_root=repo_root,
+        check_git_history=True,
+    )
+
+    assert report["status"] == "valid"
+    assert report["provenance_validation"] == "git_history"
+    assert [row["status"] for row in report["rows"]] == ["valid", "valid"]
+
+
+def test_cli_check_git_history_emits_json_for_unknown_sha(tmp_path: Path, capsys) -> None:
+    """CLI strict mode must surface unknown git SHAs in JSON so proof runs fail closed predictably."""
+    repo_root, _known_sha = _create_temp_git_repo(tmp_path)
+    row = _make_repo_backed_row()
+    row["commit_artifact"] = "deadbeef, docs/context/proof.json"
+    input_path = tmp_path / "unknown_sha.json"
+    input_path.write_text(json.dumps([row]), encoding="utf-8")
+
+    exit_code = validate_cli_main(
+        [
+            "--input",
+            str(input_path),
+            "--repo-root",
+            str(repo_root),
+            "--check-git-history",
+        ]
+    )
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "invalid"
+    assert payload["provenance_validation"] == "git_history"
+    assert payload["rows"][0]["errors"][0]["field"] == "commit_artifact"
+
+
+def _create_temp_git_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _git(repo_root, "init")
+    _git(repo_root, "config", "user.name", "Robot SF Tests")
+    _git(repo_root, "config", "user.email", "robot-sf-tests@example.com")
+    (repo_root / "docs" / "context").mkdir(parents=True)
+    (repo_root / "docs" / "context" / "proof.json").write_text(
+        '{"status": "ok"}\n', encoding="utf-8"
+    )
+    (repo_root / "docs" / "context" / "launch_packet.md").write_text(
+        "# Launch packet\n",
+        encoding="utf-8",
+    )
+    _git(repo_root, "add", "docs/context/proof.json", "docs/context/launch_packet.md")
+    _git(repo_root, "commit", "-m", "test fixture")
+    known_sha = _git(repo_root, "rev-parse", "--short=7", "HEAD")
+    return repo_root, known_sha
+
+
+def _make_repo_backed_row() -> dict[str, object]:
+    return {
+        "component": "learned_risk_model_v1",
+        "source_issue": "#1472",
+        "commit_artifact": "deadbeef, docs/context/proof.json",
+        "evaluation_slice": "stress_slice",
+        "guard_authority": {
+            "mechanism": "risk_guarded_ppo",
+            "active": True,
+            "veto_rate": 0.12,
+        },
+        "learned_component_contribution": {
+            "contribution_type": "auxiliary_cost",
+            "bound": "cost_weight in [0,1]",
+            "active_rate": 0.85,
+        },
+        "intervention_fallback_rates": {
+            "guard_veto_rate": 0.12,
+            "fallback_rate": 0.0,
+            "degraded_rate": None,
+        },
+        "outcomes": {
+            "success_rate": 0.72,
+            "collision_rate": 0.04,
+            "near_miss_rate": 0.08,
+            "low_progress_rate": 0.05,
+            "timeout_rate": 0.11,
+        },
+        "evidence_tier": "stress",
+        "verdict": "continue",
+        "scenario_manifest": "docs/context/proof.json",
+    }
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()


### PR DESCRIPTION
## Summary
- Add optional `--check-git-history` validation for `commit_artifact` SHA tokens in hybrid evidence rows.
- Keep the default validator lightweight/format-only so launch packets and remote durable pointers remain accepted without requiring local git history.
- Document the strict proof pass before #1489 synthesis and add targeted tests for known/unknown SHAs.

Closes #1534.

## Validation
- `uv run ruff format --check robot_sf/benchmark/hybrid_evidence_matrix.py scripts/validation/validate_hybrid_evidence_matrix.py tests/benchmark/test_hybrid_evidence_matrix.py`
- `uv run ruff check robot_sf/benchmark/hybrid_evidence_matrix.py scripts/validation/validate_hybrid_evidence_matrix.py tests/benchmark/test_hybrid_evidence_matrix.py`
- `uv run pytest -q tests/benchmark/test_hybrid_evidence_matrix.py` -> 10 passed
- `uv run python scripts/validation/validate_hybrid_evidence_matrix.py --input tests/fixtures/hybrid_evidence_matrix/v1/valid_rows.yaml | python -m json.tool`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4250 passed, 10 skipped; changed-file coverage warning only for `robot_sf/benchmark/hybrid_evidence_matrix.py` at 82.8%

## Delegation
- Copilot gpt-5.4 xhigh implemented the code/docs/tests in the issue worktree.
- A Copilot read-only review found no substantive issue after the unused constant it noticed was removed.
- A later post-merge Copilot review attempt was stopped after it stayed silent and produced no result artifact; it is not counted as evidence.
