### PR TITLE
workflow: add issue 1501 adversarial smoke launcher

### DIFF
--- a/SLURM/Auxme/adversarial_smoke_1501.sl
+++ b/SLURM/Auxme/adversarial_smoke_1501.sl
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=adv1501-smoke
+#SBATCH --account=mitarbeiter
+#SBATCH --partition=a30
+#SBATCH --qos=a30-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=04:00:00
+#SBATCH --gres=gpu:1
+#SBATCH --output=output/slurm/%j-adversarial-smoke1501.out
+
+# Run the bounded Issue #1501 crossing/TTC adversarial smoke.
+#
+# This launcher intentionally executes only the #1571-sharpened first child:
+# crossing_ttc with random + optuna_tpe over the frozen goal/orca planner rows.
+# The guided_route_search row is recorded as not_available for this family.
+set -euo pipefail
+
+PROJECT_ROOT=$(git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null || echo "${SLURM_SUBMIT_DIR:-$(pwd)}")
+LOCAL_OUTPUT_ROOT=${PROJECT_ROOT}/output/slurm
+OUTPUT_ROOT=${ADVERSARIAL_SMOKE_OUTPUT_ROOT:-${PROJECT_ROOT}/output/adversarial/issue_1501}
+LABEL=${ADVERSARIAL_SMOKE_LABEL:-issue1501-crossing-ttc-${SLURM_JOB_ID:-local}}
+RESULTS_ROOT=${ADVERSARIAL_SMOKE_RESULTS_DIR:-${LOCAL_OUTPUT_ROOT}/adversarial-smoke1501-job-${SLURM_JOB_ID:-local}}
+WORKDIR=${SLURM_TMPDIR:-/tmp/${USER}/adversarial-smoke1501-${SLURM_JOB_ID:-local}}
+PYTHON_BIN=${PROJECT_ROOT}/.venv/bin/python
+MODULE_LIST=${AUXME_MODULES:-"gcc/13.2.0"}
+CUDA_MODULE=${AUXME_CUDA_MODULE:-cuda/12.1}
+SMOKE_BUDGET=${ADVERSARIAL_SMOKE_BUDGET:-32}
+SMOKE_SEED=${ADVERSARIAL_SMOKE_SEED:-42}
+SMOKE_POLICIES=${ADVERSARIAL_SMOKE_POLICIES:-"goal orca"}
+SMOKE_SYNTHETIC=${ADVERSARIAL_SMOKE_SYNTHETIC:-false}
+MODULES_AVAILABLE=0
+CAMPAIGN_ROOT=""
+
+log() {
+  echo "[adv1501] $*"
+}
+
+die() {
+  echo "[adv1501] $*" >&2
+  exit 1
+}
+
+ensure_module_command() {
+  if command -v module >/dev/null 2>&1; then
+    MODULES_AVAILABLE=1
+    return 0
+  fi
+
+  local init_script
+  for init_script in /etc/profile.d/modules.sh /usr/share/Modules/init/bash; do
+    if [[ -f "${init_script}" ]]; then
+      # shellcheck disable=SC1090
+      source "${init_script}" >/dev/null 2>&1 || true
+    fi
+    if command -v module >/dev/null 2>&1; then
+      MODULES_AVAILABLE=1
+      return 0
+    fi
+  done
+
+  echo "[adv1501] module command unavailable; continuing without module loads." >&2
+  return 0
+}
+
+run_in_allocation() {
+  if [[ "${ADVERSARIAL_SMOKE_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
+    log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
+    srun --cpu_bind=cores "$@"
+  else
+    echo "[adv1501] running directly inside the batch allocation; set ADVERSARIAL_SMOKE_USE_SRUN=1 to opt into srun." >&2
+    "$@"
+  fi
+}
+
+cleanup() {
+  if [[ -n "${CAMPAIGN_ROOT}" && -d "${CAMPAIGN_ROOT}" ]]; then
+    mkdir -p "${RESULTS_ROOT}"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --partial --prune-empty-dirs "${CAMPAIGN_ROOT}/" "${RESULTS_ROOT}/" \
+        || echo "[adv1501] Warning: rsync failed to sync artifacts to ${RESULTS_ROOT}" >&2
+    else
+      cp -r "${CAMPAIGN_ROOT}/." "${RESULTS_ROOT}/" \
+        || echo "[adv1501] Warning: cp failed to sync artifacts to ${RESULTS_ROOT}" >&2
+    fi
+  fi
+}
+trap cleanup EXIT
+
+case "${SMOKE_SYNTHETIC,,}" in
+  1|true|yes|on) SMOKE_SYNTHETIC=true ;;
+  0|false|no|off|"") SMOKE_SYNTHETIC=false ;;
+  *) die "ADVERSARIAL_SMOKE_SYNTHETIC must be true/false-like, got: ${SMOKE_SYNTHETIC}" ;;
+esac
+
+if [[ ! "${SMOKE_BUDGET}" =~ ^[0-9]+$ || "${SMOKE_BUDGET}" -lt 1 ]]; then
+  die "ADVERSARIAL_SMOKE_BUDGET must be a positive integer, got: ${SMOKE_BUDGET}"
+fi
+
+if [[ ! "${SMOKE_SEED}" =~ ^[0-9]+$ ]]; then
+  die "ADVERSARIAL_SMOKE_SEED must be a non-negative integer, got: ${SMOKE_SEED}"
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  die "Expected repo virtualenv python at ${PYTHON_BIN}"
+fi
+
+for required in \
+  configs/adversarial/issue_1500_adversarial_comparison_manifest.v1.yaml \
+  configs/adversarial/crossing_ttc_space.yaml \
+  configs/scenarios/templates/crossing_ttc.yaml \
+  scripts/tools/compare_adversarial_samplers.py \
+  scripts/tools/curate_adversarial_failure_archive.py
+do
+  [[ -f "${PROJECT_ROOT}/${required}" ]] || die "Required file missing: ${required}"
+done
+
+ensure_module_command
+
+if [[ "${MODULES_AVAILABLE}" == "1" ]]; then
+  module purge
+  for mod in ${MODULE_LIST}; do
+    [[ -z "${mod}" ]] && continue
+    log "Loading module ${mod}"
+    module load "${mod}"
+  done
+  if [[ -n "${CUDA_MODULE}" ]]; then
+    log "Loading CUDA module ${CUDA_MODULE}"
+    module load "${CUDA_MODULE}"
+  fi
+fi
+
+mkdir -p "${WORKDIR}" "${LOCAL_OUTPUT_ROOT}" "${OUTPUT_ROOT}"
+CAMPAIGN_ROOT=${OUTPUT_ROOT}/${LABEL}
+mkdir -p "${CAMPAIGN_ROOT}/crossing_ttc"
+
+cd "${PROJECT_ROOT}"
+
+log "Commit: $(git rev-parse HEAD)"
+log "Campaign root: ${CAMPAIGN_ROOT}"
+log "Results sync root: ${RESULTS_ROOT}"
+log "Budget per sampler: ${SMOKE_BUDGET}"
+log "Seed: ${SMOKE_SEED}"
+log "Policies: ${SMOKE_POLICIES}"
+log "Synthetic evaluator: ${SMOKE_SYNTHETIC}"
+
+synthetic_arg=()
+if [[ "${SMOKE_SYNTHETIC}" == "true" ]]; then
+  synthetic_arg=(--synthetic)
+fi
+
+manifest_args=()
+for policy in ${SMOKE_POLICIES}; do
+  case "${policy}" in
+    goal|orca) ;;
+    *) die "Unsupported Issue #1501 policy row '${policy}'. Expected goal or orca." ;;
+  esac
+  policy_root=${CAMPAIGN_ROOT}/crossing_ttc/${policy}
+  mkdir -p "${policy_root}"
+  log "Running crossing_ttc policy=${policy} samplers=random,optuna"
+  run_in_allocation \
+    "${PYTHON_BIN}" scripts/tools/compare_adversarial_samplers.py \
+      --scenario-template configs/scenarios/templates/crossing_ttc.yaml \
+      --search-space configs/adversarial/crossing_ttc_space.yaml \
+      --policy "${policy}" \
+      --objective worst_case_snqi \
+      --output-dir "${policy_root}" \
+      --budget "${SMOKE_BUDGET}" \
+      --seed "${SMOKE_SEED}" \
+      --sampler random \
+      --sampler optuna \
+      --out-json "${policy_root}/sampler_comparison.json" \
+      "${synthetic_arg[@]}"
+  manifest_args+=("${policy_root}/random/manifest.json" "${policy_root}/optuna/manifest.json")
+done
+
+log "Curating crossing_ttc adversarial failure archive"
+run_in_allocation \
+  "${PYTHON_BIN}" scripts/tools/curate_adversarial_failure_archive.py \
+    "${manifest_args[@]}" \
+    --out "${CAMPAIGN_ROOT}/crossing_ttc/archive.json"
+
+log "Writing row-status summary"
+GIT_COMMIT=$(git rev-parse HEAD)
+"${PYTHON_BIN}" - "${CAMPAIGN_ROOT}" "${SMOKE_BUDGET}" "${SMOKE_SEED}" "${SMOKE_SYNTHETIC}" "${SMOKE_POLICIES}" "${GIT_COMMIT}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+campaign_root = Path(sys.argv[1])
+budget = int(sys.argv[2])
+seed = int(sys.argv[3])
+synthetic = sys.argv[4].lower() == "true"
+policies = sys.argv[5].split()
+git_commit = sys.argv[6]
+
+executed_counts: Counter[str] = Counter()
+manifest_paths: list[str] = []
+rows: list[dict[str, object]] = []
+
+def classify(candidate: dict[str, object]) -> str:
+    if candidate.get("error"):
+        return "simulation_error"
+    attribution = candidate.get("failure_attribution")
+    if not isinstance(attribution, dict):
+        return "simulation_error"
+    primary = str(attribution.get("primary_failure") or "")
+    status = str(attribution.get("status") or "")
+    if primary == "invalid_candidate" or status == "not_evaluated":
+        return "invalid_candidate"
+    if primary == "success":
+        return "success"
+    if primary in {"collision", "near_miss", "timeout", "comfort_violation", "incomplete"}:
+        return "valid_behavioral_failure"
+    if primary == "evaluation_error":
+        return "simulation_error"
+    return "simulation_error"
+
+for policy in policies:
+    for sampler in ("random", "optuna"):
+        manifest_path = campaign_root / "crossing_ttc" / policy / sampler / "manifest.json"
+        manifest_paths.append(manifest_path.as_posix())
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        counts: Counter[str] = Counter()
+        for candidate in manifest.get("candidates", []):
+            row_type = classify(candidate)
+            counts[row_type] += 1
+            executed_counts[row_type] += 1
+        rows.append(
+            {
+                "family": "crossing_ttc",
+                "policy": policy,
+                "sampler": sampler,
+                "availability_status": "available",
+                "manifest_path": manifest_path.as_posix(),
+                "counts": dict(sorted(counts.items())),
+            }
+        )
+
+not_available_row = {
+    "family": "crossing_ttc",
+    "policy": "all",
+    "sampler": "guided_route_search",
+    "availability_status": "not_available",
+    "reason": (
+        "guided_route_search is route-optimization based and is a design exclusion "
+        "for the parametric crossing_ttc CandidateSpec family"
+    ),
+    "counts": {"not_available": 1},
+}
+rows.append(not_available_row)
+total_counts = Counter(executed_counts)
+total_counts["not_available"] += 1
+
+payload = {
+    "schema_version": "issue-1501-adversarial-smoke-summary.v1",
+    "issue": 1501,
+    "parent_issue": 1488,
+    "commit": git_commit,
+    "family": "crossing_ttc",
+    "budget_per_sampler": budget,
+    "seed": seed,
+    "synthetic": synthetic,
+    "executed_policies": policies,
+    "executed_samplers": ["random", "optuna"],
+    "design_exclusion_samplers": ["guided_route_search"],
+    "manifest_paths": manifest_paths,
+    "archive_path": (campaign_root / "crossing_ttc" / "archive.json").as_posix(),
+    "counts": dict(sorted(total_counts.items())),
+    "rows": rows,
+    "non_success_evidence": {
+        "fallback": False,
+        "degraded": False,
+        "simulation_error": False,
+        "not_available": False,
+    },
+}
+(campaign_root / "crossing_ttc" / "row_status_summary.json").write_text(
+    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+
+log "Issue #1501 smoke completed. Campaign root: ${CAMPAIGN_ROOT}"

--- a/SLURM/Auxme/adversarial_smoke_1501.sl
+++ b/SLURM/Auxme/adversarial_smoke_1501.sl
@@ -204,21 +204,26 @@ manifest_paths: list[str] = []
 rows: list[dict[str, object]] = []
 
 def classify(candidate: dict[str, object]) -> str:
+    attribution = candidate.get("failure_attribution")
+    if isinstance(attribution, dict):
+        primary = str(attribution.get("primary_failure") or "")
+        status = str(attribution.get("status") or "")
+        if primary == "invalid_candidate" or status == "not_evaluated":
+            return "invalid_candidate"
+        if primary == "success":
+            return "success"
+        if primary in {"collision", "near_miss", "timeout", "comfort_violation", "incomplete"}:
+            return "valid_behavioral_failure"
+        if primary in {"evaluation_error", "simulation_error"}:
+            return "simulation_error"
+
+    certification = candidate.get("certification_status")
+    if isinstance(certification, dict) and str(certification.get("status") or "") != "passed":
+        return "invalid_candidate"
+
     if candidate.get("error"):
         return "simulation_error"
-    attribution = candidate.get("failure_attribution")
-    if not isinstance(attribution, dict):
-        return "simulation_error"
-    primary = str(attribution.get("primary_failure") or "")
-    status = str(attribution.get("status") or "")
-    if primary == "invalid_candidate" or status == "not_evaluated":
-        return "invalid_candidate"
-    if primary == "success":
-        return "success"
-    if primary in {"collision", "near_miss", "timeout", "comfort_violation", "incomplete"}:
-        return "valid_behavioral_failure"
-    if primary == "evaluation_error":
-        return "simulation_error"
+
     return "simulation_error"
 
 for policy in policies:
@@ -276,8 +281,9 @@ payload = {
     "non_success_evidence": {
         "fallback": False,
         "degraded": False,
-        "simulation_error": False,
-        "not_available": False,
+        "invalid_candidate": total_counts["invalid_candidate"] > 0,
+        "simulation_error": executed_counts["simulation_error"] > 0,
+        "not_available": total_counts["not_available"] > 0,
     },
 }
 (campaign_root / "crossing_ttc" / "row_status_summary.json").write_text(

--- a/SLURM/Auxme/adversarial_smoke_1501.sl
+++ b/SLURM/Auxme/adversarial_smoke_1501.sl
@@ -211,9 +211,9 @@ def classify(candidate: dict[str, object]) -> str:
         if primary == "invalid_candidate" or status == "not_evaluated":
             return "invalid_candidate"
         if primary == "success":
-            return "success"
+            return "valid_non_failure"
         if primary in {"collision", "near_miss", "timeout", "comfort_violation", "incomplete"}:
-            return "valid_behavioral_failure"
+            return "valid_failure"
         if primary in {"evaluation_error", "simulation_error"}:
             return "simulation_error"
 
@@ -229,7 +229,7 @@ def classify(candidate: dict[str, object]) -> str:
 for policy in policies:
     for sampler in ("random", "optuna"):
         manifest_path = campaign_root / "crossing_ttc" / policy / sampler / "manifest.json"
-        manifest_paths.append(manifest_path.as_posix())
+        manifest_paths.append(manifest_path.relative_to(campaign_root).as_posix())
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         counts: Counter[str] = Counter()
         for candidate in manifest.get("candidates", []):
@@ -242,7 +242,7 @@ for policy in policies:
                 "policy": policy,
                 "sampler": sampler,
                 "availability_status": "available",
-                "manifest_path": manifest_path.as_posix(),
+                "manifest_path": manifest_path.relative_to(campaign_root).as_posix(),
                 "counts": dict(sorted(counts.items())),
             }
         )
