### PR TITLE
feat: add LiDAR PPO smoke config

### DIFF
--- a/configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml
+++ b/configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml
@@ -107,12 +107,13 @@ planner_classifications:
   - planner: safety_barrier
     family: occupancy_classical
     classification: adapter_required
-    current_contract_status: blocked_by_current_contract
-    active_observation_mode: none
+    current_contract_status: requires_lidar_occupancy_adapter_config
+    active_observation_mode: sensor_fusion_state
     required_inputs:
       - robot_state
       - goal
       - local_obstacle_clearance
+      - lidar_rays
     claim_boundary: Testing-only; barrier inputs must be ray-derived and must not read hidden obstacles.
     selected_follow_up: 1659
   - planner: orca

--- a/configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml
+++ b/configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml
@@ -1,0 +1,61 @@
+# Fixed LiDAR PPO MLP smoke derived from the issue #1615 launch packet.
+#
+# This config intentionally avoids the Optuna sweep path so issue #1662 always
+# exercises the `ppo_lidar_mlp_gate_v1` candidate instead of sampling another
+# extractor family.
+
+policy_id: ppo_lidar_mlp_gate_v1_issue_1662_smoke
+scenario_config: ../../scenarios/classic_interactions.yaml
+num_envs: 4
+worker_mode: subproc
+seeds:
+  - 123
+randomize_seeds: false
+total_timesteps: 32000
+
+feature_extractor: mlp
+feature_extractor_kwargs:
+  ray_hidden_dims: [64, 32]
+  drive_hidden_dims: [16, 8]
+  dropout_rate: 0.1
+
+policy_net_arch: [64, 64]
+best_checkpoint_metric: success_rate
+
+ppo_hyperparams:
+  learning_rate: 0.0001
+  batch_size: 256
+  n_epochs: 4
+  ent_coef: 0.01
+  clip_range: 0.1
+  target_kl: 0.02
+
+convergence:
+  success_rate: 0.9
+  collision_rate: 0.05
+  plateau_window: 2000
+
+evaluation:
+  frequency_episodes: 10
+  evaluation_episodes: 3
+  hold_out_scenarios: []
+  step_schedule:
+    - every_steps: 16000
+
+env_factory_kwargs:
+  reward_name: route_completion_v2
+  reward_kwargs:
+    weights:
+      progress: 2.5
+      living: -0.01
+      collision: -5.0
+      near_miss: -0.8
+      ttc_risk: -0.6
+      comfort: -0.4
+      smoothness: -0.15
+      terminal_bonus: 2.0
+
+tracking:
+  tensorboard: false
+  wandb:
+    enabled: false

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -190,6 +190,8 @@ knowledge, not every transient iteration detail.
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
 * Issue #1615 LiDAR Learned-Policy Launch Plan (2026-05-29):
   [issue_1615_lidar_learned_policy_plan.md](issue_1615_lidar_learned_policy_plan.md)
+* Issue #1662 LiDAR PPO MLP Smoke (2026-05-29):
+  [issue_1662_lidar_ppo_smoke.md](issue_1662_lidar_ppo_smoke.md)
 * Issue #1294 seed-sensitivity perturbations:
   [issue_1294_seed_sensitivity_perturbations.md](issue_1294_seed_sensitivity_perturbations.md)
 * Issue archetypes and evidence tiers:

--- a/docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json
+++ b/docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json
@@ -1,0 +1,61 @@
+{
+  "issue": 1662,
+  "artifact_role": "compact_local_smoke_summary",
+  "candidate_id": "ppo_lidar_mlp_gate_v1",
+  "policy_id": "ppo_lidar_mlp_gate_v1_issue_1662_smoke",
+  "run_id": "ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828",
+  "source_config": "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml",
+  "source_launch_packet": "configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml",
+  "git_base_commit_at_execution": "1c5ef199a1dba425141b43bfd62fd2cac2e6f349",
+  "executed_at_utc": "2026-05-29T10:58:28Z",
+  "total_timesteps": 32000,
+  "actual_total_timesteps": 32768,
+  "seed": 123,
+  "num_envs": 4,
+  "worker_mode": "subproc",
+  "feature_extractor": "mlp",
+  "feature_extractor_kwargs": {
+    "ray_hidden_dims": [64, 32],
+    "drive_hidden_dims": [16, 8],
+    "dropout_rate": 0.1
+  },
+  "policy_net_arch": [64, 64],
+  "observation_mode": "DEFAULT_GYM",
+  "benchmark_observation_level": "lidar_2d",
+  "runtime_observation_keys": ["drive_state", "rays"],
+  "status": "completed",
+  "total_wall_clock_sec": 59.7431793830001,
+  "startup_sec": 8.032628070999635,
+  "train_env_steps_per_sec_mean": 956.233980553855,
+  "eval_steps": [16000, 32000],
+  "evaluation_episodes_per_checkpoint": 3,
+  "best_checkpoint": {
+    "metric": "success_rate",
+    "value": 0.0,
+    "eval_step": 16000,
+    "meets_convergence": false
+  },
+  "final_metrics": {
+    "success_rate": 0.0,
+    "collision_rate": 0.0,
+    "path_efficiency": 0.0,
+    "snqi": -0.8000254535636234,
+    "eval_episode_return": -5.000514531471781,
+    "eval_avg_step_reward": -0.010001029062943563
+  },
+  "local_output_manifest": [
+    "output/benchmarks/expert_policies/ppo_lidar_mlp_gate_v1_issue_1662_smoke.zip",
+    "output/benchmarks/expert_policies/ppo_lidar_mlp_gate_v1_issue_1662_smoke.config.yaml",
+    "output/benchmarks/expert_policies/ppo_lidar_mlp_gate_v1_issue_1662_smoke.json",
+    "output/benchmarks/expert_policies/checkpoints/ppo_lidar_mlp_gate_v1_issue_1662_smoke/ppo_lidar_mlp_gate_v1_issue_1662_smoke_best.zip",
+    "output/benchmarks/expert_policies/checkpoints/ppo_lidar_mlp_gate_v1_issue_1662_smoke/ppo_lidar_mlp_gate_v1_issue_1662_smoke_best.summary.json",
+    "output/benchmarks/ppo_imitation/runs/ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828.json",
+    "output/benchmarks/ppo_imitation/perf/ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828.json",
+    "output/benchmarks/ppo_imitation/eval_timeline/ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828.json",
+    "output/benchmarks/ppo_imitation/eval_by_scenario/ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828.json",
+    "output/benchmarks/ppo_imitation/episodes/ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828.jsonl",
+    "output/training/lidar_learned_policy/issue_1662/ppo_lidar_mlp_gate_v1_smoke.log"
+  ],
+  "artifact_decision": "All generated output paths are ignored worktree-local smoke artifacts; no checkpoint or raw episode log is promoted to git.",
+  "next_recommendation": "Do not open a longer training issue from this smoke alone. First add or identify a deployment adapter and rerun a slightly stronger local smoke or short train with durable checkpoint publication."
+}

