### PR TITLE
ci: report job timings and trim PR artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           key: coverage-baseline-${{ github.ref_name }}-${{ github.sha }}
 
       - name: Upload coverage reports
-        if: always()
+        if: failure() || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-reports

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -134,6 +134,8 @@ knowledge, not every transient iteration detail.
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
 * Issue #1659 LiDAR occupancy adapter:
   [issue_1659_lidar_occupancy_adapter.md](issue_1659_lidar_occupancy_adapter.md)
+* Issue #1653 CI runtime slice:
+  [issue_1653_ci_runtime_slice.md](issue_1653_ci_runtime_slice.md)
 * Issue #1613 LiDAR Observation Track Setup (2026-05-29):
   [issue_1613_lidar_observation_track.md](issue_1613_lidar_observation_track.md)
 * Issue #1614 LiDAR Planner Compatibility Audit (2026-05-29):

--- a/docs/context/issue_1653_ci_runtime_slice.md
+++ b/docs/context/issue_1653_ci_runtime_slice.md
@@ -1,0 +1,80 @@
+# Issue #1653 CI Runtime Slice
+
+Status: PR-ready implementation note
+
+## Scope
+
+This note records a conservative first slice for #1653. It does not change test selection,
+benchmark semantics, branch-protection job names, or required validation phases.
+
+## Baseline Timing
+
+Recent successful `CI` workflow runs were summarized with:
+
+```bash
+uv run python scripts/dev/ci_timing_summary.py --run-id <run-id> --top 8 --json
+```
+
+| run id | title | event | total | job span | queue |
+| --- | --- | --- | ---: | ---: | ---: |
+| 26648705023 | feat: add optional Three.js recording viewer | pull_request | 997s | 992s | 4s |
+| 26638333993 | feat: add lidar tracked social-force adapter (#1669) | push | 926s | 901s | 24s |
+| 26637972460 | docs: define learned policy adapter interface | pull_request | 904s | 900s | 3s |
+| 26637835994 | docs: audit SiT Dataset terms | pull_request | 898s | 895s | 2s |
+| 26637057677 | docs: define learned policy adapter interface | pull_request | 928s | 924s | 3s |
+| 26637057815 | feat: add lidar tracked social-force adapter | pull_request | 926s | 921s | 4s |
+| 26636789637 | fix: align lidar compatibility safety barrier gate | pull_request | 921s | 918s | 2s |
+| 26636095246 | docs: survey local planner repositories | pull_request | 1351s | 1348s | 2s |
+
+The observed successful-run median is about 927s total, with one longer documentation PR run at
+1351s. Queue time is small in this sample, so most elapsed time is inside CI jobs.
+
+## Tooling Gap
+
+`gh run view --json jobs` returns job `startedAt` and `completedAt`, but the step objects observed
+for run `26648705023` do not include step timestamps. The timing helper therefore produced empty
+`slowest_steps` output even when jobs and step names were present.
+
+This slice updates `scripts/dev/ci_timing_summary.py` to report slowest jobs as a fallback and to
+make missing step timestamps explicit in Markdown output.
+
+## Local Slowest Tests
+
+The branch readiness run used:
+
+```bash
+BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh
+```
+
+It completed in 292.71s with 4432 passed and 11 skipped. The slowest reported calls were:
+
+| test | duration |
+| --- | ---: |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/01_backend_selection.py]` | 15.79s |
+| `tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner` | 14.42s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[quickstart/01_basic_robot.py]` | 14.42s |
+| `tests/test_osm_backward_compat.py::TestOSMBackwardCompat::test_osm_map_with_robot_environment` | 13.61s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/08_multi_pedestrian.py]` | 13.08s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[benchmarks/demo_social_nav_scenarios.py]` | 12.89s |
+| `tests/adversarial/test_adversarial_search.py::test_multi_ped_adversarial_runtime_config_resets_and_steps` | 12.76s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/21_occupancy_grid_workflow.py]` | 12.72s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/07_single_pedestrian.py]` | 12.71s |
+| `tests/examples/test_examples_run.py::test_example_runs_without_error[quickstart/03_custom_map.py]` | 12.69s |
+
+The local slowest-test evidence points at example smoke coverage and one policy-stack smoke as the
+first places to inspect before changing test selection or sharding.
+
+## Low-Risk Runtime Reduction
+
+The `fast-feedback` job still computes coverage JSON and compares against the cached baseline.
+Routine pull-request runs no longer upload the full coverage HTML/database artifact on success.
+Coverage artifacts remain uploaded when `fast-feedback` fails and on `main`, where baseline
+maintenance happens.
+
+This preserves the proof bar while avoiding a success-path artifact upload for ordinary PRs.
+
+## Follow-Up
+
+Future #1653 work should use the improved job-level timing output to decide whether setup, tests,
+smoke scripts, or artifact uploads dominate current runs. Avoid moving required checks until a
+before/after CI run confirms the impact.