@@ -275,12 +275,15 @@ payload = {
     "executed_samplers": ["random", "optuna"],
     "design_exclusion_samplers": ["guided_route_search"],
     "manifest_paths": manifest_paths,
-    "archive_path": (campaign_root / "crossing_ttc" / "archive.json").as_posix(),
+    "archive_path": (campaign_root / "crossing_ttc" / "archive.json")
+    .relative_to(campaign_root)
+    .as_posix(),
     "counts": dict(sorted(total_counts.items())),
     "rows": rows,
     "non_success_evidence": {
-        "fallback": False,
-        "degraded": False,
+        "fallback": total_counts["fallback"] > 0,
+        "degraded": total_counts["degraded"] > 0,
+        "valid_failure": total_counts["valid_failure"] > 0,
         "invalid_candidate": total_counts["invalid_candidate"] > 0,
         "simulation_error": executed_counts["simulation_error"] > 0,
         "not_available": total_counts["not_available"] > 0,

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -74,5 +74,7 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   for the pre-Slurm oracle-imitation launch-packet validator.
 - `issue_1318_teb_corridor_deadlock_2026-05-20/`: compact TEB/ORCA/hybrid-rule
   classic-merging corridor-deadlock comparison summary for issue #1318.
+- `issue_1501_adversarial_smoke_2026-05-28/`: compact row-status, sampler-comparison, failure
+  archive, and checksum evidence for the first `crossing_ttc` adversarial smoke job.
 - `camera_ready_all_planners_2026-05-04/`: compact camera-ready all-planners campaign summaries and
   reports from the May 4 run.

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json
@@ -1,0 +1,831 @@
+{
+  "clusters": [
+    {
+      "cluster_id": "cluster_0000",
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "mechanism": {
+        "primary_failure": "collision",
+        "termination_reason": "collision"
+      },
+      "member_archive_ids": [
+        "failure_0000",
+        "failure_0001",
+        "failure_0002",
+        "failure_0003",
+        "failure_0004",
+        "failure_0005",
+        "failure_0006",
+        "failure_0007"
+      ],
+      "member_count": 8,
+      "representative_archive_id": "failure_0002"
+    },
+    {
+      "cluster_id": "cluster_0001",
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "mechanism": {
+        "primary_failure": "collision",
+        "termination_reason": "collision"
+      },
+      "member_archive_ids": [
+        "failure_0008",
+        "failure_0009",
+        "failure_0010",
+        "failure_0011",
+        "failure_0012",
+        "failure_0013",
+        "failure_0014"
+      ],
+      "member_count": 7,
+      "representative_archive_id": "failure_0010"
+    }
+  ],
+  "config": {
+    "grouping": [
+      "config.policy",
+      "config.scenario_template",
+      "failure_attribution.primary_failure",
+      "failure_attribution.details.termination_reason"
+    ],
+    "representative": "smallest normalized perturbation, then highest objective",
+    "selection": {
+      "failure_attribution.primary_failure": "not null, not empty, status is not not_evaluated, and primary_failure is not one of invalid_candidate, simulation_error, success"
+    },
+    "source_manifests": [
+      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json"
+    ]
+  },
+  "created_at": "2026-05-28T15:11:26.622012+00:00",
+  "entries": [
+    {
+      "archive_id": "failure_0000",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.730034241214364,
+          "y": 3.344354558952352
+        },
+        "pedestrian_delay_s": 1.7934945394817252,
+        "pedestrian_speed_mps": 0.9653352659893712,
+        "scenario_seed": 286,
+        "spawn_time_s": 1.2575715917643224,
+        "start": {
+          "theta": 0.0,
+          "x": 2.906080441973483,
+          "y": 2.8239059667727173
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.828256,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/scenario.yaml",
+      "source_candidate_index": 5,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0001",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.219119742518092,
+          "y": 3.0800689283633123
+        },
+        "pedestrian_delay_s": 1.5914777296320883,
+        "pedestrian_speed_mps": 0.9194968859736211,
+        "scenario_seed": 361,
+        "spawn_time_s": 0.41216370182660356,
+        "start": {
+          "theta": 0.0,
+          "x": 2.3402903294047634,
+          "y": 3.409431215761083
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.414951,
+      "objective_value": 11.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/scenario.yaml",
+      "source_candidate_index": 7,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0002",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.288956756845657,
+          "y": 2.807913333960939
+        },
+        "pedestrian_delay_s": 1.1762080853167522,
+        "pedestrian_speed_mps": 0.9460388097685773,
+        "scenario_seed": 320,
+        "spawn_time_s": 0.6205390536891795,
+        "start": {
+          "theta": 0.0,
+          "x": 2.3119256556477077,
+          "y": 2.5992335516140495
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.342348,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/scenario.yaml",
+      "source_candidate_index": 8,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0003",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.390521733910186,
+          "y": 2.2054855571464236
+        },
+        "pedestrian_delay_s": 1.7993472387348255,
+        "pedestrian_speed_mps": 1.1020037797356692,
+        "scenario_seed": 278,
+        "spawn_time_s": 1.8872848563685822,
+        "start": {
+          "theta": 0.0,
+          "x": 2.495541223585726,
+          "y": 3.4402932957084458
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.907091,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/scenario.yaml",
+      "source_candidate_index": 9,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0004",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.489914251064459,
+          "y": 2.2112344128051653
+        },
+        "pedestrian_delay_s": 1.9385110076621117,
+        "pedestrian_speed_mps": 1.0006933949317594,
+        "scenario_seed": 730,
+        "spawn_time_s": 0.014618987447849507,
+        "start": {
+          "theta": 0.0,
+          "x": 2.288740993227627,
+          "y": 2.4094124323413104
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 2.206461,
+      "objective_value": 21.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/scenario.yaml",
+      "source_candidate_index": 15,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0005",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.423596410884164,
+          "y": 3.0785921775589165
+        },
+        "pedestrian_delay_s": 0.6234325826017899,
+        "pedestrian_speed_mps": 0.9206906380338176,
+        "scenario_seed": 787,
+        "spawn_time_s": 1.4598621381799524,
+        "start": {
+          "theta": 0.0,
+          "x": 2.744866082170515,
+          "y": 2.846275880401774
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.493857,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/scenario.yaml",
+      "source_candidate_index": 19,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0006",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.3669760715744665,
+          "y": 2.9252561368019347
+        },
+        "pedestrian_delay_s": 1.6160444894634052,
+        "pedestrian_speed_mps": 0.8452309330245736,
+        "scenario_seed": 976,
+        "spawn_time_s": 1.7489719081411599,
+        "start": {
+          "theta": 0.0,
+          "x": 2.0725715078206886,
+          "y": 2.2803645941895487
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.857111,
+      "objective_value": 15.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/scenario.yaml",
+      "source_candidate_index": 25,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0007",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.113759159457369,
+          "y": 3.0156569939868367
+        },
+        "pedestrian_delay_s": 0.13592172675151448,
+        "pedestrian_speed_mps": 0.8411127996222755,
+        "scenario_seed": 982,
+        "spawn_time_s": 1.702685090688243,
+        "start": {
+          "theta": 0.0,
+          "x": 2.8387742616641507,
+          "y": 3.062252270541083
+        }
+      },
+      "cluster_key": {
+        "policy": "goal",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 2.116323,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/scenario.yaml",
+      "source_candidate_index": 30,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0008",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.730034241214364,
+          "y": 3.344354558952352
+        },
+        "pedestrian_delay_s": 1.7934945394817252,
+        "pedestrian_speed_mps": 0.9653352659893712,
+        "scenario_seed": 286,
+        "spawn_time_s": 1.2575715917643224,
+        "start": {
+          "theta": 0.0,
+          "x": 2.906080441973483,
+          "y": 2.8239059667727173
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.828256,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/scenario.yaml",
+      "source_candidate_index": 5,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0009",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.219119742518092,
+          "y": 3.0800689283633123
+        },
+        "pedestrian_delay_s": 1.5914777296320883,
+        "pedestrian_speed_mps": 0.9194968859736211,
+        "scenario_seed": 361,
+        "spawn_time_s": 0.41216370182660356,
+        "start": {
+          "theta": 0.0,
+          "x": 2.3402903294047634,
+          "y": 3.409431215761083
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.414951,
+      "objective_value": 11.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/scenario.yaml",
+      "source_candidate_index": 7,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0010",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.288956756845657,
+          "y": 2.807913333960939
+        },
+        "pedestrian_delay_s": 1.1762080853167522,
+        "pedestrian_speed_mps": 0.9460388097685773,
+        "scenario_seed": 320,
+        "spawn_time_s": 0.6205390536891795,
+        "start": {
+          "theta": 0.0,
+          "x": 2.3119256556477077,
+          "y": 2.5992335516140495
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.342348,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/scenario.yaml",
+      "source_candidate_index": 8,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0011",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.390521733910186,
+          "y": 2.2054855571464236
+        },
+        "pedestrian_delay_s": 1.7993472387348255,
+        "pedestrian_speed_mps": 1.1020037797356692,
+        "scenario_seed": 278,
+        "spawn_time_s": 1.8872848563685822,
+        "start": {
+          "theta": 0.0,
+          "x": 2.495541223585726,
+          "y": 3.4402932957084458
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.907091,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/scenario.yaml",
+      "source_candidate_index": 9,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0012",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 8.489914251064459,
+          "y": 2.2112344128051653
+        },
+        "pedestrian_delay_s": 1.9385110076621117,
+        "pedestrian_speed_mps": 1.0006933949317594,
+        "scenario_seed": 730,
+        "spawn_time_s": 0.014618987447849507,
+        "start": {
+          "theta": 0.0,
+          "x": 2.288740993227627,
+          "y": 2.4094124323413104
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 2.206461,
+      "objective_value": 13.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/scenario.yaml",
+      "source_candidate_index": 15,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0013",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.3669760715744665,
+          "y": 2.9252561368019347
+        },
+        "pedestrian_delay_s": 1.6160444894634052,
+        "pedestrian_speed_mps": 0.8452309330245736,
+        "scenario_seed": 976,
+        "spawn_time_s": 1.7489719081411599,
+        "start": {
+          "theta": 0.0,
+          "x": 2.0725715078206886,
+          "y": 2.2803645941895487
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 1.857111,
+      "objective_value": 12.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/scenario.yaml",
+      "source_candidate_index": 25,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/trajectory.csv"
+    },
+    {
+      "archive_id": "failure_0014",
+      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030",
+      "candidate": {
+        "goal": {
+          "theta": 0.0,
+          "x": 7.113759159457369,
+          "y": 3.0156569939868367
+        },
+        "pedestrian_delay_s": 0.13592172675151448,
+        "pedestrian_speed_mps": 0.8411127996222755,
+        "scenario_seed": 982,
+        "spawn_time_s": 1.702685090688243,
+        "start": {
+          "theta": 0.0,
+          "x": 2.8387742616641507,
+          "y": 3.062252270541083
+        }
+      },
+      "cluster_key": {
+        "policy": "orca",
+        "primary_failure": "collision",
+        "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+        "termination_reason": "collision"
+      },
+      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/episode_records.jsonl",
+      "failure_attribution": {
+        "details": {
+          "outcome": {
+            "collision_event": true,
+            "route_complete": false,
+            "timeout_event": false
+          },
+          "status": "collision",
+          "termination_reason": "collision"
+        },
+        "primary_failure": "collision",
+        "reasons": [
+          "episode outcome reports a collision"
+        ],
+        "status": "attributed"
+      },
+      "normalized_perturbation": 2.116323,
+      "objective_value": 10.0,
+      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/scenario.yaml",
+      "source_candidate_index": 30,
+      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/trajectory.csv"
+    }
+  ],
+  "schema_version": "adversarial_failure_archive.v1",
+  "summary": {
+    "archived_failure_count": 15,
+    "cluster_count": 2,
+    "source_candidate_count": 128,
+    "source_manifest_count": 4
+  }
+}

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json
@@ -62,17 +62,17 @@
       "failure_attribution.primary_failure": "not null, not empty, status is not not_evaluated, and primary_failure is not one of invalid_candidate, simulation_error, success"
     },
     "source_manifests": [
-      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
-      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json"
+      "crossing_ttc/goal/optuna/manifest.json",
+      "crossing_ttc/goal/random/manifest.json",
+      "crossing_ttc/orca/optuna/manifest.json",
+      "crossing_ttc/orca/random/manifest.json"
     ]
   },
   "created_at": "2026-05-28T15:11:26.622012+00:00",
   "entries": [
     {
       "archive_id": "failure_0000",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005",
+      "bundle_path": "crossing_ttc/goal/optuna/candidate_0005",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -95,7 +95,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/optuna/candidate_0005/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -114,15 +114,15 @@
       },
       "normalized_perturbation": 1.828256,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/optuna/candidate_0005/scenario.yaml --out crossing_ttc/goal/optuna/candidate_0005/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/optuna/candidate_0005/scenario.yaml",
       "source_candidate_index": 5,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0005/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/optuna/candidate_0005/trajectory.csv"
     },
     {
       "archive_id": "failure_0001",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007",
+      "bundle_path": "crossing_ttc/goal/optuna/candidate_0007",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -145,7 +145,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/optuna/candidate_0007/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -164,15 +164,15 @@
       },
       "normalized_perturbation": 1.414951,
       "objective_value": 11.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/optuna/candidate_0007/scenario.yaml --out crossing_ttc/goal/optuna/candidate_0007/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/optuna/candidate_0007/scenario.yaml",
       "source_candidate_index": 7,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0007/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/optuna/candidate_0007/trajectory.csv"
     },
     {
       "archive_id": "failure_0002",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008",
+      "bundle_path": "crossing_ttc/goal/optuna/candidate_0008",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -195,7 +195,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/optuna/candidate_0008/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -214,15 +214,15 @@
       },
       "normalized_perturbation": 1.342348,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/optuna/candidate_0008/scenario.yaml --out crossing_ttc/goal/optuna/candidate_0008/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/optuna/candidate_0008/scenario.yaml",
       "source_candidate_index": 8,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0008/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/optuna/candidate_0008/trajectory.csv"
     },
     {
       "archive_id": "failure_0003",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009",
+      "bundle_path": "crossing_ttc/goal/optuna/candidate_0009",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -245,7 +245,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/optuna/candidate_0009/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -264,15 +264,15 @@
       },
       "normalized_perturbation": 1.907091,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/optuna/candidate_0009/scenario.yaml --out crossing_ttc/goal/optuna/candidate_0009/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/optuna/candidate_0009/scenario.yaml",
       "source_candidate_index": 9,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0009/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/optuna/candidate_0009/trajectory.csv"
     },
     {
       "archive_id": "failure_0004",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015",
+      "bundle_path": "crossing_ttc/goal/optuna/candidate_0015",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -295,7 +295,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/optuna/candidate_0015/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -314,15 +314,15 @@
       },
       "normalized_perturbation": 2.206461,
       "objective_value": 21.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/optuna/candidate_0015/scenario.yaml --out crossing_ttc/goal/optuna/candidate_0015/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/optuna/candidate_0015/scenario.yaml",
       "source_candidate_index": 15,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/optuna/candidate_0015/trajectory.csv"
     },
     {
       "archive_id": "failure_0005",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019",
+      "bundle_path": "crossing_ttc/goal/random/candidate_0019",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -345,7 +345,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/random/candidate_0019/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -364,15 +364,15 @@
       },
       "normalized_perturbation": 1.493857,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/random/candidate_0019/scenario.yaml --out crossing_ttc/goal/random/candidate_0019/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/random/candidate_0019/scenario.yaml",
       "source_candidate_index": 19,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0019/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/random/candidate_0019/trajectory.csv"
     },
     {
       "archive_id": "failure_0006",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025",
+      "bundle_path": "crossing_ttc/goal/random/candidate_0025",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -395,7 +395,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/random/candidate_0025/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -414,15 +414,15 @@
       },
       "normalized_perturbation": 1.857111,
       "objective_value": 15.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/random/candidate_0025/scenario.yaml --out crossing_ttc/goal/random/candidate_0025/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/random/candidate_0025/scenario.yaml",
       "source_candidate_index": 25,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/random/candidate_0025/trajectory.csv"
     },
     {
       "archive_id": "failure_0007",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030",
+      "bundle_path": "crossing_ttc/goal/random/candidate_0030",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -445,7 +445,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/goal/random/candidate_0030/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -464,15 +464,15 @@
       },
       "normalized_perturbation": 2.116323,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/episode_records_replay.jsonl --algo goal --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/goal/random/candidate_0030/scenario.yaml --out crossing_ttc/goal/random/candidate_0030/episode_records_replay.jsonl --algo goal --no-video",
