### PR TITLE
refactor: share baseline observation container (#1635)

### DIFF
--- a/robot_sf/baselines/dr_mpc.py
+++ b/robot_sf/baselines/dr_mpc.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.baselines.interface import Observation, normalize_observation
+
 
 @dataclass
 class DRMPCPlannerConfig:
@@ -33,16 +35,6 @@ class DRMPCPlannerConfig:
     fallback_on_error: bool = False
     allow_testing_algorithms: bool = True
     include_in_paper: bool = False
-
-
-@dataclass
-class Observation:
-    """Observation payload for the DR-MPC baseline wrapper."""
-
-    dt: float
-    robot: dict[str, Any]
-    agents: list[dict[str, Any]]
-    obstacles: list[Any]
 
 
 class DRMPCPlanner:
@@ -140,8 +132,7 @@ class DRMPCPlanner:
         Returns:
             A dictionary action in either velocity or unicycle format.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        obs = normalize_observation(obs)
 
         if self._policy is None:
             self._policy = self._build_policy()

--- a/robot_sf/baselines/interface.py
+++ b/robot_sf/baselines/interface.py
@@ -11,6 +11,29 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 
+@dataclass
+class Observation:
+    """Shared planner-facing observation container for baseline adapters."""
+
+    dt: float
+    robot: dict[str, Any]
+    agents: list[dict[str, Any]]
+    obstacles: list[Any] = field(default_factory=list)
+
+
+def normalize_observation(obs: Observation | dict[str, Any]) -> Observation:
+    """Normalize dict payloads into the shared baseline observation dataclass.
+
+    Returns:
+        Shared Observation instance for baseline planners.
+    """
+    if isinstance(obs, Observation):
+        return obs
+    if isinstance(obs, dict):
+        return Observation(**obs)
+    raise TypeError(f"Expected Observation or dict input, got {type(obs).__name__}")
+
+
 @dataclass(frozen=True)
 class ObservationContract:
     """Planner-facing observation assumptions declared as lightweight metadata."""
@@ -156,7 +179,9 @@ class PlannerProtocol(Protocol):
 
 __all__ = [
     "ActionContract",
+    "Observation",
     "ObservationContract",
     "PlannerMetadata",
     "PlannerProtocol",
+    "normalize_observation",
 ]

--- a/robot_sf/baselines/random_policy.py
+++ b/robot_sf/baselines/random_policy.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.baselines.interface import Observation, normalize_observation
+
 
 @dataclass
 class RandomPlannerConfig:
@@ -24,16 +26,6 @@ class RandomPlannerConfig:
     dt: float = 0.1
     safety_clamp: bool = True
     noise_std: float = 0.0  # Optional Gaussian jitter applied to sampled actions
-
-
-@dataclass
-class Observation:
-    """Minimal observation container for baseline compatibility."""
-
-    dt: float
-    robot: dict[str, Any]
-    agents: list[dict[str, Any]]
-    obstacles: list[Any]
 
 
 class RandomPlanner:
@@ -90,7 +82,6 @@ class RandomPlanner:
         self.config = self._parse_config(config)
 
     def step(self, obs: Observation | dict[str, Any]) -> dict[str, float]:
-        # Support dict-style Observation
         """Return a random action for the given observation.
 
         Args:
@@ -99,8 +90,7 @@ class RandomPlanner:
         Returns:
             Action dict in configured action space.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        normalize_observation(obs)
 
         if self.config.mode == "velocity":
             # Sample vx, vy uniformly in a disk scaled to v_max

--- a/robot_sf/baselines/sicnav.py
+++ b/robot_sf/baselines/sicnav.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from robot_sf.baselines.interface import Observation, normalize_observation
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -44,16 +46,6 @@ class SICNavPlannerConfig:
     fallback_on_error: bool = False
     allow_testing_algorithms: bool = True
     include_in_paper: bool = False
-
-
-@dataclass
-class Observation:
-    """Observation payload for the SICNav baseline wrapper."""
-
-    dt: float
-    robot: dict[str, Any]
-    agents: list[dict[str, Any]]
-    obstacles: list[Any]
 
 
 class SICNavPlanner:
@@ -242,8 +234,7 @@ class SICNavPlanner:
         Returns:
             A dictionary action in either velocity or unicycle format.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        obs = normalize_observation(obs)
 
         if self._policy is None:
             self._policy = self._build_policy()

--- a/robot_sf/baselines/social_force.py
+++ b/robot_sf/baselines/social_force.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from math import atan2
 from typing import TYPE_CHECKING, Any
 
@@ -27,6 +27,7 @@ from pysocialforce.config import (
 )
 from pysocialforce.config import SocialForceConfig as PySFSocialForceConfig
 
+from robot_sf.baselines.interface import Observation, normalize_observation
 from robot_sf.sim.fast_pysf_wrapper import FastPysfWrapper
 
 if TYPE_CHECKING:
@@ -77,16 +78,6 @@ class SFPlannerConfig:
     # Adaptive behavior (tuning aids)
     speed_scale_to_vmax: bool = True  # Scale desired speed up to v_max (aggressive)
     interaction_weight: float = 3.0  # Stronger repulsion to maintain clearance
-
-
-@dataclass
-class Observation:
-    """Baseline observation container (robot + agents + obstacles)."""
-
-    dt: float
-    robot: dict[str, Any]
-    agents: list[dict[str, Any]]
-    obstacles: list[Any] = field(default_factory=list)
 
 
 class BasePolicy:
@@ -254,9 +245,7 @@ class SocialForcePlanner(BasePolicy):
         Returns:
             Action dict in configured action space.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
-        assert isinstance(obs, Observation)
+        obs = normalize_observation(obs)
 
         robot_pos = np.asarray(obs.robot["position"], dtype=float)
         robot_vel = np.asarray(obs.robot["velocity"], dtype=float)

--- a/tests/baselines/test_external_mpc_wrappers.py
+++ b/tests/baselines/test_external_mpc_wrappers.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 
 from robot_sf.baselines import get_baseline, list_baselines
-from robot_sf.baselines.dr_mpc import DRMPCPlanner, build_dr_mpc_config
+from robot_sf.baselines.dr_mpc import DRMPCPlanner, Observation, build_dr_mpc_config
+from robot_sf.baselines.interface import Observation as SharedObservation
 from robot_sf.baselines.sicnav import SICNavPlanner, build_sicnav_config
 
 
@@ -141,6 +142,86 @@ def test_dr_mpc_planner_uses_external_policy(monkeypatch: pytest.MonkeyPatch) ->
     action = planner.step(_make_robot_observation())
     assert action == {"v": 0.25, "omega": -0.05}
     assert planner.get_metadata()["status"] == "ok"
+
+
+def test_dr_mpc_observation_alias_uses_shared_container() -> None:
+    """The DR-MPC public Observation alias should use the shared baseline container."""
+    assert Observation is SharedObservation
+
+
+def test_dr_mpc_step_accepts_dict_observation_without_obstacles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dict observations should normalize with default obstacles before policy selection."""
+    fake_module = types.ModuleType("dr_mpc")
+
+    class FakePolicy:
+        """External policy stub verifying normalized observation shape."""
+
+        def __init__(self, checkpoint_path=None, device=None):
+            self.checkpoint_path = checkpoint_path
+            self.device = device
+
+        def select_action(self, obs):
+            """Return a valid unicycle action after checking defaulted obstacles."""
+            assert isinstance(obs, SharedObservation)
+            assert obs.obstacles == []
+            return {"v": 0.25, "omega": -0.05}
+
+    fake_module.DRMPCPolicy = FakePolicy
+    monkeypatch.setitem(sys.modules, "dr_mpc", fake_module)
+    planner = DRMPCPlanner({"checkpoint_path": "dummy.pt"}, seed=1)
+    obs = _make_robot_observation()
+    obs.pop("obstacles")
+
+    assert planner.step(obs) == {"v": 0.25, "omega": -0.05}
+
+
+def test_dr_mpc_load_policy_factory_and_velocity_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DR-MPC should support load_policy modules and clamp over-speed velocity actions."""
+    fake_module = types.ModuleType("dr_mpc")
+
+    class FakePolicy:
+        """External policy stub returning an over-limit velocity vector."""
+
+        def select_action(self, obs):
+            """Return a vector that requires safety clamping."""
+            assert isinstance(obs, SharedObservation)
+            return {"vx": 3.0, "vy": 4.0}
+
+    def load_policy(checkpoint_path=None, device=None):
+        assert checkpoint_path == "dummy.pt"
+        assert device == "cpu"
+        return FakePolicy()
+
+    fake_module.load_policy = load_policy
+    monkeypatch.setitem(sys.modules, "dr_mpc", fake_module)
+    planner = DRMPCPlanner({"checkpoint_path": "dummy.pt", "v_max": 2.0}, seed=1)
+
+    action = planner.step(_make_robot_observation())
+
+    assert action == pytest.approx({"vx": 1.2, "vy": 1.6})
+
+
+def test_dr_mpc_rejects_invalid_policy_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid external policy payloads should fail clearly."""
+    fake_module = types.ModuleType("dr_mpc")
+
+    class FakePolicy:
+        """External policy stub returning an invalid payload."""
+
+        def select_action(self, obs):
+            """Return a non-dict action to exercise validation."""
+            return [0.0, 0.0]
+
+    fake_module.DRMPCPolicy = lambda checkpoint_path=None, device=None: FakePolicy()
+    monkeypatch.setitem(sys.modules, "dr_mpc", fake_module)
+    planner = DRMPCPlanner({"checkpoint_path": "dummy.pt"}, seed=1)
+
+    with pytest.raises(ValueError, match="invalid action payload"):
+        planner.step(_make_robot_observation())
 
 
 def test_dr_mpc_config_builder_preserves_provenance_defaults() -> None:

--- a/tests/baselines/test_random_policy.py
+++ b/tests/baselines/test_random_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from robot_sf.baselines.interface import Observation as SharedObservation
 from robot_sf.baselines.random_policy import Observation, RandomPlanner
 
 
@@ -49,3 +50,27 @@ def test_random_planner_unicycle_actions_respect_limits() -> None:
         action = planner.step(_obs())
         assert 0.0 <= float(action["v"]) <= 1.0 + 1e-6
         assert -0.7 - 1e-6 <= float(action["omega"]) <= 0.7 + 1e-6
+
+
+def test_random_planner_uses_shared_observation_alias() -> None:
+    """The random baseline should expose the shared baseline observation container."""
+    assert Observation is SharedObservation
+
+
+def test_random_planner_accepts_dict_observation_without_obstacles() -> None:
+    """Dict observations should normalize through the shared observation container."""
+    planner = RandomPlanner({"mode": "velocity", "v_max": 1.0}, seed=0)
+    obs = {
+        "dt": 0.1,
+        "robot": {
+            "position": [0.0, 0.0],
+            "velocity": [0.0, 0.0],
+            "goal": [1.0, 0.0],
+            "radius": 0.3,
+        },
+        "agents": [],
+    }
+
+    action = planner.step(obs)
+
+    assert set(action) == {"vx", "vy"}

--- a/tests/baselines/test_social_force.py
+++ b/tests/baselines/test_social_force.py
@@ -6,6 +6,7 @@ import math
 import numpy as np
 import pytest
 
+from robot_sf.baselines.interface import Observation as SharedObservation
 from robot_sf.baselines.social_force import Observation, SFPlannerConfig, SocialForcePlanner
 
 
@@ -121,6 +122,24 @@ class TestSocialForcePlanner:
         # Should move toward goal (positive x direction)
         assert action["vx"] > 0
         assert abs(action["vy"]) < 0.1  # Should be close to zero for straight line
+
+    def test_step_accepts_dict_observation_without_obstacles(self, planner):
+        """Dict observations should normalize while preserving default obstacles."""
+        obs = {
+            "dt": 0.1,
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.0, 0.0],
+                "goal": [1.0, 0.0],
+                "radius": 0.3,
+            },
+            "agents": [],
+        }
+
+        action = planner.step(obs)
+
+        assert action["vx"] > 0
+        assert abs(action["vy"]) < 0.1
 
     def test_single_pedestrian_repulsion(self, planner):
         """Test repulsive force from single pedestrian."""
