### PR TITLE
feat: add archetype metadata sync report

### DIFF
--- a/scripts/tools/issue_archetype_sync.py
+++ b/scripts/tools/issue_archetype_sync.py
@@ -1,0 +1,325 @@
+"""Report safe issue-body archetype metadata mirror candidates.
+
+The issue body remains authoritative. This helper is intentionally read-only:
+it fetches issue metadata with ``gh api``, parses the existing
+``## Archetype Metadata`` block, and prints a dry-run JSON report. It never
+adds labels, creates labels, or writes Project fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scripts.tools.issue_template_audit import audit_archetype_metadata
+
+SAFE_ARCHETYPE_LABEL_MAP: dict[str, str] = {
+    "workflow": "type:workflow",
+    "docs": "type:docs",
+    "synthesis": "type:synthesis",
+    "benchmark-campaign": "type:benchmark",
+    "analysis": "type:analysis",
+    "training-campaign": "type:training",
+}
+
+TYPED_LABEL_PREFIX = "type:"
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+
+
+@dataclass(frozen=True, slots=True)
+class LabelCandidate:
+    """One proposed or skipped typed-label mirror candidate."""
+
+    source_field: str
+    source_value: str
+    label: str
+    status: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ArchetypeSyncReport:
+    """Dry-run report for one issue archetype metadata sync check."""
+
+    issue_number: int
+    dry_run: bool
+    body_metadata: dict[str, Any] | None
+    metadata_findings: list[str] = field(default_factory=list)
+    existing_labels: list[str] = field(default_factory=list)
+    proposed_label_additions: list[str] = field(default_factory=list)
+    skipped_label_candidates: list[LabelCandidate] = field(default_factory=list)
+    project_sync_mode: str = "report-only"
+    project_field_candidates: list[dict[str, str]] = field(default_factory=list)
+    mutation_plan: list[dict[str, Any]] = field(default_factory=list)
+    rate_limit_guidance: str = (
+        "Uses read-only gh REST calls; keep Project v2 writes out of this default path "
+        "and batch GraphQL separately per docs/context/issue_713_batch_first_issue_workflow.md."
+    )
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    """Run a read-only gh command and decode JSON output.
+
+    Returns:
+        Decoded JSON payload.
+    """
+    completed = subprocess.run(args, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def fetch_issue_payload(repo: str, issue_number: int) -> dict[str, Any]:
+    """Fetch issue body and labels through the GitHub REST API.
+
+    Returns:
+        Issue payload returned by ``gh api``.
+    """
+    payload = _run_gh_json(["gh", "api", f"repos/{repo}/issues/{issue_number}"])
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub issue payload did not decode to an object")
+    return payload
+
+
+def fetch_repo_label_names(repo: str) -> set[str]:
+    """Fetch existing repository label names using read-only REST pagination.
+
+    Returns:
+        Set of label names currently present in the repository.
+    """
+    payload = _run_gh_json(["gh", "api", f"repos/{repo}/labels", "--paginate"])
+    if not isinstance(payload, list):
+        raise RuntimeError("GitHub labels payload did not decode to a list")
+    labels: set[str] = set()
+    for item in payload:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            labels.add(item["name"])
+    return labels
+
+
+def _issue_label_names(issue_payload: dict[str, Any]) -> list[str]:
+    """Extract sorted issue label names from a GitHub issue payload.
+
+    Returns:
+        Sorted label names.
+    """
+    labels = issue_payload.get("labels")
+    if not isinstance(labels, list):
+        return []
+    names = [
+        item["name"]
+        for item in labels
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    ]
+    return sorted(names)
+
+
+def build_sync_report(
+    *,
+    issue_number: int,
+    issue_body: str,
+    existing_labels: list[str],
+    available_labels: set[str] | None = None,
+    dry_run: bool = True,
+) -> ArchetypeSyncReport:
+    """Build a no-mutation issue archetype sync report.
+
+    Returns:
+        Structured dry-run report.
+    """
+    metadata = audit_archetype_metadata(issue_body)
+    parsed = metadata.parsed_metadata
+    findings = list(metadata.findings)
+    proposed: list[str] = []
+    skipped: list[LabelCandidate] = []
+
+    if parsed is None or findings:
+        skipped.append(
+            LabelCandidate(
+                source_field="archetype",
+                source_value="",
+                label="",
+                status="skipped",
+                reason="schema_missing" if metadata.parse_error is None else "malformed",
+            )
+        )
+    else:
+        archetype = parsed.get("archetype")
+        if not isinstance(archetype, str):
+            skipped.append(
+                LabelCandidate(
+                    source_field="archetype",
+                    source_value=repr(archetype),
+                    label="",
+                    status="skipped",
+                    reason="schema_missing",
+                )
+            )
+        else:
+            target_label = SAFE_ARCHETYPE_LABEL_MAP.get(archetype)
+            existing_typed = sorted(
+                label for label in existing_labels if label.startswith(TYPED_LABEL_PREFIX)
+            )
+            if target_label is None:
+                skipped.append(
+                    LabelCandidate(
+                        source_field="archetype",
+                        source_value=archetype,
+                        label="",
+                        status="skipped",
+                        reason="not_low_risk",
+                    )
+                )
+            elif available_labels is not None and target_label not in available_labels:
+                skipped.append(
+                    LabelCandidate(
+                        source_field="archetype",
+                        source_value=archetype,
+                        label=target_label,
+                        status="skipped",
+                        reason="label_missing",
+                    )
+                )
+            elif target_label in existing_labels:
+                skipped.append(
+                    LabelCandidate(
+                        source_field="archetype",
+                        source_value=archetype,
+                        label=target_label,
+                        status="skipped",
+                        reason="already_present",
+                    )
+                )
+            elif existing_typed:
+                skipped.append(
+                    LabelCandidate(
+                        source_field="archetype",
+                        source_value=archetype,
+                        label=target_label,
+                        status="skipped",
+                        reason="ambiguous",
+                    )
+                )
+            else:
+                proposed.append(target_label)
+
+        evidence_tier = parsed.get("evidence_tier")
+        skipped.append(
+            LabelCandidate(
+                source_field="evidence_tier",
+                source_value=str(evidence_tier),
+                label="",
+                status="skipped",
+                reason="not_low_risk",
+            )
+        )
+
+    return ArchetypeSyncReport(
+        issue_number=issue_number,
+        dry_run=dry_run,
+        body_metadata=dict(parsed) if isinstance(parsed, dict) else None,
+        metadata_findings=findings,
+        existing_labels=sorted(existing_labels),
+        proposed_label_additions=proposed,
+        skipped_label_candidates=skipped,
+        project_field_candidates=[
+            {"field": "archetype", "mode": "report-only"},
+            {"field": "evidence_tier", "mode": "report-only"},
+        ],
+        mutation_plan=[],
+    )
+
+
+def build_report_from_github(
+    repo: str, issue_number: int, *, dry_run: bool = True
+) -> ArchetypeSyncReport:
+    """Fetch issue context and build a read-only sync report.
+
+    Returns:
+        Structured dry-run report.
+    """
+    issue_payload = fetch_issue_payload(repo, issue_number)
+    body = str(issue_payload.get("body") or "")
+    labels = _issue_label_names(issue_payload)
+    available_labels = fetch_repo_label_names(repo)
+    return build_sync_report(
+        issue_number=issue_number,
+        issue_body=body,
+        existing_labels=labels,
+        available_labels=available_labels,
+        dry_run=dry_run,
+    )
+
+
+def _report_to_json(report: ArchetypeSyncReport) -> str:
+    """Serialize a report to stable JSON.
+
+    Returns:
+        Pretty JSON string.
+    """
+    return json.dumps(asdict(report), indent=2, sort_keys=True) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    Returns:
+        Configured parser.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    report = subparsers.add_parser("report", help="Print a read-only sync report.")
+    report.add_argument("--issue-number", type=int, required=True)
+    report.add_argument("--repo", default=DEFAULT_REPO)
+    report.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Kept for explicitness; report mode is always read-only.",
+    )
+    report.add_argument(
+        "--body-file",
+        type=Path,
+        help="Optional local issue body for parser tests or offline inspection.",
+    )
+    report.add_argument(
+        "--labels-json",
+        type=Path,
+        help="Optional JSON list of existing issue labels for --body-file mode.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    if args.command != "report":
+        raise AssertionError(f"Unhandled command: {args.command}")
+
+    if args.body_file is not None:
+        body = args.body_file.read_text(encoding="utf-8")
+        labels: list[str] = []
+        if args.labels_json is not None:
+            raw_labels = json.loads(args.labels_json.read_text(encoding="utf-8"))
+            if not isinstance(raw_labels, list) or not all(
+                isinstance(item, str) for item in raw_labels
+            ):
+                raise ValueError("--labels-json must contain a JSON list of strings")
+            labels = raw_labels
+        report = build_sync_report(
+            issue_number=args.issue_number,
+            issue_body=body,
+            existing_labels=labels,
+            available_labels=set(SAFE_ARCHETYPE_LABEL_MAP.values()),
+            dry_run=bool(args.dry_run),
+        )
+    else:
+        report = build_report_from_github(args.repo, args.issue_number, dry_run=bool(args.dry_run))
+    print(_report_to_json(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_issue_archetype_sync.py
+++ b/tests/tools/test_issue_archetype_sync.py
@@ -1,0 +1,201 @@
+"""Tests for the issue archetype sync dry-run reporter."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from scripts.tools.issue_archetype_sync import (
+    build_sync_report,
+    main,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _body(archetype: str = "workflow", evidence_tier: str = "idea") -> str:
+    """Build a minimal issue body with canonical archetype metadata."""
+    return f"""## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: {archetype}
+evidence_tier: {evidence_tier}
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+
+def _skip_reasons(report: object) -> list[str | None]:
+    """Return skip reasons from a report object."""
+    return [candidate.reason for candidate in report.skipped_label_candidates]
+
+
+def test_report_proposes_safe_typed_label_without_mutation_plan() -> None:
+    """Safe archetype mirrors should be proposed without any write plan."""
+    report = build_sync_report(
+        issue_number=1557,
+        issue_body=_body("workflow"),
+        existing_labels=["workflow"],
+        available_labels={"type:workflow"},
+    )
+
+    assert report.body_metadata == {
+        "archetype": "workflow",
+        "evidence_tier": "idea",
+        "linked_policy": ["docs/context/issue_1512_issue_archetypes.md"],
+    }
+    assert report.existing_labels == ["workflow"]
+    assert report.proposed_label_additions == ["type:workflow"]
+    assert report.mutation_plan == []
+    assert report.project_sync_mode == "report-only"
+    assert "not_low_risk" in _skip_reasons(report)
+
+
+def test_report_keeps_evidence_tier_body_only_by_default() -> None:
+    """Evidence tiers should not be mirrored to labels by the default report."""
+    report = build_sync_report(
+        issue_number=1,
+        issue_body=_body("analysis", evidence_tier="smoke"),
+        existing_labels=[],
+        available_labels={"type:analysis", "evidence:smoke"},
+    )
+
+    assert report.proposed_label_additions == ["type:analysis"]
+    evidence_skips = [
+        candidate
+        for candidate in report.skipped_label_candidates
+        if candidate.source_field == "evidence_tier"
+    ]
+    assert len(evidence_skips) == 1
+    assert evidence_skips[0].reason == "not_low_risk"
+    assert "evidence:smoke" not in report.proposed_label_additions
+
+
+def test_report_skips_unmapped_archetype_as_not_low_risk() -> None:
+    """Archetypes without exact typed-label mirrors should be skipped."""
+    report = build_sync_report(
+        issue_number=1,
+        issue_body=_body("preflight"),
+        existing_labels=[],
+        available_labels={"type:workflow"},
+    )
+
+    assert report.proposed_label_additions == []
+    assert any(
+        candidate.source_field == "archetype" and candidate.reason == "not_low_risk"
+        for candidate in report.skipped_label_candidates
+    )
+
+
+def test_report_skips_missing_repo_label() -> None:
+    """The dry run should not propose labels that are not present in the repo."""
+    report = build_sync_report(
+        issue_number=1,
+        issue_body=_body("docs"),
+        existing_labels=[],
+        available_labels={"type:workflow"},
+    )
+
+    assert report.proposed_label_additions == []
+    assert any(candidate.reason == "label_missing" for candidate in report.skipped_label_candidates)
+
+
+def test_report_skips_ambiguous_existing_typed_label() -> None:
+    """Existing conflicting type labels should be reported instead of overwritten."""
+    report = build_sync_report(
+        issue_number=1,
+        issue_body=_body("workflow"),
+        existing_labels=["type:docs"],
+        available_labels={"type:workflow", "type:docs"},
+    )
+
+    assert report.proposed_label_additions == []
+    assert any(candidate.reason == "ambiguous" for candidate in report.skipped_label_candidates)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_reason"),
+    [
+        ("## Goal / Problem\n\nNo metadata.\n", "schema_missing"),
+        (
+            "## Archetype Metadata\n\n```yaml\narchetype: [workflow\n```\n",
+            "malformed",
+        ),
+    ],
+)
+def test_report_surfaces_missing_and_malformed_metadata(
+    body: str,
+    expected_reason: str,
+) -> None:
+    """Invalid metadata blocks should become explicit skipped candidates."""
+    report = build_sync_report(
+        issue_number=1,
+        issue_body=body,
+        existing_labels=[],
+        available_labels={"type:workflow"},
+    )
+
+    assert report.body_metadata is None
+    assert report.metadata_findings
+    assert any(candidate.reason == expected_reason for candidate in report.skipped_label_candidates)
+    assert report.mutation_plan == []
+
+
+@patch("scripts.tools.issue_archetype_sync.fetch_repo_label_names")
+@patch("scripts.tools.issue_archetype_sync.fetch_issue_payload")
+def test_cli_report_uses_read_only_fetches_and_no_mutating_calls(
+    fetch_issue_payload,
+    fetch_repo_label_names,
+    capsys,
+) -> None:
+    """The default CLI path should only fetch data and should return an empty mutation plan."""
+    fetch_issue_payload.return_value = {
+        "body": _body("benchmark-campaign"),
+        "labels": [{"name": "benchmark"}],
+    }
+    fetch_repo_label_names.return_value = {"type:benchmark"}
+
+    exit_code = main(["report", "--issue-number", "1557", "--dry-run"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    fetch_issue_payload.assert_called_once_with("ll7/robot_sf_ll7", 1557)
+    fetch_repo_label_names.assert_called_once_with("ll7/robot_sf_ll7")
+    assert payload["proposed_label_additions"] == ["type:benchmark"]
+    assert payload["mutation_plan"] == []
+    assert payload["project_sync_mode"] == "report-only"
+
+
+def test_cli_report_accepts_offline_body_file(tmp_path: Path, capsys) -> None:
+    """Offline body-file mode keeps tests and manual inspection independent from GitHub."""
+    body_path = tmp_path / "issue.md"
+    labels_path = tmp_path / "labels.json"
+    body_path.write_text(_body("training-campaign"), encoding="utf-8")
+    labels_path.write_text(json.dumps(["training"]), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "report",
+            "--issue-number",
+            "1",
+            "--body-file",
+            str(body_path),
+            "--labels-json",
+            str(labels_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["proposed_label_additions"] == ["type:training"]


### PR DESCRIPTION
## Summary

- Closes #1557 by adding `scripts/tools/issue_archetype_sync.py report --issue-number <n> --dry-run`.
- Reuses the repo issue-template archetype metadata parser and keeps issue-body metadata authoritative.
- Reports safe typed-label additions, skipped candidates with reasons, report-only Project field candidates, and an empty mutation plan.

## Validation

- BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
- scripts/dev/ruff_fix_format.sh
- pytest tests/tools/test_issue_archetype_sync.py tests/tools/test_issue_template_audit.py
- python scripts/tools/issue_archetype_sync.py report --issue-number 1557 --dry-run
- BASE_REF=origin/main scripts/dev/pr_ready_check.sh: 4278 passed, 11 skipped, 9 warnings

## Follow-up

- Opened #1561 for an explicit gated apply mode if maintainers later want label writes.

## Artifact note

Only ignored coverage output was generated locally.
