### PR TITLE
test: guard predictive producer row summaries

### DIFF
--- a/docs/context/issue_1550_predictive_same_seed_row_summary_schema.md
+++ b/docs/context/issue_1550_predictive_same_seed_row_summary_schema.md
@@ -53,6 +53,7 @@ identity and must be unique within a summary file.
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `comparison_group` | string | Stable label tying baseline and variant rows together. |
+| `feature_schema` | mapping | Optional predictive feature schema metadata for the row. When present, use the same machine-readable shape already emitted by predictive datasets/checkpoints so validators can inspect `ego_motion_channel_producer.producer_key`. |
 | `scenario_matrix` | string | Repository-relative path to the scenario matrix used for the row. |
 | `seed_manifest` | string | Repository-relative path to the committed seed manifest. |
 | `source_note` | string | Repository-relative path to the note or evidence summary that interprets the row. |
@@ -103,3 +104,13 @@ can survive worktree cleanup. Typical cases:
 Do **not** use this schema to restate old #1427 rows from memory, from screenshots, or from deleted
 local output trees. If a durable source was not preserved, keep the row as `unknown` or leave it out
 until a real source exists.
+
+When `feature_schema` is present for same-seed comparison rows, report validation must treat
+`ego_motion_channel_producer.producer_key` as a comparability guard, not as a benchmark-improvement
+signal. Mixed producer keys in one comparison context are not directly comparable. Rows that omit
+producer metadata remain valid for legacy bookkeeping, but the validator should emit an explicit
+caveat instead of implying those rows are proven comparable to producer-stamped rows. See
+`docs/context/issue_1504_ego_feature_contract.md` for the producer-specific ego-slot contract and
+comparison policy. The row validator applies this guard within each
+`campaign` + `comparison_group` + `scenario` + `seed` + `planner_grid_key` context, which matches
+the row identity fields used for same-seed baseline/candidate comparisons.

