### PR TITLE
feat: add synthetic AMV actuation stress slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added the issue-1556 synthetic AMV actuation stress slice: the new
+  `configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml` config stays
+  non-paper-facing and differential-drive-only, camera-ready campaign manifests/reports now carry
+  synthetic actuation provenance plus a diagnostic `actuation_envelope_summary.{json,md}` artifact,
+  and the map runner reports auditable saturation metrics or fails closed when the synthetic
+  profile cannot be applied.
 * Added the issue-1550 predictive same-seed row-summary validation surface:
   `robot_sf/benchmark/predictive_same_seed_row_summary.py` plus
   `scripts/validation/validate_predictive_same_seed_row_summary.py` now validate small durable

--- a/configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml
+++ b/configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml
@@ -1,0 +1,91 @@
+name: issue_1556_amv_actuation_stress_slice_v0
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+scenario_candidates:
+  - classic_overtaking_medium
+  - classic_bottleneck_high
+  - classic_cross_trap_high
+  - francis2023_blind_corner
+  - francis2023_intersection_wait
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+synthetic_actuation_profile:
+  name: amv-actuation-stress-v0
+  profile_version: v0
+  claim_scope: synthetic-only
+  max_linear_accel_m_s2: 2.0
+  max_linear_decel_m_s2: 2.5
+  max_yaw_rate_rad_s: 1.2
+  max_angular_accel_rad_s2: 4.0
+  latency_mode: one-step-delay
+  update_mode: 5hz-hold
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 3000
+
+workers: 1
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: issue-1556-amv-actuation-diagnostic
+
+planners:
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -158,6 +158,8 @@ knowledge, not every transient iteration detail.
   [issue_1353_broader_amv_preflight.md](issue_1353_broader_amv_preflight.md)
 * Issue #1546 AMV actuation-envelope stress slice:
   [issue_1546_amv_actuation_envelope_stress_slice.md](issue_1546_amv_actuation_envelope_stress_slice.md)
+* Issue #1556 synthetic AMV actuation stress slice:
+  [issue_1556_amv_actuation_stress_slice.md](issue_1556_amv_actuation_stress_slice.md)
 * Issue #1398 metric rollup reconciliation:
   [issue_1398_metric_rollup_reconciliation.md](issue_1398_metric_rollup_reconciliation.md)
 * Issue #1396 Shielded PPO Repair Launch Packet:

--- a/docs/context/issue_1556_amv_actuation_stress_slice.md
+++ b/docs/context/issue_1556_amv_actuation_stress_slice.md
@@ -1,0 +1,62 @@
+# Issue #1556 synthetic AMV actuation stress slice
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1556>
+
+Reference design note:
+
+- [`docs/context/issue_1546_amv_actuation_envelope_stress_slice.md`](issue_1546_amv_actuation_envelope_stress_slice.md)
+
+## Goal
+
+Implement the first compact synthetic AMV actuation-envelope diagnostic slice without changing
+benchmark gates or making paper-facing or hardware-calibration claims.
+
+## Implemented boundary
+
+- The benchmark config is `paper_facing: false` and `kinematics_matrix: [differential_drive]`.
+- The slice uses the compact scenario candidate set from `#1546`:
+  `classic_overtaking_medium`, `classic_bottleneck_high`, `classic_cross_trap_high`,
+  `francis2023_blind_corner`, and `francis2023_intersection_wait`.
+- The seed policy stays on the named `eval` seed set for the checked-in config.
+- Synthetic profile provenance is carried in preflight output, campaign manifests, episode
+  `scenario_params`, planner-row summaries, and the diagnostic
+  `reports/actuation_envelope_summary.{json,md}` artifacts.
+- Derived saturation metrics currently reported when the command path supports them are:
+  `command_clip_fraction`, `yaw_rate_saturation_fraction`, and `signed_braking_peak_m_s2`.
+- If the synthetic profile cannot be applied, the runner fails closed instead of silently dropping
+  the profile.
+
+## Claim boundary
+
+- This is a synthetic software stress slice only.
+- The profile values are not a real AMV hardware specification and are not a calibration claim.
+- The added actuation report is a diagnostic supplement; it does not redefine benchmark success.
+- Fallback, degraded, unavailable, skipped, and failed rows remain non-success evidence under
+  [`docs/context/issue_691_benchmark_fallback_policy.md`](issue_691_benchmark_fallback_policy.md).
+
+## Validation path
+
+Use focused proof instead of a broad campaign:
+
+```bash
+source .venv/bin/activate
+pytest tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py \
+       tests/benchmark/test_camera_ready_campaign.py \
+       tests/benchmark/test_map_runner_utils.py
+
+python scripts/tools/run_camera_ready_benchmark.py \
+       --config configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml \
+       --mode preflight \
+       --label issue1556-local \
+       --output-root output/benchmarks/camera_ready_issue1556 \
+       --log-level WARNING
+```
+
+The key contract checks are:
+
+1. config provenance for scenario candidates, eval seeds, and synthetic profile fields,
+2. preflight propagation of candidate resolution and synthetic profile metadata,
+3. campaign-summary/report artifact emission for the actuation supplement,
+4. map-runner episode metrics and fail-closed behavior for non-differential-drive scenarios.
+5. config-loader fail-closed behavior for malformed scenario candidate and synthetic profile
+   payloads.

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -50,6 +50,11 @@ from robot_sf.benchmark.seed_variance import (
     build_seed_variability_rows,
     build_statistical_sufficiency_rows,
 )
