### PR TITLE
fix: align benchmark success collision semantics (#1636)

### DIFF
--- a/robot_sf/benchmark/constants.py
+++ b/robot_sf/benchmark/constants.py
@@ -34,7 +34,14 @@ NEAR_MISS_DIST: float = 0.50
 # considered discomfort / high-exposure. Chosen empirically; see research.md.
 COMFORT_FORCE_THRESHOLD: float = 2.0
 
+# --- Lightweight benchmark runner geometry (meters) ---
+# Keep the synthetic runner observation payload and metric clearance calculation aligned.
+BENCHMARK_RUNNER_ROBOT_RADIUS_M: float = 0.3
+BENCHMARK_RUNNER_PED_RADIUS_M: float = 0.35
+
 __all__ = [
+    "BENCHMARK_RUNNER_PED_RADIUS_M",
+    "BENCHMARK_RUNNER_ROBOT_RADIUS_M",
     "COLLISION_DIST",
     "COMFORT_FORCE_THRESHOLD",
     "EPISODE_SCHEMA_VERSION",

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -514,23 +514,18 @@ def experimental_social_acceptability_metrics(
     return metrics
 
 
-# --- Metric stub functions ---
 def success(data: EpisodeData, *, horizon: int) -> float:
-    """Return 1 if goal reached before horizon with zero collisions else 0.
+    """Return the benchmark-facing binary success indicator.
 
-    Uses `reached_goal_step` if provided; if absent returns 0 (unknown / not reached).
+    This compatibility helper intentionally mirrors ``success_rate`` so all
+    public success helpers treat wall, agent, and human collisions consistently.
+    Aggregate per-episode values from this function by averaging them.
 
     Returns:
-        1.0 if successful (goal reached without collisions), 0.0 otherwise.
+        1.0 if goal was reached before ``horizon`` with zero wall, agent, or
+        human collisions; 0.0 otherwise.
     """
-    if data.reached_goal_step is None:
-        return 0.0
-    if data.reached_goal_step >= horizon:
-        return 0.0
-    # treat any collision as failure
-    if collisions(data) > 0:
-        return 0.0
-    return 1.0
+    return success_rate(data, horizon=horizon)
 
 
 def time_to_goal_norm(data: EpisodeData, horizon: int) -> float:

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -80,6 +80,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 
+BENCHMARK_RUNNER_ROBOT_RADIUS_M = 0.3
+BENCHMARK_RUNNER_PED_RADIUS_M = 0.35
+
+
 def _load_baseline_planner(algo: str, algo_config_path: str | None, seed: int):
     """Load and construct a baseline planner from the registry.
 
@@ -128,7 +132,8 @@ def _build_observation(ObservationCls, robot_pos, robot_vel, robot_goal, ped_pos
         Observation instance with current state data.
     """
     agents = [
-        {"position": pos.tolist(), "velocity": [0.0, 0.0], "radius": 0.35} for pos in ped_positions
+        {"position": pos.tolist(), "velocity": [0.0, 0.0], "radius": BENCHMARK_RUNNER_PED_RADIUS_M}
+        for pos in ped_positions
     ]
     return ObservationCls(
         dt=dt,
@@ -136,7 +141,7 @@ def _build_observation(ObservationCls, robot_pos, robot_vel, robot_goal, ped_pos
             "position": robot_pos.tolist(),
             "velocity": robot_vel.tolist(),
             "goal": robot_goal.tolist(),
-            "radius": 0.3,
+            "radius": BENCHMARK_RUNNER_ROBOT_RADIUS_M,
         },
         agents=agents,
         obstacles=[],
@@ -372,11 +377,15 @@ def _build_episode_data(  # noqa: PLR0913
     goal: np.ndarray,
     dt: float,
     reached_goal_step: int | None,
+    *,
+    robot_radius: float = BENCHMARK_RUNNER_ROBOT_RADIUS_M,
+    ped_radius: float = BENCHMARK_RUNNER_PED_RADIUS_M,
 ) -> EpisodeData:
     """Assemble EpisodeData from trajectory buffers and metadata.
 
     Returns:
-        EpisodeData instance.
+        EpisodeData instance with metric radii matching the runner observation
+        payload unless explicit radii are provided.
     """
     robot_pos = _stack_or_zero(robot_pos_traj, stack_fn=np.vstack, empty_shape=(0, 2))
     robot_vel = _stack_or_zero(robot_vel_traj, stack_fn=np.vstack, empty_shape=(0, 2))
@@ -394,6 +403,8 @@ def _build_episode_data(  # noqa: PLR0913
         goal=goal,
         dt=dt,
         reached_goal_step=reached_goal_step,
+        robot_radius=float(robot_radius),
+        ped_radius=float(ped_radius),
     )
 
 

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -49,7 +49,11 @@ else:
     _BASELINE_IMPORT_ERROR = None
 
 from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
-from robot_sf.benchmark.constants import EPISODE_SCHEMA_VERSION
+from robot_sf.benchmark.constants import (
+    BENCHMARK_RUNNER_PED_RADIUS_M,
+    BENCHMARK_RUNNER_ROBOT_RADIUS_M,
+    EPISODE_SCHEMA_VERSION,
+)
 from robot_sf.benchmark.manifest import load_manifest, save_manifest
 from robot_sf.benchmark.map_runner import run_map_batch
 from robot_sf.benchmark.metrics import EpisodeData, compute_all_metrics, post_process_metrics
@@ -78,10 +82,6 @@ from robot_sf.training.task_bundles import is_task_bundle_reference
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-
-BENCHMARK_RUNNER_ROBOT_RADIUS_M = 0.3
-BENCHMARK_RUNNER_PED_RADIUS_M = 0.35
 
 
 def _load_baseline_planner(algo: str, algo_config_path: str | None, seed: int):
@@ -403,8 +403,8 @@ def _build_episode_data(  # noqa: PLR0913
         goal=goal,
         dt=dt,
         reached_goal_step=reached_goal_step,
-        robot_radius=float(robot_radius),
-        ped_radius=float(ped_radius),
+        robot_radius=robot_radius,
+        ped_radius=ped_radius,
     )
 
 

--- a/tests/test_metrics_success_rate.py
+++ b/tests/test_metrics_success_rate.py
@@ -6,6 +6,7 @@ from robot_sf.benchmark.metrics import (
     EpisodeData,
     agent_collisions,
     human_collisions,
+    success,
     success_rate,
     wall_collisions,
 )
@@ -55,7 +56,7 @@ def test_success_without_collisions_reaches_goal():
 
 
 def test_failure_on_wall_collision():
-    """TODO docstring. Document this function."""
+    """Wall collisions should make both public success helpers fail."""
     T = 10
     robot_pos, robot_vel, robot_acc, peds_pos, ped_forces, goal, dt = make_base_episode(
         T, with_peds=False
@@ -79,10 +80,11 @@ def test_failure_on_wall_collision():
     # sanity: wall_collisions should be > 0
     assert wall_collisions(data) > 0
     assert success_rate(data, horizon=T) == 0.0
+    assert success(data, horizon=T) == success_rate(data, horizon=T)
 
 
 def test_failure_on_agent_collision():
-    """TODO docstring. Document this function."""
+    """Other-agent collisions should make both public success helpers fail."""
     T = 10
     robot_pos, robot_vel, robot_acc, peds_pos, ped_forces, goal, dt = make_base_episode(
         T, with_peds=False
@@ -106,6 +108,7 @@ def test_failure_on_agent_collision():
     )
     assert agent_collisions(data) > 0
     assert success_rate(data, horizon=T) == 0.0
+    assert success(data, horizon=T) == success_rate(data, horizon=T)
 
 
 def test_failure_on_human_collision():

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -8,13 +8,40 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from robot_sf.benchmark.runner import run_batch, run_episode, validate_and_write
+import numpy as np
+
+from robot_sf.benchmark.runner import (
+    BENCHMARK_RUNNER_PED_RADIUS_M,
+    BENCHMARK_RUNNER_ROBOT_RADIUS_M,
+    _build_episode_data,
+    run_batch,
+    run_episode,
+    validate_and_write,
+)
 from robot_sf.benchmark.schema_validator import load_schema, validate_episode
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
+
+
+def test_build_episode_data_uses_runner_observation_radii() -> None:
+    """The lightweight runner should pass its observation radii into metrics."""
+    ep = _build_episode_data(
+        robot_pos_traj=[np.array([0.0, 0.0])],
+        robot_vel_traj=[np.array([0.0, 0.0])],
+        robot_acc_traj=[np.array([0.0, 0.0])],
+        peds_pos_traj=[np.array([[1.0, 0.0]])],
+        ped_forces_traj=[np.zeros((1, 2))],
+        obstacles=None,
+        goal=np.array([1.0, 0.0]),
+        dt=0.1,
+        reached_goal_step=None,
+    )
+
+    assert ep.robot_radius == BENCHMARK_RUNNER_ROBOT_RADIUS_M
+    assert ep.ped_radius == BENCHMARK_RUNNER_PED_RADIUS_M
 
 
 def test_runner_single_episode_tmp(tmp_path: Path):

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -9,10 +9,13 @@ import json
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 
-from robot_sf.benchmark.runner import (
+from robot_sf.benchmark.constants import (
     BENCHMARK_RUNNER_PED_RADIUS_M,
     BENCHMARK_RUNNER_ROBOT_RADIUS_M,
+)
+from robot_sf.benchmark.runner import (
     _build_episode_data,
     run_batch,
     run_episode,
@@ -45,7 +48,7 @@ def test_build_episode_data_uses_runner_observation_radii() -> None:
 
 
 def test_runner_single_episode_tmp(tmp_path: Path):
-    """Run one benchmark episode and validate schema-compliant JSONL persistence.
+    """Run one episode and validate metric radii flow through JSONL persistence.
 
     Args:
         tmp_path: Temporary directory for writing the smoke output JSONL.
@@ -67,6 +70,13 @@ def test_runner_single_episode_tmp(tmp_path: Path):
     assert "metrics" in record
     assert "metric_parameters" in record
     assert "threshold_signature" in record["metric_parameters"]
+    radius_sum = BENCHMARK_RUNNER_ROBOT_RADIUS_M + BENCHMARK_RUNNER_PED_RADIUS_M
+    assert record["metrics"]["min_clearance"] == pytest.approx(
+        record["metrics"]["min_distance"] - radius_sum
+    )
+    assert record["metrics"]["mean_clearance"] == pytest.approx(
+        record["metrics"]["mean_distance"] - radius_sum
+    )
     # Validate schema
     schema = load_schema(SCHEMA_PATH)
     validate_episode(record, schema)


### PR DESCRIPTION
## Summary
Aligns the legacy `success()` helper with benchmark-facing `success_rate()` so both treat wall, other-agent, and human collisions as success failures. Also makes the lightweight benchmark runner pass its own observation radii into `EpisodeData` instead of falling back to mismatched metric defaults.

## Linked Issues
- Closes #1636

## What Changed
- Changed `robot_sf.benchmark.metrics.success()` to delegate to `success_rate()`.
- Added regression assertions for wall-collision and other-agent-collision divergence.
- Added named lightweight-runner radius constants and passed them into `EpisodeData`.
- Added a runner smoke test proving the metric radii match the runner observation radii.

## Why It Matters
- Added value: public success helpers now share one collision contract.
- Expected impact: benchmark callers no longer get contradictory success values for wall-only or other-agent-only collision cases.
- Why this is worth merging now: it resolves a ready high-priority benchmark correctness issue with targeted tests and no broad metric redesign.

## Validation / Proof
- Red check before implementation: `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests/test_metrics_success_rate.py -q` failed for wall and agent collision cases because `success()` returned 1.0 while `success_rate()` returned 0.0.
- Targeted after fix: `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests/test_metrics_success_rate.py tests/test_metrics.py tests/test_runner_smoke.py -q` passed: 73 passed.
- Final targeted after docstring cleanup: `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests/test_metrics_success_rate.py tests/test_runner_smoke.py -q` passed: 7 passed.
- `BASE_REF=origin/main PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh` passed: 4329 passed, 11 skipped. Changed-file coverage is above the 80% minimum; 100% goal misses are warning-only (`metrics.py` 93.4%, `runner.py` 85.6%).

## Risks / Rollout
- Compatibility risks: callers using `success()` as a pedestrian-only success predicate will now see wall/agent collisions fail success, matching `success_rate()`.
- Failure modes: historical ad hoc outputs computed with `success()` may differ if they contained wall-only or other-agent-only collisions.
- Rollback or fallback plan: revert the helper delegation and runner radius constants if an unintended downstream dependency is found.

## Docs / Provenance
- Updated docs: `success()` docstring now states it mirrors `success_rate()`.
- Relevant design or provenance notes: issue #1636 and `docs/context/issue_691_benchmark_fallback_policy.md`.
- Any assumptions that need to be preserved: this does not reinterpret published benchmark outputs or change paper-facing claims.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check the intentional semantic tightening of `success()` and the lightweight runner radius constants.
- Generated `output/coverage` was discarded; ignored `output/validation/pr_ready/issue-1636-success-collision-semantics.json` records the local freshness stamp and is not committed.