### PR TITLE
docs: plan LiDAR learned-policy launch

### DIFF
--- a/configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
+++ b/configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
@@ -1,0 +1,143 @@
+schema_version: lidar-learned-policy-launch-packet.v1
+campaign_id: issue_1615_lidar_learned_policy_plan_v1
+generating_commit: 4ee6eb7b3faceb25b7baa6ab8b615cb3c5be4512
+parent_issue: 1611
+issue: 1615
+observation_contract:
+  observation_mode: DEFAULT_GYM
+  benchmark_observation_level: lidar_2d
+  deployment_observable:
+    - drive_state
+    - rays
+  required_keys:
+    drive_state:
+      shape: [stack_steps, 5]
+      fields:
+        - speed_x
+        - speed_rot
+        - target_distance
+        - target_angle
+        - next_target_angle
+    rays:
+      shape: [stack_steps, num_rays]
+      fields:
+        - lidar_range_m
+  normalization:
+    source: docs/dev/observation_contract.md
+    rule: divide drive_state and rays by orig_obs_space.high
+    fit_scope: training split only for learned normalizers beyond environment bounds
+  forbidden_runtime_fields:
+    - occupancy_grid
+    - socnav_struct_robot_position
+    - socnav_struct_pedestrian_positions
+    - socnav_struct_pedestrian_velocities
+    - future_pedestrian_trajectories
+    - simulator_collision_labels
+    - route_outcome_labels
+model_registry_metadata:
+  required_fields_for_future_checkpoint:
+    - model_id
+    - observation_level
+    - observation_mode
+    - observation_keys
+    - ray_count
+    - stack_steps
+    - goal_encoding
+    - feature_extractor
+    - action_contract
+    - training_config
+    - checkpoint_artifact_uri
+    - evaluation_config
+    - no_privileged_runtime_inputs
+  observation_level: lidar_2d
+  observation_mode: DEFAULT_GYM
+  observation_keys: [drive_state, rays]
+  action_contract: velocity_command
+candidate_baselines:
+  - candidate_id: ppo_lidar_mlp_gate_v1
+    role: simple_baseline
+    algorithm: sb3_ppo
+    base_config: configs/training/ppo/feature_extractor_sweep_base.yaml
+    feature_extractor: mlp
+    feature_extractor_preset: mlp_small
+    eligibility_spec: configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+    launch_command_shape: >
+      uv run python scripts/training/optuna_feature_extractor.py --config
+      configs/training/ppo/feature_extractor_sweep_base.yaml --trials 1
+      --trial-timesteps 32000 --disable-wandb
+    smoke_validation:
+      - uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+      - uv run pytest -q tests/test_feature_extractors.py tests/training/test_lidar_learned_policy_launch_packet.py
+  - candidate_id: ppo_lidar_attention_gate_v1
+    role: richer_perception_variant
+    algorithm: sb3_ppo
+    base_config: configs/training/ppo/feature_extractor_sweep_base.yaml
+    feature_extractor: attention
+    feature_extractor_preset: attention_large
+    eligibility_spec: configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+    launch_command_shape: >
+      uv run python scripts/training/optuna_feature_extractor.py --config
+      configs/training/ppo/feature_extractor_sweep_base.yaml --trials 1
+      --trial-timesteps 32000 --disable-wandb
+    smoke_validation:
+      - uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+      - uv run pytest -q tests/test_feature_extractors.py tests/training/test_lidar_learned_policy_launch_packet.py
+  - candidate_id: ppo_lidar_lstm_history_v1
+    role: history_variant
+    algorithm: sb3_ppo
+    base_config: configs/training/ppo/feature_extractor_sweep_base.yaml
+    feature_extractor: lstm
+    feature_extractor_preset: lstm_medium
+    eligibility_spec: configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+    launch_command_shape: >
+      Use the existing feature-extractor sweep base with a fixed LSTM candidate in a follow-up
+      config before any long run; keep runtime observation keys limited to drive_state and rays.
+  - candidate_id: dreamerv3_lidar_world_model_gate_v1
+    role: research_variant
+    algorithm: rllib_dreamerv3
+    base_config: configs/training/rllib_dreamerv3/drive_state_rays.yaml
+    feature_extractor: world_model
+    verdict_boundary: research_only_until_adapter_and_checkpoint_exist
+    launch_command_shape: >
+      Use configs/training/rllib_dreamerv3/drive_state_rays.yaml for a follow-up DreamerV3
+      smoke; flatten_observation must keep flatten_keys=[drive_state, rays] and
+      include_grid=false.
+training_stages:
+  metadata_preflight:
+    required_before_training: true
+    commands:
+      - uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+      - uv run pytest -q tests/training/test_lidar_learned_policy_launch_packet.py tests/validation/test_check_learned_policy_eligibility.py tests/test_feature_extractors.py
+  local_ppo_smoke:
+    submit_from_this_issue: false
+    command_shape: >
+      uv run python scripts/training/optuna_feature_extractor.py --config
+      configs/training/ppo/feature_extractor_sweep_base.yaml --trials 1
+      --trial-timesteps 32000 --disable-wandb
+    promotion_gate: completes without privileged observation keys and writes a compact summary
+  durable_training:
+    submit_from_this_issue: false
+    expected_follow_up_issue: true
+    command_shape: >
+      Submit a dedicated SLURM or training issue after metadata preflight lands. Use a tracked
+      config derived from this packet, record exact commit/config/checkpoint lineage, and publish
+      checkpoints through W&B artifacts or another durable store before registry promotion.
+artifact_policy:
+  checkpoints_in_git: false
+  raw_training_logs_in_git: false
+  output_root: output/training/lidar_learned_policy/issue_1615
+  durable_checkpoint_source_required: true
+  tracked_manifest_required_before_registry_promotion: true
+  required_before_training:
+    - Record exact training config, git commit, seeds, ray count, stack steps, and feature extractor.
+    - Keep runtime observations limited to DEFAULT_GYM drive_state and rays.
+    - Publish checkpoints and full summaries outside git; track only compact manifests or reports.
+follow_up_boundaries:
+  full_training_in_this_issue: false
+  submit_slurm_from_this_issue: false
+  benchmark_promotion_in_this_issue: false
+  create_dedicated_issue_for:
+    - ppo_lidar_mlp_smoke_and_short_train
+    - ppo_lidar_attention_or_lstm_perception_variant
+    - dreamerv3_lidar_world_model_smoke
+    - model_registry_entry_after_checkpoint_promotion