+from robot_sf.benchmark.synthetic_actuation import (
+    SyntheticActuationProfile,
+    not_available_saturation_metrics,
+    validate_synthetic_actuation_profile,
+)
 from robot_sf.benchmark.snqi.campaign_contract import (
     SnqiContractThresholds,
     build_positioning_recommendation,
@@ -116,6 +121,25 @@ _AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
 _AMV_COVERAGE_ENFORCEMENT = {"warn", "error"}
 _SNQI_CONTRACT_ENFORCEMENT = {"warn", "error"}
 _ROUTE_CLEARANCE_WARN_THRESHOLD_M = 0.5
+_ACTUATION_REPORT_METRICS: tuple[str, ...] = (
+    "success",
+    "total_collision_count",
+    "near_misses",
+    "min_clearance",
+    "time_to_collision_min",
+    "time_to_goal_norm",
+    "failure_to_progress",
+    "stalled_time",
+    "velocity_max",
+    "acceleration_max",
+    "jerk_mean",
+    "jerk_max",
+    "curvature_mean",
+    "energy",
+    "command_clip_fraction",
+    "yaw_rate_saturation_fraction",
+    "signed_braking_peak_m_s2",
+)
 _ROUTE_CLEARANCE_CERTIFICATION_STATUSES = {
     "certified_stress_geometry",
     "excluded_from_planner_attribution",
@@ -196,6 +220,14 @@ class SeedPolicy:
 
 
 @dataclass(frozen=True)
+class ScenarioCandidateSelection:
+    """Optional named scenario subset for compact benchmark slices."""
+
+    names: tuple[str, ...] = ()
+    selection_name: str | None = None
+
+
+@dataclass(frozen=True)
 class PlannerSpec:
     """One planner entry in a benchmark campaign matrix."""
 
@@ -239,6 +271,7 @@ class CampaignConfig:
     name: str
     scenario_matrix_path: Path
     planners: tuple[PlannerSpec, ...]
+    scenario_candidates: ScenarioCandidateSelection = field(default_factory=ScenarioCandidateSelection)
     seed_policy: SeedPolicy = SeedPolicy()
     scenario_horizons_path: Path | None = None
     workers: int = 1
@@ -266,6 +299,7 @@ class CampaignConfig:
     paper_facing: bool = False
     paper_profile_version: str | None = None
     amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
+    synthetic_actuation_profile: SyntheticActuationProfile | None = None
     comparability_mapping_path: Path | None = None
     snqi_contract: SnqiContractConfig = field(default_factory=SnqiContractConfig)
     route_clearance_certifications_path: Path | None = None
@@ -606,6 +640,23 @@ def _load_campaign_scenarios(cfg: CampaignConfig) -> list[dict[str, Any]]:
         normalized.append(patched)
 
     scenario_dicts = normalized
+    if cfg.scenario_candidates.names:
+        requested_counts = {name: 0 for name in cfg.scenario_candidates.names}
+        filtered: list[dict[str, Any]] = []
+        for scenario in scenario_dicts:
+            scenario_name = str(
+                scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or ""
+            ).strip()
+            if scenario_name in requested_counts:
+                requested_counts[scenario_name] += 1
+                filtered.append(scenario)
+        missing = [name for name, count in requested_counts.items() if count <= 0]
+        if missing:
+            raise ValueError(
+                "scenario_candidates did not resolve in "
+                f"{_repo_relative(cfg.scenario_matrix_path)}: {', '.join(missing)}"
+            )
+        scenario_dicts = filtered
     scenario_dicts = _apply_scenario_horizon_schedule(
         scenario_dicts,
         schedule_path=cfg.scenario_horizons_path,
@@ -1147,6 +1198,21 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
         for value in values:
             if not str(value).strip():
                 raise ValueError(f"AMV required dimension '{key}' contains an empty value")
+    if cfg.scenario_candidates.names and any(
+        not str(name).strip() for name in cfg.scenario_candidates.names
+    ):
+        raise ValueError("scenario_candidates must not contain empty names")
+    if cfg.synthetic_actuation_profile is not None:
+        validate_synthetic_actuation_profile(cfg.synthetic_actuation_profile)
+        if cfg.paper_facing:
+            raise ValueError("synthetic_actuation_profile requires paper_facing=false")
+        normalized_kinematics = tuple(
+            str(value).strip().lower() for value in cfg.kinematics_matrix
+        )
+        if normalized_kinematics != ("differential_drive",):
+            raise ValueError(
+                "synthetic_actuation_profile requires kinematics_matrix=['differential_drive']"
+            )
     if cfg.snqi_contract.enforcement not in _SNQI_CONTRACT_ENFORCEMENT:
         known = ", ".join(sorted(_SNQI_CONTRACT_ENFORCEMENT))
         raise ValueError(
@@ -1355,11 +1421,28 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         else:
             normalized = ()
         required_dimensions[dimension] = normalized
+    scenario_candidates_raw = payload.get("scenario_candidates", [])
+    if isinstance(scenario_candidates_raw, (str, int, float)):
+        scenario_candidates = (str(scenario_candidates_raw).strip(),)
+    elif isinstance(scenario_candidates_raw, list):
+        if any(not isinstance(value, (str, int, float)) for value in scenario_candidates_raw):
+            raise TypeError("scenario_candidates entries must be scalar names")
+        scenario_candidates = tuple(
+            str(value).strip() for value in scenario_candidates_raw if str(value).strip()
+        )
+    elif "scenario_candidates" in payload:
+        raise TypeError("scenario_candidates must be a scalar name or list of scalar names")
+    else:
+        scenario_candidates = ()
+    synthetic_actuation_raw = payload.get("synthetic_actuation_profile")
+    if synthetic_actuation_raw is not None and not isinstance(synthetic_actuation_raw, dict):
+        raise TypeError("synthetic_actuation_profile must be a mapping when provided")
 
     cfg = CampaignConfig(
         name=name,
         scenario_matrix_path=scenario_matrix_path,
         planners=tuple(planner_specs),
+        scenario_candidates=ScenarioCandidateSelection(names=scenario_candidates),
         scenario_horizons_path=scenario_horizons,
         seed_policy=SeedPolicy(
             mode=mode,
@@ -1412,6 +1495,42 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
             ),
             required_dimensions=required_dimensions,
         ),
+        synthetic_actuation_profile=(
+            SyntheticActuationProfile(
+                name=str(synthetic_actuation_raw.get("name", "")).strip(),
+                profile_version=(
+                    str(synthetic_actuation_raw.get("profile_version", "v0")).strip() or "v0"
+                ),
+                claim_scope=(
+                    str(synthetic_actuation_raw.get("claim_scope", "synthetic-only")).strip()
+                    or "synthetic-only"
+                ),
+                max_linear_accel_m_s2=float(
+                    synthetic_actuation_raw.get("max_linear_accel_m_s2", 0.0)
+                ),
+                max_linear_decel_m_s2=float(
+                    synthetic_actuation_raw.get("max_linear_decel_m_s2", 0.0)
+                ),
+                max_yaw_rate_rad_s=float(
+                    synthetic_actuation_raw.get("max_yaw_rate_rad_s", 0.0)
+                ),
+                max_angular_accel_rad_s2=float(
+                    synthetic_actuation_raw.get("max_angular_accel_rad_s2", 0.0)
+                ),
+                latency_mode=(
+                    str(synthetic_actuation_raw.get("latency_mode", "zero-step-delay"))
+                    .strip()
+                    .lower()
+                ),
+                update_mode=(
+                    str(synthetic_actuation_raw.get("update_mode", "10hz-matched"))
+                    .strip()
+                    .lower()
+                ),
+            )
+            if synthetic_actuation_raw is not None
+            else None
+        ),
         comparability_mapping_path=comparability_mapping_path,
         route_clearance_certifications_path=route_clearance_certifications_path,
         snqi_contract=SnqiContractConfig(
@@ -1453,6 +1572,15 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     """Write JSON with stable formatting and trailing newline."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def _synthetic_actuation_metadata(
+    profile: SyntheticActuationProfile | None,
+) -> dict[str, Any] | None:
+    """Return a JSON-safe synthetic-actuation metadata payload when configured."""
+    if profile is None:
+        return None
+    return profile.to_metadata()
 
 
 def _write_markdown_table(path: Path, rows: list[dict[str, Any]], headers: tuple[str, ...]) -> None:
@@ -1535,6 +1663,10 @@ def _build_matrix_summary_rows(
                     "scenario_matrix": matrix_path,
                     "scenario_matrix_hash": scenario_hash,
                     "scenario_count": len(scenarios),
+                    "scenario_candidates": list(cfg.scenario_candidates.names),
+                    "synthetic_actuation_profile": _synthetic_actuation_metadata(
+                        cfg.synthetic_actuation_profile
+                    ),
                     "planner_key": planner.key,
                     "algo": planner.algo,
                     "human_model_variant": planner.human_model_variant,
@@ -1840,6 +1972,100 @@ def _write_amv_coverage_artifacts(
             f"{_escape_markdown_cell(observed_values)} | "
             f"{_escape_markdown_cell(missing_values)} |"
         )
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def _build_actuation_envelope_summary(
+    *,
+    campaign_id: str,
+    generated_at_utc: str,
+    profile: SyntheticActuationProfile,
+    planner_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a synthetic actuation-envelope diagnostic summary payload."""
+    rows: list[dict[str, Any]] = []
+    for planner_row in planner_rows:
+        saturation = {
+            "command_clip_fraction": str(
+                planner_row.get("command_clip_fraction_mean", "not_available")
+            ),
+            "yaw_rate_saturation_fraction": str(
+                planner_row.get("yaw_rate_saturation_fraction_mean", "not_available")
+            ),
+            "signed_braking_peak_m_s2": str(
+                planner_row.get("signed_braking_peak_m_s2_mean", "not_available")
+            ),
+        }
+        rows.append(
+            {
+                "planner_key": str(planner_row.get("planner_key", "")),
+                "algo": str(planner_row.get("algo", "")),
+                "planner_group": str(planner_row.get("planner_group", "")),
+                "kinematics": str(planner_row.get("kinematics", "")),
+                "status": str(planner_row.get("status", "")),
+                "readiness_status": str(planner_row.get("readiness_status", "")),
+                "benchmark_success": str(planner_row.get("benchmark_success", "")),
+                "metric_means": {
+                    metric: str(planner_row.get(f"{metric}_mean", "nan"))
+                    for metric in _ACTUATION_REPORT_METRICS
+                    if metric not in saturation
+                },
+                "saturation_metrics": saturation,
+            }
+        )
+    return {
+        "schema_version": "benchmark-actuation-envelope-summary.v1",
+        "campaign_id": campaign_id,
+        "generated_at_utc": generated_at_utc,
+        "paper_facing": False,
+        "claim_boundary": (
+            "Synthetic diagnostic only; not a hardware-calibrated or paper-facing AMV claim."
+        ),
+        "synthetic_actuation_profile": profile.to_metadata(),
+        "row_count": len(rows),
+        "rows": rows,
+    }
+
+
+def _write_actuation_envelope_artifacts(
+    reports_dir: Path,
+    payload: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write synthetic actuation-envelope JSON and Markdown artifacts."""
+    json_path = reports_dir / "actuation_envelope_summary.json"
+    md_path = reports_dir / "actuation_envelope_summary.md"
+    _write_json(json_path, payload)
+    lines = [
+        "# Synthetic Actuation Envelope Summary",
+        "",
+        f"- Campaign ID: `{payload.get('campaign_id', 'unknown')}`",
+        f"- Claim boundary: {payload.get('claim_boundary', '')}",
+        "",
+        "## Profile",
+        "",
+    ]
+    profile = payload.get("synthetic_actuation_profile")
+    if isinstance(profile, dict):
+        for key, value in profile.items():
+            lines.append(f"- {key}: `{value}`")
+    rows = payload.get("rows")
+    if isinstance(rows, list) and rows:
+        lines.extend(["", "## Planner Rows", ""])
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            saturation = row.get("saturation_metrics")
+            if not isinstance(saturation, dict):
+                saturation = {}
+            lines.append(
+                "- "
+                f"{row.get('planner_key', 'unknown')} ({row.get('algo', 'unknown')}, "
+                f"{row.get('kinematics', 'unknown')}): status={row.get('status', 'unknown')}, "
+                f"clip={saturation.get('command_clip_fraction', 'not_available')}, "
+                f"yaw_sat={saturation.get('yaw_rate_saturation_fraction', 'not_available')}, "
+                f"braking_peak={saturation.get('signed_braking_peak_m_s2', 'not_available')}"
+            )
     md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return json_path, md_path
 
@@ -2291,6 +2517,13 @@ def prepare_campaign_preflight(
         "generated_at_utc": created_at_utc,
         "scenario_matrix": _repo_relative(cfg.scenario_matrix_path),
         "scenario_count": len(scenarios),
+        "scenario_candidates": {
+            "requested": list(cfg.scenario_candidates.names),
+            "resolved": [
+                str(scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "")
+                for scenario in scenarios
+            ],
+        },
         "planner_count": len([planner for planner in cfg.planners if planner.enabled]),
         "workers": cfg.workers,
         "horizon": cfg.horizon,
@@ -2311,6 +2544,7 @@ def prepare_campaign_preflight(
                 key: list(values) for key, values in cfg.amv_profile.required_dimensions.items()
             },
         },
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
         "comparability_mapping": (
             _repo_relative(cfg.comparability_mapping_path)
             if cfg.comparability_mapping_path is not None
@@ -2358,6 +2592,8 @@ def prepare_campaign_preflight(
         "generated_at_utc": created_at_utc,
         "scenario_count": len(scenarios),
         "preview_limit": preview_limit,
+        "scenario_candidates": list(cfg.scenario_candidates.names),
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
         "route_clearance_warnings": route_clearance_warnings,
         "route_clearance_warning_count": len(route_clearance_warnings),
         "route_clearance_warning_summary": route_clearance_warning_summary,
@@ -2446,6 +2682,7 @@ def prepare_campaign_preflight(
         "started_at_utc": created_at_utc,
         "scenario_matrix": _repo_relative(cfg.scenario_matrix_path),
         "scenario_matrix_hash": scenario_hash,
+        "scenario_candidates": list(cfg.scenario_candidates.names),
         "seed_policy": {
             "mode": cfg.seed_policy.mode,
             "seed_set": cfg.seed_policy.seed_set,
@@ -2462,6 +2699,7 @@ def prepare_campaign_preflight(
         "amv_contract_version": cfg.amv_profile.contract_version,
         "amv_coverage_enforcement": cfg.amv_profile.coverage_enforcement,
         "amv_coverage_status": amv_summary.get("status", "unknown"),
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
         "comparability_mapping_path": (
             _repo_relative(comparability_mapping_path) if comparability_mapping_path else None
         ),
@@ -2565,6 +2803,7 @@ def _planner_report_row(  # noqa: C901
     aggregates: dict[str, Any] | None,
     *,
     kinematics: str,
+    synthetic_actuation_profile: SyntheticActuationProfile | None = None,
     records: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build one campaign table row for a planner run.
@@ -2611,10 +2850,24 @@ def _planner_report_row(  # noqa: C901
         "obstacle_collision_count_mean": _metric_mean(metric_block, "obstacle_collision_count"),
         "total_collision_count_mean": _metric_mean(metric_block, "total_collision_count"),
         "near_misses_mean": _metric_mean(metric_block, "near_misses"),
+        "min_clearance_mean": _metric_mean(metric_block, "min_clearance"),
+        "time_to_collision_min_mean": _metric_mean(metric_block, "time_to_collision_min"),
         "time_to_goal_norm_mean": _metric_mean(metric_block, "time_to_goal_norm"),
+        "failure_to_progress_mean": _metric_mean(metric_block, "failure_to_progress"),
+        "stalled_time_mean": _metric_mean(metric_block, "stalled_time"),
         "path_efficiency_mean": _metric_mean(metric_block, "path_efficiency"),
+        "velocity_max_mean": _metric_mean(metric_block, "velocity_max"),
+        "acceleration_max_mean": _metric_mean(metric_block, "acceleration_max"),
         "comfort_exposure_mean": _metric_mean(metric_block, "comfort_exposure"),
         "jerk_mean": _metric_mean(metric_block, "jerk_mean"),
+        "jerk_max_mean": _metric_mean(metric_block, "jerk_max"),
+        "curvature_mean_mean": _metric_mean(metric_block, "curvature_mean"),
+        "energy_mean": _metric_mean(metric_block, "energy"),
+        "command_clip_fraction_mean": _metric_mean(metric_block, "command_clip_fraction"),
+        "yaw_rate_saturation_fraction_mean": _metric_mean(
+            metric_block, "yaw_rate_saturation_fraction"
+        ),
+        "signed_braking_peak_m_s2_mean": _metric_mean(metric_block, "signed_braking_peak_m_s2"),
         "snqi_mean": _metric_mean(metric_block, "snqi"),
     }
     if records:
@@ -2625,10 +2878,22 @@ def _planner_report_row(  # noqa: C901
             "obstacle_collision_count_mean": "obstacle_collision_count",
             "total_collision_count_mean": "total_collision_count",
             "near_misses_mean": "near_misses",
+            "min_clearance_mean": "min_clearance",
+            "time_to_collision_min_mean": "time_to_collision_min",
             "time_to_goal_norm_mean": "time_to_goal_norm",
+            "failure_to_progress_mean": "failure_to_progress",
+            "stalled_time_mean": "stalled_time",
             "path_efficiency_mean": "path_efficiency",
+            "velocity_max_mean": "velocity_max",
+            "acceleration_max_mean": "acceleration_max",
             "comfort_exposure_mean": "comfort_exposure",
             "jerk_mean": "jerk_mean",
+            "jerk_max_mean": "jerk_max",
+            "curvature_mean_mean": "curvature_mean",
+            "energy_mean": "energy",
+            "command_clip_fraction_mean": "command_clip_fraction",
+            "yaw_rate_saturation_fraction_mean": "yaw_rate_saturation_fraction",
+            "signed_braking_peak_m_s2_mean": "signed_braking_peak_m_s2",
             "snqi_mean": "snqi",
         }
         for field_name, metric_name in metric_sources.items():
@@ -2667,10 +2932,26 @@ def _planner_report_row(  # noqa: C901
         ),
         "total_collision_count_mean": _safe_float(resolved_metrics["total_collision_count_mean"]),
         "near_misses_mean": _safe_float(resolved_metrics["near_misses_mean"]),
+        "min_clearance_mean": _safe_float(resolved_metrics["min_clearance_mean"]),
+        "time_to_collision_min_mean": _safe_float(resolved_metrics["time_to_collision_min_mean"]),
         "time_to_goal_norm_mean": _safe_float(resolved_metrics["time_to_goal_norm_mean"]),
+        "failure_to_progress_mean": _safe_float(resolved_metrics["failure_to_progress_mean"]),
+        "stalled_time_mean": _safe_float(resolved_metrics["stalled_time_mean"]),
         "path_efficiency_mean": _safe_float(resolved_metrics["path_efficiency_mean"]),
+        "velocity_max_mean": _safe_float(resolved_metrics["velocity_max_mean"]),
+        "acceleration_max_mean": _safe_float(resolved_metrics["acceleration_max_mean"]),
         "comfort_exposure_mean": _safe_float(resolved_metrics["comfort_exposure_mean"]),
         "jerk_mean": _safe_float(resolved_metrics["jerk_mean"]),
+        "jerk_max_mean": _safe_float(resolved_metrics["jerk_max_mean"]),
+        "curvature_mean_mean": _safe_float(resolved_metrics["curvature_mean_mean"]),
+        "energy_mean": _safe_float(resolved_metrics["energy_mean"]),
+        "command_clip_fraction_mean": _safe_float(resolved_metrics["command_clip_fraction_mean"]),
+        "yaw_rate_saturation_fraction_mean": _safe_float(
+            resolved_metrics["yaw_rate_saturation_fraction_mean"]
+        ),
+        "signed_braking_peak_m_s2_mean": _safe_float(
+            resolved_metrics["signed_braking_peak_m_s2_mean"]
+        ),
         "snqi_mean": _safe_float(resolved_metrics["snqi_mean"]),
         "success_ci_low": _safe_float(success_ci[0]),
         "success_ci_high": _safe_float(success_ci[1]),
@@ -2701,6 +2982,26 @@ def _planner_report_row(  # noqa: C901
         "learned_policy_contract_critical": contract_critical,
         "learned_policy_contract_warnings": contract_warnings,
     }
+    if synthetic_actuation_profile is not None:
+        row["synthetic_actuation_profile_name"] = synthetic_actuation_profile.name
+        row["synthetic_actuation_profile_version"] = synthetic_actuation_profile.profile_version
+        row["synthetic_actuation_latency_mode"] = synthetic_actuation_profile.latency_mode
+        row["synthetic_actuation_update_mode"] = synthetic_actuation_profile.update_mode
+        row["synthetic_actuation_max_linear_accel_m_s2"] = _safe_float(
+            synthetic_actuation_profile.max_linear_accel_m_s2
+        )
+        row["synthetic_actuation_max_linear_decel_m_s2"] = _safe_float(
+            synthetic_actuation_profile.max_linear_decel_m_s2
+        )
+        row["synthetic_actuation_max_yaw_rate_rad_s"] = _safe_float(
+            synthetic_actuation_profile.max_yaw_rate_rad_s
+        )
+        row["synthetic_actuation_max_angular_accel_rad_s2"] = _safe_float(
+            synthetic_actuation_profile.max_angular_accel_rad_s2
+        )
+    else:
+        for key, value in not_available_saturation_metrics().items():
+            row[f"{key}_mean"] = value
     feasibility = algorithm_metadata_contract.get("kinematics_feasibility")
     if isinstance(feasibility, dict):
         row["commands_evaluated"] = int(feasibility.get("commands_evaluated", 0) or 0)
@@ -3261,6 +3562,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                     adapter_impact_eval=planner.adapter_impact_eval,
                     observation_mode=active_observation_mode,
                     observation_noise=cfg.observation_noise,
+                    synthetic_actuation_profile=_synthetic_actuation_metadata(
+                        cfg.synthetic_actuation_profile
+                    ),
                     workers=effective_workers,
                     resume=cfg.resume,
                 )
@@ -3329,6 +3633,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                 summary,
                 aggregates,
                 kinematics=kinematics,
+                synthetic_actuation_profile=cfg.synthetic_actuation_profile,
                 records=records,
             )
             planner_rows.append(row)
@@ -3724,6 +4029,19 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         reports_dir,
         statistical_sufficiency_payload,
     )
+    actuation_envelope_payload: dict[str, Any] | None = None
+    actuation_envelope_json_path: Path | None = None
+    actuation_envelope_md_path: Path | None = None
+    if cfg.synthetic_actuation_profile is not None:
+        actuation_envelope_payload = _build_actuation_envelope_summary(
+            campaign_id=campaign_id,
+            generated_at_utc=campaign_finished_at_utc,
+            profile=cfg.synthetic_actuation_profile,
+            planner_rows=planner_rows,
+        )
+        actuation_envelope_json_path, actuation_envelope_md_path = (
+            _write_actuation_envelope_artifacts(reports_dir, actuation_envelope_payload)
+        )
     release_tag_value = cfg.release_tag
     expected_archive_name = f"{campaign_id}_publication_bundle.tar.gz"
     repository_url = cfg.repository_url.rstrip("/")
@@ -3919,6 +4237,11 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "amv_coverage_status": str(
                 (manifest_payload or {}).get("amv_coverage_status", "unknown")
             ),
+            "scenario_candidates": list(cfg.scenario_candidates.names),
+            "scenario_candidates_selection_name": cfg.scenario_candidates.selection_name,
+            "synthetic_actuation_profile": _synthetic_actuation_metadata(
+                cfg.synthetic_actuation_profile
+            ),
             "comparability_mapping_path": manifest_payload.get("comparability_mapping_path"),
             "comparability_mapping_version": manifest_payload.get("comparability_mapping_version"),
             "comparability_mapping_hash": manifest_payload.get("comparability_mapping_hash"),
@@ -3976,6 +4299,16 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "seed_variability_csv": _repo_relative(seed_variability_csv_path),
             "seed_episode_rows_csv": _repo_relative(seed_episode_rows_csv_path),
             "statistical_sufficiency_json": _repo_relative(statistical_sufficiency_json_path),
+            "actuation_envelope_json": (
+                _repo_relative(actuation_envelope_json_path)
+                if actuation_envelope_json_path is not None
+                else None
+            ),
+            "actuation_envelope_md": (
+                _repo_relative(actuation_envelope_md_path)
+                if actuation_envelope_md_path is not None
+                else None
+            ),
             "preflight_validate_config": _repo_relative(validate_config_path),
             "preflight_preview_scenarios": _repo_relative(preview_scenarios_path),
             "scenario_breakdown_csv": _repo_relative(scenario_csv_path),
@@ -4026,6 +4359,28 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "seed_variability_csv": _repo_relative(seed_variability_csv_path),
             "seed_episode_rows_csv": _repo_relative(seed_episode_rows_csv_path),
             "statistical_sufficiency_json": _repo_relative(statistical_sufficiency_json_path),
+            "actuation_envelope_json": (
+                _repo_relative(actuation_envelope_json_path)
+                if actuation_envelope_json_path is not None
+                else None
+            ),
+            "actuation_envelope_md": (
+                _repo_relative(actuation_envelope_md_path)
+                if actuation_envelope_md_path is not None
+                else None
+            ),
+        },
+        "synthetic_actuation_artifacts": {
+            "json": (
+                _repo_relative(actuation_envelope_json_path)
+                if actuation_envelope_json_path is not None
+                else None
+            ),
+            "md": (
+                _repo_relative(actuation_envelope_md_path)
+                if actuation_envelope_md_path is not None
+                else None
+            ),
         },
         "snqi_artifacts": {
             "diagnostics_json": _repo_relative(snqi_diagnostics_json_path),
@@ -4084,6 +4439,16 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
                 "seed_variability_csv": _repo_relative(seed_variability_csv_path),
                 "seed_episode_rows_csv": _repo_relative(seed_episode_rows_csv_path),
                 "statistical_sufficiency_json": _repo_relative(statistical_sufficiency_json_path),
+                "actuation_envelope_json": (
+                    _repo_relative(actuation_envelope_json_path)
+                    if actuation_envelope_json_path is not None
+                    else None
+                ),
+                "actuation_envelope_md": (
+                    _repo_relative(actuation_envelope_md_path)
+                    if actuation_envelope_md_path is not None
+                    else None
+                ),
                 "snqi_diagnostics_json": _repo_relative(snqi_diagnostics_json_path),
                 "snqi_diagnostics_md": _repo_relative(snqi_diagnostics_md_path),
                 "snqi_sensitivity_csv": _repo_relative(snqi_sensitivity_csv_path),
@@ -4168,6 +4533,12 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         "seed_variability_csv": str(seed_variability_csv_path),
         "seed_episode_rows_csv": str(seed_episode_rows_csv_path),
         "statistical_sufficiency_json": str(statistical_sufficiency_json_path),
+        "actuation_envelope_json": (
+            str(actuation_envelope_json_path) if actuation_envelope_json_path is not None else None
+        ),
+        "actuation_envelope_md": (
+            str(actuation_envelope_md_path) if actuation_envelope_md_path is not None else None
+        ),
         "total_runs": len(run_entries),
         "successful_runs": successful_runs,
         "non_success_runs": campaign_outcome.non_success_runs,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -50,11 +50,6 @@ from robot_sf.benchmark.seed_variance import (
     build_seed_variability_rows,
     build_statistical_sufficiency_rows,
 )
-from robot_sf.benchmark.synthetic_actuation import (
-    SyntheticActuationProfile,
-    not_available_saturation_metrics,
-    validate_synthetic_actuation_profile,
-)
 from robot_sf.benchmark.snqi.campaign_contract import (
     SnqiContractThresholds,
     build_positioning_recommendation,
@@ -70,6 +65,11 @@ from robot_sf.benchmark.snqi.campaign_contract import (
     sanitize_baseline_stats,
 )
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
+from robot_sf.benchmark.synthetic_actuation import (
+    SyntheticActuationProfile,
+    not_available_saturation_metrics,
+    validate_synthetic_actuation_profile,
+)
 from robot_sf.benchmark.utils import (
     _config_hash,
     _git_hash_fallback,
@@ -271,7 +271,9 @@ class CampaignConfig:
     name: str
     scenario_matrix_path: Path
     planners: tuple[PlannerSpec, ...]
-    scenario_candidates: ScenarioCandidateSelection = field(default_factory=ScenarioCandidateSelection)
+    scenario_candidates: ScenarioCandidateSelection = field(
+        default_factory=ScenarioCandidateSelection
+    )
     seed_policy: SeedPolicy = SeedPolicy()
     scenario_horizons_path: Path | None = None
     workers: int = 1
@@ -606,6 +608,37 @@ def _scenario_horizon_summary(
     }
 
 
+def _filter_scenario_candidates(
+    scenarios: list[dict[str, Any]],
+    *,
+    names: tuple[str, ...],
+    matrix_path: Path,
+) -> list[dict[str, Any]]:
+    """Return the configured compact candidate subset.
+
+    Returns:
+        Candidate-filtered scenario list.
+    """
+    if not names:
+        return scenarios
+    requested_counts = dict.fromkeys(names, 0)
+    filtered: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        scenario_name = str(
+            scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or ""
+        ).strip()
+        if scenario_name in requested_counts:
+            requested_counts[scenario_name] += 1
+            filtered.append(scenario)
+    missing = [name for name, count in requested_counts.items() if count <= 0]
+    if missing:
+        raise ValueError(
+            "scenario_candidates did not resolve in "
+            f"{_repo_relative(matrix_path)}: {', '.join(missing)}"
+        )
+    return filtered
+
+
 def _load_campaign_scenarios(cfg: CampaignConfig) -> list[dict[str, Any]]:
     """Load campaign scenarios and apply optional seed override.
 
@@ -639,24 +672,11 @@ def _load_campaign_scenarios(cfg: CampaignConfig) -> list[dict[str, Any]]:
                         patched["map_file"] = candidate.as_posix()
         normalized.append(patched)
 
-    scenario_dicts = normalized
-    if cfg.scenario_candidates.names:
-        requested_counts = {name: 0 for name in cfg.scenario_candidates.names}
-        filtered: list[dict[str, Any]] = []
-        for scenario in scenario_dicts:
-            scenario_name = str(
-                scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or ""
-            ).strip()
-            if scenario_name in requested_counts:
-                requested_counts[scenario_name] += 1
-                filtered.append(scenario)
-        missing = [name for name, count in requested_counts.items() if count <= 0]
-        if missing:
-            raise ValueError(
-                "scenario_candidates did not resolve in "
-                f"{_repo_relative(cfg.scenario_matrix_path)}: {', '.join(missing)}"
-            )
-        scenario_dicts = filtered
+    scenario_dicts = _filter_scenario_candidates(
+        normalized,
+        names=cfg.scenario_candidates.names,
+        matrix_path=cfg.scenario_matrix_path,
+    )
     scenario_dicts = _apply_scenario_horizon_schedule(
         scenario_dicts,
         schedule_path=cfg.scenario_horizons_path,
@@ -1206,9 +1226,7 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
         validate_synthetic_actuation_profile(cfg.synthetic_actuation_profile)
         if cfg.paper_facing:
             raise ValueError("synthetic_actuation_profile requires paper_facing=false")
-        normalized_kinematics = tuple(
-            str(value).strip().lower() for value in cfg.kinematics_matrix
-        )
+        normalized_kinematics = tuple(str(value).strip().lower() for value in cfg.kinematics_matrix)
         if normalized_kinematics != ("differential_drive",):
             raise ValueError(
                 "synthetic_actuation_profile requires kinematics_matrix=['differential_drive']"
@@ -1511,9 +1529,7 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                 max_linear_decel_m_s2=float(
                     synthetic_actuation_raw.get("max_linear_decel_m_s2", 0.0)
                 ),
-                max_yaw_rate_rad_s=float(
-                    synthetic_actuation_raw.get("max_yaw_rate_rad_s", 0.0)
-                ),
+                max_yaw_rate_rad_s=float(synthetic_actuation_raw.get("max_yaw_rate_rad_s", 0.0)),
                 max_angular_accel_rad_s2=float(
                     synthetic_actuation_raw.get("max_angular_accel_rad_s2", 0.0)
                 ),
@@ -1523,9 +1539,7 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                     .lower()
                 ),
                 update_mode=(
-                    str(synthetic_actuation_raw.get("update_mode", "10hz-matched"))
-                    .strip()
-                    .lower()
+                    str(synthetic_actuation_raw.get("update_mode", "10hz-matched")).strip().lower()
                 ),
             )
             if synthetic_actuation_raw is not None
@@ -1983,7 +1997,11 @@ def _build_actuation_envelope_summary(
     profile: SyntheticActuationProfile,
     planner_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build a synthetic actuation-envelope diagnostic summary payload."""
+    """Build a synthetic actuation-envelope diagnostic summary payload.
+
+    Returns:
+        JSON-safe actuation-envelope summary payload.
+    """
     rows: list[dict[str, Any]] = []
     for planner_row in planner_rows:
         saturation = {
@@ -2032,7 +2050,11 @@ def _write_actuation_envelope_artifacts(
     reports_dir: Path,
     payload: dict[str, Any],
 ) -> tuple[Path, Path]:
-    """Write synthetic actuation-envelope JSON and Markdown artifacts."""
+    """Write synthetic actuation-envelope JSON and Markdown artifacts.
+
+    Returns:
+        Paths to the JSON and Markdown artifacts.
+    """
     json_path = reports_dir / "actuation_envelope_summary.json"
     md_path = reports_dir / "actuation_envelope_summary.md"
     _write_json(json_path, payload)
@@ -2544,7 +2566,9 @@ def prepare_campaign_preflight(
                 key: list(values) for key, values in cfg.amv_profile.required_dimensions.items()
             },
         },
-        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(
+            cfg.synthetic_actuation_profile
+        ),
         "comparability_mapping": (
             _repo_relative(cfg.comparability_mapping_path)
             if cfg.comparability_mapping_path is not None
@@ -2593,7 +2617,9 @@ def prepare_campaign_preflight(
         "scenario_count": len(scenarios),
         "preview_limit": preview_limit,
         "scenario_candidates": list(cfg.scenario_candidates.names),
-        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(
+            cfg.synthetic_actuation_profile
+        ),
         "route_clearance_warnings": route_clearance_warnings,
         "route_clearance_warning_count": len(route_clearance_warnings),
         "route_clearance_warning_summary": route_clearance_warning_summary,
@@ -2699,7 +2725,9 @@ def prepare_campaign_preflight(
         "amv_contract_version": cfg.amv_profile.contract_version,
         "amv_coverage_enforcement": cfg.amv_profile.coverage_enforcement,
         "amv_coverage_status": amv_summary.get("status", "unknown"),
-        "synthetic_actuation_profile": _synthetic_actuation_metadata(cfg.synthetic_actuation_profile),
+        "synthetic_actuation_profile": _synthetic_actuation_metadata(
+            cfg.synthetic_actuation_profile
+        ),
         "comparability_mapping_path": (
             _repo_relative(comparability_mapping_path) if comparability_mapping_path else None
         ),
@@ -2797,7 +2825,7 @@ def prepare_campaign_preflight(
     }
 
 
-def _planner_report_row(  # noqa: C901
+def _planner_report_row(  # noqa: C901, PLR0912, PLR0915
     planner: PlannerSpec,
     summary: dict[str, Any],
     aggregates: dict[str, Any] | None,

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3165,16 +3165,17 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         snqi_weights=snqi_weights,
         snqi_baseline=snqi_baseline,
     )
-    for metric_name, metric_value in actuation_summary.items():
-        if metric_name in {
-            "schema_version",
-            "status",
-            "step_count",
-            "command_clip_steps",
-            "yaw_rate_saturation_steps",
-        }:
-            continue
-        metrics[metric_name] = metric_value
+    if actuation_controller is not None:
+        for metric_name, metric_value in actuation_summary.items():
+            if metric_name in {
+                "schema_version",
+                "status",
+                "step_count",
+                "command_clip_steps",
+                "yaw_rate_saturation_steps",
+            }:
+                continue
+            metrics[metric_name] = metric_value
 
     ts_end = datetime.now(UTC).isoformat()
     scenario_params = _scenario_identity_payload(

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -49,6 +49,12 @@ from robot_sf.benchmark.obstacle_sampling import sample_obstacle_points
 from robot_sf.benchmark.path_utils import compute_shortest_path_length
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
 from robot_sf.benchmark.schema_validator import load_schema, validate_episode
+from robot_sf.benchmark.synthetic_actuation import (
+    SyntheticActuationController,
+    SyntheticActuationProfile,
+    not_available_saturation_metrics,
+    validate_synthetic_actuation_profile,
+)
 from robot_sf.benchmark.termination_reason import (
     build_outcome_payload,
     collision_event,
@@ -232,6 +238,30 @@ _init_feasibility_metadata = planner_commands.init_feasibility_metadata
 _planner_kinematics_compatibility = planner_commands.planner_kinematics_compatibility
 _project_with_feasibility = planner_commands.project_with_feasibility
 _validate_planner_contract = planner_commands.validate_planner_contract
+
+
+def _load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile | None:
+    """Normalize optional synthetic-actuation payloads into the typed profile contract."""
+    if payload is None:
+        return None
+    if isinstance(payload, SyntheticActuationProfile):
+        validate_synthetic_actuation_profile(payload)
+        return payload
+    if not isinstance(payload, dict):
+        raise TypeError("synthetic_actuation_profile must be a mapping when provided")
+    profile = SyntheticActuationProfile(
+        name=str(payload.get("name", "")),
+        profile_version=str(payload.get("profile_version", "v0")),
+        claim_scope=str(payload.get("claim_scope", "synthetic-only")),
+        max_linear_accel_m_s2=float(payload.get("max_linear_accel_m_s2")),
+        max_linear_decel_m_s2=float(payload.get("max_linear_decel_m_s2")),
+        max_yaw_rate_rad_s=float(payload.get("max_yaw_rate_rad_s")),
+        max_angular_accel_rad_s2=float(payload.get("max_angular_accel_rad_s2")),
+        latency_mode=str(payload.get("latency_mode", "")),
+        update_mode=str(payload.get("update_mode", "")),
+    )
+    validate_synthetic_actuation_profile(profile)
+    return profile
 
 
 def _holonomic_world_velocity_command(vx: float, vy: float) -> dict[str, float | str]:
@@ -2406,6 +2436,7 @@ def _scenario_identity_payload(  # noqa: PLR0913
     observation_mode: str | None = None,
     observation_level: str | None = None,
     observation_noise: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the canonical scenario payload used for episode identity.
 
@@ -2431,6 +2462,8 @@ def _scenario_identity_payload(  # noqa: PLR0913
     if bool(noise_spec["enabled"]):
         payload["observation_noise_profile"] = str(noise_spec["profile"])
         payload["observation_noise_hash"] = observation_noise_hash(noise_spec)
+    if synthetic_actuation_profile is not None:
+        payload["synthetic_actuation_profile"] = dict(synthetic_actuation_profile)
     if horizon is not None and int(horizon) > 0:
         payload["run_horizon"] = int(horizon)
     if dt is not None and float(dt) > 0.0:
@@ -2812,6 +2845,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     observation_mode: str | None = None,
     observation_level: str | None = None,
     observation_noise: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run one scenario/seed episode and return a benchmark JSONL record.
 
@@ -2841,6 +2875,12 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         config.sim_config.time_per_step_in_secs = float(dt)
 
     robot_kinematics = _robot_kinematics_label(config)
+    actuation_profile = _load_synthetic_actuation_profile(synthetic_actuation_profile)
+    if actuation_profile is not None and robot_kinematics != _DEFAULT_KINEMATICS:
+        raise ValueError(
+            "synthetic_actuation_profile requires differential_drive scenarios; "
+            f"got {robot_kinematics!r} for scenario {scenario_id!r}"
+        )
     robot_command_mode = (
         str(getattr(getattr(config, "robot_config", None), "command_mode", "vx_vy")).strip().lower()
     )
@@ -2887,6 +2927,13 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     planner_native_action = getattr(policy_fn, "_planner_native_env_action", False)
 
     planner_runtime_snapshot: dict[str, Any] | None = None
+    actuation_controller = (
+        SyntheticActuationController(profile=actuation_profile, dt=config.sim_config.time_per_step_in_secs)
+        if actuation_profile is not None
+        else None
+    )
+    current_command = (0.0, 0.0)
+    actuation_summary: dict[str, Any] = not_available_saturation_metrics()
 
     env = make_robot_env(config=config, seed=int(seed), debug=False)
     obs, _ = env.reset(seed=int(seed))
@@ -2916,6 +2963,23 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             # Use per-step flag when available (e.g. SAC with fallback); fall back to the
             # static cached value for planners that set _planner_native_env_action once.
             step_is_native = getattr(policy_fn, "_last_step_native", planner_native_action)
+            if actuation_controller is not None and step_is_native:
+                raise ValueError(
+                    "synthetic_actuation_profile requires absolute differential-drive commands; "
+                    "native env actions cannot be wrapped safely"
+                )
+            if actuation_controller is not None:
+                if not isinstance(policy_command, (tuple, list, np.ndarray)) or len(policy_command) < 2:
+                    raise TypeError(
+                        "synthetic_actuation_profile expects planner commands shaped like "
+                        "(linear_velocity, angular_velocity)"
+                    )
+                actuation_step = actuation_controller.apply(
+                    current_command=current_command,
+                    requested_command=(float(policy_command[0]), float(policy_command[1])),
+                )
+                policy_command = actuation_step.applied_command
+                current_command = actuation_step.applied_command
             if step_is_native:
                 # Policy already outputs native env actions (e.g. delta velocities);
                 # skip the absolute→delta conversion done by _policy_command_to_env_action.
@@ -3075,6 +3139,12 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     _finalize_feasibility_metadata(algo_meta)
     if isinstance(planner_runtime_snapshot, dict):
         algo_meta["planner_runtime"] = planner_runtime_snapshot
+    if actuation_controller is not None:
+        actuation_summary = actuation_controller.summary()
+        algo_meta["synthetic_actuation"] = {
+            "profile": actuation_profile.to_metadata(),
+            "summary": dict(actuation_summary),
+        }
     visibility_settings = getattr(config, "observation_visibility", None)
     if visibility_settings is not None and hasattr(visibility_settings, "to_metadata"):
         algo_meta["observation_visibility"] = visibility_settings.to_metadata()
@@ -3086,6 +3156,10 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         snqi_weights=snqi_weights,
         snqi_baseline=snqi_baseline,
     )
+    for metric_name, metric_value in actuation_summary.items():
+        if metric_name in {"schema_version", "status", "step_count", "command_clip_steps", "yaw_rate_saturation_steps"}:
+            continue
+        metrics[metric_name] = metric_value
 
     ts_end = datetime.now(UTC).isoformat()
     scenario_params = _scenario_identity_payload(
@@ -3098,6 +3172,9 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         observation_mode=active_observation_mode,
         observation_level=active_observation_level,
         observation_noise=noise_spec,
+        synthetic_actuation_profile=(
+            actuation_profile.to_metadata() if actuation_profile is not None else None
+        ),
     )
     steps_taken = int(robot_pos_arr.shape[0])
     wall_time = float(max(1e-9, time.time() - start_time))
@@ -3206,6 +3283,7 @@ def _run_map_job_worker(
         observation_mode=params.get("observation_mode"),
         observation_level=params.get("observation_level"),
         observation_noise=params.get("observation_noise"),
+        synthetic_actuation_profile=params.get("synthetic_actuation_profile"),
     )
 
 
@@ -3343,6 +3421,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     observation_mode: str | None = None,
     observation_level: str | None = None,
     observation_noise: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
     workers: int = 1,
     resume: bool = True,
 ) -> dict[str, Any]:
@@ -3372,6 +3451,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     suite_key = _suite_key(scenario_path)
     noise_spec = normalize_observation_noise_spec(observation_noise)
     noise_hash = observation_noise_hash(noise_spec)
+    actuation_profile = _load_synthetic_actuation_profile(synthetic_actuation_profile)
 
     filtered: list[dict[str, Any]] = []
     for scenario in scenarios:
@@ -3513,6 +3593,14 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         preflight["status"] = "skipped"
         preflight["compatibility_status"] = "incompatible"
         preflight["compatibility_reason"] = incompatible_reason
+    if actuation_profile is not None:
+        if kinematics_tag != _DEFAULT_KINEMATICS:
+            preflight["status"] = "skipped"
+            preflight["compatibility_status"] = "incompatible"
+            preflight["compatibility_reason"] = (
+                "synthetic_actuation_profile requires differential_drive-only scenarios"
+            )
+        preflight["synthetic_actuation_profile"] = actuation_profile.to_metadata()
     preflight["algorithm_metadata_contract"] = algo_contract
     if preflight.get("status") == "skipped":
         summary = {
@@ -3569,6 +3657,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     observation_mode=identity_observation_mode,
                     observation_level=identity_observation_level,
                     observation_noise=noise_spec,
+                    synthetic_actuation_profile=(
+                        actuation_profile.to_metadata() if actuation_profile is not None else None
+                    ),
                 )
                 if _compute_map_episode_id(identity_payload, seed) not in existing:
                     filtered_jobs.append((sc, seed))
@@ -3591,6 +3682,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "observation_noise": noise_spec,
         "observation_mode": batch_observation_mode,
         "observation_level": observation_level,
+        "synthetic_actuation_profile": (
+            actuation_profile.to_metadata() if actuation_profile is not None else None
+        ),
     }
 
     total_jobs = len(jobs)
@@ -3770,6 +3864,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "observation_noise": noise_spec,
         "observation_noise_hash": noise_hash,
         "observation_level": active_observation_level,
+        "synthetic_actuation_profile": (
+            actuation_profile.to_metadata() if actuation_profile is not None else None
+        ),
     }
     summary["benchmark_availability"] = availability_payload(summary)
     return summary

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -241,7 +241,11 @@ _validate_planner_contract = planner_commands.validate_planner_contract
 
 
 def _load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile | None:
-    """Normalize optional synthetic-actuation payloads into the typed profile contract."""
+    """Normalize optional synthetic-actuation payloads into the typed profile contract.
+
+    Returns:
+        A validated profile, or ``None`` when the payload is absent.
+    """
     if payload is None:
         return None
     if isinstance(payload, SyntheticActuationProfile):
@@ -2928,7 +2932,9 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
 
     planner_runtime_snapshot: dict[str, Any] | None = None
     actuation_controller = (
-        SyntheticActuationController(profile=actuation_profile, dt=config.sim_config.time_per_step_in_secs)
+        SyntheticActuationController(
+            profile=actuation_profile, dt=config.sim_config.time_per_step_in_secs
+        )
         if actuation_profile is not None
         else None
     )
@@ -2969,7 +2975,10 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     "native env actions cannot be wrapped safely"
                 )
             if actuation_controller is not None:
-                if not isinstance(policy_command, (tuple, list, np.ndarray)) or len(policy_command) < 2:
+                if (
+                    not isinstance(policy_command, (tuple, list, np.ndarray))
+                    or len(policy_command) < 2
+                ):
                     raise TypeError(
                         "synthetic_actuation_profile expects planner commands shaped like "
                         "(linear_velocity, angular_velocity)"
@@ -3157,7 +3166,13 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         snqi_baseline=snqi_baseline,
     )
     for metric_name, metric_value in actuation_summary.items():
-        if metric_name in {"schema_version", "status", "step_count", "command_clip_steps", "yaw_rate_saturation_steps"}:
+        if metric_name in {
+            "schema_version",
+            "status",
+            "step_count",
+            "command_clip_steps",
+            "yaw_rate_saturation_steps",
+        }:
             continue
         metrics[metric_name] = metric_value
 

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1646,6 +1646,7 @@ def run_batch(  # noqa: PLR0913
     observation_mode: str | None = None,
     observation_level: str | None = None,
     observation_noise: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
     workers: int = 1,
     resume: bool = True,
 ) -> dict[str, Any]:
@@ -1687,6 +1688,7 @@ def run_batch(  # noqa: PLR0913
             observation_mode=observation_mode,
             observation_level=observation_level,
             observation_noise=observation_noise,
+            synthetic_actuation_profile=synthetic_actuation_profile,
             workers=workers,
             resume=resume,
         )

--- a/robot_sf/benchmark/synthetic_actuation.py
+++ b/robot_sf/benchmark/synthetic_actuation.py
@@ -6,7 +6,6 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
-
 _LATENCY_MODE_TO_STEPS = {
     "zero-step-delay": 0,
     "one-step-delay": 1,

--- a/robot_sf/benchmark/synthetic_actuation.py
+++ b/robot_sf/benchmark/synthetic_actuation.py
@@ -1,0 +1,225 @@
+"""Synthetic differential-drive actuation-envelope helpers for diagnostic benchmark slices."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+
+_LATENCY_MODE_TO_STEPS = {
+    "zero-step-delay": 0,
+    "one-step-delay": 1,
+    "two-step-delay": 2,
+}
+_UPDATE_MODE_TO_STEPS = {
+    "10hz-matched": 1,
+    "5hz-hold": 2,
+}
+_SATURATION_TOL = 1e-9
+
+
+@dataclass(frozen=True)
+class SyntheticActuationProfile:
+    """Serializable synthetic actuation-envelope profile for one diagnostic campaign."""
+
+    name: str
+    max_linear_accel_m_s2: float
+    max_linear_decel_m_s2: float
+    max_yaw_rate_rad_s: float
+    max_angular_accel_rad_s2: float
+    latency_mode: str
+    update_mode: str
+    profile_version: str = "v0"
+    claim_scope: str = "synthetic-only"
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-safe metadata payload."""
+        return {
+            "name": self.name,
+            "profile_version": self.profile_version,
+            "claim_scope": self.claim_scope,
+            "max_linear_accel_m_s2": float(self.max_linear_accel_m_s2),
+            "max_linear_decel_m_s2": float(self.max_linear_decel_m_s2),
+            "max_yaw_rate_rad_s": float(self.max_yaw_rate_rad_s),
+            "max_angular_accel_rad_s2": float(self.max_angular_accel_rad_s2),
+            "latency_mode": self.latency_mode,
+            "update_mode": self.update_mode,
+        }
+
+
+def known_latency_modes() -> tuple[str, ...]:
+    """Return supported synthetic latency-mode labels."""
+    return tuple(_LATENCY_MODE_TO_STEPS)
+
+
+def known_update_modes() -> tuple[str, ...]:
+    """Return supported synthetic update-mode labels."""
+    return tuple(_UPDATE_MODE_TO_STEPS)
+
+
+def validate_synthetic_actuation_profile(profile: SyntheticActuationProfile) -> None:
+    """Validate that one synthetic profile is usable for differential-drive diagnostics."""
+    if not profile.name.strip():
+        raise ValueError("synthetic_actuation_profile.name must be non-empty")
+    if not profile.profile_version.strip():
+        raise ValueError("synthetic_actuation_profile.profile_version must be non-empty")
+    if profile.claim_scope.strip() != "synthetic-only":
+        raise ValueError("synthetic_actuation_profile.claim_scope must be 'synthetic-only'")
+    if profile.max_linear_accel_m_s2 <= 0.0:
+        raise ValueError("synthetic_actuation_profile.max_linear_accel_m_s2 must be > 0")
+    if profile.max_linear_decel_m_s2 <= 0.0:
+        raise ValueError("synthetic_actuation_profile.max_linear_decel_m_s2 must be > 0")
+    if profile.max_yaw_rate_rad_s <= 0.0:
+        raise ValueError("synthetic_actuation_profile.max_yaw_rate_rad_s must be > 0")
+    if profile.max_angular_accel_rad_s2 <= 0.0:
+        raise ValueError("synthetic_actuation_profile.max_angular_accel_rad_s2 must be > 0")
+    if profile.latency_mode not in _LATENCY_MODE_TO_STEPS:
+        known = ", ".join(known_latency_modes())
+        raise ValueError(
+            "Unsupported synthetic_actuation_profile.latency_mode "
+            f"'{profile.latency_mode}'. Expected one of: {known}"
+        )
+    if profile.update_mode not in _UPDATE_MODE_TO_STEPS:
+        known = ", ".join(known_update_modes())
+        raise ValueError(
+            "Unsupported synthetic_actuation_profile.update_mode "
+            f"'{profile.update_mode}'. Expected one of: {known}"
+        )
+
+
+@dataclass(frozen=True)
+class SyntheticActuationStep:
+    """One synthetic-actuation trace step."""
+
+    requested_command: tuple[float, float]
+    delayed_command: tuple[float, float]
+    held_command: tuple[float, float]
+    applied_command: tuple[float, float]
+    command_clipped: bool
+    yaw_rate_saturated: bool
+    linear_accel_applied_m_s2: float
+    angular_accel_applied_rad_s2: float
+
+
+class SyntheticActuationController:
+    """Apply a synthetic differential-drive envelope to absolute ``(v, omega)`` commands."""
+
+    def __init__(self, profile: SyntheticActuationProfile, *, dt: float) -> None:
+        """Initialize controller state for one episode."""
+        validate_synthetic_actuation_profile(profile)
+        if dt <= 0.0:
+            raise ValueError("Synthetic actuation controller requires dt > 0")
+        self.profile = profile
+        self.dt = float(dt)
+        self._latency_steps = _LATENCY_MODE_TO_STEPS[profile.latency_mode]
+        self._hold_steps = _UPDATE_MODE_TO_STEPS[profile.update_mode]
+        self._delay_buffer: deque[tuple[float, float]] = deque(
+            [(0.0, 0.0)] * max(1, self._latency_steps + 1),
+            maxlen=max(1, self._latency_steps + 1),
+        )
+        self._held_command = (0.0, 0.0)
+        self._hold_counter = 0
+        self._step_count = 0
+        self._clip_count = 0
+        self._yaw_saturation_count = 0
+        self._signed_braking_peak = 0.0
+
+    def apply(
+        self,
+        *,
+        current_command: tuple[float, float],
+        requested_command: tuple[float, float],
+    ) -> SyntheticActuationStep:
+        """Return the delayed, held, and clipped command for one benchmark step."""
+        requested_linear = float(requested_command[0])
+        requested_angular = float(requested_command[1])
+        self._delay_buffer.append((requested_linear, requested_angular))
+        delayed_command = self._delay_buffer[0]
+        if self._step_count == 0 or self._hold_counter <= 0:
+            self._held_command = delayed_command
+            self._hold_counter = self._hold_steps
+        self._hold_counter -= 1
+        held_command = self._held_command
+
+        current_linear = float(current_command[0])
+        current_angular = float(current_command[1])
+        target_linear = float(held_command[0])
+        target_angular = float(held_command[1])
+
+        allowed_linear_up = float(self.profile.max_linear_accel_m_s2) * self.dt
+        allowed_linear_down = float(self.profile.max_linear_decel_m_s2) * self.dt
+        requested_linear_delta = target_linear - current_linear
+        if requested_linear_delta >= 0.0:
+            applied_linear = current_linear + min(requested_linear_delta, allowed_linear_up)
+        else:
+            applied_linear = current_linear + max(requested_linear_delta, -allowed_linear_down)
+
+        bounded_target_angular = max(
+            -float(self.profile.max_yaw_rate_rad_s),
+            min(float(self.profile.max_yaw_rate_rad_s), target_angular),
+        )
+        allowed_angular_delta = float(self.profile.max_angular_accel_rad_s2) * self.dt
+        requested_angular_delta = bounded_target_angular - current_angular
+        applied_angular = current_angular + max(
+            -allowed_angular_delta,
+            min(allowed_angular_delta, requested_angular_delta),
+        )
+
+        applied_command = (float(applied_linear), float(applied_angular))
+        command_clipped = (
+            abs(applied_linear - target_linear) > _SATURATION_TOL
+            or abs(applied_angular - target_angular) > _SATURATION_TOL
+        )
+        yaw_rate_saturated = abs(bounded_target_angular - target_angular) > _SATURATION_TOL
+
+        self._step_count += 1
+        if command_clipped:
+            self._clip_count += 1
+        if yaw_rate_saturated:
+            self._yaw_saturation_count += 1
+
+        linear_accel = float((applied_linear - current_linear) / self.dt)
+        angular_accel = float((applied_angular - current_angular) / self.dt)
+        self._signed_braking_peak = min(self._signed_braking_peak, linear_accel)
+        return SyntheticActuationStep(
+            requested_command=(requested_linear, requested_angular),
+            delayed_command=(float(delayed_command[0]), float(delayed_command[1])),
+            held_command=(float(held_command[0]), float(held_command[1])),
+            applied_command=applied_command,
+            command_clipped=command_clipped,
+            yaw_rate_saturated=yaw_rate_saturated,
+            linear_accel_applied_m_s2=linear_accel,
+            angular_accel_applied_rad_s2=angular_accel,
+        )
+
+    def summary(self) -> dict[str, Any]:
+        """Return auditable per-episode saturation diagnostics."""
+        if self._step_count <= 0:
+            return {
+                "schema_version": "synthetic-actuation-summary.v1",
+                "status": "not_available",
+                "command_clip_fraction": "not_available",
+                "yaw_rate_saturation_fraction": "not_available",
+                "signed_braking_peak_m_s2": "not_available",
+                "step_count": 0,
+            }
+        return {
+            "schema_version": "synthetic-actuation-summary.v1",
+            "status": "ok",
+            "command_clip_fraction": float(self._clip_count / self._step_count),
+            "yaw_rate_saturation_fraction": float(self._yaw_saturation_count / self._step_count),
+            "signed_braking_peak_m_s2": float(self._signed_braking_peak),
+            "step_count": int(self._step_count),
+            "command_clip_steps": int(self._clip_count),
+            "yaw_rate_saturation_steps": int(self._yaw_saturation_count),
+        }
+
+
+def not_available_saturation_metrics() -> dict[str, str]:
+    """Return explicit placeholders for unimplemented saturation metrics."""
+    return {
+        "command_clip_fraction": "not_available",
+        "yaw_rate_saturation_fraction": "not_available",
+        "signed_braking_peak_m_s2": "not_available",
+    }

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -353,7 +353,9 @@ def test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata(
     cfg = load_campaign_config(config_path)
     prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue1556")
 
-    preview_payload = json.loads(Path(prepared["preview_scenarios_path"]).read_text(encoding="utf-8"))
+    preview_payload = json.loads(
+        Path(prepared["preview_scenarios_path"]).read_text(encoding="utf-8")
+    )
     assert preview_payload["scenario_count"] == 5
     assert [scenario["name"] for scenario in preview_payload["scenarios"]] == [
         "classic_overtaking_medium",
@@ -364,7 +366,9 @@ def test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata(
     ]
 
     manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
-    validate_payload = json.loads(Path(prepared["validate_config_path"]).read_text(encoding="utf-8"))
+    validate_payload = json.loads(
+        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
+    )
     assert validate_payload["scenario_candidates"]["requested"] == [
         "classic_overtaking_medium",
         "classic_bottleneck_high",
@@ -1650,7 +1654,11 @@ def test_run_campaign_writes_synthetic_actuation_artifacts(
             "failed_jobs": 0,
             "failures": [],
             "out_path": str(out_file),
-            "algorithm_readiness": {"name": algo, "tier": "baseline-ready", "profile": "baseline-safe"},
+            "algorithm_readiness": {
+                "name": algo,
+                "tier": "baseline-ready",
+                "profile": "baseline-safe",
+            },
             "preflight": {
                 "status": "ok",
                 "synthetic_actuation_profile": kwargs["synthetic_actuation_profile"],

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -164,6 +164,232 @@ def test_load_campaign_config_rejects_directory_observation_noise_profile(
         load_campaign_config(cfg_path)
 
 
+def test_load_campaign_config_rejects_malformed_scenario_candidates(
+    tmp_path: Path,
+) -> None:
+    """Malformed scenario candidate selectors should not silently expand the slice."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad_candidates",
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "scenario_candidates": {"name": "francis2023_blind_corner"},
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="scenario_candidates must be"):
+        load_campaign_config(config_path)
+
+
+def test_load_campaign_config_rejects_malformed_synthetic_actuation_profile(
+    tmp_path: Path,
+) -> None:
+    """Malformed synthetic actuation profile payloads should fail closed."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad_actuation_profile",
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "synthetic_actuation_profile": [],
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="synthetic_actuation_profile must be a mapping"):
+        load_campaign_config(config_path)
+
+
+def test_load_campaign_config_rejects_non_synthetic_actuation_claim_scope(
+    tmp_path: Path,
+) -> None:
+    """Synthetic actuation diagnostics should reject hardware or paper-facing claim scopes."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad_actuation_scope",
+                "paper_facing": False,
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "kinematics_matrix": ["differential_drive"],
+                "synthetic_actuation_profile": {
+                    "name": "amv-actuation-stress-v0",
+                    "profile_version": "v0",
+                    "claim_scope": "hardware-calibrated",
+                    "max_linear_accel_m_s2": 2.0,
+                    "max_linear_decel_m_s2": 2.5,
+                    "max_yaw_rate_rad_s": 1.2,
+                    "max_angular_accel_rad_s2": 4.0,
+                    "latency_mode": "one-step-delay",
+                    "update_mode": "5hz-hold",
+                },
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="claim_scope must be 'synthetic-only'"):
+        load_campaign_config(config_path)
+
+
+def test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata(
+    tmp_path: Path,
+) -> None:
+    """Preflight should resolve candidate scenarios, eval seeds, and synthetic profile metadata."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "classic_overtaking_medium",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "overtake",
+                    },
+                },
+                {
+                    "name": "classic_bottleneck_high",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "bottleneck",
+                    },
+                },
+                {
+                    "name": "classic_cross_trap_high",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "shared_space_micromobility",
+                        "context": "shared_space",
+                        "speed_regime": "scooter_speed",
+                        "maneuver_type": "crossing",
+                    },
+                },
+                {
+                    "name": "francis2023_blind_corner",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "crossing",
+                    },
+                },
+                {
+                    "name": "francis2023_intersection_wait",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "shared_space_micromobility",
+                        "context": "shared_space",
+                        "speed_regime": "scooter_speed",
+                        "maneuver_type": "bottleneck",
+                    },
+                },
+                {
+                    "name": "unused_extra_row",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                    "amv": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "crossing",
+                    },
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "issue_1556_preflight",
+                "paper_facing": False,
+                "scenario_matrix": str(scenario_path),
+                "kinematics_matrix": ["differential_drive"],
+                "scenario_candidates": [
+                    "classic_overtaking_medium",
+                    "classic_bottleneck_high",
+                    "classic_cross_trap_high",
+                    "francis2023_blind_corner",
+                    "francis2023_intersection_wait",
+                ],
+                "seed_policy": {"mode": "seed-set", "seed_set": "eval"},
+                "synthetic_actuation_profile": {
+                    "name": "amv-actuation-stress-v0",
+                    "profile_version": "v0",
+                    "claim_scope": "synthetic-only",
+                    "max_linear_accel_m_s2": 2.0,
+                    "max_linear_decel_m_s2": 2.5,
+                    "max_yaw_rate_rad_s": 1.2,
+                    "max_angular_accel_rad_s2": 4.0,
+                    "latency_mode": "one-step-delay",
+                    "update_mode": "5hz-hold",
+                },
+                "planners": [{"key": "goal", "algo": "goal", "planner_group": "core"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+    prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue1556")
+
+    preview_payload = json.loads(Path(prepared["preview_scenarios_path"]).read_text(encoding="utf-8"))
+    assert preview_payload["scenario_count"] == 5
+    assert [scenario["name"] for scenario in preview_payload["scenarios"]] == [
+        "classic_overtaking_medium",
+        "classic_bottleneck_high",
+        "classic_cross_trap_high",
+        "francis2023_blind_corner",
+        "francis2023_intersection_wait",
+    ]
+
+    manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
+    validate_payload = json.loads(Path(prepared["validate_config_path"]).read_text(encoding="utf-8"))
+    assert validate_payload["scenario_candidates"]["requested"] == [
+        "classic_overtaking_medium",
+        "classic_bottleneck_high",
+        "classic_cross_trap_high",
+        "francis2023_blind_corner",
+        "francis2023_intersection_wait",
+    ]
+    assert validate_payload["scenario_candidates"]["resolved"] == [
+        "classic_overtaking_medium",
+        "classic_bottleneck_high",
+        "classic_cross_trap_high",
+        "francis2023_blind_corner",
+        "francis2023_intersection_wait",
+    ]
+    assert manifest["scenario_candidates"] == [
+        "classic_overtaking_medium",
+        "classic_bottleneck_high",
+        "classic_cross_trap_high",
+        "francis2023_blind_corner",
+        "francis2023_intersection_wait",
+    ]
+    assert manifest["synthetic_actuation_profile"]["name"] == "amv-actuation-stress-v0"
+    assert manifest["seed_policy"]["seed_set"] == "eval"
+
+
 def test_load_campaign_config_parses_observation_mode_overrides(tmp_path: Path) -> None:
     """Campaign configs should support global and per-planner observation-mode overrides."""
     scenario_path = tmp_path / "scenarios.yaml"
@@ -1322,6 +1548,178 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
         "Publication bundle export skipped because benchmark_success=false." in warning
         for warning in summary_payload["warnings"]
     )
+
+
+def test_run_campaign_writes_synthetic_actuation_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Synthetic actuation slices should emit diagnostic artifacts and propagate profile metadata."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        "- name: classic_overtaking_medium\n  map_file: maps/svg_maps/classic_crossing.svg\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "issue_1556_runner",
+                "paper_facing": False,
+                "scenario_matrix": str(scenario_path),
+                "kinematics_matrix": ["differential_drive"],
+                "scenario_candidates": ["classic_overtaking_medium"],
+                "seed_policy": {"mode": "fixed-list", "seeds": [111]},
+                "synthetic_actuation_profile": {
+                    "name": "amv-actuation-stress-v0",
+                    "profile_version": "v0",
+                    "claim_scope": "synthetic-only",
+                    "max_linear_accel_m_s2": 2.0,
+                    "max_linear_decel_m_s2": 2.5,
+                    "max_yaw_rate_rad_s": 1.2,
+                    "max_angular_accel_rad_s2": 4.0,
+                    "latency_mode": "one-step-delay",
+                    "update_mode": "5hz-hold",
+                },
+                "planners": [{"key": "goal", "algo": "goal", "planner_group": "core"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+    run_batch_calls: list[dict[str, object]] = []
+
+    def _fake_run_batch(
+        scenarios_or_path,
+        out_path,
+        schema_path,
+        *,
+        algo,
+        benchmark_profile,
+        **kwargs,
+    ):
+        del scenarios_or_path, schema_path, benchmark_profile
+        run_batch_calls.append({"algo": algo, **kwargs})
+        out_file = Path(out_path)
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "episode_id": "e-goal-0",
+            "scenario_id": "classic_overtaking_medium",
+            "seed": 111,
+            "scenario_params": {
+                "algo": algo,
+                "synthetic_actuation_profile": kwargs["synthetic_actuation_profile"],
+            },
+            "metrics": {
+                "success": 1.0,
+                "collisions": 0.0,
+                "near_misses": 0.0,
+                "command_clip_fraction": 0.25,
+                "yaw_rate_saturation_fraction": 0.5,
+                "signed_braking_peak_m_s2": -1.5,
+                "stalled_time": 0.0,
+                "failure_to_progress": 0.0,
+                "jerk_mean": 0.1,
+                "jerk_max": 0.2,
+                "curvature_mean": 0.3,
+                "energy": 1.0,
+                "min_clearance": 0.8,
+                "time_to_collision_min": 1.2,
+                "time_to_goal_norm": 0.7,
+                "velocity_max": 1.0,
+                "acceleration_max": 2.0,
+                "total_collision_count": 0.0,
+            },
+            "algorithm_metadata": {
+                "algorithm": algo,
+                "status": "ok",
+                "synthetic_actuation": {
+                    "profile": kwargs["synthetic_actuation_profile"],
+                    "summary": {
+                        "status": "ok",
+                        "command_clip_fraction": 0.25,
+                        "yaw_rate_saturation_fraction": 0.5,
+                        "signed_braking_peak_m_s2": -1.5,
+                    },
+                },
+            },
+        }
+        out_file.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        return {
+            "total_jobs": 1,
+            "written": 1,
+            "failed_jobs": 0,
+            "failures": [],
+            "out_path": str(out_file),
+            "algorithm_readiness": {"name": algo, "tier": "baseline-ready", "profile": "baseline-safe"},
+            "preflight": {
+                "status": "ok",
+                "synthetic_actuation_profile": kwargs["synthetic_actuation_profile"],
+            },
+            "synthetic_actuation_profile": kwargs["synthetic_actuation_profile"],
+        }
+
+    def _fake_compute_aggregates_with_ci(
+        records,
+        *,
+        group_by,
+        bootstrap_samples,
+        bootstrap_confidence,
+        bootstrap_seed,
+    ):
+        del records, group_by, bootstrap_samples, bootstrap_confidence, bootstrap_seed
+        return {
+            "mock_group": {
+                "success": {"mean": 1.0, "mean_ci": [1.0, 1.0]},
+                "time_to_goal_norm": {"mean": 0.7, "mean_ci": [0.6, 0.8]},
+                "total_collision_count": {"mean": 0.0, "mean_ci": [0.0, 0.0]},
+                "near_misses": {"mean": 0.0, "mean_ci": [0.0, 0.0]},
+                "min_clearance": {"mean": 0.8, "mean_ci": [0.8, 0.8]},
+                "time_to_collision_min": {"mean": 1.2, "mean_ci": [1.2, 1.2]},
+                "velocity_max": {"mean": 1.0, "mean_ci": [1.0, 1.0]},
+                "acceleration_max": {"mean": 2.0, "mean_ci": [2.0, 2.0]},
+                "jerk_mean": {"mean": 0.1, "mean_ci": [0.1, 0.1]},
+                "jerk_max": {"mean": 0.2, "mean_ci": [0.2, 0.2]},
+                "curvature_mean": {"mean": 0.3, "mean_ci": [0.3, 0.3]},
+                "energy": {"mean": 1.0, "mean_ci": [1.0, 1.0]},
+                "stalled_time": {"mean": 0.0, "mean_ci": [0.0, 0.0]},
+                "failure_to_progress": {"mean": 0.0, "mean_ci": [0.0, 0.0]},
+                "command_clip_fraction": {"mean": 0.25, "mean_ci": [0.25, 0.25]},
+                "yaw_rate_saturation_fraction": {"mean": 0.5, "mean_ci": [0.5, 0.5]},
+                "signed_braking_peak_m_s2": {"mean": -1.5, "mean_ci": [-1.5, -1.5]},
+            },
+            "_meta": {"warnings": [], "missing_algorithms": []},
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.camera_ready_campaign.compute_aggregates_with_ci",
+        _fake_compute_aggregates_with_ci,
+    )
+
+    result = run_campaign(cfg, output_root=tmp_path / "out", label="issue1556")
+    campaign_root = Path(result["campaign_root"])
+    summary_payload = json.loads(
+        (campaign_root / "reports" / "campaign_summary.json").read_text(encoding="utf-8")
+    )
+    actuation_payload = json.loads(
+        (campaign_root / "reports" / "actuation_envelope_summary.json").read_text(encoding="utf-8")
+    )
+
+    assert run_batch_calls[0]["synthetic_actuation_profile"]["name"] == "amv-actuation-stress-v0"
+    assert summary_payload["campaign"]["synthetic_actuation_profile"]["name"] == (
+        "amv-actuation-stress-v0"
+    )
+    assert summary_payload["artifacts"]["actuation_envelope_json"].endswith(
+        "reports/actuation_envelope_summary.json"
+    )
+    assert summary_payload["artifacts"]["actuation_envelope_md"].endswith(
+        "reports/actuation_envelope_summary.md"
+    )
+    assert actuation_payload["claim_boundary"].startswith("Synthetic diagnostic only")
+    assert actuation_payload["synthetic_actuation_profile"]["update_mode"] == "5hz-hold"
+    assert "metric_means" in actuation_payload["rows"][0]
+    assert "metrics" not in actuation_payload["rows"][0]
+    assert actuation_payload["rows"][0]["saturation_metrics"]["command_clip_fraction"] == "0.2500"
 
 
 def test_load_campaign_config_uses_repo_default_seed_sets_path(tmp_path: Path):

--- a/tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py
+++ b/tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py
@@ -1,0 +1,74 @@
+"""Contract tests for issue #1556 synthetic AMV actuation stress slice config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / "configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a benchmark YAML file."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_issue_1556_config_declares_synthetic_differential_drive_slice() -> None:
+    """The config should stay synthetic-only, non-paper-facing, and differential-drive-only."""
+    payload = _load_yaml(CONFIG_PATH)
+
+    assert payload["paper_facing"] is False
+    assert payload["kinematics_matrix"] == ["differential_drive"]
+    assert payload["seed_policy"]["mode"] == "seed-set"
+    assert payload["seed_policy"]["seed_set"] == "eval"
+    assert payload["scenario_candidates"] == [
+        "classic_overtaking_medium",
+        "classic_bottleneck_high",
+        "classic_cross_trap_high",
+        "francis2023_blind_corner",
+        "francis2023_intersection_wait",
+    ]
+
+    profile = payload["synthetic_actuation_profile"]
+    assert profile == {
+        "name": "amv-actuation-stress-v0",
+        "profile_version": "v0",
+        "claim_scope": "synthetic-only",
+        "max_linear_accel_m_s2": 2.0,
+        "max_linear_decel_m_s2": 2.5,
+        "max_yaw_rate_rad_s": 1.2,
+        "max_angular_accel_rad_s2": 4.0,
+        "latency_mode": "one-step-delay",
+        "update_mode": "5hz-hold",
+    }
+
+
+def test_issue_1556_config_reuses_compact_primary_planner_set() -> None:
+    """The slice should stay compact and avoid broad planner expansion."""
+    payload = _load_yaml(CONFIG_PATH)
+
+    assert payload["paper_interpretation_profile"] == "issue-1556-amv-actuation-diagnostic"
+    assert payload["planners"] == [
+        {
+            "key": "goal",
+            "algo": "goal",
+            "planner_group": "core",
+            "benchmark_profile": "baseline-safe",
+        },
+        {
+            "key": "social_force",
+            "algo": "social_force",
+            "planner_group": "core",
+            "benchmark_profile": "baseline-safe",
+        },
+        {
+            "key": "orca",
+            "algo": "orca",
+            "planner_group": "core",
+            "benchmark_profile": "baseline-safe",
+            "socnav_missing_prereq_policy": "fallback",
+        },
+    ]

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2094,6 +2094,116 @@ def test_run_map_episode_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "infeasible_rate" in feasibility
 
 
+def test_run_map_episode_records_synthetic_actuation_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthetic actuation profiles should annotate episodes with auditable saturation metrics."""
+
+    class _DummySim:
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+            self.ped_pos = np.zeros((0, 2), dtype=float)
+            self.goal_pos = [np.array([1.0, 1.0], dtype=float)]
+            self.map_def = map_def
+            self.last_ped_forces = np.zeros((0, 2), dtype=float)
+
+    class _DummyEnv:
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.simulator = _DummySim(map_def)
+            self._steps = 0
+
+        def reset(self, seed: int | None = None):
+            del seed
+            obs = {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+                "goal": {"current": [1.0, 1.0]},
+            }
+            return obs, {}
+
+        def step(self, action):
+            del action
+            self._steps += 1
+            obs = {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+                "goal": {"current": [1.0, 1.0]},
+            }
+            terminated = self._steps >= 4
+            return obs, 0.0, terminated, False, {"success": terminated}
+
+        def close(self) -> None:
+            return None
+
+    def _policy(_obs: dict[str, object]) -> tuple[float, float]:
+        return (3.0, 2.0)
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_policy",
+        lambda *args, **kwargs: (_policy, {"algorithm": "goal", "status": "ok"}),
+    )
+    map_def = _minimal_map_def()
+    dummy_config = SimpleNamespace(
+        sim_config=SimpleNamespace(time_per_step_in_secs=0.1, ped_radius=0.4),
+        robot_config=DifferentialDriveSettings(max_linear_speed=1.0),
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_env_config",
+        lambda scenario, scenario_path: dummy_config,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.make_robot_env",
+        lambda config, seed, debug: _DummyEnv(map_def),
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_shortest_path_length",
+        lambda *args: 1.0,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_all_metrics",
+        lambda *args, **kwargs: {"success": 0.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._policy_command_to_env_action",
+        lambda env, config, command: np.asarray(command, dtype=np.float32),
+    )
+
+    record = _run_map_episode(
+        {"name": "s1", "simulation_config": {"max_episode_steps": 4}},
+        seed=1,
+        horizon=None,
+        dt=0.1,
+        record_forces=True,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        algo_config_path=None,
+        scenario_path=Path("."),
+        synthetic_actuation_profile={
+            "name": "amv-actuation-stress-v0",
+            "profile_version": "v0",
+            "claim_scope": "synthetic-only",
+            "max_linear_accel_m_s2": 2.0,
+            "max_linear_decel_m_s2": 2.5,
+            "max_yaw_rate_rad_s": 1.2,
+            "max_angular_accel_rad_s2": 4.0,
+            "latency_mode": "one-step-delay",
+            "update_mode": "5hz-hold",
+        },
+    )
+
+    synthetic_meta = record["algorithm_metadata"]["synthetic_actuation"]
+    assert synthetic_meta["profile"]["name"] == "amv-actuation-stress-v0"
+    assert synthetic_meta["summary"]["status"] == "ok"
+    assert float(record["metrics"]["command_clip_fraction"]) > 0.0
+    assert float(record["metrics"]["yaw_rate_saturation_fraction"]) > 0.0
+    assert record["metrics"]["signed_braking_peak_m_s2"] == pytest.approx(0.0)
+    assert record["scenario_params"]["synthetic_actuation_profile"]["update_mode"] == "5hz-hold"
+
+
 def test_run_map_episode_calls_planner_reset_hook(monkeypatch: pytest.MonkeyPatch) -> None:
     """Episode start should reset stateful planner adapters before stepping."""
 
@@ -2903,6 +3013,46 @@ def test_run_map_batch_rejects_unsupported_observation_override(
             resume=False,
         )
     assert not out_path.exists()
+
+
+def test_run_map_batch_fail_closed_when_synthetic_actuation_profile_is_not_diff_drive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Synthetic actuation slices should skip closed when scenarios are not differential-drive."""
+    scenario = {
+        "name": "holonomic_only",
+        "metadata": {"supported": True},
+        "robot_config": {"type": "holonomic"},
+    }
+    out_path = tmp_path / "episodes.jsonl"
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+
+    result = run_map_batch(
+        [scenario],
+        out_path,
+        schema_path=tmp_path / "schema.json",
+        synthetic_actuation_profile={
+            "name": "amv-actuation-stress-v0",
+            "profile_version": "v0",
+            "claim_scope": "synthetic-only",
+            "max_linear_accel_m_s2": 2.0,
+            "max_linear_decel_m_s2": 2.5,
+            "max_yaw_rate_rad_s": 1.2,
+            "max_angular_accel_rad_s2": 4.0,
+            "latency_mode": "one-step-delay",
+            "update_mode": "5hz-hold",
+        },
+        resume=False,
+    )
+
+    assert result["written"] == 0
+    assert result["preflight"]["status"] == "skipped"
+    assert result["preflight"]["compatibility_status"] == "incompatible"
+    assert "differential_drive-only" in result["preflight"]["compatibility_reason"]
+    assert result["preflight"]["synthetic_actuation_profile"]["name"] == "amv-actuation-stress-v0"
 
 
 def test_run_map_batch_parallel_writes_results_in_job_order(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2085,6 +2085,9 @@ def test_run_map_episode_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
     assert record["observation_level"] == "oracle_full_state"
     assert record["scenario_params"]["observation_mode"] == "goal_state"
     assert record["scenario_params"]["observation_level"] == "oracle_full_state"
+    assert "command_clip_fraction" not in record["metrics"]
+    assert "yaw_rate_saturation_fraction" not in record["metrics"]
+    assert "signed_braking_peak_m_s2" not in record["metrics"]
     assert algo_md["observation_spec"]["active_mode"] == "goal_state"
     assert algo_md["observation_level"]["key"] == "oracle_full_state"
     assert algo_md["planner_kinematics"]["robot_kinematics"] in {"unknown", "differential_drive"}


### PR DESCRIPTION
## Summary\n\n- Closes #1556 by adding a non-paper-facing, differential-drive-only synthetic AMV actuation stress slice config.\n- Adds typed synthetic actuation profile validation, map-runner command wrapping, provenance propagation, and diagnostic actuation-envelope summary artifacts.\n- Keeps ordinary episode metrics unchanged when no synthetic profile is configured, and documents the claim boundary in docs/context.\n\n## Validation\n\n- scripts/dev/ruff_fix_format.sh\n- pytest tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner tests/benchmark/test_map_runner_utils.py::test_run_map_episode_smoke tests/benchmark/test_map_runner_utils.py::test_run_map_episode_records_synthetic_actuation_metrics tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py tests/benchmark/test_camera_ready_campaign.py\n- python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml --mode preflight --label issue1556-local --output-root output/benchmarks/camera_ready_issue1556 --log-level WARNING\n- BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh\n- BASE_REF=origin/main scripts/dev/pr_ready_check.sh: 4270 passed, 10 skipped, 8 warnings\n\n## Follow-up\n\n- Opened #1559 for calibrated AMV actuation-envelope work before any paper-facing use.\n\n## Artifact note\n\nGenerated preflight and coverage artifacts remain ignored under output/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synthetic differential-drive actuation stress benchmark with configurable profiles for scenario testing
  * New actuation envelope diagnostic summaries with saturation metrics (clipping, yaw-rate saturation, braking diagnostics)

* **Documentation**
  * Added documentation for the synthetic AMV actuation stress slice benchmark, including validation procedures and contract checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->