--- a/robot_sf/benchmark/predictive_same_seed_row_summary.py
+++ b/robot_sf/benchmark/predictive_same_seed_row_summary.py
@@ -11,6 +11,11 @@ from typing import Any
 import yaml
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.planner.obstacle_features import (
+    ObstacleFeatureSchemaError,
+    predictive_ego_motion_channel_producer_key,
+    validate_predictive_feature_schema_metadata,
+)
 
 ROW_STATUSES = frozenset({"ok", "failed", "degraded", "unavailable", "unknown"})
 ROW_REQUIRED_FIELDS = frozenset(
@@ -36,6 +41,7 @@ ROW_REQUIRED_FIELDS = frozenset(
 ROW_OPTIONAL_FIELDS = frozenset(
     {
         "comparison_group",
+        "feature_schema",
         "scenario_matrix",
         "seed_manifest",
         "source_note",
@@ -133,6 +139,8 @@ def validate_predictive_same_seed_row_summary_rows(
         for index, row in enumerate(rows)
     ]
     _mark_duplicate_row_keys(row_reports)
+    _guard_mixed_ego_motion_producer_keys(row_reports)
+    _strip_internal_row_metadata(row_reports)
     invalid_row_count = sum(1 for row in row_reports if row["status"] == "invalid")
     return {
         "status": "valid" if invalid_row_count == 0 else "invalid",
@@ -224,6 +232,7 @@ def _validate_row(
     _validate_optional_reference(row, "source_note", repo_root=repo_root, errors=errors)
     if "comparison_group" in row:
         _require_non_empty_string(row, "comparison_group", errors)
+    feature_schema = _validate_optional_feature_schema(row, errors=errors)
 
     _validate_semantics(
         row_status=row_status,
@@ -261,7 +270,201 @@ def _validate_row(
         "status": "valid" if not errors else "invalid",
         "errors": errors,
         "warnings": warnings,
+        "_comparison_context": _comparison_context(
+            campaign=campaign,
+            comparison_group=row.get("comparison_group"),
+            scenario=scenario,
+            seed=seed,
+            planner_grid_key=planner_grid_key,
+        ),
+        "_feature_schema_present": feature_schema is not None,
+        "_producer_key": (
+            predictive_ego_motion_channel_producer_key(feature_schema)
+            if isinstance(feature_schema, dict)
+            else None
+        ),
     }
+
+
+def _validate_optional_feature_schema(
+    mapping: dict[str, Any],
+    *,
+    errors: list[dict[str, str]],
+) -> dict[str, Any] | None:
+    if "feature_schema" not in mapping or mapping["feature_schema"] is None:
+        return None
+    feature_schema = mapping.get("feature_schema")
+    if not isinstance(feature_schema, dict):
+        _append_problem(errors, "feature_schema", "must be a mapping when provided")
+        return None
+    try:
+        validate_predictive_feature_schema_metadata(
+            feature_schema,
+            input_dim=_feature_schema_input_dim(feature_schema),
+        )
+    except (ObstacleFeatureSchemaError, TypeError, ValueError) as exc:
+        _append_problem(
+            errors, "feature_schema", f"invalid predictive feature schema metadata: {exc}"
+        )
+        return None
+    return feature_schema
+
+
+def _feature_schema_input_dim(feature_schema: dict[str, Any]) -> int:
+    input_dim = feature_schema.get("input_dim")
+    if isinstance(input_dim, bool) or not isinstance(input_dim, int):
+        raise ValueError("feature_schema.input_dim must be an integer")
+    return int(input_dim)
+
+
+def _comparison_context(
+    *,
+    campaign: str | None,
+    comparison_group: object,
+    scenario: str | None,
+    seed: int | None,
+    planner_grid_key: str | None,
+) -> tuple[str | None, str | None, str | None, int | None, str | None] | None:
+    if scenario is None or seed is None or planner_grid_key is None:
+        return None
+    normalized_group = None
+    if isinstance(comparison_group, str) and comparison_group.strip():
+        normalized_group = comparison_group.strip()
+    return (campaign, normalized_group, scenario, seed, planner_grid_key)
+
+
+def _guard_mixed_ego_motion_producer_keys(row_reports: list[dict[str, Any]]) -> None:
+    grouped_reports: dict[
+        tuple[str | None, str | None, str | None, int | None, str | None],
+        list[dict[str, Any]],
+    ] = {}
+    for row_report in row_reports:
+        context = row_report.get("_comparison_context")
+        if context is None:
+            continue
+        grouped_reports.setdefault(context, []).append(row_report)
+    for context, grouped in grouped_reports.items():
+        if len(grouped) < 2:
+            continue
+        if not any(row_report.get("_feature_schema_present") for row_report in grouped):
+            continue
+        _apply_ego_motion_producer_guard(grouped, context=context)
+
+
+def _apply_ego_motion_producer_guard(
+    grouped: list[dict[str, Any]],
+    *,
+    context: tuple[str | None, str | None, str | None, int | None, str | None],
+) -> None:
+    producer_keys = sorted(
+        {
+            str(producer_key)
+            for producer_key in (row_report.get("_producer_key") for row_report in grouped)
+            if producer_key
+        }
+    )
+    rows_without_producer = [
+        row_report for row_report in grouped if row_report.get("_producer_key") is None
+    ]
+    if len(producer_keys) > 1:
+        _mark_grouped_rows_invalid_for_mixed_producers(
+            grouped, context=context, producer_keys=producer_keys
+        )
+    if rows_without_producer and producer_keys:
+        _warn_grouped_rows_for_missing_producers(
+            grouped,
+            context=context,
+            producer_keys=producer_keys,
+        )
+        return
+    if rows_without_producer:
+        _warn_grouped_rows_for_unknown_comparability(grouped, context=context)
+
+
+def _mark_grouped_rows_invalid_for_mixed_producers(
+    grouped: list[dict[str, Any]],
+    *,
+    context: tuple[str | None, str | None, str | None, int | None, str | None],
+    producer_keys: list[str],
+) -> None:
+    producer_list = ", ".join(repr(key) for key in producer_keys)
+    message = (
+        f"{_format_comparison_context(context)} mixes "
+        "ego_motion_channel_producer.producer_key values "
+        f"[{producer_list}]; rows are not directly comparable without grouping or an explicit caveat"
+    )
+    for row_report in grouped:
+        _append_problem(
+            row_report["errors"],
+            "feature_schema.ego_motion_channel_producer.producer_key",
+            message,
+        )
+        row_report["status"] = "invalid"
+
+
+def _warn_grouped_rows_for_missing_producers(
+    grouped: list[dict[str, Any]],
+    *,
+    context: tuple[str | None, str | None, str | None, int | None, str | None],
+    producer_keys: list[str],
+) -> None:
+    producer_list = ", ".join(repr(key) for key in producer_keys)
+    message = (
+        f"{_format_comparison_context(context)} includes legacy/no-metadata rows without "
+        "ego_motion_channel_producer.producer_key alongside producer-stamped rows "
+        f"[{producer_list}]; direct comparability is not proven"
+    )
+    for row_report in grouped:
+        _append_problem(
+            row_report["warnings"],
+            "feature_schema.ego_motion_channel_producer.producer_key",
+            message,
+        )
+
+
+def _warn_grouped_rows_for_unknown_comparability(
+    grouped: list[dict[str, Any]],
+    *,
+    context: tuple[str | None, str | None, str | None, int | None, str | None],
+) -> None:
+    message = (
+        f"{_format_comparison_context(context)} has rows without "
+        "ego_motion_channel_producer.producer_key metadata; direct comparability is not proven"
+    )
+    for row_report in grouped:
+        _append_problem(
+            row_report["warnings"],
+            "feature_schema.ego_motion_channel_producer.producer_key",
+            message,
+        )
+
+
+def _format_comparison_context(
+    context: tuple[str | None, str | None, str | None, int | None, str | None],
+) -> str:
+    campaign, comparison_group, scenario, seed, planner_grid_key = context
+    parts = []
+    if campaign:
+        parts.append(f"campaign={campaign!r}")
+    if comparison_group:
+        parts.append(f"comparison_group={comparison_group!r}")
+    if scenario:
+        parts.append(f"scenario={scenario!r}")
+    if seed is not None:
+        parts.append(f"seed={seed}")
+    if planner_grid_key:
+        parts.append(f"planner_grid_key={planner_grid_key!r}")
+    return "comparison context " + ", ".join(parts)
+
+
+def _strip_internal_row_metadata(row_reports: list[dict[str, Any]]) -> None:
+    for row_report in row_reports:
+        for field in (
+            "_comparison_context",
+            "_feature_schema_present",
+            "_producer_key",
+        ):
+            row_report.pop(field, None)
 
 
 def _validate_semantics(

--- a/tests/benchmark/test_predictive_same_seed_row_summary.py
+++ b/tests/benchmark/test_predictive_same_seed_row_summary.py
@@ -14,9 +14,28 @@ from robot_sf.benchmark.predictive_same_seed_row_summary import (
     validate_predictive_same_seed_row_summary_file,
     validate_predictive_same_seed_row_summary_rows,
 )
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_EGO_FEATURE_SCHEMA,
+    PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+    PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
+    PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+    predictive_feature_schema_metadata,
+)
 from scripts.validation.validate_predictive_same_seed_row_summary import main as validate_cli_main
 
 FIXTURE_ROOT = Path("tests/fixtures/predictive_same_seed_row_summary/v1")
+
+
+def _predictive_feature_schema(
+    *,
+    model_family: str,
+    producer_key: str | None = None,
+) -> dict[str, object]:
+    """Return valid predictive feature schema metadata for row-summary validation tests."""
+    kwargs: dict[str, object] = {"model_family": model_family}
+    if model_family == PREDICTIVE_EGO_FEATURE_SCHEMA:
+        kwargs["ego_motion_channel_producer"] = producer_key
+    return predictive_feature_schema_metadata(**kwargs)
 
 
 def test_valid_rows_accept_ok_and_unavailable_records() -> None:
@@ -208,6 +227,108 @@ def test_status_specific_nullability_and_degraded_warning() -> None:
             ),
         }
     ]
+
+
+def test_same_producer_rows_remain_valid_when_feature_schema_matches() -> None:
+    """Matching producer-stamped rows must remain comparable within one same-seed group."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    stamped_rows = copy.deepcopy(rows)
+    runtime_schema = _predictive_feature_schema(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        producer_key=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+    )
+    stamped_rows[0]["feature_schema"] = runtime_schema
+    stamped_rows[1]["feature_schema"] = runtime_schema
+
+    report = validate_predictive_same_seed_row_summary_rows(stamped_rows)
+
+    assert report["status"] == "valid"
+    assert all(row["warnings"] == [] for row in report["rows"])
+
+
+def test_mixed_producer_rows_fail_closed_with_named_producer_keys() -> None:
+    """Mixed producer keys must invalidate the comparison group instead of looking comparable."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    stamped_rows = copy.deepcopy(rows)
+    stamped_rows[0]["feature_schema"] = _predictive_feature_schema(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        producer_key=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+    )
+    stamped_rows[1]["feature_schema"] = _predictive_feature_schema(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        producer_key=PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
+    )
+
+    report = validate_predictive_same_seed_row_summary_rows(stamped_rows)
+
+    assert report["status"] == "invalid"
+    for row in report["rows"]:
+        producer_errors = [
+            error
+            for error in row["errors"]
+            if error["field"] == "feature_schema.ego_motion_channel_producer.producer_key"
+        ]
+        assert producer_errors
+        assert "ego_motion_channel_producer.producer_key" in producer_errors[0]["message"]
+        assert PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME in producer_errors[0]["message"]
+        assert PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE in producer_errors[0]["message"]
+
+
+def test_legacy_or_missing_producer_metadata_rows_emit_conservative_caveat() -> None:
+    """Legacy or unstamped rows stay valid but must not be treated as proven comparable."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    mixed_rows = copy.deepcopy(rows)
+    mixed_rows[0]["feature_schema"] = _predictive_feature_schema(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        producer_key=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+    )
+    mixed_rows[1]["feature_schema"] = _predictive_feature_schema(
+        model_family=PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+    )
+
+    report = validate_predictive_same_seed_row_summary_rows(mixed_rows)
+
+    assert report["status"] == "valid"
+    for row in report["rows"]:
+        producer_warnings = [
+            warning
+            for warning in row["warnings"]
+            if warning["field"] == "feature_schema.ego_motion_channel_producer.producer_key"
+        ]
+        assert producer_warnings
+        assert "ego_motion_channel_producer.producer_key" in producer_warnings[0]["message"]
+        assert PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME in producer_warnings[0]["message"]
+        assert "legacy/no-metadata rows" in producer_warnings[0]["message"]
+
+
+def test_all_legacy_feature_schema_rows_emit_unknown_comparability_caveat() -> None:
+    """All-legacy feature schemas remain valid while carrying an explicit comparability caveat."""
+    _input_format, rows = load_predictive_same_seed_row_summary_input(
+        FIXTURE_ROOT / "valid_rows.yaml"
+    )
+    legacy_rows = copy.deepcopy(rows)
+    legacy_schema = _predictive_feature_schema(model_family=PREDICTIVE_LEGACY_FEATURE_SCHEMA)
+    legacy_rows[0]["feature_schema"] = legacy_schema
+    legacy_rows[1]["feature_schema"] = legacy_schema
+
+    report = validate_predictive_same_seed_row_summary_rows(legacy_rows)
+
+    assert report["status"] == "valid"
+    for row in report["rows"]:
+        producer_warnings = [
+            warning
+            for warning in row["warnings"]
+            if warning["field"] == "feature_schema.ego_motion_channel_producer.producer_key"
+        ]
+        assert producer_warnings
+        assert "ego_motion_channel_producer.producer_key" in producer_warnings[0]["message"]
+        assert "direct comparability is not proven" in producer_warnings[0]["message"]
 
 
 def test_repository_reference_guards_reject_unsafe_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Extends predictive same-seed row summaries with optional `feature_schema` metadata so report validation can inspect `ego_motion_channel_producer.producer_key`.
- Adds a comparison-context guard that fails closed on mixed predictive ego producer keys and emits conservative caveats for legacy/no-producer metadata rows.
- Documents the row-summary feature-schema field and grouping context, linking back to the #1537 ego-slot producer policy.

Closes #1567.

## Validation

- `uv run pytest tests/benchmark/test_predictive_same_seed_row_summary.py` -> 15 passed
- `uv run ruff check robot_sf/benchmark/predictive_same_seed_row_summary.py tests/benchmark/test_predictive_same_seed_row_summary.py` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `scripts/dev/ruff_fix_format.sh` -> passed, 1 file reformatted, 1315 files unchanged
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` before commit -> 4297 passed, 11 skipped, 9 warnings
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` after commit -> 4297 passed, 11 skipped, 8 warnings; changed-file coverage warning only at 90.8% for `robot_sf/benchmark/predictive_same_seed_row_summary.py`

## Notes

- Ignored `output/coverage/*` files were generated by local validation and left untracked.
- Copilot implementation and review artifacts are under `.git/codex-agent-runs/`; the review found no blocking issues. I fixed its two minor polish observations before final validation.
