### PR TITLE
docs: add proxemic comfort profile slice (#1676)

### DIFF
--- a/configs/policy_search/candidates/proxemic_profile_conservative_issue_1676.yaml
+++ b/configs/policy_search/candidates/proxemic_profile_conservative_issue_1676.yaml
@@ -1,0 +1,13 @@
+name: proxemic_profile_conservative_issue_1676
+algo: hybrid_rule_local_planner
+base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
+params:
+  desired_dynamic_clearance: 1.25
+  dynamic_clearance_weight: 2.4
+  ttc_weight: 1.2
+  stop_distance_human: 0.65
+  slow_distance_human: 1.25
+  moderate_distance_human: 2.6
+  moderate_speed: 0.45
+  near_human_angular_limit_distance: 1.0
+  near_human_max_angular_speed: 0.55

--- a/configs/policy_search/candidates/proxemic_profile_neutral_issue_1676.yaml
+++ b/configs/policy_search/candidates/proxemic_profile_neutral_issue_1676.yaml
@@ -1,0 +1,13 @@
+name: proxemic_profile_neutral_issue_1676
+algo: hybrid_rule_local_planner
+base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
+params:
+  desired_dynamic_clearance: 0.9
+  dynamic_clearance_weight: 1.8
+  ttc_weight: 0.8
+  stop_distance_human: 0.5
+  slow_distance_human: 1.0
+  moderate_distance_human: 2.0
+  moderate_speed: 0.6
+  near_human_angular_limit_distance: 0.8
+  near_human_max_angular_speed: 0.7

--- a/configs/policy_search/candidates/proxemic_profile_open_issue_1676.yaml
+++ b/configs/policy_search/candidates/proxemic_profile_open_issue_1676.yaml
@@ -1,0 +1,13 @@
+name: proxemic_profile_open_issue_1676
+algo: hybrid_rule_local_planner
+base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
+params:
+  desired_dynamic_clearance: 0.7
+  dynamic_clearance_weight: 1.1
+  ttc_weight: 0.5
+  stop_distance_human: 0.4
+  slow_distance_human: 0.75
+  moderate_distance_human: 1.4
+  moderate_speed: 0.85
+  near_human_angular_limit_distance: 0.6
+  near_human_max_angular_speed: 0.9

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -198,6 +198,8 @@ knowledge, not every transient iteration detail.
   [issue_1618_learned_policy_adapter_interface.md](issue_1618_learned_policy_adapter_interface.md)
 * Issue #1677 SiT Dataset Terms Audit (2026-05-29):
   [issue_1677_sit_dataset_terms.md](issue_1677_sit_dataset_terms.md)
+* Issue #1676 proxemic profile comfort slice:
+  [issue_1676_proxemic_profile_comfort_slice.md](issue_1676_proxemic_profile_comfort_slice.md)
 * Issue #1617 Local-Planner Repository Survey (2026-05-29):
   [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)
 * Issue #1662 LiDAR PPO MLP Smoke (2026-05-29):

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -198,7 +198,7 @@ knowledge, not every transient iteration detail.
   [issue_1618_learned_policy_adapter_interface.md](issue_1618_learned_policy_adapter_interface.md)
 * Issue #1677 SiT Dataset Terms Audit (2026-05-29):
   [issue_1677_sit_dataset_terms.md](issue_1677_sit_dataset_terms.md)
-* Issue #1676 proxemic profile comfort slice:
+* Issue #1676 Proxemic Profile Comfort Slice (2026-05-30):
   [issue_1676_proxemic_profile_comfort_slice.md](issue_1676_proxemic_profile_comfort_slice.md)
 * Issue #1617 Local-Planner Repository Survey (2026-05-29):
   [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)

--- a/docs/context/issue_1676_proxemic_profile_comfort_slice.md
+++ b/docs/context/issue_1676_proxemic_profile_comfort_slice.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-30
 
-Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1676>  
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1676>
 Parent survey: [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)
 
 ## Goal

--- a/docs/context/issue_1676_proxemic_profile_comfort_slice.md
+++ b/docs/context/issue_1676_proxemic_profile_comfort_slice.md
@@ -1,0 +1,92 @@
+# Issue #1676 Proxemic Profile Comfort Slice
+
+Date: 2026-05-30
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1676>  
+Parent survey: [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)
+
+## Goal
+
+Issue #1676 asks for a Robot SF-native scenario/config slice inspired by proxemic-profile work in
+the local-planner survey. This change keeps the slice inside existing policy-search machinery and
+does not import Webots code, external assets, or subjective social-navigation labels.
+
+## Metric Coverage
+
+Existing Robot SF metrics can represent a limited comfort-vs-efficiency proxy:
+
+- `min_clearance` and `mean_clearance`: robot-pedestrian surface clearance in meters.
+- `near_misses`: thresholded intrusive-clearance events.
+- `force_exceed_events` and `comfort_exposure`: force-based comfort exposure when force arrays are
+  available.
+- `time_to_goal_norm`, `path_efficiency`, and `success`: efficiency/progress side of the tradeoff.
+- `snqi_mean`: composite score when a campaign declares the existing SNQI weights and baseline.
+
+Missing metric contract: the repo does not currently have a subjective proxemic-comfort label,
+human preference score, profile-specific comfort acceptance threshold, or social-norm success
+metric. Profile tuning must therefore be interpreted as clearance/comfort-proxy diagnostics, not as
+benchmark-strength social acceptability evidence.
+
+## Profile Config Slice
+
+The slice registers three exploratory policy-search candidates over the existing
+`hybrid_rule_v3_teb_like_rollout` planner. The profiles change only social clearance and speed-cap
+knobs so smoke runs remain comparable:
+
+| Profile | Candidate | Intent |
+| --- | --- | --- |
+| Conservative | `proxemic_profile_conservative_issue_1676` | Larger desired dynamic clearance, stronger TTC/clearance weighting, wider slow zone, lower near-human speed. |
+| Neutral | `proxemic_profile_neutral_issue_1676` | Explicit copy of the base v3 social-distance knobs for comparison. |
+| Open | `proxemic_profile_open_issue_1676` | Smaller desired dynamic clearance, lower social weighting, narrower slow zone, higher near-human speed. |
+
+Config files:
+
+- `configs/policy_search/candidates/proxemic_profile_conservative_issue_1676.yaml`
+- `configs/policy_search/candidates/proxemic_profile_neutral_issue_1676.yaml`
+- `configs/policy_search/candidates/proxemic_profile_open_issue_1676.yaml`
+
+The candidates are registered in `docs/context/policy_search/candidate_registry.yaml` with smoke
+and nominal-sanity stages only. They are exploratory diagnostics, not promoted planners.
+
+## Smoke Result
+
+Observed locally on 2026-05-30:
+
+| Candidate | Decision | Episodes | Success | Collision | Near miss | Mean min distance | Report |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `proxemic_profile_conservative_issue_1676` | pass | 1 | 1.0000 | 0.0000 | 0.0000 | n/a | [2026-05-30_proxemic_profile_conservative_issue_1676_smoke.md](policy_search/reports/2026-05-30_proxemic_profile_conservative_issue_1676_smoke.md) |
+| `proxemic_profile_neutral_issue_1676` | pass | 1 | 1.0000 | 0.0000 | 0.0000 | n/a | [2026-05-30_proxemic_profile_neutral_issue_1676_smoke.md](policy_search/reports/2026-05-30_proxemic_profile_neutral_issue_1676_smoke.md) |
+| `proxemic_profile_open_issue_1676` | pass | 1 | 1.0000 | 0.0000 | 0.0000 | n/a | [2026-05-30_proxemic_profile_open_issue_1676_smoke.md](policy_search/reports/2026-05-30_proxemic_profile_open_issue_1676_smoke.md) |
+
+The smoke stage proves only that the three profile configs are executable through the policy-search
+runner. It does not compare comfort because the smoke scenario does not produce robot-pedestrian
+clearance samples (`mean_min_distance=n/a`).
+
+## Next Preflight Path
+
+The next useful local command is the `nominal_sanity` stage for all three profiles. Only after that
+should a stress-slice or repeated-seed analysis be considered.
+
+## Interpretation Limits
+
+- A profile with higher clearance or lower comfort exposure is not automatically a better social
+  navigation policy if success or time-to-goal regresses.
+- A profile with higher success is not socially preferable if it increases near misses, force
+  exposure, or fallback/degraded rows.
+- Missing force arrays make `comfort_exposure` unavailable, not zero.
+- These configs do not prove any external Webots or social-stress DRL result transfers to Robot SF.
+- Any benchmark report using this slice must preserve fallback/degraded row status according to
+  [issue_691_benchmark_fallback_policy.md](issue_691_benchmark_fallback_policy.md).
+
+## Validation
+
+For this config/docs change:
+
+```bash
+git diff --check origin/main...HEAD
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+uv run pytest -q tests/validation/test_run_policy_search_candidate.py
+```
+
+Smoke commands and results should be recorded in the PR body. Generated `output/policy_search/...`
+artifacts are local and ignored unless a compact evidence summary is deliberately promoted.

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -310,6 +310,49 @@ candidates:
       - smoke
       - nominal_sanity
 
+  proxemic_profile_conservative_issue_1676:
+    status: implemented
+    family: proxemic_profile_diagnostic
+    training_required: false
+    promotion_gate: tier_b
+    candidate_config_path: configs/policy_search/candidates/proxemic_profile_conservative_issue_1676.yaml
+    hypothesis: >
+      A conservative proxemic profile with larger dynamic-clearance targets,
+      wider human slow zones, and stronger TTC pressure should reduce
+      intrusive-clearance and comfort-exposure proxies, with a likely efficiency
+      tradeoff.
+    required_stages:
+      - smoke
+      - nominal_sanity
+
+  proxemic_profile_neutral_issue_1676:
+    status: implemented
+    family: proxemic_profile_diagnostic
+    training_required: false
+    promotion_gate: tier_b
+    candidate_config_path: configs/policy_search/candidates/proxemic_profile_neutral_issue_1676.yaml
+    hypothesis: >
+      The neutral profile restates the base hybrid-rule v3 social-distance knobs
+      so conservative and open profiles can be compared against an explicit
+      middle setting.
+    required_stages:
+      - smoke
+      - nominal_sanity
+
+  proxemic_profile_open_issue_1676:
+    status: implemented
+    family: proxemic_profile_diagnostic
+    training_required: false
+    promotion_gate: tier_b
+    candidate_config_path: configs/policy_search/candidates/proxemic_profile_open_issue_1676.yaml
+    hypothesis: >
+      An open proxemic profile with lower dynamic-clearance pressure and a
+      narrower human slow zone should improve progress in crowds while risking
+      higher near-miss or comfort-exposure proxy values.
+    required_stages:
+      - smoke
+      - nominal_sanity
+
   hybrid_rule_v3_waypoint2_progress:
     status: implemented
     family: hybrid_rule_based

--- a/docs/context/policy_search/reports/2026-05-30_proxemic_profile_conservative_issue_1676_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-30_proxemic_profile_conservative_issue_1676_smoke.md
@@ -1,0 +1,43 @@
+# Candidate Report: proxemic_profile_conservative_issue_1676 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+A conservative proxemic profile with larger dynamic-clearance targets, wider human slow zones, and stronger TTC pressure should reduce intrusive-clearance and comfort-exposure proxies, with a likely efficiency tradeoff.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `hybrid_rule_local_planner`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/proxemic_profile_conservative_issue_1676/smoke/summary.json`
+- Git commit: `922c3cc1d49f4ca01f6a9d888fbbbfbeef608e71`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.8941 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- No failures recorded.
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |

--- a/docs/context/policy_search/reports/2026-05-30_proxemic_profile_neutral_issue_1676_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-30_proxemic_profile_neutral_issue_1676_smoke.md
@@ -1,0 +1,43 @@
+# Candidate Report: proxemic_profile_neutral_issue_1676 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+The neutral profile restates the base hybrid-rule v3 social-distance knobs so conservative and open profiles can be compared against an explicit middle setting.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `hybrid_rule_local_planner`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/proxemic_profile_neutral_issue_1676/smoke/summary.json`
+- Git commit: `922c3cc1d49f4ca01f6a9d888fbbbfbeef608e71`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.8941 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- No failures recorded.
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |

--- a/docs/context/policy_search/reports/2026-05-30_proxemic_profile_open_issue_1676_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-30_proxemic_profile_open_issue_1676_smoke.md
@@ -1,0 +1,43 @@
+# Candidate Report: proxemic_profile_open_issue_1676 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+An open proxemic profile with lower dynamic-clearance pressure and a narrower human slow zone should improve progress in crowds while risking higher near-miss or comfort-exposure proxy values.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `hybrid_rule_local_planner`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/proxemic_profile_open_issue_1676/smoke/summary.json`
+- Git commit: `922c3cc1d49f4ca01f6a9d888fbbbfbeef608e71`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.8941 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- No failures recorded.
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |


### PR DESCRIPTION
## Summary
Adds a Robot SF-native proxemic-profile comfort slice for #1676 using three exploratory policy-search candidate configs: conservative, neutral, and open.

## Linked Issues
- Closes #1676
- Relates to #1617

## What Changed
- Registered three `proxemic_profile_*_issue_1676` policy-search candidates over `hybrid_rule_v3_teb_like_rollout`.
- Added `docs/context/issue_1676_proxemic_profile_comfort_slice.md` to document metric coverage, missing subjective-comfort contract, smoke results, and interpretation limits.
- Added smoke reports under `docs/context/policy_search/reports/` for all three profiles.

## Why It Matters
- Added value: gives future agents a concrete conservative/neutral/open profile slice instead of vague proxemic tuning notes.
- Expected impact: enables low-cost nominal/stress follow-up runs that compare clearance and comfort proxies against efficiency.
- Why this is worth merging now: it closes the config/design gap opened by the local-planner survey without importing external Webots code or overclaiming social acceptability.

## Validation / Proof
- Commands run:
  - `git diff --check origin/main...HEAD`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `uv run pytest -q tests/validation/test_run_policy_search_candidate.py`
  - `uv run python scripts/validation/run_policy_search_candidate.py --candidate proxemic_profile_conservative_issue_1676 --stage smoke --workers 1 --output-dir output/policy_search/proxemic_profile_conservative_issue_1676/smoke`
  - `uv run python scripts/validation/run_policy_search_candidate.py --candidate proxemic_profile_neutral_issue_1676 --stage smoke --workers 1 --output-dir output/policy_search/proxemic_profile_neutral_issue_1676/smoke`
  - `uv run python scripts/validation/run_policy_search_candidate.py --candidate proxemic_profile_open_issue_1676 --stage smoke --workers 1 --output-dir output/policy_search/proxemic_profile_open_issue_1676/smoke`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Policy-search loader resolved all three candidates with intended clearance weights.
  - Smoke stage passed for all three candidates: 1 episode, success 1.0000, collision 0.0000, near miss 0.0000.
  - Full readiness passed: `4432 passed, 11 skipped`.
- Benchmarks or smoke tests, if applicable:
  - Smoke reports are tracked in `docs/context/policy_search/reports/2026-05-30_proxemic_profile_*_smoke.md`.

## Risks / Rollout
- Compatibility risks: low; the change is additive config/docs under policy-search.
- Failure modes: the smoke scenario has no comfort-producing interaction, so it proves executability only.
- Rollback or fallback plan: remove the three candidate registry entries and config files.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1676_proxemic_profile_comfort_slice.md`
  - `docs/context/README.md`
  - `docs/context/policy_search/candidate_registry.yaml`
- Relevant design or provenance notes:
  - `docs/context/issue_1617_local_planner_repo_survey.md`
  - `docs/context/issue_1434_stress_uncertainty_coverage_schema.md`
  - `docs/dev/issues/social-navigation-benchmark/metrics_spec.md`
- Any assumptions that need to be preserved:
  - Clearance and force metrics are comfort proxies, not subjective social-acceptability labels.

## Follow-Up Issues
- Deferred work: run nominal-sanity and then stress/repeated-seed comparisons if the profiles remain useful.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that the profile names and interpretation boundary are clear enough to prevent benchmark overclaim.
- Known limitation: `mean_min_distance=n/a` in the smoke reports because the smoke scenario does not exercise pedestrian clearance.
