### PR TITLE
docs: decide predictive ego motion policy

### DIFF
--- a/docs/context/issue_1504_ego_feature_contract.md
+++ b/docs/context/issue_1504_ego_feature_contract.md
@@ -2,15 +2,28 @@
 
 Related issues: [Issue #1504](https://github.com/ll7/robot_sf_ll7/issues/1504),
 [Issue #1490](https://github.com/ll7/robot_sf_ll7/issues/1490),
-[Issue #1427](https://github.com/ll7/robot_sf_ll7/issues/1427).
+[Issue #1427](https://github.com/ll7/robot_sf_ll7/issues/1427),
+[Issue #1519](https://github.com/ll7/robot_sf_ll7/issues/1519),
+[Issue #1537](https://github.com/ll7/robot_sf_ll7/issues/1537).
 
 ## Decision
 
 The `predictive_ego_v1` 9D row shape is already wired through the predictive planner stack, but
 the code paths do not currently populate channels [4:6] with one identical semantic payload.
-This note documents the current implementation rather than inventing a cleaner contract than the
-code actually provides. Issue #1519 keeps that producer-specific behavior and requires
-machine-readable producer metadata whenever ego-conditioned rows are serialized or compared.
+Issue #1537 records the conservative long-term policy decision to **keep producer-specific
+semantics** instead of rewriting all paths to one unified source today.
+
+Rationale:
+
+- The current producers reflect different real collection/runtime data paths rather than an
+  incidental implementation mismatch.
+- Reinterpreting existing datasets or checkpoints as `robot.speed`-only or
+  `robot.velocity_xy`-only would silently change the meaning of already-collected artifacts.
+- Issue #1519 already established machine-readable producer metadata plus fail-closed validation as
+  the compatibility contract.
+
+This note therefore documents the current implementation and the selected long-term policy rather
+than inventing a cleaner contract than the code actually provides.
 
 Current producer behavior:
 
@@ -41,7 +54,8 @@ those two channels.
 ## Producer Metadata Policy
 
 Issue #1519 adds a machine-readable `ego_motion_channel_producer` object to ego-conditioned schema
-metadata. The stable producer keys are:
+metadata. Issue #1537 keeps that metadata as the long-term policy surface. The stable producer keys
+are:
 
 | Producer key | Path(s) | Slots [4:6] source | Comparison rule |
 | --- | --- | --- | --- |
@@ -50,6 +64,30 @@ metadata. The stable producer keys are:
 
 This metadata is provenance, not a benchmark-improvement claim. It prevents future reports or
 preflights from treating mixed-producer rows as identical just because they share the same width.
+
+### Mixed-producer comparison and reporting policy
+
+- Mixed producer keys are **not directly comparable/equivalent** for benchmark or report rows.
+- Comparison/report tooling must either group rows by the same `producer_key` or carry an explicit
+  caveat that the ego motion slots came from different producers.
+- Same-seed/runtime rows remain aligned to
+  `same_seed_hardcase_runtime_robot_speed_v1`.
+- Standalone rollout rows remain aligned to
+  `standalone_rollout_velocity_xy_preferred_v1`.
+
+### Existing validator behavior
+
+- Mixed-dataset validation fails closed when ego-conditioned inputs disagree on
+  `ego_motion_channel_producer.producer_key`, or when one ego-conditioned input omits schema
+  metadata entirely (`tests/training/test_build_predictive_mixed_dataset.py`).
+- Runtime loading fails closed when a checkpoint explicitly declares the standalone producer for an
+  ego-conditioned runtime path that expects the same-seed/runtime producer
+  (`tests/planner/test_predictive_obstacle_runtime_contract.py`).
+- Schema metadata keeps an explicit comparability contract:
+  `group=predictive_ego_motion_slots_v1`,
+  `same_producer_key_required=True`, and
+  `mixed_producer_status=not_comparable_without_caveat`
+  (`tests/test_predictive_model.py`).
 
 ## Feature Layout (`predictive_ego_v1`, input_dim=9)
 
@@ -222,6 +260,13 @@ for path in configs/training/predictive/predictive_same_seed_issue_1427_base_see
     [ -f "$path" ] && echo "OK: $path" || echo "MISSING: $path"
 done
 
+# Issue #1537 proof path
+uv run pytest tests/test_predictive_model.py \
+    tests/training/test_build_predictive_mixed_dataset.py \
+    tests/training/test_collect_predictive_planner_data.py \
+    tests/training/test_collect_predictive_hardcase_data.py \
+    tests/planner/test_predictive_obstacle_runtime_contract.py
+
 # Diff/doc proof checks for the issue-scoped patch
 git --no-pager diff --check origin/main...HEAD
 BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
@@ -241,6 +286,7 @@ Issue #1507 (transfer analysis) should:
 - Compare forecast-to-control transfer across the four variants.
 - Keep ADE/FDE and navigation metrics separate in the report.
 
-Issue [#1519](https://github.com/ll7/robot_sf_ll7/issues/1519) now records producer-specific
-metadata and adds a narrow runtime mismatch guard. A future follow-up can still decide whether
-slots [4:6] should converge on one motion-channel source instead of remaining producer-specific.
+Issue [#1519](https://github.com/ll7/robot_sf_ll7/issues/1519) records producer-specific metadata
+and adds the narrow runtime mismatch guard. Issue [#1537](https://github.com/ll7/robot_sf_ll7/issues/1537)
+keeps that producer-specific policy in place; any future migration would need a new explicit
+artifact-compatibility plan rather than silently reinterpreting existing checkpoints or datasets.

--- a/tests/test_predictive_model.py
+++ b/tests/test_predictive_model.py
@@ -2,6 +2,7 @@
 
 from dataclasses import asdict
 
+import pytest
 import torch
 
 from robot_sf.planner.obstacle_features import (
@@ -166,26 +167,48 @@ def test_predictive_schema_validation_rejects_legacy_name_with_ego_dimension() -
     )
 
 
-def test_predictive_schema_metadata_records_ego_motion_producers() -> None:
-    """Ego-conditioned schema metadata should encode the active motion-channel producer."""
-    ego_schema = predictive_feature_schema_metadata(
-        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
-        ego_motion_channel_producer=PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
-    )
-    ego_obstacle_schema = predictive_feature_schema_metadata(
-        model_family=PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
-        ego_conditioning=True,
-        ego_motion_channel_producer=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+@pytest.mark.parametrize(
+    ("model_family", "ego_conditioning", "producer_key", "expected_input_dim"),
+    [
+        (PREDICTIVE_EGO_FEATURE_SCHEMA, False, PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME, 9),
+        (PREDICTIVE_EGO_FEATURE_SCHEMA, False, PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE, 9),
+        (
+            PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+            True,
+            PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+            15,
+        ),
+        (
+            PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
+            True,
+            PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
+            15,
+        ),
+    ],
+)
+def test_predictive_schema_metadata_records_ego_motion_producers(
+    model_family: str,
+    ego_conditioning: bool,
+    producer_key: str,
+    expected_input_dim: int,
+) -> None:
+    """Ego-conditioned schema metadata should pin the producer comparability contract."""
+    schema = predictive_feature_schema_metadata(
+        model_family=model_family,
+        ego_conditioning=ego_conditioning,
+        ego_motion_channel_producer=producer_key,
     )
 
-    assert ego_schema["ego_motion_channel_producer"]["producer_key"] == (
-        PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE
-    )
-    assert ego_obstacle_schema["base_schema"] == PREDICTIVE_EGO_FEATURE_SCHEMA
-    assert ego_obstacle_schema["input_dim"] == 15
-    assert ego_obstacle_schema["ego_motion_channel_producer"]["producer_key"] == (
-        PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME
-    )
+    producer_meta = schema["ego_motion_channel_producer"]
+
+    assert schema["base_schema"] == PREDICTIVE_EGO_FEATURE_SCHEMA
+    assert schema["input_dim"] == expected_input_dim
+    assert producer_meta["producer_key"] == producer_key
+    assert producer_meta["comparability"] == {
+        "group": "predictive_ego_motion_slots_v1",
+        "same_producer_key_required": True,
+        "mixed_producer_status": "not_comparable_without_caveat",
+    }
 
     malformed_missing_key = predictive_feature_schema_metadata(
         model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,


### PR DESCRIPTION
## Summary

- Records the #1537 long-term policy decision to keep predictive ego slots `[4:6]` producer-specific rather than silently unifying historical datasets/checkpoints on one source.
- Documents the mixed-producer comparison/reporting policy: group by `ego_motion_channel_producer.producer_key` or carry an explicit caveat.
- Expands predictive schema metadata tests so both `predictive_ego_v1` and `predictive_obstacle_features_v1` with `base_schema=predictive_ego_v1` pin the comparability contract.

Closes #1537.

## Validation

- `uv run pytest tests/test_predictive_model.py tests/training/test_build_predictive_mixed_dataset.py tests/training/test_collect_predictive_planner_data.py tests/training/test_collect_predictive_hardcase_data.py tests/planner/test_predictive_obstacle_runtime_contract.py` -> 35 passed
- `uv run ruff check tests/test_predictive_model.py robot_sf/planner/obstacle_features.py` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `scripts/dev/ruff_fix_format.sh` -> passed, 1316 files unchanged
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` before commit -> 4294 passed, 10 skipped, 9 warnings
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` after commit -> 4294 passed, 10 skipped, 8 warnings

## Notes

- Ignored `output/coverage/*` files were generated by local validation and left untracked.
- Copilot implementation and review artifacts are under `.git/codex-agent-runs/`; the review found no blockers and recommended a narrow follow-up for report-layer producer-key guards if mixed-producer aggregation is expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ego-conditioned motion channel documentation with clearer behavior descriptions and producer metadata policies.
  * Added detailed validator behavior and comparability contract specifications.

* **Tests**
  * Expanded test coverage for ego-motion producer metadata validation across multiple configurations.
  * Strengthened assertions to verify producer comparability contracts and schema specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->