### PR TITLE
feat: add optional Three.js recording viewer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,6 +89,7 @@ Feature-focused demos for developers exploring capabilities.
 | [26 Telemetry Pane](./advanced/26_telemetry_pane.py) | Live telemetry visualization with docked charts in the Pygame window showing FPS, reward, collisions, and pedestrian distance. | _None_ | telemetry, visualization, pygame, interactive | ⚠️ Interactive pygame session not reliable for CI; use headless variant instead. |
 | [27 Telemetry Headless Smoke](./advanced/27_telemetry_headless_smoke.py) | Headless telemetry smoke test producing JSONL and summary PNG/JSON artifacts without rendering. | _None_ | telemetry, visualization, headless, ci | ⚠️ Requires file output inspection; not suitable for smoke tests. |
 | [32 Demo Adversarial Pedestrian](./advanced/32_demo_adversarial_pedestrian.py) | Run a modernized debug rollout for pedestrian PPO policies with factory-based setup. | maps/svg_maps/masterthesis/intersection.svg<br>model/run_043<br>model_ped/ppo_intersection.zip | pedestrian, policy, debug, ppo | ⚠️ Interactive pygame debug demo with offline checkpoints. |
+| [33 Three.js Recording Viewer](./advanced/33_threejs_recording_viewer.py) | Export a JSONL or pickle recording to a static browser viewer. | recordings/<file>.jsonl | visualization, recording, threejs | ✅ |
 | [Occupancy Reward Shaping](./occupancy_reward_shaping.py) | Derive a clearance penalty from occupancy grid observations in a short rollout. | _None_ | occupancy, reward, grid | ✅ |
 
 ## Benchmarks

