### PR TITLE
docs: audit LiDAR planner compatibility

### DIFF
--- a/configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml
+++ b/configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml
@@ -1,0 +1,211 @@
+schema_version: lidar-planner-compatibility-audit.v1
+issue: 1614
+parent_issue: 1611
+generated_from_commit: 4ee6eb7b3faceb25b7baa6ab8b615cb3c5be4512
+observation_contract:
+  benchmark_observation_level: lidar_2d
+  compatible_observation_modes:
+    - sensor_fusion_state
+    - lidar_human_state
+  required_runtime_inputs:
+    - robot_state
+    - goal
+    - lidar_rays
+  excluded_runtime_inputs:
+    - full_map_occupancy
+    - simulator_backed_grid
+    - socnav_state_pedestrian_positions
+    - socnav_state_pedestrian_velocities
+    - future_pedestrian_trajectories
+    - collision_or_success_labels
+classification_legend:
+  native_lidar_compatible: Runs through the current benchmark contract with observation_level=lidar_2d.
+  adapter_required: Needs a new LiDAR-derived adapter before benchmark rows may be written.
+  training_required: Runtime contract is plausible but a compatible checkpoint/config must be trained.
+  excluded_or_blocked: Current planner would use unavailable privileged inputs or lacks provenance.
+  diagnostic_only: Useful for smoke or contract debugging, not benchmark evidence.
+planner_classifications:
+  - planner: ppo
+    family: learned_policy
+    classification: training_required
+    current_contract_status: passes_lidar_2d_gate
+    active_observation_mode: sensor_fusion_state
+    required_inputs:
+      - robot_state
+      - goal
+      - lidar_rays
+      - history
+    claim_boundary: Needs a LiDAR-trained checkpoint and registry provenance before benchmark use.
+    selected_follow_up: 1662
+  - planner: guarded_ppo
+    family: learned_policy
+    classification: training_required
+    current_contract_status: passes_lidar_2d_gate
+    active_observation_mode: sensor_fusion_state
+    required_inputs:
+      - robot_state
+      - goal
+      - lidar_rays
+      - history
+      - safety_guard
+    claim_boundary: Guard activation must be reported as a caveat; LiDAR-trained checkpoint still required.
+    selected_follow_up: 1662
+  - planner: sac
+    family: learned_policy
+    classification: training_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - lidar_rays
+    claim_boundary: Training config exists, but benchmark metadata currently defaults SAC to socnav_state.
+    selected_follow_up: 1662
+  - planner: crowdnav_height
+    family: learned_social_state_policy
+    classification: adapter_required
+    current_contract_status: passes_lidar_2d_gate_but_requires_human_fields
+    active_observation_mode: lidar_human_state
+    required_inputs:
+      - robot_state
+      - goal
+      - lidar_rays
+      - humans
+    claim_boundary: Do not count as LiDAR-only until humans are reconstructed from LiDAR-derived tracks.
+    selected_follow_up: 1660
+  - planner: goal
+    family: diagnostic_goal_baseline
+    classification: diagnostic_only
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+    claim_boundary: In principle ignores pedestrians, but current observation-level gate does not expose a lidar goal-only mode.
+  - planner: grid_route
+    family: occupancy_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - occupancy_grid
+    claim_boundary: Must consume ego occupancy derived from rays, not simulator/global occupancy.
+    selected_follow_up: 1659
+  - planner: teb
+    family: occupancy_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - short_horizon_occupancy
+    claim_boundary: Testing-only until local occupancy probes are derived from rays and metadata records adapter mode.
+    selected_follow_up: 1659
+  - planner: safety_barrier
+    family: occupancy_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - local_obstacle_clearance
+    claim_boundary: Testing-only; barrier inputs must be ray-derived and must not read hidden obstacles.
+    selected_follow_up: 1659
+  - planner: orca
+    family: tracked_agent_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - tracked_agents
+    claim_boundary: Needs LiDAR-derived tracked agents with explicit noise, occlusion, and history assumptions.
+    selected_follow_up: 1660
+  - planner: social_force
+    family: tracked_agent_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - tracked_agents
+    claim_boundary: Needs LiDAR-derived tracked agents; direct socnav pedestrian state is privileged.
+    selected_follow_up: 1660
+  - planner: risk_dwa
+    family: tracked_agent_or_local_risk_classical
+    classification: adapter_required
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - tracked_agents
+      - local_risk_features
+    claim_boundary: Candidate for ray-derived tracks or occupancy, but current structured-state path is not LiDAR-only.
+    selected_follow_up: 1660
+  - planner: prediction_planner
+    family: prediction_aware
+    classification: excluded_or_blocked
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - pedestrians
+      - history
+      - prediction_model
+    claim_boundary: Exclude until prediction inputs can be derived from LiDAR observations without privileged future/state leakage.
+  - planner: predictive_mppi
+    family: prediction_aware
+    classification: excluded_or_blocked
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - pedestrians
+      - prediction_model
+    claim_boundary: Exclude from first LiDAR track; current path is structured/predictive, not ray-derived.
+  - planner: socnav_bench
+    family: upstream_adapter
+    classification: excluded_or_blocked
+    current_contract_status: blocked_by_current_contract
+    active_observation_mode: none
+    required_inputs:
+      - robot_state
+      - goal
+      - pedestrians
+    claim_boundary: External adapter remains privileged structured-state unless a LiDAR-derived wrapper is implemented.
+selected_adapter_paths:
+  - issue: 1659
+    adapter_contract: lidar_rays_to_ego_occupancy_grid
+    candidate_planners:
+      - grid_route
+      - teb
+      - safety_barrier
+    first_validation: smoke one planner with observation_level=lidar_2d and adapter execution metadata.
+  - issue: 1660
+    adapter_contract: lidar_rays_to_tracked_agents
+    candidate_planners:
+      - orca
+      - social_force
+      - risk_dwa
+      - crowdnav_height
+    first_validation: smoke one planner from reconstructed tracks and prove direct socnav pedestrian state is not read.
+  - issue: 1662
+    adapter_contract: train_lidar_learned_policy
+    candidate_planners:
+      - ppo
+      - guarded_ppo
+      - sac
+    first_validation: run metadata preflight and bounded smoke training from the #1615 launch packet.
+validation:
+  contract_gate_smoke: uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py
+  fallback_policy: docs/context/issue_691_benchmark_fallback_policy.md
+  result_rule: fallback_or_degraded_rows_are_caveats_not_lidar_success_evidence

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -128,7 +128,7 @@ knowledge, not every transient iteration detail.
   [issue_1416_converted_map_cache_evaluation.md](issue_1416_converted_map_cache_evaluation.md)
 * Issue #1246 graded observation levels:
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
-* Issue #1614 LiDAR planner compatibility audit:
+* Issue #1614 LiDAR Planner Compatibility Audit (2026-05-29):
   [issue_1614_lidar_planner_compatibility.md](issue_1614_lidar_planner_compatibility.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -128,6 +128,8 @@ knowledge, not every transient iteration detail.
   [issue_1416_converted_map_cache_evaluation.md](issue_1416_converted_map_cache_evaluation.md)
 * Issue #1246 graded observation levels:
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
+* Issue #1614 LiDAR planner compatibility audit:
+  [issue_1614_lidar_planner_compatibility.md](issue_1614_lidar_planner_compatibility.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)
 * Issue #1255 open-issue dependency graph:

--- a/docs/context/issue_1614_lidar_planner_compatibility.md
+++ b/docs/context/issue_1614_lidar_planner_compatibility.md
@@ -1,0 +1,61 @@
+# Issue #1614 LiDAR Planner Compatibility Audit
+
+Date: 2026-05-29
+
+## Scope
+
+This note classifies representative planners for the LiDAR-observation benchmark track under
+parent epic #1611. It does not implement adapters, launch benchmark campaigns, or claim benchmark
+performance. The machine-readable matrix is
+`configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml`.
+
+## Contract Boundary
+
+The LiDAR track uses benchmark observation level `lidar_2d`. Runtime inputs must be limited to
+robot state, goal information, and LiDAR/range rays. The track must not read simulator-backed
+global occupancy, hidden obstacles, direct SocNav pedestrian positions/velocities, future
+trajectories, or outcome labels.
+
+The current contract gate already rejects most structured-state planners when
+`observation_level=lidar_2d`. That fail-closed behavior is desirable: a planner should be
+unavailable until a real LiDAR-derived adapter supplies its required inputs.
+
+## Classification Summary
+
+| Planner family | Current classification | Why |
+| --- | --- | --- |
+| PPO / guarded PPO | Training required | The contract gate accepts `sensor_fusion_state` under `lidar_2d`, but a LiDAR-trained checkpoint and registry provenance are still required. |
+| SAC | Training and metadata work required | SAC is plausible for `drive_state+rays`, but current benchmark metadata does not yet expose it as a LiDAR-compatible benchmark row. |
+| CrowdNav HEIGHT | Adapter required | The current `lidar_human_state` contract includes LiDAR rays plus human fields; it must not count as LiDAR-only until those human fields are LiDAR-derived. |
+| `grid_route`, `teb`, `safety_barrier` | Ego-occupancy adapter required | These planners need local occupancy/clearance structure. The safe path is `lidar_rays -> ego occupancy_grid`, with no global map or hidden-obstacle access. |
+| `orca`, `social_force`, `risk_dwa` | Tracked-agent adapter required | These planners need agent positions/velocities. The safe path is `lidar_rays -> tracked_agents` with explicit noise, occlusion, and history assumptions. |
+| Prediction-aware planners | Excluded from first LiDAR track | Current paths depend on structured pedestrians, history, or prediction features that are not yet derived from LiDAR observations. |
+| SocNavBench-style adapters | Excluded until wrapped | Current external-style adapters consume structured state and should remain unavailable for LiDAR evidence unless a LiDAR-derived wrapper is built. |
+
+## Selected Adapter Paths
+
+- #1659: implement a `lidar_rays -> ego occupancy_grid` adapter and smoke one occupancy-backed
+  classical planner such as `grid_route`, `teb`, or `safety_barrier`.
+- #1660: implement a `lidar_rays -> tracked_agents` adapter and smoke one social-state planner
+  such as `orca`, `social_force`, or `risk_dwa`.
+- #1662: run the first LiDAR learned-policy smoke from the #1615 launch packet before any longer
+  PPO/SAC/DreamerV3 training or registry promotion.
+
+## Validation
+
+Contract and matrix smoke:
+
+```bash
+uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py
+```
+
+Expected result: current PPO and guarded-PPO metadata pass the `lidar_2d` gate through
+`sensor_fusion_state`; structured/grid planners fail closed; CrowdNav HEIGHT keeps its
+`humans`-field caveat visible; and selected follow-up issues are recorded.
+
+## Claim Boundary
+
+Fallback, degraded, or unavailable rows are caveats or exclusions, not successful LiDAR-track
+evidence. A planner becomes LiDAR-track evidence only after a targeted smoke run proves it consumes
+LiDAR-derived inputs and the benchmark metadata records observation level, active observation mode,
+execution mode, and adapter assumptions.

--- a/tests/benchmark/test_lidar_planner_compatibility.py
+++ b/tests/benchmark/test_lidar_planner_compatibility.py
@@ -39,6 +39,10 @@ def _planners_with_status(status: str) -> list[str]:
     return [str(row["planner"]) for row in rows if row["current_contract_status"] == status]
 
 
+_NATIVE_CANDIDATES = _planners_with_status("passes_lidar_2d_gate")
+_BLOCKED_PLANNERS = _planners_with_status("blocked_by_current_contract")
+
+
 def test_lidar_matrix_records_required_runtime_boundary() -> None:
     """The audit should make privileged runtime inputs explicit."""
     contract = _load_matrix()["observation_contract"]
@@ -49,19 +53,19 @@ def test_lidar_matrix_records_required_runtime_boundary() -> None:
     assert "full_map_occupancy" in contract["excluded_runtime_inputs"]
 
 
-def test_current_lidar_native_candidates_match_contract_gate() -> None:
+@pytest.mark.parametrize("planner", _NATIVE_CANDIDATES)
+def test_current_lidar_native_candidates_match_contract_gate(planner: str) -> None:
     """Only current sensor-fusion learned-policy contracts should pass the LiDAR gate."""
-    for planner in ("ppo", "guarded_ppo"):
-        row = _planner_row(planner)
-        contract = planner_contract_for_algorithm(planner, observation_level="lidar_2d")
+    row = _planner_row(planner)
+    contract = planner_contract_for_algorithm(planner, observation_level="lidar_2d")
 
-        assert row["current_contract_status"] == "passes_lidar_2d_gate"
-        assert contract.observation_contract.observation_level == "lidar_2d"
-        assert contract.observation_contract.active_mode == "sensor_fusion_state"
-        assert "lidar_rays" in contract.observation_contract.required_inputs
+    assert row["current_contract_status"] == "passes_lidar_2d_gate"
+    assert contract.observation_contract.observation_level == "lidar_2d"
+    assert contract.observation_contract.active_mode == "sensor_fusion_state"
+    assert "lidar_rays" in contract.observation_contract.required_inputs
 
 
-@pytest.mark.parametrize("planner", _planners_with_status("blocked_by_current_contract"))
+@pytest.mark.parametrize("planner", _BLOCKED_PLANNERS)
 def test_current_structured_or_grid_planners_fail_closed_for_lidar_level(planner: str) -> None:
     """Existing structured/grid planners should not silently run as LiDAR evidence."""
     row = _planner_row(planner)

--- a/tests/benchmark/test_lidar_planner_compatibility.py
+++ b/tests/benchmark/test_lidar_planner_compatibility.py
@@ -1,0 +1,99 @@
+"""Regression tests for the issue #1614 LiDAR planner-compatibility audit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
+from robot_sf.benchmark.planner_command_contract import (
+    PlannerContractValidationError,
+    validate_planner_contract,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MATRIX_PATH = _REPO_ROOT / "configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml"
+
+
+def _load_matrix() -> dict[str, object]:
+    payload = yaml.safe_load(_MATRIX_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _planner_row(planner: str) -> dict[str, object]:
+    matrix = _load_matrix()
+    rows = matrix["planner_classifications"]
+    for row in rows:
+        if row["planner"] == planner:
+            return row
+    raise AssertionError(f"Missing planner row: {planner}")
+
+
+def test_lidar_matrix_records_required_runtime_boundary() -> None:
+    """The audit should make privileged runtime inputs explicit."""
+    contract = _load_matrix()["observation_contract"]
+
+    assert contract["benchmark_observation_level"] == "lidar_2d"
+    assert contract["required_runtime_inputs"] == ["robot_state", "goal", "lidar_rays"]
+    assert "socnav_state_pedestrian_positions" in contract["excluded_runtime_inputs"]
+    assert "full_map_occupancy" in contract["excluded_runtime_inputs"]
+
+
+def test_current_lidar_native_candidates_match_contract_gate() -> None:
+    """Only current sensor-fusion learned-policy contracts should pass the LiDAR gate."""
+    for planner in ("ppo", "guarded_ppo"):
+        row = _planner_row(planner)
+        contract = planner_contract_for_algorithm(planner, observation_level="lidar_2d")
+
+        assert row["current_contract_status"] == "passes_lidar_2d_gate"
+        assert contract.observation_contract.observation_level == "lidar_2d"
+        assert contract.observation_contract.active_mode == "sensor_fusion_state"
+        assert "lidar_rays" in contract.observation_contract.required_inputs
+
+
+@pytest.mark.parametrize(
+    "planner",
+    ["goal", "orca", "social_force", "grid_route", "teb", "risk_dwa", "prediction_planner"],
+)
+def test_current_structured_or_grid_planners_fail_closed_for_lidar_level(planner: str) -> None:
+    """Existing structured/grid planners should not silently run as LiDAR evidence."""
+    row = _planner_row(planner)
+
+    with pytest.raises(PlannerContractValidationError):
+        validate_planner_contract(
+            algo=planner,
+            robot_kinematics="differential_drive",
+            algo_config={},
+            observation_level="lidar_2d",
+        )
+
+    assert row["current_contract_status"] == "blocked_by_current_contract"
+
+
+def test_crowdnav_height_lidar_gate_keeps_human_field_caveat_visible() -> None:
+    """HEIGHT may pass the named LiDAR level but still requires human-state provenance."""
+    row = _planner_row("crowdnav_height")
+    contract = planner_contract_for_algorithm("crowdnav_height", observation_level="lidar_2d")
+
+    assert row["current_contract_status"] == "passes_lidar_2d_gate_but_requires_human_fields"
+    assert contract.observation_contract.active_mode == "lidar_human_state"
+    assert set(contract.observation_contract.required_inputs) == {
+        "robot_state",
+        "goal",
+        "lidar_rays",
+        "humans",
+    }
+    assert "Do not count as LiDAR-only" in row["claim_boundary"]
+
+
+def test_selected_adapter_followups_are_recorded() -> None:
+    """The audit should route implementation work to concrete follow-up issues."""
+    adapter_paths = {path["issue"]: path for path in _load_matrix()["selected_adapter_paths"]}
+
+    assert set(adapter_paths) == {1659, 1660, 1662}
+    assert adapter_paths[1659]["adapter_contract"] == "lidar_rays_to_ego_occupancy_grid"
+    assert adapter_paths[1660]["adapter_contract"] == "lidar_rays_to_tracked_agents"
+    assert adapter_paths[1662]["adapter_contract"] == "train_lidar_learned_policy"

--- a/tests/benchmark/test_lidar_planner_compatibility.py
+++ b/tests/benchmark/test_lidar_planner_compatibility.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MATRIX_PATH = _REPO_ROOT / "configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml"
 
 
+@lru_cache(maxsize=1)
 def _load_matrix() -> dict[str, object]:
     payload = yaml.safe_load(_MATRIX_PATH.read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
@@ -30,6 +32,11 @@ def _planner_row(planner: str) -> dict[str, object]:
         if row["planner"] == planner:
             return row
     raise AssertionError(f"Missing planner row: {planner}")
+
+
+def _planners_with_status(status: str) -> list[str]:
+    rows = _load_matrix()["planner_classifications"]
+    return [str(row["planner"]) for row in rows if row["current_contract_status"] == status]
 
 
 def test_lidar_matrix_records_required_runtime_boundary() -> None:
@@ -54,10 +61,7 @@ def test_current_lidar_native_candidates_match_contract_gate() -> None:
         assert "lidar_rays" in contract.observation_contract.required_inputs
 
 
-@pytest.mark.parametrize(
-    "planner",
-    ["goal", "orca", "social_force", "grid_route", "teb", "risk_dwa", "prediction_planner"],
-)
+@pytest.mark.parametrize("planner", _planners_with_status("blocked_by_current_contract"))
 def test_current_structured_or_grid_planners_fail_closed_for_lidar_level(planner: str) -> None:
     """Existing structured/grid planners should not silently run as LiDAR evidence."""
     row = _planner_row(planner)


### PR DESCRIPTION
## Summary

- Adds a machine-readable LiDAR planner compatibility matrix for #1614.
- Documents current planner classifications, adapter-required paths, exclusions, and safe claim boundaries in `docs/context/issue_1614_lidar_planner_compatibility.md`.
- Adds regression tests proving the current contract gate accepts only the existing sensor-fusion learned-policy LiDAR path, keeps CrowdNav HEIGHT's human-field caveat visible, and fail-closes structured/grid planners for `observation_level=lidar_2d`.

Closes #1614.

## Follow-Ups Routed

- #1659: `lidar_rays -> ego occupancy_grid` adapter path.
- #1660: `lidar_rays -> tracked_agents` adapter path.
- #1662: LiDAR learned-policy smoke training from the #1615 packet.

## Validation

- `uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py`
- `uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_utils.py::test_preflight_policy_skips_non_socnav_planner_when_metadata_reports_fallback`
- `uv run ruff check tests/benchmark/test_lidar_planner_compatibility.py`
- `git diff --check`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4371 passed, 11 skipped, 9 warnings`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh=true`)

## Output Artifacts

Ignored, disposable local outputs only:

- `output/coverage/`
- `output/validation/pr_ready/issue-1614-lidar-planner-compatibility.json`
