### PR TITLE
feat: add planner tradeoff plotting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -349,6 +349,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Trajectory Visualization](./trajectory_visualization.md)** - Generate trajectory plots
 * **[Force Field Visualization](./force_field_visualization.md)** - Heatmap + quiver figures (PNG/PDF)
 * **[Pareto Plotting](./pareto_plotting.md)** - Generate Pareto frontier plots
+* **[Planner Tradeoff Plotting](./planner_tradeoff_plotting.md)** - Generate success/collision tradeoff figures from publication bundles
 * **[Force Field Heatmap](./force_field_heatmap.md)** - Heatmap + vector overlays figure (PNG/PDF)
 
 ### Performance & CI
@@ -423,6 +424,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
   + [Random baseline](./dev/baselines/random.md) — how to use and configure
 * [**Force Field Visualization**](./force_field_visualization.md) — How to generate heatmap + quiver figures (PNG/PDF)
 * [**Scenario Thumbnails & Montage**](./scenario_thumbnails.md) — Generate per-scenario thumbnails and montage grids (PNG/PDF)
+* [**Planner Tradeoff Plotting**](./planner_tradeoff_plotting.md) — Generate safety-efficiency figures from publication bundles
 * [**Force Field Heatmap**](./force_field_heatmap.md) — Heatmap + vector overlays figure (PNG/PDF)
 
 </details>

--- a/docs/planner_tradeoff_plotting.md
+++ b/docs/planner_tradeoff_plotting.md
@@ -1,0 +1,55 @@
+# Planner Tradeoff Plotting
+
+Create a paper-ready safety-efficiency scatter plot from a Robot SF publication bundle. The plot
+places collision rate on the x-axis and success rate on the y-axis, with optional bootstrap
+confidence intervals computed over per-seed planner means.
+
+## Input Contract
+
+The command expects a publication bundle with:
+
+- `payload/reports/campaign_table.csv`
+- `payload/runs/<planner>*/episodes.jsonl`
+- optional `publication_manifest.json` for run-id metadata
+
+The campaign table supplies planner-level means. Episode JSONL files supply seed-level bootstrap
+confidence intervals. Collision indicators are read from `outcome.collision_event` when present, so
+the figure matches camera-ready bundles where `metrics.collisions` is a stale or non-indicator count.
+
+## CLI Usage
+
+```bash
+robot_sf_bench plot-planner-tradeoff \
+  --bundle-path output/benchmarks/camera_ready/<campaign_id>_publication_bundle \
+  --out output/figures/planner_tradeoff_safety_efficiency.png \
+  --out-pdf output/figures/planner_tradeoff_safety_efficiency.pdf \
+  --metadata-out output/figures/planner_tradeoff_safety_efficiency.json
+```
+
+Options:
+
+- `--bootstrap-samples` controls resamples over seed-level means. Default: `400`.
+- `--ci-confidence` controls the interval level. Default: `0.95`.
+- `--bootstrap-seed` makes bootstrap intervals reproducible. Default: `42`.
+- `--title ""` suppresses the default preferred-region title.
+
+## Programmatic Usage
+
+```python
+from pathlib import Path
+
+from robot_sf.benchmark.planner_tradeoff_plot import save_planner_tradeoff_figure
+
+meta = save_planner_tradeoff_figure(
+    Path("output/benchmarks/camera_ready/my_publication_bundle"),
+    out_png=Path("output/figures/planner_tradeoff_safety_efficiency.png"),
+    out_pdf=Path("output/figures/planner_tradeoff_safety_efficiency.pdf"),
+)
+print(meta["run_id"])
+```
+
+## Artifact Policy
+
+Generated figures should live under `output/` during iteration. Promote only small, reviewable
+metadata or evidence copies into `docs/context/evidence/` when a PR, issue, or release needs a
+durable proof artifact.

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -883,7 +883,8 @@ def _handle_plot_planner_tradeoff(args) -> int:
             metadata_path.parent.mkdir(parents=True, exist_ok=True)
             metadata_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
         return 0
