### PR TITLE
refactor: extract RobotEnv SNQI proxy

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -154,6 +154,8 @@ knowledge, not every transient iteration detail.
   [issue_1571_adversarial_smoke_packet_sharpening.md](issue_1571_adversarial_smoke_packet_sharpening.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
+* Issue #1633 RobotEnv SNQI proxy extraction:
+  [issue_1633_robot_env_snqi_proxy.md](issue_1633_robot_env_snqi_proxy.md)
 * Issue #1342 GH-Act Runtime Requirements:
   [issue_1342_gh_act_runtime_requirements.md](issue_1342_gh_act_runtime_requirements.md)
 * Issue #1387 Tentabot-style value scorer spike:

--- a/docs/context/issue_1633_robot_env_snqi_proxy.md
+++ b/docs/context/issue_1633_robot_env_snqi_proxy.md
@@ -1,0 +1,48 @@
+# Issue #1633 RobotEnv SNQI Proxy Extraction
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1633>
+
+## Goal
+
+Decompose one cohesive `RobotEnv` runtime concern without changing Gymnasium behavior. The first
+extraction target is step-level SNQI proxy metadata because it is stateful, simulator-backed, and
+testable without constructing the full environment.
+
+## Refactor Plan
+
+`RobotEnv` should remain the public environment facade. Runtime concerns can move behind small
+collaborators while preserving thin compatibility methods where tests or downstream code already
+reach into private helpers.
+
+First extraction implemented here:
+
+- `robot_sf/gym_env/snqi_proxy.py`
+  - owns `StepSNQIProxy` and `StepSNQIProxyState`,
+  - resolves SNQI thresholds lazily,
+  - extracts robot pose and pedestrian/force rows from simulator-shaped payloads,
+  - computes `near_misses`, `force_exceed_events`, `comfort_exposure`, and running `jerk_mean`.
+- `RobotEnv` now primes and calls `StepSNQIProxy` during reset/step reward metadata assembly.
+
+Candidate follow-up collaborators identified during the scan:
+
+- `OccupancyGridRuntime`: grid enablement, static obstacle cache, grid generation, and observation
+  injection currently spread across setup, reset, step, and obstacle normalization helpers.
+- `ObservationRuntime`: SocNav/default observation setup, flattening, grid-space insertion, and
+  asymmetric critic observation augmentation.
+- `TelemetryVisualizationRuntime`: telemetry session creation/emission plus visualizable state
+  capture used by rendering and recording.
+
+## Acceptance Tests
+
+The extraction is pinned by:
+
+- `tests/gym_env/test_snqi_step_proxy.py` for the direct collaborator contract.
+- `tests/gym_env/test_robot_env_snqi_step_metadata.py` for RobotEnv metadata plumbing.
+- `uv run pytest tests -k "robot_env or environment_factory" -q` for the requested environment
+  factory slice.
+
+## Boundaries
+
+This refactor does not change benchmark metrics, reward semantics, simulator stepping, observation
+space shape, or Gymnasium return values. It only moves SNQI proxy state and computation out of
+`robot_env.py`.

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -11,7 +11,6 @@ It also defines the action and observation spaces for the robot.
 """
 
 import hashlib
-import importlib
 import json
 import random
 import time
@@ -19,7 +18,7 @@ import uuid
 from collections.abc import Callable
 from contextlib import contextmanager
 from copy import deepcopy
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +38,7 @@ from robot_sf.gym_env.env_util import (
 )
 from robot_sf.gym_env.observation_mode import ObservationMode
 from robot_sf.gym_env.reward import route_completion_v2_reward
+from robot_sf.gym_env.snqi_proxy import StepSNQIProxy
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.nav.occupancy_grid import OccupancyGrid
 from robot_sf.render.lidar_visual import render_lidar
@@ -60,10 +60,6 @@ DEFAULT_PANE_WIDTH = 320
 DEFAULT_PANE_HEIGHT = 240
 MIN_PANE_WIDTH = 200
 MIN_PANE_HEIGHT = 160
-_DEFAULT_COLLISION_DIST = 0.25
-_DEFAULT_NEAR_MISS_DIST = 0.50
-_DEFAULT_COMFORT_FORCE_THRESHOLD = 2.0
-_SNQI_THRESHOLD_CACHE: tuple[float, float, float] | None = None
 _TELEMETRY_ANALYZER_STEP_METRIC_KEYS: tuple[str, ...] = (
     "near_misses",
     "force_exceed_events",
@@ -95,21 +91,6 @@ def _temporary_global_reset_seed(seed: int | None):
     finally:
         random.setstate(random_state)
         np.random.set_state(numpy_state)
-
-
-@dataclass(slots=True)
-class _StepSNQIProxyState:
-    """Running state for SNQI step-level proxy computation.
-
-    The benchmark ``jerk_mean`` is an episodic quantity. For per-step reward metadata we
-    maintain a running proxy from finite differences of robot position.
-    """
-
-    prev_robot_pos: np.ndarray | None = None
-    prev_robot_vel: np.ndarray | None = None
-    prev_robot_acc: np.ndarray | None = None
-    jerk_sum: float = 0.0
-    jerk_count: int = 0
 
 
 # Helper to compute a stable, short hash for env_config
@@ -407,143 +388,12 @@ def _extract_step_metrics(meta: dict[str, Any]) -> dict[str, float]:
     return extracted
 
 
-def _extract_robot_xy(robot_pose: Any) -> np.ndarray:
-    """Extract a 2D robot position from heterogeneous simulator pose payloads.
-
-    Args:
-        robot_pose: Backend-dependent pose object; typically ``((x, y), theta)``.
-
-    Returns:
-        np.ndarray: ``[x, y]`` position vector.
-    """
-    source = robot_pose[0] if isinstance(robot_pose, (tuple, list)) else robot_pose
-    flattened = np.asarray(source, dtype=float).reshape(-1)
-    if flattened.size >= 2:
-        return flattened[:2]
-    return np.zeros(2, dtype=float)
-
-
-def _coerce_xy_rows(data: Any) -> np.ndarray:
-    """Coerce simulator arrays into ``(N, 2)`` float rows.
-
-    Returns:
-        np.ndarray: Array with shape ``(N, 2)``; invalid layouts produce an empty array.
-    """
-    values = np.asarray(data, dtype=float)
-    if values.ndim == 1:
-        return values.reshape(-1, 2) if values.size % 2 == 0 else np.zeros((0, 2), dtype=float)
-    if values.ndim == 2 and values.shape[-1] >= 2:
-        return values[:, :2]
-    return np.zeros((0, 2), dtype=float)
-
-
-def _resolve_snqi_thresholds() -> tuple[float, float, float]:
-    """Resolve SNQI threshold constants lazily to avoid import cycles.
-
-    Returns:
-        tuple[float, float, float]: ``(collision_dist, near_miss_dist, comfort_force_threshold)``.
-    """
-    global _SNQI_THRESHOLD_CACHE
-    if _SNQI_THRESHOLD_CACHE is not None:
-        return _SNQI_THRESHOLD_CACHE
-    try:
-        constants_module = importlib.import_module("robot_sf.benchmark.constants")
-        collision_dist = float(constants_module.COLLISION_DIST)
-        near_miss_dist = float(constants_module.NEAR_MISS_DIST)
-        comfort_force_threshold = float(constants_module.COMFORT_FORCE_THRESHOLD)
-
-        _SNQI_THRESHOLD_CACHE = (
-            collision_dist,
-            near_miss_dist,
-            comfort_force_threshold,
-        )
-    except (ImportError, ModuleNotFoundError, AttributeError):
-        _SNQI_THRESHOLD_CACHE = (
-            _DEFAULT_COLLISION_DIST,
-            _DEFAULT_NEAR_MISS_DIST,
-            _DEFAULT_COMFORT_FORCE_THRESHOLD,
-        )
-    return _SNQI_THRESHOLD_CACHE
-
-
-def _compute_snqi_step_proxies(
-    *,
-    simulator: Any,
-    dt: float,
-    proxy_state: _StepSNQIProxyState,
-) -> dict[str, float]:
-    """Compute per-step SNQI proxy terms from simulator state.
-
-    The generated values are intentionally lightweight proxies:
-    - ``near_misses``: exact per-step threshold event for robot-ped min distance.
-    - ``force_exceed_events``: exact per-step count above comfort threshold.
-    - ``comfort_exposure``: per-step normalized force exceed ratio.
-    - ``jerk_mean``: running mean of finite-difference jerk magnitude proxy.
-
-    Args:
-        simulator: Active simulator backend for the environment.
-        dt: Simulation timestep in seconds.
-        proxy_state: Running state used to estimate jerk proxy over steps.
-
-    Returns:
-        dict[str, float]: Step-level SNQI-aligned metadata terms.
-    """
-    d_coll, d_near, comfort_force_threshold = _resolve_snqi_thresholds()
-    robot_poses = getattr(simulator, "robot_poses", [])
-    robot_pos = (
-        _extract_robot_xy(robot_poses[0])
-        if isinstance(robot_poses, list) and robot_poses
-        else np.zeros(2)
-    )
-
-    ped_pos = _coerce_xy_rows(getattr(simulator, "ped_pos", np.zeros((0, 2), dtype=float)))
-
-    near_misses = 0.0
-    if ped_pos.size > 0:
-        deltas = ped_pos[:, :2] - robot_pos
-        min_dist = float(np.linalg.norm(deltas, axis=1).min())
-        near_misses = 1.0 if d_coll <= min_dist < d_near else 0.0
-
-    ped_forces = _coerce_xy_rows(
-        getattr(simulator, "last_ped_forces", np.zeros((0, 2), dtype=float))
-    )
-    force_magnitudes = np.linalg.norm(ped_forces, axis=1) if ped_forces.size > 0 else np.zeros((0,))
-    force_exceed_events = float(np.count_nonzero(force_magnitudes > comfort_force_threshold))
-    # Some backends can transiently report different lengths for ped positions/forces between ticks.
-    ped_count = max(int(ped_pos.shape[0]), int(force_magnitudes.shape[0]))
-    comfort_exposure = force_exceed_events / float(max(1, ped_count))
-
-    # Running jerk proxy from robot position finite differences.
-    if dt > 1e-9:
-        if proxy_state.prev_robot_pos is not None:
-            vel = (robot_pos - proxy_state.prev_robot_pos) / dt
-            if proxy_state.prev_robot_vel is not None:
-                acc = (vel - proxy_state.prev_robot_vel) / dt
-                if proxy_state.prev_robot_acc is not None:
-                    jerk = (acc - proxy_state.prev_robot_acc) / dt
-                    jerk_mag = float(np.linalg.norm(jerk))
-                    if np.isfinite(jerk_mag):
-                        proxy_state.jerk_sum += jerk_mag
-                        proxy_state.jerk_count += 1
-                proxy_state.prev_robot_acc = acc
-            proxy_state.prev_robot_vel = vel
-        proxy_state.prev_robot_pos = robot_pos
-    jerk_mean = (
-        proxy_state.jerk_sum / float(proxy_state.jerk_count) if proxy_state.jerk_count > 0 else 0.0
-    )
-
-    return {
-        "near_misses": float(near_misses),
-        "force_exceed_events": float(force_exceed_events),
-        "comfort_exposure": float(comfort_exposure),
-        "jerk_mean": float(jerk_mean),
-    }
-
-
 class RobotEnv(BaseEnv):
-    """
-    Representing a Gymnasium environment for training a self-driving robot
-    with reinforcement learning.
+    """Gymnasium environment facade for Robot SF simulation episodes.
+
+    ``RobotEnv`` remains the public environment API. Focused runtime collaborators own
+    extractable concerns such as step-level SNQI proxy metadata, while this class coordinates
+    simulator lifecycle, observation assembly, reward evaluation, recording, and rendering.
     """
 
     def __init__(  # noqa: PLR0913
@@ -671,17 +521,14 @@ class RobotEnv(BaseEnv):
         self._last_wall_time = time.perf_counter()
         self._frame_idx = 0
         self._telemetry_episode_id = -1
-        self._snqi_proxy_state = _StepSNQIProxyState()
+        self._snqi_proxy = StepSNQIProxy()
         self._grid_obstacle_cache_key: _GridObstacleCacheKey | None = None
         self._grid_obstacle_cache_value: _GridObstacleCacheValue | None = None
         self._prime_snqi_proxy_state()
 
     def _prime_snqi_proxy_state(self) -> None:
         """Reset and prime step-level SNQI proxy state for a fresh episode."""
-        self._snqi_proxy_state = _StepSNQIProxyState()
-        robot_poses = getattr(self.simulator, "robot_poses", [])
-        if isinstance(robot_poses, list) and robot_poses:
-            self._snqi_proxy_state.prev_robot_pos = _extract_robot_xy(robot_poses[0])
+        self._snqi_proxy.prime(self.simulator)
 
     def _build_occupancy_grid(self, env_config: EnvSettings) -> OccupancyGrid | None:
         """Initialize occupancy grid if configured and return the instance.
@@ -983,10 +830,9 @@ class RobotEnv(BaseEnv):
         # Fetch metadata about the current state
         reward_dict = self.state.meta_dict()
         reward_dict.update(
-            _compute_snqi_step_proxies(
-                simulator=self.simulator,
+            self._snqi_proxy.compute_step_metrics(
+                self.simulator,
                 dt=float(self.state.d_t),
-                proxy_state=self._snqi_proxy_state,
             )
         )
         # add the action space to dict

--- a/robot_sf/gym_env/snqi_proxy.py
+++ b/robot_sf/gym_env/snqi_proxy.py
@@ -1,0 +1,188 @@
+"""Step-level SNQI proxy metrics used by ``RobotEnv`` reward metadata."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+_DEFAULT_COLLISION_DIST = 0.25
+_DEFAULT_NEAR_MISS_DIST = 0.50
+_DEFAULT_COMFORT_FORCE_THRESHOLD = 2.0
+_SNQI_THRESHOLD_CACHE: tuple[float, float, float] | None = None
+
+
+@dataclass(slots=True)
+class StepSNQIProxyState:
+    """Running state for SNQI step-level proxy computation.
+
+    The benchmark ``jerk_mean`` is an episodic quantity. For per-step reward metadata this
+    state maintains a running proxy from finite differences of robot position.
+    """
+
+    prev_robot_pos: np.ndarray | None = None
+    prev_robot_vel: np.ndarray | None = None
+    prev_robot_acc: np.ndarray | None = None
+    jerk_sum: float = 0.0
+    jerk_count: int = 0
+
+
+class StepSNQIProxy:
+    """Own per-episode SNQI proxy state for ``RobotEnv`` step metadata."""
+
+    def __init__(self) -> None:
+        """Initialize a fresh proxy state."""
+        self.state = StepSNQIProxyState()
+
+    def prime(self, simulator: Any) -> None:
+        """Reset state and seed previous robot position from ``simulator`` when available."""
+        self.state = StepSNQIProxyState()
+        robot_poses = getattr(simulator, "robot_poses", [])
+        if isinstance(robot_poses, list) and robot_poses:
+            self.state.prev_robot_pos = extract_robot_xy(robot_poses[0])
+
+    def compute_step_metrics(self, simulator: Any, *, dt: float) -> dict[str, float]:
+        """Compute SNQI-aligned proxy metrics and update running state.
+
+        Returns:
+            dict[str, float]: Step-level SNQI proxy metadata.
+        """
+        return compute_snqi_step_proxies(
+            simulator=simulator,
+            dt=dt,
+            proxy_state=self.state,
+        )
+
+
+def extract_robot_xy(robot_pose: Any) -> np.ndarray:
+    """Extract a 2D robot position from heterogeneous simulator pose payloads.
+
+    Args:
+        robot_pose: Backend-dependent pose object; typically ``((x, y), theta)``.
+
+    Returns:
+        np.ndarray: ``[x, y]`` position vector, or zeros for invalid payloads.
+    """
+    source = robot_pose[0] if isinstance(robot_pose, (tuple, list)) else robot_pose
+    flattened = np.asarray(source, dtype=float).reshape(-1)
+    if flattened.size >= 2:
+        return flattened[:2]
+    return np.zeros(2, dtype=float)
+
+
+def coerce_xy_rows(data: Any) -> np.ndarray:
+    """Coerce simulator arrays into ``(N, 2)`` float rows.
+
+    Returns:
+        np.ndarray: Array with shape ``(N, 2)``; invalid layouts produce an empty array.
+    """
+    values = np.asarray(data, dtype=float)
+    if values.ndim == 1:
+        return values.reshape(-1, 2) if values.size % 2 == 0 else np.zeros((0, 2), dtype=float)
+    if values.ndim == 2 and values.shape[-1] >= 2:
+        return values[:, :2]
+    return np.zeros((0, 2), dtype=float)
+
+
+def resolve_snqi_thresholds() -> tuple[float, float, float]:
+    """Resolve SNQI threshold constants lazily to avoid import cycles.
+
+    Returns:
+        tuple[float, float, float]: ``(collision_dist, near_miss_dist, comfort_force_threshold)``.
+    """
+    global _SNQI_THRESHOLD_CACHE
+    if _SNQI_THRESHOLD_CACHE is not None:
+        return _SNQI_THRESHOLD_CACHE
+    try:
+        constants_module = importlib.import_module("robot_sf.benchmark.constants")
+        collision_dist = float(constants_module.COLLISION_DIST)
+        near_miss_dist = float(constants_module.NEAR_MISS_DIST)
+        comfort_force_threshold = float(constants_module.COMFORT_FORCE_THRESHOLD)
+
+        _SNQI_THRESHOLD_CACHE = (
+            collision_dist,
+            near_miss_dist,
+            comfort_force_threshold,
+        )
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        _SNQI_THRESHOLD_CACHE = (
+            _DEFAULT_COLLISION_DIST,
+            _DEFAULT_NEAR_MISS_DIST,
+            _DEFAULT_COMFORT_FORCE_THRESHOLD,
+        )
+    return _SNQI_THRESHOLD_CACHE
+
+
+def compute_snqi_step_proxies(
+    *,
+    simulator: Any,
+    dt: float,
+    proxy_state: StepSNQIProxyState,
+) -> dict[str, float]:
+    """Compute per-step SNQI proxy terms from simulator state.
+
+    The generated values are intentionally lightweight proxies:
+    - ``near_misses``: exact per-step threshold event for robot-ped min distance.
+    - ``force_exceed_events``: exact per-step count above comfort threshold.
+    - ``comfort_exposure``: per-step normalized force exceed ratio.
+    - ``jerk_mean``: running mean of finite-difference jerk magnitude proxy.
+
+    Args:
+        simulator: Active simulator backend for the environment.
+        dt: Simulation timestep in seconds.
+        proxy_state: Running state used to estimate jerk proxy over steps.
+
+    Returns:
+        dict[str, float]: Step-level SNQI-aligned metadata terms.
+    """
+    d_coll, d_near, comfort_force_threshold = resolve_snqi_thresholds()
+    robot_poses = getattr(simulator, "robot_poses", [])
+    robot_pos = (
+        extract_robot_xy(robot_poses[0])
+        if isinstance(robot_poses, list) and robot_poses
+        else np.zeros(2)
+    )
+
+    ped_pos = coerce_xy_rows(getattr(simulator, "ped_pos", np.zeros((0, 2), dtype=float)))
+
+    near_misses = 0.0
+    if ped_pos.size > 0:
+        deltas = ped_pos[:, :2] - robot_pos
+        min_dist = float(np.linalg.norm(deltas, axis=1).min())
+        near_misses = 1.0 if d_coll <= min_dist < d_near else 0.0
+
+    ped_forces = coerce_xy_rows(
+        getattr(simulator, "last_ped_forces", np.zeros((0, 2), dtype=float))
+    )
+    force_magnitudes = np.linalg.norm(ped_forces, axis=1) if ped_forces.size > 0 else np.zeros((0,))
+    force_exceed_events = float(np.count_nonzero(force_magnitudes > comfort_force_threshold))
+    # Backends can transiently report different lengths for positions/forces between ticks.
+    ped_count = max(int(ped_pos.shape[0]), int(force_magnitudes.shape[0]))
+    comfort_exposure = force_exceed_events / float(max(1, ped_count))
+
+    if dt > 1e-9:
+        if proxy_state.prev_robot_pos is not None:
+            vel = (robot_pos - proxy_state.prev_robot_pos) / dt
+            if proxy_state.prev_robot_vel is not None:
+                acc = (vel - proxy_state.prev_robot_vel) / dt
+                if proxy_state.prev_robot_acc is not None:
+                    jerk = (acc - proxy_state.prev_robot_acc) / dt
+                    jerk_mag = float(np.linalg.norm(jerk))
+                    if np.isfinite(jerk_mag):
+                        proxy_state.jerk_sum += jerk_mag
+                        proxy_state.jerk_count += 1
+                proxy_state.prev_robot_acc = acc
+            proxy_state.prev_robot_vel = vel
+        proxy_state.prev_robot_pos = robot_pos
+    jerk_mean = (
+        proxy_state.jerk_sum / float(proxy_state.jerk_count) if proxy_state.jerk_count > 0 else 0.0
+    )
+
+    return {
+        "near_misses": float(near_misses),
+        "force_exceed_events": float(force_exceed_events),
+        "comfort_exposure": float(comfort_exposure),
+        "jerk_mean": float(jerk_mean),
+    }

--- a/robot_sf/gym_env/snqi_proxy.py
+++ b/robot_sf/gym_env/snqi_proxy.py
@@ -39,9 +39,9 @@ class StepSNQIProxy:
     def prime(self, simulator: Any) -> None:
         """Reset state and seed previous robot position from ``simulator`` when available."""
         self.state = StepSNQIProxyState()
-        robot_poses = getattr(simulator, "robot_poses", [])
-        if isinstance(robot_poses, list) and robot_poses:
-            self.state.prev_robot_pos = extract_robot_xy(robot_poses[0])
+        robot_pose = first_robot_pose(getattr(simulator, "robot_poses", []))
+        if robot_pose is not None:
+            self.state.prev_robot_pos = extract_robot_xy(robot_pose)
 
     def compute_step_metrics(self, simulator: Any, *, dt: float) -> dict[str, float]:
         """Compute SNQI-aligned proxy metrics and update running state.
@@ -65,11 +65,25 @@ def extract_robot_xy(robot_pose: Any) -> np.ndarray:
     Returns:
         np.ndarray: ``[x, y]`` position vector, or zeros for invalid payloads.
     """
+    if robot_pose is None:
+        return np.zeros(2, dtype=float)
     source = robot_pose[0] if isinstance(robot_pose, (tuple, list)) else robot_pose
-    flattened = np.asarray(source, dtype=float).reshape(-1)
+    try:
+        flattened = np.asarray(source, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return np.zeros(2, dtype=float)
     if flattened.size >= 2:
         return flattened[:2]
     return np.zeros(2, dtype=float)
+
+
+def first_robot_pose(robot_poses: Any) -> Any | None:
+    """Return the first robot pose from common sequence or array payloads."""
+    if isinstance(robot_poses, (list, tuple)):
+        return robot_poses[0] if robot_poses else None
+    if isinstance(robot_poses, np.ndarray) and robot_poses.size > 0:
+        return robot_poses if robot_poses.ndim == 1 else robot_poses[0]
+    return None
 
 
 def coerce_xy_rows(data: Any) -> np.ndarray:
@@ -78,7 +92,12 @@ def coerce_xy_rows(data: Any) -> np.ndarray:
     Returns:
         np.ndarray: Array with shape ``(N, 2)``; invalid layouts produce an empty array.
     """
-    values = np.asarray(data, dtype=float)
+    if data is None:
+        return np.zeros((0, 2), dtype=float)
+    try:
+        values = np.asarray(data, dtype=float)
+    except (TypeError, ValueError, KeyError, IndexError):
+        return np.zeros((0, 2), dtype=float)
     if values.ndim == 1:
         return values.reshape(-1, 2) if values.size % 2 == 0 else np.zeros((0, 2), dtype=float)
     if values.ndim == 2 and values.shape[-1] >= 2:
@@ -138,12 +157,7 @@ def compute_snqi_step_proxies(
         dict[str, float]: Step-level SNQI-aligned metadata terms.
     """
     d_coll, d_near, comfort_force_threshold = resolve_snqi_thresholds()
-    robot_poses = getattr(simulator, "robot_poses", [])
-    robot_pos = (
-        extract_robot_xy(robot_poses[0])
-        if isinstance(robot_poses, list) and robot_poses
-        else np.zeros(2)
-    )
+    robot_pos = extract_robot_xy(first_robot_pose(getattr(simulator, "robot_poses", [])))
 
     ped_pos = coerce_xy_rows(getattr(simulator, "ped_pos", np.zeros((0, 2), dtype=float)))
 

--- a/tests/gym_env/test_robot_env_snqi_step_metadata.py
+++ b/tests/gym_env/test_robot_env_snqi_step_metadata.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from robot_sf.gym_env.environment_factory import make_robot_env
-from robot_sf.gym_env.robot_env import _compute_snqi_step_proxies, _StepSNQIProxyState
+from robot_sf.gym_env.snqi_proxy import StepSNQIProxy, compute_snqi_step_proxies
 
 
 class _FakeSimulator:
@@ -33,12 +33,12 @@ def test_compute_snqi_step_proxies_emits_non_default_terms(
         dtype=float,
     )
     monkeypatch.setattr(
-        "robot_sf.gym_env.robot_env._resolve_snqi_thresholds",
+        "robot_sf.gym_env.snqi_proxy.resolve_snqi_thresholds",
         lambda: (d_coll, d_near, comfort_threshold),
     )
-    state = _StepSNQIProxyState()
+    proxy = StepSNQIProxy()
 
-    first = _compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=state)
+    first = compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=proxy.state)
     assert first["near_misses"] == 1.0
     assert first["force_exceed_events"] == 1.0
     assert first["comfort_exposure"] == 0.5
@@ -46,11 +46,11 @@ def test_compute_snqi_step_proxies_emits_non_default_terms(
 
     # Drive a non-linear position profile so finite-difference jerk becomes non-zero.
     sim.robot_poses = [((0.1, 0.0), 0.0)]
-    _compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=state)
+    compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=proxy.state)
     sim.robot_poses = [((0.3, 0.0), 0.0)]
