### PR TITLE
feat: gate archetype sync label apply

### DIFF
--- a/scripts/tools/issue_archetype_sync.py
+++ b/scripts/tools/issue_archetype_sync.py
@@ -1,9 +1,13 @@
-"""Report safe issue-body archetype metadata mirror candidates.
+"""Report and apply safe issue-body archetype metadata mirror candidates.
 
-The issue body remains authoritative. This helper is intentionally read-only:
+The issue body remains authoritative. The ``report`` subcommand is read-only:
 it fetches issue metadata with ``gh api``, parses the existing
-``## Archetype Metadata`` block, and prints a dry-run JSON report. It never
-adds labels, creates labels, or writes Project fields.
+``## Archetype Metadata`` block, and prints a dry-run JSON report.
+
+The ``apply`` subcommand builds the same pre-apply JSON report, checks the
+GitHub API rate limit, and applies only the proposed typed labels when
+``--confirm-apply-labels`` is passed. It never creates labels, never mirrors
+``evidence_tier``, and never writes Project fields.
 """
 
 from __future__ import annotations
@@ -11,7 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +31,13 @@ SAFE_ARCHETYPE_LABEL_MAP: dict[str, str] = {
 }
 
 TYPED_LABEL_PREFIX = "type:"
+RATE_LIMIT_FLOOR = 10
 DEFAULT_REPO = "ll7/robot_sf_ll7"
+APPLY_RATE_LIMIT_GUIDANCE = (
+    "Uses REST for issue label writes after a core rate-limit preflight; Project v2 writes "
+    "remain out of scope and should be batched separately per "
+    "docs/context/issue_713_batch_first_issue_workflow.md."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +79,81 @@ def _run_gh_json(args: list[str]) -> Any:
     """
     completed = subprocess.run(args, check=True, capture_output=True, text=True)
     return json.loads(completed.stdout)
+
+
+def check_rate_limit() -> dict[str, Any]:
+    """Fetch the current GitHub API rate-limit status.
+
+    Returns:
+        Decoded rate-limit payload.
+
+    Raises:
+        RuntimeError: When core remaining is below ``RATE_LIMIT_FLOOR``.
+    """
+    payload = _run_gh_json(["gh", "api", "rate_limit"])
+    if not isinstance(payload, dict):
+        raise RuntimeError("Rate-limit payload did not decode to an object")
+    resources = payload.get("resources")
+    if not isinstance(resources, dict):
+        raise RuntimeError("Rate-limit resources block is missing or invalid")
+    core = resources.get("core")
+    if not isinstance(core, dict):
+        raise RuntimeError("Rate-limit core block is missing or invalid")
+    remaining = core.get("remaining")
+    if not isinstance(remaining, int):
+        raise RuntimeError("Rate-limit core.remaining is missing or not an int")
+    if remaining < RATE_LIMIT_FLOOR:
+        raise RuntimeError(
+            f"Core rate-limit remaining ({remaining}) is below the safe floor "
+            f"({RATE_LIMIT_FLOOR}); refusing to mutate."
+        )
+    return payload
+
+
+def apply_labels(repo: str, issue_number: int, labels: list[str]) -> list[dict[str, Any]]:
+    """Apply a list of typed labels to a GitHub issue via REST POST.
+
+    This must only be called after the rate-limit check passes.
+
+    Note:
+        Calls ``gh api -X POST repos/{repo}/issues/{issue_number}/labels``
+        with a JSON body of ``{"labels": [...]}``.  Existing labels are
+        preserved --- the endpoint adds labels rather than replacing them.
+    """
+    completed = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/issues/{issue_number}/labels",
+            "--input",
+            "-",
+        ],
+        input=json.dumps({"labels": labels}),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, list):
+        raise RuntimeError("GitHub label mutation payload did not decode to a list")
+    return payload
+
+
+def _apply_mutation_plan(report: ArchetypeSyncReport, repo: str) -> list[dict[str, Any]]:
+    """Return the ordered label mutation plan for an apply report."""
+    if not report.proposed_label_additions:
+        return []
+    return [
+        {
+            "operation": "add_labels",
+            "repo": repo,
+            "issue_number": report.issue_number,
+            "labels": list(report.proposed_label_additions),
+            "api": f"POST repos/{repo}/issues/{report.issue_number}/labels",
+        }
+    ]
 
 
 def fetch_issue_payload(repo: str, issue_number: int) -> dict[str, Any]:
@@ -270,6 +355,7 @@ def _build_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
+
     report = subparsers.add_parser("report", help="Print a read-only sync report.")
     report.add_argument("--issue-number", type=int, required=True)
     report.add_argument("--repo", default=DEFAULT_REPO)
@@ -289,16 +375,29 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional JSON list of existing issue labels for --body-file mode.",
     )
+
+    apply_parser = subparsers.add_parser(
+        "apply", help="Build a report then apply proposed typed labels when confirmed."
+    )
+    apply_parser.add_argument("--issue-number", type=int, required=True)
+    apply_parser.add_argument("--repo", default=DEFAULT_REPO)
+    apply_parser.add_argument(
+        "--confirm-apply-labels",
+        action="store_true",
+        default=False,
+        help="Required gate before any label mutation.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = _build_parser().parse_args(argv)
-    if args.command != "report":
+
+    if args.command not in ("report", "apply"):
         raise AssertionError(f"Unhandled command: {args.command}")
 
-    if args.body_file is not None:
+    if getattr(args, "body_file", None) is not None:
         body = args.body_file.read_text(encoding="utf-8")
         labels: list[str] = []
         if args.labels_json is not None:
@@ -313,11 +412,39 @@ def main(argv: list[str] | None = None) -> int:
             issue_body=body,
             existing_labels=labels,
             available_labels=set(SAFE_ARCHETYPE_LABEL_MAP.values()),
-            dry_run=bool(args.dry_run),
+            dry_run=True,
         )
     else:
-        report = build_report_from_github(args.repo, args.issue_number, dry_run=bool(args.dry_run))
+        report = build_report_from_github(args.repo, args.issue_number, dry_run=True)
+
+    if args.command != "apply":
+        print(_report_to_json(report), end="")
+        return 0
+
+    if not args.confirm_apply_labels:
+        print(_report_to_json(report), end="")
+        print(
+            "Re-run with --confirm-apply-labels to apply the proposed typed labels.",
+            flush=True,
+        )
+        return 0
+
+    report = replace(
+        report,
+        dry_run=False,
+        mutation_plan=_apply_mutation_plan(report, args.repo),
+        rate_limit_guidance=APPLY_RATE_LIMIT_GUIDANCE,
+    )
     print(_report_to_json(report), end="")
+
+    proposed = report.proposed_label_additions
+    if not proposed:
+        print("No proposed label additions; nothing to apply.")
+        return 0
+
+    check_rate_limit()
+    apply_labels(args.repo, args.issue_number, proposed)
+    print(f"Applied labels to issue #{args.issue_number}: {proposed}")
     return 0
 
 

--- a/tests/tools/test_issue_archetype_sync.py
+++ b/tests/tools/test_issue_archetype_sync.py
@@ -1,4 +1,4 @@
-"""Tests for the issue archetype sync dry-run reporter."""
+"""Tests for the issue archetype sync dry-run reporter and apply mode."""
 
 from __future__ import annotations
 
@@ -9,7 +9,9 @@ from unittest.mock import patch
 import pytest
 
 from scripts.tools.issue_archetype_sync import (
+    apply_labels,
     build_sync_report,
+    check_rate_limit,
     main,
 )
 
@@ -199,3 +201,236 @@ def test_cli_report_accepts_offline_body_file(tmp_path: Path, capsys) -> None:
 
     assert exit_code == 0
     assert payload["proposed_label_additions"] == ["type:training"]