@@ -301,6 +320,10 @@ class TestSocialForcePlanner:
 
 class TestObservation:
     """Tests for the Observation dataclass."""
+
+    def test_observation_uses_shared_baseline_container(self):
+        """Social-force's public Observation alias should be the shared baseline class."""
+        assert Observation is SharedObservation
 
     def test_observation_creation(self):
         """Test observation can be created with required fields."""


### PR DESCRIPTION
## Summary
Extracts the duplicated baseline planner `Observation` dataclass into `robot_sf.baselines.interface` and updates random, DR-MPC, SICNav, and social-force baselines to use the shared container. Preserves public per-module `Observation` aliases and dict-style observation inputs.

## Linked Issues
- Closes #1635

## What Changed
- Added shared `Observation` and `normalize_observation()` in `robot_sf/baselines/interface.py`.
- Replaced duplicated `Observation` dataclasses in random, DR-MPC, SICNav, and social-force wrappers with imports from the shared interface.
- Added regression coverage for random/social-force dict normalization and DR-MPC alias, dict normalization, load-policy, clamping, and invalid-action paths.

## Why It Matters
- Added value: one canonical baseline observation payload reduces contract drift across local planner wrappers.
- Expected impact: future observation-space work has a smaller baseline surface to audit.
- Why this is worth merging now: resolves the duplicated dataclass cluster without changing planner action behavior.

