### PR TITLE
Validate predictive same-seed row summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1550 predictive same-seed row-summary validation surface:
+  `robot_sf/benchmark/predictive_same_seed_row_summary.py` plus
+  `scripts/validation/validate_predictive_same_seed_row_summary.py` now validate small durable
+  predictive comparison rows for variant/scenario/seed/planner-grid outcomes, provenance pointers,
+  and explicit `unavailable`/`unknown` handling, with a checked-in template and focused regression
+  coverage under `tests/benchmark/test_predictive_same_seed_row_summary.py`.
 * Added the issue-1515 hybrid-evidence matrix validation surface: `robot_sf/benchmark/hybrid_evidence_matrix.py`
   and `scripts/validation/validate_hybrid_evidence_matrix.py` now validate the #1499 row contract
   for enums, nullability, repository-relative provenance, fail-closed fallback/degraded semantics,

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -98,6 +98,8 @@ knowledge, not every transient iteration detail.
   [issue_1240_scenario_coverage_entropy.md](issue_1240_scenario_coverage_entropy.md)
 * Issue #1167 predictive obstacle-feature pipeline:
   [issue_1167_predictive_obstacle_pipeline.md](issue_1167_predictive_obstacle_pipeline.md)
+* Issue #1550 predictive same-seed row summary schema:
+  [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
 * Issue #1530 optional planner preflight audit:

--- a/docs/context/evidence/predictive_same_seed_row_summary_template.yaml
+++ b/docs/context/evidence/predictive_same_seed_row_summary_template.yaml
@@ -1,0 +1,41 @@
+rows:
+  - source_issue: "#1550"
+    campaign: "replace_with_campaign_id"
+    comparison_group: "replace_with_same_seed_pair_label"
+    variant: "replace_with_baseline_variant_name"
+    scenario: "replace_with_scenario_id"
+    seed: 0
+    planner_grid_row: "replace_with_grid_row_name"
+    planner_grid_key: "replace_with_grid_row_key"
+    status: "ok"
+    success: false
+    collision_event: false
+    near_miss: false
+    low_progress: true
+    timeout: false
+    min_distance: 0.42
+    artifact_pointer: "docs/context/evidence/predictive_same_seed_row_summary_template.yaml"
+    commit_artifact: "deadbeef, docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+    scenario_matrix: "configs/scenarios/classic_interactions.yaml"
+    seed_manifest: "configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml"
+    source_note: "docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+  - source_issue: "#1550"
+    campaign: "replace_with_campaign_id"
+    comparison_group: "replace_with_same_seed_pair_label"
+    variant: "replace_with_unavailable_variant_name"
+    scenario: "replace_with_scenario_id"
+    seed: 0
+    planner_grid_row: "replace_with_grid_row_name"
+    planner_grid_key: "replace_with_grid_row_key"
+    status: "unavailable"
+    success: null
+    collision_event: null
+    near_miss: null
+    low_progress: null
+    timeout: null
+    min_distance: null
+    artifact_pointer: "docs/context/evidence/predictive_same_seed_row_summary_template.yaml"
+    commit_artifact: "deadbeef, docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+    scenario_matrix: "configs/scenarios/classic_interactions.yaml"
+    seed_manifest: "configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml"
+    source_note: "docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"

--- a/docs/context/issue_1167_predictive_obstacle_pipeline.md
+++ b/docs/context/issue_1167_predictive_obstacle_pipeline.md
@@ -218,3 +218,8 @@ git diff --check
 Issue #1167's runnable same-seed surface has now produced a complete #1427 comparison. PR #1480
 should be treated as workflow/artifact-contract progress plus negative same-seed evidence for
 obstacle-feature promotion, not as a successful benchmark promotion.
+
+Issue #1550 adds a forward-looking tracked row-summary schema for future same-seed comparisons:
+`docs/context/issue_1550_predictive_same_seed_row_summary_schema.md`. That schema exists to preserve
+future durable per-row outcomes only. It must not be used to reconstruct or invent missing #1427 row
+values that were never preserved in a durable source.

--- a/docs/context/issue_1550_predictive_same_seed_row_summary_schema.md
+++ b/docs/context/issue_1550_predictive_same_seed_row_summary_schema.md
@@ -1,0 +1,105 @@
+# Issue #1550 Predictive Same-Seed Row Summary Schema
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1550>
+
+## Purpose
+
+Define a small tracked schema for future predictive same-seed comparison outcome rows so bounded,
+durable row summaries can live in git without depending on local `output/` artifacts. This schema is
+for per-row comparison bookkeeping, not for benchmark synthesis or paper-facing claims.
+
+## Scope Boundary
+
+- **In scope**: a machine-readable row contract, validator, checked-in template, and docs guidance
+  for future predictive same-seed campaigns.
+- **Out of scope**: reconstructing or inventing missing historical #1427 per-row results, wiring new
+  campaign emitters, or upgrading these rows into benchmark-strength evidence.
+
+Issue #1427 already has high-level same-seed conclusions in
+`docs/context/issue_1167_predictive_obstacle_pipeline.md`. If a historical row was not preserved in
+a durable artifact at the time, this schema must **not** be used to backfill or infer that missing
+row later.
+
+## Row Contract
+
+Each row represents one variant/scenario/seed/planner-grid outcome within a same-seed comparison
+campaign. Store rows as YAML or JSON mappings and validate them with the dedicated CLI before
+committing them. The tuple `(variant, scenario, seed, planner_grid_key)` is the canonical row
+identity and must be unique within a summary file.
+
+### Required fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `source_issue` | string | Issue number that owns the row summary, e.g. `#1550`. |
+| `campaign` | string | Stable campaign label or run grouping identifier. |
+| `variant` | string | Variant/checkpoint label for the row. |
+| `scenario` | string | Scenario identifier used for the evaluation row. |
+| `seed` | integer | Exact deterministic seed for the row. |
+| `planner_grid_row` | string | Human-readable planner-grid row name. |
+| `planner_grid_key` | string | Stable planner-grid key when present; duplicate `planner_grid_row` if no separate key exists. |
+| `status` | enum | One of `ok`, `failed`, `degraded`, `unavailable`, `unknown`. |
+| `success` | boolean or null | Episode success outcome. Must be null for `unavailable`/`unknown`. |
+| `collision_event` | boolean or null | Whether a collision-like terminal event was observed. |
+| `near_miss` | boolean or null | Whether a near-miss event was observed or flagged. |
+| `low_progress` | boolean or null | Whether the row ended in low-progress failure. |
+| `timeout` | boolean or null | Whether the row ended by timeout. |
+| `min_distance` | number or null | Minimum observed clearance for the row. |
+| `artifact_pointer` | string | One durable pointer for the row summary, such as a tracked note/table path or durable remote artifact URI. |
+| `commit_artifact` | string | Git SHA plus one or more provenance tokens for the row source, using the same comma/newline token style as the hybrid-evidence matrix validator. |
+
+### Optional fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `comparison_group` | string | Stable label tying baseline and variant rows together. |
+| `scenario_matrix` | string | Repository-relative path to the scenario matrix used for the row. |
+| `seed_manifest` | string | Repository-relative path to the committed seed manifest. |
+| `source_note` | string | Repository-relative path to the note or evidence summary that interprets the row. |
+
+## Status Semantics
+
+| `status` | Expected outcome fields |
+| --- | --- |
+| `ok` | All booleans plus `min_distance` must be populated. |
+| `failed` | Known outcome fields may be populated; unknown values may remain null. |
+| `degraded` | Partial outcome information may be recorded, but the row remains an explicit caveat. |
+| `unavailable` | All outcome fields must be null. Use this when the planner/dependency/source artifact could not satisfy the row contract. |
+| `unknown` | All outcome fields must be null. Use this when the row should exist but no durable outcome was preserved. |
+
+These rows are **diagnostic-only**. They are not substitutes for the benchmark-facing evidence matrix
+from `docs/context/issue_1499_hybrid_evidence_matrix_schema.md`, and they must not be treated as
+synthesis-grade evidence for issue #1489.
+
+## Tracked Template And Validator
+
+- Template:
+  `docs/context/evidence/predictive_same_seed_row_summary_template.yaml`
+- Python validator:
+  `robot_sf/benchmark/predictive_same_seed_row_summary.py`
+- CLI:
+  `scripts/validation/validate_predictive_same_seed_row_summary.py`
+
+Default validation is format-only so future row drafts can be checked before the final campaign SHA
+is available locally. For stricter provenance checks, rerun the same file with `--check-git-history`
+from a checkout whose git history contains the cited commit.
+
+Canonical command:
+
+```bash
+uv run python scripts/validation/validate_predictive_same_seed_row_summary.py \
+  --input docs/context/evidence/predictive_same_seed_row_summary_template.yaml
+```
+
+## Usage Guidance
+
+Use this schema when a predictive same-seed campaign needs a small tracked table of row outcomes that
+can survive worktree cleanup. Typical cases:
+
+1. preserving a planner-grid row outcome that would otherwise only exist inside ignored JSONL output,
+2. carrying one unavailable/unknown row forward without inventing metrics,
+3. linking a future predictive comparison note to a compact tracked YAML summary.
+
+Do **not** use this schema to restate old #1427 rows from memory, from screenshots, or from deleted
+local output trees. If a durable source was not preserved, keep the row as `unknown` or leave it out
+until a real source exists.

--- a/robot_sf/benchmark/predictive_same_seed_row_summary.py
+++ b/robot_sf/benchmark/predictive_same_seed_row_summary.py
@@ -1,0 +1,552 @@
+"""Validation helpers for predictive same-seed comparison outcome rows."""
+
+from __future__ import annotations
+
+import math
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.common.artifact_paths import get_repository_root
+
+ROW_STATUSES = frozenset({"ok", "failed", "degraded", "unavailable", "unknown"})
+ROW_REQUIRED_FIELDS = frozenset(
+    {
+        "source_issue",
+        "campaign",
+        "variant",
+        "scenario",
+        "seed",
+        "planner_grid_row",
+        "planner_grid_key",
+        "status",
+        "success",
+        "collision_event",
+        "near_miss",
+        "low_progress",
+        "timeout",
+        "min_distance",
+        "artifact_pointer",
+        "commit_artifact",
+    }
+)
+ROW_OPTIONAL_FIELDS = frozenset(
+    {
+        "comparison_group",
+        "scenario_matrix",
+        "seed_manifest",
+        "source_note",
+    }
+)
+DURABLE_URI_PREFIXES = (
+    "wandb://",
+    "wandb-artifact://",
+    "artifact://",
+    "s3://",
+    "gs://",
+    "https://",
+)
+_ISSUE_RE = re.compile(r"^#\d+$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class PredictiveSameSeedRowSummaryValidationError(ValueError):
+    """Raised when a predictive same-seed row-summary payload cannot be loaded."""
+
+
+def load_predictive_same_seed_row_summary_input(path: Path) -> tuple[str, list[dict[str, Any]]]:
+    """Load a row-summary file as one or more row mappings.
+
+    Returns:
+        Tuple containing the detected input format label and the loaded row list.
+    """
+    if not path.is_file():
+        raise PredictiveSameSeedRowSummaryValidationError(f"input file does not exist: {path}")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        rows = payload
+        input_format = "rows"
+    elif isinstance(payload, dict) and "rows" in payload:
+        rows = payload["rows"]
+        input_format = "matrix"
+    elif isinstance(payload, dict):
+        rows = [payload]
+        input_format = "row"
+    else:
+        raise PredictiveSameSeedRowSummaryValidationError(
+            "input payload must be a mapping, a list of rows, or a mapping with a 'rows' list"
+        )
+    if not isinstance(rows, list):
+        raise PredictiveSameSeedRowSummaryValidationError("rows must be a list of mappings")
+    return input_format, rows
+
+
+def validate_predictive_same_seed_row_summary_file(
+    path: Path,
+    *,
+    repo_root: Path | None = None,
+    check_git_history: bool = False,
+) -> dict[str, Any]:
+    """Load and validate a predictive same-seed row-summary file.
+
+    Returns:
+        Structured validation report with aggregate counts and per-row details.
+    """
+    input_format, rows = load_predictive_same_seed_row_summary_input(path)
+    report = validate_predictive_same_seed_row_summary_rows(
+        rows,
+        repo_root=repo_root,
+        check_git_history=check_git_history,
+    )
+    report["input_format"] = input_format
+    report["input_path"] = _repo_relative_or_absolute(
+        path.resolve(), root=(repo_root or get_repository_root())
+    )
+    return report
+
+
+def validate_predictive_same_seed_row_summary_rows(
+    rows: list[dict[str, Any]],
+    *,
+    repo_root: Path | None = None,
+    check_git_history: bool = False,
+) -> dict[str, Any]:
+    """Validate predictive same-seed comparison outcome rows.
+
+    Returns:
+        Structured validation report with aggregate counts and per-row details.
+    """
+    root = (repo_root or get_repository_root()).resolve()
+    provenance_validation = "git_history" if check_git_history else "format_only"
+    git_commit_cache: dict[str, bool] = {}
+    row_reports = [
+        _validate_row(
+            row,
+            index=index,
+            repo_root=root,
+            provenance_validation=provenance_validation,
+            git_commit_cache=git_commit_cache,
+        )
+        for index, row in enumerate(rows)
+    ]
+    _mark_duplicate_row_keys(row_reports)
+    invalid_row_count = sum(1 for row in row_reports if row["status"] == "invalid")
+    return {
+        "status": "valid" if invalid_row_count == 0 else "invalid",
+        "provenance_validation": provenance_validation,
+        "row_count": len(row_reports),
+        "valid_row_count": len(row_reports) - invalid_row_count,
+        "invalid_row_count": invalid_row_count,
+        "rows": row_reports,
+    }
+
+
+def _mark_duplicate_row_keys(row_reports: list[dict[str, Any]]) -> None:
+    seen: dict[str, int] = {}
+    for row_report in row_reports:
+        row_key = row_report.get("row_key")
+        if not row_key:
+            continue
+        first_index = seen.get(row_key)
+        if first_index is None:
+            seen[row_key] = int(row_report["index"])
+            continue
+        _append_problem(
+            row_report["errors"],
+            "row_key",
+            f"duplicates row key {row_key!r} first seen at row index {first_index}",
+        )
+        row_report["status"] = "invalid"
+
+
+def _validate_row(
+    row: object,
+    *,
+    index: int,
+    repo_root: Path,
+    provenance_validation: str,
+    git_commit_cache: dict[str, bool],
+) -> dict[str, Any]:
+    errors: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+    if not isinstance(row, dict):
+        _append_problem(errors, "row", "must be a mapping")
+        return {
+            "index": index,
+            "row_key": None,
+            "row_status": None,
+            "status": "invalid",
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+    _check_expected_fields(
+        row,
+        required=ROW_REQUIRED_FIELDS,
+        optional=ROW_OPTIONAL_FIELDS,
+        prefix="row",
+        errors=errors,
+    )
+
+    source_issue = _require_non_empty_string(row, "source_issue", errors)
+    if source_issue is not None and not _ISSUE_RE.fullmatch(source_issue):
+        _append_problem(errors, "source_issue", "must match '#<number>'")
+    campaign = _require_non_empty_string(row, "campaign", errors)
+    variant = _require_non_empty_string(row, "variant", errors)
+    scenario = _require_non_empty_string(row, "scenario", errors)
+    planner_grid_row = _require_non_empty_string(row, "planner_grid_row", errors)
+    planner_grid_key = _require_non_empty_string(row, "planner_grid_key", errors)
+    seed = _require_non_negative_int(row, "seed", errors)
+    row_status = _require_enum(row, "status", ROW_STATUSES, errors)
+    success = _require_nullable_bool(row, "success", errors)
+    collision_event = _require_nullable_bool(row, "collision_event", errors)
+    near_miss = _require_nullable_bool(row, "near_miss", errors)
+    low_progress = _require_nullable_bool(row, "low_progress", errors)
+    timeout = _require_nullable_bool(row, "timeout", errors)
+    min_distance = _require_nullable_non_negative_number(row, "min_distance", errors)
+
+    _validate_artifact_pointer(
+        row.get("artifact_pointer"), field="artifact_pointer", repo_root=repo_root, errors=errors
+    )
+    _validate_commit_artifact(
+        row.get("commit_artifact"),
+        field="commit_artifact",
+        repo_root=repo_root,
+        provenance_validation=provenance_validation,
+        git_commit_cache=git_commit_cache,
+        errors=errors,
+    )
+    _validate_optional_reference(row, "scenario_matrix", repo_root=repo_root, errors=errors)
+    _validate_optional_reference(row, "seed_manifest", repo_root=repo_root, errors=errors)
+    _validate_optional_reference(row, "source_note", repo_root=repo_root, errors=errors)
+    if "comparison_group" in row:
+        _require_non_empty_string(row, "comparison_group", errors)
+
+    _validate_semantics(
+        row_status=row_status,
+        outcomes={
+            "success": success,
+            "collision_event": collision_event,
+            "near_miss": near_miss,
+            "low_progress": low_progress,
+            "timeout": timeout,
+        },
+        min_distance=min_distance,
+        errors=errors,
+        warnings=warnings,
+    )
+
+    row_key = None
+    if (
+        variant is not None
+        and scenario is not None
+        and seed is not None
+        and planner_grid_key is not None
+    ):
+        row_key = f"{variant}:{scenario}:{seed}:{planner_grid_key}"
+    return {
+        "index": index,
+        "row_key": row_key,
+        "source_issue": source_issue,
+        "campaign": campaign,
+        "variant": variant,
+        "scenario": scenario,
+        "seed": seed,
+        "planner_grid_row": planner_grid_row,
+        "planner_grid_key": planner_grid_key,
+        "row_status": row_status,
+        "status": "valid" if not errors else "invalid",
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _validate_semantics(
+    *,
+    row_status: str | None,
+    outcomes: dict[str, bool | None],
+    min_distance: float | None,
+    errors: list[dict[str, str]],
+    warnings: list[dict[str, str]],
+) -> None:
+    _validate_status_specific_nullability(
+        row_status=row_status,
+        outcomes=outcomes,
+        min_distance=min_distance,
+        errors=errors,
+    )
+    success = outcomes["success"]
+    if success is True:
+        for field in ("collision_event", "low_progress", "timeout"):
+            if outcomes[field] is True:
+                _append_problem(errors, field, "cannot be true when success is true")
+    if row_status == "failed" and success is True:
+        _append_problem(errors, "success", "cannot be true when status is 'failed'")
+    if outcomes["low_progress"] is True and outcomes["timeout"] is True:
+        _append_problem(
+            errors,
+            "timeout",
+            "cannot be true when low_progress is already true for the same row",
+        )
+    if row_status == "degraded" and all(value is None for value in (*outcomes.values(), min_distance)):
+        _append_problem(
+            warnings,
+            "status",
+            "degraded rows should preserve any known outcome flags instead of leaving every field null",
+        )
+
+
+def _validate_status_specific_nullability(
+    *,
+    row_status: str | None,
+    outcomes: dict[str, bool | None],
+    min_distance: float | None,
+    errors: list[dict[str, str]],
+) -> None:
+    if row_status == "ok":
+        for field, value in outcomes.items():
+            if value is None:
+                _append_problem(errors, field, "must be a boolean when status is 'ok'")
+        if min_distance is None:
+            _append_problem(errors, "min_distance", "must be a number when status is 'ok'")
+        return
+    if row_status not in {"unavailable", "unknown"}:
+        return
+    for field, value in outcomes.items():
+        if value is not None:
+            _append_problem(errors, field, f"must be null when status is {row_status!r}")
+    if min_distance is not None:
+        _append_problem(errors, "min_distance", f"must be null when status is {row_status!r}")
+
+
+def _validate_artifact_pointer(
+    value: object,
+    *,
+    field: str,
+    repo_root: Path,
+    errors: list[dict[str, str]],
+) -> None:
+    if not isinstance(value, str) or not value.strip():
+        _append_problem(errors, field, "must be a non-empty string")
+        return
+    if len(_split_reference_tokens(value)) != 1:
+        _append_problem(errors, field, "must be a single durable pointer token")
+        return
+    _validate_reference_token(value.strip(), field, repo_root=repo_root, errors=errors)
+
+
+def _validate_commit_artifact(
+    value: object,
+    *,
+    field: str,
+    repo_root: Path,
+    provenance_validation: str,
+    git_commit_cache: dict[str, bool],
+    errors: list[dict[str, str]],
+) -> None:
+    if not isinstance(value, str) or not value.strip():
+        _append_problem(errors, field, "must be a non-empty string")
+        return
+    tokens = [token for token in _split_reference_tokens(value) if token]
+    if not tokens:
+        _append_problem(
+            errors,
+            field,
+            "must include a git SHA token plus one or more provenance tokens",
+        )
+        return
+    has_git_sha = False
+    has_provenance_token = False
+    git_sha_tokens: list[str] = []
+    for token in tokens:
+        normalized = token.lower()
+        if _GIT_SHA_RE.fullmatch(normalized):
+            has_git_sha = True
+            git_sha_tokens.append(normalized)
+            continue
+        has_provenance_token = True
+        _validate_reference_token(token, field, repo_root=repo_root, errors=errors)
+    if not has_git_sha:
+        _append_problem(errors, field, "must include a 7-40 character git SHA token")
+    if not has_provenance_token:
+        _append_problem(errors, field, "must include at least one provenance pointer token")
+    if provenance_validation == "git_history":
+        for sha in git_sha_tokens:
+            if _git_commit_exists(sha, repo_root=repo_root, cache=git_commit_cache):
+                continue
+            _append_problem(
+                errors,
+                field,
+                f"references unknown git commit SHA in repository history: {sha!r}",
+            )
+
+
+def _git_commit_exists(sha: str, *, repo_root: Path, cache: dict[str, bool]) -> bool:
+    cached = cache.get(sha)
+    if cached is not None:
+        return cached
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    exists = result.returncode == 0
+    cache[sha] = exists
+    return exists
+
+
+def _validate_optional_reference(
+    mapping: dict[str, Any],
+    field: str,
+    *,
+    repo_root: Path,
+    errors: list[dict[str, str]],
+) -> None:
+    if field not in mapping or mapping[field] is None:
+        return
+    value = _require_non_empty_string(mapping, field, errors)
+    if value is not None:
+        _validate_reference_token(value, field, repo_root=repo_root, errors=errors)
+
+
+def _validate_reference_token(
+    token: str,
+    field: str,
+    *,
+    repo_root: Path,
+    errors: list[dict[str, str]],
+) -> None:
+    if token.startswith(DURABLE_URI_PREFIXES):
+        return
+    path = Path(token)
+    if path.is_absolute():
+        _append_problem(
+            errors, field, f"must use repository-root-relative paths, not absolute path {token!r}"
+        )
+        return
+    if ".." in path.parts:
+        _append_problem(errors, field, f"must not escape the repository root: {token!r}")
+        return
+    resolved = (repo_root / path).resolve()
+    output_dir = (repo_root / "output").resolve()
+    if resolved == output_dir or output_dir in resolved.parents:
+        _append_problem(errors, field, f"must not depend on worktree-local output paths: {token!r}")
+        return
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        _append_problem(errors, field, f"must resolve inside the repository root: {token!r}")
+        return
+    if not resolved.exists():
+        _append_problem(errors, field, f"references a missing repository path: {token!r}")
+
+
+def _check_expected_fields(
+    mapping: dict[str, Any],
+    *,
+    required: frozenset[str],
+    optional: frozenset[str],
+    prefix: str,
+    errors: list[dict[str, str]],
+) -> None:
+    missing = sorted(required - mapping.keys())
+    for field in missing:
+        _append_problem(errors, f"{prefix}.{field}" if prefix != "row" else field, "is required")
+    allowed = required | optional
+    unexpected = sorted(set(mapping) - allowed)
+    for field in unexpected:
+        _append_problem(
+            errors,
+            f"{prefix}.{field}" if prefix != "row" else field,
+            "is not part of the canonical schema",
+        )
+
+
+def _require_non_empty_string(
+    mapping: dict[str, Any], field: str, errors: list[dict[str, str]]
+) -> str | None:
+    value = mapping.get(field)
+    if not isinstance(value, str) or not value.strip():
+        _append_problem(errors, field, "must be a non-empty string")
+        return None
+    return value.strip()
+
+
+def _require_enum(
+    mapping: dict[str, Any],
+    field: str,
+    allowed: frozenset[str],
+    errors: list[dict[str, str]],
+) -> str | None:
+    value = mapping.get(field)
+    if not isinstance(value, str) or value not in allowed:
+        _append_problem(errors, field, f"must be one of {sorted(allowed)!r}")
+        return None
+    return value
+
+
+def _require_non_negative_int(
+    mapping: dict[str, Any], field: str, errors: list[dict[str, str]]
+) -> int | None:
+    value = mapping.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        _append_problem(errors, field, "must be a non-negative integer")
+        return None
+    if value < 0:
+        _append_problem(errors, field, "must be a non-negative integer")
+        return None
+    return value
+
+
+def _require_nullable_bool(
+    mapping: dict[str, Any], field: str, errors: list[dict[str, str]]
+) -> bool | None:
+    value = mapping.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        _append_problem(errors, field, "must be a boolean or null")
+        return None
+    return value
+
+
+def _require_nullable_non_negative_number(
+    mapping: dict[str, Any], field: str, errors: list[dict[str, str]]
+) -> float | None:
+    value = mapping.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        _append_problem(errors, field, "must be a finite number or null")
+        return None
+    normalized = float(value)
+    if normalized < 0.0:
+        _append_problem(errors, field, "must be greater than or equal to 0.0")
+    return normalized
+
+
+def _split_reference_tokens(value: str) -> list[str]:
+    return [token.strip() for token in re.split(r"[\n,]+", value) if token.strip()]
+
+
+def _append_problem(problems: list[dict[str, str]], field: str, message: str) -> None:
+    problems.append({"field": field, "message": message})
+
+
+def _repo_relative_or_absolute(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+__all__ = [
+    "PredictiveSameSeedRowSummaryValidationError",
+    "load_predictive_same_seed_row_summary_input",
+    "validate_predictive_same_seed_row_summary_file",
+    "validate_predictive_same_seed_row_summary_rows",
+]

--- a/robot_sf/benchmark/predictive_same_seed_row_summary.py
+++ b/robot_sf/benchmark/predictive_same_seed_row_summary.py
@@ -291,7 +291,9 @@ def _validate_semantics(
             "timeout",
             "cannot be true when low_progress is already true for the same row",
         )
-    if row_status == "degraded" and all(value is None for value in (*outcomes.values(), min_distance)):
+    if row_status == "degraded" and all(
+        value is None for value in (*outcomes.values(), min_distance)
+    ):
         _append_problem(
             warnings,
             "status",

--- a/scripts/validation/validate_predictive_same_seed_row_summary.py
+++ b/scripts/validation/validate_predictive_same_seed_row_summary.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate predictive same-seed comparison outcome rows and emit a JSON report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.predictive_same_seed_row_summary import (
+    PredictiveSameSeedRowSummaryValidationError,
+    validate_predictive_same_seed_row_summary_file,
+)
+from robot_sf.common.artifact_paths import get_repository_root
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Validate predictive same-seed row summaries against the #1550 contract."
+    )
+    parser.add_argument("--input", required=True, type=Path, help="YAML or JSON row-summary file.")
+    parser.add_argument(
+        "--repo-root",
+        default=get_repository_root(),
+        type=Path,
+        help="Repository root used to resolve repository-relative provenance paths.",
+    )
+    parser.add_argument(
+        "--check-git-history",
+        action="store_true",
+        help=(
+            "Also verify that each git SHA token in commit_artifact resolves to a commit in the "
+            "local repository history. Default validation remains format-only."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate a row-summary file and return a shell-friendly exit code."""
+    args = build_arg_parser().parse_args(argv)
+    try:
+        report = validate_predictive_same_seed_row_summary_file(
+            args.input,
+            repo_root=args.repo_root,
+            check_git_history=args.check_git_history,
+        )
+    except PredictiveSameSeedRowSummaryValidationError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "valid" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/benchmark/test_predictive_same_seed_row_summary.py
+++ b/tests/benchmark/test_predictive_same_seed_row_summary.py
@@ -37,7 +37,9 @@ def test_valid_rows_accept_ok_and_unavailable_records() -> None:
 
 def test_missing_required_field_reports_actionable_error() -> None:
     """Required-field failures should point at the specific missing field."""
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     mutated_rows = copy.deepcopy(rows[:1])
     del mutated_rows[0]["artifact_pointer"]
 
@@ -49,7 +51,9 @@ def test_missing_required_field_reports_actionable_error() -> None:
 
 def test_invalid_status_boolean_and_numeric_values_are_rejected() -> None:
     """Enum, boolean, and numeric contract violations should all fail closed."""
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     invalid_status = copy.deepcopy(rows[:1])
     invalid_status[0]["status"] = "complete"
 
@@ -74,7 +78,9 @@ def test_invalid_status_boolean_and_numeric_values_are_rejected() -> None:
 
 def test_unavailable_and_unknown_rows_require_null_outcomes() -> None:
     """Unavailable and unknown rows must not invent outcome values."""
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     unavailable_with_success = copy.deepcopy(rows[1:2])
     unavailable_with_success[0]["success"] = False
 
@@ -85,16 +91,15 @@ def test_unavailable_and_unknown_rows_require_null_outcomes() -> None:
     unknown_report = validate_predictive_same_seed_row_summary_rows(unknown_row)
 
     assert unavailable_report["status"] == "invalid"
-    assert {
-        error["field"]
-        for error in unavailable_report["rows"][0]["errors"]
-    } == {"success"}
+    assert {error["field"] for error in unavailable_report["rows"][0]["errors"]} == {"success"}
     assert unknown_report["status"] == "valid"
 
 
 def test_duplicate_row_keys_are_rejected() -> None:
     """Contradictory rows for one variant/scenario/seed/grid key should fail closed."""
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     duplicate_rows = copy.deepcopy(rows[:1])
     duplicate_rows.append(copy.deepcopy(rows[0]))
     duplicate_rows[1]["status"] = "failed"
@@ -105,15 +110,136 @@ def test_duplicate_row_keys_are_rejected() -> None:
 
     assert report["status"] == "invalid"
     assert report["invalid_row_count"] == 1
+    assert {error["field"] for error in report["rows"][1]["errors"]} == {"row_key"}
+
+
+def test_loader_accepts_supported_shapes_and_rejects_bad_payloads(tmp_path: Path) -> None:
+    """The file loader should make accepted YAML shapes explicit."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    single_row_path = tmp_path / "single_row.yaml"
+    single_row_path.write_text(yaml.safe_dump(rows[0], sort_keys=False), encoding="utf-8")
+    row_list_path = tmp_path / "row_list.yaml"
+    row_list_path.write_text(yaml.safe_dump(rows[:1], sort_keys=False), encoding="utf-8")
+    bad_rows_path = tmp_path / "bad_rows.yaml"
+    bad_rows_path.write_text(yaml.safe_dump({"rows": "not-a-list"}), encoding="utf-8")
+    scalar_path = tmp_path / "scalar.yaml"
+    scalar_path.write_text("true\n", encoding="utf-8")
+
+    assert load_predictive_same_seed_row_summary_input(single_row_path)[0] == "row"
+    assert load_predictive_same_seed_row_summary_input(row_list_path)[0] == "rows"
+    for path in (bad_rows_path, scalar_path, tmp_path / "missing.yaml"):
+        try:
+            load_predictive_same_seed_row_summary_input(path)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected loader failure for {path}")
+
+
+def test_semantic_contradictions_and_reference_guards_are_reported() -> None:
+    """Safety semantics and durable-reference boundaries should fail closed."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    row = copy.deepcopy(rows[0])
+    row["success"] = True
+    row["collision_event"] = True
+    row["low_progress"] = True
+    row["timeout"] = True
+    row["artifact_pointer"] = "docs/context/a.yaml, docs/context/b.yaml"
+    row["commit_artifact"] = "docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+    row["source_issue"] = "1550"
+    row["unexpected"] = "value"
+
+    report = validate_predictive_same_seed_row_summary_rows([row])
+
+    error_fields = {error["field"] for error in report["rows"][0]["errors"]}
+    assert report["status"] == "invalid"
     assert {
-        error["field"]
-        for error in report["rows"][1]["errors"]
-    } == {"row_key"}
+        "artifact_pointer",
+        "collision_event",
+        "commit_artifact",
+        "low_progress",
+        "source_issue",
+        "timeout",
+        "unexpected",
+    } <= error_fields
+
+
+def test_status_specific_nullability_and_degraded_warning() -> None:
+    """Status contracts should distinguish missing, failed, unknown, and degraded rows."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    ok_missing_min_distance = copy.deepcopy(rows[0])
+    ok_missing_min_distance["min_distance"] = None
+    failed_success = copy.deepcopy(rows[0])
+    failed_success["variant"] = "schema_fixture_failed"
+    failed_success["status"] = "failed"
+    failed_success["success"] = True
+    unknown_with_min_distance = copy.deepcopy(rows[1])
+    unknown_with_min_distance["status"] = "unknown"
+    unknown_with_min_distance["min_distance"] = 1.0
+    degraded_empty = copy.deepcopy(rows[1])
+    degraded_empty["variant"] = "schema_fixture_degraded"
+    degraded_empty["status"] = "degraded"
+
+    report = validate_predictive_same_seed_row_summary_rows(
+        [ok_missing_min_distance, failed_success, unknown_with_min_distance, degraded_empty]
+    )
+
+    assert report["status"] == "invalid"
+    assert any(
+        error["field"] == "min_distance" and "status is 'ok'" in error["message"]
+        for error in report["rows"][0]["errors"]
+    )
+    assert {"success", "collision_event"} <= {
+        error["field"] for error in report["rows"][1]["errors"]
+    }
+    assert {error["field"] for error in report["rows"][2]["errors"]} == {"min_distance"}
+    assert report["rows"][3]["status"] == "valid"
+    assert report["rows"][3]["warnings"] == [
+        {
+            "field": "status",
+            "message": (
+                "degraded rows should preserve any known outcome flags instead of leaving every "
+                "field null"
+            ),
+        }
+    ]
+
+
+def test_repository_reference_guards_reject_unsafe_paths(tmp_path: Path) -> None:
+    """Repository-relative provenance must not point outside the durable evidence boundary."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "docs" / "context").mkdir(parents=True)
+    (repo_root / "docs" / "context" / "proof.md").write_text("ok\n", encoding="utf-8")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    cases = {
+        "absolute": str((repo_root / "docs" / "context" / "proof.md").resolve()),
+        "escape": "../proof.md",
+        "output": "output/proof.md",
+        "missing": "docs/context/missing.md",
+    }
+    for expected_message, value in cases.items():
+        row = copy.deepcopy(rows[0])
+        row["artifact_pointer"] = value
+
+        report = validate_predictive_same_seed_row_summary_rows([row], repo_root=repo_root)
+
+        messages = [error["message"] for error in report["rows"][0]["errors"]]
+        assert any(expected_message in message for message in messages)
 
 
 def test_cli_emits_json_for_invalid_input(tmp_path: Path, capsys) -> None:
     """The CLI should return a structured JSON report and the invalid-data exit code."""
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     mutated_rows = copy.deepcopy(rows[:1])
     mutated_rows[0]["timeout"] = "later"
     input_path = tmp_path / "invalid_rows.yaml"
@@ -130,7 +256,9 @@ def test_cli_emits_json_for_invalid_input(tmp_path: Path, capsys) -> None:
 def test_git_history_validation_rejects_unknown_git_sha(tmp_path: Path) -> None:
     """Strict provenance mode must fail closed on git SHAs absent from repository history."""
     repo_root, _known_sha = _create_temp_git_repo(tmp_path)
-    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
     mutated_rows = copy.deepcopy(rows[:1])
     mutated_rows[0]["artifact_pointer"] = "docs/context/proof.json"
     mutated_rows[0]["commit_artifact"] = "deadbeef, docs/context/proof.json"

--- a/tests/benchmark/test_predictive_same_seed_row_summary.py
+++ b/tests/benchmark/test_predictive_same_seed_row_summary.py
@@ -1,0 +1,178 @@
+"""Tests for predictive same-seed row-summary validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.predictive_same_seed_row_summary import (
+    load_predictive_same_seed_row_summary_input,
+    validate_predictive_same_seed_row_summary_file,
+    validate_predictive_same_seed_row_summary_rows,
+)
+from scripts.validation.validate_predictive_same_seed_row_summary import main as validate_cli_main
+
+FIXTURE_ROOT = Path("tests/fixtures/predictive_same_seed_row_summary/v1")
+
+
+def test_valid_rows_accept_ok_and_unavailable_records() -> None:
+    """Executed and unavailable same-seed rows should both validate deterministically."""
+    report = validate_predictive_same_seed_row_summary_file(FIXTURE_ROOT / "valid_rows.yaml")
+
+    assert report["status"] == "valid"
+    assert report["provenance_validation"] == "format_only"
+    assert report["row_count"] == 2
+    assert report["valid_row_count"] == 2
+    assert report["rows"][0]["row_status"] == "ok"
+    assert report["rows"][0]["row_key"] == (
+        "schema_fixture_baseline:schema_fixture_scenario:102:schema_fixture_grid_key"
+    )
+    assert report["rows"][1]["row_status"] == "unavailable"
+    assert report["rows"][1]["errors"] == []
+
+
+def test_missing_required_field_reports_actionable_error() -> None:
+    """Required-field failures should point at the specific missing field."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    mutated_rows = copy.deepcopy(rows[:1])
+    del mutated_rows[0]["artifact_pointer"]
+
+    report = validate_predictive_same_seed_row_summary_rows(mutated_rows)
+
+    assert report["status"] == "invalid"
+    assert {"field": "artifact_pointer", "message": "is required"} in report["rows"][0]["errors"]
+
+
+def test_invalid_status_boolean_and_numeric_values_are_rejected() -> None:
+    """Enum, boolean, and numeric contract violations should all fail closed."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    invalid_status = copy.deepcopy(rows[:1])
+    invalid_status[0]["status"] = "complete"
+
+    invalid_boolean = copy.deepcopy(rows[:1])
+    invalid_boolean[0]["success"] = "yes"
+
+    invalid_numeric = copy.deepcopy(rows[:1])
+    invalid_numeric[0]["min_distance"] = -0.2
+
+    cases = [
+        (invalid_status, "status"),
+        (invalid_boolean, "success"),
+        (invalid_numeric, "min_distance"),
+    ]
+    for mutated_rows, expected_field in cases:
+        report = validate_predictive_same_seed_row_summary_rows(mutated_rows)
+
+        assert report["status"] == "invalid"
+        error_fields = {error["field"] for error in report["rows"][0]["errors"]}
+        assert expected_field in error_fields
+
+
+def test_unavailable_and_unknown_rows_require_null_outcomes() -> None:
+    """Unavailable and unknown rows must not invent outcome values."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    unavailable_with_success = copy.deepcopy(rows[1:2])
+    unavailable_with_success[0]["success"] = False
+
+    unknown_row = copy.deepcopy(rows[1:2])
+    unknown_row[0]["status"] = "unknown"
+
+    unavailable_report = validate_predictive_same_seed_row_summary_rows(unavailable_with_success)
+    unknown_report = validate_predictive_same_seed_row_summary_rows(unknown_row)
+
+    assert unavailable_report["status"] == "invalid"
+    assert {
+        error["field"]
+        for error in unavailable_report["rows"][0]["errors"]
+    } == {"success"}
+    assert unknown_report["status"] == "valid"
+
+
+def test_duplicate_row_keys_are_rejected() -> None:
+    """Contradictory rows for one variant/scenario/seed/grid key should fail closed."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    duplicate_rows = copy.deepcopy(rows[:1])
+    duplicate_rows.append(copy.deepcopy(rows[0]))
+    duplicate_rows[1]["status"] = "failed"
+    duplicate_rows[1]["success"] = False
+    duplicate_rows[1]["min_distance"] = None
+
+    report = validate_predictive_same_seed_row_summary_rows(duplicate_rows)
+
+    assert report["status"] == "invalid"
+    assert report["invalid_row_count"] == 1
+    assert {
+        error["field"]
+        for error in report["rows"][1]["errors"]
+    } == {"row_key"}
+
+
+def test_cli_emits_json_for_invalid_input(tmp_path: Path, capsys) -> None:
+    """The CLI should return a structured JSON report and the invalid-data exit code."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    mutated_rows = copy.deepcopy(rows[:1])
+    mutated_rows[0]["timeout"] = "later"
+    input_path = tmp_path / "invalid_rows.yaml"
+    input_path.write_text(yaml.safe_dump({"rows": mutated_rows}, sort_keys=False), encoding="utf-8")
+
+    exit_code = validate_cli_main(["--input", str(input_path)])
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "invalid"
+    assert payload["rows"][0]["errors"][0]["field"] == "timeout"
+
+
+def test_git_history_validation_rejects_unknown_git_sha(tmp_path: Path) -> None:
+    """Strict provenance mode must fail closed on git SHAs absent from repository history."""
+    repo_root, _known_sha = _create_temp_git_repo(tmp_path)
+    _input_format, rows = load_predictive_same_seed_row_summary_input(FIXTURE_ROOT / "valid_rows.yaml")
+    mutated_rows = copy.deepcopy(rows[:1])
+    mutated_rows[0]["artifact_pointer"] = "docs/context/proof.json"
+    mutated_rows[0]["commit_artifact"] = "deadbeef, docs/context/proof.json"
+    mutated_rows[0]["source_note"] = "docs/context/proof.json"
+    mutated_rows[0]["scenario_matrix"] = "docs/context/proof.json"
+    mutated_rows[0]["seed_manifest"] = "docs/context/proof.json"
+
+    report = validate_predictive_same_seed_row_summary_rows(
+        mutated_rows, repo_root=repo_root, check_git_history=True
+    )
+
+    assert report["status"] == "invalid"
+    assert report["provenance_validation"] == "git_history"
+    messages = {
+        error["message"]
+        for error in report["rows"][0]["errors"]
+        if error["field"] == "commit_artifact"
+    }
+    assert "references unknown git commit SHA in repository history: 'deadbeef'" in messages
+
+
+def _create_temp_git_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _git(repo_root, "init")
+    _git(repo_root, "config", "user.name", "Robot SF Tests")
+    _git(repo_root, "config", "user.email", "robot-sf-tests@example.com")
+    (repo_root / "docs" / "context").mkdir(parents=True)
+    (repo_root / "docs" / "context" / "proof.json").write_text(
+        '{"status": "ok"}\n', encoding="utf-8"
+    )
+    _git(repo_root, "add", "docs/context/proof.json")
+    _git(repo_root, "commit", "-m", "test fixture")
+    known_sha = _git(repo_root, "rev-parse", "--short=7", "HEAD")
+    return repo_root, known_sha
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()

--- a/tests/fixtures/predictive_same_seed_row_summary/v1/valid_rows.yaml
+++ b/tests/fixtures/predictive_same_seed_row_summary/v1/valid_rows.yaml
@@ -1,0 +1,41 @@
+rows:
+  - source_issue: "#1550"
+    campaign: "schema_fixture_campaign"
+    comparison_group: "schema_fixture_pair"
+    variant: "schema_fixture_baseline"
+    scenario: "schema_fixture_scenario"
+    seed: 102
+    planner_grid_row: "schema_fixture_grid_row"
+    planner_grid_key: "schema_fixture_grid_key"
+    status: "ok"
+    success: false
+    collision_event: true
+    near_miss: true
+    low_progress: false
+    timeout: false
+    min_distance: 0.18
+    artifact_pointer: "docs/context/evidence/predictive_same_seed_row_summary_template.yaml"
+    commit_artifact: "deadbeef, docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+    scenario_matrix: "configs/scenarios/classic_interactions.yaml"
+    seed_manifest: "configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml"
+    source_note: "docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+  - source_issue: "#1550"
+    campaign: "schema_fixture_campaign"
+    comparison_group: "schema_fixture_pair"
+    variant: "schema_fixture_candidate"
+    scenario: "schema_fixture_scenario"
+    seed: 102
+    planner_grid_row: "schema_fixture_grid_row"
+    planner_grid_key: "schema_fixture_grid_key"
+    status: "unavailable"
+    success: null
+    collision_event: null
+    near_miss: null
+    low_progress: null
+    timeout: null
+    min_distance: null
+    artifact_pointer: "docs/context/evidence/predictive_same_seed_row_summary_template.yaml"
+    commit_artifact: "deadbeef, docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"
+    scenario_matrix: "configs/scenarios/classic_interactions.yaml"
+    seed_manifest: "configs/training/predictive/predictive_same_seed_issue_1427_base_seed_manifest.yaml"
+    source_note: "docs/context/issue_1550_predictive_same_seed_row_summary_schema.md"


### PR DESCRIPTION
## Summary
- Add a predictive same-seed row-summary validator and CLI for compact durable per-row outcome summaries.
- Add a checked-in YAML template plus schema note that explicitly forbids reconstructing missing #1427 row values without durable row-level provenance.
- Add focused regression tests for valid rows, unavailable/unknown nullability, duplicate row keys, unsafe provenance paths, loader shapes, and git-SHA strict mode.

Closes #1550.

## Validation
- `source .venv/bin/activate && pytest tests/benchmark/test_predictive_same_seed_row_summary.py -q` -> 11 passed
- `source .venv/bin/activate && ruff check robot_sf/benchmark/predictive_same_seed_row_summary.py scripts/validation/validate_predictive_same_seed_row_summary.py tests/benchmark/test_predictive_same_seed_row_summary.py`
- `source .venv/bin/activate && python scripts/validation/validate_predictive_same_seed_row_summary.py --input docs/context/evidence/predictive_same_seed_row_summary_template.yaml` -> valid, 2 rows
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4261 passed, 10 skipped; changed-file coverage 90.8% warning only

## Delegation / Review
- Copilot gpt-5.4 xhigh implemented the initial validator/docs/tests patch.
- Copilot gpt-5.4 xhigh read-only review found two real issues: a fixture that looked like fabricated #1427 row evidence and missing duplicate-row rejection. Both were fixed before PR creation.