--- a/examples/advanced/33_threejs_recording_viewer.py
+++ b/examples/advanced/33_threejs_recording_viewer.py
@@ -1,0 +1,67 @@
+"""Export a JSONL or pickle recording to a static browser viewer.
+
+Usage:
+    uv run python examples/advanced/33_threejs_recording_viewer.py
+    uv run python examples/advanced/33_threejs_recording_viewer.py path/to/episode.jsonl
+
+Expected Output:
+    - Static viewer files under `output/threejs_viewer/`.
+
+Limitations:
+    - This is an optional qualitative playback view. Pygame remains the reference renderer.
+    - The browser loads Three.js from a CDN, so offline use requires vendoring that asset first.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.common.artifact_paths import resolve_artifact_path
+from robot_sf.render.threejs_viewer import main as viewer_main
+
+
+def _write_demo_recording() -> Path:
+    """Write a tiny self-contained JSONL recording for smoke/demo runs.
+
+    Returns:
+        Path: Path to the generated JSONL recording.
+    """
+    demo_dir = Path(resolve_artifact_path("output/threejs_viewer_demo"))
+    demo_dir.mkdir(parents=True, exist_ok=True)
+    recording = demo_dir / "demo_episode.jsonl"
+    records = [
+        {
+            "episode_id": 0,
+            "step_idx": step,
+            "event": "step",
+            "timestamp": float(step),
+            "state": {
+                "timestep": step,
+                "robot_pose": [[1.0 + step, 2.0], 0.1 * step],
+                "pedestrian_positions": [[3.0, 4.0]],
+                "ray_vecs": [[[1.0 + step, 2.0], [2.0 + step, 3.0]]],
+            },
+        }
+        for step in range(3)
+    ]
+    recording.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return recording
+
+
+def main() -> int:
+    """Run the viewer exporter against a provided or generated recording.
+
+    Returns:
+        int: Process exit status code.
+    """
+    args = sys.argv[1:]
+    if not args:
+        args = [str(_write_demo_recording())]
+    return viewer_main(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/examples_manifest.yaml
+++ b/examples/examples_manifest.yaml
@@ -215,8 +215,7 @@ examples:
     name: "33 Three.js Recording Viewer"
     summary: "Export a JSONL or pickle recording to a static browser viewer."
     category_slug: advanced
-    prerequisites:
-      - recordings/<file>.jsonl
+    prerequisites: []
     ci_enabled: true
     ci_reason: null
     doc_reference: docs/dev_guide.md#advanced-feature-demos

--- a/examples/examples_manifest.yaml
+++ b/examples/examples_manifest.yaml
@@ -211,6 +211,16 @@ examples:
     ci_reason: "Interactive pygame debug demo with offline checkpoints."
     doc_reference: docs/dev_guide.md#advanced-feature-demos
     tags: [pedestrian, policy, debug, ppo]
+  - path: advanced/33_threejs_recording_viewer.py
+    name: "33 Three.js Recording Viewer"
+    summary: "Export a JSONL or pickle recording to a static browser viewer."
+    category_slug: advanced
+    prerequisites:
+      - recordings/<file>.jsonl
+    ci_enabled: true
+    ci_reason: null
+    doc_reference: docs/dev_guide.md#advanced-feature-demos
+    tags: [visualization, recording, threejs]
   - path: advanced/08_multi_pedestrian.py
     name: "08 Multi-Pedestrian"
     summary: "Build a multi-pedestrian scenario using map definitions."

--- a/robot_sf/render/threejs_viewer.py
+++ b/robot_sf/render/threejs_viewer.py
@@ -96,20 +96,42 @@ def _copy_web_asset(asset_name: str, destination: Path) -> None:
 
 
 def _map_to_payload(map_def: MapDefinition) -> dict[str, Any]:
+    """Convert a map definition into JSON-safe scalar geometry lists.
+
+    Returns:
+        dict[str, Any]: Map dimensions, bounds, obstacles, and zones as JSON-safe lists.
+    """
     return {
         "width": float(map_def.width),
         "height": float(map_def.height),
-        "bounds": [_line_to_list(bound) for bound in map_def.bounds],
-        "obstacles": [_obstacle_to_payload(obstacle) for obstacle in map_def.obstacles],
-        "robot_spawn_zones": [_zone_to_payload(zone) for zone in map_def.robot_spawn_zones],
-        "robot_goal_zones": [_zone_to_payload(zone) for zone in map_def.robot_goal_zones],
-        "ped_spawn_zones": [_zone_to_payload(zone) for zone in map_def.ped_spawn_zones],
-        "ped_goal_zones": [_zone_to_payload(zone) for zone in map_def.ped_goal_zones],
-        "ped_crowded_zones": [_zone_to_payload(zone) for zone in map_def.ped_crowded_zones],
+        "bounds": [_line_to_list(bound) for bound in getattr(map_def, "bounds", [])],
+        "obstacles": [
+            _obstacle_to_payload(obstacle) for obstacle in getattr(map_def, "obstacles", [])
+        ],
+        "robot_spawn_zones": [
+            _zone_to_payload(zone) for zone in getattr(map_def, "robot_spawn_zones", [])
+        ],
+        "robot_goal_zones": [
+            _zone_to_payload(zone) for zone in getattr(map_def, "robot_goal_zones", [])
+        ],
+        "ped_spawn_zones": [
+            _zone_to_payload(zone) for zone in getattr(map_def, "ped_spawn_zones", [])
+        ],
+        "ped_goal_zones": [
+            _zone_to_payload(zone) for zone in getattr(map_def, "ped_goal_zones", [])
+        ],
+        "ped_crowded_zones": [
+            _zone_to_payload(zone) for zone in getattr(map_def, "ped_crowded_zones", [])
+        ],
     }
 
 
 def _obstacle_to_payload(obstacle: Obstacle) -> dict[str, Any]:
+    """Convert an obstacle object into JSON-safe vertices and line segments.
+
+    Returns:
+        dict[str, Any]: Obstacle vertices and lines as float lists.
+    """
     return {
         "vertices": [_point_to_list(vertex) for vertex in obstacle.vertices],
         "lines": [_line_to_list(line) for line in obstacle.lines],
@@ -117,22 +139,36 @@ def _obstacle_to_payload(obstacle: Obstacle) -> dict[str, Any]:
 
 
 def _state_to_frame(state: VisualizableSimState, frame_idx: int) -> dict[str, Any]:
+    """Convert one visualizable state into a JSON-safe animation frame.
+
+    Returns:
+        dict[str, Any]: Frame metadata, poses, pedestrians, rays, and planned path.
+    """
     frame = {
         "frame_idx": frame_idx,
-        "timestep": int(state.timestep),
-        "time_s": float(state.timestep) * float(state.time_per_step_in_secs or 0.1),
-        "robot": _pose_to_payload(state.robot_pose),
+        "timestep": int(getattr(state, "timestep", frame_idx)),
+        "time_s": float(getattr(state, "timestep", frame_idx))
+        * float(getattr(state, "time_per_step_in_secs", 0.1) or 0.1),
+        "robot": _pose_to_payload(getattr(state, "robot_pose", None)),
         "pedestrians": _pedestrians_to_payload(state),
-        "rays": _vectors_to_payload(state.ray_vecs),
-        "planned_path": [_point_to_list(point) for point in state.planned_path or []],
+        "rays": _vectors_to_payload(getattr(state, "ray_vecs", None)),
+        "planned_path": [
+            _point_to_list(point) for point in (getattr(state, "planned_path", None) or [])
+        ],
     }
-    if state.ego_ped_pose is not None:
-        frame["ego_pedestrian"] = _pose_to_payload(state.ego_ped_pose)
+    ego_ped_pose = getattr(state, "ego_ped_pose", None)
+    if ego_ped_pose is not None:
+        frame["ego_pedestrian"] = _pose_to_payload(ego_ped_pose)
     return frame
 
 
 def _pedestrians_to_payload(state: VisualizableSimState) -> list[dict[str, Any]]:
-    positions = state.pedestrian_positions
+    """Convert optional pedestrian positions into JSON-safe id/position entries.
+
+    Returns:
+        list[dict[str, Any]]: Pedestrian ids and two-dimensional positions, or an empty list.
+    """
+    positions = getattr(state, "pedestrian_positions", None)
     if positions is None:
         return []
     return [
@@ -143,6 +179,11 @@ def _pedestrians_to_payload(state: VisualizableSimState) -> list[dict[str, Any]]
 
 
 def _pose_to_payload(pose: Any) -> dict[str, Any] | None:
+    """Convert an optional ``(position, heading)`` pose into a JSON-safe dict.
+
+    Returns:
+        dict[str, Any] | None: Position and heading, or ``None`` for absent poses.
+    """
     if pose is None:
         return None
     position, heading = pose
@@ -150,6 +191,11 @@ def _pose_to_payload(pose: Any) -> dict[str, Any] | None:
 
 
 def _vectors_to_payload(vectors: Any) -> list[list[list[float]]]:
+    """Convert optional ray vectors into nested JSON-safe float lists.
+
+    Returns:
+        list[list[list[float]]]: Ray vectors, or an empty list when absent.
+    """
     if vectors is None:
         return []
     if hasattr(vectors, "tolist"):
@@ -158,14 +204,29 @@ def _vectors_to_payload(vectors: Any) -> list[list[list[float]]]:
 
 
 def _zone_to_payload(zone: Any) -> list[list[float]]:
+    """Convert a polygon-like zone into JSON-safe point lists.
+
+    Returns:
+        list[list[float]]: Zone vertices as ``[x, y]`` lists.
+    """
     return [_point_to_list(point) for point in zone]
 
 
 def _line_to_list(line: Any) -> list[float]:
+    """Convert a four-value line-like object into JSON-safe floats.
+
+    Returns:
+        list[float]: Four line coordinates.
+    """
     return [float(value) for value in line]
 
 
 def _point_to_list(point: Any) -> list[float]:
+    """Convert a two-value point-like object into a JSON-safe ``[x, y]`` list.
+
+    Returns:
+        list[float]: Two point coordinates.
+    """
     return [float(point[0]), float(point[1])]
 
 

--- a/robot_sf/render/threejs_viewer.py
+++ b/robot_sf/render/threejs_viewer.py
@@ -1,0 +1,194 @@
+"""Export JSONL simulation recordings for an optional Three.js viewer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from robot_sf.render.jsonl_playback import JSONLPlaybackLoader, PlaybackEpisode
+
+if TYPE_CHECKING:
+    from robot_sf.nav.map_config import MapDefinition
+    from robot_sf.nav.obstacle import Obstacle
+    from robot_sf.render.sim_view import VisualizableSimState
+
+
+SCENE_SCHEMA_VERSION = "threejs-viewer.v1"
+
+
+@dataclass(frozen=True)
+class ThreeJSExportResult:
+    """Files written for a browser-viewable recording export."""
+
+    output_dir: Path
+    html_path: Path
+    scene_path: Path
+
+
+def build_threejs_scene(
+    episode: PlaybackEpisode,
+    map_def: MapDefinition,
+    *,
+    source: str | None = None,
+) -> dict[str, Any]:
+    """Build the renderer-neutral scene payload consumed by the web viewer.
+
+    Returns:
+        dict[str, Any]: JSON-safe scene payload with map geometry, zones, and animation frames.
+    """
+    frames = [_state_to_frame(state, frame_idx) for frame_idx, state in enumerate(episode.states)]
+    if not frames:
+        raise ValueError("Three.js viewer export requires at least one playback frame")
+
+    return {
+        "schema_version": SCENE_SCHEMA_VERSION,
+        "source": source,
+        "episode_id": episode.episode_id,
+        "metadata": episode.metadata or {},
+        "map": _map_to_payload(map_def),
+        "frames": frames,
+        "trajectory": [frame["robot"]["position"] for frame in frames if frame.get("robot")],
+        "reset_points": episode.reset_points or [],
+        "limitations": [
+            "Initial Three.js viewer slice for qualitative playback review.",
+            "Pygame remains the reference renderer for full overlay parity.",
+        ],
+    }
+
+
+def export_threejs_viewer(
+    recording_path: str | Path, output_dir: str | Path
+) -> ThreeJSExportResult:
+    """Export a JSONL or pickle recording into static browser viewer files.
+
+    Returns:
+        ThreeJSExportResult: Paths to the generated viewer directory, HTML file, and scene JSON.
+    """
+    recording_path = Path(recording_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    episode, map_def = JSONLPlaybackLoader().load_single_episode(recording_path)
+    scene = build_threejs_scene(episode, map_def, source=str(recording_path))
+
+    scene_path = output_dir / "scene.json"
+    scene_path.write_text(json.dumps(scene, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    html_path = output_dir / "index.html"
+    _copy_web_asset("index.html", html_path)
+    _copy_web_asset("viewer.js", output_dir / "viewer.js")
+
+    return ThreeJSExportResult(output_dir=output_dir, html_path=html_path, scene_path=scene_path)
+
+
+def _copy_web_asset(asset_name: str, destination: Path) -> None:
+    """Copy a packaged static web asset into an export directory."""
+    asset = resources.files("robot_sf.render.web_assets").joinpath(asset_name)
+    with resources.as_file(asset) as asset_path:
+        shutil.copyfile(asset_path, destination)
+
+
+def _map_to_payload(map_def: MapDefinition) -> dict[str, Any]:
+    return {
+        "width": float(map_def.width),
+        "height": float(map_def.height),
+        "bounds": [_line_to_list(bound) for bound in map_def.bounds],
+        "obstacles": [_obstacle_to_payload(obstacle) for obstacle in map_def.obstacles],
+        "robot_spawn_zones": [_zone_to_payload(zone) for zone in map_def.robot_spawn_zones],
+        "robot_goal_zones": [_zone_to_payload(zone) for zone in map_def.robot_goal_zones],
+        "ped_spawn_zones": [_zone_to_payload(zone) for zone in map_def.ped_spawn_zones],
+        "ped_goal_zones": [_zone_to_payload(zone) for zone in map_def.ped_goal_zones],
+        "ped_crowded_zones": [_zone_to_payload(zone) for zone in map_def.ped_crowded_zones],
+    }
+
+
+def _obstacle_to_payload(obstacle: Obstacle) -> dict[str, Any]:
+    return {
+        "vertices": [_point_to_list(vertex) for vertex in obstacle.vertices],
+        "lines": [_line_to_list(line) for line in obstacle.lines],
+    }
+
+
+def _state_to_frame(state: VisualizableSimState, frame_idx: int) -> dict[str, Any]:
+    frame = {
+        "frame_idx": frame_idx,
+        "timestep": int(state.timestep),
+        "time_s": float(state.timestep) * float(state.time_per_step_in_secs or 0.1),
+        "robot": _pose_to_payload(state.robot_pose),
+        "pedestrians": _pedestrians_to_payload(state),
+        "rays": _vectors_to_payload(state.ray_vecs),
+        "planned_path": [_point_to_list(point) for point in state.planned_path or []],
+    }
+    if state.ego_ped_pose is not None:
+        frame["ego_pedestrian"] = _pose_to_payload(state.ego_ped_pose)
+    return frame
+
+
+def _pedestrians_to_payload(state: VisualizableSimState) -> list[dict[str, Any]]:
+    positions = state.pedestrian_positions
+    if positions is None:
+        return []
+    return [
+        {"id": idx, "position": _point_to_list(position)}
+        for idx, position in enumerate(positions)
+        if len(position) >= 2
+    ]
+
+
+def _pose_to_payload(pose: Any) -> dict[str, Any] | None:
+    if pose is None:
+        return None
+    position, heading = pose
+    return {"position": _point_to_list(position), "heading": float(heading)}
+
+
+def _vectors_to_payload(vectors: Any) -> list[list[list[float]]]:
+    if vectors is None:
+        return []
+    if hasattr(vectors, "tolist"):
+        vectors = vectors.tolist()
+    return vectors
+
+
+def _zone_to_payload(zone: Any) -> list[list[float]]:
+    return [_point_to_list(point) for point in zone]
+
+
+def _line_to_list(line: Any) -> list[float]:
+    return [float(value) for value in line]
+
+
+def _point_to_list(point: Any) -> list[float]:
+    return [float(point[0]), float(point[1])]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for exporting a static Three.js recording viewer.
+
+    Returns:
+        int: Process exit status code.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("recording", help="JSONL or legacy pickle recording to export")
+    parser.add_argument(
+        "--output-dir",
+        default="output/threejs_viewer",
+        help="Directory for index.html, viewer.js, and scene.json",
+    )
+    args = parser.parse_args(argv)
+
+    result = export_threejs_viewer(args.recording, args.output_dir)
+    logger.info("Wrote Three.js viewer: {}", result.html_path)
+    logger.info("Wrote scene payload: {}", result.scene_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robot_sf/render/web_assets/__init__.py
+++ b/robot_sf/render/web_assets/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged static assets for browser-based Robot SF viewers."""

--- a/robot_sf/render/web_assets/index.html
+++ b/robot_sf/render/web_assets/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Robot SF Three.js Viewer</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        background: #111827;
+        color: #f8fafc;
+      }
+      #viewer {
+        height: 100%;
+      }
+      #hud {
+        position: fixed;
+        left: 16px;
+        top: 16px;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: rgb(15 23 42 / 88%);
+        font-size: 14px;
+      }
+      #timeline {
+        position: fixed;
+        left: 16px;
+        right: 16px;
+        bottom: 16px;
+      }
+      input[type="range"] {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="viewer"></div>
+    <div id="hud">Loading scene...</div>
+    <input id="timeline" type="range" min="0" max="0" value="0" />
+    <script type="module" src="./viewer.js"></script>
+  </body>
+</html>

--- a/robot_sf/render/web_assets/viewer.js
+++ b/robot_sf/render/web_assets/viewer.js
@@ -8,6 +8,7 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x111827);
 
 const camera = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 1000);
+camera.up.set(0, 0, -1);
 camera.position.set(0, 55, 0);
 camera.lookAt(0, 0, 0);
 
@@ -29,6 +30,7 @@ world.add(robot, egoPedestrian, pedestrianGroup, trajectory, rays);
 let payload = null;
 let currentFrame = 0;
 let playing = true;
+let lastFrameTime = 0;
 
 fetch("./scene.json")
   .then((response) => response.json())
@@ -111,7 +113,8 @@ function drawFrame(index) {
 
 function animate() {
   requestAnimationFrame(animate);
-  if (playing && payload?.frames.length > 1) {
+  if (playing && payload?.frames.length > 1 && performance.now() - lastFrameTime >= 100) {
+    lastFrameTime = performance.now();
     drawFrame((currentFrame + 1) % payload.frames.length);
   }
   renderer.render(scene, camera);
@@ -151,17 +154,45 @@ function makePolyline(points, color) {
 }
 
 function replaceChildren(group, children) {
+  group.traverse((object) => {
+    if (object === group) return;
+    disposeObject(object);
+  });
   group.clear();
   children.filter(Boolean).forEach((child) => group.add(child));
 }
 
+function disposeObject(object) {
+  if (object.geometry) object.geometry.dispose();
+  const materials = Array.isArray(object.material) ? object.material : [object.material];
+  materials.filter(Boolean).forEach((material) => {
+    if (material.map) material.map.dispose();
+    material.dispose();
+  });
+}
+
 function fitCamera(map) {
-  camera.left = -map.width * 0.08;
-  camera.right = map.width * 1.08;
-  camera.top = -map.height * 0.08;
-  camera.bottom = map.height * 1.08;
-  camera.position.set(map.width / 2, Math.max(map.width, map.height) * 2.1, map.height / 2);
-  camera.lookAt(map.width / 2, 0, map.height / 2);
+  const width = root.clientWidth || window.innerWidth;
+  const height = root.clientHeight || window.innerHeight;
+  const aspect = width / Math.max(height, 1);
+  const centerX = map.width / 2;
+  const centerY = map.height / 2;
+  const margin = 1.16;
+  let halfWidth = (map.width * margin) / 2;
+  let halfHeight = (map.height * margin) / 2;
+
+  if (halfWidth / halfHeight > aspect) {
+    halfHeight = halfWidth / aspect;
+  } else {
+    halfWidth = halfHeight * aspect;
+  }
+
+  camera.left = centerX - halfWidth;
+  camera.right = centerX + halfWidth;
+  camera.top = halfHeight;
+  camera.bottom = -halfHeight;
+  camera.position.set(centerX, Math.max(map.width, map.height) * 2.1, centerY);
+  camera.lookAt(centerX, 0, centerY);
   camera.updateProjectionMatrix();
 }
 
@@ -169,4 +200,5 @@ function resize() {
   const width = root.clientWidth || window.innerWidth;
   const height = root.clientHeight || window.innerHeight;
   renderer.setSize(width, height);
+  if (payload) fitCamera(payload.map);
 }

--- a/robot_sf/render/web_assets/viewer.js
+++ b/robot_sf/render/web_assets/viewer.js
@@ -1,0 +1,172 @@
+import * as THREE from "https://unpkg.com/three@0.164.1/build/three.module.js";
+
+const root = document.querySelector("#viewer");
+const hud = document.querySelector("#hud");
+const timeline = document.querySelector("#timeline");
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x111827);
+
+const camera = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 1000);
+camera.position.set(0, 55, 0);
+camera.lookAt(0, 0, 0);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+root.appendChild(renderer.domElement);
+
+const world = new THREE.Group();
+scene.add(world);
+scene.add(new THREE.AmbientLight(0xffffff, 1));
+
+const robot = makeAgent(0x22c55e, 0.42);
+const egoPedestrian = makeAgent(0xf59e0b, 0.34);
+const pedestrianGroup = new THREE.Group();
+const trajectory = new THREE.Group();
+const rays = new THREE.Group();
+world.add(robot, egoPedestrian, pedestrianGroup, trajectory, rays);
+
+let payload = null;
+let currentFrame = 0;
+let playing = true;
+
+fetch("./scene.json")
+  .then((response) => response.json())
+  .then((scenePayload) => {
+    payload = scenePayload;
+    buildStaticMap(scenePayload.map);
+    timeline.max = Math.max(scenePayload.frames.length - 1, 0);
+    fitCamera(scenePayload.map);
+    drawFrame(0);
+    animate();
+  })
+  .catch((error) => {
+    hud.textContent = `Failed to load scene.json: ${error}`;
+  });
+
+timeline.addEventListener("input", () => {
+  playing = false;
+  drawFrame(Number(timeline.value));
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.code === "Space") {
+    event.preventDefault();
+    playing = !playing;
+  }
+});
+
+window.addEventListener("resize", resize);
+resize();
+
+function buildStaticMap(map) {
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(map.width, map.height),
+    new THREE.MeshBasicMaterial({ color: 0x243041 })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.set(map.width / 2, -0.02, map.height / 2);
+  world.add(floor);
+
+  map.bounds.forEach((line) => world.add(makeLine(line, 0xe5e7eb)));
+  map.obstacles.forEach((obstacle) => {
+    obstacle.lines.forEach((line) => world.add(makeLine(line, 0xef4444)));
+  });
+  addZones(map.robot_spawn_zones, 0x60a5fa);
+  addZones(map.robot_goal_zones, 0x22c55e);
+  addZones(map.ped_spawn_zones, 0xa78bfa);
+  addZones(map.ped_goal_zones, 0xfbbf24);
+}
+
+function addZones(zones, color) {
+  zones.forEach((zone) => {
+    const shape = new THREE.Shape(zone.map(([x, y]) => new THREE.Vector2(x, y)));
+    const mesh = new THREE.Mesh(
+      new THREE.ShapeGeometry(shape),
+      new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.28, side: THREE.DoubleSide })
+    );
+    mesh.rotation.x = -Math.PI / 2;
+    world.add(mesh);
+  });
+}
+
+function drawFrame(index) {
+  if (!payload) return;
+  currentFrame = Math.max(0, Math.min(index, payload.frames.length - 1));
+  const frame = payload.frames[currentFrame];
+  timeline.value = currentFrame;
+
+  setAgent(robot, frame.robot);
+  setAgent(egoPedestrian, frame.ego_pedestrian);
+  replaceChildren(pedestrianGroup, frame.pedestrians.map((ped) => {
+    const marker = makeAgent(0x38bdf8, 0.24);
+    setAgent(marker, { position: ped.position, heading: 0 });
+    return marker;
+  }));
+  replaceChildren(trajectory, [makePolyline(payload.trajectory.slice(0, currentFrame + 1), 0x86efac)]);
+  replaceChildren(rays, frame.rays.map((ray) => makeLine([ray[0][0], ray[1][0], ray[0][1], ray[1][1]], 0xf8fafc)));
+
+  hud.textContent = `Episode ${payload.episode_id} | frame ${currentFrame + 1}/${payload.frames.length} | t=${frame.time_s.toFixed(2)}s`;
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  if (playing && payload?.frames.length > 1) {
+    drawFrame((currentFrame + 1) % payload.frames.length);
+  }
+  renderer.render(scene, camera);
+}
+
+function makeAgent(color, radius) {
+  const group = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, 0.28, 24),
+    new THREE.MeshBasicMaterial({ color })
+  );
+  const heading = new THREE.Mesh(
+    new THREE.BoxGeometry(radius * 1.8, 0.08, 0.08),
+    new THREE.MeshBasicMaterial({ color: 0xf8fafc })
+  );
+  heading.position.x = radius;
+  group.add(body, heading);
+  return group;
+}
+
+function setAgent(agent, pose) {
+  agent.visible = Boolean(pose);
+  if (!pose) return;
+  agent.position.set(pose.position[0], 0.18, pose.position[1]);
+  agent.rotation.y = -pose.heading;
+}
+
+function makeLine(line, color) {
+  return makePolyline([[line[0], line[2]], [line[1], line[3]]], color);
+}
+
+function makePolyline(points, color) {
+  const geometry = new THREE.BufferGeometry().setFromPoints(
+    points.map(([x, y]) => new THREE.Vector3(x, 0.05, y))
+  );
+  return new THREE.Line(geometry, new THREE.LineBasicMaterial({ color }));
+}
+
+function replaceChildren(group, children) {
+  group.clear();
+  children.filter(Boolean).forEach((child) => group.add(child));
+}
+
+function fitCamera(map) {
+  camera.left = -map.width * 0.08;
+  camera.right = map.width * 1.08;
+  camera.top = -map.height * 0.08;
+  camera.bottom = map.height * 1.08;
+  camera.position.set(map.width / 2, Math.max(map.width, map.height) * 2.1, map.height / 2);
+  camera.lookAt(map.width / 2, 0, map.height / 2);
+  camera.updateProjectionMatrix();
+}
+
+function resize() {
+  const width = root.clientWidth || window.innerWidth;
+  const height = root.clientHeight || window.innerHeight;
+  renderer.setSize(width, height);
+}

--- a/tests/render/test_threejs_viewer.py
+++ b/tests/render/test_threejs_viewer.py
@@ -1,6 +1,7 @@
 """Smoke tests for the optional Three.js recording viewer export."""
 
 import json
+from types import SimpleNamespace
 
 import numpy as np
 
@@ -61,6 +62,23 @@ def test_build_threejs_scene_contains_non_empty_playback_payload() -> None:
     assert scene["frames"][0]["pedestrians"][0]["position"] == [3.0, 4.0]
     assert scene["trajectory"] == [[1.0, 2.0], [2.0, 2.0]]
     assert "Pygame remains" in scene["limitations"][1]
+
+
+def test_build_threejs_scene_tolerates_legacy_states_without_optional_fields() -> None:
+    """Legacy pickle states may not carry every modern visualizer attribute."""
+    legacy_state = SimpleNamespace(
+        timestep=0,
+        robot_pose=((1.0, 2.0), 0.25),
+        pedestrian_positions=np.array([[3.0, 4.0]]),
+    )
+    episode = PlaybackEpisode(episode_id=8, states=[legacy_state])
+
+    scene = build_threejs_scene(episode, _map(), source="legacy.pkl")
+
+    assert scene["frames"][0]["time_s"] == 0.0
+    assert scene["frames"][0]["rays"] == []
+    assert scene["frames"][0]["planned_path"] == []
+    assert "ego_pedestrian" not in scene["frames"][0]
 
 
 def test_export_threejs_viewer_writes_static_assets(tmp_path) -> None:

--- a/tests/render/test_threejs_viewer.py
+++ b/tests/render/test_threejs_viewer.py
@@ -1,0 +1,95 @@
+"""Smoke tests for the optional Three.js recording viewer export."""
+
+import json
+
+import numpy as np
+
+from robot_sf.nav.map_config import MapDefinition
+from robot_sf.nav.obstacle import Obstacle
+from robot_sf.render.jsonl_playback import PlaybackEpisode
+from robot_sf.render.sim_state import VisualizableSimState
+from robot_sf.render.threejs_viewer import (
+    SCENE_SCHEMA_VERSION,
+    build_threejs_scene,
+    export_threejs_viewer,
+)
+
+
+def _state(timestep: int) -> VisualizableSimState:
+    return VisualizableSimState(
+        timestep=timestep,
+        robot_action=None,
+        robot_pose=((1.0 + timestep, 2.0), 0.25),
+        pedestrian_positions=np.array([[3.0, 4.0]]),
+        ray_vecs=np.array([[[1.0, 2.0], [2.0, 3.0]]]),
+        ped_actions=np.array([]),
+        planned_path=[(1.0, 2.0), (5.0, 6.0)],
+    )
+
+
+def _map() -> MapDefinition:
+    zone = ((0.0, 0.0), (2.0, 0.0), (2.0, 2.0))
+    return MapDefinition(
+        width=10.0,
+        height=8.0,
+        obstacles=[Obstacle([(4.0, 4.0), (5.0, 4.0), (5.0, 5.0), (4.0, 5.0)])],
+        robot_spawn_zones=[zone],
+        robot_goal_zones=[zone],
+        ped_spawn_zones=[zone],
+        bounds=[
+            (0.0, 10.0, 0.0, 0.0),
+            (0.0, 10.0, 8.0, 8.0),
+            (0.0, 0.0, 0.0, 8.0),
+            (10.0, 10.0, 0.0, 8.0),
+        ],
+        robot_routes=[],
+        ped_goal_zones=[zone],
+        ped_crowded_zones=[],
+        ped_routes=[],
+    )
+
+
+def test_build_threejs_scene_contains_non_empty_playback_payload() -> None:
+    """The exported scene keeps map geometry, robot trajectory, and pedestrian frames."""
+    episode = PlaybackEpisode(episode_id=7, states=[_state(0), _state(1)])
+
+    scene = build_threejs_scene(episode, _map(), source="synthetic.jsonl")
+
+    assert scene["schema_version"] == SCENE_SCHEMA_VERSION
+    assert scene["map"]["obstacles"][0]["vertices"]
+    assert scene["frames"][0]["robot"]["position"] == [1.0, 2.0]
+    assert scene["frames"][0]["pedestrians"][0]["position"] == [3.0, 4.0]
+    assert scene["trajectory"] == [[1.0, 2.0], [2.0, 2.0]]
+    assert "Pygame remains" in scene["limitations"][1]
+
+
+def test_export_threejs_viewer_writes_static_assets(tmp_path) -> None:
+    """A tiny JSONL recording can be exported without launching a browser."""
+    recording = tmp_path / "episode.jsonl"
+    recording.write_text(
+        json.dumps(
+            {
+                "episode_id": 3,
+                "step_idx": 0,
+                "event": "step",
+                "timestamp": 0.0,
+                "state": {
+                    "timestep": 0,
+                    "robot_pose": [[1.0, 2.0], 0.0],
+                    "pedestrian_positions": [[3.0, 4.0]],
+                    "ray_vecs": [[[1.0, 2.0], [2.0, 3.0]]],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = export_threejs_viewer(recording, tmp_path / "viewer")
+
+    assert result.html_path.exists()
+    assert (result.output_dir / "viewer.js").exists()
+    scene = json.loads(result.scene_path.read_text(encoding="utf-8"))
+    assert scene["episode_id"] == 3
+    assert len(scene["frames"]) == 1
+    assert "three.module.js" in (result.output_dir / "viewer.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Adds an optional static Three.js browser viewer for Robot SF JSONL or legacy pickle recordings, alongside the existing pygame renderer.

## Linked Issues
- Closes #1645

## What Changed
- Added `robot_sf/render/threejs_viewer.py` to export playback episodes into `scene.json` plus packaged static viewer assets.
- Added a self-contained advanced example that generates a tiny demo recording when no input path is supplied, while still accepting real recordings.
- Added smoke tests for the scene payload and static export path.
- Registered the example in `examples/examples_manifest.yaml` and `examples/README.md`.

## Why It Matters
- Added value: contributors can inspect/share recorded simulation state in a browser without replacing pygame.
- Expected impact: lower-friction qualitative review for demos, debugging, and recording artifacts.
- Why this is worth merging now: it reuses the existing JSONL playback contract and keeps the first viewer slice opt-in and bounded.

## Validation / Proof
- `uv run ruff check robot_sf/render/threejs_viewer.py tests/render/test_threejs_viewer.py examples/advanced/33_threejs_recording_viewer.py` passed.
- `uv run pytest tests/render/test_threejs_viewer.py` passed.
- `uv run pytest tests/render/test_threejs_viewer.py tests/examples/test_examples_run.py::test_example_runs_without_error --maxfail=1 -q` passed: 27 passed.
- `uv build --wheel` plus wheel inspection confirmed `robot_sf/render/web_assets/index.html` and `viewer.js` are packaged.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed after syncing extras: 4434 passed, 11 skipped, 8 warnings; validation stamp recorded for head `b96c401f703ee5106288ab681fe5d11c140721cb`.

## Risks / Rollout
- Compatibility risks: the browser viewer loads Three.js from a CDN, so offline use requires vendoring that asset later.
- Failure modes: viewer parity is intentionally incomplete for pygame overlays; scene export remains qualitative playback support.
- Rollback or fallback plan: remove the optional exporter/example/assets; existing pygame rendering and recording code paths are unchanged.

## Docs / Provenance
- Updated docs: `examples/README.md`, `examples/examples_manifest.yaml`, and the example module docstring.
- Relevant design or provenance notes: #1645 issue scope requested an optional Three.js path built on existing visualizable state/JSONL concepts.
- Any assumptions that need to be preserved: generated `output/` files from validation are disposable and ignored; no benchmark claims are made.

## Follow-Up Issues
- Deferred work: live streaming, offline vendored Three.js, richer pygame overlay parity, and browser automation/pixel-level render verification.
- Issues opened for follow-up: none in this PR.

## Reviewer Notes
- Please verify the first-slice scope is acceptable: static JSONL/pickle playback export, top-down Three.js view, packaged static assets, and no pygame replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Three.js-based browser viewer for exporting and visualizing recorded simulation episodes with interactive playback controls, frame-by-frame navigation, and real-time agent/trajectory rendering.
  * Included a demo example demonstrating how to use the new viewer.

* **Documentation**
  * Updated examples index with the new Three.js Recording Viewer entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->