### PR TITLE
docs: add queue exhaustion audit example (#1688)

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -137,6 +137,36 @@ hardware, SLURM, CARLA, private artifacts, checkpoint aliases, datasets, or a cl
 mark it blocked or send it to issue clarification instead of counting the queue as empty. Keep this
 audit read-only until the orchestrator has reviewed the proposed label/body changes.
 
+Example compact exhausted-queue audit:
+
+```text
+Queue exhaustion audit
+- Query used:
+  gh issue list --state open --label state:ready --json number,title,labels,url --limit 100
+  gh issue list --state open --search "repo:ll7/robot_sf_ll7 is:issue is:open -label:state:ready -label:state:blocked -label:state:hold" --json number,title,labels,url --limit 100
+- Remaining ready issues:
+  - #1234 blocked locally: needs SLURM/Auxme allocation; mark `state:blocked` with unblock condition.
+  - #1235 ambiguous: acceptance criteria mix benchmark claim and exploratory probe; route to
+    `gh-issue-clarifier`.
+  - #1236 too broad for one PR: split into fixture migration, docs migration, and compatibility
+    validation issues.
+- Remaining open issues without `state:*` labels:
+  - 17 proposal/research issues need template repair before implementation routing.
+- Best issue-splitting candidate:
+  - #1236, because the child issues can have independent validation gates and avoid one broad
+    path-rewrite PR.
+- Writes applied:
+  - none yet; audit is read-only pending orchestrator review.
+- Next action:
+  - clarify #1235 or split #1236 before claiming the implementation queue is exhausted.
+```
+
+This is an illustrative report shape, not a required machine-readable schema. Prefer this compact
+summary in final handoffs and PR comments when the queue is genuinely exhausted. If a remaining
+issue only needs a clearer contract, route it to issue clarification. If a remaining issue bundles
+several independently validatable changes, create child issues with `gh-issue-creator` and leave the
+parent as the coordination issue instead of treating the bundle as unimplementable.
+
 ## Process
 
 1. Select one issue (`gh-issue-sequencer` output or explicit user target).

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -143,7 +143,7 @@ Example compact exhausted-queue audit:
 Queue exhaustion audit
 - Query used:
   gh issue list --state open --label state:ready --json number,title,labels,url --limit 100
-  gh issue list --state open --search "repo:ll7/robot_sf_ll7 is:issue is:open -label:state:ready -label:state:blocked -label:state:hold" --json number,title,labels,url --limit 100
+  gh issue list --search "repo:ll7/robot_sf_ll7 is:issue is:open -label:state:ready -label:state:blocked -label:state:hold" --json number,title,labels,url --limit 100
 - Remaining ready issues:
   - #1234 blocked locally: needs SLURM/Auxme allocation; mark `state:blocked` with unblock condition.
   - #1235 ambiguous: acceptance criteria mix benchmark claim and exploratory probe; route to


### PR DESCRIPTION
## Summary

- Adds a compact exhausted-queue audit example to `goal-issue-implementation`.
- Shows the query used, remaining issue classes, a best issue-splitting candidate, writes applied, and next action.
- Clarifies that the example is illustrative, not a new machine-readable schema, and routes remaining work to clarification or child issues as appropriate.

## Validation

- `uv run python scripts/dev/check_skills.py`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `git diff --check origin/main...HEAD`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4439 passed, 11 skipped, 9 warnings in 298.47s`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true`)

Closes #1688
