### PR TITLE
docs: add SLURM runtime suitability gate

### DIFF
--- a/.agents/skills/schemas/campaign_submission.v1.yaml
+++ b/.agents/skills/schemas/campaign_submission.v1.yaml
@@ -7,6 +7,11 @@ campaign_submission:
   stdout: path
   stderr: path
   output_root: path
+  slurm_suitability: local-smoke | compute-node-smoke | slurm-campaign | blocked-needs-scope
+  estimated_runtime_minutes: number
+  runtime_basis: string
+  local_default_overridden: boolean
+  evidence_claim: smoke | compatibility | campaign | blocked
   expected_artifacts:
   - manifest
   - checkpoint

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -23,19 +23,40 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 
 1. Read local cluster guidance (`local.machine.md` if present, then `SLURM/AGENTS.md` and `docs/dev/slurm_submission.md`).
 2. Confirm config path, command surface, current commit SHA, and dirty-tree risk.
-3. Run any campaign-specific launch-packet validator before `sbatch` when one exists under `scripts/validation/`.
-4. Submit with explicit config and job name; capture job ID plus stdout/stderr paths.
-5. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
-6. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
-7. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
+3. Run the SLURM suitability gate before any `sbatch`:
+   - estimate rows, seeds, scenarios, episodes, horizon, workers, expected walltime, GPU need, and
+     expected artifacts from the config or preflight output;
+   - classify the planned run as `local-smoke`, `compute-node-smoke`, `slurm-campaign`, or
+     `blocked-needs-scope`;
+   - default to local execution for jobs expected to finish in under 1 hour unless they require a
+     compute-node-only dependency, GPU, queue/runtime parity proof, or explicit maintainer approval;
+   - when a short run is submitted to SLURM anyway, label it as a smoke/probe in the job label,
+     handoff note, issue comment, and PR text, not as completed campaign evidence.
+4. Run any campaign-specific launch-packet validator before `sbatch` when one exists under `scripts/validation/`.
+5. Submit with explicit config and job name; capture job ID plus stdout/stderr paths.
+6. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
+7. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
+8. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
 
 ## Guardrails
 
 - Do not infer live cluster capacity from stale logs.
 - Do not submit from an unintended branch or dirty tree without calling that out.
 - Do not treat a queued job as completed evidence.
+- Do not let an issue's `slurm` label override the suitability gate. A `slurm` label means the
+  issue may need cluster execution, not that every bounded smoke must be submitted.
+- Do not call a short compatibility run a campaign-sized result. If the estimated or observed
+  runtime is under 1 hour, preserve it as smoke/probe evidence unless the issue explicitly asks for
+  a short compute-node proof.
 - Do not upload artifacts externally unless the user explicitly requests it.
 
 ## Output
 
-Use `campaign_submission.v1`.
+Use `campaign_submission.v1`. Include:
+
+- `slurm_suitability`: one of `local-smoke`, `compute-node-smoke`, `slurm-campaign`, or
+  `blocked-needs-scope`;
+- `estimated_runtime_minutes`;
+- `runtime_basis`: the rows/seeds/scenarios/horizon/workers calculation or preflight source;
+- `local_default_overridden`: `true` only when a sub-1-hour run still has a compute-node-only reason;
+- `evidence_claim`: `smoke`, `compatibility`, `campaign`, or `blocked`.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -56,7 +56,7 @@ Use `campaign_submission.v1`. Include:
 
 - `slurm_suitability`: one of `local-smoke`, `compute-node-smoke`, `slurm-campaign`, or
   `blocked-needs-scope`;
-- `estimated_runtime_minutes`;
+- `estimated_runtime_minutes`: the estimated runtime of the campaign in minutes;
 - `runtime_basis`: the rows/seeds/scenarios/horizon/workers calculation or preflight source;
 - `local_default_overridden`: `true` only when a sub-1-hour run still has a compute-node-only reason;
 - `evidence_claim`: `smoke`, `compatibility`, `campaign`, or `blocked`.

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -48,6 +48,14 @@ scripts/dev/sbatch_use_max_time.sh --time 08:00:00 SLURM/Auxme/auxme_gpu.sl
 - Prefer the wrapper for long-running training jobs.
 - Keep explicit short limits only for intentionally bounded jobs such as setup or quick
   interactive sessions.
+- Before submitting, estimate the intended runtime from the config or preflight output: rows,
+  scenarios, seeds, episodes, horizon, workers, GPU need, and expected artifacts. A benchmark or
+  training run expected to finish in under 1 hour should default to local execution, not SLURM.
+- Submit a sub-1-hour run to SLURM only when the point is compute-node proof: GPU-only execution,
+  cluster-only dependencies, queue/runtime parity, or a maintainer-approved smoke. Label that job
+  and any issue/PR follow-up as `smoke` or `probe`, not as completed campaign evidence.
+- Do not let a GitHub `slurm` label alone justify submission. The label means cluster execution may
+  be required; the config still needs a suitability check.
 - When adding a new batch script, include `#SBATCH --partition` and `#SBATCH --qos` so
   the wrapper can resolve the correct limit without extra flags.
 - If Slurm tools are unavailable in the current shell, fall back to a manual `sbatch`


### PR DESCRIPTION
## Summary

- Add a suitability gate to `slurm-campaign-submit` before `sbatch`: estimate rows, seeds, scenarios, episodes, horizon, workers, expected walltime, GPU need, and artifacts.
- Default expected sub-1-hour benchmark/training jobs to local execution unless they need compute-node-only proof, GPU/runtime parity, or maintainer approval.
- Require short SLURM submissions to be labeled as smoke/probe evidence rather than completed campaign evidence.
- Mirror the same rule in `docs/dev/slurm_submission.md` so the human-facing workflow matches the skill behavior.

## Validation

- `uv run python scripts/dev/check_skills.py`
- `git diff --check origin/main...HEAD`

Refs #1484.