--- a/configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+++ b/configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
@@ -1,0 +1,48 @@
+verdict: eligible_for_research_only
+observation_t: decision step t before learned perception/action adapter inference
+observation_fields:
+  deployment_observable:
+    - DEFAULT_GYM drive_state
+    - DEFAULT_GYM rays
+  training_only:
+    - auxiliary reconstruction labels derived from training episodes
+    - optional self-supervised ray masking targets
+    - reward and return labels for policy optimization
+  forbidden_evaluation_time: []
+split_provenance:
+  training_data_source: Robot SF training environments with LiDAR ray observations and held-out validation maps
+  validation_split: held-out validation maps and seeds, to be materialized before long training
+  test_split: benchmark test scenarios excluded from training, normalization fitting, and feature selection
+  checkpoint_or_model_provenance: no checkpoint yet; launch packet only
+  privileged_training_inputs: optional auxiliary labels may be generated offline from training traces only
+  privileged_training_inputs_enter_evaluation: false
+  normalization_statistics: environment bounds plus any learned normalizer fit on training data only
+  normalization_statistics_fit_on_training_only: true
+  evidence_source: configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
+action_contract:
+  output_family: velocity_command
+  frame: robot local frame
+  units: linear m/s and angular rad/s
+  bounds: clip to Robot SF differential-drive command bounds
+  kinematics_compatibility: differential-drive compatible
+  projection_policy: clip raw model output to configured Robot SF action bounds
+  raw_to_robot_sf_action: map perception-conditioned learned action vector to linear and angular command
+  guard_or_projection_policy: report clipping, fallback, and guard status separately from policy success
+per_step_logging:
+  raw_model_action: candidate.raw_model_action
+  adapted_action: candidate.adapted_action
+  post_guard_action: candidate.post_guard_action
+  guard_applied: candidate.guard_applied
+  guard_or_fallback_reason: candidate.guard_or_fallback_reason
+  observation_level: lidar_2d
+  planner_observation_mode: DEFAULT_GYM
+  action_bounds: active Robot SF action bounds
+  action_projection_metadata: clip/projection details and whether clipping occurred
+candidate_registry:
+  entry_planned: true
+  candidate_config_path: configs/policy_search/candidates/lidar_perception_adapter_issue_1615.yaml
+  adapter_path: robot_sf/planner/learned_lidar_policy.py
+  smoke_or_validation_command: uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+  missing_checkpoint_policy: fail closed with not_available before benchmark episodes are written
+  unsupported_observation_policy: fail closed unless observation level is lidar_2d and keys are drive_state+rays
+  guard_activation_policy: report guard activation as a caveat, not benchmark success evidence