## Validation / Proof
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests -k "baseline or random or social_force or dr_mpc or sicnav" -q` passed: 172 passed, 4157 deselected, 1 warning before the DR-MPC coverage additions.
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests/baselines/test_external_mpc_wrappers.py -q` passed: 11 passed.
- `rg "class Observation" robot_sf/baselines` shows only the shared `Observation` class plus `ObservationContract`.
- `BASE_REF=origin/main PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh` passed: 4336 passed, 11 skipped. Changed-file coverage is above the 80% minimum; 100% goal misses are warning-only (`dr_mpc.py` 86.0%, `interface.py` 98.2%, `random_policy.py` 83.1%, `sicnav.py` 81.8%, `social_force.py` 96.2%).

## Risks / Rollout
- Compatibility risks: modules still export `Observation`, but it is now the shared dataclass from `robot_sf.baselines.interface`.
- Failure modes: callers relying on class identity being module-local would observe the alias identity change; field shape is preserved.
- Rollback or fallback plan: restore per-module dataclasses if an external caller depends on module-local identity.

## Docs / Provenance
- Updated docs: shared dataclass docstring in `robot_sf/baselines/interface.py`.
- Relevant design or provenance notes: issue #1635.
- Any assumptions that need to be preserved: this is baseline-only and does not force learned-policy observation contracts into the shared type.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Review the public alias behavior: `robot_sf.baselines.social_force.Observation` and peers now refer to `robot_sf.baselines.interface.Observation`.
- Generated `output/coverage` was discarded; ignored `output/validation/pr_ready/issue-1635-shared-baseline-observation.json` records the local freshness stamp and is not committed.