### PR TITLE
feat: add learned risk surface interface (#1675)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -140,6 +140,8 @@ knowledge, not every transient iteration detail.
   [issue_1613_lidar_observation_track.md](issue_1613_lidar_observation_track.md)
 * Issue #1614 LiDAR Planner Compatibility Audit (2026-05-29):
   [issue_1614_lidar_planner_compatibility.md](issue_1614_lidar_planner_compatibility.md)
+* Issue #1675 learned risk-surface interface:
+  [issue_1675_learned_risk_surface_interface.md](issue_1675_learned_risk_surface_interface.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)
 * Issue #1255 open-issue dependency graph:

--- a/docs/context/issue_1675_learned_risk_surface_interface.md
+++ b/docs/context/issue_1675_learned_risk_surface_interface.md
@@ -1,0 +1,65 @@
+# Issue #1675 Learned Risk-Surface Interface
+
+Date: 2026-05-30
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1675>
+
+## Scope
+
+This note defines the first Robot SF-native local risk/potential surface contract inspired by the
+Dyn-NPField pattern identified in issue #1617. It does not import upstream code, load a learned
+checkpoint, or create benchmark-strength evidence. The implementation is a deterministic fixture
+producer plus an adapter that projects the surface into the existing occupancy-grid contract.
+
+## Contract
+
+The code surface is `robot_sf.planner.learned_risk_surface`.
+
+* `LocalRiskSurfaceSpec` defines the frame, resolution, size, origin, threshold, and producer ID.
+* `LocalRiskSurface` stores a normalized `float32` grid with shape `(height_cells, width_cells)`.
+* Frame convention is ego-frame only: `+x` forward, `+y` left, robot at `(0, 0, heading=0)`.
+* Resolution is metres per cell; the default surface is 4 m by 4 m at 0.25 m/cell.
+* Values are normalized to `[0, 1]`; invalid shape, non-finite values, unsupported frames, or
+  invalid geometry raise `RiskSurfaceUnavailable`.
+* `occupancy_grid()` exposes the risk surface as obstacle and combined channels so existing
+  occupancy-aware planners can consume it without hidden fallback behavior.
+
+## Smoke Path
+
+`RiskSurfacePlannerAdapter` is the deterministic produce-and-consume smoke path:
+
+1. `deterministic_pedestrian_risk_surface(...)` builds a Gaussian local risk field from structured
+   Robot SF pedestrian positions.
+2. `attach_risk_surface_to_observation(...)` adds `occupancy_grid`, `occupancy_grid_meta`, and
+   `local_risk_surface_diagnostics`.
+3. The wrapped `RiskDWAPlannerAdapter` consumes the surface through the normal
+   `OccupancyAwarePlannerMixin` helpers.
+4. Missing robot state, invalid pedestrian data, or malformed surface metadata fails closed to a
+   `(0.0, 0.0)` command with `availability_status=not_available`.
+
+This proves the interface can be produced and consumed locally. It is not a claim that a learned
+surface improves navigation.
+
+## Benchmark Boundary
+
+Before this interface can support benchmark-strength evidence, a follow-up must add:
+
+* model provenance and license review for any learned producer,
+* training/evaluation config lineage and normalization metadata,
+* deterministic inference and device handling,
+* a scenario matrix that actually exercises pedestrian and obstacle risk,
+* per-step diagnostics showing raw surface values, planner consumption, and guard/fallback status,
+* comparison against existing local planners without counting fallback or degraded execution as
+  success.
+
+The adapter diagnostics keep `benchmark_strength=false` until those requirements are met.
+
+## Validation
+
+Targeted validation for this implementation:
+
+```bash
+uv run pytest -q tests/planner/test_learned_risk_surface.py
+git diff --check origin/main...HEAD
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+```

--- a/robot_sf/planner/__init__.py
+++ b/robot_sf/planner/__init__.py
@@ -22,6 +22,14 @@ from robot_sf.planner.classic_planner_adapter import (
     PlannerActionAdapter,
     attach_classic_global_planner,
 )
+from robot_sf.planner.learned_risk_surface import (
+    LocalRiskSurface,
+    LocalRiskSurfaceSpec,
+    RiskSurfacePlannerAdapter,
+    RiskSurfaceUnavailable,
+    attach_risk_surface_to_observation,
+    deterministic_pedestrian_risk_surface,
+)
 from robot_sf.planner.poi_sampler import POISampler
 from robot_sf.planner.policy_stack_v1 import PolicyStackV1Adapter, PolicyStackV1Config
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, RiskDWAPlannerConfig
@@ -40,6 +48,8 @@ __all__ = [
     "ClassicGlobalPlanner",
     "ClassicPlannerConfig",
     "GlobalPlanner",
+    "LocalRiskSurface",
+    "LocalRiskSurfaceSpec",
     "POISampler",
     "PlannerActionAdapter",
     "PlannerConfig",
@@ -49,10 +59,14 @@ __all__ = [
     "PolicyStackV1Config",
     "RiskDWAPlannerAdapter",
     "RiskDWAPlannerConfig",
+    "RiskSurfacePlannerAdapter",
+    "RiskSurfaceUnavailable",
     "TEBCommitmentConfig",
     "TEBCommitmentPlannerAdapter",
     "VisibilityPlanner",
     "attach_classic_global_planner",
+    "attach_risk_surface_to_observation",
+    "deterministic_pedestrian_risk_surface",
     "plot_global_plan",
     "plot_visibility_graph",
 ]

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -88,7 +88,7 @@ class LocalRiskSurface:
             raise RiskSurfaceUnavailable("risk surface shape must match spec grid height and width")
         if not np.all(np.isfinite(values)):
             raise RiskSurfaceUnavailable("risk surface values must be finite")
-        if float(values.min(initial=0.0)) < 0.0 or float(values.max(initial=0.0)) > 1.0:
+        if float(np.min(values)) < 0.0 or float(np.max(values)) > 1.0:
             raise RiskSurfaceUnavailable("risk surface values must be normalized to [0, 1]")
         if self.status != "available":
             raise RiskSurfaceUnavailable("risk surface status must be 'available'")

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -1,0 +1,349 @@
+"""Local risk/potential surface contract for learned planner prototypes.
+
+This module provides the Robot SF-native boundary for issue #1675: a learned
+or hand-authored local model may produce a bounded ego-frame risk surface, and
+existing local planners may consume that surface through the repository's
+occupancy-grid metadata contract. It intentionally does not load external code,
+weights, or datasets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.common.math_utils import wrap_angle_pi
+from robot_sf.nav.occupancy_grid_utils import world_to_ego
+from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
+
+
+class RiskSurfaceUnavailable(ValueError):
+    """Raised when a local risk surface cannot satisfy the runtime contract."""
+
+
+@dataclass(frozen=True)
+class LocalRiskSurfaceSpec:
+    """Reviewable spatial contract for local learned risk or potential fields.
+
+    The default frame is robot ego-frame: +x points forward, +y points left, and
+    the robot sits at `(0, 0, heading=0)`. `origin` is the lower-left grid corner
+    in that frame and `resolution` is metres per cell.
+    """
+
+    resolution: float = 0.25
+    width: float = 4.0
+    height: float = 4.0
+    origin: tuple[float, float] | None = None
+    frame: str = "ego"
+    risk_threshold: float = 0.5
+    producer_id: str = "deterministic_fixture_v0"
+
+    def __post_init__(self) -> None:
+        """Validate risk-surface dimensions and conventions."""
+        if self.frame != "ego":
+            raise RiskSurfaceUnavailable("local risk surfaces currently require frame='ego'")
+        if self.resolution <= 0.0:
+            raise RiskSurfaceUnavailable("risk surface resolution must be > 0")
+        if self.width <= 0.0 or self.height <= 0.0:
+            raise RiskSurfaceUnavailable("risk surface width and height must be > 0")
+        if not 0.0 <= self.risk_threshold <= 1.0:
+            raise RiskSurfaceUnavailable("risk_threshold must be in [0, 1]")
+        if self.origin is not None:
+            origin = np.asarray(self.origin, dtype=float)
+            if origin.shape != (2,) or not np.all(np.isfinite(origin)):
+                raise RiskSurfaceUnavailable("origin must contain two finite values")
+
+    @property
+    def grid_width(self) -> int:
+        """Number of columns in the surface."""
+        return int(np.ceil(self.width / self.resolution))
+
+    @property
+    def grid_height(self) -> int:
+        """Number of rows in the surface."""
+        return int(np.ceil(self.height / self.resolution))
+
+    @property
+    def grid_origin(self) -> tuple[float, float]:
+        """Lower-left origin in the local risk-surface frame."""
+        if self.origin is not None:
+            return (float(self.origin[0]), float(self.origin[1]))
+        return (-float(self.width) / 2.0, -float(self.height) / 2.0)
+
+
+@dataclass(frozen=True)
+class LocalRiskSurface:
+    """Bounded local risk field with occupancy-compatible metadata."""
+
+    values: np.ndarray
+    spec: LocalRiskSurfaceSpec
+    status: str = "available"
+
+    def __post_init__(self) -> None:
+        """Validate shape, finite values, and status semantics."""
+        values = np.asarray(self.values, dtype=np.float32)
+        if values.shape != (self.spec.grid_height, self.spec.grid_width):
+            raise RiskSurfaceUnavailable("risk surface shape must match spec grid height and width")
+        if not np.all(np.isfinite(values)):
+            raise RiskSurfaceUnavailable("risk surface values must be finite")
+        if float(values.min(initial=0.0)) < 0.0 or float(values.max(initial=0.0)) > 1.0:
+            raise RiskSurfaceUnavailable("risk surface values must be normalized to [0, 1]")
+        if self.status != "available":
+            raise RiskSurfaceUnavailable("risk surface status must be 'available'")
+        object.__setattr__(self, "values", values)
+
+    def occupancy_grid(self) -> np.ndarray:
+        """Return a three-channel occupancy-compatible risk payload.
+
+        The same normalized risk values are exposed as obstacle and combined
+        channels so existing occupancy-aware planners can consume the surface
+        without a special-case code path. The pedestrian channel remains empty
+        because this payload is a model output, not raw pedestrian state.
+        """
+        grid = np.zeros((3, self.spec.grid_height, self.spec.grid_width), dtype=np.float32)
+        grid[0] = self.values
+        grid[2] = self.values
+        return grid
+
+    def occupancy_meta(self) -> dict[str, Any]:
+        """Return metadata compatible with `OccupancyAwarePlannerMixin`."""
+        return {
+            "origin": list(self.spec.grid_origin),
+            "resolution": [float(self.spec.resolution)],
+            "size": [float(self.spec.width), float(self.spec.height)],
+            "use_ego_frame": [1.0],
+            "center_on_robot": [1.0],
+            "channel_indices": [0, 1, -1, 2],
+            "robot_pose": [0.0, 0.0, 0.0],
+            "risk_surface": {
+                "producer_id": self.spec.producer_id,
+                "status": self.status,
+                "frame": self.spec.frame,
+                "risk_threshold": float(self.spec.risk_threshold),
+            },
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return JSON-compatible contract diagnostics for smoke reports."""
+        return {
+            "status": self.status,
+            "producer_id": self.spec.producer_id,
+            "frame": self.spec.frame,
+            "resolution": float(self.spec.resolution),
+            "size": [float(self.spec.width), float(self.spec.height)],
+            "risk_threshold": float(self.spec.risk_threshold),
+            "max_risk": float(np.max(self.values)),
+            "mean_risk": float(np.mean(self.values)),
+            "risk_cells_at_or_above_threshold": int(
+                np.count_nonzero(self.values >= float(self.spec.risk_threshold))
+            ),
+        }
+
+
+def _as_2d_points(values: Any, *, name: str) -> np.ndarray:
+    """Normalize point-like values into an `(N, 2)` finite float array.
+
+    Returns:
+        np.ndarray: Finite point array with shape `(N, 2)`.
+    """
+    arr = np.asarray(values, dtype=float)
+    if arr.size == 0:
+        return np.zeros((0, 2), dtype=float)
+    if arr.ndim == 1 and arr.size % 2 == 0:
+        arr = arr.reshape((-1, 2))
+    if arr.ndim != 2 or arr.shape[1] != 2:
+        raise RiskSurfaceUnavailable(f"{name} must be an array of 2D points")
+    if not np.all(np.isfinite(arr)):
+        raise RiskSurfaceUnavailable(f"{name} must contain finite values")
+    return arr.astype(float, copy=False)
+
+
+def _extract_robot_pose(observation: dict[str, Any]) -> tuple[tuple[float, float], float]:
+    """Extract finite robot pose from a structured Robot SF observation.
+
+    Returns:
+        tuple[tuple[float, float], float]: Robot position and heading.
+    """
+    robot = observation.get("robot")
+    if not isinstance(robot, dict):
+        raise RiskSurfaceUnavailable("observation must contain structured robot state")
+    position = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)
+    heading = np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)
+    if position.size < 2 or heading.size < 1:
+        raise RiskSurfaceUnavailable("robot position and heading are required")
+    if not np.all(np.isfinite(position[:2])) or not np.isfinite(heading[0]):
+        raise RiskSurfaceUnavailable("robot pose must contain finite values")
+    return (float(position[0]), float(position[1])), float(heading[0])
+
+
+def _pedestrian_positions(observation: dict[str, Any]) -> np.ndarray:
+    """Extract pedestrian positions from a structured Robot SF observation.
+
+    Returns:
+        np.ndarray: Pedestrian positions with shape `(N, 2)`.
+    """
+    pedestrians = observation.get("pedestrians", {})
+    if not isinstance(pedestrians, dict):
+        raise RiskSurfaceUnavailable("pedestrians field must be a mapping")
+    positions = _as_2d_points(pedestrians.get("positions", []), name="pedestrian positions")
+    count_raw = np.asarray(pedestrians.get("count", [positions.shape[0]]), dtype=float).reshape(-1)
+    count = max(int(count_raw[0]), 0) if count_raw.size else positions.shape[0]
+    return positions[:count]
+
+
+def deterministic_pedestrian_risk_surface(
+    observation: dict[str, Any],
+    spec: LocalRiskSurfaceSpec | None = None,
+    *,
+    pedestrian_sigma: float = 0.45,
+    floor_risk: float = 0.0,
+) -> LocalRiskSurface:
+    """Produce a deterministic local risk surface from pedestrian positions.
+
+    This is the smoke fixture and reference producer for the contract. A future
+    learned model may replace the value computation, but it must preserve the
+    same shape, frame, normalization, and fail-closed behavior.
+
+    Returns:
+        LocalRiskSurface: Normalized local ego-frame risk surface.
+    """
+    if not isinstance(observation, dict):
+        raise RiskSurfaceUnavailable("observation must be a mapping")
+    cfg = spec or LocalRiskSurfaceSpec()
+    if pedestrian_sigma <= 0.0:
+        raise RiskSurfaceUnavailable("pedestrian_sigma must be > 0")
+    if not 0.0 <= floor_risk <= 1.0:
+        raise RiskSurfaceUnavailable("floor_risk must be in [0, 1]")
+
+    robot_pose = _extract_robot_pose(observation)
+    ped_positions = _pedestrian_positions(observation)
+    origin = np.asarray(cfg.grid_origin, dtype=float)
+    xs = origin[0] + (np.arange(cfg.grid_width, dtype=float) + 0.5) * float(cfg.resolution)
+    ys = origin[1] + (np.arange(cfg.grid_height, dtype=float) + 0.5) * float(cfg.resolution)
+    xx, yy = np.meshgrid(xs, ys)
+    values = np.full((cfg.grid_height, cfg.grid_width), float(floor_risk), dtype=np.float32)
+
+    for ped in ped_positions:
+        px, py = world_to_ego(float(ped[0]), float(ped[1]), robot_pose)
+        dist_sq = (xx - px) ** 2 + (yy - py) ** 2
+        bump = np.exp(-0.5 * dist_sq / float(pedestrian_sigma) ** 2)
+        values = np.maximum(values, bump.astype(np.float32))
+
+    return LocalRiskSurface(values=np.clip(values, 0.0, 1.0), spec=cfg)
+
+
+def attach_risk_surface_to_observation(
+    observation: dict[str, Any],
+    surface: LocalRiskSurface,
+) -> dict[str, Any]:
+    """Attach a local risk surface as an occupancy-grid payload.
+
+    Returns:
+        dict[str, Any]: Observation copy enriched with risk-surface grid metadata.
+    """
+    if not isinstance(observation, dict):
+        raise RiskSurfaceUnavailable("observation must be a mapping")
+    enriched = dict(observation)
+    enriched["occupancy_grid"] = surface.occupancy_grid()
+    enriched["occupancy_grid_meta"] = surface.occupancy_meta()
+    enriched["local_risk_surface_diagnostics"] = surface.diagnostics()
+    return enriched
+
+
+class RiskSurfacePlannerAdapter:
+    """Adapter that lets an existing local planner consume a risk surface."""
+
+    def __init__(
+        self,
+        *,
+        spec: LocalRiskSurfaceSpec | None = None,
+        planner: Any | None = None,
+    ) -> None:
+        """Initialize with a risk-surface spec and occupancy-aware planner."""
+        self.spec = spec or LocalRiskSurfaceSpec()
+        self.planner = planner or RiskDWAPlannerAdapter()
+        self._last_status = "not_run"
+        self._last_error: str | None = None
+        self._last_surface: dict[str, Any] | None = None
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset wrapped planner state when it exposes a reset hook."""
+        reset = getattr(self.planner, "reset", None)
+        if callable(reset):
+            try:
+                reset(seed=seed)
+            except TypeError:
+                reset()
+        self._last_status = "not_run"
+        self._last_error = None
+        self._last_surface = None
+
+    def adapt_observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+        """Produce and attach a local risk surface for planner consumption.
+
+        Returns:
+            dict[str, Any]: Observation copy enriched with the surface payload.
+        """
+        surface = deterministic_pedestrian_risk_surface(observation, self.spec)
+        self._last_surface = surface.diagnostics()
+        return attach_risk_surface_to_observation(observation, surface)
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        """Plan with fail-closed behavior when the surface is unavailable.
+
+        Returns:
+            tuple[float, float]: Linear and angular velocity command.
+        """
+        try:
+            adapted = self.adapt_observation(observation)
+            linear, angular = self.planner.plan(adapted)
+        except Exception as exc:  # noqa: BLE001 - adapter boundary must fail closed.
+            self._last_status = "not_available"
+            self._last_error = str(exc)
+            self._last_surface = None
+            return 0.0, 0.0
+        self._last_status = "ok"
+        self._last_error = None
+        return float(linear), float(wrap_angle_pi(float(angular)))
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Expose adapter status and contract details.
+
+        Returns:
+            dict[str, Any]: JSON-compatible diagnostics for the last plan call.
+        """
+        return {
+            "adapter": "RiskSurfacePlannerAdapter",
+            "status": self._last_status,
+            "error": self._last_error,
+            "execution_mode": "adapter",
+            "readiness_status": "adapter" if self._last_status == "ok" else "not_available",
+            "availability_status": "available" if self._last_status == "ok" else self._last_status,
+            "surface_contract": {
+                "frame": self.spec.frame,
+                "resolution": float(self.spec.resolution),
+                "size": [float(self.spec.width), float(self.spec.height)],
+                "risk_threshold": float(self.spec.risk_threshold),
+                "producer_id": self.spec.producer_id,
+            },
+            "derived_payload": "local_risk_surface_as_occupancy_grid",
+            "surface": self._last_surface,
+            "benchmark_strength": False,
+            "benchmark_strength_blockers": [
+                "deterministic fixture only",
+                "no trained model provenance",
+                "no multi-scenario benchmark validation",
+            ],
+        }
+
+
+__all__ = [
+    "LocalRiskSurface",
+    "LocalRiskSurfaceSpec",
+    "RiskSurfacePlannerAdapter",
+    "RiskSurfaceUnavailable",
+    "attach_risk_surface_to_observation",
+    "deterministic_pedestrian_risk_surface",
+]

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -169,8 +169,10 @@ def _extract_robot_pose(observation: dict[str, Any]) -> tuple[tuple[float, float
     robot = observation.get("robot")
     if not isinstance(robot, dict):
         raise RiskSurfaceUnavailable("observation must contain structured robot state")
-    position = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)
-    heading = np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)
+    if "position" not in robot or "heading" not in robot:
+        raise RiskSurfaceUnavailable("robot position and heading are required")
+    position = np.asarray(robot["position"], dtype=float).reshape(-1)
+    heading = np.asarray(robot["heading"], dtype=float).reshape(-1)
     if position.size < 2 or heading.size < 1:
         raise RiskSurfaceUnavailable("robot position and heading are required")
     if not np.all(np.isfinite(position[:2])) or not np.isfinite(heading[0]):

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -43,7 +43,12 @@ def test_deterministic_surface_has_reviewable_contract_and_peak_near_pedestrian(
     assert surface.values.shape == (8, 8)
     assert diagnostics["status"] == "available"
     assert diagnostics["frame"] == "ego"
-    assert diagnostics["risk_cells_at_or_above_threshold"] > 0
+    peak_row, peak_col = np.unravel_index(np.argmax(surface.values), surface.values.shape)
+    origin_x, origin_y = spec.grid_origin
+    expected_col = int((0.75 - origin_x) / spec.resolution)
+    expected_row = int((0.0 - origin_y) / spec.resolution)
+    assert abs(int(peak_col) - expected_col) <= 1
+    assert abs(int(peak_row) - expected_row) <= 1
     assert 0.0 <= diagnostics["mean_risk"] <= diagnostics["max_risk"] <= 1.0
 
     meta = surface.occupancy_meta()

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -1,0 +1,106 @@
+"""Tests for the local learned-risk surface planner contract."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.planner.learned_risk_surface import (
+    LocalRiskSurfaceSpec,
+    RiskSurfacePlannerAdapter,
+    RiskSurfaceUnavailable,
+    attach_risk_surface_to_observation,
+    deterministic_pedestrian_risk_surface,
+)
+
+
+def _observation_with_pedestrian() -> dict:
+    """Return a tiny structured observation with one pedestrian in front."""
+    return {
+        "robot": {
+            "position": [0.0, 0.0],
+            "heading": [0.0],
+            "speed": [0.0],
+            "radius": [0.3],
+        },
+        "goal": {"current": [2.0, 0.0], "next": [2.0, 0.0]},
+        "pedestrians": {
+            "positions": [[0.75, 0.0]],
+            "velocities": [[0.0, 0.0]],
+            "count": [1],
+            "radius": [0.3],
+        },
+    }
+
+
+def test_deterministic_surface_has_reviewable_contract_and_peak_near_pedestrian() -> None:
+    """The fixture producer should emit a normalized ego-frame risk surface."""
+    spec = LocalRiskSurfaceSpec(resolution=0.25, width=2.0, height=2.0, risk_threshold=0.6)
+
+    surface = deterministic_pedestrian_risk_surface(_observation_with_pedestrian(), spec)
+    diagnostics = surface.diagnostics()
+
+    assert surface.values.shape == (8, 8)
+    assert diagnostics["status"] == "available"
+    assert diagnostics["frame"] == "ego"
+    assert diagnostics["risk_cells_at_or_above_threshold"] > 0
+    assert 0.0 <= diagnostics["mean_risk"] <= diagnostics["max_risk"] <= 1.0
+
+    meta = surface.occupancy_meta()
+    assert meta["use_ego_frame"] == [1.0]
+    assert meta["channel_indices"] == [0, 1, -1, 2]
+    assert meta["risk_surface"]["risk_threshold"] == 0.6
+
+
+def test_surface_attaches_as_occupancy_payload_consumable_by_planners() -> None:
+    """Risk surfaces should use the existing occupancy-grid observation contract."""
+    spec = LocalRiskSurfaceSpec(resolution=0.5, width=3.0, height=3.0)
+    surface = deterministic_pedestrian_risk_surface(_observation_with_pedestrian(), spec)
+
+    enriched = attach_risk_surface_to_observation(_observation_with_pedestrian(), surface)
+
+    assert enriched["occupancy_grid"].shape == (3, 6, 6)
+    np.testing.assert_allclose(enriched["occupancy_grid"][0], surface.values)
+    np.testing.assert_allclose(enriched["occupancy_grid"][2], surface.values)
+    assert enriched["local_risk_surface_diagnostics"]["producer_id"] == ("deterministic_fixture_v0")
+
+
+def test_risk_surface_planner_adapter_produces_bounded_command_and_diagnostics() -> None:
+    """A wrapped occupancy-aware planner should consume the produced surface."""
+    adapter = RiskSurfacePlannerAdapter(
+        spec=LocalRiskSurfaceSpec(resolution=0.25, width=4.0, height=4.0)
+    )
+
+    linear, angular = adapter.plan(_observation_with_pedestrian())
+    diagnostics = adapter.diagnostics()
+
+    assert 0.0 <= linear <= 1.2
+    assert abs(angular) <= np.pi
+    assert diagnostics["status"] == "ok"
+    assert diagnostics["execution_mode"] == "adapter"
+    assert diagnostics["availability_status"] == "available"
+    assert diagnostics["benchmark_strength"] is False
+    assert diagnostics["surface"]["risk_cells_at_or_above_threshold"] > 0
+
+
+def test_risk_surface_adapter_fails_closed_without_robot_state() -> None:
+    """Missing required state should stop instead of falling back silently."""
+    adapter = RiskSurfacePlannerAdapter()
+
+    assert adapter.plan({"pedestrians": {"positions": [[1.0, 0.0]], "count": [1]}}) == (
+        0.0,
+        0.0,
+    )
+    diagnostics = adapter.diagnostics()
+    assert diagnostics["status"] == "not_available"
+    assert diagnostics["availability_status"] == "not_available"
+    assert "robot state" in str(diagnostics["error"])
+
+
+def test_risk_surface_contract_rejects_invalid_resolution() -> None:
+    """Invalid geometry should be rejected before any planner run."""
+    try:
+        LocalRiskSurfaceSpec(resolution=0.0)
+    except RiskSurfaceUnavailable as exc:
+        assert "resolution" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected RiskSurfaceUnavailable")

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from robot_sf.planner.learned_risk_surface import (
     LocalRiskSurfaceSpec,
@@ -98,9 +99,5 @@ def test_risk_surface_adapter_fails_closed_without_robot_state() -> None:
 
 def test_risk_surface_contract_rejects_invalid_resolution() -> None:
     """Invalid geometry should be rejected before any planner run."""
-    try:
+    with pytest.raises(RiskSurfaceUnavailable, match="resolution"):
         LocalRiskSurfaceSpec(resolution=0.0)
-    except RiskSurfaceUnavailable as exc:
-        assert "resolution" in str(exc)
-    else:  # pragma: no cover - assertion clarity
-        raise AssertionError("expected RiskSurfaceUnavailable")


### PR DESCRIPTION
## Summary
Adds a Robot SF-native local risk/potential surface interface for #1675. The implementation defines a reviewable ego-frame surface contract, a deterministic fixture producer, and a fail-closed adapter that lets existing occupancy-aware planners consume the surface through the normal occupancy-grid metadata path.

## Linked Issues
- Closes #1675
- Relates to #1617
- Relates to #1618

## What Changed
- Added `robot_sf.planner.learned_risk_surface` with:
  - `LocalRiskSurfaceSpec`
  - `LocalRiskSurface`
  - `deterministic_pedestrian_risk_surface(...)`
  - `attach_risk_surface_to_observation(...)`
  - `RiskSurfacePlannerAdapter`
- Exported the new helper types from `robot_sf.planner`.
- Added deterministic smoke/contract tests in `tests/planner/test_learned_risk_surface.py`.
- Added `docs/context/issue_1675_learned_risk_surface_interface.md` and linked it from `docs/context/README.md`.

## Why It Matters
- Defines the data contract, frame convention, resolution, normalized value range, and fail-closed behavior for future learned risk-surface producers.
- Proves a tiny produce-and-consume path without importing external code or pretending a trained model exists.
- Keeps benchmark-strength boundaries explicit: this is interface proof, not evidence that a learned surface improves navigation.

## Validation / Proof
- Commands run:
  - `uv run ruff check robot_sf/planner/learned_risk_surface.py tests/planner/test_learned_risk_surface.py`
  - `uv run ruff format --check robot_sf/planner/learned_risk_surface.py tests/planner/test_learned_risk_surface.py`
  - `uv run pytest -q tests/planner/test_learned_risk_surface.py`
  - `git diff --check origin/main...HEAD`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `uv run pytest -q tests/planner/test_risk_dwa_mppi_hybrid.py tests/planner/test_learned_risk_surface.py`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused learned-risk tests passed: `5 passed`.
  - Related planner regression tests passed: `31 passed`.
  - Full readiness passed: `4444 passed, 11 skipped`.
  - PR readiness freshness stamp is current for head `f1ce7378764f6f3e4b612cc6a966dbb3bdd90052`.
- Note:
  - Readiness reported a warning-only changed-file coverage item: `robot_sf/planner/learned_risk_surface.py` at `80.7%`. The full readiness gate still passed.

## Risks / Rollout
- Compatibility risk is low; this is additive planner helper code and docs.
- The deterministic producer is a fixture/reference path, not a learned model.
- `RiskSurfacePlannerAdapter` fails closed to `(0.0, 0.0)` with `availability_status=not_available` on invalid inputs.
- Rollback: remove the helper module, its exports, the focused tests, and the context note link.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1675_learned_risk_surface_interface.md`
  - `docs/context/README.md`
- Relevant predecessor notes:
  - `docs/context/issue_1617_local_planner_repo_survey.md`
  - `docs/context/issue_1618_learned_policy_adapter_interface.md`
- Worker/process note:
  - Gemini auto completed a read-only scout and supported the occupancy-grid contract direction.
  - Qwen `Qwen3.6-27B`, Qwen `qwen3-coder-plus`, and OpenCode Go scout routes timed out; their output was not used as acceptance evidence.
  - A workflow self-review note was written under `.git/codex-agent-runs/notes/inbox/`.

## Artifact Decision
- Generated `output/coverage/*` and `output/validation/pr_ready/*` files are ignored, disposable local validation artifacts.
- No generated benchmark artifacts, checkpoints, or bulky outputs are required for this PR.

## Reviewer Notes
- Please check the benchmark boundary language: the adapter deliberately reports `benchmark_strength=false` until a future trained producer has provenance, diagnostics, and scenario-matrix proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a local learned risk surface interface for ego-frame risk assessment, compatible with existing path planning systems
  * Added a risk-surface-augmented planner adapter providing safe failure handling and integration with existing occupancy-aware planners

* **Documentation**
  * Added detailed documentation for the learned risk surface planning interface

* **Tests**
  * Added comprehensive test coverage for risk surface generation, attachment, and planner integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->