--- a/configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+++ b/configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
@@ -39,9 +39,10 @@ per_step_logging:
   action_bounds: active Robot SF action bounds
   action_projection_metadata: clip/projection details and whether clipping occurred
 candidate_registry:
-  entry_planned: true
-  candidate_config_path: configs/policy_search/candidates/lidar_perception_adapter_issue_1615.yaml
-  adapter_path: robot_sf/planner/learned_lidar_policy.py
+  entry_planned: false
+  planning_status: deferred to follow-up issue 1662; this PR is a launch packet only
+  planned_candidate_config_path: configs/policy_search/candidates/lidar_perception_adapter_issue_1615.yaml
+  planned_adapter_path: robot_sf/planner/learned_lidar_policy.py
   smoke_or_validation_command: uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
   missing_checkpoint_policy: fail closed with not_available before benchmark episodes are written
   unsupported_observation_policy: fail closed unless observation level is lidar_2d and keys are drive_state+rays

--- a/configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+++ b/configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
@@ -39,9 +39,10 @@ per_step_logging:
   action_bounds: active Robot SF action bounds
   action_projection_metadata: clip/projection details and whether clipping occurred
 candidate_registry:
-  entry_planned: true
-  candidate_config_path: configs/policy_search/candidates/lidar_ppo_mlp_issue_1615.yaml
-  adapter_path: robot_sf/planner/learned_lidar_policy.py
+  entry_planned: false
+  planning_status: deferred to follow-up issue 1662; this PR is a launch packet only
+  planned_candidate_config_path: configs/policy_search/candidates/lidar_ppo_mlp_issue_1615.yaml
+  planned_adapter_path: robot_sf/planner/learned_lidar_policy.py
   smoke_or_validation_command: uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
   missing_checkpoint_policy: fail closed with not_available before benchmark episodes are written
   unsupported_observation_policy: fail closed unless observation level is lidar_2d and keys are drive_state+rays