-    except Exception:  # pragma: no cover - error path
+    except Exception as exc:  # pragma: no cover - error path
+        logging.exception("Planner tradeoff plot failed: %s", exc)
         return 2
 
 

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -47,6 +47,9 @@ from robot_sf.benchmark.planner_inclusion import (
     run_planner_inclusion_check,
     to_jsonable_payload,
 )
+from robot_sf.benchmark.planner_tradeoff_plot import (
+    save_planner_tradeoff_figure as _save_planner_tradeoff_figure,
+)
 from robot_sf.benchmark.plots import save_pareto_png as _save_pareto_png
 from robot_sf.benchmark.ranking import compute_ranking as _compute_ranking
 from robot_sf.benchmark.ranking import format_csv as _rank_format_csv
@@ -854,6 +857,31 @@ def _handle_plot_distributions(args) -> int:
             ci_confidence=float(getattr(args, "ci_confidence", 0.95)),
             ci_seed=(int(args.ci_seed) if getattr(args, "ci_seed", None) is not None else None),
         )
+        return 0
+    except Exception:  # pragma: no cover - error path
+        return 2
+
+
+def _handle_plot_planner_tradeoff(args) -> int:
+    """Render the paper-style planner safety-efficiency tradeoff plot.
+
+    Returns:
+        Exit code (0 success, 2 failure).
+    """
+    try:
+        meta = _save_planner_tradeoff_figure(
+            Path(args.bundle_path),
+            out_png=Path(args.out),
+            out_pdf=(Path(args.out_pdf) if getattr(args, "out_pdf", None) else None),
+            bootstrap_samples=int(args.bootstrap_samples),
+            ci_confidence=float(args.ci_confidence),
+            bootstrap_seed=int(args.bootstrap_seed),
+            title=(str(args.title) if args.title is not None else None),
+        )
+        if getattr(args, "metadata_out", None):
+            metadata_path = Path(args.metadata_out)
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            metadata_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
         return 0
     except Exception:  # pragma: no cover - error path
         return 2
