### PR TITLE
docs: define learned policy artifact manifests (#1686)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -192,7 +192,7 @@ knowledge, not every transient iteration detail.
   [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
-* Issue #1686 learned-policy artifact manifest fields:
+* Issue #1686 Learned-Policy Artifact Manifest Fields (2026-05-30):
   [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md) and
   [open_issues_training_split_audit_2026-05-30.md](open_issues_training_split_audit_2026-05-30.md)
 * Learned local-navigation policy registry:

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -192,6 +192,9 @@ knowledge, not every transient iteration detail.
   [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
+* Issue #1686 learned-policy artifact manifest fields:
+  [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md) and
+  [open_issues_training_split_audit_2026-05-30.md](open_issues_training_split_audit_2026-05-30.md)
 * Learned local-navigation policy registry:
   [policy_search/learned_policy_registry.md](policy_search/learned_policy_registry.md)
 * Issue #1615 LiDAR Learned-Policy Launch Plan (2026-05-29):

--- a/docs/context/artifact_evidence_vocabulary.md
+++ b/docs/context/artifact_evidence_vocabulary.md
@@ -50,6 +50,67 @@ coverage, temporary exports, videos, and caches, but it is not a durable depende
 - When evidence is expensive or too large to commit, track a manifest or pointer instead of copying
   raw episodes, videos, checkpoints, model caches, or logs into git.
 
+## Learned-Policy Artifact Manifests
+
+Learned local-policy checkpoints, normalizers, imitation datasets, and residual-policy artifacts
+should specialize this vocabulary instead of creating a parallel evidence system. A learned-policy
+artifact manifest is a compact pointer record. It is not the checkpoint, not a model registry, and
+not benchmark evidence by itself.
+
+Required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `policy_id` | Stable policy or component id, such as `learned_risk_model_v1`. |
+| `artifact_role` | One of `checkpoint`, `normalizer`, `dataset_manifest`, `adapter_config`, or `launch_packet`. |
+| `artifact_uri` | Durable URI, release URL, or tracked config/evidence path. Local `output/` paths are allowed only as regeneration or hydration targets, not as durable URIs. |
+| `sha256` | Checksum for tracked fixtures, release artifacts, or local files promoted to durable storage. Use `pending` only before benchmark eligibility. |
+| `training_config` | Repository path to the config or launch packet that produced or will produce the artifact. |
+| `training_commit` | Git commit for the training, data-generation, or launch-packet contract. |
+| `observation_schema` | Observation contract path or named schema, including `observation_t` and deployment-visible fields. |
+| `action_schema` | Action-output family, bounds, frame, projection, and guard/fallback behavior. |
+| `normalizer_uri` | Durable normalizer artifact URI or `not_required`; learned normalizers must state the fit split. |
+| `license` | License or access note for the artifact and source data. |
+| `split_contract` | Train/validation/test split contract or note. |
+| `benchmark_eligibility` | One of `not_eligible`, `research_only`, `adapter_preflight`, or `benchmark_candidate`. |
+| `fail_closed_behavior` | Action when the artifact, checksum, normalizer, or schema is missing or mismatched. |
+
+Example manifest shape for the existing learned-risk launch lane:
+
+```yaml
+policy_id: learned_risk_model_v1
+artifact_role: launch_packet
+artifact_uri: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+sha256: pending
+training_config: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+training_commit: e14e2f8bc2058d9f0e071219629915dd5b5dd5a8
+observation_schema:
+  contract: docs/context/policy_search/contracts/learned_local_policy_eligibility.md
+  observation_t: current decision step
+  deployment_fields:
+    - trajectory_features.min_rollout_clearance_m
+    - trajectory_features.mean_pedestrian_distance_m
+    - trajectory_features.route_progress_delta
+action_schema:
+  family: auxiliary_cost
+  role: rank otherwise-safe local commands only
+  hard_guards_authoritative: true
+normalizer_uri: not_required_for_launch_packet
+license: repository-internal pre-SLURM launch packet; no checkpoint distributed
+split_contract: docs/context/open_issues_training_split_audit_2026-05-30.md
+benchmark_eligibility: adapter_preflight
+fail_closed_behavior:
+  missing_artifact: reject learned-policy benchmark row
+  checksum_mismatch: reject learned-policy benchmark row
+  missing_observation_or_action_schema: classify as not_eligible
+  missing_normalizer: reject if the policy declares learned normalization
+```
+
+Benchmark-facing learned-policy claims must resolve any `pending` checksum or artifact URI first.
+If a checkpoint, normalizer, dataset, or schema cannot be hydrated from the manifest, the dependent
+adapter or benchmark row must fail closed with `not_available` or `failed` status. Do not silently
+fall back to a non-learned planner and report that row as learned-policy success.
+
 ## Acceptable References
 
 - Exploratory run:
@@ -95,6 +156,11 @@ coverage, temporary exports, videos, and caches, but it is not a durable depende
 - [Issue #1108 BC Warm-Start PPO Execution](https://github.com/ll7/robot_sf_ll7/issues/1108):
   SLURM logs, W&B run folders, and local `output/` paths are execution-run or exploratory evidence
   until a manifest, model registry entry, release artifact, or tracked evidence copy is published.
+- Learned-policy artifact manifests:
+  `docs/context/policy_search/contracts/learned_local_policy_eligibility.md` defines the
+  observation/action review contract, and
+  `docs/context/open_issues_training_split_audit_2026-05-30.md` records the current training-lane
+  split/provenance pointers that manifests should reference.
 - CARLA runtime qualification issues
   ([#872](https://github.com/ll7/robot_sf_ll7/issues/872),
   [#1111](https://github.com/ll7/robot_sf_ll7/issues/1111),

--- a/docs/context/artifact_evidence_vocabulary.md
+++ b/docs/context/artifact_evidence_vocabulary.md
@@ -156,7 +156,7 @@ fall back to a non-learned planner and report that row as learned-policy success
 - [Issue #1108 BC Warm-Start PPO Execution](https://github.com/ll7/robot_sf_ll7/issues/1108):
   SLURM logs, W&B run folders, and local `output/` paths are execution-run or exploratory evidence
   until a manifest, model registry entry, release artifact, or tracked evidence copy is published.
-- Learned-policy artifact manifests:
+- [Issue #1686 Learned-Policy Artifact Manifests](https://github.com/ll7/robot_sf_ll7/issues/1686):
   `docs/context/policy_search/contracts/learned_local_policy_eligibility.md` defines the
   observation/action review contract, and
   `docs/context/open_issues_training_split_audit_2026-05-30.md` records the current training-lane

--- a/docs/context/open_issues_training_split_audit_2026-05-30.md
+++ b/docs/context/open_issues_training_split_audit_2026-05-30.md
@@ -1,0 +1,41 @@
+# Open Issues Training Split Audit
+
+Date: 2026-05-30
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1686>
+
+## Scope
+
+This note is a lightweight pointer for learned-policy artifact manifests. It does not run training,
+move checkpoints, upload artifacts, or make benchmark claims. It identifies current training lanes
+whose future checkpoints, normalizers, datasets, or adapter configs should cite the learned-policy
+manifest fields in
+[artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md).
+
+## Training Lane Pointers
+
+| Lane | Current source | Split/provenance implication |
+| --- | --- | --- |
+| learned risk model v1 | `configs/training/learned_risk_model_issue_1395_launch_packet.yaml` and [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md) | Manifest must keep hard guards authoritative, preserve trace-contract checksums, and replace `pending` durable aliases before benchmark eligibility. |
+| shielded PPO repair | `configs/training/shielded_ppo_issue_1396_launch_packet.yaml` and [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md) | Manifest must state the PPO checkpoint lineage, repair config, comparison-freeze checksum, and guard/fallback policy. |
+| oracle imitation dataset | `configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml` and [issue_1397_oracle_imitation_launch_packet.md](issue_1397_oracle_imitation_launch_packet.md) | Manifest must cite the dataset split contract, durable dataset artifacts, and whether the resulting policy is training-only/oracle or deployable. |
+| ORCA residual BC | `configs/training/orca_residual/orca_residual_bc_issue_1428.yaml` and [issue_1428_orca_residual_lineage.md](issue_1428_orca_residual_lineage.md) | Manifest must separate base ORCA behavior, residual bounds, candidate config, diagnostic checksums, and guarded fallback behavior. |
+| LiDAR PPO MLP | `configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml` and [issue_1615_lidar_learned_policy_plan.md](issue_1615_lidar_learned_policy_plan.md) | Manifest must state the LiDAR observation schema, learned normalizer fit split if any, and cross-observation benchmark eligibility boundary. |
+
+## Fail-Closed Rule
+
+If a lane lacks a durable artifact URI, checksum, training config, training commit, observation
+schema, action schema, normalizer URI or `not_required` declaration, license/access note, split
+contract, or benchmark eligibility verdict, it may remain a launch packet or research-only record
+but must not be promoted as a learned-policy benchmark row.
+
+Worktree-local `output/` paths may describe exploratory runs or hydration targets only. They are not
+durable learned-policy artifacts.
+
+## Validation
+
+For updates to this note:
+
+```bash
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+```

--- a/docs/context/policy_search/contracts/learned_local_policy_eligibility.md
+++ b/docs/context/policy_search/contracts/learned_local_policy_eligibility.md
@@ -85,6 +85,14 @@ The assessment must state:
 - whether normalization statistics were fit on training data only,
 - whether candidate evidence comes from source claims, Robot SF local execution, or synthesis.
 
+For any concrete checkpoint, normalizer, dataset, adapter config, or launch packet, record the
+learned-policy artifact manifest fields in
+`docs/context/artifact_evidence_vocabulary.md`. The manifest must name the policy id, artifact URI,
+checksum, training config and commit, observation/action schemas, normalizer URI or `not_required`,
+license/access note, split contract, benchmark eligibility, and fail-closed behavior. Missing or
+mismatched artifacts, checksums, normalizers, observation schemas, or action schemas make the
+candidate `not_available` for benchmark use until the manifest is repaired.
+
 Do not compare learned policies as benchmark candidates when their training/evaluation split leaks
 the exact test scenarios, future trajectories, or outcome labels used by Robot SF metrics.
 


### PR DESCRIPTION
## Summary

- Adds learned-policy artifact manifest fields to the existing artifact evidence vocabulary instead of creating a parallel evidence system.
- Adds a learned-risk launch-lane example covering policy id, artifact URI, checksum, training config/commit, observation/action schema, normalizer, license, split contract, benchmark eligibility, and fail-closed behavior.
- Cross-links the learned-policy eligibility checklist and adds a lightweight open training split/provenance pointer note for current learned-policy lanes.

## Scope Guardrails

- No checkpoints, datasets, normalizers, or generated artifacts are added.
- No loader/model behavior changes.
- Manifest examples are preflight/provenance guidance, not benchmark evidence.

## Validation

- `rg -n "LearnedLocalPolicy|observation_t|post_guard_action|privileged" docs/context docs/README.md`
- `git diff --check origin/main...HEAD`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4439 passed, 11 skipped, 9 warnings in 299.24s`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true`)

Closes #1686
