### PR TITLE
docs: replace sensor TODO docstrings (#1603)

### DIFF
--- a/robot_sf/sensor/fusion_adapter.py
+++ b/robot_sf/sensor/fusion_adapter.py
@@ -197,17 +197,23 @@ class MergedObservationFusion:
     ) -> None:
         """Store the base fusion object and registry-backed sensor instances.
 
-        Args:
-            base_fusion: Existing fusion object that provides ``next_obs`` and
-                optionally ``reset_cache``.
-            sensors: Additional registry-created sensors to step after the base
-                observation is produced.
-            sensor_names: Names used to place sensor observations under
-                ``custom.<name>`` keys. Must align with ``sensors`` order.
-            sim: Optional simulator handle passed to custom sensors in their
-                lightweight state dict.
-            robot_id: Optional robot identifier passed to custom sensors in
-                their lightweight state dict.
+        Parameters
+        ----------
+        base_fusion : Any
+            Existing fusion object that provides ``next_obs`` and optionally
+            ``reset_cache``.
+        sensors : list[Sensor]
+            Additional registry-created sensors to step after the base
+            observation is produced.
+        sensor_names : list[str]
+            Names used to place sensor observations under ``custom.<name>``
+            keys. Must align with ``sensors`` order.
+        sim : Any | None
+            Optional simulator handle passed to custom sensors in their
+            lightweight state dict.
+        robot_id : int | None
+            Optional robot identifier passed to custom sensors in their
+            lightweight state dict.
         """
         self._base = base_fusion
         self._sensors = sensors
@@ -222,7 +228,9 @@ class MergedObservationFusion:
         ``robot_id`` before its observation is read. Sensor failures are logged
         with the configured sensor name and then re-raised.
 
-        Returns:
+        Returns
+        -------
+        dict[str, Any]
             Observation dictionary from the base fusion plus ``custom.<name>``
             entries for every configured registry sensor.
         """

--- a/robot_sf/sensor/fusion_adapter.py
+++ b/robot_sf/sensor/fusion_adapter.py
@@ -195,14 +195,19 @@ class MergedObservationFusion:
         sim: Any | None = None,
         robot_id: int | None = None,
     ) -> None:
-        """TODO docstring. Document this function.
+        """Store the base fusion object and registry-backed sensor instances.
 
         Args:
-            base_fusion: TODO docstring.
-            sensors: TODO docstring.
-            sensor_names: TODO docstring.
-            sim: TODO docstring.
-            robot_id: TODO docstring.
+            base_fusion: Existing fusion object that provides ``next_obs`` and
+                optionally ``reset_cache``.
+            sensors: Additional registry-created sensors to step after the base
+                observation is produced.
+            sensor_names: Names used to place sensor observations under
+                ``custom.<name>`` keys. Must align with ``sensors`` order.
+            sim: Optional simulator handle passed to custom sensors in their
+                lightweight state dict.
+            robot_id: Optional robot identifier passed to custom sensors in
+                their lightweight state dict.
         """
         self._base = base_fusion
         self._sensors = sensors
@@ -211,11 +216,15 @@ class MergedObservationFusion:
         self._robot_id = robot_id
 
     def next_obs(self) -> dict[str, Any]:
-        """TODO docstring. Document this function.
+        """Return base observations augmented with registry sensor outputs.
 
+        Each custom sensor receives a state dict containing ``sim`` and
+        ``robot_id`` before its observation is read. Sensor failures are logged
+        with the configured sensor name and then re-raised.
 
         Returns:
-            TODO docstring.
+            Observation dictionary from the base fusion plus ``custom.<name>``
+            entries for every configured registry sensor.
         """
         obs = self._base.next_obs()
         state = {"sim": self._sim, "robot_id": self._robot_id}
@@ -230,7 +239,7 @@ class MergedObservationFusion:
 
     # Pass-through API used by RobotState
     def reset_cache(self) -> None:
-        """TODO docstring. Document this function."""
+        """Reset cached base-fusion state and custom sensors when supported."""
         if hasattr(self._base, "reset_cache"):
             self._base.reset_cache()
         for sensor in self._sensors:

--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -1,4 +1,10 @@
-"""TODO docstring. Document this module."""
+"""LiDAR-style range scanning utilities for continuous occupancy maps.
+
+The helpers in this module cast radial rays from a robot or ego pedestrian pose
+against line-segment obstacles and circular dynamic objects. Distances are
+reported in world units and clipped/noised to match the configured scanner
+settings before they are exposed as Gymnasium observation spaces.
+"""
 
 from dataclasses import dataclass, field
 from math import cos, sin
@@ -123,7 +129,12 @@ class LidarScannerSettings:
     angle_opening: Range = field(init=False)
 
     def __post_init__(self):
-        """TODO docstring. Document this function."""
+        """Validate scanner settings and derive the symmetric angular opening.
+
+        ``visual_angle_portion`` is a fraction of a full circle, so ``1.0``
+        scans 360 degrees and ``1 / 3`` scans 120 degrees. ``scan_noise`` stores
+        scan-loss and corruption probabilities, both constrained to ``[0, 1]``.
+        """
         if not 0 < self.visual_angle_portion <= 1:
             raise ValueError("Scan angle portion needs to be within (0, 1]!")
         if self.max_scan_dist <= 0:
@@ -232,13 +243,16 @@ def raycast_obstacles(
     obstacles: np.ndarray,
     ray_angles: np.ndarray,
 ):
-    """TODO docstring. Document this function.
+    """Update ray ranges with intersections against static obstacle segments.
 
     Args:
-        out_ranges: TODO docstring.
-        scanner_pos: TODO docstring.
-        obstacles: TODO docstring.
-        ray_angles: TODO docstring.
+        out_ranges: Mutable per-ray distances. Entries are replaced in place
+            when a nearer obstacle intersection is found.
+        scanner_pos: Scanner origin in world coordinates.
+        obstacles: Obstacle segments as an ``(N, 4)`` array of
+            ``start_x, start_y, end_x, end_y`` rows.
+        ray_angles: Absolute ray directions in radians, one per ``out_ranges``
+            entry.
     """
     if len(obstacles.shape) != 2 or obstacles.shape[0] == 0 or obstacles.shape[1] != 4:
         return
@@ -395,14 +409,16 @@ def lidar_ray_scan(
 
 
 def lidar_sensor_space(num_rays: int, max_scan_dist: float) -> spaces.Box:
-    """TODO docstring. Document this function.
+    """Build the Gymnasium observation space for LiDAR range readings.
 
     Args:
-        num_rays: TODO docstring.
-        max_scan_dist: TODO docstring.
+        num_rays: Number of scalar range readings in each scan.
+        max_scan_dist: Inclusive upper bound for each range reading, in world
+            distance units.
 
     Returns:
-        TODO docstring.
+        A float32 ``Box`` with shape ``(num_rays,)`` and bounds
+        ``[0, max_scan_dist]`` for every ray.
     """
     high = np.full((num_rays), max_scan_dist, dtype=np.float32)
     low = np.zeros((num_rays), dtype=np.float32)


### PR DESCRIPTION
## Summary

Replaces the remaining `TODO docstring` placeholders in the two public sensor surfaces named by #1603.

## Linked Issues
- Closes #1603

## What Changed
- Documented `robot_sf/sensor/range_sensor.py` module behavior, LiDAR settings validation, obstacle raycast inputs, and LiDAR observation-space bounds.
- Documented `robot_sf/sensor/fusion_adapter.py` `MergedObservationFusion` setup, observation merging, error propagation, and reset behavior.

## Why It Matters
- Added value: contributors can understand range scans and registry-backed sensor fusion without reverse-engineering the implementation.
- Expected impact: documentation-only cleanup; no runtime behavior changed.
- Why this is worth merging now: this resolves a bounded production-module slice from the TODO-docstring backlog report.

## Validation / Proof
- Commands run:
  - `rg -n "TODO docstring" robot_sf/sensor/range_sensor.py robot_sf/sensor/fusion_adapter.py` returned no matches.
  - `uv run ruff check robot_sf/sensor/range_sensor.py robot_sf/sensor/fusion_adapter.py` passed.
  - `uv run python scripts/validation/check_docstring_todos.py --mode report` passed and no longer listed the two target files.
  - `uv run pytest tests/sensor tests/test_range_sensor.py -q` passed: 43 passed.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed: 4315 passed, 11 skipped, 9 warnings.
- Evidence that the change works here: readiness stamp `output/validation/pr_ready/issue-1603-sensor-docstrings.json` recorded `status: passed` for head `33fc4e9e477a4c8b31830b05cb3e8406d8dfeb34` against `origin/main`.
- Benchmarks or smoke tests, if applicable: not applicable; docs-only sensor cleanup.

## Risks / Rollout
- Compatibility risks: none expected; docstring-only change.
- Failure modes: inaccurate docs could mislead maintainers; wording was checked against existing implementation and targeted tests.
- Rollback or fallback plan: revert the single docs commit if reviewers find wording misleading.

## Docs / Provenance
- Updated docs: inline docstrings in the two issue-scoped sensor modules.
- Relevant design or provenance notes: #1603 was created from the TODO-docstring backlog report.
- Any assumptions that need to be preserved: distances are described as world units because the scanner uses the occupancy/map coordinate system.

## Follow-Up Issues
- Deferred work: broader TODO-docstring debt remains outside #1603 scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: docstrings only; please check wording for scanner units and custom sensor observation-key behavior.
- Any known limitations: unrelated placeholder docstrings remain in other repo areas by design.
