### PR TITLE
docs: document AMV taxonomy breakdown convention (#1591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Filled the issue-1572 AMV actuation metadata gaps so the issue-1556 synthetic slice can carry
+  slice-local scenario AMV taxonomy without editing global scenario files, local `social_force`
+  rows now expose explicit command-space/projection-policy metadata, and compact actuation summary
+  artifacts distinguish AMV coverage status from adapter projection metadata without weakening
+  fail-closed unavailable/fallback semantics.
 * Fixed the issue-1527 ORCA benchmark preflight gap by moving the `rvo2` fail-fast check into the
   shared camera-ready campaign layer, so direct `prepare_campaign_preflight(...)`,
   `run_campaign(...)`, and wrapper entrypoints such as `scripts/tools/run_benchmark_release.py`

--- a/configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml
+++ b/configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml
@@ -22,6 +22,33 @@ scenario_candidates:
   - francis2023_blind_corner
   - francis2023_intersection_wait
 
+scenario_amv_overrides:
+  classic_overtaking_medium:
+    use_case: delivery_robot
+    context: sidewalk
+    speed_regime: walking_speed
+    maneuver_type: overtake
+  classic_bottleneck_high:
+    use_case: delivery_robot
+    context: sidewalk
+    speed_regime: walking_speed
+    maneuver_type: bottleneck
+  classic_cross_trap_high:
+    use_case: shared_space_micromobility
+    context: shared_space
+    speed_regime: scooter_speed
+    maneuver_type: crossing
+  francis2023_blind_corner:
+    use_case: delivery_robot
+    context: sidewalk
+    speed_regime: walking_speed
+    maneuver_type: crossing
+  francis2023_intersection_wait:
+    use_case: shared_space_micromobility
+    context: shared_space
+    speed_regime: scooter_speed
+    maneuver_type: bottleneck
+
 seed_policy:
   mode: seed-set
   seed_set: eval

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -635,8 +635,9 @@ Additional diagnostics generated per campaign:
   + AMV taxonomy columns aggregate the distinct non-empty values from contributing
     scenarios per dimension, sorted and joined with semicolons
 
-Empty AMV taxonomy cells mean the source scenario had no AMV metadata for that
-dimension. They are descriptors only: they do not encode planner success,
+Empty AMV taxonomy cells mean the source scenario, or all contributing scenarios
+for a family, had no AMV metadata for that dimension. They are descriptors only:
+they do not encode planner success,
 failure, fallback, degraded execution, or availability. Continue to interpret
 benchmark evidence through `availability_status`, `benchmark_success`, and the
 fail-closed fallback policy above.

--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -628,8 +628,18 @@ Additional diagnostics generated per campaign:
 
 * `reports/scenario_breakdown.csv` and `reports/scenario_breakdown.md`
   + per-planner, per-scenario metric means
+  + AMV taxonomy columns (`use_case`, `context`, `speed_regime`, `maneuver_type`)
+    carry the direct source scenario metadata when present
 * `reports/scenario_family_breakdown.csv` and `reports/scenario_family_breakdown.md`
   + per-planner, per-family (archetype) metric means
+  + AMV taxonomy columns aggregate the distinct non-empty values from contributing
+    scenarios per dimension, sorted and joined with semicolons
+
+Empty AMV taxonomy cells mean the source scenario had no AMV metadata for that
+dimension. They are descriptors only: they do not encode planner success,
+failure, fallback, degraded execution, or availability. Continue to interpret
+benchmark evidence through `availability_status`, `benchmark_success`, and the
+fail-closed fallback policy above.
 
 ## Notes on Experimental Planners
 

--- a/docs/context/issue_1556_amv_actuation_stress_slice.md
+++ b/docs/context/issue_1556_amv_actuation_stress_slice.md
@@ -17,10 +17,16 @@ benchmark gates or making paper-facing or hardware-calibration claims.
 - The slice uses the compact scenario candidate set from `#1546`:
   `classic_overtaking_medium`, `classic_bottleneck_high`, `classic_cross_trap_high`,
   `francis2023_blind_corner`, and `francis2023_intersection_wait`.
+- The checked-in config now carries slice-local `scenario_amv_overrides` for those five scenarios so
+  AMV coverage artifacts and compact actuation summaries do not depend on unrelated global scenario
+  files carrying the same taxonomy.
 - The seed policy stays on the named `eval` seed set for the checked-in config.
 - Synthetic profile provenance is carried in preflight output, campaign manifests, episode
   `scenario_params`, planner-row summaries, and the diagnostic
   `reports/actuation_envelope_summary.{json,md}` artifacts.
+- The diagnostic actuation summary now also records AMV coverage status, compact scenario-level AMV
+  rows, and planner command-space/projection-policy metadata so issue-1572-style evidence review can
+  distinguish scenario taxonomy gaps from adapter metadata gaps without reopening raw campaign rows.
 - Derived saturation metrics currently reported when the command path supports them are:
   `command_clip_fraction`, `yaw_rate_saturation_fraction`, and `signed_braking_peak_m_s2`.
 - If the synthetic profile cannot be applied, the runner fails closed instead of silently dropping
@@ -57,6 +63,7 @@ The key contract checks are:
 1. config provenance for scenario candidates, eval seeds, and synthetic profile fields,
 2. preflight propagation of candidate resolution and synthetic profile metadata,
 3. campaign-summary/report artifact emission for the actuation supplement,
-4. map-runner episode metrics and fail-closed behavior for non-differential-drive scenarios.
-5. config-loader fail-closed behavior for malformed scenario candidate and synthetic profile
+4. slice-local scenario AMV override propagation into preflight and compact actuation artifacts,
+5. map-runner episode metrics and fail-closed behavior for non-differential-drive scenarios.
+6. config-loader fail-closed behavior for malformed scenario candidate, scenario AMV override, and synthetic profile
    payloads.

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -470,6 +470,10 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "supports_adapter_commands": True,
         "default_execution_mode": "adapter",
         "default_adapter_name": "SocialForcePlannerAdapter",
+        "upstream_command_space": "velocity_vector_xy",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "heading_safe_velocity_to_unicycle_vw",
+        "projection_documented": True,
     },
     "orca": {
         "planner_command_space": "unicycle_vw",

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -14,6 +14,7 @@ import math
 import re
 import subprocess
 import time
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -85,7 +86,7 @@ from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.training.scenario_loader import load_scenarios
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
@@ -274,6 +275,7 @@ class CampaignConfig:
     scenario_candidates: ScenarioCandidateSelection = field(
         default_factory=ScenarioCandidateSelection
     )
+    scenario_amv_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
     seed_policy: SeedPolicy = SeedPolicy()
     scenario_horizons_path: Path | None = None
     workers: int = 1
@@ -639,6 +641,69 @@ def _filter_scenario_candidates(
     return filtered
 
 
+def _scenario_name_key(scenario: Mapping[str, Any]) -> str:
+    """Return the normalized scenario name key used by campaign selectors."""
+    return str(
+        scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or ""
+    ).strip()
+
+
+def _validate_scenario_amv_override_keys(
+    scenarios: Sequence[Mapping[str, Any]],
+    *,
+    overrides: Mapping[str, Mapping[str, str]],
+    matrix_path: Path,
+) -> None:
+    """Fail closed when AMV overrides target scenarios outside the loaded slice."""
+    if not overrides:
+        return
+
+    loaded_names = {_scenario_name_key(scenario) for scenario in scenarios}
+    unmatched = sorted(name for name in overrides if name not in loaded_names)
+    if unmatched:
+        raise ValueError(
+            "scenario_amv_overrides did not resolve in "
+            f"{_repo_relative(matrix_path)}: {', '.join(unmatched)}"
+        )
+
+
+def _apply_scenario_amv_overrides(
+    scenarios: list[dict[str, Any]],
+    *,
+    overrides: Mapping[str, Mapping[str, str]],
+) -> list[dict[str, Any]]:
+    """Apply slice-local AMV taxonomy overrides without mutating source scenarios.
+
+    Returns:
+        Scenario list with any configured AMV taxonomy overrides merged into
+        both ``scenario["amv"]`` and ``scenario["metadata"]["amv"]``.
+    """
+    if not overrides:
+        return scenarios
+
+    patched_scenarios: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        patched = dict(scenario)
+        scenario_name = _scenario_name_key(scenario)
+        taxonomy_override = overrides.get(scenario_name)
+        if isinstance(taxonomy_override, Mapping) and taxonomy_override:
+            amv = dict(scenario.get("amv")) if isinstance(scenario.get("amv"), dict) else {}
+            amv.update({key: str(value) for key, value in taxonomy_override.items()})
+            patched["amv"] = amv
+
+            metadata = (
+                dict(scenario.get("metadata")) if isinstance(scenario.get("metadata"), dict) else {}
+            )
+            metadata_amv = (
+                dict(metadata.get("amv")) if isinstance(metadata.get("amv"), dict) else {}
+            )
+            metadata_amv.update(amv)
+            metadata["amv"] = metadata_amv
+            patched["metadata"] = metadata
+        patched_scenarios.append(patched)
+    return patched_scenarios
+
+
 def _load_campaign_scenarios(cfg: CampaignConfig) -> list[dict[str, Any]]:
     """Load campaign scenarios and apply optional seed override.
 
@@ -676,6 +741,15 @@ def _load_campaign_scenarios(cfg: CampaignConfig) -> list[dict[str, Any]]:
         normalized,
         names=cfg.scenario_candidates.names,
         matrix_path=cfg.scenario_matrix_path,
+    )
+    _validate_scenario_amv_override_keys(
+        scenario_dicts,
+        overrides=cfg.scenario_amv_overrides,
+        matrix_path=cfg.scenario_matrix_path,
+    )
+    scenario_dicts = _apply_scenario_amv_overrides(
+        scenario_dicts,
+        overrides=cfg.scenario_amv_overrides,
     )
     scenario_dicts = _apply_scenario_horizon_schedule(
         scenario_dicts,
@@ -1222,6 +1296,13 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
         not str(name).strip() for name in cfg.scenario_candidates.names
     ):
         raise ValueError("scenario_candidates must not contain empty names")
+    for scenario_name, amv_override in cfg.scenario_amv_overrides.items():
+        if not str(scenario_name).strip():
+            raise ValueError("scenario_amv_overrides keys must be non-empty scenario names")
+        if not amv_override:
+            raise ValueError(
+                "scenario_amv_overrides entries must include at least one AMV taxonomy dimension"
+            )
     if cfg.synthetic_actuation_profile is not None:
         validate_synthetic_actuation_profile(cfg.synthetic_actuation_profile)
         if cfg.paper_facing:
@@ -1452,6 +1533,43 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         raise TypeError("scenario_candidates must be a scalar name or list of scalar names")
     else:
         scenario_candidates = ()
+    scenario_amv_overrides_raw = payload.get("scenario_amv_overrides")
+    if scenario_amv_overrides_raw is None:
+        scenario_amv_overrides: dict[str, dict[str, str]] = {}
+    elif not isinstance(scenario_amv_overrides_raw, dict):
+        raise TypeError(
+            "scenario_amv_overrides must be a mapping of scenario names to AMV mappings"
+        )
+    else:
+        scenario_amv_overrides = {}
+        for raw_scenario_name, raw_taxonomy in scenario_amv_overrides_raw.items():
+            scenario_name = str(raw_scenario_name).strip()
+            if not scenario_name:
+                raise ValueError("scenario_amv_overrides keys must be non-empty scenario names")
+            if not isinstance(raw_taxonomy, dict):
+                raise TypeError(
+                    "scenario_amv_overrides entries must be mappings keyed by AMV dimension"
+                )
+            taxonomy: dict[str, str] = {}
+            for raw_dimension, raw_value in raw_taxonomy.items():
+                dimension = str(raw_dimension).strip()
+                if dimension not in _AMV_DIMENSIONS:
+                    known = ", ".join(_AMV_DIMENSIONS)
+                    raise ValueError(
+                        f"Unsupported scenario_amv_overrides dimension '{dimension}'. "
+                        f"Expected: {known}"
+                    )
+                value = str(raw_value).strip()
+                if not value:
+                    raise ValueError(
+                        "scenario_amv_overrides values must be non-empty strings when provided"
+                    )
+                taxonomy[dimension] = value
+            if not taxonomy:
+                raise ValueError(
+                    "scenario_amv_overrides entries must include at least one AMV taxonomy dimension"
+                )
+            scenario_amv_overrides[scenario_name] = taxonomy
     synthetic_actuation_raw = payload.get("synthetic_actuation_profile")
     if synthetic_actuation_raw is not None and not isinstance(synthetic_actuation_raw, dict):
         raise TypeError("synthetic_actuation_profile must be a mapping when provided")
@@ -1461,6 +1579,7 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         scenario_matrix_path=scenario_matrix_path,
         planners=tuple(planner_specs),
         scenario_candidates=ScenarioCandidateSelection(names=scenario_candidates),
+        scenario_amv_overrides=scenario_amv_overrides,
         scenario_horizons_path=scenario_horizons,
         seed_policy=SeedPolicy(
             mode=mode,
@@ -1996,6 +2115,7 @@ def _build_actuation_envelope_summary(
     generated_at_utc: str,
     profile: SyntheticActuationProfile,
     planner_rows: list[dict[str, Any]],
+    amv_summary: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a synthetic actuation-envelope diagnostic summary payload.
 
@@ -2004,6 +2124,9 @@ def _build_actuation_envelope_summary(
     """
     rows: list[dict[str, Any]] = []
     for planner_row in planner_rows:
+        planner_command_space = str(planner_row.get("planner_command_space", "unknown"))
+        benchmark_command_space = str(planner_row.get("benchmark_command_space", "unknown"))
+        projection_policy = str(planner_row.get("projection_policy", "unknown"))
         saturation = {
             "command_clip_fraction": str(
                 planner_row.get("command_clip_fraction_mean", "not_available")
@@ -2023,7 +2146,25 @@ def _build_actuation_envelope_summary(
                 "kinematics": str(planner_row.get("kinematics", "")),
                 "status": str(planner_row.get("status", "")),
                 "readiness_status": str(planner_row.get("readiness_status", "")),
+                "availability_status": str(planner_row.get("availability_status", "")),
                 "benchmark_success": str(planner_row.get("benchmark_success", "")),
+                "execution_mode": str(planner_row.get("execution_mode", "unknown")),
+                "execution_detail": str(planner_row.get("execution_detail", "unspecified")),
+                "planner_command_space": planner_command_space,
+                "benchmark_command_space": benchmark_command_space,
+                "projection_policy": projection_policy,
+                "projection_metadata_status": (
+                    "explicit"
+                    if all(
+                        value and value != "unknown"
+                        for value in (
+                            planner_command_space,
+                            benchmark_command_space,
+                            projection_policy,
+                        )
+                    )
+                    else "unknown"
+                ),
                 "metric_means": {
                     metric: str(planner_row.get(f"{metric}_mean", "nan"))
                     for metric in _ACTUATION_REPORT_METRICS
@@ -2032,6 +2173,23 @@ def _build_actuation_envelope_summary(
                 "saturation_metrics": saturation,
             }
         )
+    scenario_amv_rows: list[dict[str, Any]] = []
+    amv_coverage_status = "unknown"
+    if isinstance(amv_summary, dict):
+        amv_coverage_status = str(amv_summary.get("status", "unknown"))
+        raw_rows = amv_summary.get("scenario_rows")
+        if isinstance(raw_rows, list):
+            for row in raw_rows:
+                if not isinstance(row, dict):
+                    continue
+                amv = row.get("amv")
+                scenario_amv_rows.append(
+                    {
+                        "name": str(row.get("name", "")),
+                        "scenario_family": str(row.get("scenario_family", "")),
+                        "amv": dict(amv) if isinstance(amv, dict) else {},
+                    }
+                )
     return {
         "schema_version": "benchmark-actuation-envelope-summary.v1",
         "campaign_id": campaign_id,
@@ -2041,6 +2199,8 @@ def _build_actuation_envelope_summary(
             "Synthetic diagnostic only; not a hardware-calibrated or paper-facing AMV claim."
         ),
         "synthetic_actuation_profile": profile.to_metadata(),
+        "amv_coverage_status": amv_coverage_status,
+        "scenario_amv_rows": scenario_amv_rows,
         "row_count": len(rows),
         "rows": rows,
     }
@@ -2071,6 +2231,18 @@ def _write_actuation_envelope_artifacts(
     if isinstance(profile, dict):
         for key, value in profile.items():
             lines.append(f"- {key}: `{value}`")
+    lines.append(f"- AMV coverage status: `{payload.get('amv_coverage_status', 'unknown')}`")
+    scenario_rows = payload.get("scenario_amv_rows")
+    if isinstance(scenario_rows, list) and scenario_rows:
+        lines.extend(["", "## Scenario AMV Rows", ""])
+        for row in scenario_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "- "
+                f"{row.get('name', 'unknown')} ({row.get('scenario_family', 'unknown')}): "
+                f"{json.dumps(row.get('amv', {}), sort_keys=True)}"
+            )
     rows = payload.get("rows")
     if isinstance(rows, list) and rows:
         lines.extend(["", "## Planner Rows", ""])
@@ -2084,6 +2256,9 @@ def _write_actuation_envelope_artifacts(
                 "- "
                 f"{row.get('planner_key', 'unknown')} ({row.get('algo', 'unknown')}, "
                 f"{row.get('kinematics', 'unknown')}): status={row.get('status', 'unknown')}, "
+                f"projection={row.get('projection_policy', 'unknown')}, "
+                f"planner_cmd={row.get('planner_command_space', 'unknown')}, "
+                f"benchmark_cmd={row.get('benchmark_command_space', 'unknown')}, "
                 f"clip={saturation.get('command_clip_fraction', 'not_available')}, "
                 f"yaw_sat={saturation.get('yaw_rate_saturation_fraction', 'not_available')}, "
                 f"braking_peak={saturation.get('signed_braking_peak_m_s2', 'not_available')}"
@@ -2546,6 +2721,10 @@ def prepare_campaign_preflight(
                 for scenario in scenarios
             ],
         },
+        "scenario_amv_overrides": {
+            scenario_name: dict(values)
+            for scenario_name, values in sorted(cfg.scenario_amv_overrides.items())
+        },
         "planner_count": len([planner for planner in cfg.planners if planner.enabled]),
         "workers": cfg.workers,
         "horizon": cfg.horizon,
@@ -2709,6 +2888,10 @@ def prepare_campaign_preflight(
         "scenario_matrix": _repo_relative(cfg.scenario_matrix_path),
         "scenario_matrix_hash": scenario_hash,
         "scenario_candidates": list(cfg.scenario_candidates.names),
+        "scenario_amv_overrides": {
+            scenario_name: dict(values)
+            for scenario_name, values in sorted(cfg.scenario_amv_overrides.items())
+        },
         "seed_policy": {
             "mode": cfg.seed_policy.mode,
             "seed_set": cfg.seed_policy.seed_set,
@@ -2813,6 +2996,7 @@ def prepare_campaign_preflight(
         "matrix_summary_csv_path": matrix_summary_csv_path,
         "amv_coverage_json_path": amv_coverage_json_path,
         "amv_coverage_md_path": amv_coverage_md_path,
+        "amv_summary": amv_summary,
         "comparability_json_path": comparability_json_path,
         "comparability_md_path": comparability_md_path,
         "manifest_payload": manifest_payload,
@@ -3490,6 +3674,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     )
     comparability_md_path = Path(path) if (path := prepared.get("comparability_md_path")) else None
     manifest_payload = dict(prepared["manifest_payload"])
+    amv_summary = dict(prepared["amv_summary"])
     campaign_started_at_utc = str(prepared["created_at_utc"])
     scenarios = list(prepared["scenarios"])
     resolved_seeds = list(prepared["resolved_seeds"])
@@ -4066,6 +4251,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             generated_at_utc=campaign_finished_at_utc,
             profile=cfg.synthetic_actuation_profile,
             planner_rows=planner_rows,
+            amv_summary=amv_summary,
         )
         actuation_envelope_json_path, actuation_envelope_md_path = (
             _write_actuation_envelope_artifacts(reports_dir, actuation_envelope_payload)
@@ -4265,6 +4451,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "amv_coverage_status": str(
                 (manifest_payload or {}).get("amv_coverage_status", "unknown")
             ),
+            "scenario_amv_overrides": {
+                scenario_name: dict(values)
+                for scenario_name, values in sorted(cfg.scenario_amv_overrides.items())
+            },
             "scenario_candidates": list(cfg.scenario_candidates.names),
             "scenario_candidates_selection_name": cfg.scenario_candidates.selection_name,
             "synthetic_actuation_profile": _synthetic_actuation_metadata(

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -1559,6 +1559,10 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                         f"Unsupported scenario_amv_overrides dimension '{dimension}'. "
                         f"Expected: {known}"
                     )
+                if raw_value is None:
+                    raise ValueError(
+                        "scenario_amv_overrides values must be non-empty strings when provided"
+                    )
                 value = str(raw_value).strip()
                 if not value:
                     raise ValueError(

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -14,6 +14,7 @@ import math
 import re
 import subprocess
 import time
+from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
@@ -3252,16 +3253,50 @@ def _scenario_family(record: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _build_scenario_amv_lookup(
+    scenarios: list[dict[str, Any]],
+) -> dict[str, dict[str, str]]:
+    """Build a lookup from scenario identifier to AMV taxonomy dimensions.
+
+    Returns:
+        dict[str, dict[str, str]]: Mapping from scenario name/id to AMV taxonomy
+        values keyed by dimension name. Scenarios without AMV data map to empty
+        dicts so downstream code can distinguish absent from empty.
+    """
+    lookup: dict[str, dict[str, str]] = {}
+    for scenario in scenarios:
+        scenario_id = _campaign_scenario_id(scenario)
+        taxonomy = _extract_amv_taxonomy(scenario)
+        lookup[scenario_id] = taxonomy
+    return lookup
+
+
 def _build_breakdown_rows(  # noqa: C901
     run_entries: list[dict[str, Any]],
+    *,
+    scenario_amv_lookup: dict[str, dict[str, str]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Build per-scenario and per-family campaign diagnostic rows.
+
+    When ``scenario_amv_lookup`` is provided, AMV taxonomy columns
+    (``use_case``, ``context``, ``speed_regime``, ``maneuver_type``) are
+    merged into per-scenario rows from the matching scenario identifier.
+    Per-family rows receive the union of AMV dimension values observed
+    across contributing scenarios, joined by semicolons. Scenarios or
+    families without AMV data emit empty-string placeholders rather than
+    absent columns, so downstream consumers never mistake a missing column
+    for an unavailable taxonomy dimension.
 
     Returns:
         Tuple of per-scenario rows and per-family rows.
     """
+    amv_lookup = scenario_amv_lookup if scenario_amv_lookup is not None else {}
     per_scenario: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     per_family: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    family_amv_values: defaultdict[tuple[str, str, str], defaultdict[str, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
 
     def _add_metric(bucket: dict[str, Any], metric: str, value: float | None) -> None:
         """Append one finite metric sample to an aggregation bucket."""
@@ -3326,6 +3361,15 @@ def _build_breakdown_rows(  # noqa: C901
                 _add_metric(scenario_bucket, metric, value)
                 _add_metric(family_bucket, metric, value)
 
+            scenario_amv = amv_lookup.get(scenario_id, {})
+            for dimension in _AMV_DIMENSIONS:
+                scenario_bucket.setdefault(dimension, scenario_amv.get(dimension, ""))
+
+            for dimension in _AMV_DIMENSIONS:
+                dim_value = scenario_amv.get(dimension, "")
+                if dim_value:
+                    family_amv_values[family_key][dimension].add(dim_value)
+
     def _finalize(row: dict[str, Any]) -> dict[str, Any]:
         """Replace metric sample lists with report-ready mean fields.
 
@@ -3348,14 +3392,25 @@ def _build_breakdown_rows(  # noqa: C901
             row.get("scenario_family", ""),
         ),
     )
-    family_rows = sorted(
-        (_finalize(row) for row in per_family.values()),
+    family_rows_data: list[dict[str, Any]] = []
+    for family_key, family_row in per_family.items():
+        finalized = _finalize(family_row)
+        family_dims = family_amv_values.get(family_key, {})
+        for dimension in _AMV_DIMENSIONS:
+            values = family_dims.get(dimension)
+            if values:
+                finalized[dimension] = ";".join(sorted(values))
+            else:
+                finalized[dimension] = ""
+        family_rows_data.append(finalized)
+
+    family_rows_data.sort(
         key=lambda row: (
             row.get("planner_key", ""),
             row.get("scenario_family", ""),
         ),
     )
-    return scenario_rows, family_rows
+    return scenario_rows, family_rows_data
 
 
 def _strict_vs_fallback_comparisons(rows: list[dict[str, Any]]) -> list[str]:
@@ -4024,7 +4079,11 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "snqi_mean",
         ),
     )
-    scenario_rows, family_rows = _build_breakdown_rows(run_entries)
+    scenario_amv_lookup = _build_scenario_amv_lookup(scenarios)
+    scenario_rows, family_rows = _build_breakdown_rows(
+        run_entries,
+        scenario_amv_lookup=scenario_amv_lookup,
+    )
     scenario_csv_path, scenario_md_path = _write_table_artifacts(
         reports_dir,
         "scenario_breakdown",
@@ -4034,6 +4093,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "algo",
             "scenario_family",
             "scenario_id",
+            "use_case",
+            "context",
+            "speed_regime",
+            "maneuver_type",
             "episodes",
             "success_mean",
             "collisions_mean",
@@ -4056,6 +4119,10 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             "planner_key",
             "algo",
             "scenario_family",
+            "use_case",
+            "context",
+            "speed_regime",
+            "maneuver_type",
             "episodes",
             "success_mean",
             "collisions_mean",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -206,6 +206,27 @@ def test_load_campaign_config_rejects_malformed_scenario_amv_overrides(tmp_path:
         load_campaign_config(config_path)
 
 
+def test_load_campaign_config_rejects_null_scenario_amv_override_values(
+    tmp_path: Path,
+) -> None:
+    """Scenario AMV override values must not coerce YAML null to the string ``None``."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad_scenario_amv_null",
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "scenario_amv_overrides": {"francis2023_blind_corner": {"use_case": None}},
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="scenario_amv_overrides values must be non-empty"):
+        load_campaign_config(config_path)
+
+
 def test_load_campaign_config_rejects_malformed_synthetic_actuation_profile(
     tmp_path: Path,
 ) -> None:
@@ -386,7 +407,9 @@ def test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata(
         "francis2023_intersection_wait",
     ]
 
-    manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
+    manifest = json.loads(
+        (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
+    )
     validate_payload = json.loads(
         Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
     )
@@ -490,7 +513,9 @@ def test_prepare_campaign_preflight_applies_scenario_amv_overrides(tmp_path: Pat
     assert amv_payload["scenario_rows"][0]["amv"]["use_case"] == "delivery_robot"
     assert amv_payload["scenario_rows"][1]["amv"]["use_case"] == "shared_space_micromobility"
 
-    manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
+    manifest = json.loads(
+        (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
+    )
     assert manifest["amv_coverage_status"] == "pass"
     assert manifest["scenario_amv_overrides"]["classic_overtaking_medium"]["maneuver_type"] == (
         "overtake"
@@ -774,8 +799,12 @@ def test_preflight_reports_scenario_horizon_schedule_summary(tmp_path: Path) -> 
         output_root=tmp_path / "out",
         campaign_id="scheduled_preflight",
     )
-    validate_payload = json.loads(Path(prepared["validate_config_path"]).read_text())
-    matrix_payload = json.loads(Path(prepared["matrix_summary_json_path"]).read_text())
+    validate_payload = json.loads(
+        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
+    )
+    matrix_payload = json.loads(
+        Path(prepared["matrix_summary_json_path"]).read_text(encoding="utf-8")
+    )
 
     assert validate_payload["scenario_horizons"] == {
         "path": str(schedule_path.resolve()),

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -513,6 +513,16 @@ def test_prepare_campaign_preflight_applies_scenario_amv_overrides(tmp_path: Pat
     assert amv_payload["scenario_rows"][0]["amv"]["use_case"] == "delivery_robot"
     assert amv_payload["scenario_rows"][1]["amv"]["use_case"] == "shared_space_micromobility"
 
+    validate_payload = json.loads(
+        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
+    )
+    assert validate_payload["scenario_amv_overrides"][
+        "classic_overtaking_medium"
+    ]["maneuver_type"] == "overtake"
+    assert validate_payload["scenario_amv_overrides"][
+        "francis2023_intersection_wait"
+    ]["speed_regime"] == "scooter_speed"
+
     manifest = json.loads(
         (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
     )
@@ -2547,6 +2557,8 @@ def test_build_actuation_envelope_summary_carries_amv_and_projection_metadata() 
 
     assert payload["amv_coverage_status"] == "pass"
     assert payload["scenario_amv_rows"][0]["amv"]["maneuver_type"] == "overtake"
+    assert payload["rows"][0]["planner_command_space"] == "unicycle_vw"
+    assert payload["rows"][0]["benchmark_command_space"] == "unicycle_vw"
     assert payload["rows"][0]["projection_policy"] == "heading_safe_velocity_to_unicycle_vw"
     assert payload["rows"][0]["projection_metadata_status"] == "explicit"
 

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -513,6 +513,18 @@ def test_prepare_campaign_preflight_applies_scenario_amv_overrides(tmp_path: Pat
     assert amv_payload["scenario_rows"][0]["amv"]["use_case"] == "delivery_robot"
     assert amv_payload["scenario_rows"][1]["amv"]["use_case"] == "shared_space_micromobility"
 
+    validate_payload = json.loads(
+        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
+    )
+    assert (
+        validate_payload["scenario_amv_overrides"]["classic_overtaking_medium"]["maneuver_type"]
+        == "overtake"
+    )
+    assert (
+        validate_payload["scenario_amv_overrides"]["francis2023_intersection_wait"]["speed_regime"]
+        == "scooter_speed"
+    )
+
     manifest = json.loads(
         (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
     )
@@ -2547,6 +2559,8 @@ def test_build_actuation_envelope_summary_carries_amv_and_projection_metadata() 
 
     assert payload["amv_coverage_status"] == "pass"
     assert payload["scenario_amv_rows"][0]["amv"]["maneuver_type"] == "overtake"
+    assert payload["rows"][0]["planner_command_space"] == "unicycle_vw"
+    assert payload["rows"][0]["benchmark_command_space"] == "unicycle_vw"
     assert payload["rows"][0]["projection_policy"] == "heading_safe_velocity_to_unicycle_vw"
     assert payload["rows"][0]["projection_metadata_status"] == "explicit"
 

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -21,6 +21,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     CampaignConfig,
     PlannerSpec,
     SeedPolicy,
+    _build_actuation_envelope_summary,
     _jsonable_repo_relative,
     _load_campaign_scenarios,
     _load_route_clearance_certifications,
@@ -36,6 +37,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     write_campaign_report,
 )
 from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+from robot_sf.benchmark.synthetic_actuation import SyntheticActuationProfile
 from robot_sf.common.artifact_paths import get_repository_root
 
 
@@ -182,6 +184,25 @@ def test_load_campaign_config_rejects_malformed_scenario_candidates(
     )
 
     with pytest.raises(TypeError, match="scenario_candidates must be"):
+        load_campaign_config(config_path)
+
+
+def test_load_campaign_config_rejects_malformed_scenario_amv_overrides(tmp_path: Path) -> None:
+    """Scenario AMV overrides must stay a mapping of scenario names to AMV mappings."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad_scenario_amv",
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "scenario_amv_overrides": {"francis2023_blind_corner": ["delivery_robot"]},
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="scenario_amv_overrides entries must be mappings"):
         load_campaign_config(config_path)
 
 
@@ -392,6 +413,136 @@ def test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata(
     ]
     assert manifest["synthetic_actuation_profile"]["name"] == "amv-actuation-stress-v0"
     assert manifest["seed_policy"]["seed_set"] == "eval"
+
+
+def test_prepare_campaign_preflight_applies_scenario_amv_overrides(tmp_path: Path) -> None:
+    """Slice-local scenario AMV overrides should populate preview and coverage artifacts."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "classic_overtaking_medium",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "classic_crossing"},
+                },
+                {
+                    "name": "francis2023_intersection_wait",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                    "metadata": {"archetype": "francis2023"},
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "issue_1572_preflight",
+                "paper_facing": False,
+                "scenario_matrix": str(scenario_path),
+                "kinematics_matrix": ["differential_drive"],
+                "scenario_candidates": [
+                    "classic_overtaking_medium",
+                    "francis2023_intersection_wait",
+                ],
+                "scenario_amv_overrides": {
+                    "classic_overtaking_medium": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "overtake",
+                    },
+                    "francis2023_intersection_wait": {
+                        "use_case": "shared_space_micromobility",
+                        "context": "shared_space",
+                        "speed_regime": "scooter_speed",
+                        "maneuver_type": "bottleneck",
+                    },
+                },
+                "amv_profile": {
+                    "coverage_enforcement": "warn",
+                    "required_dimensions": {
+                        "use_case": ["delivery_robot", "shared_space_micromobility"],
+                        "context": ["sidewalk", "shared_space"],
+                        "speed_regime": ["walking_speed", "scooter_speed"],
+                        "maneuver_type": ["overtake", "bottleneck"],
+                    },
+                },
+                "planners": [{"key": "goal", "algo": "goal", "planner_group": "core"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+    prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue1572")
+
+    preview_payload = json.loads(
+        Path(prepared["preview_scenarios_path"]).read_text(encoding="utf-8")
+    )
+    assert preview_payload["scenarios"][0]["amv"]["maneuver_type"] == "overtake"
+    assert preview_payload["scenarios"][1]["amv"]["speed_regime"] == "scooter_speed"
+
+    amv_payload = json.loads(Path(prepared["amv_coverage_json_path"]).read_text(encoding="utf-8"))
+    assert amv_payload["status"] == "pass"
+    assert amv_payload["scenario_rows"][0]["amv"]["use_case"] == "delivery_robot"
+    assert amv_payload["scenario_rows"][1]["amv"]["use_case"] == "shared_space_micromobility"
+
+    manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
+    assert manifest["amv_coverage_status"] == "pass"
+    assert manifest["scenario_amv_overrides"]["classic_overtaking_medium"]["maneuver_type"] == (
+        "overtake"
+    )
+
+
+def test_load_campaign_scenarios_rejects_unmatched_scenario_amv_overrides(tmp_path: Path) -> None:
+    """AMV overrides should fail closed when they target scenarios outside the loaded slice."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "classic_overtaking_medium",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                },
+                {
+                    "name": "francis2023_intersection_wait",
+                    "map_file": "maps/svg_maps/classic_crossing.svg",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "issue_1572_unmatched_override",
+                "scenario_matrix": str(scenario_path),
+                "scenario_candidates": ["classic_overtaking_medium"],
+                "scenario_amv_overrides": {
+                    "francis2023_intersection_wait": {
+                        "use_case": "shared_space_micromobility",
+                        "context": "shared_space",
+                        "speed_regime": "scooter_speed",
+                        "maneuver_type": "bottleneck",
+                    }
+                },
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"scenario_amv_overrides did not resolve .*francis2023_intersection_wait",
+    ):
+        _load_campaign_scenarios(cfg)
 
 
 def test_load_campaign_config_parses_observation_mode_overrides(tmp_path: Path) -> None:
@@ -2309,6 +2460,66 @@ def test_planner_report_row_exposes_execution_detail_and_command_spaces() -> Non
     assert row["planner_command_space"] == "holonomic_vxy_world"
     assert row["benchmark_command_space"] == "holonomic_vxy_world"
     assert row["projection_policy"] == "world_velocity_passthrough"
+
+
+def test_build_actuation_envelope_summary_carries_amv_and_projection_metadata() -> None:
+    """Compact actuation summaries should carry scenario AMV and planner projection metadata."""
+    payload = _build_actuation_envelope_summary(
+        campaign_id="issue1572",
+        generated_at_utc="2026-05-27T09:00:00Z",
+        profile=SyntheticActuationProfile(
+            name="amv-actuation-stress-v0",
+            profile_version="v0",
+            claim_scope="synthetic-only",
+            max_linear_accel_m_s2=2.0,
+            max_linear_decel_m_s2=2.5,
+            max_yaw_rate_rad_s=1.2,
+            max_angular_accel_rad_s2=4.0,
+            latency_mode="one-step-delay",
+            update_mode="5hz-hold",
+        ),
+        planner_rows=[
+            {
+                "planner_key": "social_force",
+                "algo": "social_force",
+                "planner_group": "core",
+                "kinematics": "differential_drive",
+                "status": "ok",
+                "readiness_status": "adapter",
+                "availability_status": "available",
+                "benchmark_success": "true",
+                "execution_mode": "adapter",
+                "execution_detail": "adapter_projected_unicycle_vw",
+                "planner_command_space": "unicycle_vw",
+                "benchmark_command_space": "unicycle_vw",
+                "projection_policy": "heading_safe_velocity_to_unicycle_vw",
+                "success_mean": "1.0000",
+                "command_clip_fraction_mean": "0.2500",
+                "yaw_rate_saturation_fraction_mean": "0.5000",
+                "signed_braking_peak_m_s2_mean": "-1.5000",
+            }
+        ],
+        amv_summary={
+            "status": "pass",
+            "scenario_rows": [
+                {
+                    "name": "classic_overtaking_medium",
+                    "scenario_family": "classic_crossing",
+                    "amv": {
+                        "use_case": "delivery_robot",
+                        "context": "sidewalk",
+                        "speed_regime": "walking_speed",
+                        "maneuver_type": "overtake",
+                    },
+                }
+            ],
+        },
+    )
+
+    assert payload["amv_coverage_status"] == "pass"
+    assert payload["scenario_amv_rows"][0]["amv"]["maneuver_type"] == "overtake"
+    assert payload["rows"][0]["projection_policy"] == "heading_safe_velocity_to_unicycle_vw"
+    assert payload["rows"][0]["projection_metadata_status"] == "explicit"
 
 
 def test_planner_report_row_backfills_collision_means_from_termination_reason() -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -22,6 +22,9 @@ from robot_sf.benchmark.camera_ready_campaign import (
     PlannerSpec,
     SeedPolicy,
     _build_actuation_envelope_summary,
+    _build_breakdown_rows,
+    _build_scenario_amv_lookup,
+    _extract_amv_taxonomy,
     _jsonable_repo_relative,
     _load_campaign_scenarios,
     _load_route_clearance_certifications,
@@ -4373,3 +4376,229 @@ def test_prepare_campaign_preflight_rejects_missing_planner_key_mapping_for_pape
     cfg = load_campaign_config(config_path)
     with pytest.raises(ValueError, match="prediction_planner_v2_xl_ego"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="missing_planner")
+
+
+class TestBuildScenarioAmvLookup:
+    """Tests for _build_scenario_amv_lookup and AMV taxonomy in breakdown rows."""
+
+    def test_build_scenario_amv_lookup_extracts_amv_from_scenario(self) -> None:
+        """Lookup maps scenario names to their AMV taxonomy dimensions."""
+        scenarios = [
+            {"name": "corridor_low", "amv": {"use_case": "corridor", "context": "low_density"}},
+            {
+                "name": "crossing_high",
+                "amv": {"use_case": "crossing", "speed_regime": "high_speed"},
+            },
+            {"name": "no_amv"},
+        ]
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert lookup["corridor_low"] == {"use_case": "corridor", "context": "low_density"}
+        assert lookup["crossing_high"] == {"use_case": "crossing", "speed_regime": "high_speed"}
+        assert lookup["no_amv"] == {}
+
+    def test_build_scenario_amv_lookup_from_metadata_amv(self) -> None:
+        """Lookup falls back to metadata.amv when top-level amv is absent."""
+        scenarios = [
+            {
+                "name": "meta_amv",
+                "metadata": {"amv": {"use_case": "hallway", "maneuver_type": "turn"}},
+            }
+        ]
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert lookup["meta_amv"] == {"use_case": "hallway", "maneuver_type": "turn"}
+
+    def test_extract_amv_taxonomy_prefers_top_level_over_metadata(self) -> None:
+        """Top-level amv takes precedence over metadata.amv for overlapping keys."""
+        scenario = {
+            "name": "both",
+            "amv": {"use_case": "top_level"},
+            "metadata": {"amv": {"use_case": "metadata_level"}},
+        }
+        result = _extract_amv_taxonomy(scenario)
+        assert result["use_case"] == "top_level"
+
+    def test_extract_amv_taxonomy_ignores_empty_values(self) -> None:
+        """Empty or whitespace-only AMV dimension values are excluded."""
+        scenario = {
+            "name": "sparse",
+            "amv": {"use_case": "corridor", "context": "", "speed_regime": "   "},
+        }
+        result = _extract_amv_taxonomy(scenario)
+        assert result == {"use_case": "corridor"}
+
+    def test_extract_amv_taxonomy_returns_empty_when_no_amv(self) -> None:
+        """Scenarios without any AMV block produce an empty taxonomy."""
+        result = _extract_amv_taxonomy({"name": "no_amv_at_all"})
+        assert result == {}
+
+    def test_build_breakdown_rows_without_amv_lookup_preserves_existing_columns(self) -> None:
+        """Empty input produces empty scenario and family rows."""
+        scenario_rows, family_rows = _build_breakdown_rows([])
+        assert scenario_rows == []
+        assert family_rows == []
+
+    def test_build_breakdown_rows_includes_amv_columns(self, tmp_path: Path) -> None:
+        """AMV taxonomy columns appear in scenario and family breakdown rows."""
+        episodes_path = tmp_path / "episodes.jsonl"
+        episodes_path.write_text(
+            json.dumps({"scenario_id": "corridor_low", "ped_collision_count": 0}) + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(episodes_path),
+            }
+        ]
+        scenario_amv_lookup = {
+            "corridor_low": {"use_case": "corridor", "context": "low_density"},
+        }
+        scenario_rows, family_rows = _build_breakdown_rows(
+            run_entries,
+            scenario_amv_lookup=scenario_amv_lookup,
+        )
+        assert len(scenario_rows) == 1
+        row = scenario_rows[0]
+        assert row["scenario_id"] == "corridor_low"
+        assert row["use_case"] == "corridor"
+        assert row["context"] == "low_density"
+        assert row["speed_regime"] == ""
+        assert row["maneuver_type"] == ""
+        assert len(family_rows) == 1
+        fam = family_rows[0]
+        assert fam["use_case"] == "corridor"
+        assert fam["context"] == "low_density"
+        assert fam["speed_regime"] == ""
+        assert fam["maneuver_type"] == ""
+
+    def test_build_breakdown_rows_family_aggregates_multiple_amv_values(
+        self, tmp_path: Path
+    ) -> None:
+        """Family rows aggregate distinct AMV dimension values with semicolons."""
+        ep1_path = tmp_path / "ep1.jsonl"
+        ep1_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"scenario_id": "sc_a", "ped_collision_count": 0}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        ep2_path = tmp_path / "ep2.jsonl"
+        ep2_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"scenario_id": "sc_b", "ped_collision_count": 0}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(ep1_path),
+            },
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(ep2_path),
+            },
+        ]
+        scenario_amv_lookup = {
+            "sc_a": {"use_case": "corridor", "context": "low_density"},
+            "sc_b": {"use_case": "corridor", "context": "high_density"},
+        }
+        scenario_rows, family_rows = _build_breakdown_rows(
+            run_entries,
+            scenario_amv_lookup=scenario_amv_lookup,
+        )
+        assert len(scenario_rows) == 2
+        corridor_scenarios_ids = {r["scenario_id"] for r in scenario_rows}
+        assert "sc_a" in corridor_scenarios_ids
+        assert "sc_b" in corridor_scenarios_ids
+        for row in scenario_rows:
+            assert row["use_case"] == "corridor"
+            assert row["context"] in ("low_density", "high_density")
+        assert len(family_rows) == 1
+        assert family_rows[0]["use_case"] == "corridor"
+        assert family_rows[0]["context"] == "high_density;low_density"
+
+    def test_build_breakdown_rows_without_lookup_produces_empty_amv_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a lookup, AMV columns exist but contain empty strings."""
+        episodes_path = tmp_path / "episodes.jsonl"
+        episodes_path.write_text(
+            json.dumps({"scenario_id": "s1", "ped_collision_count": 0}) + "\n",
+            encoding="utf-8",
+        )
+        run_entries = [
+            {
+                "planner": {"key": "orca", "algo": "orca"},
+                "status": "ok",
+                "episodes_path": str(episodes_path),
+            }
+        ]
+        scenario_rows, _family_rows = _build_breakdown_rows(run_entries)
+        assert len(scenario_rows) == 1
+        row = scenario_rows[0]
+        for dimension in ("use_case", "context", "speed_regime", "maneuver_type"):
+            assert dimension in row, f"AMV dimension '{dimension}' missing from scenario row"
+            assert row[dimension] == "", f"Expected empty string for {dimension} without AMV lookup"
+
+    def test_scenario_breakdown_csv_contains_amv_headers_in_campaign(self, tmp_path: Path) -> None:
+        """End-to-end: AMV columns flow from scenario definitions through the campaign config."""
+        scenario_path = tmp_path / "scenarios.yaml"
+        scenario_content = (
+            "scenarios:\n"
+            "  - name: corridor_amv\n"
+            "    map_file: maps/svg_maps/francis2023_blind_corner.svg\n"
+            "    robot_config:\n"
+            "      type: differential_drive\n"
+            "      radius: 0.3\n"
+            "    ped_config:\n"
+            "      robot_visible: false\n"
+            "    amv:\n"
+            "      use_case: corridor\n"
+            "      context: low_density\n"
+            "    simulation_config:\n"
+            "      max_episode_steps: 200\n"
+            "      steps_per_action: 4\n"
+            "    robot_spawn_id: 0\n"
+            "    robot_goal_id: 0\n"
+        )
+        scenario_path.write_text(scenario_content, encoding="utf-8")
+        config_path = tmp_path / "campaign.yaml"
+        config_content = (
+            "\n".join(
+                [
+                    "name: amv_breakdown_test",
+                    f"scenario_matrix: {scenario_path.as_posix()}",
+                    "planners:",
+                    "  - key: social_force",
+                    "    algo: social_force",
+                    "    planner_group: core",
+                    "paper_facing: true",
+                    "paper_profile_version: paper-seed-variability-v1",
+                    f"comparability_mapping: {_get_comparability_path()}",
+                ]
+            )
+            + "\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        cfg = load_campaign_config(config_path)
+        scenarios = _load_campaign_scenarios(cfg)
+        lookup = _build_scenario_amv_lookup(scenarios)
+        assert "corridor_amv" in lookup
+        assert lookup["corridor_amv"]["use_case"] == "corridor"
+        assert lookup["corridor_amv"]["context"] == "low_density"
+
+
+def _get_comparability_path() -> str:
+    repo_root = get_repository_root()
+    path = repo_root / "configs" / "benchmarks" / "alyassi_comparability_map_v1.yaml"
+    return path.as_posix()

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -4199,7 +4199,9 @@ def test_prepare_campaign_preflight_writes_amv_and_comparability_artifacts(tmp_p
     assert Path(prepared["comparability_json_path"]).exists()
     assert Path(prepared["comparability_md_path"]).exists()
 
-    manifest = json.loads((Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text())
+    manifest = json.loads(
+        (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
+    )
     assert manifest["amv_coverage_status"] == "pass"
     assert manifest["comparability_mapping_version"] == "alyassi-comparability-v1"
     assert manifest["artifacts"]["amv_coverage_json"].endswith("reports/amv_coverage_summary.json")

--- a/tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py
+++ b/tests/benchmark/test_issue_1556_amv_actuation_stress_slice.py
@@ -31,6 +31,38 @@ def test_issue_1556_config_declares_synthetic_differential_drive_slice() -> None
         "francis2023_blind_corner",
         "francis2023_intersection_wait",
     ]
+    assert payload["scenario_amv_overrides"] == {
+        "classic_overtaking_medium": {
+            "use_case": "delivery_robot",
+            "context": "sidewalk",
+            "speed_regime": "walking_speed",
+            "maneuver_type": "overtake",
+        },
+        "classic_bottleneck_high": {
+            "use_case": "delivery_robot",
+            "context": "sidewalk",
+            "speed_regime": "walking_speed",
+            "maneuver_type": "bottleneck",
+        },
+        "classic_cross_trap_high": {
+            "use_case": "shared_space_micromobility",
+            "context": "shared_space",
+            "speed_regime": "scooter_speed",
+            "maneuver_type": "crossing",
+        },
+        "francis2023_blind_corner": {
+            "use_case": "delivery_robot",
+            "context": "sidewalk",
+            "speed_regime": "walking_speed",
+            "maneuver_type": "crossing",
+        },
+        "francis2023_intersection_wait": {
+            "use_case": "shared_space_micromobility",
+            "context": "shared_space",
+            "speed_regime": "scooter_speed",
+            "maneuver_type": "bottleneck",
+        },
+    }
 
     profile = payload["synthetic_actuation_profile"]
     assert profile == {

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -446,6 +446,20 @@ def test_build_policy_orca_preserves_provenance_metadata() -> None:
     )
 
 
+def test_build_policy_social_force_exposes_projection_metadata() -> None:
+    """Local SocialForce metadata should expose explicit adapter projection fields."""
+    _, meta = _build_policy(
+        "social_force",
+        {"allow_testing_algorithms": True},
+        robot_kinematics="differential_drive",
+    )
+
+    planner_meta = meta["planner_kinematics"]
+    assert planner_meta["planner_command_space"] == "unicycle_vw"
+    assert planner_meta["benchmark_command_space"] == "unicycle_vw"
+    assert planner_meta["projection_policy"] == "heading_safe_velocity_to_unicycle_vw"
+
+
 def test_build_policy_hrvo_preserves_local_provenance_metadata() -> None:
     """HRVO metadata should expose its local implementation boundary explicitly."""
     _, meta = _build_policy(


### PR DESCRIPTION
## Summary

- documents AMV taxonomy columns for `scenario_breakdown` and `scenario_family_breakdown`
- records the per-family aggregation convention: distinct non-empty values sorted and joined with semicolons
- states that empty AMV taxonomy cells are descriptors only, not planner success/failure or fallback evidence

## Stacking

This PR is intentionally stacked on `issue-1572-amv-metadata-gaps` because PR #1588 added the AMV breakdown columns there, and PR #1580 has not landed on `main` yet.

Closes #1591.

## Validation

- `git diff --check`
- `BASE_REF=origin/issue-1572-amv-metadata-gaps scripts/dev/check_docs_proof_consistency_diff.sh`
- `rg -n "AMV taxonomy|scenario_family_breakdown|availability_status|benchmark_success|fail-closed" docs/benchmark_camera_ready.md`
- `uv run pytest tests/test_robot_with_ped_obstacle_force.py::test_can_create_env -q` after one stochastic full-suite route-sampling failure
- `BASE_REF=origin/issue-1572-amv-metadata-gaps PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed after commit: 4313 passed, 11 skipped, 8 warnings

## Artifacts

- Full readiness regenerated ignored local `output/coverage/*`; no durable artifact promotion needed for this docs-only change.