-    _compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=state)
+    compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=proxy.state)
     sim.robot_poses = [((0.5, 0.0), 0.0)]
-    fourth = _compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=state)
+    fourth = compute_snqi_step_proxies(simulator=sim, dt=0.1, proxy_state=proxy.state)
     assert fourth["jerk_mean"] > 0.0
 
 

--- a/tests/gym_env/test_snqi_step_proxy.py
+++ b/tests/gym_env/test_snqi_step_proxy.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from robot_sf.gym_env.snqi_proxy import StepSNQIProxy, extract_robot_xy
+from robot_sf.gym_env.snqi_proxy import StepSNQIProxy, coerce_xy_rows, extract_robot_xy
 
 
 def _simulator(robot_xy: tuple[float, float], *, ped_pos=None, ped_forces=None) -> SimpleNamespace:
@@ -58,3 +58,32 @@ def test_extract_robot_xy_accepts_backend_pose_shapes() -> None:
     assert np.allclose(extract_robot_xy(((1.0, 2.0), 0.25)), np.array([1.0, 2.0]))
     assert np.allclose(extract_robot_xy(np.array([3.0, 4.0, 1.57])), np.array([3.0, 4.0]))
     assert np.allclose(extract_robot_xy(np.array([5.0])), np.zeros(2))
