### PR TITLE
feat: add config schema version gates (#1637)

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -54,6 +54,7 @@ per-scenario and per-archetype YAMLs into a single scenario list.
 
 ```yaml
 # configs/scenarios/sets/classic_cross_trap_subset.yaml
+schema_version: robot_sf.scenario_matrix.v1
 includes:
   - ../archetypes/classic_cross_trap.yaml
 select_scenarios:
@@ -68,6 +69,10 @@ The loader expands includes relative to the manifest file and then applies
 order controls the final scenario order. Duplicate names in the expanded pool
 raise an error so subset manifests fail closed when the source data is
 ambiguous.
+
+The optional `schema_version` field is metadata for manifest validation. Use
+`robot_sf.scenario_matrix.v1`; `robot_sf_bench validate-config --matrix <manifest>` rejects
+unsupported values before a run starts.
 
 If `map_file` paths in included scenarios are not resolvable, you can set
 `map_search_paths` to help locate map files. Each manifest resolves its own

--- a/configs/scenarios/confirmation_v1.yaml
+++ b/configs/scenarios/confirmation_v1.yaml
@@ -11,6 +11,7 @@
 #   robot_sf_bench validate-config --matrix configs/scenarios/confirmation_v1.yaml
 #   robot_sf_bench preview-scenarios --matrix configs/scenarios/confirmation_v1.yaml
 
+schema_version: robot_sf.scenario_matrix.v1
 includes:
   - archetypes/issue_596_frame_consistency.yaml
   - archetypes/issue_596_static_obstacles.yaml

--- a/configs/scenarios/nominal_v1.yaml
+++ b/configs/scenarios/nominal_v1.yaml
@@ -15,6 +15,7 @@
 #     --algo simple_policy --out output/benchmarks/nominal_v1/episodes.jsonl \
 #     --workers 1 --no-resume
 
+schema_version: robot_sf.scenario_matrix.v1
 includes:
   - sets/verified_simple_subset_v1.yaml
   - archetypes/classic_doorway.yaml

--- a/configs/scenarios/sanity_v1.yaml
+++ b/configs/scenarios/sanity_v1.yaml
@@ -4,6 +4,7 @@
 # route-following and sparse-interaction cases so baseline competence can be checked separately
 # from stress-test robustness.
 
+schema_version: robot_sf.scenario_matrix.v1
 includes:
   - single/planner_sanity_simple.yaml
   - sets/verified_simple_subset_v1.yaml

--- a/configs/training/ppo_imitation/README.md
+++ b/configs/training/ppo_imitation/README.md
@@ -28,3 +28,6 @@ This directory hosts configuration files used by the expert-policy, trajectory c
 5. W&B is enabled by default for Optuna launcher runs; set `disable_wandb: true` only for offline/reliability scenarios.
 6. Safety-gated Optuna sweeps can set `constraint_collision_rate_max` (and optional
 `constraint_comfort_exposure_max` ) plus `constraint_handling: penalize|prune` .
+7. Optuna launcher configs use `schema_version: robot_sf.optuna_expert_ppo_launcher.v1`.
+Unsupported versions fail at `scripts/training/launch_optuna_expert_ppo.py --config <path>`
+before any trials are launched.

--- a/configs/training/ppo_imitation/optuna_expert_ppo.yaml
+++ b/configs/training/ppo_imitation/optuna_expert_ppo.yaml
@@ -1,3 +1,4 @@
+schema_version: robot_sf.optuna_expert_ppo_launcher.v1
 base_config: expert_ppo.yaml
 
 # Study settings

--- a/docs/dev/scenario-schema/README.md
+++ b/docs/dev/scenario-schema/README.md
@@ -5,6 +5,7 @@ This document describes the JSON Schema used to validate benchmark scenario matr
 - Schema file: `robot_sf/benchmark/schema/scenarios.schema.json`
 - Validator helper: `robot_sf/benchmark/scenario_schema.py`
 - CLI validation: `robot_sf_bench validate-config --matrix <path>.yaml`
+- Current manifest metadata version: `robot_sf.scenario_matrix.v1`
 
 A scenario matrix is a YAML (or JSON) list of scenario objects. Minimal valid entry:
 
@@ -22,6 +23,10 @@ Optional fields:
 - goal_topology: point | swap | circulate
 - robot_context: ahead | behind | embedded
 
+Manifest-style matrices may include `schema_version: robot_sf.scenario_matrix.v1` next to
+`includes`, `scenario_files`, `select_scenarios`, or `scenarios`. Unsupported versions fail early
+in `validate-config` with an error at `/schema_version`.
+
 Notes:
 - The CLI also checks for duplicate `id` values.
 - The validator uses Draft-07 JSON Schema.
@@ -32,4 +37,5 @@ Example:
 uv run robot_sf_bench validate-config --matrix configs/baselines/example_matrix.yaml
 ```
 
-This prints a JSON report with `num_scenarios`, `errors`, and `warnings`, and exits non‑zero on errors.
+This prints a JSON report with `num_scenarios`, `errors`, `warnings`, and source metadata, and
+exits non-zero on errors.

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -57,7 +57,10 @@ from robot_sf.benchmark.report_table import format_latex_booktabs as _tbl_format
 from robot_sf.benchmark.report_table import format_markdown as _tbl_format_md
 from robot_sf.benchmark.report_table import to_json as _tbl_to_json
 from robot_sf.benchmark.runner import load_scenario_matrix, run_batch
-from robot_sf.benchmark.scenario_schema import validate_scenario_list
+from robot_sf.benchmark.scenario_schema import (
+    validate_scenario_list,
+    validate_scenario_matrix_metadata,
+)
 from robot_sf.benchmark.scenario_thumbnails import (
     resolve_scenario_label as _thumb_resolve_label,
 )
@@ -950,7 +953,9 @@ def _extract_matrix_source(matrix_path: str | Path) -> dict[str, object]:
             "select_scenarios": select_scenarios,
         }
     doc = docs[0]