+
+
+# -- apply-mode tests ---------------------------------------------------------
+
+
+def _apply_body_file_args(
+    tmp_path: Path,
+    issue_number: int = 1588,
+    archetype: str = "workflow",
+    evidence_tier: str = "idea",
+    existing: list[str] | None = None,
+    confirm: bool = True,
+) -> tuple[list[str], str]:
+    """Write body + labels files in tmp_path and return apply CLI argv."""
+    if existing is None:
+        existing = []
+    body_path = tmp_path / "issue.md"
+    labels_path = tmp_path / "labels.json"
+    body_path.write_text(_body(archetype, evidence_tier=evidence_tier), encoding="utf-8")
+    labels_path.write_text(json.dumps(existing), encoding="utf-8")
+    argv = [
+        "apply",
+        "--issue-number",
+        str(issue_number),
+        "--body-file",
+        str(body_path),
+        "--labels-json",
+        str(labels_path),
+    ]
+    if confirm:
+        argv.append("--confirm-apply-labels")
+    return argv, str(body_path)
+
+
+def _apply_github_args(issue_number: int = 1588, confirm: bool = True) -> list[str]:
+    """Return apply CLI argv for the live GitHub metadata path."""
+    argv = ["apply", "--issue-number", str(issue_number)]
+    if confirm:
+        argv.append("--confirm-apply-labels")
+    return argv
+
+
+def _report(
+    *,
+    issue_number: int = 1588,
+    archetype: str = "workflow",
+    evidence_tier: str = "idea",
+    existing_labels: list[str] | None = None,
+) -> object:
+    """Build an in-memory report for mocked apply-mode tests."""
+    return build_sync_report(
+        issue_number=issue_number,
+        issue_body=_body(archetype, evidence_tier=evidence_tier),
+        existing_labels=existing_labels or [],
+        available_labels={"type:workflow", "type:analysis", "evidence:smoke"},
+    )
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_apply_without_confirm_refuses_mutation(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+    capsys,
+) -> None:
+    """apply without --confirm-apply-labels prints report but never mutates."""
+    mock_build_report_from_github.return_value = _report()
+
+    exit_code = main(_apply_github_args(confirm=False))
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Re-run with --confirm-apply-labels" in captured.out
+    mock_check_rate_limit.assert_not_called()
+    mock_apply_labels.assert_not_called()
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_confirmed_apply_calls_mutation_with_proposed_labels(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+    capsys,
+) -> None:
+    """Confirmed apply should call check_rate_limit then apply_labels with the proposed label."""
+    mock_build_report_from_github.return_value = _report()
+
+    exit_code = main(_apply_github_args(confirm=True))
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    mock_check_rate_limit.assert_called_once_with()
+    mock_apply_labels.assert_called_once_with("ll7/robot_sf_ll7", 1588, ["type:workflow"])
+    payload_text = captured.out[: captured.out.index("\nApplied labels")]
+    payload = json.loads(payload_text)
+    assert payload["dry_run"] is False
+    assert "label writes" in payload["rate_limit_guidance"]
+    assert payload["mutation_plan"] == [
+        {
+            "api": "POST repos/ll7/robot_sf_ll7/issues/1588/labels",
+            "issue_number": 1588,
+            "labels": ["type:workflow"],
+            "operation": "add_labels",
+            "repo": "ll7/robot_sf_ll7",
+        }
+    ]
+    assert "Applied labels to issue" in captured.out
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_apply_noop_with_no_proposed_labels_skips_mutation(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+    capsys,
+) -> None:
+    """When proposed_label_additions is empty even after confirm, skip mutation."""
+    mock_build_report_from_github.return_value = _report(existing_labels=["type:workflow"])
+
+    exit_code = main(_apply_github_args(confirm=True))
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "No proposed label additions" in captured.out
+    payload_text = captured.out[: captured.out.index("\nNo proposed label additions")]
+    payload = json.loads(payload_text)
+    assert payload["dry_run"] is False
+    assert payload["mutation_plan"] == []
+    mock_check_rate_limit.assert_not_called()
+    mock_apply_labels.assert_not_called()
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_apply_with_evidence_tier_never_includes_tier_label(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+) -> None:
+    """Evidence tier is always skipped; confirmed apply must never propose or apply it."""
+    mock_build_report_from_github.return_value = _report(evidence_tier="smoke")
+
+    exit_code = main(_apply_github_args(confirm=True))
+
+    assert exit_code == 0
+    mock_apply_labels.assert_called_once()
+    called_labels = mock_apply_labels.call_args[0][2]
+    assert "type:workflow" in called_labels
+    for label in called_labels:
+        assert "evidence" not in label.lower()
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_low_rate_limit_fails_closed(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+) -> None:
+    """When core rate-limit remaining is too low, mutation should fail with RuntimeError."""
+    mock_build_report_from_github.return_value = _report()
+    mock_check_rate_limit.side_effect = RuntimeError("core remaining too low")
+
+    with pytest.raises(RuntimeError, match="core remaining too low"):
+        main(_apply_github_args(confirm=True))
+
+    mock_apply_labels.assert_not_called()
+
+
+def test_apply_rejects_offline_body_file_arguments(tmp_path: Path) -> None:
+    """Apply mode should not accept local-only issue metadata arguments."""
+    argv, _ = _apply_body_file_args(tmp_path, confirm=True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+    assert exc_info.value.code == 2
+
+
+def test_report_subcommand_does_not_mutate(tmp_path, capsys) -> None:
+    """The report subcommand must never trigger mutation even in apply-like scenarios."""
+    body_path = tmp_path / "issue.md"
+    labels_path = tmp_path / "labels.json"
+    body_path.write_text(_body("workflow"), encoding="utf-8")
+    labels_path.write_text(json.dumps([]), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "report",
+            "--issue-number",
+            "1",
+            "--body-file",
+            str(body_path),
+            "--labels-json",
+            str(labels_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["proposed_label_additions"] == ["type:workflow"]
+    assert payload["mutation_plan"] == []
+    assert payload["project_sync_mode"] == "report-only"
+    assert "Re-run with --confirm-apply-labels" not in captured.out
+
+
+def test_check_rate_limit_fails_on_low_remaining() -> None:
+    """check_rate_limit should raise when core.remaining is below the floor."""
+    stub_payload = {"resources": {"core": {"limit": 5000, "remaining": 2, "reset": 9999999999}}}
+    with patch("scripts.tools.issue_archetype_sync._run_gh_json", return_value=stub_payload):
+        with pytest.raises(RuntimeError, match="below the safe floor"):
+            check_rate_limit()
+
+
+def test_apply_labels_constructs_correct_rest_post() -> None:
+    """apply_labels must POST the expected labels JSON to the issue labels endpoint."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.stdout = json.dumps([{"name": "type:docs"}])
+        apply_labels("ll7/robot_sf_ll7", 1, ["type:docs"])
+
+    mock_run.assert_called_once()
+    call_args, call_kwargs = mock_run.call_args
+    assert "POST" in call_args[0]
+    assert "repos/ll7/robot_sf_ll7/issues/1/labels" in call_args[0][4]
+    assert call_kwargs["input"] == json.dumps({"labels": ["type:docs"]})


### PR DESCRIPTION
## Summary

- Adds an explicit `apply` subcommand to `scripts/tools/issue_archetype_sync.py` for gated typed-label mirroring.
- Keeps `report` read-only by default and requires `apply --confirm-apply-labels` before any label write.
- Emits the pre-mutation JSON report with an auditable `mutation_plan`, rejects offline body-file metadata for apply, checks REST core rate-limit before mutation, and only posts labels from safe `proposed_label_additions`.
- Extends tests around no-confirm behavior, no-op behavior, evidence-tier non-mirroring, rate-limit fail-closed handling, REST POST construction, and report-mode read-only behavior.

Closes #1561.

## Validation

- `uv run pytest tests/tools/test_issue_archetype_sync.py tests/tools/test_issue_template_audit.py` -> 30 passed
- `uv run ruff check scripts/tools/issue_archetype_sync.py tests/tools/test_issue_archetype_sync.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `scripts/dev/ruff_fix_format.sh` -> passed, 1316 files unchanged
- `uv run python scripts/tools/issue_archetype_sync.py report --issue-number 1561` -> read-only JSON report produced
- `uv run python scripts/tools/issue_archetype_sync.py apply --issue-number 1561` -> no mutation; printed report plus confirmation hint
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` before commit -> 4288 passed, 10 skipped, 9 warnings
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` after commit -> 4288 passed, 10 skipped, 8 warnings

## Delegation / Review

- Copilot implementation and review attempts were made first, but both hit the current Copilot session/rate-limit path and produced no usable diff.
- OpenCode Go implemented the bounded patch; local review fixed two safety/audit gaps before acceptance.
- OpenCode Go read-only review found stale apply-output contract fields; fixed before final validation.
- Workflow self-review note recorded under `.git/codex-agent-runs/notes/inbox/20260526_issue_1561_archetype_sync_apply.md`.

## Output Artifacts

- `output/coverage/*` was generated by validation and remains ignored/disposable; nothing was promoted or committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue archetype synchronization tool now includes an `apply` mode to automatically add labels to GitHub issues with explicit user confirmation.
  * Added rate-limit protection to validate available API quota before mutations.

* **Tests**
  * Expanded test coverage for apply-mode workflows, including confirmation gates and rate-limit validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->