--- a/scripts/dev/ci_timing_summary.py
+++ b/scripts/dev/ci_timing_summary.py
@@ -70,8 +70,8 @@ def _duration_seconds(start: str | None, end: str | None) -> float | None:
 def _completed_step_timings(payload: dict[str, Any]) -> list[StepTiming]:
     """Extract completed step durations from all jobs in a run payload."""
     timings: list[StepTiming] = []
-    for job in payload.get("jobs", []):
-        for step in job.get("steps", []):
+    for job in _iter_dicts(payload.get("jobs")):
+        for step in _iter_dicts(job.get("steps")):
             duration = _duration_seconds(step.get("startedAt"), step.get("completedAt"))
             if duration is None:
                 continue
@@ -89,7 +89,7 @@ def _completed_step_timings(payload: dict[str, Any]) -> list[StepTiming]:
 def _completed_job_timings(payload: dict[str, Any]) -> list[JobTiming]:
     """Extract completed job durations from a run payload."""
     timings: list[JobTiming] = []
-    for job in payload.get("jobs", []):
+    for job in _iter_dicts(payload.get("jobs")):
         duration = _duration_seconds(job.get("startedAt"), job.get("completedAt"))
         if duration is None:
             continue
@@ -106,7 +106,7 @@ def _completed_job_timings(payload: dict[str, Any]) -> list[JobTiming]:
 
 def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary:
     """Summarize queue, job, total, slowest-job, and slowest-step durations."""