--- a/configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+++ b/configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
@@ -1,0 +1,48 @@
+verdict: eligible_for_research_only
+observation_t: decision step t before learned-policy action selection
+observation_fields:
+  deployment_observable:
+    - DEFAULT_GYM drive_state
+    - DEFAULT_GYM rays
+  training_only:
+    - training split episode returns
+    - PPO advantage estimates
+    - rollout rewards
+  forbidden_evaluation_time: []
+split_provenance:
+  training_data_source: Robot SF training environments using DEFAULT_GYM drive_state+rays
+  validation_split: held-out Robot SF validation maps and seeds, to be fixed in follow-up training config
+  test_split: benchmark test scenarios excluded from training and tuning
+  checkpoint_or_model_provenance: no checkpoint yet; launch packet only
+  privileged_training_inputs: none required for runtime policy; PPO uses rewards and advantages during training only
+  privileged_training_inputs_enter_evaluation: false
+  normalization_statistics: environment bounds from orig_obs_space.high; any learned normalizers fit on training split only
+  normalization_statistics_fit_on_training_only: true
+  evidence_source: configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
+action_contract:
+  output_family: velocity_command
+  frame: robot local frame
+  units: linear m/s and angular rad/s
+  bounds: clip to Robot SF differential-drive command bounds
+  kinematics_compatibility: differential-drive compatible
+  projection_policy: clip raw model output to configured Robot SF action bounds
+  raw_to_robot_sf_action: map learned action vector to linear and angular command
+  guard_or_projection_policy: report clipping, fallback, and guard status separately from policy success
+per_step_logging:
+  raw_model_action: candidate.raw_model_action
+  adapted_action: candidate.adapted_action
+  post_guard_action: candidate.post_guard_action
+  guard_applied: candidate.guard_applied
+  guard_or_fallback_reason: candidate.guard_or_fallback_reason
+  observation_level: lidar_2d
+  planner_observation_mode: DEFAULT_GYM
+  action_bounds: active Robot SF action bounds
+  action_projection_metadata: clip/projection details and whether clipping occurred
+candidate_registry:
+  entry_planned: true
+  candidate_config_path: configs/policy_search/candidates/lidar_ppo_mlp_issue_1615.yaml
+  adapter_path: robot_sf/planner/learned_lidar_policy.py
+  smoke_or_validation_command: uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+  missing_checkpoint_policy: fail closed with not_available before benchmark episodes are written
+  unsupported_observation_policy: fail closed unless observation level is lidar_2d and keys are drive_state+rays
+  guard_activation_policy: report guard activation as a caveat, not benchmark success evidence

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -178,6 +178,8 @@ knowledge, not every transient iteration detail.
   [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
+* Issue #1615 LiDAR learned-policy launch plan:
+  [issue_1615_lidar_learned_policy_plan.md](issue_1615_lidar_learned_policy_plan.md)
 * Issue #1294 seed-sensitivity perturbations:
   [issue_1294_seed_sensitivity_perturbations.md](issue_1294_seed_sensitivity_perturbations.md)
 * Issue archetypes and evidence tiers:

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -178,7 +178,7 @@ knowledge, not every transient iteration detail.
   [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
-* Issue #1615 LiDAR learned-policy launch plan:
+* Issue #1615 LiDAR Learned-Policy Launch Plan (2026-05-29):
   [issue_1615_lidar_learned_policy_plan.md](issue_1615_lidar_learned_policy_plan.md)
 * Issue #1294 seed-sensitivity perturbations:
   [issue_1294_seed_sensitivity_perturbations.md](issue_1294_seed_sensitivity_perturbations.md)

--- a/docs/context/issue_1615_lidar_learned_policy_plan.md
+++ b/docs/context/issue_1615_lidar_learned_policy_plan.md
@@ -5,7 +5,7 @@ Date: 2026-05-29
 ## Scope
 
 This note records the launch packet for LiDAR-based learned local policies requested by issue
-#1615. It plans candidate baselines, feature-extractor variants, registry metadata, smoke
+number 1615. It plans candidate baselines, feature-extractor variants, registry metadata, smoke
 validation, and artifact promotion. It does not launch training, submit SLURM jobs, promote a
 checkpoint, or claim benchmark performance.
 

--- a/docs/context/issue_1615_lidar_learned_policy_plan.md
+++ b/docs/context/issue_1615_lidar_learned_policy_plan.md
@@ -1,0 +1,85 @@
+# Issue #1615 LiDAR Learned-Policy Launch Plan
+
+Date: 2026-05-29
+
+## Scope
+
+This note records the launch packet for LiDAR-based learned local policies requested by issue
+#1615. It plans candidate baselines, feature-extractor variants, registry metadata, smoke
+validation, and artifact promotion. It does not launch training, submit SLURM jobs, promote a
+checkpoint, or claim benchmark performance.
+
+## Launch Packet
+
+- Packet:
+  `configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml`
+- Eligibility specs:
+  `configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml`
+  and `configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml`
+- Observation source of truth: `docs/dev/observation_contract.md`
+- Feature extractor overview: `docs/feature_extractors/README.md`
+- Checklist helper: `scripts/validation/check_learned_policy_eligibility.py`
+
+## Observation Boundary
+
+The planned policies use `ObservationMode.DEFAULT_GYM` and benchmark observation level `lidar_2d`.
+Deployment-time inputs are limited to `drive_state` and `rays`. Occupancy grids, SocNav structured
+pedestrian state, future trajectories, simulator collision labels, and route outcome labels are
+forbidden at evaluation time.
+
+This matters because the future policy should test whether LiDAR-style perception is enough for a
+local learned baseline, not whether privileged simulator state can be smuggled into a learned
+planner.
+
+## Candidate Set
+
+- `ppo_lidar_mlp_gate_v1`: simple PPO baseline using the existing feature-extractor sweep base and
+  an MLP extractor.
+- `ppo_lidar_attention_gate_v1`: richer PPO perception variant using the attention extractor over
+  ray/drive-state features.
+- `ppo_lidar_lstm_history_v1`: history-oriented PPO variant using the existing LSTM extractor path.
+- `dreamerv3_lidar_world_model_gate_v1`: research-only DreamerV3 candidate based on
+  `configs/training/rllib_dreamerv3/drive_state_rays.yaml`.
+
+The launch packet keeps these as future training candidates. A dedicated follow-up should
+materialize fixed training configs and run only after the metadata preflight remains green.
+
+## Registry Metadata
+
+A future promoted checkpoint needs explicit registry fields for `observation_level`,
+`observation_mode`, `observation_keys`, `ray_count`, `stack_steps`, `goal_encoding`,
+`feature_extractor`, `action_contract`, `training_config`, `checkpoint_artifact_uri`,
+`evaluation_config`, and `no_privileged_runtime_inputs`.
+
+Until a durable checkpoint exists, the checklist verdict is `eligible_for_research_only`, not a
+benchmark-ready adapter claim.
+
+## Validation
+
+Checklist preflight:
+
+```bash
+uv run python scripts/validation/check_learned_policy_eligibility.py \
+  configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml \
+  configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+```
+
+Targeted tests:
+
+```bash
+uv run pytest -q \
+  tests/training/test_lidar_learned_policy_launch_packet.py \
+  tests/validation/test_check_learned_policy_eligibility.py \
+  tests/test_feature_extractors.py
+```
+
+Expected result: both eligibility specs pass, feature extractors still import and instantiate, and
+the launch packet test confirms LiDAR-only runtime inputs plus artifact-promotion boundaries.
+
+## Follow-Up Boundary
+
+Future training work should create dedicated issues for a PPO MLP smoke/short run, a richer
+attention or LSTM perception variant, a DreamerV3 LiDAR smoke, and eventual registry promotion.
+Each follow-up must record exact commit, config, seeds, ray count, stack steps, checkpoint artifact
+URI, smoke result, and whether any guard or projection was active. Checkpoints and raw logs stay
+out of git; only compact manifests or summaries should be tracked.

--- a/tests/training/test_lidar_learned_policy_launch_packet.py
+++ b/tests/training/test_lidar_learned_policy_launch_packet.py
@@ -1,0 +1,74 @@
+"""Tests for the issue #1615 LiDAR learned-policy launch packet."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from robot_sf.feature_extractors.config import FeatureExtractorPresets
+from scripts.validation.check_learned_policy_eligibility import (
+    load_candidate_spec,
+    validate_learned_policy_eligibility,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACKET_PATH = (
+    _REPO_ROOT / "configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml"
+)
+_ELIGIBILITY_SPECS = (
+    _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml",
+    _REPO_ROOT / "configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml",
+)
+
+
+def _load_packet() -> dict[str, object]:
+    payload = yaml.safe_load(_PACKET_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_issue_1615_launch_packet_keeps_lidar_runtime_contract() -> None:
+    """Runtime inputs should stay at LiDAR rays plus drive-state metadata."""
+    packet = _load_packet()
+    contract = packet["observation_contract"]
+
+    assert contract["observation_mode"] == "DEFAULT_GYM"
+    assert contract["benchmark_observation_level"] == "lidar_2d"
+    assert contract["deployment_observable"] == ["drive_state", "rays"]
+    assert set(contract["required_keys"]) == {"drive_state", "rays"}
+    assert "occupancy_grid" in contract["forbidden_runtime_fields"]
+    assert "socnav_struct_pedestrian_positions" in contract["forbidden_runtime_fields"]
+
+
+def test_issue_1615_candidates_reference_existing_training_entrypoints() -> None:
+    """Candidate baselines should point at checked-in config and extractor entrypoints."""
+    packet = _load_packet()
+    candidate_ids = [candidate["candidate_id"] for candidate in packet["candidate_baselines"]]
+
+    assert len(candidate_ids) == len(set(candidate_ids))
+    for candidate in packet["candidate_baselines"]:
+        base_config = candidate.get("base_config")
+        if base_config is not None:
+            assert (_REPO_ROOT / str(base_config)).exists()
+        preset = candidate.get("feature_extractor_preset")
+        if preset is not None:
+            assert hasattr(FeatureExtractorPresets, str(preset))
+
+
+def test_issue_1615_eligibility_specs_pass_preflight() -> None:
+    """The checked-in learned-policy checklist specs should be complete."""
+    for spec_path in _ELIGIBILITY_SPECS:
+        assert validate_learned_policy_eligibility(load_candidate_spec(spec_path)) == []
+
+
+def test_issue_1615_artifact_policy_defers_checkpoint_promotion() -> None:
+    """The launch packet should not imply that a checkpoint belongs in git."""
+    packet = _load_packet()
+    artifact_policy = packet["artifact_policy"]
+    follow_up = packet["follow_up_boundaries"]
+
+    assert artifact_policy["checkpoints_in_git"] is False
+    assert artifact_policy["durable_checkpoint_source_required"] is True
+    assert follow_up["full_training_in_this_issue"] is False
+    assert follow_up["benchmark_promotion_in_this_issue"] is False


### PR DESCRIPTION
## Summary

- Adds a #1615 LiDAR learned-policy launch packet with DEFAULT_GYM `drive_state` + `rays` runtime inputs and explicit privileged-field exclusions.
- Adds learned-policy eligibility specs for the simple PPO MLP baseline and richer perception-adapter variants.
- Documents candidate baselines, registry metadata, artifact-promotion boundaries, and targeted validation in `docs/context/issue_1615_lidar_learned_policy_plan.md`.
- Adds tests that validate the packet's LiDAR-only runtime contract, checked-in training entrypoints, feature-extractor presets, eligibility specs, and checkpoint promotion boundary.

Closes #1615.

## Validation

- `uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml`
- `uv run pytest -q tests/training/test_lidar_learned_policy_launch_packet.py tests/validation/test_check_learned_policy_eligibility.py tests/test_feature_extractors.py`
- `uv run ruff check configs/training/lidar docs/context/issue_1615_lidar_learned_policy_plan.md tests/training/test_lidar_learned_policy_launch_packet.py`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4364 passed, 11 skipped, 9 warnings`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh=true`)

## Output Artifacts

Ignored, disposable local outputs only:

- `output/coverage/`
- `output/validation/pr_ready/issue-1615-lidar-learned-policy-plan.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added training configuration and eligibility specifications for LiDAR-based learned policy training with support for multiple model variants (PPO and DreamerV3 options).

* **Documentation**
  * Added launch plan documentation detailing the training process and validation requirements for LiDAR learned policies.

* **Tests**
  * Added test suite to validate configuration integrity and eligibility requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->