### PR TITLE
feat: expose AMV taxonomy in scenario breakdowns

### DIFF
--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -14,6 +14,7 @@ import math
 import re
 import subprocess
 import time
+from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
@@ -3293,7 +3294,9 @@ def _build_breakdown_rows(  # noqa: C901
     per_scenario: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     per_family: dict[tuple[str, str, str], dict[str, Any]] = {}
 
-    family_amv_values: dict[tuple[str, str, str], dict[str, set[str]]] = {}
+    family_amv_values: defaultdict[tuple[str, str, str], defaultdict[str, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
 
     def _add_metric(bucket: dict[str, Any], metric: str, value: float | None) -> None:
         """Append one finite metric sample to an aggregation bucket."""
@@ -3362,11 +3365,10 @@ def _build_breakdown_rows(  # noqa: C901
             for dimension in _AMV_DIMENSIONS:
                 scenario_bucket.setdefault(dimension, scenario_amv.get(dimension, ""))
 
-            family_amv_bucket = family_amv_values.setdefault(family_key, {})
             for dimension in _AMV_DIMENSIONS:
                 dim_value = scenario_amv.get(dimension, "")
                 if dim_value:
-                    family_amv_bucket.setdefault(dimension, set()).add(dim_value)
+                    family_amv_values[family_key][dimension].add(dim_value)
 
     def _finalize(row: dict[str, Any]) -> dict[str, Any]:
         """Replace metric sample lists with report-ready mean fields.

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -3248,16 +3248,48 @@ def _scenario_family(record: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _build_scenario_amv_lookup(
+    scenarios: list[dict[str, Any]],
+) -> dict[str, dict[str, str]]:
+    """Build a lookup from scenario identifier to AMV taxonomy dimensions.
+
+    Returns:
+        dict[str, dict[str, str]]: Mapping from scenario name/id to AMV taxonomy
+        values keyed by dimension name. Scenarios without AMV data map to empty
+        dicts so downstream code can distinguish absent from empty.
+    """
+    lookup: dict[str, dict[str, str]] = {}
+    for scenario in scenarios:
+        scenario_id = _campaign_scenario_id(scenario)
+        taxonomy = _extract_amv_taxonomy(scenario)
+        lookup[scenario_id] = taxonomy
+    return lookup
+
+
 def _build_breakdown_rows(  # noqa: C901
     run_entries: list[dict[str, Any]],
+    *,
+    scenario_amv_lookup: dict[str, dict[str, str]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Build per-scenario and per-family campaign diagnostic rows.
+
+    When ``scenario_amv_lookup`` is provided, AMV taxonomy columns
+    (``use_case``, ``context``, ``speed_regime``, ``maneuver_type``) are
+    merged into per-scenario rows from the matching scenario identifier.
+    Per-family rows receive the union of AMV dimension values observed
+    across contributing scenarios, joined by semicolons. Scenarios or
+    families without AMV data emit empty-string placeholders rather than
+    absent columns, so downstream consumers never mistake a missing column
+    for an unavailable taxonomy dimension.
 
     Returns:
         Tuple of per-scenario rows and per-family rows.
     """
+    amv_lookup = scenario_amv_lookup if scenario_amv_lookup is not None else {}
     per_scenario: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     per_family: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    family_amv_values: dict[tuple[str, str, str], dict[str, set[str]]] = {}
 
     def _add_metric(bucket: dict[str, Any], metric: str, value: float | None) -> None:
         """Append one finite metric sample to an aggregation bucket."""
@@ -3322,6 +3354,16 @@ def _build_breakdown_rows(  # noqa: C901
                 _add_metric(scenario_bucket, metric, value)
                 _add_metric(family_bucket, metric, value)
 
+            scenario_amv = amv_lookup.get(scenario_id, {})
+            for dimension in _AMV_DIMENSIONS:
+                scenario_bucket.setdefault(dimension, scenario_amv.get(dimension, ""))
+
+            family_amv_bucket = family_amv_values.setdefault(family_key, {})
+            for dimension in _AMV_DIMENSIONS:
+                dim_value = scenario_amv.get(dimension, "")
+                if dim_value:
+                    family_amv_bucket.setdefault(dimension, set()).add(dim_value)
+
     def _finalize(row: dict[str, Any]) -> dict[str, Any]:
         """Replace metric sample lists with report-ready mean fields.
 
@@ -3344,14 +3386,25 @@ def _build_breakdown_rows(  # noqa: C901
             row.get("scenario_family", ""),
         ),
     )
-    family_rows = sorted(
-        (_finalize(row) for row in per_family.values()),
+    family_rows_data: list[dict[str, Any]] = []
+    for family_key, family_row in per_family.items():
+        finalized = _finalize(family_row)
+        family_dims = family_amv_values.get(family_key, {})
+        for dimension in _AMV_DIMENSIONS:
+            values = family_dims.get(dimension)
+            if values:
+                finalized[dimension] = ";".join(sorted(values))
+            else:
+                finalized[dimension] = ""
+        family_rows_data.append(finalized)
+
+    family_rows_data.sort(
         key=lambda row: (
             row.get("planner_key", ""),
             row.get("scenario_family", ""),
         ),
     )
-    return scenario_rows, family_rows
+    return scenario_rows, family_rows_data
 
 
 def _strict_vs_fallback_comparisons(rows: list[dict[str, Any]]) -> list[str]:
@@ -4020,7 +4073,11 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "snqi_mean",
         ),
     )
-    scenario_rows, family_rows = _build_breakdown_rows(run_entries)
+    scenario_amv_lookup = _build_scenario_amv_lookup(scenarios)
+    scenario_rows, family_rows = _build_breakdown_rows(
+        run_entries,
+        scenario_amv_lookup=scenario_amv_lookup,
+    )
     scenario_csv_path, scenario_md_path = _write_table_artifacts(
         reports_dir,
         "scenario_breakdown",
@@ -4030,6 +4087,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "algo",
             "scenario_family",
             "scenario_id",
+            "use_case",
+            "context",
+            "speed_regime",
+            "maneuver_type",
             "episodes",
             "success_mean",
             "collisions_mean",
@@ -4052,6 +4113,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "planner_key",
             "algo",
             "scenario_family",
+            "use_case",
+            "context",
+            "speed_regime",
+            "maneuver_type",
             "episodes",
             "success_mean",
             "collisions_mean",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -22,6 +22,9 @@ from robot_sf.benchmark.camera_ready_campaign import (
     PlannerSpec,
     SeedPolicy,
     _build_actuation_envelope_summary,
+    _build_breakdown_rows,
+    _build_scenario_amv_lookup,
+    _extract_amv_taxonomy,
     _jsonable_repo_relative,
     _load_campaign_scenarios,
     _load_route_clearance_certifications,
@@ -4330,3 +4333,229 @@ def test_prepare_campaign_preflight_rejects_missing_planner_key_mapping_for_pape
     cfg = load_campaign_config(config_path)
     with pytest.raises(ValueError, match="prediction_planner_v2_xl_ego"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="missing_planner")
+
+
+class TestBuildScenarioAmvLookup:
+    """Tests for _build_scenario_amv_lookup and AMV taxonomy in breakdown rows."""
+
+    def test_build_scenario_amv_lookup_extracts_amv_from_scenario(self) -> None:
+        """Lookup maps scenario names to their AMV taxonomy dimensions."""
+        scenarios = [
+            {"name": "corridor_low", "amv": {"use_case": "corridor", "context": "low_density"}},
+            {
+                "name": "crossing_high",
+                "amv": {"use_case": "crossing", "speed_regime": "high_speed"},
+            },
+            {"name": "no_amv"},
+        ]
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert lookup["corridor_low"] == {"use_case": "corridor", "context": "low_density"}
+        assert lookup["crossing_high"] == {"use_case": "crossing", "speed_regime": "high_speed"}
+        assert lookup["no_amv"] == {}
+
+    def test_build_scenario_amv_lookup_from_metadata_amv(self) -> None:
+        """Lookup falls back to metadata.amv when top-level amv is absent."""
+        scenarios = [
+            {
+                "name": "meta_amv",
+                "metadata": {"amv": {"use_case": "hallway", "maneuver_type": "turn"}},
+            }
+        ]
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert lookup["meta_amv"] == {"use_case": "hallway", "maneuver_type": "turn"}
+
+    def test_extract_amv_taxonomy_prefers_top_level_over_metadata(self) -> None:
+        """Top-level amv takes precedence over metadata.amv for overlapping keys."""
+        scenario = {
+            "name": "both",
+            "amv": {"use_case": "top_level"},
+            "metadata": {"amv": {"use_case": "metadata_level"}},
+        }
+        result = _extract_amv_taxonomy(scenario)
+        assert result["use_case"] == "top_level"
+
+    def test_extract_amv_taxonomy_ignores_empty_values(self) -> None:
+        """Empty or whitespace-only AMV dimension values are excluded."""
+        scenario = {
+            "name": "sparse",
+            "amv": {"use_case": "corridor", "context": "", "speed_regime": "   "},
+        }
+        result = _extract_amv_taxonomy(scenario)
+        assert result == {"use_case": "corridor"}
+
+    def test_extract_amv_taxonomy_returns_empty_when_no_amv(self) -> None:
+        """Scenarios without any AMV block produce an empty taxonomy."""
+        result = _extract_amv_taxonomy({"name": "no_amv_at_all"})
+        assert result == {}
+
+    def test_build_breakdown_rows_without_amv_lookup_preserves_existing_columns(self) -> None:
+        """Empty input produces empty scenario and family rows."""
+        scenario_rows, family_rows = _build_breakdown_rows([])
+        assert scenario_rows == []
+        assert family_rows == []
+
+    def test_build_breakdown_rows_includes_amv_columns(self, tmp_path: Path) -> None:
+        """AMV taxonomy columns appear in scenario and family breakdown rows."""
+        episodes_path = tmp_path / "episodes.jsonl"
+        episodes_path.write_text(
+            json.dumps({"scenario_id": "corridor_low", "ped_collision_count": 0}) + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(episodes_path),
+            }
+        ]
+        scenario_amv_lookup = {
+            "corridor_low": {"use_case": "corridor", "context": "low_density"},
+        }
+        scenario_rows, family_rows = _build_breakdown_rows(
+            run_entries,
+            scenario_amv_lookup=scenario_amv_lookup,
+        )
+        assert len(scenario_rows) == 1
+        row = scenario_rows[0]
+        assert row["scenario_id"] == "corridor_low"
+        assert row["use_case"] == "corridor"
+        assert row["context"] == "low_density"
+        assert row["speed_regime"] == ""
+        assert row["maneuver_type"] == ""
+        assert len(family_rows) == 1
+        fam = family_rows[0]
+        assert fam["use_case"] == "corridor"
+        assert fam["context"] == "low_density"
+        assert fam["speed_regime"] == ""
+        assert fam["maneuver_type"] == ""
+
+    def test_build_breakdown_rows_family_aggregates_multiple_amv_values(
+        self, tmp_path: Path
+    ) -> None:
+        """Family rows aggregate distinct AMV dimension values with semicolons."""
+        ep1_path = tmp_path / "ep1.jsonl"
+        ep1_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"scenario_id": "sc_a", "ped_collision_count": 0}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        ep2_path = tmp_path / "ep2.jsonl"
+        ep2_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"scenario_id": "sc_b", "ped_collision_count": 0}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(ep1_path),
+            },
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(ep2_path),
+            },
+        ]
+        scenario_amv_lookup = {
+            "sc_a": {"use_case": "corridor", "context": "low_density"},
+            "sc_b": {"use_case": "corridor", "context": "high_density"},
+        }
+        scenario_rows, family_rows = _build_breakdown_rows(
+            run_entries,
+            scenario_amv_lookup=scenario_amv_lookup,
+        )
+        assert len(scenario_rows) == 2
+        corridor_scenarios_ids = {r["scenario_id"] for r in scenario_rows}
+        assert "sc_a" in corridor_scenarios_ids
+        assert "sc_b" in corridor_scenarios_ids
+        for row in scenario_rows:
+            assert row["use_case"] == "corridor"
+            assert row["context"] in ("low_density", "high_density")
+        assert len(family_rows) == 1
+        assert family_rows[0]["use_case"] == "corridor"
+        assert family_rows[0]["context"] == "high_density;low_density"
+
+    def test_build_breakdown_rows_without_lookup_produces_empty_amv_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a lookup, AMV columns exist but contain empty strings."""
+        episodes_path = tmp_path / "episodes.jsonl"
+        episodes_path.write_text(
+            json.dumps({"scenario_id": "s1", "ped_collision_count": 0}) + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(episodes_path),
+            }
+        ]
+        scenario_rows, _family_rows = _build_breakdown_rows(run_entries)
+        assert len(scenario_rows) == 1
+        row = scenario_rows[0]
+        for dimension in ("use_case", "context", "speed_regime", "maneuver_type"):
+            assert dimension in row, f"AMV dimension '{dimension}' missing from scenario row"
+            assert row[dimension] == "", f"Expected empty string for {dimension} without AMV lookup"
+
+    def test_scenario_breakdown_csv_contains_amv_headers_in_campaign(self, tmp_path: Path) -> None:
+        """End-to-end: AMV columns flow from scenario definitions through the campaign config."""
+        scenario_path = tmp_path / "scenarios.yaml"
+        scenario_content = (
+            "scenarios:\n"
+            "  - name: corridor_amv\n"
+            "    map_file: maps/svg_maps/francis2023_blind_corner.svg\n"
+            "    robot_config:\n"
+            "      type: differential_drive\n"
+            "      radius: 0.3\n"
+            "    ped_config:\n"
+            "      robot_visible: false\n"
+            "    amv:\n"
+            "      use_case: corridor\n"
+            "      context: low_density\n"
+            "    simulation_config:\n"
+            "      max_episode_steps: 200\n"
+            "      steps_per_action: 4\n"
+            "    robot_spawn_id: 0\n"
+            "    robot_goal_id: 0\n"
+        )
+        scenario_path.write_text(scenario_content, encoding="utf-8")
+        config_path = tmp_path / "campaign.yaml"
+        config_content = (
+            "\n".join(
+                [
+                    "name: amv_breakdown_test",
+                    f"scenario_matrix: {scenario_path.as_posix()}",
+                    "planners:",
+                    "  - key: social_force",
+                    "    algo: social_force",
+                    "    planner_group: core",
+                    "paper_facing: true",
+                    "paper_profile_version: paper-seed-variability-v1",
+                    f"comparability_mapping: {_get_comparability_path()}",
+                ]
+            )
+            + "\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        cfg = load_campaign_config(config_path)
+        scenarios = _load_campaign_scenarios(cfg)
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert "corridor_amv" in lookup
+        assert lookup["corridor_amv"]["use_case"] == "corridor"
+        assert lookup["corridor_amv"]["context"] == "low_density"
+
+
+def _get_comparability_path() -> str:
+    repo_root = get_repository_root()
+    path = repo_root / "configs" / "benchmarks" / "alyassi_comparability_map_v1.yaml"
+    return path.as_posix()


### PR DESCRIPTION
## Summary
- Adds AMV taxonomy columns to `scenario_breakdown` and `scenario_family_breakdown` artifacts.
- Builds scenario-id AMV lookup from campaign scenarios, including #1572 override semantics.
- Adds targeted tests for lookup extraction, empty values, per-scenario columns, and per-family aggregation.

Closes #1577

## Stacking
- Base branch: `issue-1572-amv-metadata-gaps`
- Depends on PR #1580.

## Validation
- Worker validation: `uv run pytest tests/benchmark/test_camera_ready_campaign.py -x -q`, `uv run ruff check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py`, `uv run ruff format`, `git diff --check`.
- Orchestrator tightened family aggregation assertion.
- Post-base-merge validation: `uv run pytest tests/benchmark/test_camera_ready_campaign.py -x -q` -> 97 passed.
- Post-base-merge validation: `uv run ruff check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py` -> passed.
- Post-base-merge validation: `uv run ruff format --check robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py` -> passed.
- Post-base-merge validation: `git diff --check` -> passed.

## Artifact Decision
- Coverage files under `output/coverage/` are ignored local validation artifacts.
