### PR TITLE
docs: define incomplete archetype sync policy

### DIFF
--- a/docs/context/issue_1532_archetype_metadata_sync_decision.md
+++ b/docs/context/issue_1532_archetype_metadata_sync_decision.md
@@ -43,6 +43,13 @@ provisioned first. The current repository exposes both broad labels such as `wor
 automation should treat the typed families as the only candidate programmatic mirrors. Broad labels
 may remain human-facing discovery or triage labels, but they are not canonical metadata mirrors.
 
+Any metadata-audit finding must fail closed for label mirroring. If the
+`## Archetype Metadata` block is malformed, has invalid canonical values, or is
+missing required keys such as `linked_policy`, the sync report/apply path
+should not propose typed-label mirrors from that block even when
+`archetype` or `evidence_tier` individually look valid. The full metadata block
+stays authoritative until a human repairs it.
+
 Recommended conservative archetype mappings:
 
 | Body metadata | Existing/provisioned typed label | Recommendation |
@@ -58,10 +65,12 @@ Everything else should remain body-only unless maintainers explicitly add and do
 typed label taxonomy first. In particular, do **not** infer new labels for `preflight`,
 `slurm-execution`, `blocked-asset`, or any other archetype that lacks an exact typed label.
 
-`evidence_tier` should remain body-only by default. If maintainers later want evidence-tier label
-mirrors, they should document exact `evidence:*` mappings separately and keep them optional. Do not
-infer evidence-tier labels from partial name similarity, and do not treat labels such as
-`evidence:proposal` as changing the canonical body value.
+`evidence_tier` should remain body-only by default, including when an incomplete
+metadata block otherwise contains a valid-looking evidence tier. If maintainers
+later want evidence-tier label mirrors, they should document exact
+`evidence:*` mappings separately and keep them optional. Do not infer
+evidence-tier labels from partial name similarity, and do not treat labels such
+as `evidence:proposal` as changing the canonical body value.
 
 ### Project #5
 

--- a/scripts/tools/issue_archetype_sync.py
+++ b/scripts/tools/issue_archetype_sync.py
@@ -1,13 +1,18 @@
 """Report and apply safe issue-body archetype metadata mirror candidates.
 
-The issue body remains authoritative. The ``report`` subcommand is read-only:
-it fetches issue metadata with ``gh api``, parses the existing
-``## Archetype Metadata`` block, and prints a dry-run JSON report.
+The issue body remains authoritative as a full metadata block. The ``report``
+subcommand is read-only: it fetches issue metadata with ``gh api``, parses the
+existing ``## Archetype Metadata`` block, and prints a dry-run JSON report.
+
+Any archetype-metadata audit finding fails closed for label mirroring. If the
+body block is malformed, missing required keys, or otherwise incomplete, this
+tool does not propose typed-label mirrors from that block even when individual
+fields like ``archetype`` look valid.
 
 The ``apply`` subcommand builds the same pre-apply JSON report, checks the
 GitHub API rate limit, and applies only the proposed typed labels when
-``--confirm-apply-labels`` is passed. It never creates labels, never mirrors
-``evidence_tier``, and never writes Project fields.
+``--confirm-apply-labels`` is passed. It never creates labels, keeps
+``evidence_tier`` body-only by default, and never writes Project fields.
 """
 
 from __future__ import annotations
@@ -201,6 +206,43 @@ def _issue_label_names(issue_payload: dict[str, Any]) -> list[str]:
     return sorted(names)
 
 