@@ -2026,6 +2054,52 @@ def _add_plot_distributions_subparser(
     p.set_defaults(cmd="plot-distributions")
 
 
+def _add_plot_planner_tradeoff_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the plot-planner-tradeoff subcommand parser."""
+    p = subparsers.add_parser(
+        "plot-planner-tradeoff",
+        help="Plot planner collision-rate versus success-rate from a publication bundle",
+    )
+    p.add_argument(
+        "--bundle-path",
+        required=True,
+        help="Publication bundle root containing payload/reports and payload/runs.",
+    )
+    p.add_argument("--out", required=True, help="Output PNG path")
+    p.add_argument("--out-pdf", default=None, help="Optional path to also export vector PDF")
+    p.add_argument(
+        "--metadata-out",
+        default=None,
+        help="Optional JSON metadata path with plotted points and CI values",
+    )
+    p.add_argument(
+        "--bootstrap-samples",
+        type=int,
+        default=400,
+        help="Bootstrap resamples over seed-level means. Default: 400",
+    )
+    p.add_argument(
+        "--ci-confidence",
+        type=float,
+        default=0.95,
+        help="Bootstrap confidence level. Default: 0.95",
+    )
+    p.add_argument(
+        "--bootstrap-seed",
+        type=int,
+        default=42,
+        help="Seed for deterministic bootstrap resampling. Default: 42",
+    )
+    p.add_argument(
+        "--title",
+        default="Preferred region: lower collision, higher success",
+        help="Optional plot title; pass an empty string for no title.",
+    )
+    p.set_defaults(cmd="plot-planner-tradeoff")
+
+
 def _add_plot_scenarios_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2112,6 +2186,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_debug_seeds_subparser(subparsers)
     _add_plot_pareto_subparser(subparsers)
     _add_plot_distributions_subparser(subparsers)
+    _add_plot_planner_tradeoff_subparser(subparsers)
     _add_plot_scenarios_subparser(subparsers)
     _add_list_subparser(subparsers)
     _add_planner_inclusion_subparser(subparsers)
@@ -2563,6 +2638,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "debug-seeds": _handle_debug_seeds,
         "plot-pareto": _handle_plot_pareto,
         "plot-distributions": _handle_plot_distributions,
+        "plot-planner-tradeoff": _handle_plot_planner_tradeoff,
         "plot-scenarios": _handle_plot_scenarios,
     }
     handler = handlers.get(args.cmd)

--- a/robot_sf/benchmark/planner_tradeoff_plot.py
+++ b/robot_sf/benchmark/planner_tradeoff_plot.py
@@ -1,0 +1,487 @@
+"""Planner safety-efficiency tradeoff plotting for publication bundles.
+
+The helpers in this module turn a camera-ready/publication benchmark bundle into
+a scatter plot of collision rate versus success rate.  They intentionally read
+the same bundle artifacts used by downstream paper repositories:
+
+- ``payload/reports/campaign_table.csv`` for planner-level means
+- ``payload/runs/<planner>*/episodes.jsonl`` for seed-level bootstrap intervals
+
+This keeps paper-facing figures reproducible from Robot SF artifacts without
+requiring a separate manuscript repository.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.lines import Line2D
+
+from robot_sf.benchmark.plotting_style import apply_latex_style
+from robot_sf.benchmark.utils import episode_collision_value, episode_success_value
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+DEFAULT_PLANNER_LABELS: dict[str, str] = {
+    "goal": "goal",
+    "orca": "orca",
+    "ppo": "ppo",
+    "social_force": "social_force",
+    "prediction_planner": "prediction",
+    "sacadrl": "sacadrl",
+    "socnav_sampling": "socnav_samp.",
+}
+
+DEFAULT_HEADLINE_PLANNERS = ("orca", "ppo")
+DEFAULT_CONTROL_PLANNERS = ("goal",)
+DEFAULT_BOOTSTRAP_SAMPLES = 400
+DEFAULT_CI_CONFIDENCE = 0.95
+DEFAULT_BOOTSTRAP_SEED = 42
+
+_ROLE_COLORS: dict[str, str] = {
+    "headline_orca": "#2166ac",
+    "headline_ppo": "#d6604d",
+    "control": "#888888",
+    "experimental": "#626262",
+}
+
+
+@dataclass(frozen=True)
+class PlannerTradeoffPoint:
+    """One planner point plus optional bootstrap confidence intervals."""
+
+    planner_key: str
+    label: str
+    role: str
+    success_mean: float
+    collision_mean: float
+    success_ci: tuple[float, float] | None = None
+    collision_ci: tuple[float, float] | None = None
+    episodes_path: Path | None = None
+
+
+def load_campaign_table(bundle_path: Path) -> list[dict[str, str]]:
+    """Load planner rows from ``payload/reports/campaign_table.csv``.
+
+    Older and newer bundles differ slightly in collision column naming.  This
+    reader normalizes ``collisions_mean`` to ``collision_mean`` for the plotting
+    layer while preserving the rest of the row values.
+
+    Returns:
+        Campaign table rows keyed by CSV header.
+    """
+    csv_path = bundle_path / "payload" / "reports" / "campaign_table.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"campaign_table.csv not found at {csv_path}")
+
+    with csv_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    for row in rows:
+        if "collision_mean" not in row and "collisions_mean" in row:
+            row["collision_mean"] = row["collisions_mean"]
+    return rows
+
+
+def read_publication_run_id(bundle_path: Path) -> str:
+    """Return the best available run identifier for a publication bundle."""
+    manifest_path = bundle_path / "publication_manifest.json"
+    if manifest_path.exists():
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        run_id = payload.get("provenance", {}).get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    return bundle_path.name
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read JSONL episode records from ``path``.
+
+    Returns:
+        Parsed JSON objects in file order.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"episodes.jsonl not found at {path}")
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                rows.append(json.loads(stripped))
+    if not rows:
+        raise ValueError(f"No episode records found at {path}")
+    return rows
+
+
+def find_planner_episodes_path(bundle_path: Path, planner_key: str) -> Path | None:
+    """Find the episode JSONL for ``planner_key`` inside a bundle.
+
+    Returns:
+        Matching ``episodes.jsonl`` path, or ``None`` when absent.
+    """
+    runs_dir = bundle_path / "payload" / "runs"
+    candidates = [*sorted(runs_dir.glob(f"{planner_key}__*")), runs_dir / planner_key]
+    for candidate in candidates:
+        episodes_path = candidate / "episodes.jsonl"
+        if episodes_path.exists():
+            return episodes_path
+    return None
+
+
+def _episode_metric_value(episode: Mapping[str, Any], metric: str) -> float | None:
+    """Extract a supported logical metric from an episode record.
+
+    Returns:
+        Parsed metric value, or ``None`` when the metric is unavailable.
+    """
+    if metric == "success":
+        value = episode_success_value(episode)
+        return float(value) if value is not None else None
+    if metric == "collisions":
+        outcome = episode.get("outcome")
+        if isinstance(outcome, Mapping) and "collision_event" in outcome:
+            return 1.0 if bool(outcome.get("collision_event")) else 0.0
+        value = episode_collision_value(episode)
+        return float(value) if value is not None else None
+    metrics = episode.get("metrics")
+    if isinstance(metrics, Mapping):
+        raw = metrics.get(metric)
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def bootstrap_seed_mean_ci(
+    episodes_jsonl: Path,
+    metric: str,
+    *,
+    samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    confidence: float = DEFAULT_CI_CONFIDENCE,
+    seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> tuple[float, float]:
+    """Bootstrap a confidence interval over per-seed metric means.
+
+    The sampling unit is the seed-level mean, not the individual episode.  This
+    matches the AMV paper plotting convention and avoids overstating precision
+    when scenarios share the same deterministic seed schedule.
+
+    Returns:
+        Lower and upper confidence interval bounds.
+    """
+    if samples <= 0:
+        raise ValueError("samples must be positive")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be between 0 and 1")
+
+    by_seed: dict[int, list[float]] = {}
+    for episode in _read_jsonl(episodes_jsonl):
+        value = _episode_metric_value(episode, metric)
+        if value is None:
+            continue
+        by_seed.setdefault(int(episode["seed"]), []).append(value)
+
+    seed_means = np.array(
+        [float(np.mean(values)) for values in by_seed.values() if values],
+        dtype=float,
+    )
+    if seed_means.size == 0:
+        raise ValueError(f"Metric {metric!r} could not be extracted from {episodes_jsonl}")
+
+    rng = np.random.default_rng(seed)
+    draws = np.array(
+        [rng.choice(seed_means, size=seed_means.size, replace=True).mean() for _ in range(samples)],
+        dtype=float,
+    )
+    alpha = (1.0 - confidence) / 2.0
+    return (
+        float(np.percentile(draws, 100.0 * alpha)),
+        float(np.percentile(draws, 100.0 * (1.0 - alpha))),
+    )
+
+
+def build_tradeoff_points(
+    bundle_path: Path,
+    *,
+    headline_planners: Sequence[str] = DEFAULT_HEADLINE_PLANNERS,
+    control_planners: Sequence[str] = DEFAULT_CONTROL_PLANNERS,
+    labels: Mapping[str, str] | None = None,
+    bootstrap_samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    ci_confidence: float = DEFAULT_CI_CONFIDENCE,
+    bootstrap_seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> list[PlannerTradeoffPoint]:
+    """Build planner tradeoff points from a publication bundle.
+
+    Returns:
+        Planner points ready for plotting.
+    """
+    label_map = {**DEFAULT_PLANNER_LABELS, **(dict(labels) if labels else {})}
+    headline = set(headline_planners)
+    controls = set(control_planners)
+    points: list[PlannerTradeoffPoint] = []
+
+    for row in load_campaign_table(bundle_path):
+        planner_key = str(row.get("planner_key", "")).strip()
+        if not planner_key:
+            continue
+        if "success_mean" not in row or "collision_mean" not in row:
+            raise ValueError(
+                "campaign_table.csv must contain planner_key, success_mean, "
+                "and collision_mean/collisions_mean columns"
+            )
+
+        episodes_path = find_planner_episodes_path(bundle_path, planner_key)
+        success_ci = None
+        collision_ci = None
+        if episodes_path is not None:
+            success_ci = bootstrap_seed_mean_ci(
+                episodes_path,
+                "success",
+                samples=bootstrap_samples,
+                confidence=ci_confidence,
+                seed=bootstrap_seed,
+            )
+            collision_ci = bootstrap_seed_mean_ci(
+                episodes_path,
+                "collisions",
+                samples=bootstrap_samples,
+                confidence=ci_confidence,
+                seed=bootstrap_seed,
+            )
+
+        if planner_key in headline:
+            role = "headline"
+        elif planner_key in controls:
+            role = "control"
+        else:
+            role = "experimental"
+
+        points.append(
+            PlannerTradeoffPoint(
+                planner_key=planner_key,
+                label=label_map.get(planner_key, planner_key),
+                role=role,
+                success_mean=float(row["success_mean"]),
+                collision_mean=float(row["collision_mean"]),
+                success_ci=success_ci,
+                collision_ci=collision_ci,
+                episodes_path=episodes_path,
+            )
+        )
+
+    if not points:
+        raise ValueError(f"No planner rows found in bundle {bundle_path}")
+    return points
+
+
+def _finite_error(mean: float, ci: tuple[float, float] | None) -> tuple[float, float] | None:
+    """Return asymmetric error-bar widths, or ``None`` for missing/non-finite CIs."""
+    if ci is None:
+        return None
+    low, high = ci
+    if not all(math.isfinite(v) for v in (mean, low, high)):
+        return None
+    return (max(0.0, mean - low), max(0.0, high - mean))
+
+
+def plot_planner_tradeoff(
+    points: Sequence[PlannerTradeoffPoint],
+    *,
+    title: str | None = "Preferred region: lower collision, higher success",
+) -> plt.Figure:
+    """Render a planner safety-efficiency tradeoff figure.
+
+    Returns:
+        Matplotlib figure with the plotted planner tradeoff.
+    """
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    apply_latex_style(
+        {
+            "figure.figsize": (5.2, 3.6),
+            "axes.grid": True,
+            "grid.alpha": 0.2,
+            "axes.titlesize": 9,
+            "ps.fonttype": 42,
+        }
+    )
+    fig, ax = plt.subplots()
+
+    for index, point in enumerate(points):
+        x = point.collision_mean
+        y = point.success_mean
+        if point.role == "headline":
+            color = _ROLE_COLORS.get(f"headline_{point.planner_key}", "#2166ac")
+            xerr = _finite_error(x, point.collision_ci)
+            yerr = _finite_error(y, point.success_ci)
+            ax.errorbar(
+                x,
+                y,
+                xerr=([[xerr[0]], [xerr[1]]] if xerr else None),
+                yerr=([[yerr[0]], [yerr[1]]] if yerr else None),
+                fmt="o",
+                color=color,
+                markersize=7,
+                capsize=3,
+                linewidth=1.2,
+                zorder=4,
+            )
+        elif point.role == "control":
+            color = _ROLE_COLORS["control"]
+            ax.plot(
+                x,
+                y,
+                "o",
+                color="white",
+                markeredgecolor=color,
+                markeredgewidth=1.4,
+                markersize=7,
+                zorder=4,
+            )
+        else:
+            color = _ROLE_COLORS["experimental"]
+            ax.plot(x, y, "^", color=color, markersize=6, alpha=0.9, zorder=3)
+
+        # Deterministic, dependency-free label staggering.  It is less elaborate
+        # than adjustText, but keeps the core package free of another plotting
+        # dependency while avoiding exact label overlap in common bundles.
+        offset_y = 0.012 if index % 2 == 0 else -0.012
+        ax.annotate(
+            point.label,
+            xy=(x, y),
+            xytext=(5, 6 if offset_y > 0 else -8),
+            textcoords="offset points",
+            fontsize=8.0 if point.role == "experimental" else 7.5,
+            color=color,
+            alpha=0.95,
+        )
+
+    ax.set_xlabel("Collision rate (lower is safer)")
+    ax.set_ylabel("Success rate (higher is better)")
+    ax.set_xlim(left=-0.02)
+    ax.set_ylim(bottom=-0.02)
+    if title:
+        ax.set_title(title, loc="left", color="#4a4a4a")
+
+    legend_elements = [
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=_ROLE_COLORS["headline_orca"],
+            markersize=6,
+            label="orca (main)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=_ROLE_COLORS["headline_ppo"],
+            markersize=6,
+            label="ppo (main)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor="white",
+            markeredgecolor=_ROLE_COLORS["control"],
+            markeredgewidth=1.2,
+            markersize=6,
+            label="goal (control)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="^",
+            color="w",
+            markerfacecolor=_ROLE_COLORS["experimental"],
+            markersize=6,
+            label="experimental planners",
+        ),
+    ]
+    ax.legend(handles=legend_elements, loc="best", frameon=True, framealpha=0.9)
+    fig.tight_layout()
+    return fig
+
+
+def save_planner_tradeoff_figure(
+    bundle_path: Path,
+    *,
+    out_png: Path,
+    out_pdf: Path | None = None,
+    bootstrap_samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    ci_confidence: float = DEFAULT_CI_CONFIDENCE,
+    bootstrap_seed: int = DEFAULT_BOOTSTRAP_SEED,
+    title: str | None = "Preferred region: lower collision, higher success",
+) -> dict[str, Any]:
+    """Build and save a planner tradeoff figure from a publication bundle.
+
+    Returns:
+        Metadata for the saved figure and plotted planner points.
+    """
+    points = build_tradeoff_points(
+        bundle_path,
+        bootstrap_samples=bootstrap_samples,
+        ci_confidence=ci_confidence,
+        bootstrap_seed=bootstrap_seed,
+    )
+    fig = plot_planner_tradeoff(points, title=title)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, dpi=300)
+    if out_pdf is not None:
+        out_pdf.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out_pdf)
+    plt.close(fig)
+    return {
+        "run_id": read_publication_run_id(bundle_path),
+        "bundle_path": str(bundle_path),
+        "png": str(out_png),
+        "pdf": str(out_pdf) if out_pdf is not None else None,
+        "bootstrap_samples": bootstrap_samples,
+        "ci_confidence": ci_confidence,
+        "points": [
+            {
+                "planner_key": point.planner_key,
+                "label": point.label,
+                "role": point.role,
+                "success_mean": point.success_mean,
+                "collision_mean": point.collision_mean,
+                "success_ci": point.success_ci,
+                "collision_ci": point.collision_ci,
+                "episodes_path": str(point.episodes_path) if point.episodes_path else None,
+            }
+            for point in points
+        ],
+    }
+
+
+__all__ = [
+    "DEFAULT_BOOTSTRAP_SAMPLES",
+    "DEFAULT_BOOTSTRAP_SEED",
+    "DEFAULT_CI_CONFIDENCE",
+    "PlannerTradeoffPoint",
+    "bootstrap_seed_mean_ci",
+    "build_tradeoff_points",
+    "find_planner_episodes_path",
+    "load_campaign_table",
+    "plot_planner_tradeoff",
+    "read_publication_run_id",
+    "save_planner_tradeoff_figure",
+]