+    assert np.allclose(extract_robot_xy(None), np.zeros(2))
+    assert np.allclose(extract_robot_xy("invalid"), np.zeros(2))
+
+
+def test_snqi_proxy_accepts_tuple_and_array_robot_pose_sequences() -> None:
+    """Robot pose payloads may be lists, tuples, or arrays depending on backend."""
+    proxy = StepSNQIProxy()
+
+    proxy.prime(SimpleNamespace(robot_poses=(((1.0, 2.0), 0.0),)))
+    assert np.allclose(proxy.state.prev_robot_pos, np.array([1.0, 2.0]))
+
+    metrics = proxy.compute_step_metrics(
+        SimpleNamespace(
+            robot_poses=np.array([[1.5, 2.0, 0.0]]),
+            ped_pos=None,
+            last_ped_forces=None,
+        ),
+        dt=0.1,
+    )
+
+    assert metrics["near_misses"] == 0.0
+    assert metrics["force_exceed_events"] == 0.0
+
+
+def test_coerce_xy_rows_handles_malformed_payloads() -> None:
+    """Malformed simulator payloads should coerce to empty rows."""
+    assert coerce_xy_rows(None).shape == (0, 2)
+    assert coerce_xy_rows("invalid").shape == (0, 2)
+    assert coerce_xy_rows({"x": 1.0}).shape == (0, 2)

