### PR TITLE
feat: add simulation trace export schema (#1689)

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -200,7 +200,7 @@ knowledge, not every transient iteration detail.
   [issue_1618_learned_policy_adapter_interface.md](issue_1618_learned_policy_adapter_interface.md)
 * Issue #1677 SiT Dataset Terms Audit (2026-05-29):
   [issue_1677_sit_dataset_terms.md](issue_1677_sit_dataset_terms.md)
-* Issue #1689 simulation trace export schema:
+* Issue #1689 Simulation Trace Export Schema (2026-05-30):
   [issue_1689_simulation_trace_export_schema.md](issue_1689_simulation_trace_export_schema.md)
 * Issue #1617 Local-Planner Repository Survey (2026-05-29):
   [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -200,6 +200,8 @@ knowledge, not every transient iteration detail.
   [issue_1618_learned_policy_adapter_interface.md](issue_1618_learned_policy_adapter_interface.md)
 * Issue #1677 SiT Dataset Terms Audit (2026-05-29):
   [issue_1677_sit_dataset_terms.md](issue_1677_sit_dataset_terms.md)
+* Issue #1689 simulation trace export schema:
+  [issue_1689_simulation_trace_export_schema.md](issue_1689_simulation_trace_export_schema.md)
 * Issue #1617 Local-Planner Repository Survey (2026-05-29):
   [issue_1617_local_planner_repo_survey.md](issue_1617_local_planner_repo_survey.md)
 * Issue #1662 LiDAR PPO MLP Smoke (2026-05-29):

--- a/docs/context/issue_1689_simulation_trace_export_schema.md
+++ b/docs/context/issue_1689_simulation_trace_export_schema.md
@@ -1,0 +1,41 @@
+# Issue #1689 Simulation Trace Export Schema
+
+Date: 2026-05-30
+
+Related issues:
+
+- <https://github.com/ll7/robot_sf_ll7/issues/1689>
+- <https://github.com/ll7/robot_sf_ll7/issues/1646>
+
+## Scope
+
+This note records the first analysis-workbench input contract. It defines a tiny
+`simulation_trace_export.v1` schema, a typed loader, and a reviewable fixture for future workbench
+consumers. It does not add a frontend, renderer, benchmark metric, or paper-facing claim.
+
+## Contract
+
+- Schema: `robot_sf/analysis_workbench/schemas/simulation_trace_export.v1.json`
+- Loader: `robot_sf/analysis_workbench/simulation_trace_export.py`
+- Fixture: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json`
+- Test: `tests/analysis_workbench/test_simulation_trace_export.py`
+
+The trace contains source metadata, a strict `analysis_workbench_only` evidence boundary, frame
+units, robot state, pedestrian state, and a small planner action/event block. The typed loader also
+checks that frame steps and times are strictly increasing so playback consumers can rely on
+deterministic ordering.
+
+## Evidence Boundary
+
+`simulation_trace_export.v1` is analysis and visualization input only. A valid trace export is not
+benchmark evidence, not a success claim, and not a replacement for schema-checked benchmark episode
+records or durable campaign summaries. If a payload changes `evidence_boundary` to
+`benchmark_evidence`, validation fails closed.
+
+## Validation
+
+```bash
+uv run pytest -q tests/analysis_workbench/test_simulation_trace_export.py
+```
+
+Expected result: `3 passed`.

--- a/robot_sf/analysis_workbench/__init__.py
+++ b/robot_sf/analysis_workbench/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis-workbench contracts and helpers."""

--- a/robot_sf/analysis_workbench/schemas/simulation_trace_export.v1.json
+++ b/robot_sf/analysis_workbench/schemas/simulation_trace_export.v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/simulation_trace_export.v1.json",
+  "title": "Robot SF Simulation Trace Export v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trace_id",
+    "source",
+    "evidence_boundary",
+    "coordinate_frame",
+    "units",
+    "frames"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "simulation_trace_export.v1"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario_id", "seed", "planner_id", "episode_id", "generated_by"],
+      "properties": {
+        "scenario_id": {"type": "string", "minLength": 1},
+        "seed": {"type": "integer"},
+        "planner_id": {"type": "string", "minLength": 1},
+        "episode_id": {"type": "string", "minLength": 1},
+        "generated_by": {"type": "string", "minLength": 1}
+      }
+    },
+    "evidence_boundary": {
+      "const": "analysis_workbench_only"
+    },
+    "coordinate_frame": {
+      "enum": ["world", "robot"]
+    },
+    "units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position", "heading", "time", "velocity"],
+      "properties": {
+        "position": {"const": "m"},
+        "heading": {"const": "rad"},
+        "time": {"const": "s"},
+        "velocity": {"const": "m/s"}
+      }
+    },
+    "frames": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step", "time_s", "robot", "pedestrians", "planner"],
+        "properties": {
+          "step": {"type": "integer", "minimum": 0},
+          "time_s": {"type": "number", "minimum": 0},
+          "robot": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["position", "heading", "velocity"],
+            "properties": {
+              "position": {"$ref": "#/$defs/vector2"},
+              "heading": {"type": "number"},
+              "velocity": {"$ref": "#/$defs/vector2"}
+            }
+          },
+          "pedestrians": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "position", "velocity"],
+              "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "position": {"$ref": "#/$defs/vector2"},
+                "velocity": {"$ref": "#/$defs/vector2"}
+              }
+            }
+          },
+          "planner": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["selected_action"],
+            "properties": {
+              "selected_action": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["linear_velocity", "angular_velocity"],
+                "properties": {
+                  "linear_velocity": {"type": "number"},
+                  "angular_velocity": {"type": "number"}
+                }
+              },
+              "event": {"type": "string"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": {
+      "type": "array",
+      "prefixItems": [{"type": "number"}, {"type": "number"}],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  }
+}

--- a/robot_sf/analysis_workbench/simulation_trace_export.py
+++ b/robot_sf/analysis_workbench/simulation_trace_export.py
@@ -1,0 +1,196 @@
+"""Typed loader for ``simulation_trace_export.v1`` analysis-workbench traces."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+SIMULATION_TRACE_EXPORT_SCHEMA_VERSION = "simulation_trace_export.v1"
+SIMULATION_TRACE_EXPORT_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "simulation_trace_export.v1.json"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationTraceSource:
+    """Source metadata for an exported simulation trace."""
+
+    scenario_id: str
+    seed: int
+    planner_id: str
+    episode_id: str
+    generated_by: str
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationTraceFrame:
+    """One playback frame in an analysis-workbench trace."""
+
+    step: int
+    time_s: float
+    robot: dict[str, Any]
+    pedestrians: list[dict[str, Any]]
+    planner: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationTraceExport:
+    """Typed ``simulation_trace_export.v1`` payload."""
+
+    schema_version: str
+    trace_id: str
+    source: SimulationTraceSource
+    evidence_boundary: str
+    coordinate_frame: str
+    units: dict[str, str]
+    frames: list[SimulationTraceFrame]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the export to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation suitable for JSON Schema validation.
+        """
+
+        return asdict(self)
+
+
+class SimulationTraceExportValidationError(ValueError):
+    """Raised when a simulation trace export fails validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_simulation_trace_export_schema() -> dict[str, Any]:
+    """Load the public ``simulation_trace_export.v1`` JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(SIMULATION_TRACE_EXPORT_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_simulation_trace_export(path: Path) -> SimulationTraceExport:
+    """Load one simulation trace export from JSON.
+
+    Returns:
+        Typed simulation trace export.
+    """
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise SimulationTraceExportValidationError(["expected a mapping payload"], source=path)
+    return simulation_trace_export_from_dict(raw, source=path)
+
+
+def simulation_trace_export_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> SimulationTraceExport:
+    """Validate and convert a mapping into a typed simulation trace export.
+
+    Returns:
+        Typed simulation trace export.
+    """
+
+    errors = _schema_validation_errors(payload)
+    errors.extend(_semantic_validation_errors(payload))
+    if errors:
+        raise SimulationTraceExportValidationError(errors, source=source)
+    return _export_from_payload(payload)
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors."""
+
+    validator = Draft202012Validator(load_simulation_trace_export_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return trace-order validation errors not expressible in the JSON Schema."""
+
+    frames = payload.get("frames")
+    if not isinstance(frames, list):
+        return []
+    errors: list[str] = []
+    previous_step: int | None = None
+    previous_time: float | None = None
+    for index, frame in enumerate(frames):
+        if not isinstance(frame, Mapping):
+            continue
+        step = frame.get("step")
+        time_s = frame.get("time_s")
+        if isinstance(step, int):
+            if previous_step is not None and step <= previous_step:
+                errors.append(f"/frames/{index}/step: expected strictly increasing step")
+            previous_step = step
+        if isinstance(time_s, int | float):
+            time_value = float(time_s)
+            if previous_time is not None and time_value <= previous_time:
+                errors.append(f"/frames/{index}/time_s: expected strictly increasing time_s")
+            previous_time = time_value
+    return errors
+
+
+def _export_from_payload(payload: Mapping[str, Any]) -> SimulationTraceExport:
+    """Build a typed export from a schema-valid payload.
+
+    Returns:
+        Typed simulation trace export.
+    """
+
+    source = payload["source"]
+    return SimulationTraceExport(
+        schema_version=str(payload["schema_version"]),
+        trace_id=str(payload["trace_id"]),
+        source=SimulationTraceSource(
+            scenario_id=str(source["scenario_id"]),
+            seed=int(source["seed"]),
+            planner_id=str(source["planner_id"]),
+            episode_id=str(source["episode_id"]),
+            generated_by=str(source["generated_by"]),
+        ),
+        evidence_boundary=str(payload["evidence_boundary"]),
+        coordinate_frame=str(payload["coordinate_frame"]),
+        units=dict(payload["units"]),
+        frames=[
+            SimulationTraceFrame(
+                step=int(frame["step"]),
+                time_s=float(frame["time_s"]),
+                robot=dict(frame["robot"]),
+                pedestrians=[dict(pedestrian) for pedestrian in frame["pedestrians"]],
+                planner=dict(frame["planner"]),
+            )
+            for frame in payload["frames"]
+        ],
+    )
+
+
+def _json_pointer(path: Any) -> str:
+    """Render a JSON Schema error path as an RFC6901-style pointer.
+
+    Returns:
+        JSON pointer string for the provided path.
+    """
+
+    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
+    return "/" + "/".join(parts) if parts else "/"

--- a/robot_sf/analysis_workbench/simulation_trace_export.py
+++ b/robot_sf/analysis_workbench/simulation_trace_export.py
@@ -121,7 +121,10 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
     validator = Draft202012Validator(load_simulation_trace_export_schema())
     return [
         f"{_json_pointer(error.absolute_path)}: {error.message}"
-        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+        for error in sorted(
+            validator.iter_errors(payload),
+            key=lambda err: tuple(str(path_part) for path_part in err.absolute_path),
+        )
     ]
 
 

--- a/robot_sf/analysis_workbench/simulation_trace_export.py
+++ b/robot_sf/analysis_workbench/simulation_trace_export.py
@@ -123,7 +123,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
         f"{_json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(
             validator.iter_errors(payload),
-            key=lambda err: tuple(str(path_part) for path_part in err.absolute_path),
+            key=lambda err: list(err.absolute_path),
         )
     ]
 

--- a/tests/analysis_workbench/test_simulation_trace_export.py
+++ b/tests/analysis_workbench/test_simulation_trace_export.py
@@ -1,0 +1,57 @@
+"""Contract tests for analysis-workbench simulation trace exports."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SIMULATION_TRACE_EXPORT_SCHEMA_VERSION,
+    SimulationTraceExportValidationError,
+    load_simulation_trace_export,
+    simulation_trace_export_from_dict,
+)
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "minimal_trace.json"
+)
+
+
+def test_load_minimal_simulation_trace_export_fixture() -> None:
+    """The tiny fixture should validate as analysis input, not benchmark evidence."""
+
+    trace = load_simulation_trace_export(FIXTURE_PATH)
+
+    assert trace.schema_version == SIMULATION_TRACE_EXPORT_SCHEMA_VERSION
+    assert trace.trace_id == "fixture_trace_001"
+    assert trace.source.scenario_id == "classic_bottleneck_medium"
+    assert trace.evidence_boundary == "analysis_workbench_only"
+    assert [frame.step for frame in trace.frames] == [0, 1]
+    assert trace.frames[0].planner["event"] == "start"
+
+
+def test_simulation_trace_export_rejects_benchmark_evidence_boundary() -> None:
+    """Trace exports should fail closed if presented as benchmark evidence."""
+
+    payload = load_simulation_trace_export(FIXTURE_PATH).to_dict()
+    payload["evidence_boundary"] = "benchmark_evidence"
+
+    with pytest.raises(SimulationTraceExportValidationError, match="/evidence_boundary"):
+        simulation_trace_export_from_dict(payload, source=FIXTURE_PATH)
+
+
+def test_simulation_trace_export_requires_monotonic_steps() -> None:
+    """Workbench traces should expose ordered frames for deterministic playback."""
+
+    payload = load_simulation_trace_export(FIXTURE_PATH).to_dict()
+    invalid = deepcopy(payload)
+    invalid["frames"][1]["step"] = 0
+
+    with pytest.raises(SimulationTraceExportValidationError, match="/frames/1/step"):
+        simulation_trace_export_from_dict(invalid, source=FIXTURE_PATH)

--- a/tests/analysis_workbench/test_simulation_trace_export.py
+++ b/tests/analysis_workbench/test_simulation_trace_export.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -50,8 +49,7 @@ def test_simulation_trace_export_requires_monotonic_steps() -> None:
     """Workbench traces should expose ordered frames for deterministic playback."""
 
     payload = load_simulation_trace_export(FIXTURE_PATH).to_dict()
-    invalid = deepcopy(payload)
-    invalid["frames"][1]["step"] = 0
+    payload["frames"][1]["step"] = 0
 
     with pytest.raises(SimulationTraceExportValidationError, match="/frames/1/step"):
-        simulation_trace_export_from_dict(invalid, source=FIXTURE_PATH)
+        simulation_trace_export_from_dict(payload, source=FIXTURE_PATH)

--- a/tests/analysis_workbench/test_simulation_trace_export.py
+++ b/tests/analysis_workbench/test_simulation_trace_export.py
@@ -53,3 +53,43 @@ def test_simulation_trace_export_requires_monotonic_steps() -> None:
 
     with pytest.raises(SimulationTraceExportValidationError, match="/frames/1/step"):
         simulation_trace_export_from_dict(payload, source=FIXTURE_PATH)
+
+
+def test_simulation_trace_export_requires_monotonic_time() -> None:
+    """Workbench traces should expose increasing timestamps for playback."""
+
+    payload = load_simulation_trace_export(FIXTURE_PATH).to_dict()
+    payload["frames"][1]["time_s"] = 0.0
+
+    with pytest.raises(SimulationTraceExportValidationError, match="/frames/1/time_s"):
+        simulation_trace_export_from_dict(payload, source=FIXTURE_PATH)
+
+
+def test_simulation_trace_export_schema_errors_keep_numeric_frame_order() -> None:
+    """Schema errors should sort array indices numerically, not lexicographically."""
+
+    payload = load_simulation_trace_export(FIXTURE_PATH).to_dict()
+    template_frame = payload["frames"][-1]
+    while len(payload["frames"]) <= 10:
+        next_frame = dict(template_frame)
+        next_frame["robot"] = dict(template_frame["robot"])
+        next_frame["pedestrians"] = [
+            dict(pedestrian) for pedestrian in template_frame["pedestrians"]
+        ]
+        next_frame["planner"] = dict(template_frame["planner"])
+        next_frame["planner"]["selected_action"] = dict(
+            template_frame["planner"]["selected_action"]
+        )
+        next_frame["step"] = len(payload["frames"])
+        next_frame["time_s"] = float(len(payload["frames"]))
+        payload["frames"].append(next_frame)
+    payload["frames"][2]["unexpected"] = True
+    payload["frames"][10]["unexpected"] = True
+
+    with pytest.raises(SimulationTraceExportValidationError) as exc_info:
+        simulation_trace_export_from_dict(payload, source=FIXTURE_PATH)
+
+    errors = exc_info.value.errors
+    assert next(
+        index for index, error in enumerate(errors) if error.startswith("/frames/2:")
+    ) < next(index for index, error in enumerate(errors) if error.startswith("/frames/10:"))

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "fixture_trace_001",
+  "source": {
+    "scenario_id": "classic_bottleneck_medium",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "fixture_episode_001",
+    "generated_by": "unit-test fixture"
+  },
+  "evidence_boundary": "analysis_workbench_only",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [0.0, 0.0],
+        "heading": 0.0,
+        "velocity": [0.1, 0.0]
+      },
+      "pedestrians": [
+        {
+          "id": "ped_1",
+          "position": [1.0, 0.5],
+          "velocity": [0.0, 0.0]
+        }
+      ],
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.1,
+          "angular_velocity": 0.0
+        },
+        "event": "start"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [0.01, 0.0],
+        "heading": 0.0,
+        "velocity": [0.1, 0.0]
+      },
+      "pedestrians": [
+        {
+          "id": "ped_1",
+          "position": [1.0, 0.5],
+          "velocity": [0.0, 0.0]
+        }
+      ],
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.1,
+          "angular_velocity": 0.0
+        },
+        "event": "advance"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `simulation_trace_export.v1`, a JSON schema for analysis-workbench trace inputs.
- Adds a typed loader/validator with explicit semantic checks for schema version, evidence boundary, and monotonic frame order.
- Adds a tiny fixture, focused tests, and a context note clarifying this is analysis/workbench input only, not benchmark evidence.

## TDD
- RED: `uv run pytest -q tests/analysis_workbench/test_simulation_trace_export.py` failed with `ModuleNotFoundError: No module named 'robot_sf.analysis_workbench'` before implementation.
- GREEN: targeted test now passes with `3 passed`.

## Validation
- `uv run ruff check robot_sf/analysis_workbench tests/analysis_workbench/test_simulation_trace_export.py`
- `uv run ruff format --check robot_sf/analysis_workbench tests/analysis_workbench/test_simulation_trace_export.py`
- `uv run pytest -q tests/analysis_workbench/test_simulation_trace_export.py` (`3 passed`)
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4442 passed, 11 skipped, 9 warnings in 297.91s`; changed-file coverage warning only at 95.3%)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true`)

Closes #1689