+      "scenario_yaml_path": "crossing_ttc/goal/random/candidate_0030/scenario.yaml",
       "source_candidate_index": 30,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0030/trajectory.csv"
+      "source_manifest": "crossing_ttc/goal/random/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/goal/random/candidate_0030/trajectory.csv"
     },
     {
       "archive_id": "failure_0008",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005",
+      "bundle_path": "crossing_ttc/orca/optuna/candidate_0005",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -495,7 +495,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/optuna/candidate_0005/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -514,15 +514,15 @@
       },
       "normalized_perturbation": 1.828256,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/optuna/candidate_0005/scenario.yaml --out crossing_ttc/orca/optuna/candidate_0005/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/optuna/candidate_0005/scenario.yaml",
       "source_candidate_index": 5,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0005/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/optuna/candidate_0005/trajectory.csv"
     },
     {
       "archive_id": "failure_0009",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007",
+      "bundle_path": "crossing_ttc/orca/optuna/candidate_0007",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -545,7 +545,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/optuna/candidate_0007/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -564,15 +564,15 @@
       },
       "normalized_perturbation": 1.414951,
       "objective_value": 11.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/optuna/candidate_0007/scenario.yaml --out crossing_ttc/orca/optuna/candidate_0007/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/optuna/candidate_0007/scenario.yaml",
       "source_candidate_index": 7,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0007/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/optuna/candidate_0007/trajectory.csv"
     },
     {
       "archive_id": "failure_0010",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008",
+      "bundle_path": "crossing_ttc/orca/optuna/candidate_0008",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -595,7 +595,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/optuna/candidate_0008/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -614,15 +614,15 @@
       },
       "normalized_perturbation": 1.342348,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/optuna/candidate_0008/scenario.yaml --out crossing_ttc/orca/optuna/candidate_0008/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/optuna/candidate_0008/scenario.yaml",
       "source_candidate_index": 8,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0008/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/optuna/candidate_0008/trajectory.csv"
     },
     {
       "archive_id": "failure_0011",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009",
+      "bundle_path": "crossing_ttc/orca/optuna/candidate_0009",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -645,7 +645,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/optuna/candidate_0009/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -664,15 +664,15 @@
       },
       "normalized_perturbation": 1.907091,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/optuna/candidate_0009/scenario.yaml --out crossing_ttc/orca/optuna/candidate_0009/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/optuna/candidate_0009/scenario.yaml",
       "source_candidate_index": 9,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0009/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/optuna/candidate_0009/trajectory.csv"
     },
     {
       "archive_id": "failure_0012",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015",
+      "bundle_path": "crossing_ttc/orca/optuna/candidate_0015",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -695,7 +695,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/optuna/candidate_0015/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -714,15 +714,15 @@
       },
       "normalized_perturbation": 2.206461,
       "objective_value": 13.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/optuna/candidate_0015/scenario.yaml --out crossing_ttc/orca/optuna/candidate_0015/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/optuna/candidate_0015/scenario.yaml",
       "source_candidate_index": 15,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/optuna/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/optuna/candidate_0015/trajectory.csv"
     },
     {
       "archive_id": "failure_0013",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025",
+      "bundle_path": "crossing_ttc/orca/random/candidate_0025",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -745,7 +745,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/random/candidate_0025/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -764,15 +764,15 @@
       },
       "normalized_perturbation": 1.857111,
       "objective_value": 12.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/random/candidate_0025/scenario.yaml --out crossing_ttc/orca/random/candidate_0025/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/random/candidate_0025/scenario.yaml",
       "source_candidate_index": 25,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/random/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/random/candidate_0025/trajectory.csv"
     },
     {
       "archive_id": "failure_0014",
-      "bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030",
+      "bundle_path": "crossing_ttc/orca/random/candidate_0030",
       "candidate": {
         "goal": {
           "theta": 0.0,
@@ -795,7 +795,7 @@
         "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
         "termination_reason": "collision"
       },
-      "episode_record_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/episode_records.jsonl",
+      "episode_record_path": "crossing_ttc/orca/random/candidate_0030/episode_records.jsonl",
       "failure_attribution": {
         "details": {
           "outcome": {
@@ -814,11 +814,11 @@
       },
       "normalized_perturbation": 2.116323,
       "objective_value": 10.0,
-      "replay_command": "uv run robot_sf_bench run --matrix /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/scenario.yaml --out /home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/episode_records_replay.jsonl --algo orca --no-video",
-      "scenario_yaml_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/scenario.yaml",
+      "replay_command": "uv run robot_sf_bench run --matrix crossing_ttc/orca/random/candidate_0030/scenario.yaml --out crossing_ttc/orca/random/candidate_0030/episode_records_replay.jsonl --algo orca --no-video",
+      "scenario_yaml_path": "crossing_ttc/orca/random/candidate_0030/scenario.yaml",
       "source_candidate_index": 30,
-      "source_manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
-      "trajectory_csv_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0030/trajectory.csv"
+      "source_manifest": "crossing_ttc/orca/random/manifest.json",
+      "trajectory_csv_path": "crossing_ttc/orca/random/candidate_0030/trajectory.csv"
     }
   ],
   "schema_version": "adversarial_failure_archive.v1",

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
@@ -1,0 +1,12 @@
+# Issue #1501 Adversarial Smoke Evidence Checksums
+
+Date: 2026-05-28
+
+These checksums identify the compact evidence copied from SLURM job `12656`.
+
+| SHA256 | Path |
+|---|---|
+| `6beb6ca4c82b51613b79e23c89b6d5b1c21f03a2b14e23f58cda5bc7fb28cee1` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json` |
+| `7f9cc9b00df845bc398ef69aa730f92827b8707819909c0915e82a1225954abd` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json` |
+| `257651f0be993eb951bc861fe9dcd127a7f409c940e400bb8cf26e3cb95d162c` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json` |
+| `3c26cfeb571133e7f6e90f460171e75100c5938c54fa414b49559063f3459892` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json` |

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
@@ -6,7 +6,7 @@ These checksums identify the compact evidence copied from SLURM job `12656`.
 
 | SHA256 | Path |
 |---|---|
-| `6beb6ca4c82b51613b79e23c89b6d5b1c21f03a2b14e23f58cda5bc7fb28cee1` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json` |
-| `7f9cc9b00df845bc398ef69aa730f92827b8707819909c0915e82a1225954abd` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json` |
-| `257651f0be993eb951bc861fe9dcd127a7f409c940e400bb8cf26e3cb95d162c` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json` |
-| `b0cdf3be054cea6637f0907075d55d6ab6b67a65831f6c313a2c1cf5db124f83` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json` |
+| `a7da3bf59cb57cbe8231cbac75e184222950037cf24c184a9eac729223a4b393` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json` |
+| `27e48513763c55c869773a0aab9cae23cf85560418d653cd85ab4d4a1da577c5` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json` |
+| `67b615db355274298a63797c7ae5908eca910b2a114dbefc95b14d17fd4b895b` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json` |
+| `c824896ba538c843be3168cf19d4bfba6ea37e8e0bde574dad2b0cf1a077ac84` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json` |

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/checksums.md
@@ -1,4 +1,4 @@
-# Issue #1501 Adversarial Smoke Evidence Checksums
+# Issue #1501 Adversarial Smoke Evidence Checksums (2026-05-28)
 
 Date: 2026-05-28
 
@@ -9,4 +9,4 @@ These checksums identify the compact evidence copied from SLURM job `12656`.
 | `6beb6ca4c82b51613b79e23c89b6d5b1c21f03a2b14e23f58cda5bc7fb28cee1` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/archive.json` |
 | `7f9cc9b00df845bc398ef69aa730f92827b8707819909c0915e82a1225954abd` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json` |
 | `257651f0be993eb951bc861fe9dcd127a7f409c940e400bb8cf26e3cb95d162c` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json` |
-| `3c26cfeb571133e7f6e90f460171e75100c5938c54fa414b49559063f3459892` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json` |
+| `b0cdf3be054cea6637f0907075d55d6ab6b67a65831f6c313a2c1cf5db124f83` | `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json` |

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json
@@ -1,9 +1,9 @@
 {
   "rows": [
     {
-      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025",
+      "best_bundle_path": "crossing_ttc/goal/random/candidate_0025",
       "best_objective_value": 15.0,
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "manifest_path": "crossing_ttc/goal/random/manifest.json",
       "num_candidates": 32,
       "num_failed_evaluations": 0,
       "num_invalid_candidates": 11,
@@ -11,9 +11,9 @@
       "sampler": "random"
     },
     {
-      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015",
+      "best_bundle_path": "crossing_ttc/goal/optuna/candidate_0015",
       "best_objective_value": 21.0,
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "manifest_path": "crossing_ttc/goal/optuna/manifest.json",
       "num_candidates": 32,
       "num_failed_evaluations": 0,
       "num_invalid_candidates": 22,

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/goal_sampler_comparison.json
@@ -1,0 +1,25 @@
+{
+  "rows": [
+    {
+      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/candidate_0025",
+      "best_objective_value": 15.0,
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "num_candidates": 32,
+      "num_failed_evaluations": 0,
+      "num_invalid_candidates": 11,
+      "num_valid_candidates": 21,
+      "sampler": "random"
+    },
+    {
+      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/candidate_0015",
+      "best_objective_value": 21.0,
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "num_candidates": 32,
+      "num_failed_evaluations": 0,
+      "num_invalid_candidates": 22,
+      "num_valid_candidates": 10,
+      "sampler": "optuna"
+    }
+  ],
+  "schema_version": "adversarial-sampler-comparison.v1"
+}

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json
@@ -1,9 +1,9 @@
 {
   "rows": [
     {
-      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025",
+      "best_bundle_path": "crossing_ttc/orca/random/candidate_0025",
       "best_objective_value": 12.0,
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "manifest_path": "crossing_ttc/orca/random/manifest.json",
       "num_candidates": 32,
       "num_failed_evaluations": 0,
       "num_invalid_candidates": 11,
@@ -11,9 +11,9 @@
       "sampler": "random"
     },
     {
-      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015",
+      "best_bundle_path": "crossing_ttc/orca/optuna/candidate_0015",
       "best_objective_value": 13.0,
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "manifest_path": "crossing_ttc/orca/optuna/manifest.json",
       "num_candidates": 32,
       "num_failed_evaluations": 0,
       "num_invalid_candidates": 22,

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/orca_sampler_comparison.json
@@ -1,0 +1,25 @@
+{
+  "rows": [
+    {
+      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/candidate_0025",
+      "best_objective_value": 12.0,
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "num_candidates": 32,
+      "num_failed_evaluations": 0,
+      "num_invalid_candidates": 11,
+      "num_valid_candidates": 21,
+      "sampler": "random"
+    },
+    {
+      "best_bundle_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/candidate_0015",
+      "best_objective_value": 13.0,
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "num_candidates": 32,
+      "num_failed_evaluations": 0,
+      "num_invalid_candidates": 22,
+      "num_valid_candidates": 10,
+      "sampler": "optuna"
+    }
+  ],
+  "schema_version": "adversarial-sampler-comparison.v1"
+}

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
@@ -1,0 +1,100 @@
+{
+  "archive_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/archive.json",
+  "budget_per_sampler": 32,
+  "commit": "4bd5fb412d2bf023d26f674833dd379aedf8c17e",
+  "counts": {
+    "not_available": 1,
+    "simulation_error": 66,
+    "success": 47,
+    "valid_behavioral_failure": 15
+  },
+  "design_exclusion_samplers": [
+    "guided_route_search"
+  ],
+  "executed_policies": [
+    "goal",
+    "orca"
+  ],
+  "executed_samplers": [
+    "random",
+    "optuna"
+  ],
+  "family": "crossing_ttc",
+  "issue": 1501,
+  "manifest_paths": [
+    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json"
+  ],
+  "non_success_evidence": {
+    "degraded": false,
+    "fallback": false,
+    "not_available": false,
+    "simulation_error": false
+  },
+  "parent_issue": 1488,
+  "rows": [
+    {
+      "availability_status": "available",
+      "counts": {
+        "simulation_error": 11,
+        "success": 18,
+        "valid_behavioral_failure": 3
+      },
+      "family": "crossing_ttc",
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "policy": "goal",
+      "sampler": "random"
+    },
+    {
+      "availability_status": "available",
+      "counts": {
+        "simulation_error": 22,
+        "success": 5,
+        "valid_behavioral_failure": 5
+      },
+      "family": "crossing_ttc",
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "policy": "goal",
+      "sampler": "optuna"
+    },
+    {
+      "availability_status": "available",
+      "counts": {
+        "simulation_error": 11,
+        "success": 19,
+        "valid_behavioral_failure": 2
+      },
+      "family": "crossing_ttc",
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "policy": "orca",
+      "sampler": "random"
+    },
+    {
+      "availability_status": "available",
+      "counts": {
+        "simulation_error": 22,
+        "success": 5,
+        "valid_behavioral_failure": 5
+      },
+      "family": "crossing_ttc",
+      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "policy": "orca",
+      "sampler": "optuna"
+    },
+    {
+      "availability_status": "not_available",
+      "counts": {
+        "not_available": 1
+      },
+      "family": "crossing_ttc",
+      "policy": "all",
+      "reason": "guided_route_search is route-optimization based and is a design exclusion for the parametric crossing_ttc CandidateSpec family",
+      "sampler": "guided_route_search"
+    }
+  ],
+  "schema_version": "issue-1501-adversarial-smoke-summary.v1",
+  "seed": 42,
+  "synthetic": false
+}

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
@@ -1,12 +1,12 @@
 {
-  "archive_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/archive.json",
+  "archive_path": "crossing_ttc/archive.json",
   "budget_per_sampler": 32,
   "commit": "4bd5fb412d2bf023d26f674833dd379aedf8c17e",
   "counts": {
     "invalid_candidate": 66,
     "not_available": 1,
-    "success": 47,
-    "valid_behavioral_failure": 15
+    "valid_non_failure": 47,
+    "valid_failure": 15
   },
   "design_exclusion_samplers": [
     "guided_route_search"
@@ -22,17 +22,18 @@
   "family": "crossing_ttc",
   "issue": 1501,
   "manifest_paths": [
-    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
-    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
-    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
-    "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json"
+    "crossing_ttc/goal/random/manifest.json",
+    "crossing_ttc/goal/optuna/manifest.json",
+    "crossing_ttc/orca/random/manifest.json",
+    "crossing_ttc/orca/optuna/manifest.json"
   ],
   "non_success_evidence": {
     "degraded": false,
     "fallback": false,
     "invalid_candidate": true,
     "not_available": true,
-    "simulation_error": false
+    "simulation_error": false,
+    "valid_failure": true
   },
   "parent_issue": 1488,
   "rows": [
@@ -40,11 +41,11 @@
       "availability_status": "available",
       "counts": {
         "invalid_candidate": 11,
-        "success": 18,
-        "valid_behavioral_failure": 3
+        "valid_non_failure": 18,
+        "valid_failure": 3
       },
       "family": "crossing_ttc",
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/random/manifest.json",
+      "manifest_path": "crossing_ttc/goal/random/manifest.json",
       "policy": "goal",
       "sampler": "random"
     },
@@ -52,11 +53,11 @@
       "availability_status": "available",
       "counts": {
         "invalid_candidate": 22,
-        "success": 5,
-        "valid_behavioral_failure": 5
+        "valid_non_failure": 5,
+        "valid_failure": 5
       },
       "family": "crossing_ttc",
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/goal/optuna/manifest.json",
+      "manifest_path": "crossing_ttc/goal/optuna/manifest.json",
       "policy": "goal",
       "sampler": "optuna"
     },
@@ -64,11 +65,11 @@
       "availability_status": "available",
       "counts": {
         "invalid_candidate": 11,
-        "success": 19,
-        "valid_behavioral_failure": 2
+        "valid_non_failure": 19,
+        "valid_failure": 2
       },
       "family": "crossing_ttc",
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/random/manifest.json",
+      "manifest_path": "crossing_ttc/orca/random/manifest.json",
       "policy": "orca",
       "sampler": "random"
     },
@@ -76,11 +77,11 @@
       "availability_status": "available",
       "counts": {
         "invalid_candidate": 22,
-        "success": 5,
-        "valid_behavioral_failure": 5
+        "valid_non_failure": 5,
+        "valid_failure": 5
       },
       "family": "crossing_ttc",
-      "manifest_path": "/home/luttkule/git/robot_sf_ll7.worktrees/1501-adversarial-smoke/output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/crossing_ttc/orca/optuna/manifest.json",
+      "manifest_path": "crossing_ttc/orca/optuna/manifest.json",
       "policy": "orca",
       "sampler": "optuna"
     },

--- a/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
+++ b/docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/row_status_summary.json
@@ -3,8 +3,8 @@
   "budget_per_sampler": 32,
   "commit": "4bd5fb412d2bf023d26f674833dd379aedf8c17e",
   "counts": {
+    "invalid_candidate": 66,
     "not_available": 1,
-    "simulation_error": 66,
     "success": 47,
     "valid_behavioral_failure": 15
   },
@@ -30,7 +30,8 @@
   "non_success_evidence": {
     "degraded": false,
     "fallback": false,
-    "not_available": false,
+    "invalid_candidate": true,
+    "not_available": true,
     "simulation_error": false
   },
   "parent_issue": 1488,
@@ -38,7 +39,7 @@
     {
       "availability_status": "available",
       "counts": {
-        "simulation_error": 11,
+        "invalid_candidate": 11,
         "success": 18,
         "valid_behavioral_failure": 3
       },
@@ -50,7 +51,7 @@
     {
       "availability_status": "available",
       "counts": {
-        "simulation_error": 22,
+        "invalid_candidate": 22,
         "success": 5,
         "valid_behavioral_failure": 5
       },
@@ -62,7 +63,7 @@
     {
       "availability_status": "available",
       "counts": {
-        "simulation_error": 11,
+        "invalid_candidate": 11,
         "success": 19,
         "valid_behavioral_failure": 2
       },
@@ -74,7 +75,7 @@
     {
       "availability_status": "available",
       "counts": {
-        "simulation_error": 22,
+        "invalid_candidate": 22,
         "success": 5,
         "valid_behavioral_failure": 5
       },

--- a/docs/context/issue_1501_adversarial_smoke_run.md
+++ b/docs/context/issue_1501_adversarial_smoke_run.md
@@ -1,0 +1,144 @@
+# Issue #1501 Adversarial Smoke Run (2026-05-28)
+
+Date: 2026-05-28
+
+Related issues:
+
+- <https://github.com/ll7/robot_sf_ll7/issues/1501>
+- <https://github.com/ll7/robot_sf_ll7/issues/1488>
+- <https://github.com/ll7/robot_sf_ll7/issues/1571>
+- <https://github.com/ll7/robot_sf_ll7/issues/1500>
+- <https://github.com/ll7/robot_sf_ll7/issues/691>
+
+## Scope
+
+This note records the first executable `crossing_ttc` smoke for #1501. It follows the scope
+clarified in `docs/context/issue_1571_adversarial_smoke_packet_sharpening.md`:
+
+- run only `crossing_ttc`,
+- run `random` and `optuna` samplers,
+- map the frozen `classic_global_theta_star` planner row to the current `goal` benchmark policy,
+- run the `orca` row directly,
+- record `guided_route_search` as a `not_available` design exclusion for this family,
+- keep `simulation_error` and `not_available` separate from success evidence.
+
+## Launcher And Job
+
+- Branch: `issue-1501-adversarial-smoke`
+- Commit: `4bd5fb412d2bf023d26f674833dd379aedf8c17e`
+- Launcher: `SLURM/Auxme/adversarial_smoke_1501.sl`
+- Submitted job: `12656`
+- SLURM result: `COMPLETED`, exit code `0:0`, partition `a30`, elapsed `00:01:59`
+- Label: `issue1501-crossing-ttc-20260528-g4bd5fb41`
+- Budget: 32 candidates per sampler
+- Seed: 42
+
+Command:
+
+```bash
+ADVERSARIAL_SMOKE_LABEL=issue1501-crossing-ttc-20260528-g4bd5fb41 \
+ADVERSARIAL_SMOKE_BUDGET=32 \
+ADVERSARIAL_SMOKE_SEED=42 \
+scripts/dev/sbatch_use_max_time.sh --time 04:00:00 --partition a30 --qos a30-gpu \
+  SLURM/Auxme/adversarial_smoke_1501.sl
+```
+
+## Outputs
+
+Worktree-local output root:
+
+`output/adversarial/issue_1501/issue1501-crossing-ttc-20260528-g4bd5fb41/`
+
+Synced SLURM output root:
+
+`output/slurm/adversarial-smoke1501-job-12656/`
+
+Compact tracked evidence:
+
+`docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/`
+
+Tracked files:
+
+- `row_status_summary.json`
+- `goal_sampler_comparison.json`
+- `orca_sampler_comparison.json`
+- `archive.json`
+- `checksums.md`
+
+Raw candidate bundles, trajectories, episode records, and the full SLURM log remain under ignored
+`output/`.
+
+## Row Status Summary
+
+The run produced four executed rows plus one design-exclusion row.
+
+| Policy | Sampler | Status | Success | Valid Behavioral Failure | Simulation Error | Not Available |
+|---|---|---|---:|---:|---:|---:|
+| `goal` | `random` | available | 18 | 3 | 11 | 0 |
+| `goal` | `optuna` | available | 5 | 5 | 22 | 0 |
+| `orca` | `random` | available | 19 | 2 | 11 | 0 |
+| `orca` | `optuna` | available | 5 | 5 | 22 | 0 |
+| `all` | `guided_route_search` | not_available | 0 | 0 | 0 | 1 |
+
+Aggregate counts:
+
+- `success`: 47
+- `valid_behavioral_failure`: 15
+- `simulation_error`: 66
+- `not_available`: 1
+
+`simulation_error` and `not_available` rows do not count as success evidence.
+
+## Sampler Comparison
+
+Best objective values reported by `scripts/tools/compare_adversarial_samplers.py`:
+
+| Policy | Sampler | Best Objective | Valid Candidates | Invalid Candidates | Failed Evaluations |
+|---|---|---:|---:|---:|---:|
+| `goal` | `random` | 15 | 21 | 11 | 0 |
+| `goal` | `optuna` | 21 | 10 | 22 | 0 |
+| `orca` | `random` | 12 | 21 | 11 | 0 |
+| `orca` | `optuna` | 13 | 10 | 22 | 0 |
+
+The Optuna rows found the highest objective values for both policies, but also produced more
+simulation-error rows in this bounded smoke.
+
+## Failure Archive
+
+The curated archive has schema `adversarial_failure_archive.v1` and contains:
+
+- `source_candidate_count`: 128
+- `source_manifest_count`: 4
+- `archived_failure_count`: 15
+- `cluster_count`: 2
+
+Clusters:
+
+| Cluster | Policy | Primary Failure | Termination | Members | Representative |
+|---|---|---|---|---:|---|
+| `cluster_0000` | `goal` | collision | collision | 8 | `failure_0002` |
+| `cluster_0001` | `orca` | collision | collision | 7 | `failure_0010` |
+
+## Validation And Limits
+
+Pre-submit checks:
+
+- `bash -n SLURM/Auxme/adversarial_smoke_1501.sl`
+- `scripts/dev/sbatch_use_max_time.sh --dry-run --partition a30 --qos a30-gpu SLURM/Auxme/adversarial_smoke_1501.sl`
+- direct synthetic one-policy preflight with `compare_adversarial_samplers.py`
+- full wrapper synthetic preflight with `ADVERSARIAL_SMOKE_SYNTHETIC=true ADVERSARIAL_SMOKE_BUDGET=1`
+- `git diff --check`
+
+Runtime proof:
+
+- SLURM job `12656` completed with exit code `0:0`.
+- Four available `crossing_ttc` policy x sampler rows emitted manifests.
+- The archive builder completed and found two collision clusters.
+
+Limitations:
+
+- This is a smoke/execution packet, not paper-facing benchmark evidence.
+- Replay determinism checks are represented by replay commands in the archive entries, but were not
+  run as a separate verification sweep in this job.
+- The high simulation-error count is part of the row-status evidence and should be interpreted as a
+  candidate-generation/runtime quality signal, not successful stress evidence.

--- a/docs/context/issue_1501_adversarial_smoke_run.md
+++ b/docs/context/issue_1501_adversarial_smoke_run.md
@@ -72,22 +72,23 @@ Raw candidate bundles, trajectories, episode records, and the full SLURM log rem
 
 The run produced four executed rows plus one design-exclusion row.
 
-| Policy | Sampler | Status | Success | Valid Behavioral Failure | Simulation Error | Not Available |
+| Policy | Sampler | Status | Success | Valid Behavioral Failure | Invalid Candidate | Simulation Error | Not Available |
 |---|---|---|---:|---:|---:|---:|
-| `goal` | `random` | available | 18 | 3 | 11 | 0 |
-| `goal` | `optuna` | available | 5 | 5 | 22 | 0 |
-| `orca` | `random` | available | 19 | 2 | 11 | 0 |
-| `orca` | `optuna` | available | 5 | 5 | 22 | 0 |
-| `all` | `guided_route_search` | not_available | 0 | 0 | 0 | 1 |
+| `goal` | `random` | available | 18 | 3 | 11 | 0 | 0 |
+| `goal` | `optuna` | available | 5 | 5 | 22 | 0 | 0 |
+| `orca` | `random` | available | 19 | 2 | 11 | 0 | 0 |
+| `orca` | `optuna` | available | 5 | 5 | 22 | 0 | 0 |
+| `all` | `guided_route_search` | not_available | 0 | 0 | 0 | 0 | 1 |
 
 Aggregate counts:
 
 - `success`: 47
 - `valid_behavioral_failure`: 15
-- `simulation_error`: 66
+- `invalid_candidate`: 66
+- `simulation_error`: 0
 - `not_available`: 1
 
-`simulation_error` and `not_available` rows do not count as success evidence.
+`invalid_candidate`, `simulation_error`, and `not_available` rows do not count as success evidence.
 
 ## Sampler Comparison
 

--- a/docs/context/issue_1501_adversarial_smoke_run.md
+++ b/docs/context/issue_1501_adversarial_smoke_run.md
@@ -72,8 +72,8 @@ Raw candidate bundles, trajectories, episode records, and the full SLURM log rem
 
 The run produced four executed rows plus one design-exclusion row.
 
-| Policy | Sampler | Status | Success | Valid Behavioral Failure | Invalid Candidate | Simulation Error | Not Available |
-|---|---|---|---:|---:|---:|---:|
+| Policy | Sampler | Status | Valid Non-Failure | Valid Failure | Invalid Candidate | Simulation Error | Not Available |
+|---|---|---|---:|---:|---:|---:|---:|
 | `goal` | `random` | available | 18 | 3 | 11 | 0 | 0 |
 | `goal` | `optuna` | available | 5 | 5 | 22 | 0 | 0 |
 | `orca` | `random` | available | 19 | 2 | 11 | 0 | 0 |
@@ -82,13 +82,13 @@ The run produced four executed rows plus one design-exclusion row.
 
 Aggregate counts:
 
-- `success`: 47
-- `valid_behavioral_failure`: 15
+- `valid_non_failure`: 47
+- `valid_failure`: 15
 - `invalid_candidate`: 66
 - `simulation_error`: 0
 - `not_available`: 1
 
-`invalid_candidate`, `simulation_error`, and `not_available` rows do not count as success evidence.
+`valid_failure`, `invalid_candidate`, `simulation_error`, `fallback`, `degraded`, and `not_available` rows do not count as success evidence.
 
 ## Sampler Comparison
 
@@ -102,7 +102,7 @@ Best objective values reported by `scripts/tools/compare_adversarial_samplers.py
 | `orca` | `optuna` | 13 | 10 | 22 | 0 |
 
 The Optuna rows found the highest objective values for both policies, but also produced more
-simulation-error rows in this bounded smoke.
+invalid-candidate rows in this bounded smoke.
 
 ## Failure Archive
 
@@ -141,5 +141,5 @@ Limitations:
 - This is a smoke/execution packet, not paper-facing benchmark evidence.
 - Replay determinism checks are represented by replay commands in the archive entries, but were not
   run as a separate verification sweep in this job.
-- The high simulation-error count is part of the row-status evidence and should be interpreted as a
-  candidate-generation/runtime quality signal, not successful stress evidence.
+- The high invalid-candidate count is part of the row-status evidence and should be interpreted as a
+  candidate-generation quality signal, not successful stress evidence.


### PR DESCRIPTION
## Summary

- Add `SLURM/Auxme/adversarial_smoke_1501.sl` for the bounded #1501 `crossing_ttc` smoke.
- Preserve compact job evidence under `docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/`.
- Add `docs/context/issue_1501_adversarial_smoke_run.md` with the SLURM job, row counts, archive summary, and limitations.

## Validation

- `bash -n SLURM/Auxme/adversarial_smoke_1501.sl`
- `scripts/dev/sbatch_use_max_time.sh --dry-run --partition a30 --qos a30-gpu SLURM/Auxme/adversarial_smoke_1501.sl`
- Direct synthetic one-policy preflight with `scripts/tools/compare_adversarial_samplers.py`
- Full wrapper synthetic preflight with `ADVERSARIAL_SMOKE_SYNTHETIC=true ADVERSARIAL_SMOKE_BUDGET=1`
- `git diff --check`
- SLURM job `12656`: `COMPLETED`, exit code `0:0`, partition `a30`, elapsed `00:01:59`
- `jq empty docs/context/evidence/issue_1501_adversarial_smoke_2026-05-28/*.json`

Closes #1501.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Issue `#1501` adversarial smoke testing campaign, including test methodology and results summary
  * Updated evidence bundle registry with new testing artifacts and checksums

* **Chores**
  * Added test automation infrastructure for adversarial scenario validation with multi-policy and multi-sampler comparison capabilities
  * Generated curated evidence archives and failure analysis artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->