--- a/tests/gym_env/test_snqi_step_proxy.py
+++ b/tests/gym_env/test_snqi_step_proxy.py
@@ -1,0 +1,60 @@
+"""Tests for RobotEnv's extracted step-level SNQI proxy collaborator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from robot_sf.gym_env.snqi_proxy import StepSNQIProxy, extract_robot_xy
+
+
+def _simulator(robot_xy: tuple[float, float], *, ped_pos=None, ped_forces=None) -> SimpleNamespace:
+    """Build a compact simulator stub exposing only SNQI proxy inputs."""
+    return SimpleNamespace(
+        robot_poses=[(robot_xy, 0.0)],
+        ped_pos=np.asarray(ped_pos if ped_pos is not None else [], dtype=float).reshape(-1, 2),
+        last_ped_forces=np.asarray(
+            ped_forces if ped_forces is not None else [],
+            dtype=float,
+        ).reshape(-1, 2),
+    )
+
+
+def test_snqi_proxy_reports_near_miss_and_force_exposure() -> None:
+    """Step proxy should expose SNQI-aligned scalar metadata from simulator state."""
+    proxy = StepSNQIProxy()
+    proxy.prime(_simulator((0.0, 0.0)))
+
+    metrics = proxy.compute_step_metrics(
+        _simulator(
+            (0.0, 0.0),
+            ped_pos=[(0.30, 0.0), (2.0, 0.0)],
+            ped_forces=[(3.0, 0.0), (0.1, 0.0)],
+        ),
+        dt=0.1,
+    )
+
+    assert metrics["near_misses"] == 1.0
+    assert metrics["force_exceed_events"] == 1.0
+    assert metrics["comfort_exposure"] == 0.5
+    assert metrics["jerk_mean"] == 0.0
+
+
+def test_snqi_proxy_accumulates_running_jerk_mean() -> None:
+    """Step proxy should keep finite-difference jerk state across calls."""
+    proxy = StepSNQIProxy()
+    proxy.prime(_simulator((0.0, 0.0)))
+
+    proxy.compute_step_metrics(_simulator((1.0, 0.0)), dt=1.0)
+    proxy.compute_step_metrics(_simulator((3.0, 0.0)), dt=1.0)
+    metrics = proxy.compute_step_metrics(_simulator((6.5, 0.0)), dt=1.0)
+
+    assert metrics["jerk_mean"] == 0.5
+
+
+def test_extract_robot_xy_accepts_backend_pose_shapes() -> None:
+    """Robot pose extraction should stay tolerant of simulator backend payloads."""
+    assert np.allclose(extract_robot_xy(((1.0, 2.0), 0.25)), np.array([1.0, 2.0]))
+    assert np.allclose(extract_robot_xy(np.array([3.0, 4.0, 1.57])), np.array([3.0, 4.0]))
+    assert np.allclose(extract_robot_xy(np.array([5.0])), np.zeros(2))


### PR DESCRIPTION
## Summary
Extracts RobotEnv's step-level SNQI proxy metadata into a focused collaborator while preserving
the public Gymnasium environment behavior.

## Linked Issues
- Closes #1633

## What Changed
- Added `robot_sf/gym_env/snqi_proxy.py` with `StepSNQIProxy`, state management, threshold
  resolution, simulator payload coercion, and SNQI proxy metric computation.
- Rewired `RobotEnv` to prime and call the collaborator during reset/step reward metadata assembly.
- Added direct collaborator tests plus updated existing RobotEnv SNQI metadata plumbing tests.
- Added `docs/context/issue_1633_robot_env_snqi_proxy.md` with the first extraction target and
  follow-up collaborator candidates.

## Why It Matters
- Added value: reduces `RobotEnv`'s embedded step-metadata responsibility without changing rollout
  semantics.
- Expected impact: future RobotEnv refactors can continue through focused collaborators rather than
  adding more logic to the environment facade.
- Why this is worth merging now: it creates one tested extraction seam and records the next likely
  seams for occupancy-grid, observation, and telemetry/runtime work.

## Validation / Proof
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests/gym_env/test_snqi_step_proxy.py tests/gym_env/test_robot_env_snqi_step_metadata.py -q`
  - `5 passed`
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 uv run pytest tests -k "robot_env or environment_factory" -q`
  - `53 passed, 4307 deselected`
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 scripts/dev/ruff_fix_format.sh`
  - `All checks passed`
- `PYTHONPATH=$PWD UV_PROJECT_ENVIRONMENT=/home/luttkule/git/robot_sf_ll7/.venv UV_NO_SYNC=1 PYTEST_NUM_WORKERS=16 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `4363 passed, 11 skipped, 8 warnings`
  - readiness stamp: `output/validation/pr_ready/issue-1633-robot-env-collaborator.json`
  - stamp head: `d859a203f5a08075dc778555b27c14908e18ae92`

## Risks / Rollout
- Compatibility risks: existing imports of private `_compute_snqi_step_proxies` or
  `_StepSNQIProxyState` from `robot_env.py` would need to import from `snqi_proxy.py`; repository
  tests were updated accordingly.
- Failure modes: simulator payload coercion could differ if a backend emits unusual pose or force
  shapes; direct tests cover the current tolerant shapes.
- Rollback or fallback plan: revert the extraction commit to restore the previous inline helpers in
  `robot_env.py`.

## Docs / Provenance
- Updated docs: `docs/context/issue_1633_robot_env_snqi_proxy.md`,
  `docs/context/README.md`.
- Relevant design or provenance notes: context note records the chosen first extraction and deferred
  collaborator candidates from the read-only scan.
- Artifact classification: generated `output/coverage/*` and
  `output/validation/pr_ready/issue-1633-robot-env-collaborator.json` are ignored local validation
  artifacts and are not committed.

## Follow-Up Issues
- Deferred work: no new issue opened; the context note records likely next extraction candidates.

## Reviewer Notes
- Verify that the new collaborator preserves the existing SNQI proxy formulas exactly.
- Changed-file coverage warning is non-blocking from the repo readiness gate:
  `robot_env.py` 80.5%, `snqi_proxy.py` 95.1%.
- Qwen Code was tried as a read-only sidecar and timed out after 300 seconds with no stdout or file
  changes; local validation is the acceptance evidence for this PR.
