### PR TITLE
docs: inventory root layout cleanup options

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -100,7 +100,7 @@ knowledge, not every transient iteration detail.
   [issue_1167_predictive_obstacle_pipeline.md](issue_1167_predictive_obstacle_pipeline.md)
 * Issue #1550 predictive same-seed row summary schema:
   [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
-* Issue #1573 root-layout inventory:
+* Issue #1573 Root-Layout Inventory:
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -100,6 +100,8 @@ knowledge, not every transient iteration detail.
   [issue_1167_predictive_obstacle_pipeline.md](issue_1167_predictive_obstacle_pipeline.md)
 * Issue #1550 predictive same-seed row summary schema:
   [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
+* Issue #1573 root-layout inventory:
+  [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
 * Issue #1543 predictive v2 negative audit:

--- a/docs/context/issue_1573_root_layout_inventory.md
+++ b/docs/context/issue_1573_root_layout_inventory.md
@@ -1,4 +1,4 @@
-# Issue #1573 root-layout inventory
+# Issue #1573 Root-Layout Inventory (2026-05-27)
 
 Issue: [#1573](https://github.com/ll7/robot_sf_ll7/issues/1573)
 
@@ -43,7 +43,7 @@ Action meanings:
 | `.pre-commit-config.yaml` | Canonical pre-commit entrypoint; directly references `hooks/prevent_schema_duplicates.py`. | `keep` | User boundary forbids moving it here, and repo tooling expects it at root. |
 | `CITATION.cff` | `docs/RELEASE.md` and `docs/benchmark_release_reproducibility.md` explicitly require `CITATION.cff`. | `keep` | Publication/citation metadata must remain root-visible and untouched in this PR. |
 
-## Validation path used for this inventory
+## Validation Path Used For This Inventory
 
 - `git status --short`
 - `git ls-files --error-unmatch <path>` / `git check-ignore <path>` for candidate-path state
@@ -54,7 +54,7 @@ Action meanings:
   `svg_conv/README.md`, `test_pygame/README.md`, `output/repos/README.md`, `.cursorrules`,
   `.git-blame-ignore-revs`, and `CITATION.cff`
 
-## Follow-up boundary
+## Follow-Up Boundary
 
 If #1573 later needs actual path changes, the safest order is:
 

--- a/docs/context/issue_1573_root_layout_inventory.md
+++ b/docs/context/issue_1573_root_layout_inventory.md
@@ -1,4 +1,4 @@
-# Issue #1573 Root-Layout Inventory (2026-05-27)
+# Issue #1573 Root-Layout Inventory - 2026-05-27
 
 Issue: [#1573](https://github.com/ll7/robot_sf_ll7/issues/1573)
 

--- a/docs/context/issue_1573_root_layout_inventory.md
+++ b/docs/context/issue_1573_root_layout_inventory.md
@@ -1,0 +1,65 @@
+# Issue #1573 root-layout inventory
+
+Issue: [#1573](https://github.com/ll7/robot_sf_ll7/issues/1573)
+
+This note is the conservative foundation slice for #1573. It inventories the candidate first-level
+paths, records the local evidence checked on this branch, and makes an explicit action call for
+each path without performing a bulk directory move.
+
+Scope boundary for this PR:
+
+- no first-level directory moves,
+- no deletion of publication or contributor metadata,
+- no movement of `specs/`, `model_ped/`, `test_pygame/`, `test_scenarios/`, `output/`,
+  `experiments/`, `.pre-commit-config.yaml`, `.cursorrules`, or `CITATION.cff`,
+- no claim based only on prior-agent output; the table below is based on local `git`/`rg` checks.
+
+Action meanings:
+
+- `keep`: current root location is intentional or already part of an explicit repo contract.
+- `low-risk move candidate`: limited references; a future dedicated PR could relocate it with small
+  path churn.
+- `delete candidate`: looks like stale/generated root clutter and already conflicts with current
+  repo policy.
+- `deferred follow-up`: plausible cleanup target, but current references or workflow coupling make a
+  move too risky for this foundation PR.
+
+| Path | Local evidence checked | Action | Why this is the conservative call |
+| --- | --- | --- | --- |
+| `.agent/` | `AGENTS.md` points to `.agent/PLANS.md` as the repo plan-writing convention. | `keep` | This is already part of the agent-context contract, so moving it would ripple through agent instructions. |
+| `class_diagram/` | No repo-wide references found outside the directory itself; contents are generated SVGs plus `class_diagram/generate_uml.sh`. | `low-risk move candidate` | Self-contained docs/tooling asset; a later PR could move it under a docs/tooling subtree with limited breakage. |
+| `experiments/` | `docs/dev_guide.md` and `docs/README.md` explicitly describe `experiments/registry.yaml` and `experiments/README.md` as the question-first experiment registry. | `keep` | This path is already documented as a canonical workflow surface. |
+| `hooks/` | `.pre-commit-config.yaml` invokes `hooks/prevent_schema_duplicates.py`; tests also cover the hook contract/API surface under `tests/contract/` and related integration checks. | `deferred follow-up` | Cleanup is possible later, but this path is wired into pre-commit and test hook contracts, so any relocation still needs coordinated updates if the entrypoint or module path changes. |
+| `model_ped/` | Multiple scripts and tests resolve checkpoints from `model_ped/`. | `keep` | Direct runtime and test references make this a high-blast-radius path; keep unchanged in the foundation PR. |
+| `output/` | `AGENTS.md`, `docs/README.md`, `docs/dev_guide.md`, `.gitignore`, and coverage docs all treat `output/` as the canonical artifact root. | `keep` | Root-level artifact policy is intentional and already documented. |
+| `specs/` | `docs/README.md`, `docs/dev_guide.md`, and multiple docs deep-link into `specs/...` quickstarts, plans, tasks, and contracts. | `deferred follow-up` | A future relocation would require broad doc-link migration; that is outside a conservative foundation PR. |
+| `svg_conv/` | Only lightweight config/docs references were found; `svg_conv/README.md` itself says to prefer `robot_sf/nav/svg_map_parser.py`. | `low-risk move candidate` | Looks like legacy single-purpose tooling rather than a current root contract. |
+| `test_pygame/` | `docs/dev_guide.md`, `pyproject.toml`, tests, and helper scripts all reference `test_pygame/` explicitly. | `keep` | This is a documented, active test surface with exact path references. |
+| `test_scenarios/` | Tests load fixtures from `test_scenarios/osm_fixtures/...`; root fixtures are also part of current local test inputs. | `deferred follow-up` | Possible future consolidation into a test-fixture subtree, but not without updating multiple tests and docs. |
+| `utilities/` | Refactoring docs and example commands explicitly reference `utilities/migrate_environments.py`; `pyproject.toml` also has per-path lint rules for `utilities/**/*.py`. No confirmed doc references to `utilities/n.py` were found in this check. | `deferred follow-up` | This is not a core runtime package, but current docs/tooling still point to a root `utilities/` path, so moving it needs a conservative dedicated cleanup PR. |
+| `.coverage` | Root `.coverage` is a tracked SQLite database, while `pyproject.toml` and `docs/coverage_guide.md` now set the canonical coverage data file to `output/coverage/.coverage`. | `delete candidate` | This root artifact no longer matches the current coverage contract and is the clearest stale-root cleanup candidate. |
+| `.cursorrules` | Root editor/agent metadata file; current content is a simple pointer back to `AGENTS.md`. | `keep` | User boundary forbids moving it here, and keeping editor metadata at repo root is conventional. |
+| `.git-blame-ignore-revs` | Standard root-level Git metadata file with formatter/import-sort SHAs. | `keep` | Root placement matches normal Git tooling expectations. |
+| `.pre-commit-config.yaml` | Canonical pre-commit entrypoint; directly references `hooks/prevent_schema_duplicates.py`. | `keep` | User boundary forbids moving it here, and repo tooling expects it at root. |
+| `CITATION.cff` | `docs/RELEASE.md` and `docs/benchmark_release_reproducibility.md` explicitly require `CITATION.cff`. | `keep` | Publication/citation metadata must remain root-visible and untouched in this PR. |
+
+## Validation path used for this inventory
+
+- `git status --short`
+- `git ls-files --error-unmatch <path>` / `git check-ignore <path>` for candidate-path state
+- `rg` lookups across `AGENTS.md`, `docs/`, `scripts/`, `tests/`, `pyproject.toml`, and
+  `.pre-commit-config.yaml`
+- direct file inspection for `class_diagram/generate_uml.sh`, `hooks/prevent_schema_duplicates.py`,
+  `experiments/README.md`, `utilities/migrate_environments.py`, `docs/refactoring/README.md`,
+  `svg_conv/README.md`, `test_pygame/README.md`, `output/repos/README.md`, `.cursorrules`,
+  `.git-blame-ignore-revs`, and `CITATION.cff`
+
+## Follow-up boundary
+
+If #1573 later needs actual path changes, the safest order is:
+
+1. remove the stale root `.coverage` artifact first and add a `.gitignore` rule for root
+   `.coverage` so it does not reappear,
+2. decide whether `class_diagram/` and `svg_conv/` should move under docs/tooling,
+3. handle any `hooks/`, `specs/`, `test_scenarios/`, or `utilities/` relocation only in dedicated
+   PRs that update every exact-path reference together.


### PR DESCRIPTION
## Summary

Adds the conservative #1573 root-layout inventory/decision note and links it from the context index.

## Linked Issues

- Closes #1573
- Follow-up: #1578
- Follow-up: #1579

## What Changed

- Added `docs/context/issue_1573_root_layout_inventory.md` with an explicit action for each requested root candidate: keep, low-risk move candidate, delete candidate, or deferred follow-up.
- Linked the note from `docs/context/README.md`.
- Kept the first PR as a foundation slice; no high-blast-radius directories or publication metadata were moved.

## Validation / Proof

- Gemini large-context read-only inventory pass.
- Copilot GPT-5.4 xhigh implementation pass.
- OpenCode Go review pass, followed by a Copilot correction pass and local verification of corrected claims.
- `git diff --check origin/main...HEAD`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed.
- Local `rg` verification for `hooks/prevent_schema_duplicates.py`, `utilities/migrate_environments.py`, root `.coverage`, and related references.

## Risks / Rollout

- This PR intentionally does not move root paths; it makes the cleanup decision trail reviewable first.
- #1578 tracks root `.coverage` removal.
- #1579 tracks low-risk relocation for `class_diagram/` and `svg_conv/`.