+def _failed_metadata_skips(metadata: Any) -> list[LabelCandidate]:
+    """Return skipped candidates for incomplete or malformed metadata blocks."""
+    parsed = metadata.parsed_metadata
+    archetype_value = ""
+    target_label = ""
+    evidence_tier_value = ""
+    if isinstance(parsed, dict):
+        archetype = parsed.get("archetype")
+        if isinstance(archetype, str):
+            archetype_value = archetype
+            target_label = SAFE_ARCHETYPE_LABEL_MAP.get(archetype, "")
+        evidence_tier = parsed.get("evidence_tier")
+        if evidence_tier is not None:
+            evidence_tier_value = str(evidence_tier)
+
+    skipped = [
+        LabelCandidate(
+            source_field="archetype",
+            source_value=archetype_value,
+            label=target_label,
+            status="skipped",
+            reason="schema_missing" if metadata.parse_error is None else "malformed",
+        )
+    ]
+    if evidence_tier_value:
+        skipped.append(
+            LabelCandidate(
+                source_field="evidence_tier",
+                source_value=evidence_tier_value,
+                label="",
+                status="skipped",
+                reason="not_low_risk",
+            )
+        )
+    return skipped
+
+
 def build_sync_report(
     *,
     issue_number: int,
@@ -210,6 +252,10 @@ def build_sync_report(
     dry_run: bool = True,
 ) -> ArchetypeSyncReport:
     """Build a no-mutation issue archetype sync report.
+
+    The issue-body metadata block is authoritative as a whole. If the metadata
+    audit reports any finding, the report fails closed and proposes no typed
+    label mirrors from that block, even when a single field parses cleanly.
 
     Returns:
         Structured dry-run report.
@@ -221,15 +267,7 @@ def build_sync_report(
     skipped: list[LabelCandidate] = []
 
     if parsed is None or findings:
-        skipped.append(
-            LabelCandidate(
-                source_field="archetype",
-                source_value="",
-                label="",
-                status="skipped",
-                reason="schema_missing" if metadata.parse_error is None else "malformed",
-            )
-        )
+        skipped.extend(_failed_metadata_skips(metadata))
     else:
         archetype = parsed.get("archetype")
         if not isinstance(archetype, str):

--- a/tests/tools/test_issue_archetype_sync.py
+++ b/tests/tools/test_issue_archetype_sync.py
@@ -82,6 +82,79 @@ def test_report_keeps_evidence_tier_body_only_by_default() -> None:
     assert "evidence:smoke" not in report.proposed_label_additions
 
 
+def test_report_fails_closed_on_incomplete_metadata_block() -> None:
+    """Incomplete metadata blocks should block all typed-label mirrors.
+
+    This matters because the full issue-body metadata block is authoritative,
+    so a missing required key must prevent archetype label mirroring even when
+    the parsed archetype and evidence tier look individually valid.
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: workflow
+evidence_tier: smoke
+```
+"""
+    report = build_sync_report(
+        issue_number=1564,
+        issue_body=body,
+        existing_labels=[],
+        available_labels={"type:workflow", "evidence:smoke"},
+    )
+
+    assert report.metadata_findings == ["Missing archetype metadata keys: linked_policy"]
+    assert report.proposed_label_additions == []
+    assert any(
+        candidate.source_field == "archetype" and candidate.reason == "schema_missing"
+        for candidate in report.skipped_label_candidates
+    )
+    evidence_skips = [
+        candidate
+        for candidate in report.skipped_label_candidates
+        if candidate.source_field == "evidence_tier"
+    ]
+    assert len(evidence_skips) == 1
+    assert evidence_skips[0].reason == "not_low_risk"
+    assert "evidence:smoke" not in report.proposed_label_additions
+
+
+def test_report_fails_closed_on_invalid_metadata_values() -> None:
+    """Parsed blocks with invalid canonical values should not propose labels."""
+    body = """## Archetype Metadata
+
+```yaml
+archetype: workflow-ish
+evidence_tier: maybe
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+    report = build_sync_report(
+        issue_number=1564,
+        issue_body=body,
+        existing_labels=[],
+        available_labels={"type:workflow", "evidence:proposal"},
+    )
+
+    assert any("Invalid 'archetype' value" in finding for finding in report.metadata_findings)
+    assert any("Invalid 'evidence_tier' value" in finding for finding in report.metadata_findings)
+    assert report.proposed_label_additions == []
+    assert any(
+        candidate.source_field == "archetype" and candidate.reason == "schema_missing"
+        for candidate in report.skipped_label_candidates
+    )
+    assert any(
+        candidate.source_field == "evidence_tier" and candidate.reason == "not_low_risk"
+        for candidate in report.skipped_label_candidates
+    )
+
+
 def test_report_skips_unmapped_archetype_as_not_low_risk() -> None:
     """Archetypes without exact typed-label mirrors should be skipped."""
     report = build_sync_report(
@@ -334,6 +407,44 @@ def test_apply_noop_with_no_proposed_labels_skips_mutation(
     payload_text = captured.out[: captured.out.index("\nNo proposed label additions")]
     payload = json.loads(payload_text)
     assert payload["dry_run"] is False
+    assert payload["mutation_plan"] == []
+    mock_check_rate_limit.assert_not_called()
+    mock_apply_labels.assert_not_called()
+
+
+@patch("scripts.tools.issue_archetype_sync.apply_labels")
+@patch("scripts.tools.issue_archetype_sync.check_rate_limit")
+@patch("scripts.tools.issue_archetype_sync.build_report_from_github")
+def test_confirmed_apply_noops_for_incomplete_metadata(
+    mock_build_report_from_github,
+    mock_check_rate_limit,
+    mock_apply_labels,
+    capsys,
+) -> None:
+    """Confirmed apply should not mutate when metadata findings fail closed."""
+    body = """## Archetype Metadata
+
+```yaml
+archetype: workflow
+evidence_tier: smoke
+```
+"""
+    mock_build_report_from_github.return_value = build_sync_report(
+        issue_number=1564,
+        issue_body=body,
+        existing_labels=[],
+        available_labels={"type:workflow"},
+    )
+
+    exit_code = main(_apply_github_args(issue_number=1564, confirm=True))
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "No proposed label additions" in captured.out
+    payload_text = captured.out[: captured.out.index("\nNo proposed label additions")]
+    payload = json.loads(payload_text)
+    assert payload["metadata_findings"] == ["Missing archetype metadata keys: linked_policy"]
+    assert payload["proposed_label_additions"] == []
     assert payload["mutation_plan"] == []
     mock_check_rate_limit.assert_not_called()
     mock_apply_labels.assert_not_called()


### PR DESCRIPTION
## Summary

- Documents the conservative fail-closed policy for incomplete or invalid archetype metadata blocks.
- Makes the sync helper docstring explicit that any archetype metadata audit finding blocks typed-label mirror proposals.
- Adds regression tests for missing `linked_policy`, parsed-but-invalid metadata values, and confirmed apply no-op behavior when metadata findings are present.

Closes #1564.

## Validation

- `uv run pytest tests/tools/test_issue_archetype_sync.py tests/tools/test_issue_template_audit.py` -> 33 passed
- `uv run ruff check scripts/tools/issue_archetype_sync.py tests/tools/test_issue_archetype_sync.py` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `scripts/dev/ruff_fix_format.sh` -> passed, 1316 files unchanged
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` before commit -> 4291 passed, 10 skipped, 9 warnings
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` after commit -> 4291 passed, 10 skipped, 8 warnings

## Delegation / Review

- Copilot gpt-5.4 xhigh implemented the scoped policy/test/doc patch.
- Copilot gpt-5.4 xhigh performed a read-only review and found two coverage gaps; both were fixed before final validation.
- Workflow self-review note recorded under `.git/codex-agent-runs/notes/inbox/20260526_issue_1564_incomplete_archetype_policy.md`.

## Output Artifacts

- `output/coverage/*` was generated by validation and remains ignored/disposable; nothing was promoted or committed.