-    jobs = list(payload.get("jobs", []))
+    jobs = _iter_dicts(payload.get("jobs"))
     created = _parse_timestamp(payload.get("createdAt"))
     updated = _parse_timestamp(payload.get("updatedAt"))
     job_starts = [
@@ -153,6 +153,18 @@ def _format_seconds(seconds: float) -> str:
     return f"{seconds:.1f}s"
 
 
+def _iter_dicts(value: Any) -> list[dict[str, Any]]:
+    """Return only dictionary items from a possibly malformed list payload."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _escape_md_table_cell(value: str) -> str:
+    """Escape Markdown table separators in generated cell text."""
+    return value.replace("|", r"\|")
+
+
 def format_markdown(summary: RunTimingSummary) -> str:
     """Format a timing summary as Markdown for issues and PR comments."""
     lines = [
@@ -173,7 +185,7 @@ def format_markdown(summary: RunTimingSummary) -> str:
     for job in summary.slowest_jobs:
         lines.append(
             "| "
-            f"{job.name} | {_format_seconds(job.duration_seconds)} | "
+            f"{_escape_md_table_cell(job.name)} | {_format_seconds(job.duration_seconds)} | "
             f"{job.started_at} | {job.completed_at} |",
         )
 
@@ -192,7 +204,7 @@ def format_markdown(summary: RunTimingSummary) -> str:
     for step in summary.slowest_steps:
         lines.append(
             "| "
-            f"{step.name} | {_format_seconds(step.duration_seconds)} | "
+            f"{_escape_md_table_cell(step.name)} | {_format_seconds(step.duration_seconds)} | "
             f"{step.started_at} | {step.completed_at} |",
         )
     return "\n".join(lines)

--- a/scripts/dev/ci_timing_summary.py
+++ b/scripts/dev/ci_timing_summary.py
@@ -25,6 +25,16 @@ class StepTiming:
 
 
 @dataclass(frozen=True, slots=True)
+class JobTiming:
+    """Duration for one GitHub Actions job."""
+
+    name: str
+    duration_seconds: float
+    started_at: str
+    completed_at: str
+
+
+@dataclass(frozen=True, slots=True)
 class RunTimingSummary:
     """Compact timing summary for one GitHub Actions workflow run."""
 
@@ -33,6 +43,7 @@ class RunTimingSummary:
     queue_seconds: float
     job_seconds: float
     total_seconds: float
+    slowest_jobs: list[JobTiming]
     slowest_steps: list[StepTiming]
 
     def to_json(self) -> str:
@@ -75,8 +86,26 @@ def _completed_step_timings(payload: dict[str, Any]) -> list[StepTiming]:
     return timings
 
 
+def _completed_job_timings(payload: dict[str, Any]) -> list[JobTiming]:
+    """Extract completed job durations from a run payload."""
+    timings: list[JobTiming] = []
+    for job in payload.get("jobs", []):
+        duration = _duration_seconds(job.get("startedAt"), job.get("completedAt"))
+        if duration is None:
+            continue
+        timings.append(
+            JobTiming(
+                name=str(job.get("name", "")),
+                duration_seconds=duration,
+                started_at=str(job.get("startedAt", "")),
+                completed_at=str(job.get("completedAt", "")),
+            ),
+        )
+    return timings
+
+
 def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary:
-    """Summarize queue, job, total, and slowest-step durations from a run payload."""
+    """Summarize queue, job, total, slowest-job, and slowest-step durations."""
     jobs = list(payload.get("jobs", []))
     created = _parse_timestamp(payload.get("createdAt"))
     updated = _parse_timestamp(payload.get("updatedAt"))
@@ -103,6 +132,10 @@ def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary
         _completed_step_timings(payload),
         key=lambda step: (-step.duration_seconds, step.name),
     )[:top]
+    slowest_jobs = sorted(
+        _completed_job_timings(payload),
+        key=lambda job: (-job.duration_seconds, job.name),
+    )[:top]
 
     return RunTimingSummary(
         run_id=int(payload.get("databaseId") or 0),
@@ -110,6 +143,7 @@ def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary
         queue_seconds=queue_seconds,
         job_seconds=job_seconds,
         total_seconds=total_seconds,
+        slowest_jobs=slowest_jobs,
         slowest_steps=slowest_steps,
     )
 
@@ -132,10 +166,29 @@ def format_markdown(summary: RunTimingSummary) -> str:
         f"| job | {_format_seconds(summary.job_seconds)} |",
         f"| total | {_format_seconds(summary.total_seconds)} |",
         "",
-        "## Slowest steps",
-        "| step | duration | started | completed |",
+        "## Slowest jobs",
+        "| job | duration | started | completed |",
         "| --- | --- | --- | --- |",
     ]
+    for job in summary.slowest_jobs:
+        lines.append(
+            "| "
+            f"{job.name} | {_format_seconds(job.duration_seconds)} | "
+            f"{job.started_at} | {job.completed_at} |",
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Slowest steps",
+            "| step | duration | started | completed |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    if not summary.slowest_steps:
+        lines.append("| _No step timestamps reported by `gh run view`_ | n/a | n/a | n/a |")
+        return "\n".join(lines)
+
     for step in summary.slowest_steps:
         lines.append(
             "| "

--- a/tests/dev/test_ci_timing_summary.py
+++ b/tests/dev/test_ci_timing_summary.py
@@ -70,6 +70,36 @@ def test_format_markdown_includes_phase_totals() -> None:
     assert "| Validation smoke tests | 30.0s |" in markdown
 
 
+def test_format_markdown_escapes_table_separators() -> None:
+    """Markdown tables should not break when GitHub names contain pipes."""
+    payload = _sample_run_payload()
+    payload["jobs"][0]["name"] = "ci | linux"
+    payload["jobs"][0]["steps"][1]["name"] = "Unit | tests"
+
+    markdown = format_markdown(summarize_run(payload, top=2))
+
+    assert "| ci \\| linux | 170.0s |" in markdown
+    assert "| Unit \\| tests | 120.0s |" in markdown
+
+
+def test_summarize_run_ignores_malformed_job_payloads() -> None:
+    """Malformed GitHub job payloads should degrade to an empty timing summary."""
+    payload = {
+        "databaseId": 123,
+        "displayTitle": "sample",
+        "createdAt": "2026-05-05T11:00:00Z",
+        "updatedAt": "2026-05-05T11:03:00Z",
+        "jobs": None,
+    }
+
+    summary = summarize_run(payload)
+
+    assert summary.slowest_jobs == []
+    assert summary.slowest_steps == []
+    assert summary.queue_seconds == 0.0
+    assert summary.job_seconds == 0.0
+
+
 def test_format_markdown_reports_missing_step_timestamps() -> None:
     """Markdown should still expose job timing when steps lack timestamps."""
     payload = _sample_run_payload()

--- a/tests/dev/test_ci_timing_summary.py
+++ b/tests/dev/test_ci_timing_summary.py
@@ -48,6 +48,8 @@ def test_summarize_run_reports_queue_job_and_slowest_steps() -> None:
     assert summary.run_id == 123
     assert summary.queue_seconds == 10.0
     assert summary.job_seconds == 170.0
+    assert summary.slowest_jobs[0].name == "ci"
+    assert summary.slowest_jobs[0].duration_seconds == 170.0
     assert [step.name for step in summary.slowest_steps] == [
         "Unit tests",
         "Validation smoke tests",
@@ -63,8 +65,23 @@ def test_format_markdown_includes_phase_totals() -> None:
 
     assert "Run 123" in markdown
     assert "| queue | 10.0s |" in markdown
+    assert "| ci | 170.0s |" in markdown
     assert "| Unit tests | 120.0s |" in markdown
     assert "| Validation smoke tests | 30.0s |" in markdown
+
+
+def test_format_markdown_reports_missing_step_timestamps() -> None:
+    """Markdown should still expose job timing when steps lack timestamps."""
+    payload = _sample_run_payload()
+    for job in payload["jobs"]:
+        for step in job["steps"]:
+            step.pop("startedAt", None)
+            step.pop("completedAt", None)
+
+    markdown = format_markdown(summarize_run(payload))
+
+    assert "| ci | 170.0s |" in markdown
+    assert "No step timestamps reported" in markdown
 
 
 def test_main_reads_run_json_and_prints_markdown(tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary
Adds job-level CI timing output to the timing helper, records an eight-run #1653 baseline, and avoids uploading full coverage artifacts on successful pull-request runs while preserving coverage computation/comparison.

## Linked Issues
- Relates to #1653

## What Changed
- `scripts/dev/ci_timing_summary.py` now reports slowest jobs and explicitly notes when `gh run view` does not expose step timestamps.
- `tests/dev/test_ci_timing_summary.py` covers job timing output and missing step timestamps.
- `.github/workflows/ci.yml` now uploads coverage reports on `fast-feedback` failure or on `main`, instead of every successful PR run.
- `docs/context/issue_1653_ci_runtime_slice.md` records the CI timing baseline, local slowest-test evidence, tooling gap, and follow-up boundary.

## Why It Matters
- Added value: #1653 now has reproducible job-level timing even when step timestamps are unavailable.
- Expected impact: ordinary successful PRs skip a large coverage artifact upload while coverage JSON/comparison still run.
- Why this is worth merging now: it is a low-risk first runtime slice that preserves all required checks and branch-protection job names.

## Validation / Proof
- `uv run pytest tests/dev/test_ci_timing_summary.py -q` - 4 passed.
- `uv run ruff check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py` - passed.
- `uv run ruff format --check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py` - passed.
- `uv run python scripts/dev/ci_timing_summary.py --run-id 26648705023 --top 3` - showed `fast-feedback` 984s, `smoke-artifacts` 259s, and an explicit missing-step-timestamps row.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` - passed.
- `scripts/dev/ci_driver.sh --list-phases` and `CI_DRIVER_EVENT_NAME=pull_request CI_DRIVER_GITHUB_REF=refs/pull/1/merge scripts/dev/ci_driver.sh artifact-policy` - passed.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed at `da2641d314d63c3d8bb97572c7614a65c61eec3c`: 4432 passed, 11 skipped, 8 warnings.

## Risks / Rollout
- Compatibility risks: low; coverage data is still produced and compared, but successful PRs no longer retain full HTML/database artifacts by default.
- Failure modes: if reviewers need coverage HTML for a successful PR, they can rerun locally or inspect main/failure artifacts.
- Rollback or fallback plan: restore `if: always()` on the coverage upload step.

## Docs / Provenance
- Updated docs: `docs/context/README.md`, `docs/context/issue_1653_ci_runtime_slice.md`.
- Relevant design or provenance notes: #1653 issue body and the recorded CI runs in the context note.
- Assumptions: this PR intentionally does not change test selection, benchmark semantics, smoke phases, or job names.

## Follow-Up Issues
- Deferred work: path-aware CI, slow-example smoke investigation, setup deduplication, and any test sharding should follow after CI confirms this slice's impact.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that the coverage artifact upload condition matches the intended rollout: upload on failure or `main`, skip on successful PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI coverage artifact uploads to operate selectively based on workflow status and branch conditions to optimize resource usage
  * Enhanced CI timing analysis tools with new job-level duration reporting capabilities alongside existing step-level performance metrics

* **Documentation**
  * Added CI runtime optimization documentation including baseline measurements, timing analysis, and strategic recommendations for improved resource efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->