--- a/robot_sf/benchmark/planner_tradeoff_plot.py
+++ b/robot_sf/benchmark/planner_tradeoff_plot.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import csv
 import json
 import math
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -139,7 +138,7 @@ def find_planner_episodes_path(bundle_path: Path, planner_key: str) -> Path | No
     return None
 
 
-def _episode_metric_value(episode: Mapping[str, Any], metric: str) -> float | None:
+def _episode_metric_value(episode: dict[str, Any], metric: str) -> float | None:
     """Extract a supported logical metric from an episode record.
 
     Returns:
@@ -308,7 +307,7 @@ def plot_planner_tradeoff(
     Returns:
         Matplotlib figure with the plotted planner tradeoff.
     """
-    os.environ.setdefault("MPLBACKEND", "Agg")
+    plt.switch_backend("Agg")
     apply_latex_style(
         {
             "figure.figsize": (5.2, 3.6),

--- a/tests/test_planner_tradeoff_plot.py
+++ b/tests/test_planner_tradeoff_plot.py
@@ -1,0 +1,153 @@
+"""Tests for publication-bundle planner tradeoff plotting."""
+
+from __future__ import annotations
+
+import csv
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.benchmark.planner_tradeoff_plot import (
+    bootstrap_seed_mean_ci,
+    build_tradeoff_points,
+    save_planner_tradeoff_figure,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    """Write JSONL rows for a tiny publication-bundle fixture."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _episode(planner: str, seed: int, success: bool, collision: bool) -> dict:
+    """Build a minimal episode row with April-2026 collision schema semantics."""
+    return {
+        "episode_id": f"{planner}-{seed}-{success}-{collision}",
+        "scenario_id": "tradeoff-smoke",
+        "seed": seed,
+        "termination_reason": "success" if success else "max_steps",
+        "outcome": {"collision_event": collision},
+        "scenario_params": {"algo": planner},
+        "metrics": {
+            "success": success,
+            # Deliberately zero to prove plotting uses outcome.collision_event.
+            "collisions": 0,
+        },
+    }
+
+
+def _write_bundle(root: Path) -> Path:
+    """Create a small publication-bundle fixture."""
+    bundle = root / "tiny_publication_bundle"
+    reports = bundle / "payload" / "reports"
+    reports.mkdir(parents=True)
+    with (reports / "campaign_table.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["planner_key", "success_mean", "collisions_mean"],
+        )
+        writer.writeheader()
+        writer.writerow({"planner_key": "orca", "success_mean": "0.75", "collisions_mean": "0.0"})
+        writer.writerow({"planner_key": "ppo", "success_mean": "0.5", "collisions_mean": "0.5"})
+        writer.writerow({"planner_key": "goal", "success_mean": "0.25", "collisions_mean": "0.0"})
+
+    _write_jsonl(
+        bundle / "payload" / "runs" / "orca__differential_drive" / "episodes.jsonl",
+        [
+            _episode("orca", 1, True, False),
+            _episode("orca", 1, True, False),
+            _episode("orca", 2, True, False),
+            _episode("orca", 2, False, False),
+        ],
+    )
+    _write_jsonl(
+        bundle / "payload" / "runs" / "ppo__differential_drive" / "episodes.jsonl",
+        [
+            _episode("ppo", 1, True, True),
+            _episode("ppo", 1, False, True),
+            _episode("ppo", 2, True, False),
+            _episode("ppo", 2, False, False),
+        ],
+    )
+    _write_jsonl(
+        bundle / "payload" / "runs" / "goal__differential_drive" / "episodes.jsonl",
+        [
+            _episode("goal", 1, False, False),
+            _episode("goal", 2, True, False),
+        ],
+    )
+    (bundle / "publication_manifest.json").write_text(
+        json.dumps({"provenance": {"run_id": "tiny-run"}}) + "\n",
+        encoding="utf-8",
+    )
+    return bundle
+
+
+def test_build_tradeoff_points_uses_outcome_collision_event(tmp_path: Path) -> None:
+    """Planner CIs should use outcome.collision_event, not stale metrics.collisions."""
+    bundle = _write_bundle(tmp_path)
+    points = build_tradeoff_points(bundle, bootstrap_samples=50, bootstrap_seed=7)
+    by_key = {point.planner_key: point for point in points}
+
+    assert by_key["ppo"].role == "headline"
+    assert by_key["goal"].role == "control"
+    assert by_key["ppo"].collision_mean == 0.5
+    assert by_key["ppo"].collision_ci is not None
+    assert by_key["ppo"].collision_ci[1] > 0.0
+
+
+def test_bootstrap_seed_mean_ci_is_deterministic(tmp_path: Path) -> None:
+    """Bootstrap CIs should be reproducible for a fixed seed."""
+    bundle = _write_bundle(tmp_path)
+    episodes = bundle / "payload" / "runs" / "ppo__differential_drive" / "episodes.jsonl"
+
+    ci1 = bootstrap_seed_mean_ci(episodes, "collisions", samples=100, seed=123)
+    ci2 = bootstrap_seed_mean_ci(episodes, "collisions", samples=100, seed=123)
+
+    assert ci1 == ci2
+    assert ci1[0] <= ci1[1]
+
+
+def test_save_planner_tradeoff_figure_and_cli(tmp_path: Path, capsys) -> None:
+    """Both the library helper and CLI should write PNG/PDF plus metadata."""
+    bundle = _write_bundle(tmp_path)
+    out_png = tmp_path / "tradeoff.png"
+    out_pdf = tmp_path / "tradeoff.pdf"
+    meta = save_planner_tradeoff_figure(
+        bundle,
+        out_png=out_png,
+        out_pdf=out_pdf,
+        bootstrap_samples=20,
+    )
+
+    assert out_png.exists() and out_png.stat().st_size > 0
+    assert out_pdf.exists() and out_pdf.stat().st_size > 0
+    assert meta["run_id"] == "tiny-run"
+
+    cli_png = tmp_path / "cli_tradeoff.png"
+    cli_meta = tmp_path / "cli_tradeoff.json"
+    rc = cli_main(
+        [
+            "plot-planner-tradeoff",
+            "--bundle-path",
+            str(bundle),
+            "--out",
+            str(cli_png),
+            "--metadata-out",
+            str(cli_meta),
+            "--bootstrap-samples",
+            "20",
+        ]
+    )
+    cap = capsys.readouterr()
+    assert rc == 0, f"plot-planner-tradeoff failed: {cap.err}"
+    assert cli_png.exists() and cli_png.stat().st_size > 0
+    payload = json.loads(cli_meta.read_text(encoding="utf-8"))
+    assert payload["run_id"] == "tiny-run"


### PR DESCRIPTION
## Summary
- add `robot_sf.benchmark.planner_tradeoff_plot` for publication-bundle success/collision tradeoff figures
- add `robot_sf_bench plot-planner-tradeoff` with PNG/PDF export and optional metadata JSON
- document the workflow and cover bundle parsing, seed-level bootstrap CIs, and outcome-based collision semantics with tests

## Validation
- `uv run pytest tests/test_planner_tradeoff_plot.py -q`
- `uv run pytest tests/test_planner_tradeoff_plot.py tests/test_cli_plot_distributions.py tests/test_plots_pareto.py -q`
- `uv run robot_sf_bench plot-planner-tradeoff --bundle-path /Users/lennart/git/amv_benchmark_paper/artifacts/robot_sf_ll7/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle --out output/figures/planner_tradeoff_smoke.png --out-pdf output/figures/planner_tradeoff_smoke.pdf --metadata-out output/figures/planner_tradeoff_smoke.json --bootstrap-samples 40`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4332 passed, 10 skipped`; touched-file coverage warnings only: `robot_sf/benchmark/cli.py` 87.8%, `robot_sf/benchmark/planner_tradeoff_plot.py` 83.8%)

## Notes
- Collision CIs prefer `outcome.collision_event` when present so camera-ready bundles with stale `metrics.collisions` still plot the same collision semantics as the paper tooling.
- Generated smoke outputs stayed under ignored `output/` and were removed before handoff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `plot-planner-tradeoff` CLI command to generate planner safety-efficiency tradeoff scatter plots from publication bundles in PNG/PDF formats
  * Supports optional confidence interval visualization and Python API for programmatic use

* **Documentation**
  * Added comprehensive guide for planner tradeoff plot generation with input requirements and usage examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->