+    schema_version: object = None
     if isinstance(doc, Mapping):
+        schema_version = doc.get("schema_version")
         raw_includes = doc.get("includes") or doc.get("include") or doc.get("scenario_files")
         if isinstance(raw_includes, list):
             includes = [str(entry) for entry in raw_includes]
@@ -971,7 +976,23 @@ def _extract_matrix_source(matrix_path: str | Path) -> dict[str, object]:
         "format": format_hint,
         "includes": includes,
         "select_scenarios": select_scenarios,
+        **({"schema_version": schema_version} if isinstance(schema_version, str) else {}),
     }
+
+
+def _load_matrix_metadata(matrix_path: str | Path) -> object:
+    """Load raw top-level YAML metadata for validation without expanding includes.
+
+    Returns:
+        object: First YAML document, or ``None`` when unavailable.
+    """
+    if is_task_bundle_reference(matrix_path):
+        return None
+    try:
+        with Path(matrix_path).open("r", encoding="utf-8") as handle:
+            return next(yaml.safe_load_all(handle), None)
+    except Exception:
+        return None
 
 
 def _summarize_scenarios(scenarios: list[dict[str, Any]]) -> dict[str, object]:
@@ -1190,7 +1211,8 @@ def _handle_validate_config(args) -> int:
     """
     try:
         scenarios = load_scenario_matrix(args.matrix)
-        errors = validate_scenario_list(scenarios)
+        metadata_errors = validate_scenario_matrix_metadata(_load_matrix_metadata(args.matrix))
+        errors = [*metadata_errors, *validate_scenario_list(scenarios)]
         warnings = _collect_scenario_warnings(scenarios, matrix_path=args.matrix)
         summary = _summarize_scenarios(scenarios)
         source = _extract_matrix_source(args.matrix)

--- a/robot_sf/benchmark/scenario_schema.py
+++ b/robot_sf/benchmark/scenario_schema.py
@@ -26,6 +26,7 @@ try:
 except Exception as e:  # pragma: no cover - jsonschema is project dependency
     raise RuntimeError("jsonschema package is required for scenario validation") from e
 
+SCENARIO_MATRIX_SCHEMA_VERSION = "robot_sf.scenario_matrix.v1"
 SCHEMA_FILE = Path(__file__).with_name("schema").joinpath("scenarios.schema.json")
 
 
@@ -138,4 +139,34 @@ def validate_scenario_list(scenarios: list[dict[str, Any]]) -> list[dict[str, An
     return errors
 
 
-__all__ = ["SCHEMA_FILE", "load_scenario_schema", "validate_scenario_list"]
+def validate_scenario_matrix_metadata(payload: object) -> list[dict[str, Any]]:
+    """Validate optional top-level scenario-matrix metadata.
+
+    Returns:
+        list[dict[str, Any]]: Metadata validation errors, empty when supported or absent.
+    """
+    if not isinstance(payload, dict) or "schema_version" not in payload:
+        return []
+    schema_version = payload.get("schema_version")
+    if schema_version == SCENARIO_MATRIX_SCHEMA_VERSION:
+        return []
+    return [
+        {
+            "index": None,
+            "id": None,
+            "error": (
+                f"unsupported scenario matrix schema_version {schema_version!r}; "
+                f"expected {SCENARIO_MATRIX_SCHEMA_VERSION!r}"
+            ),
+            "path": "/schema_version",
+        }
+    ]
+
+
+__all__ = [
+    "SCENARIO_MATRIX_SCHEMA_VERSION",
+    "SCHEMA_FILE",
+    "load_scenario_schema",
+    "validate_scenario_list",
+    "validate_scenario_matrix_metadata",
+]

--- a/scripts/training/launch_optuna_expert_ppo.py
+++ b/scripts/training/launch_optuna_expert_ppo.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine import make_url
 _OBJECTIVE_MODES = ("best_checkpoint", "final_eval", "last_n_mean", "auc", "episodic_snqi")
 _CONSTRAINT_HANDLING_CHOICES = ("penalize", "prune")
 _LOG_LEVEL_CHOICES = ("TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL")
-OPTUNA_LAUNCHER_SCHEMA_VERSION = "robot_sf.optuna_expert_ppo_launcher.v1"
+OPTUNA_LAUNCHER_SCHEMA_VERSION: str = "robot_sf.optuna_expert_ppo_launcher.v1"
 
 _SUPPORTED_LAUNCH_KEYS = {
     "schema_version",

--- a/scripts/training/launch_optuna_expert_ppo.py
+++ b/scripts/training/launch_optuna_expert_ppo.py
@@ -16,8 +16,10 @@ from sqlalchemy.engine import make_url
 _OBJECTIVE_MODES = ("best_checkpoint", "final_eval", "last_n_mean", "auc", "episodic_snqi")
 _CONSTRAINT_HANDLING_CHOICES = ("penalize", "prune")
 _LOG_LEVEL_CHOICES = ("TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL")
+OPTUNA_LAUNCHER_SCHEMA_VERSION = "robot_sf.optuna_expert_ppo_launcher.v1"
 
 _SUPPORTED_LAUNCH_KEYS = {
+    "schema_version",
     "base_config",
     "trials",
     "metric",
@@ -148,6 +150,12 @@ def load_launch_config(path: Path) -> dict[str, object]:
     unknown = sorted(set(payload) - _SUPPORTED_LAUNCH_KEYS)
     if unknown:
         raise ValueError(f"Unknown launcher config key(s): {', '.join(unknown)}")
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and schema_version != OPTUNA_LAUNCHER_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported Optuna launcher schema_version {schema_version!r}; "
+            f"expected {OPTUNA_LAUNCHER_SCHEMA_VERSION!r}."
+        )
     if "base_config" not in payload:
         raise ValueError("Launcher config must define 'base_config'.")
     return payload

--- a/tests/test_scenario_schema.py
+++ b/tests/test_scenario_schema.py
@@ -79,6 +79,62 @@ def test_cli_validate_config_manifest_source(tmp_path: Path, capsys):
     assert "include.yaml" in report["source"]["includes"]
 
 
+def test_cli_validate_config_reports_manifest_schema_version(tmp_path: Path, capsys):
+    """Ensure scenario manifests expose supported schema metadata in validation reports."""
+    matrix_path = tmp_path / "matrix.yaml"
+    matrix_path.write_text(
+        "schema_version: robot_sf.scenario_matrix.v1\n"
+        "scenarios:\n"
+        "  - id: ok\n"
+        "    density: low\n"
+        "    flow: uni\n"
+        "    obstacle: open\n"
+        "    repeats: 1\n",
+        encoding="utf-8",
+    )
+
+    rc = cli_main(["validate-config", "--matrix", str(matrix_path)])
+    out = capsys.readouterr().out
+    report = json.loads(out)
+
+    assert rc == 0
+    assert report["source"]["schema_version"] == "robot_sf.scenario_matrix.v1"
+    assert report["errors"] == []
+
+
+def test_cli_validate_config_rejects_unsupported_manifest_schema_version(tmp_path: Path, capsys):
+    """Ensure unsupported scenario manifest versions fail with actionable JSON errors."""
+    matrix_path = tmp_path / "matrix.yaml"
+    matrix_path.write_text(
+        "schema_version: robot_sf.scenario_matrix.v0\n"
+        "scenarios:\n"
+        "  - id: ok\n"
+        "    density: low\n"
+        "    flow: uni\n"
+        "    obstacle: open\n"
+        "    repeats: 1\n",
+        encoding="utf-8",
+    )
+
+    rc = cli_main(["validate-config", "--matrix", str(matrix_path)])
+    out = capsys.readouterr().out
+    report = json.loads(out)
+
+    assert rc == 2
+    assert report["num_scenarios"] == 1
+    assert report["errors"] == [
+        {
+            "index": None,
+            "id": None,
+            "error": (
+                "unsupported scenario matrix schema_version "
+                "'robot_sf.scenario_matrix.v0'; expected 'robot_sf.scenario_matrix.v1'"
+            ),
+            "path": "/schema_version",
+        }
+    ]
+
+
 def test_cli_validate_config_task_bundle_source(capsys):
     """Ensure validate-config reports task-bundle provenance when using bundle:<name>."""
     rc = cli_main(["validate-config", "--matrix", "bundle:sanity-smoke-v1"])

--- a/tests/training/test_launch_optuna_expert_ppo.py
+++ b/tests/training/test_launch_optuna_expert_ppo.py
@@ -50,6 +50,32 @@ def test_load_launch_config_rejects_unknown_keys(tmp_path: Path):
         load_launch_config(config_path)
 
 
+def test_load_launch_config_accepts_supported_schema_version(tmp_path: Path):
+    """Versioned Optuna launcher configs should load without changing semantics."""
+    config_path = tmp_path / "optuna.yaml"
+    config_path.write_text(
+        "schema_version: robot_sf.optuna_expert_ppo_launcher.v1\nbase_config: expert_ppo.yaml\n",
+        encoding="utf-8",
+    )
+
+    payload = load_launch_config(config_path)
+
+    assert payload["schema_version"] == "robot_sf.optuna_expert_ppo_launcher.v1"
+    assert payload["base_config"] == "expert_ppo.yaml"
+
+
+def test_load_launch_config_rejects_unsupported_schema_version(tmp_path: Path):
+    """Unsupported Optuna launcher schema versions should fail at the config boundary."""
+    config_path = tmp_path / "optuna.yaml"
+    config_path.write_text(
+        "schema_version: robot_sf.optuna_expert_ppo_launcher.v0\nbase_config: expert_ppo.yaml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version"):
+        load_launch_config(config_path)
+
+
 def test_build_optuna_cli_args_resolves_relative_paths(tmp_path: Path):
     """Relative base config should resolve from launcher config location."""
     launch_dir = tmp_path / "configs"


### PR DESCRIPTION
## Summary

Closes #1637.

- Adds `robot_sf.scenario_matrix.v1` metadata validation for scenario manifests and includes the supported version in `validate-config` source reports.
- Tags the sanity, nominal, and confirmation scenario manifests with the supported schema version.
- Adds `robot_sf.optuna_expert_ppo_launcher.v1` gating to the Optuna PPO-imitation launcher config, with docs and tests for supported/unsupported versions.

## Validation

- Red test pass: `uv run pytest tests/test_scenario_schema.py tests/training/test_launch_optuna_expert_ppo.py -q` failed before implementation on missing schema-version behavior.
- `uv run pytest tests/test_scenario_schema.py tests/training/test_launch_optuna_expert_ppo.py tests/training/test_task_bundles.py -q` -> 27 passed
- `uv run ruff check robot_sf/benchmark/scenario_schema.py robot_sf/benchmark/cli.py scripts/training/launch_optuna_expert_ppo.py tests/test_scenario_schema.py tests/training/test_launch_optuna_expert_ppo.py tests/training/test_task_bundles.py`
- `git diff --check`
- `uv run robot_sf_bench validate-config --matrix configs/scenarios/sanity_v1.yaml` -> zero errors
- `uv run robot_sf_bench validate-config --matrix configs/scenarios/nominal_v1.yaml` -> zero errors
- `uv run robot_sf_bench validate-config --matrix configs/scenarios/confirmation_v1.yaml` -> zero errors
- `uv run robot_sf_bench validate-config --matrix bundle:sanity-smoke-v1` -> zero errors
- `uv run python scripts/training/launch_optuna_expert_ppo.py --config configs/training/ppo_imitation/optuna_expert_ppo.yaml --dry-run`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4319 passed, 11 skipped
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` -> fresh for `def63c61d86fe58d9d3108e75fca08e7837c4780`

## Artifact Decision

- Generated `output/coverage/*` and `output/validation/pr_ready/issue-1637-config-schema-validation.json` are ignored local validation artifacts. No durable benchmark artifact or tracked manifest is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now include explicit schema version declarations for validation during config checks and training launcher startup.
  * Schema version validation rejects unsupported versions early before runs begin.

* **Documentation**
  * Updated configuration guides to document schema version requirements and validation behavior.

* **Tests**
  * Added tests for schema version validation in config validation and training launcher workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->