### PR TITLE
docs: decide root compatibility boundaries (#1598, #1599)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -104,6 +104,8 @@ knowledge, not every transient iteration detail.
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
 * Issue #1583 high-risk root path boundaries:
   [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
+* Issues #1598/#1599 root compatibility decisions:
+  [issue_1598_1599_root_compatibility_decisions.md](issue_1598_1599_root_compatibility_decisions.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
 * Issue #1543 predictive v2 negative audit:

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -104,7 +104,7 @@ knowledge, not every transient iteration detail.
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
 * Issue #1583 high-risk root path boundaries:
   [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
-* Issues #1598/#1599 root compatibility decisions:
+* Issues #1598/#1599 Root Compatibility Decisions (2026-05-28):
   [issue_1598_1599_root_compatibility_decisions.md](issue_1598_1599_root_compatibility_decisions.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -102,6 +102,8 @@ knowledge, not every transient iteration detail.
   [issue_1550_predictive_same_seed_row_summary_schema.md](issue_1550_predictive_same_seed_row_summary_schema.md)
 * Issue #1573 Root-Layout Inventory:
   [issue_1573_root_layout_inventory.md](issue_1573_root_layout_inventory.md)
+* Issue #1583 high-risk root path boundaries:
+  [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
 * Issue #1504 ego-conditioned feature contract:
   [issue_1504_ego_feature_contract.md](issue_1504_ego_feature_contract.md)
 * Issue #1543 predictive v2 negative audit:

--- a/docs/context/issue_1573_root_layout_inventory.md
+++ b/docs/context/issue_1573_root_layout_inventory.md
@@ -6,6 +6,11 @@ This note is the conservative foundation slice for #1573. It inventories the can
 paths, records the local evidence checked on this branch, and makes an explicit action call for
 each path without performing a bulk directory move.
 
+High-risk root path migration boundaries are now split to
+[issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md). That note keeps
+`.agent/`, `model_ped/`, `test_pygame/`, and `CITATION.cff` at root, and delegates any future
+`specs/` or `test_scenarios/` migration to dedicated follow-up issues.
+
 Scope boundary for this PR:
 
 - no first-level directory moves,
@@ -29,14 +34,12 @@ Action meanings:
 | --- | --- | --- | --- |
 | `.agent/` | `AGENTS.md` points to `.agent/PLANS.md` as the repo plan-writing convention. | `keep` | This is already part of the agent-context contract, so moving it would ripple through agent instructions. |
 | `class_diagram/` | No repo-wide references found outside the directory itself; contents are generated SVGs plus `class_diagram/generate_uml.sh`. | `moved` (#1579) | Relocated to `docs/tooling/class_diagram/`. |
-| `class_diagram/` | No repo-wide references found outside the directory itself; contents are generated SVGs plus `class_diagram/generate_uml.sh`. | `low-risk move candidate` | Self-contained docs/tooling asset; a later PR could move it under a docs/tooling subtree with limited breakage. |
 | `experiments/` | `docs/dev_guide.md` and `docs/README.md` explicitly describe `experiments/registry.yaml` and `experiments/README.md` as the question-first experiment registry. | `keep` | This path is already documented as a canonical workflow surface. |
 | `hooks/` | `.pre-commit-config.yaml` invokes `hooks/prevent_schema_duplicates.py`; tests also cover the hook contract/API surface under `tests/contract/` and related integration checks. | `deferred follow-up` | Cleanup is possible later, but this path is wired into pre-commit and test hook contracts, so any relocation still needs coordinated updates if the entrypoint or module path changes. |
 | `model_ped/` | Multiple scripts and tests resolve checkpoints from `model_ped/`. | `keep` | Direct runtime and test references make this a high-blast-radius path; keep unchanged in the foundation PR. |
 | `output/` | `AGENTS.md`, `docs/README.md`, `docs/dev_guide.md`, `.gitignore`, and coverage docs all treat `output/` as the canonical artifact root. | `keep` | Root-level artifact policy is intentional and already documented. |
 | `specs/` | `docs/README.md`, `docs/dev_guide.md`, and multiple docs deep-link into `specs/...` quickstarts, plans, tasks, and contracts. | `deferred follow-up` | A future relocation would require broad doc-link migration; that is outside a conservative foundation PR. |
 | `svg_conv/` | Only lightweight config/docs references were found; `svg_conv/README.md` itself says to prefer `robot_sf/nav/svg_map_parser.py`. | `moved` (#1579) | Relocated to `docs/tooling/svg_conv/`. |
-| `svg_conv/` | Only lightweight config/docs references were found; `svg_conv/README.md` itself says to prefer `robot_sf/nav/svg_map_parser.py`. | `low-risk move candidate` | Looks like legacy single-purpose tooling rather than a current root contract. |
 | `test_pygame/` | `docs/dev_guide.md`, `pyproject.toml`, tests, and helper scripts all reference `test_pygame/` explicitly. | `keep` | This is a documented, active test surface with exact path references. |
 | `test_scenarios/` | Tests load fixtures from `test_scenarios/osm_fixtures/...`; root fixtures are also part of current local test inputs. | `deferred follow-up` | Possible future consolidation into a test-fixture subtree, but not without updating multiple tests and docs. |
 | `utilities/` | Refactoring docs and example commands explicitly reference `utilities/migrate_environments.py`; `pyproject.toml` also has per-path lint rules for `utilities/**/*.py`. No confirmed doc references to `utilities/n.py` were found in this check. | `deferred follow-up` | This is not a core runtime package, but current docs/tooling still point to a root `utilities/` path, so moving it needs a conservative dedicated cleanup PR. |
@@ -65,6 +68,5 @@ If #1573 later needs actual path changes, the safest order is:
    `.coverage` so it does not reappear,
 2. decide whether `class_diagram/` and `svg_conv/` should move under docs/tooling: completed in
    PR #1579 (now at `docs/tooling/class_diagram/` and `docs/tooling/svg_conv/`),
-2. decide whether `class_diagram/` and `svg_conv/` should move under docs/tooling,
 3. handle any `hooks/`, `specs/`, `test_scenarios/`, or `utilities/` relocation only in dedicated
    PRs that update every exact-path reference together.

--- a/docs/context/issue_1583_high_risk_root_boundaries.md
+++ b/docs/context/issue_1583_high_risk_root_boundaries.md
@@ -21,8 +21,10 @@ dedicated follow-up issues with compatibility plans and targeted validation.
 
 ## Follow-Up Split
 
-- Issue #1599 owns the `specs/` compatibility plan.
-- Issue #1598 owns the `test_scenarios/` fixture relocation boundary.
+- Issue #1599 owns the `specs/` compatibility plan and is resolved by
+  [issue_1598_1599_root_compatibility_decisions.md](issue_1598_1599_root_compatibility_decisions.md).
+- Issue #1598 owns the `test_scenarios/` fixture relocation boundary and is resolved by
+  [issue_1598_1599_root_compatibility_decisions.md](issue_1598_1599_root_compatibility_decisions.md).
 - No follow-up issue is needed for `.agent/`, `model_ped/`, `test_pygame/`, or `CITATION.cff`
   unless a maintainer later requests a migration despite the current keep decision.
 

--- a/docs/context/issue_1583_high_risk_root_boundaries.md
+++ b/docs/context/issue_1583_high_risk_root_boundaries.md
@@ -1,0 +1,45 @@
+# Issue #1583 High-Risk Root Path Boundaries
+
+Date: 2026-05-28
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1583>
+
+## Decision
+
+No high-risk root paths should move in the current root-layout cleanup stream. Four paths are
+intentional root contracts and should stay where they are. Two paths may be revisited, but only in
+dedicated follow-up issues with compatibility plans and targeted validation.
+
+| Path | Active references | Decision | Validation gate | Compatibility burden | Rollback plan |
+| --- | --- | --- | --- | --- | --- |
+| `.agent/` | `AGENTS.md`, `docs/ai/repo_overview.md`, repo-local skills, and compatibility notes point to `.agent/PLANS.md`. | Keep. | `rg -nF ".agent/" AGENTS.md docs .github .vscode .agents` | Low, but it is part of the agent workflow contract. | Restore `.agent/` and revert docs/instruction links. |
+| `specs/` | Docs, examples, schemas, visual contract tests, helper docs, and runtime comments deep-link into `specs/...`. | Defer to Issue #1599. | `rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode` plus targeted schema/docs tests from the follow-up inventory. | Very high: broad docs/schema/test path churn and potential broken contract links. | Keep root path or provide compatibility links until every consumer is migrated. |
+| `model_ped/` | Pedestrian PPO training scripts, collision benchmark script, adversarial pedestrian demo, examples manifest, and `tests/test_training_ped_ppo.py` encode checkpoint paths. | Keep. | `rg -nF "model_ped/" AGENTS.md docs tests scripts examples robot_sf`; if behavior changes, `uv run pytest tests/test_training_ped_ppo.py -q`. | High: checkpoint paths are user-facing and test-visible. | Restore root `model_ped/` and checkpoint path defaults. |
+| `test_pygame/` | `AGENTS.md`, `docs/dev_guide.md`, `pyproject.toml`, demo scripts, and JSONL/recording tests reference GUI tests and recordings there. | Keep. | `rg -nF "test_pygame/" AGENTS.md docs tests scripts examples pyproject.toml`; for GUI changes, run the headless pygame test command from `AGENTS.md`. | Medium: active test surface and fixture path assumptions. | Restore root `test_pygame/` and revert config/test path edits. |
+| `test_scenarios/` | OSM examples and tests reference `test_scenarios/osm_fixtures/sample_block.pbf` directly. | Defer to Issue #1598. | `rg -nF "test_scenarios/" tests examples docs scripts robot_sf`; targeted OSM tests from Issue #1598. | Medium-high: fixture-relative paths and example defaults need lockstep migration. | Keep root fixtures or provide compatibility path until examples/tests are migrated. |
+| `CITATION.cff` | Release docs, release manifests, and release-protocol tests require a root citation file. | Keep. | `rg -nF "CITATION.cff" AGENTS.md docs tests configs .github`; for release changes, `uv run pytest tests/benchmark/test_release_protocol.py -q`. | High: publication metadata and release manifests expect the root path. | Restore root `CITATION.cff` and manifest `citation_path` values. |
+
+## Follow-Up Split
+
+- Issue #1599 owns the `specs/` compatibility plan.
+- Issue #1598 owns the `test_scenarios/` fixture relocation boundary.
+- No follow-up issue is needed for `.agent/`, `model_ped/`, `test_pygame/`, or `CITATION.cff`
+  unless a maintainer later requests a migration despite the current keep decision.
+
+## Evidence Checked
+
+The decisions above combine the read-only Spark sidecar inventory with local `rg` checks run on this
+branch. The sidecar did not edit files; final decisions and GitHub writes were handled locally.
+
+Reference commands:
+
+```bash
+rg -nF ".agent/" AGENTS.md docs .github .vscode .agents --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "model_ped/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "test_pygame/" AGENTS.md docs tests scripts examples pyproject.toml --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "test_scenarios/" AGENTS.md docs tests scripts examples robot_sf --glob '!docs/context/evidence/**' --glob '!output/**'
+rg -nF "CITATION.cff" AGENTS.md docs tests configs .github --glob '!docs/context/evidence/**' --glob '!output/**'
+```
+
+No files were moved and no generated artifacts were promoted.

--- a/docs/context/issue_1598_1599_root_compatibility_decisions.md
+++ b/docs/context/issue_1598_1599_root_compatibility_decisions.md
@@ -1,4 +1,4 @@
-# Issues #1598 And #1599 Root Compatibility Decisions
+# Issues #1598 and #1599 Root Compatibility Decisions (2026-05-28)
 
 Date: 2026-05-28
 

--- a/docs/context/issue_1598_1599_root_compatibility_decisions.md
+++ b/docs/context/issue_1598_1599_root_compatibility_decisions.md
@@ -1,0 +1,72 @@
+# Issues #1598 And #1599 Root Compatibility Decisions
+
+Date: 2026-05-28
+
+Issues:
+
+- <https://github.com/ll7/robot_sf_ll7/issues/1598>
+- <https://github.com/ll7/robot_sf_ll7/issues/1599>
+
+Predecessor: [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md)
+
+## Decision
+
+Keep both `test_scenarios/` and `specs/` at the repository root for now. They are not cleanup
+leftovers: current tests, examples, docs, schemas, and runtime comments treat those root paths as
+stable contracts. A future move should be a dedicated compatibility migration, not part of the
+root-layout cleanup stream.
+
+| Path | Decision | Compatibility burden | Required migration shape | Rollback plan |
+| --- | --- | --- | --- | --- |
+| `test_scenarios/` | Keep at root. | Medium: OSM examples and tests directly reference `test_scenarios/osm_fixtures/sample_block.pbf`. | If a later fixture move is accepted, keep a compatibility path or update every example/test default in one PR, then run the OSM gates below. | Restore root `test_scenarios/` fixture paths and revert example/test path defaults. |
+| `specs/` | Keep at root. | Very high: docs, example manifests, schema tests, runtime comments, and schema loaders deep-link into `specs/...`. | If a later migration is accepted, preserve root `specs/` compatibility links until all docs, tests, schema `$id` references, and runtime path assumptions are updated. | Restore root `specs/` and any contract paths consumed by schema tests or runtime loaders. |
+
+## Reference Inventory
+
+`test_scenarios/` root references are concentrated in OSM fixture consumers:
+
+- `examples/osm_map_editor_demo.py`
+- `examples/osm_map_quickstart.py`
+- `tests/test_osm_map_builder.py`
+- `tests/test_osm_backward_compat.py`
+- `tests/test_osm_background_renderer.py`
+
+`specs/` references are broad and mixed-purpose:
+
+- user docs including `docs/README.md`, `docs/dev_guide.md`,
+  `docs/imitation_learning_pipeline.md`, and benchmark docs,
+- example metadata in `examples/examples_manifest.yaml`,
+- schema and visual contract tests under `tests/visuals/` and `tests/maps/`,
+- runtime comments and path construction in `robot_sf/benchmark/`,
+  `robot_sf/maps/verification/`, `robot_sf/research/`, and `robot_sf/telemetry/`,
+- validation and tooling scripts under `scripts/`.
+
+This distribution argues against moving either path without a separate compatibility phase.
+
+## Validation Gates
+
+Reference inventory:
+
+```bash
+rg -nF "test_scenarios/" tests examples docs scripts robot_sf
+rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode
+```
+
+Targeted gates before any future `test_scenarios/` move:
+
+```bash
+uv run pytest tests/test_osm_map_builder.py tests/test_osm_background_renderer.py tests/test_osm_backward_compat.py -q
+uv run python examples/osm_map_quickstart.py
+```
+
+Targeted gates before any future `specs/` move:
+
+```bash
+uv run pytest tests/visuals/test_plot_schema_validation.py \
+  tests/visuals/test_video_schema_validation.py \
+  tests/visuals/test_performance_schema_validation.py \
+  tests/maps/test_map_verifier.py -q
+```
+
+The future migration PR should also run the normal PR readiness path after updating all path
+contracts.


### PR DESCRIPTION
## Summary

- records that `test_scenarios/` should remain at the repository root for now
- records that `specs/` should remain at the repository root for now
- documents compatibility burden, required migration shape, rollback plans, and targeted validation gates for any future move
- links the follow-up note from `docs/context/README.md` and the parent #1583 note

## Stacking

This PR is intentionally stacked on `issue-1583-high-risk-root-boundaries` / PR #1600 because these decisions are the follow-up split from #1583.

Closes #1598.
Closes #1599.

## Validation

- `rg -nF "test_scenarios/" tests examples docs scripts robot_sf`
- `rg -nF "specs/" AGENTS.md docs tests scripts robot_sf examples .github .vscode`
- `git diff --check`
- `BASE_REF=origin/issue-1583-high-risk-root-boundaries scripts/dev/check_docs_proof_consistency_diff.sh`
- `uv run pytest tests/test_osm_map_builder.py tests/test_osm_background_renderer.py tests/test_osm_backward_compat.py -q` passed: 31 passed
- `uv run pytest tests/visuals/test_plot_schema_validation.py tests/visuals/test_video_schema_validation.py tests/visuals/test_performance_schema_validation.py tests/maps/test_map_verifier.py -q` passed: 13 passed
- `uv run python examples/osm_map_quickstart.py` passed and wrote ignored demo output under `output/maps/osm_demo`
- `BASE_REF=origin/issue-1583-high-risk-root-boundaries PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed: 4299 passed, 11 skipped, 8 warnings; stamp `output/validation/pr_ready/issue-1598-1599-root-boundary-decisions.json`

## Artifacts

- Ignored local `output/coverage/*`, `output/maps/osm_demo/*`, and the readiness stamp were generated for validation.
- No durable artifact promotion is needed for this docs-only decision PR.
