### PR TITLE
docs: record high-risk root path decisions (#1583)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -102,7 +102,7 @@ knowledge, not every transient iteration detail.
   [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
 * Issue #1573 Root-Layout Inventory:
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
-* Issue #1583 high-risk root path boundaries:
+* Issue #1583 High-Risk Root Path Boundaries:
   [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -102,6 +102,8 @@ knowledge, not every transient iteration detail.
   [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
 * Issue #1573 Root-Layout Inventory:
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
+* Issue #1583 high-risk root path boundaries:
+  [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
 * Issue #1543 predictive v2 negative audit:

--- a/docs/context/issue_1573_root_layout_inventory.md
+++ b/docs/context/issue_1573_root_layout_inventory.md
@@ -6,6 +6,11 @@ This note is the conservative foundation slice for #1573. It inventories the can
 paths, records the local evidence checked on this branch, and makes an explicit action call for
 each path without performing a bulk directory move.
 
+High-risk root path migration boundaries are now split to
+[issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md). That note keeps
+`.agent/`, `model_ped/`, `test_pygame/`, and `CITATION.cff` at root, and delegates any future
+`specs/` or `test_scenarios/` migration to dedicated follow-up issues.
+
 Scope boundary for this PR:
 
 - no first-level directory moves,
@@ -29,14 +34,12 @@ Action meanings:
 | --- | --- | --- | --- |
 | `.agent/` | `AGENTS.md` points to `.agent/PLANS.md` as the repo plan-writing convention. | `keep` | This is already part of the agent-context contract, so moving it would ripple through agent instructions. |
 | `class_diagram/` | No repo-wide references found outside the directory itself; contents are generated SVGs plus `class_diagram/generate_uml.sh`. | `moved` (#1579) | Relocated to `docs/tooling/class_diagram/`. |
-| `class_diagram/` | No repo-wide references found outside the directory itself; contents are generated SVGs plus `class_diagram/generate_uml.sh`. | `low-risk move candidate` | Self-contained docs/tooling asset; a later PR could move it under a docs/tooling subtree with limited breakage. |
 | `experiments/` | `docs/dev_guide.md` and `docs/README.md` explicitly describe `experiments/registry.yaml` and `experiments/README.md` as the question-first experiment registry. | `keep` | This path is already documented as a canonical workflow surface. |
 | `hooks/` | `.pre-commit-config.yaml` invokes `hooks/prevent_schema_duplicates.py`; tests also cover the hook contract/API surface under `tests/contract/` and related integration checks. | `deferred follow-up` | Cleanup is possible later, but this path is wired into pre-commit and test hook contracts, so any relocation still needs coordinated updates if the entrypoint or module path changes. |
 | `model_ped/` | Multiple scripts and tests resolve checkpoints from `model_ped/`. | `keep` | Direct runtime and test references make this a high-blast-radius path; keep unchanged in the foundation PR. |
 | `output/` | `AGENTS.md`, `docs/README.md`, `docs/dev_guide.md`, `.gitignore`, and coverage docs all treat `output/` as the canonical artifact root. | `keep` | Root-level artifact policy is intentional and already documented. |
 | `specs/` | `docs/README.md`, `docs/dev_guide.md`, and multiple docs deep-link into `specs/...` quickstarts, plans, tasks, and contracts. | `deferred follow-up` | A future relocation would require broad doc-link migration; that is outside a conservative foundation PR. |
 | `svg_conv/` | Only lightweight config/docs references were found; `svg_conv/README.md` itself says to prefer `robot_sf/nav/svg_map_parser.py`. | `moved` (#1579) | Relocated to `docs/tooling/svg_conv/`. |
-| `svg_conv/` | Only lightweight config/docs references were found; `svg_conv/README.md` itself says to prefer `robot_sf/nav/svg_map_parser.py`. | `low-risk move candidate` | Looks like legacy single-purpose tooling rather than a current root contract. |
 | `test_pygame/` | `docs/dev_guide.md`, `pyproject.toml`, tests, and helper scripts all reference `test_pygame/` explicitly. | `keep` | This is a documented, active test surface with exact path references. |
 | `test_scenarios/` | Tests load fixtures from `test_scenarios/osm_fixtures/...`; root fixtures are also part of current local test inputs. | `deferred follow-up` | Possible future consolidation into a test-fixture subtree, but not without updating multiple tests and docs. |
 | `utilities/` | Refactoring docs and example commands explicitly reference `utilities/migrate_environments.py`; `pyproject.toml` also has per-path lint rules for `utilities/**/*.py`. No confirmed doc references to `utilities/n.py` were found in this check. | `deferred follow-up` | This is not a core runtime package, but current docs/tooling still point to a root `utilities/` path, so moving it needs a conservative dedicated cleanup PR. |
@@ -65,6 +68,5 @@ If #1573 later needs actual path changes, the safest order is:
    `.coverage` so it does not reappear,
 2. decide whether `class_diagram/` and `svg_conv/` should move under docs/tooling: completed in
    PR #1579 (now at `docs/tooling/class_diagram/` and `docs/tooling/svg_conv/`),
-2. decide whether `class_diagram/` and `svg_conv/` should move under docs/tooling,
 3. handle any `hooks/`, `specs/`, `test_scenarios/`, or `utilities/` relocation only in dedicated
    PRs that update every exact-path reference together.

--- a/docs/context/issue_1583_high_risk_root_boundaries.md
+++ b/docs/context/issue_1583_high_risk_root_boundaries.md
@@ -1,4 +1,4 @@
-# Issue #1583 High-Risk Root Path Boundaries
+# Issue #1583 High-Risk Root Path Boundaries - 2026-05-28
 
 Date: 2026-05-28
 

--- a/docs/context/issue_1583_high_risk_root_boundaries.md
+++ b/docs/context/issue_1583_high_risk_root_boundaries.md
@@ -1,0 +1,45 @@
+# Issue #1583 High-Risk Root Path Boundaries
+
+Date: 2026-05-28
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1583>
+
+## Decision
+
+No high-risk root paths should move in the current root-layout cleanup stream. Four paths are
+intentional root contracts and should stay where they are. Two paths may be revisited, but only in
+dedicated follow-up issues with compatibility plans and targeted validation.
+
+| Path | Active references | Decision | Validation gate | Compatibility burden | Rollback plan |
+| --- | --- | --- | --- | --- | --- |
+| `.agent/` | `AGENTS.md`, `docs/ai/repo_overview.md`, repo-local skills, and compatibility notes point to `.agent/PLANS.md`. | Keep. | `rg -nF ".agent/" AGENTS.md docs .github .vscode .agents` | Low, but it is part of the agent workflow contract. | Restore `.agent/` and revert docs/instruction links. |
+| `specs/` | Docs, examples, schemas, visual contract tests, helper docs, and runtime comments deep-link into `specs/...`. | Defer to Issue #1599. | `rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode` plus targeted schema/docs tests from the follow-up inventory. | Very high: broad docs/schema/test path churn and potential broken contract links. | Keep root path or provide compatibility links until every consumer is migrated. |
+| `model_ped/` | Pedestrian PPO training scripts, collision benchmark script, adversarial pedestrian demo, examples manifest, and `tests/test_training_ped_ppo.py` encode checkpoint paths. | Keep. | `rg -nF "model_ped/" AGENTS.md docs tests scripts examples robot_sf`; if behavior changes, `uv run pytest tests/test_training_ped_ppo.py -q`. | High: checkpoint paths are user-facing and test-visible. | Restore root `model_ped/` and checkpoint path defaults. |
+| `test_pygame/` | `AGENTS.md`, `docs/dev_guide.md`, `pyproject.toml`, demo scripts, and JSONL/recording tests reference GUI tests and recordings there. | Keep. | `rg -nF "test_pygame/" AGENTS.md docs tests scripts examples pyproject.toml`; for GUI changes, run the headless pygame test command from `AGENTS.md`. | Medium: active test surface and fixture path assumptions. | Restore root `test_pygame/` and revert config/test path edits. |
+| `test_scenarios/` | OSM examples and tests reference `test_scenarios/osm_fixtures/sample_block.pbf` directly. | Defer to Issue #1598. | `rg -nF "test_scenarios/" tests examples docs scripts robot_sf`; targeted OSM tests from Issue #1598. | Medium-high: fixture-relative paths and example defaults need lockstep migration. | Keep root fixtures or provide compatibility path until examples/tests are migrated. |
+| `CITATION.cff` | Release docs, release manifests, and release-protocol tests require a root citation file. | Keep. | `rg -nF "CITATION.cff" AGENTS.md docs tests configs .github`; for release changes, `uv run pytest tests/benchmark/test_release_protocol.py -q`. | High: publication metadata and release manifests expect the root path. | Restore root `CITATION.cff` and manifest `citation_path` values. |
+
+## Follow-Up Split
+
+- Issue #1599 owns the `specs/` compatibility plan.
+- Issue #1598 owns the `test_scenarios/` fixture relocation boundary.
+- No follow-up issue is needed for `.agent/`, `model_ped/`, `test_pygame/`, or `CITATION.cff`
+  unless a maintainer later requests a migration despite the current keep decision.
+
+## Evidence Checked
+
+The decisions above combine the read-only Spark sidecar inventory with local `rg` checks run on this
+branch. The sidecar did not edit files; final decisions and GitHub writes were handled locally.
+
+Reference commands:
+
+```bash
+rg -nF ".agent/" AGENTS.md docs .github .vscode .agents --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "model_ped/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "test_pygame/" AGENTS.md docs tests scripts examples pyproject.toml --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "test_scenarios/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "CITATION.cff" AGENTS.md docs tests configs .github --glob '!docs/context/evidence/**' --glob '!output/**'
+```
+
+No files were moved and no generated artifacts were promoted.


### PR DESCRIPTION
## Summary
Records the high-risk root path migration decisions for `.agent/`, `specs/`, `model_ped/`, `test_pygame/`, `test_scenarios/`, and `CITATION.cff`.

## Linked Issues
- Closes #1583
- Relates to #1573
- Relates to #1598
- Relates to #1599

## What Changed
- Added `docs/context/issue_1583_high_risk_root_boundaries.md` with the decision table, validation gates, compatibility burden, and rollback plan for all six high-risk surfaces.
- Updated `docs/context/issue_1573_root_layout_inventory.md` to point high-risk migration work to the new note and removed stale duplicated low-risk relocation rows.
- Linked the new note from `docs/context/README.md`.
- Created follow-up issues for deferred migration candidates:
  - #1598: `test_scenarios/` fixture relocation boundary.
  - #1599: `specs/` root migration compatibility plan.

## Why It Matters
- Added value: high-risk root paths now have explicit keep/defer decisions instead of being implied by the earlier low-risk tooling relocation.
- Expected impact: future path cleanup work has clear boundaries and separate follow-ups.
- Why this is worth merging now: it prevents broad filesystem churn from being bundled into root-layout cleanup.

## Validation / Proof
- Commands run:
  - `rg -nF ".agent/" AGENTS.md docs .github .vscode .agents --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `rg -nF "model_ped/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `rg -nF "test_pygame/" AGENTS.md docs tests scripts examples pyproject.toml --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `rg -nF "test_scenarios/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `rg -nF "CITATION.cff" AGENTS.md docs tests configs .github --glob '!docs/context/evidence/**' --glob '!output/**'`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Docs proof consistency passed for the three changed files.
  - PR readiness passed on `3c5306f297295097e833175b93b071bd5481e805`: 4299 passed, 11 skipped, 8 warnings.
- Benchmarks or smoke tests, if applicable:
  - Not run; decision documentation only.

## Risks / Rollout
- Compatibility risks: low for this PR because no paths move.
- Failure modes: future migration work could still under-scope exact-path references if it skips #1598/#1599.
- Rollback or fallback plan: revert the new note and inventory link; no runtime state is affected.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1583_high_risk_root_boundaries.md`
  - `docs/context/issue_1573_root_layout_inventory.md`
  - `docs/context/README.md`
- Relevant design or provenance notes:
  - `docs/context/issue_1573_root_layout_inventory.md`
- Any assumptions that need to be preserved:
  - `.agent/`, `model_ped/`, `test_pygame/`, and `CITATION.cff` stay at root unless a maintainer explicitly reopens the migration decision.

## Follow-Up Issues
- Deferred work:
  - #1598 for `test_scenarios/`.
  - #1599 for `specs/`.
- Issues opened for follow-up:
  - #1598
  - #1599

## Reviewer Notes
- Artifact classification: readiness generated ignored local artifacts under `output/coverage/*` and `output/validation/pr_ready/*`; none are promoted.
- Known limitations: this is a decision PR; it intentionally does not move root paths.