--- a/docs/context/issue_1614_lidar_planner_compatibility.md
+++ b/docs/context/issue_1614_lidar_planner_compatibility.md
@@ -50,8 +50,9 @@ uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py
 ```
 
 Expected result: current PPO and guarded-PPO metadata pass the `lidar_2d` gate through
-`sensor_fusion_state`; structured/grid planners fail closed; CrowdNav HEIGHT keeps its
-`humans`-field caveat visible; and selected follow-up issues are recorded.
+`sensor_fusion_state`; `safety_barrier` passes the sensor-fusion contract only when the explicit
+LiDAR occupancy adapter config is present; other structured/grid planners fail closed; CrowdNav
+HEIGHT keeps its `humans`-field caveat visible; and selected follow-up issues are recorded.
 
 ## Claim Boundary
 

--- a/docs/context/issue_1662_lidar_ppo_smoke.md
+++ b/docs/context/issue_1662_lidar_ppo_smoke.md
@@ -1,0 +1,121 @@
+# Issue #1662 LiDAR PPO MLP Smoke
+
+Date: 2026-05-29
+
+## Goal
+
+Issue #1662 asked for the first bounded LiDAR learned-policy training smoke after the #1615 launch
+packet. The target candidate was `ppo_lidar_mlp_gate_v1`, with runtime observations limited to
+`ObservationMode.DEFAULT_GYM` `drive_state` and `rays`, and no benchmark claim from the smoke.
+
+## Fixed Smoke Config
+
+The #1615 launch packet included an Optuna command shape, but a one-trial Optuna run can sample a
+non-MLP extractor. This issue therefore materializes a fixed config:
+
+- `configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml`
+- `policy_id`: `ppo_lidar_mlp_gate_v1_issue_1662_smoke`
+- `total_timesteps`: 32,000 requested, 32,768 executed by PPO rollout chunking
+- `seed`: 123
+- `num_envs`: 4, `worker_mode`: `subproc`
+- `feature_extractor`: `mlp`
+- `feature_extractor_kwargs`: `ray_hidden_dims=[64, 32]`,
+  `drive_hidden_dims=[16, 8]`, `dropout_rate=0.1`
+- `policy_net_arch`: `[64, 64]`
+- tracking disabled for both TensorBoard and W&B
+
+The config is deliberately a training smoke config, not a benchmark adapter config and not a model
+registry entry.
+
+## Validation
+
+Metadata preflight:
+
+```bash
+uv run python scripts/validation/check_learned_policy_eligibility.py \
+  configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml \
+  configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+```
+
+Result: both specs passed.
+
+Focused tests:
+
+```bash
+uv run pytest -q \
+  tests/training/test_lidar_ppo_smoke_issue_1662.py \
+  tests/training/test_lidar_learned_policy_launch_packet.py \
+  tests/validation/test_check_learned_policy_eligibility.py \
+  tests/test_feature_extractors.py
+```
+
+Result: `39 passed`.
+
+Smoke command:
+
+```bash
+DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/training/train_ppo.py \
+  --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml \
+  --log-level INFO \
+  --log-file output/training/lidar_learned_policy/issue_1662/ppo_lidar_mlp_gate_v1_smoke.log
+```
+
+Result: completed successfully with run id
+`ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828`.
+
+Compact evidence:
+
+- `docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json`
+
+## Observed Smoke Metrics
+
+The smoke proved that the fixed LiDAR PPO MLP path trains and evaluates end to end on this
+repository checkout. It did not prove benchmark readiness.
+
+- Wall clock: 59.74 seconds
+- Mean train env steps/sec: 956.23
+- Best checkpoint metric: `success_rate=0.0` at step 16,000
+- Final aggregate success rate: 0.0
+- Final aggregate collision rate: 0.0
+- Final aggregate SNQI: -0.8000
+- Convergence: not met
+
+The zero success rate is acceptable for this issue because the command is a 32k-step smoke. It is
+not evidence that the candidate should be promoted to benchmark comparison or model registry use.
+
+## Artifact Decision
+
+Generated outputs remain ignored under `output/`:
+
+- checkpoints and config manifests under `output/benchmarks/expert_policies/`
+- run, perf, timeline, per-scenario, and episode records under
+  `output/benchmarks/ppo_imitation/`
+- the smoke log under `output/training/lidar_learned_policy/issue_1662/`
+- coverage artifacts from the focused pytest run under `output/coverage/`
+
+No checkpoint is committed. A future checkpoint intended for reuse must be published to W&B or
+another durable artifact store and represented by a compact tracked manifest.
+
+## Qwen Scout
+
+Qwen Code was run as a read-only scout:
+
+```bash
+codex-agent-worker --provider qwen --model Qwen3.6-27B --timeout 900 \
+  --slug issue-1662-qwen-scout --task-file /tmp/qwen_issue1662_scout.md
+```
+
+Run directory:
+`.git/worktrees/issue-1662-lidar-training-smoke/codex-agent-runs/20260529T105401Z_qwen_issue-1662-qwen-scout`.
+
+Qwen agreed that the fixed config is preferable to the one-trial Optuna command for this issue,
+because it pins `ppo_lidar_mlp_gate_v1`. The scout overlapped with local edits, so its
+`changed_files` summary includes orchestrator-created files; local validation above is the source
+of truth.
+
+## Follow-Up Boundary
+
+Do not open a long training issue solely from this smoke. The next useful step is to add or identify
+a deployment adapter and rerun a stronger local smoke or short train with a durable checkpoint
+publication plan. The current smoke is evidence of executable training plumbing, not benchmark
+performance.

--- a/tests/benchmark/test_lidar_planner_compatibility.py
+++ b/tests/benchmark/test_lidar_planner_compatibility.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
+from robot_sf.benchmark.map_runner import _validate_sensor_fusion_adapter_config
 from robot_sf.benchmark.planner_command_contract import (
     PlannerContractValidationError,
     validate_planner_contract,
@@ -41,6 +42,7 @@ def _planners_with_status(status: str) -> list[str]:
 
 _NATIVE_CANDIDATES = _planners_with_status("passes_lidar_2d_gate")
 _BLOCKED_PLANNERS = _planners_with_status("blocked_by_current_contract")
+_ADAPTER_CONFIG_REQUIRED = _planners_with_status("requires_lidar_occupancy_adapter_config")
 
 
 def test_lidar_matrix_records_required_runtime_boundary() -> None:
@@ -79,6 +81,32 @@ def test_current_structured_or_grid_planners_fail_closed_for_lidar_level(planner
         )
 
     assert row["current_contract_status"] == "blocked_by_current_contract"
+
+
+@pytest.mark.parametrize("planner", _ADAPTER_CONFIG_REQUIRED)
+def test_lidar_adapter_config_required_planners_fail_closed_without_adapter(
+    planner: str,
+) -> None:
+    """Adapter-capable planners should still reject LiDAR rows without adapter config."""
+    row = _planner_row(planner)
+    contract = planner_contract_for_algorithm(planner, observation_level="lidar_2d")
+
+    validate_planner_contract(
+        algo=planner,
+        robot_kinematics="differential_drive",
+        algo_config={},
+        observation_level="lidar_2d",
+    )
+    with pytest.raises(ValueError, match="requires .*lidar_occupancy_adapter"):
+        _validate_sensor_fusion_adapter_config(
+            algo=planner,
+            active_observation_mode=contract.observation_contract.active_mode,
+            algo_config={},
+        )
+
+    assert row["classification"] == "adapter_required"
+    assert row["current_contract_status"] == "requires_lidar_occupancy_adapter_config"
+    assert contract.observation_contract.active_mode == "sensor_fusion_state"
 
 
 def test_crowdnav_height_lidar_gate_keeps_human_field_caveat_visible() -> None:

--- a/tests/training/test_lidar_ppo_smoke_issue_1662.py
+++ b/tests/training/test_lidar_ppo_smoke_issue_1662.py
@@ -1,0 +1,61 @@
+"""Contract tests for the issue #1662 fixed LiDAR PPO MLP smoke config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SMOKE_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
+_LAUNCH_PACKET = (
+    _REPO_ROOT / "configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml"
+)
+_ELIGIBILITY_SPEC = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml"
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_issue_1662_smoke_config_materializes_ppo_lidar_mlp_gate() -> None:
+    """The fixed smoke should exercise the intended issue #1615 MLP baseline."""
+    config = _load_yaml(_SMOKE_CONFIG)
+    packet = _load_yaml(_LAUNCH_PACKET)
+    candidates = {
+        str(candidate["candidate_id"]): candidate
+        for candidate in packet["candidate_baselines"]  # type: ignore[index]
+    }
+    candidate = candidates["ppo_lidar_mlp_gate_v1"]
+
+    assert config["policy_id"] == "ppo_lidar_mlp_gate_v1_issue_1662_smoke"
+    assert config["feature_extractor"] == candidate["feature_extractor"] == "mlp"
+    assert config["feature_extractor_kwargs"] == {
+        "ray_hidden_dims": [64, 32],
+        "drive_hidden_dims": [16, 8],
+        "dropout_rate": 0.1,
+    }
+    assert config["policy_net_arch"] == [64, 64]
+    assert config["total_timesteps"] == 32000
+    assert config["seeds"] == [123]
+    assert config["randomize_seeds"] is False
+
+
+def test_issue_1662_smoke_config_keeps_lidar_only_training_boundary() -> None:
+    """The smoke should stay aligned with the LiDAR-only eligibility metadata."""
+    config = _load_yaml(_SMOKE_CONFIG)
+    eligibility = _load_yaml(_ELIGIBILITY_SPEC)
+
+    assert config["scenario_config"] == "../../scenarios/classic_interactions.yaml"
+    assert config["tracking"] == {"tensorboard": False, "wandb": {"enabled": False}}
+    assert config["num_envs"] == 4
+    assert config["worker_mode"] == "subproc"
+    observation_fields = eligibility["observation_fields"]
+    assert observation_fields["deployment_observable"] == [
+        "DEFAULT_GYM drive_state",
+        "DEFAULT_GYM rays",
+    ]
+    assert observation_fields["forbidden_evaluation_time"] == []
+    assert "rollout rewards" in observation_fields["training_only"]


### PR DESCRIPTION
## Summary
- Closes #1662 by materializing a fixed `ppo_lidar_mlp_gate_v1` smoke config derived from the #1615 LiDAR learned-policy launch packet.
- Adds contract tests proving the smoke pins the MLP extractor, `drive_state` + `rays` runtime boundary, seed, and short 32k-step training budget.
- Records the completed local smoke in `docs/context/issue_1662_lidar_ppo_smoke.md` with compact tracked evidence in `docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json`.
- Aligns the #1614 LiDAR compatibility audit for the current `safety_barrier` middle state: the LiDAR contract exists, but runtime still fails closed without explicit `lidar_occupancy_adapter` config.

## Smoke Result
- Command completed: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/training/train_ppo.py --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml --log-level INFO --log-file output/training/lidar_learned_policy/issue_1662/ppo_lidar_mlp_gate_v1_smoke.log`
- Run id: `ppo_lidar_mlp_gate_v1_issue_1662_smoke_20260529T105828`
- Requested timesteps: `32000`; PPO executed `32768` due rollout chunking.
- Wall clock: `59.74s`; mean train env steps/sec: `956.23`.
- Best checkpoint success rate: `0.0`; convergence not met.

