### PR TITLE
refactor: centralize pedestrian force alias sync (#1631)

### DIFF
--- a/robot_sf/gym_env/base_env.py
+++ b/robot_sf/gym_env/base_env.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from robot_sf.common.artifact_paths import resolve_artifact_path
 from robot_sf.gym_env.env_config import EnvSettings
+from robot_sf.gym_env.unified_config import sync_pedestrian_obstacle_force_alias
 from robot_sf.planner import (
     ClassicPlannerConfig,
     GlobalPlanner,
@@ -127,16 +128,18 @@ class BaseEnv(Env):
                 seed=seed,
             )
 
-        # Resolve obstacle-force flag with backwards compatibility.
-        static_obstacle_forces = getattr(
-            env_config,
-            "peds_have_static_obstacle_forces",
-            None,
+        # Resolve obstacle-force flag with backwards compatibility. Unified configs already
+        # carry the canonical value, while legacy env_config classes still use the kwarg.
+        legacy_override = (
+            None
+            if hasattr(env_config, "peds_have_static_obstacle_forces")
+            else peds_have_obstacle_forces
         )
-        if static_obstacle_forces is None:
-            static_obstacle_forces = peds_have_obstacle_forces
-            if hasattr(env_config, "peds_have_static_obstacle_forces"):
-                env_config.peds_have_static_obstacle_forces = static_obstacle_forces
+        static_obstacle_forces = sync_pedestrian_obstacle_force_alias(
+            env_config,
+            legacy_override,
+            warn=False,
+        )
 
         # Initialize simulator via backend registry (falls back to legacy init on error)
         backend_key = getattr(env_config, "backend", "fast-pysf")

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -238,7 +238,8 @@ class EnvironmentFactory:
         if config is None:
             config = ImageRobotConfig() if use_image_obs else RobotSimulationConfig()
         config.use_image_obs = use_image_obs
-        sync_pedestrian_obstacle_force_alias(config, peds_have_obstacle_forces)
+        legacy_override = None if peds_have_obstacle_forces is True else peds_have_obstacle_forces
+        sync_pedestrian_obstacle_force_alias(config, legacy_override)
         config.enable_telemetry_panel = enable_telemetry_panel
         config.telemetry_record = telemetry_record
         config.telemetry_refresh_hz = telemetry_refresh_hz
@@ -311,7 +312,8 @@ class EnvironmentFactory:
         if reward_func is None:
             reward_func = simple_ped_reward
 
-        sync_pedestrian_obstacle_force_alias(config, peds_have_obstacle_forces)
+        legacy_override = None if peds_have_obstacle_forces is True else peds_have_obstacle_forces
+        sync_pedestrian_obstacle_force_alias(config, legacy_override)
 
         return PedestrianEnv(
             env_config=config,  # type: ignore[arg-type]

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -70,6 +70,7 @@ from robot_sf.gym_env.unified_config import (
     MultiRobotConfig,
     PedestrianSimulationConfig,
     RobotSimulationConfig,
+    sync_pedestrian_obstacle_force_alias,
 )
 
 if TYPE_CHECKING:
@@ -237,16 +238,7 @@ class EnvironmentFactory:
         if config is None:
             config = ImageRobotConfig() if use_image_obs else RobotSimulationConfig()
         config.use_image_obs = use_image_obs
-        if peds_have_obstacle_forces is not True:
-            logger.warning(
-                "peds_have_obstacle_forces is deprecated; use "
-                "peds_have_static_obstacle_forces on the config instead.",
-            )
-        if hasattr(config, "peds_have_static_obstacle_forces"):
-            config.peds_have_static_obstacle_forces = peds_have_obstacle_forces
-            config.peds_have_obstacle_forces = peds_have_obstacle_forces
-        else:
-            config.peds_have_obstacle_forces = peds_have_obstacle_forces
+        sync_pedestrian_obstacle_force_alias(config, peds_have_obstacle_forces)
         config.enable_telemetry_panel = enable_telemetry_panel
         config.telemetry_record = telemetry_record
         config.telemetry_refresh_hz = telemetry_refresh_hz
@@ -319,16 +311,7 @@ class EnvironmentFactory:
         if reward_func is None:
             reward_func = simple_ped_reward
 
-        if peds_have_obstacle_forces is not True:
-            logger.warning(
-                "peds_have_obstacle_forces is deprecated; use "
-                "peds_have_static_obstacle_forces on the config instead.",
-            )
-        if hasattr(config, "peds_have_static_obstacle_forces"):
-            config.peds_have_static_obstacle_forces = peds_have_obstacle_forces
-            config.peds_have_obstacle_forces = peds_have_obstacle_forces
-        else:
-            config.peds_have_obstacle_forces = peds_have_obstacle_forces
+        sync_pedestrian_obstacle_force_alias(config, peds_have_obstacle_forces)
 
         return PedestrianEnv(
             env_config=config,  # type: ignore[arg-type]

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -27,7 +27,10 @@ from robot_sf.gym_env.env_util import (
 )
 from robot_sf.gym_env.reward import simple_ped_reward
 from robot_sf.gym_env.robot_env import _build_step_info
-from robot_sf.gym_env.unified_config import PedestrianSimulationConfig
+from robot_sf.gym_env.unified_config import (
+    PedestrianSimulationConfig,
+    sync_pedestrian_obstacle_force_alias,
+)
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.ped_ego.pedestrian_state import PedestrianState
 from robot_sf.render.lidar_visual import render_lidar
@@ -133,7 +136,7 @@ class PedestrianEnv(SingleAgentEnv):
         if peds_have_obstacle_forces is not None:
             if env_config is original_env_config:
                 env_config = deepcopy(env_config)
-            env_config.peds_have_static_obstacle_forces = peds_have_obstacle_forces
+            sync_pedestrian_obstacle_force_alias(env_config, peds_have_obstacle_forces)
 
         # Store robot model
         if robot_model is None:

--- a/robot_sf/gym_env/unified_config.py
+++ b/robot_sf/gym_env/unified_config.py
@@ -35,6 +35,47 @@ from robot_sf.sensor.image_sensor import ImageSensorSettings
 from robot_sf.sensor.range_sensor import LidarScannerSettings
 from robot_sf.sim.sim_config import SimulationSettings
 
+PED_OBSTACLE_FORCE_ALIAS_WARNING = (
+    "peds_have_obstacle_forces is deprecated; use peds_have_static_obstacle_forces instead."
+)
+
+
+def sync_pedestrian_obstacle_force_alias(
+    config: object,
+    override: bool | None = None,
+    *,
+    warn: bool = True,
+) -> bool:
+    """Synchronize the deprecated pedestrian obstacle-force alias on a config object.
+
+    Args:
+        config: Environment config that may expose ``peds_have_static_obstacle_forces``
+            and/or the deprecated ``peds_have_obstacle_forces`` alias.
+        override: Optional legacy kwarg value. When provided, it wins for backwards
+            compatibility and is copied into the canonical static-obstacle field.
+        warn: Emit the deprecation warning when a legacy value changes the canonical value.
+
+    Returns:
+        bool: Effective static-obstacle force setting to pass to simulator construction.
+    """
+    static_value = bool(getattr(config, "peds_have_static_obstacle_forces", True))
+    alias_value = override
+    if alias_value is None:
+        alias_value = getattr(config, "peds_have_obstacle_forces", None)
+
+    if alias_value is not None:
+        alias_bool = bool(alias_value)
+        if warn and alias_bool != static_value:
+            logger.warning(PED_OBSTACLE_FORCE_ALIAS_WARNING)
+        static_value = alias_bool
+        if hasattr(config, "peds_have_static_obstacle_forces"):
+            config.peds_have_static_obstacle_forces = static_value  # type: ignore[attr-defined]
+
+    if hasattr(config, "peds_have_obstacle_forces"):
+        config.peds_have_obstacle_forces = static_value  # type: ignore[attr-defined]
+
+    return static_value
+
 
 @dataclass
 class ObservationVisibilitySettings:
@@ -253,21 +294,12 @@ class RobotSimulationConfig(BaseSimulationConfig):
 
     def _sync_force_flags(self) -> None:
         """Sync deprecated force flags and prf_config for backwards compatibility."""
-        if self.peds_have_obstacle_forces is not None:
-            if self.peds_have_obstacle_forces != self.peds_have_static_obstacle_forces:
-                logger.warning(
-                    "peds_have_obstacle_forces is deprecated; use "
-                    "peds_have_static_obstacle_forces instead.",
-                )
-            self.peds_have_static_obstacle_forces = bool(self.peds_have_obstacle_forces)
+        sync_pedestrian_obstacle_force_alias(self)
 
         if self.peds_have_robot_repulsion is not None:
             self.sim_config.prf_config.is_active = bool(self.peds_have_robot_repulsion)
         else:
             self.peds_have_robot_repulsion = bool(self.sim_config.prf_config.is_active)
-
-        # Keep deprecated alias in sync for external consumers.
-        self.peds_have_obstacle_forces = self.peds_have_static_obstacle_forces
 
     def _validate_global_sampling(self) -> None:
         """Ensure global sampling is only enabled when planner-based routing is active."""

--- a/tests/test_environment_factory_signatures.py
+++ b/tests/test_environment_factory_signatures.py
@@ -17,6 +17,7 @@ from robot_sf.gym_env.base_env import BaseEnv
 from robot_sf.gym_env.crowd_sim_env import CrowdSimEnv, CrowdSimulationConfig
 from robot_sf.gym_env.env_config import SimulationSettings
 from robot_sf.gym_env.environment_factory import (
+    EnvironmentFactory,
     make_crowd_sim_env,
     make_image_robot_env,
     make_multi_robot_env,
@@ -26,6 +27,7 @@ from robot_sf.gym_env.environment_factory import (
 from robot_sf.gym_env.multi_robot_env import MultiRobotEnv
 from robot_sf.gym_env.robot_env import RobotEnv
 from robot_sf.gym_env.robot_env_with_image import RobotEnvWithImage
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
 
 
 def _param_names(func):
@@ -81,6 +83,37 @@ def test_public_factories_reject_retired_legacy_kwargs(factory, kwargs):
     """Retired catch-all factory kwargs should fail at the Python signature boundary."""
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         factory(**kwargs)
+
+
+def test_robot_factory_normalizes_deprecated_force_flag_once(monkeypatch):
+    """Internal factory should sync the legacy kwarg through the shared config helper."""
+    captured = {}
+
+    class FakeRobotEnv:
+        """Minimal robot env stub for factory normalization assertions."""
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(environment_factory_module, "RobotEnv", FakeRobotEnv)
+    config = RobotSimulationConfig()
+
+    env = EnvironmentFactory.create_robot_env(
+        config=config,
+        use_image_obs=False,
+        peds_have_obstacle_forces=False,
+        reward_func=None,
+        debug=False,
+        recording_enabled=False,
+        record_video=False,
+        video_path=None,
+        video_fps=None,
+    )
+
+    assert isinstance(env, FakeRobotEnv)
+    assert config.peds_have_static_obstacle_forces is False
+    assert config.peds_have_obstacle_forces is False
+    assert captured["peds_have_obstacle_forces"] is False
 
 
 def test_make_multi_robot_env_signature_explicit():

--- a/tests/test_environment_factory_signatures.py
+++ b/tests/test_environment_factory_signatures.py
@@ -27,7 +27,7 @@ from robot_sf.gym_env.environment_factory import (
 from robot_sf.gym_env.multi_robot_env import MultiRobotEnv
 from robot_sf.gym_env.robot_env import RobotEnv
 from robot_sf.gym_env.robot_env_with_image import RobotEnvWithImage
-from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
 
 
 def _param_names(func):
@@ -114,6 +114,49 @@ def test_robot_factory_normalizes_deprecated_force_flag_once(monkeypatch):
     assert config.peds_have_static_obstacle_forces is False
     assert config.peds_have_obstacle_forces is False
     assert captured["peds_have_obstacle_forces"] is False
+
+    explicit_false_config = RobotSimulationConfig(peds_have_static_obstacle_forces=False)
+    EnvironmentFactory.create_robot_env(
+        config=explicit_false_config,
+        use_image_obs=False,
+        peds_have_obstacle_forces=True,
+        reward_func=None,
+        debug=False,
+        recording_enabled=False,
+        record_video=False,
+        video_path=None,
+        video_fps=None,
+    )
+
+    assert explicit_false_config.peds_have_static_obstacle_forces is False
+    assert explicit_false_config.peds_have_obstacle_forces is False
+
+
+def test_pedestrian_factory_preserves_explicit_static_force_config(monkeypatch):
+    """Default legacy kwarg should not override an explicit canonical false value."""
+    captured = {}
+
+    class FakePedestrianEnv:
+        """Minimal pedestrian env stub for factory normalization assertions."""
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        environment_factory_module, "_load_pedestrian_env", lambda: FakePedestrianEnv
+    )
+    config = PedestrianSimulationConfig(peds_have_static_obstacle_forces=False)
+
+    env = EnvironmentFactory.create_pedestrian_env(
+        robot_model=None,
+        config=config,
+        peds_have_obstacle_forces=True,
+    )
+
+    assert isinstance(env, FakePedestrianEnv)
+    assert config.peds_have_static_obstacle_forces is False
+    assert config.peds_have_obstacle_forces is False
+    assert captured["peds_have_obstacle_forces"] is True
 
 
 def test_make_multi_robot_env_signature_explicit():

--- a/tests/test_pedestrian_env_compat.py
+++ b/tests/test_pedestrian_env_compat.py
@@ -15,7 +15,11 @@ from robot_sf.gym_env.env_config import PedEnvSettings as LegacyPedEnvSettings
 from robot_sf.gym_env.environment_factory import make_pedestrian_env
 from robot_sf.gym_env.pedestrian_env import PedestrianEnv, _reward_function_name
 from robot_sf.gym_env.reward import simple_ped_reward
-from robot_sf.gym_env.unified_config import PedestrianSimulationConfig
+from robot_sf.gym_env.unified_config import (
+    PedestrianSimulationConfig,
+    RobotSimulationConfig,
+    sync_pedestrian_obstacle_force_alias,
+)
 
 
 def test_pedestrian_env_uses_stub_robot_model() -> None:
@@ -74,6 +78,28 @@ def test_pedestrian_env_does_not_mutate_input_config_for_deprecated_force_flag()
         assert env.config.peds_have_static_obstacle_forces is False
     finally:
         env.exit()
+
+
+def test_deprecated_force_alias_helper_syncs_override_to_canonical_field() -> None:
+    """The shared helper keeps legacy and canonical force fields consistent."""
+    config = RobotSimulationConfig()
+
+    effective = sync_pedestrian_obstacle_force_alias(config, False)
+
+    assert effective is False
+    assert config.peds_have_static_obstacle_forces is False
+    assert config.peds_have_obstacle_forces is False
+
+
+def test_deprecated_force_alias_helper_preserves_canonical_field_without_override() -> None:
+    """No legacy override should leave the canonical config field in charge."""
+    config = RobotSimulationConfig(peds_have_static_obstacle_forces=False)
+
+    effective = sync_pedestrian_obstacle_force_alias(config)
+
+    assert effective is False
+    assert config.peds_have_static_obstacle_forces is False
+    assert config.peds_have_obstacle_forces is False
 
 
 def test_pedestrian_env_avoids_deepcopy_for_default_deprecated_force_flag(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Centralize `peds_have_obstacle_forces` compatibility synchronization so unified configs, robot/pedestrian factories, `BaseEnv`, and direct `PedestrianEnv` construction share one helper.

## Linked Issues
- Closes #1631

## What Changed
- Added `sync_pedestrian_obstacle_force_alias()` in `robot_sf/gym_env/unified_config.py` as the canonical deprecated-alias sync helper.
- Replaced duplicate factory and base-env sync logic with the shared helper while preserving public signatures and old-call behavior.
- Updated direct `PedestrianEnv(..., peds_have_obstacle_forces=...)` handling so copied configs keep both canonical and deprecated fields synchronized.
- Added compatibility/factory tests for helper behavior and factory normalization.

## Why It Matters
- Added value: the deprecated obstacle-force alias now has one implementation path instead of several drifting copies.
- Expected impact: users can keep old calls while canonical `peds_have_static_obstacle_forces` remains the documented source of truth.
- Why this is worth merging now: it closes a ready technical-debt issue without removing compatibility or changing physics semantics.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_pedestrian_env_compat.py tests/test_config_validation.py tests/test_environment_factory_signatures.py tests/factories/test_current_factory_signatures.py tests/factories/test_pedestrian_factory_normalization.py -q` -> 53 passed.
  - `uv run ruff check robot_sf/gym_env/unified_config.py robot_sf/gym_env/environment_factory.py robot_sf/gym_env/base_env.py robot_sf/gym_env/pedestrian_env.py tests/test_pedestrian_env_compat.py tests/test_environment_factory_signatures.py` -> passed.
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4318 passed, 11 skipped; freshness stamp recorded for `3cc3c94b98c0b3e6f087a4730a3e3b590ae045b6`.
- Evidence that the change works here: targeted tests cover old-call direct env construction, helper canonical/alias sync, and factory normalization; the full repository readiness gate passed on the pushed head.
- Benchmarks or smoke tests, if applicable: not benchmark-facing; no benchmark artifacts generated.

## Risks / Rollout
- Compatibility risks: low; public kwargs remain and the deprecated alias still syncs for external consumers.
- Failure modes: callers relying on divergent alias/canonical values now get normalized behavior through one helper.
- Rollback or fallback plan: revert the single commit to restore previous duplicate sync blocks.

## Docs / Provenance
- Updated docs: helper docstring documents canonical/deprecated field behavior.
- Relevant design or provenance notes: issue #1631 requested import-site audit and centralized `peds_have_obstacle_forces` compatibility behavior.
- Any assumptions that need to be preserved: legacy `env_config.py` classes remain in place because current examples/tests still intentionally import them.

## Follow-Up Issues
- Deferred work: removing or further migrating legacy `EnvSettings`/`RobotEnvSettings`/`PedEnvSettings` imports remains out of scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the warning behavior is acceptable: the shared helper warns when a legacy alias/override changes the canonical value, matching the old conflict-warning intent.
- Artifact decision: generated `output/coverage/*` and `output/validation/pr_ready/*` are ignored, disposable local validation artifacts; nothing under `output/` is committed or durable-required.
