### PR TITLE
fix: count classic planner obstacle cells (#1605)

### DIFF
--- a/robot_sf/planner/classic_global_planner.py
+++ b/robot_sf/planner/classic_global_planner.py
@@ -301,8 +301,15 @@ def count_obstacle_cells(grid: Grid) -> int:
         >>> obstacle_count = count_obstacle_cells(grid)
         >>> print(f"Grid has {obstacle_count} obstacle cells")
     """
-    type_map_np = np.asarray(grid.type_map)
+    type_map_np = _grid_type_map_array(grid)
     return np.count_nonzero(type_map_np == TYPES.OBSTACLE)
+
+
+def _grid_type_map_array(grid: Grid) -> np.ndarray:
+    """Return the concrete cell-type array from a python_motion_planning grid."""
+    type_map = grid.type_map
+    raw_array = getattr(type_map, "array", type_map)
+    return np.asarray(raw_array)
 
 
 def _sanitize_visualization_output_path(output_path: Path | str) -> Path:
@@ -480,8 +487,9 @@ def set_start_goal_on_grid(
 def get_obstacle_statistics(grid: Grid) -> dict[str, float]:
     """Calculate basic statistics about obstacle occupancy.
 
-    TODO: Percentage for obstacles is likely not calculated correctly.
-    `INFO   | 29_osm_global_planner_test.py:55 | Planning grid: (513, 393), 0 obstacle cells (0.00%)`
+    This diagnostic counts cells marked as ``TYPES.OBSTACLE``. Inflated
+    clearance cells remain separate ``TYPES.INFLATION`` cells and are not
+    included in the obstacle percentage.
 
     Args:
         grid: Grid to analyze.
@@ -496,13 +504,15 @@ def get_obstacle_statistics(grid: Grid) -> dict[str, float]:
         >>> stats = get_obstacle_statistics(grid)
         >>> print(f"Grid is {stats['obstacle_percentage']:.1f}% occupied")
     """
-    type_map_np = np.asarray(grid.type_map)
+    type_map_np = _grid_type_map_array(grid)
     obstacle_count = np.count_nonzero(type_map_np == TYPES.OBSTACLE)
     total_cells = type_map_np.size
     return {
-        "obstacle_count": obstacle_count,
-        "total_cells": total_cells,
-        "obstacle_percentage": (obstacle_count / total_cells * 100) if total_cells > 0 else 0.0,
+        "obstacle_count": int(obstacle_count),
+        "total_cells": int(total_cells),
+        "obstacle_percentage": float(obstacle_count / total_cells * 100)
+        if total_cells > 0
+        else 0.0,
     }
 
 

--- a/tests/test_motion_planning_adapter.py
+++ b/tests/test_motion_planning_adapter.py
@@ -72,13 +72,42 @@ def test_map_definition_to_motion_planning_grid_marks_obstacles() -> None:
     """Verify rasterization marks obstacle cells and preserves scale metadata."""
     grid = map_definition_to_motion_planning_grid(
         _map_def_with_obstacle(),
-        MotionPlanningGridConfig(cells_per_meter=1.0, inflate_radius_cells=None),
+        MotionPlanningGridConfig(
+            cells_per_meter=1.0,
+            add_boundary_obstacles=False,
+            inflate_radius_cells=None,
+        ),
     )
     assert grid.cells_per_meter == 1.0
     obstacle_count = count_obstacle_cells(grid)
+    assert obstacle_count == 4
     assert isinstance(obstacle_count, (int, np.integer))
     stats = get_obstacle_statistics(grid)
-    assert stats["total_cells"] > 0
+    assert stats == {
+        "obstacle_count": 4,
+        "total_cells": 16,
+        "obstacle_percentage": 25.0,
+    }
+
+
+def test_obstacle_statistics_exclude_inflated_clearance_cells() -> None:
+    """Obstacle occupancy reports physical obstacles separately from inflation."""
+    grid = map_definition_to_motion_planning_grid(
+        _map_def_with_obstacle(),
+        MotionPlanningGridConfig(
+            cells_per_meter=1.0,
+            add_boundary_obstacles=False,
+            inflate_radius_cells=1,
+        ),
+    )
+
+    assert count_obstacle_cells(grid) == 4
+    assert np.count_nonzero(grid.type_map.array == TYPES.INFLATION) == 8
+    assert get_obstacle_statistics(grid) == {
+        "obstacle_count": 4,
+        "total_cells": 16,
+        "obstacle_percentage": 25.0,
+    }
 
 
 def test_set_start_goal_on_grid_marks_cells() -> None:

--- a/tests/test_motion_planning_adapter.py
+++ b/tests/test_motion_planning_adapter.py
@@ -102,7 +102,8 @@ def test_obstacle_statistics_exclude_inflated_clearance_cells() -> None:
     )
 
     assert count_obstacle_cells(grid) == 4
-    assert np.count_nonzero(grid.type_map.array == TYPES.INFLATION) == 8
+    type_map = np.asarray(getattr(grid.type_map, "array", grid.type_map))
+    assert np.count_nonzero(type_map == TYPES.INFLATION) == 8
     assert get_obstacle_statistics(grid) == {
         "obstacle_count": 4,
         "total_cells": 16,


### PR DESCRIPTION
## Summary

Fixes classic planner obstacle occupancy diagnostics by reading the concrete `GridTypeMap.array` instead of treating the wrapper as a NumPy scalar.

## Linked Issues
- Closes #1605

## What Changed
- Added a small helper that normalizes `python_motion_planning` grid type maps to a real NumPy array before counting cells.
- Updated `count_obstacle_cells()` and `get_obstacle_statistics()` to report real obstacle counts, total cells, and percentage values.
- Added deterministic tests for a 4x4 map fixture with four obstacle cells, including a case proving inflated clearance cells are not counted as physical obstacle occupancy.

## Why It Matters
- Added value: classic planner examples and diagnostics no longer report `0 obstacle cells (0.00%)` for maps with obstacles.
- Expected impact: diagnostic-only behavior; planner pathfinding and rasterization semantics are unchanged.
- Why this is worth merging now: the inline TODO was a real wrapper-conversion bug with a bounded fix and direct test coverage.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_motion_planning_adapter.py -q` passed: 21 passed.
  - `uv run ruff check robot_sf/planner/classic_global_planner.py tests/test_motion_planning_adapter.py` passed.
  - `git diff --check` passed.
  - `MPLBACKEND=Agg uv run python examples/advanced/29_osm_global_planner_test.py` reached the corrected diagnostic log: `214837 obstacle cells (26.70%)`, then failed later on an existing invalid goal cell. I am not treating that optional smoke as passed.
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed: 4316 passed, 11 skipped, 9 warnings.
- Evidence that the change works here: readiness stamp `output/validation/pr_ready/issue-1605-obstacle-stats.json` recorded `status: passed` for head `d80bc40a981cb7594e01bec97c73485ed8415da4` against `origin/main`.
- Benchmarks or smoke tests, if applicable: no benchmark evidence claimed; this is diagnostic/statistic validation only.

## Risks / Rollout
- Compatibility risks: return keys are preserved; numeric values now reflect the actual type-map array.
- Failure modes: downstream code that implicitly depended on the erroneous zero count would see corrected nonzero values.
- Rollback or fallback plan: revert the single fix commit if an unexpected consumer incompatibility appears.

## Docs / Provenance
- Updated docs: replaced the stale inline TODO with the precise `TYPES.OBSTACLE` vs `TYPES.INFLATION` boundary.
- Relevant design or provenance notes: #1605 cites the original TODO and advanced example diagnostic.
- Any assumptions that need to be preserved: obstacle occupancy intentionally excludes inflated clearance cells.

## Follow-Up Issues
- Deferred work: the optional advanced example still fails later because the hardcoded goal lies in an inflated cell; that is outside this diagnostic-statistics issue.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the semantic choice that `obstacle_percentage` counts `TYPES.OBSTACLE` only, not `TYPES.INFLATION`.
- Any known limitations: this PR does not change rasterization, inflation, or planner start/goal selection behavior.