## Artifact Policy
- No checkpoint, raw episode JSONL, or coverage HTML is committed.
- Generated output remains ignored under `output/`; the tracked JSON summary is the durable review evidence.
- This is not benchmark evidence and does not promote a model registry entry.

## Validation
- `uv run python scripts/validation/check_learned_policy_eligibility.py configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml` (PASS)
- `uv run pytest -q tests/training/test_lidar_ppo_smoke_issue_1662.py tests/training/test_lidar_learned_policy_launch_packet.py tests/validation/test_check_learned_policy_eligibility.py tests/test_feature_extractors.py` (`39 passed`)
- `uv run ruff check tests/benchmark/test_lidar_planner_compatibility.py tests/training/test_lidar_ppo_smoke_issue_1662.py`
- `uv run pytest -q tests/benchmark/test_lidar_planner_compatibility.py tests/benchmark/test_lidar_occupancy_adapter.py::test_lidar_safety_barrier_requires_explicit_occupancy_adapter tests/benchmark/test_algorithm_metadata_contract.py::test_safety_barrier_accepts_lidar_level_through_sensor_fusion_contract` (`18 passed`)
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after merging latest `origin/main` (`4406 passed, 11 skipped, 8 warnings`; stamp head `277809886f8cd8f051d19b451254473b81f79754`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true`)
- Qwen Code scout completed with `Qwen3.6-27B`; local validation remains the source of truth.
