### PR TITLE
docs: add tooling subtree index (#1590)

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -1,0 +1,26 @@
+# Documentation Tooling
+
+This subtree holds documentation-adjacent tooling and legacy assets that do not belong in the
+repository root.
+
+The relocation decision comes from the root-layout inventory in
+[docs/context/issue_1573_root_layout_inventory.md](../context/issue_1573_root_layout_inventory.md)
+and the low-risk tooling move tracked by Issue #1579.
+
+## Contents
+
+| Path | Status | Use |
+| --- | --- | --- |
+| [class_diagram/](class_diagram/) | generated docs tooling | Stores generated Pyreverse SVG class/package diagrams and the helper script that refreshes them from the repository root. |
+| [svg_conv/](svg_conv/) | legacy tooling | Preserves an older OpenStreetMap SVG-to-JSON converter plus sample files for historical reference. Prefer the maintained parser in [robot_sf/nav/svg_map_parser.py](../../robot_sf/nav/svg_map_parser.py) for current map ingestion work. |
+
+## Notes
+
+Run the UML helper from the repository root:
+
+```bash
+./docs/tooling/class_diagram/generate_uml.sh
+```
+
+Treat `svg_conv/` as compatibility/reference material, not the preferred implementation path for
+new SVG map parser features.


### PR DESCRIPTION
## Summary
Adds a local index for the newly relocated `docs/tooling/` subtree.

## Linked Issues
- Closes #1590
- Relates to #1579
- Relates to #1573

## What Changed
- Added `docs/tooling/README.md` with entries for `class_diagram/` and `svg_conv/`.
- Marked `svg_conv/` as legacy/reference material and pointed current map ingestion work to `robot_sf/nav/svg_map_parser.py`.
- Linked the root-layout inventory note.

## Why It Matters
- Added value: the relocated docs/tooling assets now have a discoverable local index.
- Expected impact: contributors can tell maintained generated-doc tooling from legacy conversion material.
- Why this is worth merging now: it finishes the documentation follow-up from the root tooling relocation without moving more paths.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `test -f docs/context/issue_1573_root_layout_inventory.md && test -f robot_sf/nav/svg_map_parser.py && test -x docs/tooling/class_diagram/generate_uml.sh`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Docs proof consistency passed for the changed file.
  - Referenced context/parser/script paths exist.
  - PR readiness passed on `ee05d53ae209476e7c1bbb61ac6490379b318d9e`: 4299 passed, 11 skipped, 8 warnings.
- Benchmarks or smoke tests, if applicable:
  - Not run; documentation-only index change.

## Risks / Rollout
- Compatibility risks: low; no runtime code or path movement.
- Failure modes: stale status wording if `svg_conv/` is revived later as maintained tooling.
- Rollback or fallback plan: remove `docs/tooling/README.md`; relocated files remain unchanged.

## Docs / Provenance
- Updated docs:
  - `docs/tooling/README.md`
- Relevant design or provenance notes:
  - `docs/context/issue_1573_root_layout_inventory.md`
- Any assumptions that need to be preserved:
  - `svg_conv/` remains legacy/reference material; `robot_sf/nav/svg_map_parser.py` is the maintained parser path.

## Follow-Up Issues
- Deferred work:
  - None for this scope.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Artifact classification: readiness generated ignored local artifacts under `output/coverage/*` and `output/validation/pr_ready/*`; none are promoted.
- Known limitations: this does not clean up duplicated historical rows in `docs/context/issue_1573_root_layout_inventory.md`, which are outside #1590.