### PR TITLE
docs: add issue splitting workflow skill (#1684)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -129,9 +129,10 @@ generated routing index; read the specific `SKILL.md` before applying a skill.
 | `gh-issue-sequencer` | atomic | context | yes | no | no | none | Maintain a clear next-work queue in GitHub Project #5 by normalizing issue status, priority, and execution order. |
 | `gh-issue-template-auditor` | atomic | context | yes | no | no | none | Review existing GitHub issues against the repo's issue-template contract and repair underspecified issues when the fix is clear. |
 | `goal-issue-discovery` | orchestrator | analysis | yes | no | no | `gh-issue-creator`, `gh-issue-sequencer`, `gh-issue-priority-assessor`, `agentic-eval`, `auto-improvement`, `autoresearch`, `context-map` | Use for an autonomous Robot SF issue-discovery loop that finds bounded improvement opportunities and creates evidence-graded GitHub issues; not for implementation. |
-| `goal-issue-implementation` | orchestrator | implementation | yes | no | no | `gh-issue-sequencer`, `gh-issue-autopilot`, `implementation-verification`, `pr-ready-check`, `gh-pr-opener`, `gh-issue-creator`, `context-note-maintainer` | Use for an autonomous Robot SF issue-to-PR loop that selects eligible GitHub issues, implements one scoped issue at a time, validates, pushes, and opens PRs. |
+| `goal-issue-implementation` | orchestrator | implementation | yes | no | no | `gh-issue-sequencer`, `gh-issue-autopilot`, `implementation-verification`, `pr-ready-check`, `gh-pr-opener`, `gh-issue-creator`, `context-note-maintainer`, `issue-splitter` | Use for an autonomous Robot SF issue-to-PR loop that selects eligible GitHub issues, implements one scoped issue at a time, validates, pushes, and opens PRs. |
 | `issue-audit` | atomic | context | yes | no | no | none | User-in-the-loop open-issue audit that asks one readiness-blocking question at a time and updates issues as decisions are made. |
-| `issue-contract-maintainer` | orchestrator | planning | yes | no | no | `gh-issue-clarifier`, `gh-issue-template-auditor`, `issue-audit` | Maintain GitHub issue contracts through template audits, ambiguity clarification, and user-decision application. |
+| `issue-contract-maintainer` | orchestrator | planning | yes | no | no | `gh-issue-clarifier`, `gh-issue-template-auditor`, `issue-audit`, `issue-splitter` | Maintain GitHub issue contracts through template audits, ambiguity clarification, and user-decision application. |
+| `issue-splitter` | atomic | planning | yes | no | no | `gh-issue-creator` | Split a parent, epic, decision, or research issue into the smallest independently implementable child issue with duplicate checks and conservative parent linking. |
 
 ### PR Lifecycle
 
@@ -179,6 +180,7 @@ generated routing index; read the specific `SKILL.md` before applying a skill.
 | `issue-discovery` | `goal-issue-discovery` |
 | `issue-queue-runner` | `goal-issue-implementation` |
 | `issue-to-pr` | `gh-issue-autopilot` |
+| `parent-to-child-issue` | `issue-splitter` |
 | `pr-review-runner` | `goal-pr-review` |
 | `proof-policy` | `quality-playbook` |
 | `quality-strategy` | `quality-playbook` |

--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -32,6 +32,8 @@ execution.
 3. Normalize prompt into required fields:
    - goal, scope/non-scope, value/effort/complexity/risk, definition of done, success metrics,
      validation plan.
+   - for child issues, include `Parent issue`, `Non-goals`, `Validation / Testing`, and
+     `Blocked by` fields before creation.
 4. Assign an archetype and evidence tier using the convention in
    `docs/context/issue_1512_issue_archetypes.md`. Include the archetype metadata block in
    the issue body. Use only the canonical values from that note. When the archetype is unclear,
@@ -56,6 +58,8 @@ execution.
 - Keep assumptions explicit and conservative.
 - If template fit is unclear, pick the smallest viable template and note the assumption.
 - Do not proceed with speculative follow-up links unless concrete and actionable.
+- For parent-derived child issues, require a duplicate check from `issue-splitter` or perform one
+  before calling `gh issue create`.
 - Use REST for deterministic issue operations; use GraphQL/MCP only where useful for Project #5.
 
 ## Output

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -16,6 +16,7 @@ delegates_to:
 - gh-pr-opener
 - gh-issue-creator
 - context-note-maintainer
+- issue-splitter
 output_schema: issue_to_pr_summary.v1
 aliases:
 - issue-queue-runner
@@ -34,6 +35,7 @@ It is an orchestrator over:
 - `gh-pr-opener`
 - `gh-issue-creator`
 - `context-note-maintainer`
+- `issue-splitter`
 
 It does not define subordinate command details; it standardizes queue policy, evidence and proof
 requirements, and loop boundaries.
@@ -136,6 +138,11 @@ machine and with the available durable artifacts. If a supposedly ready issue ne
 hardware, SLURM, CARLA, private artifacts, checkpoint aliases, datasets, or a clearer proof path,
 mark it blocked or send it to issue clarification instead of counting the queue as empty. Keep this
 audit read-only until the orchestrator has reviewed the proposed label/body changes.
+
+If the final audit leaves only parent, epic, decision, or research issues that are not directly
+implementable, hand exactly one parent to `issue-splitter` instead of stopping with a prose-only
+report. The splitter should produce or create one `Next Implementable Child` only after duplicate
+checks show that no equivalent child already exists.
 
 ## Process
 

--- a/.agents/skills/issue-contract-maintainer/SKILL.md
+++ b/.agents/skills/issue-contract-maintainer/SKILL.md
@@ -12,6 +12,7 @@ delegates_to:
 - gh-issue-clarifier
 - gh-issue-template-auditor
 - issue-audit
+- issue-splitter
 output_schema: skill_run_summary.v1
 aliases:
 - issue-contract-audit
@@ -29,6 +30,8 @@ Use this skill when an issue needs contract maintenance before implementation: t
 - `audit-template-compliance`: compare issue bodies with `.github/ISSUE_TEMPLATE/` and repair clear gaps without changing intent.
 - `clarify-ambiguity`: identify problem, scope, solution, or validation ambiguity and post concise options with pros/cons.
 - `apply-user-decision`: update issue text, labels, and Project #5 state after the user resolves a readiness question.
+- `split-parent-to-child`: hand a parent, epic, decision, or research issue to `issue-splitter`
+  when one smallest independently implementable child can be extracted without changing intent.
 
 For `audit-template-compliance`, treat the `## Archetype Metadata` YAML block as part of the issue
 contract. Preserve the block, validate `archetype` and `evidence_tier` against
@@ -42,18 +45,21 @@ flag malformed YAML or invalid values instead of inventing replacements.
 3. Preserve `docs/context/issue_713_batch_first_issue_workflow.md` batching discipline.
 4. Use `gh` REST operations for ordinary issue edits; reserve GraphQL for Project #5 fields.
 5. If the fix is not obvious, add or preserve `decision-required`, write the smallest decision prompt, and stop.
+6. For `split-parent-to-child`, require a duplicate child check first and update the parent with
+   `Next Implementable Child` only after a child issue exists and the relationship is clear.
 
 ## Guardrails
 
 - Do not expand the issue beyond the original intent.
 - Do not implement the issue from this skill; hand ready work to `gh-issue-autopilot`.
+- Do not split a parent into more than one child in a single pass.
 - Ask one readiness-blocking question at a time when user input is needed.
 - Keep issue-body edits auditable and mention source comments when applying decisions.
 
 ## Output
 
 ```yaml
-mode: audit-template-compliance | clarify-ambiguity | apply-user-decision
+mode: audit-template-compliance | clarify-ambiguity | apply-user-decision | split-parent-to-child
 issue: "#..."
 edits_made:
   - "..."
@@ -61,5 +67,5 @@ project_updates:
   - "..."
 blockers:
   - "..."
-next_skill: gh-issue-autopilot | gh-issue-sequencer | none
+next_skill: gh-issue-autopilot | gh-issue-sequencer | issue-splitter | none
 ```

--- a/.agents/skills/issue-splitter/SKILL.md
+++ b/.agents/skills/issue-splitter/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: issue-splitter
+description: Split a parent, epic, decision, or research issue into the smallest independently implementable
+  child issue with duplicate checks and conservative parent linking.
+category: github-issue
+kind: atomic
+phase: planning
+requires_write: true
+requires_slurm: false
+requires_benchmark_artifacts: false
+delegates_to:
+- gh-issue-creator
+output_schema: skill_run_summary.v1
+aliases:
+- parent-to-child-issue
+---
+
+# Issue Splitter
+
+## When to use
+
+Use this skill when an open parent, epic, decision, or research issue is too broad to implement
+directly, but contains enough context to extract one smallest independently implementable child.
+
+Prefer this skill after an implementation queue audit finds no immediately implementable issue, or
+when `issue-contract-maintainer` selects `split-parent-to-child` for a parent issue.
+
+Do not use it for automatic broad decomposition of multiple epics, Project #5 field updates, or
+creating speculative children that do not have a clear validation path.
+
+## Workflow
+
+1. Read the parent issue body, labels, linked issues/PRs, and recent comments.
+2. Identify whether the parent can yield exactly one smallest independently implementable child.
+3. Run a duplicate check before drafting anything:
+   - search open and closed issues by parent issue number, distinctive title words, and likely child
+     labels,
+   - inspect explicit child links in the parent body and recent comments,
+   - stop if an equivalent child already exists and report that issue instead.
+4. Draft the child in `draft-only` mode by default. Create the issue only when the caller explicitly
+   asks for creation or the parent workflow already authorizes GitHub issue writes.
+5. Use `gh-issue-creator` for the final issue body shape when creating a child.
+6. Update the parent with `Next Implementable Child` only when the relationship is clear and the
+   child issue was actually created. Otherwise, return the draft and the exact duplicate check
+   query results.
+
+## Child Issue Contract
+
+The child body must include these fields or equivalent headings:
+
+- `Parent issue`: link the parent issue, and name whether the child is extracted from an epic,
+  decision, research, or workflow parent.
+- `Scope`: the smallest concrete behavior, docs change, validation run, fixture, or analysis that
+  can close independently.
+- `Non-goals`: parent work deliberately excluded from the child.
+- `Validation / Testing`: one command or concrete evidence path that can prove the child.
+- `Blocked by`: `none` when the child is ready, or a specific issue, artifact, runtime, maintainer
+  decision, or external dependency.
+
+When the child is created, add a concise parent comment or body note:
+
+```markdown
+## Next Implementable Child
+
+- <child issue link> - <one-line scope>
+```
+
+## Guardrails
+
+- Create at most one child issue per run.
+- Do not mutate Project #5 fields; leave prioritization and status routing to the normal issue
+  batching workflow.
+- Do not split an issue whose scope is already implementable as one PR; hand it back to
+  `goal-issue-implementation`.
+- Do not turn a blocked parent into a ready child unless the child's `Blocked by` field is `none`
+  and its proof path is available on the current machine.
+- Keep duplicate check evidence in the output so future agents can audit why a child was or was not
+  created.
+
+## Output
+
+```yaml
+parent_issue: "#..."
+mode: draft-only | created
+duplicate_check:
+  queries:
+    - "..."
+  matches:
+    - "#..."
+child_issue:
+  title: "..."
+  url: "..."
+  body_fields:
+    parent_issue: "..."
+    scope: "..."
+    non_goals: "..."
+    validation_testing: "..."
+    blocked_by: "none | ..."
+parent_update:
+  next_implementable_child: "added | skipped"
+blockers:
+  - "..."
+next_skill: gh-issue-creator | goal-issue-implementation | none
+```

--- a/.agents/skills/skills.yaml
+++ b/.agents/skills/skills.yaml
@@ -628,6 +628,7 @@ skills:
     - gh-pr-opener
     - gh-issue-creator
     - context-note-maintainer
+    - issue-splitter
     output_schema: issue_to_pr_summary.v1
     aliases:
     - issue-queue-runner
@@ -746,12 +747,36 @@ skills:
     - gh-issue-clarifier
     - gh-issue-template-auditor
     - issue-audit
+    - issue-splitter
     output_schema: skill_run_summary.v1
     aliases:
     - issue-contract-audit
     - issue-clarification
     requires_slurm: false
     requires_benchmark_artifacts: false
+  issue-splitter:
+    description: Split a parent, epic, decision, or research issue into the smallest independently
+      implementable child issue with duplicate checks and conservative parent linking.
+    category: github-issue
+    kind: atomic
+    phase: planning
+    requires_write: true
+    requires_slurm: false
+    requires_benchmark_artifacts: false
+    writes:
+      git: false
+      github_issue: true
+      github_project: false
+      github_pr: false
+      filesystem: true
+    requires:
+    - gh
+    - git
+    delegates_to:
+    - gh-issue-creator
+    output_schema: skill_run_summary.v1
+    aliases:
+    - parent-to-child-issue
   oracle-imitation-campaign:
     writes:
       git: false

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -17,6 +17,7 @@ SKILL_FILES = [
     ROOT / ".agents" / "skills" / "gh-issue-template-auditor" / "SKILL.md",
     ROOT / ".agents" / "skills" / "gh-issue-priority-assessor" / "SKILL.md",
     ROOT / ".agents" / "skills" / "issue-contract-maintainer" / "SKILL.md",
+    ROOT / ".agents" / "skills" / "issue-splitter" / "SKILL.md",
 ]
 KNOWN_LABELS = {
     "agent",
@@ -231,3 +232,36 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
 
     documentation_text = (TEMPLATE_DIR / "documentation.md").read_text(encoding="utf-8")
     assert "docs/README.md" in documentation_text
+
+
+def test_issue_splitter_skill_defines_parent_child_contract() -> None:
+    """Verify the parent-to-child issue-splitting mode stays conservative and auditable."""
+
+    splitter_text = SKILL_FILES[4].read_text(encoding="utf-8")
+    expected_markers = [
+        "smallest independently implementable child",
+        "duplicate check",
+        "Next Implementable Child",
+        "Parent issue",
+        "Non-goals",
+        "Validation / Testing",
+        "Blocked by",
+        "Project #5",
+        "draft-only",
+    ]
+    for marker in expected_markers:
+        assert marker in splitter_text, f"missing issue-splitter marker {marker!r}"
+
+    maintainer_text = SKILL_FILES[3].read_text(encoding="utf-8")
+    assert "split-parent-to-child" in maintainer_text
+    assert "issue-splitter" in maintainer_text
+
+    creator_text = SKILL_FILES[0].read_text(encoding="utf-8")
+    assert "Parent issue" in creator_text
+    assert "Blocked by" in creator_text
+
+    goal_text = (ROOT / ".agents" / "skills" / "goal-issue-implementation" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "issue-splitter" in goal_text
+    assert "Next Implementable Child" in goal_text

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -12,13 +12,12 @@ from scripts.tools.issue_template_audit import SECTION_ORDER
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
 DOCS_GUIDE = ROOT / "docs" / "dev_guide.md"
-SKILL_FILES = [
-    ROOT / ".agents" / "skills" / "gh-issue-creator" / "SKILL.md",
-    ROOT / ".agents" / "skills" / "gh-issue-template-auditor" / "SKILL.md",
-    ROOT / ".agents" / "skills" / "gh-issue-priority-assessor" / "SKILL.md",
-    ROOT / ".agents" / "skills" / "issue-contract-maintainer" / "SKILL.md",
-    ROOT / ".agents" / "skills" / "issue-splitter" / "SKILL.md",
-]
+def _skill_path(name: str) -> Path:
+    """Resolve an agent skill file by its directory name."""
+
+    skill_file = ROOT / ".agents" / "skills" / name / "SKILL.md"
+    assert skill_file.exists(), f"missing skill file: {skill_file}"
+    return skill_file
 KNOWN_LABELS = {
     "agent",
     "benchmark",
@@ -194,7 +193,7 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "High `Improvement`" in prioritization_text
     assert "High `Success Probability`" in prioritization_text
 
-    creator_text = SKILL_FILES[0].read_text(encoding="utf-8")
+    creator_text = _skill_path("gh-issue-creator").read_text(encoding="utf-8")
     assert "GitHub MCP / GitHub app tools" in creator_text
     assert "gh issue create" in creator_text
     assert "gh project item-add" in creator_text
@@ -206,7 +205,7 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "Expected Duration in Hours" in creator_text
     assert "Reviewed" in creator_text
 
-    auditor_text = SKILL_FILES[1].read_text(encoding="utf-8")
+    auditor_text = _skill_path("gh-issue-template-auditor").read_text(encoding="utf-8")
     assert "GitHub MCP / GitHub app tools" in auditor_text
     assert "uv run python scripts/tools/issue_template_audit.py" in auditor_text
     assert "gh issue view" in auditor_text
@@ -215,7 +214,7 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "Archetype Metadata" in auditor_text
     assert "docs/context/issue_1512_issue_archetypes.md" in auditor_text
 
-    assessor_text = SKILL_FILES[2].read_text(encoding="utf-8")
+    assessor_text = _skill_path("gh-issue-priority-assessor").read_text(encoding="utf-8")
     assert "GitHub MCP / GitHub app tools" in assessor_text
     assert "docs/project_prioritization.md" in assessor_text
     assert "gh issue view" in assessor_text
@@ -225,7 +224,7 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
     assert "Estimate Discussion" in assessor_text
     assert "plausibility" in assessor_text.lower()
 
-    maintainer_text = SKILL_FILES[3].read_text(encoding="utf-8")
+    maintainer_text = _skill_path("issue-contract-maintainer").read_text(encoding="utf-8")
     assert "audit-template-compliance" in maintainer_text
     assert "Archetype Metadata" in maintainer_text
     assert "docs/context/issue_1512_issue_archetypes.md" in maintainer_text
@@ -237,7 +236,7 @@ def test_issue_template_docs_and_skills_reference_real_paths() -> None:
 def test_issue_splitter_skill_defines_parent_child_contract() -> None:
     """Verify the parent-to-child issue-splitting mode stays conservative and auditable."""
 
-    splitter_text = SKILL_FILES[4].read_text(encoding="utf-8")
+    splitter_text = _skill_path("issue-splitter").read_text(encoding="utf-8")
     expected_markers = [
         "smallest independently implementable child",
         "duplicate check",
@@ -252,11 +251,11 @@ def test_issue_splitter_skill_defines_parent_child_contract() -> None:
     for marker in expected_markers:
         assert marker in splitter_text, f"missing issue-splitter marker {marker!r}"
 
-    maintainer_text = SKILL_FILES[3].read_text(encoding="utf-8")
+    maintainer_text = _skill_path("issue-contract-maintainer").read_text(encoding="utf-8")
     assert "split-parent-to-child" in maintainer_text
     assert "issue-splitter" in maintainer_text
 
-    creator_text = SKILL_FILES[0].read_text(encoding="utf-8")
+    creator_text = _skill_path("gh-issue-creator").read_text(encoding="utf-8")
     assert "Parent issue" in creator_text
     assert "Blocked by" in creator_text
 

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -12,12 +12,16 @@ from scripts.tools.issue_template_audit import SECTION_ORDER
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
 DOCS_GUIDE = ROOT / "docs" / "dev_guide.md"
+
+
 def _skill_path(name: str) -> Path:
     """Resolve an agent skill file by its directory name."""
 
     skill_file = ROOT / ".agents" / "skills" / name / "SKILL.md"
     assert skill_file.exists(), f"missing skill file: {skill_file}"
     return skill_file
+
+
 KNOWN_LABELS = {
     "agent",
     "benchmark",


### PR DESCRIPTION
## Summary
- Adds a new `issue-splitter` skill for extracting one smallest independently implementable child issue from a parent/epic/decision/research issue.
- Wires the splitter into `issue-contract-maintainer`, `goal-issue-implementation`, `gh-issue-creator`, and the generated skills registry/index.
- Adds a focused test that pins the parent/child contract, duplicate-check requirement, `Next Implementable Child` parent update, and child issue fields.

## Delegation Notes
- Gemini auto completed a read-only design check and independently recommended a dedicated splitter skill.
- Qwen `Qwen3.6-27B`, Qwen `qwen3-coder-plus`, and OpenCode Go `opencode-go/deepseek-v4-pro` timed out with no stdout; their compact changed-file artifacts overlap local orchestrator edits and were not used as implementation evidence.
- Recorded workflow self-review note under the worktree-local `.git/codex-agent-runs/notes/inbox/`.

## Validation
- RED: `uv run pytest -q tests/test_issue_templates.py::test_issue_splitter_skill_defines_parent_child_contract -q` failed before implementation with missing `.agents/skills/issue-splitter/SKILL.md`.
- GREEN: `uv run pytest -q tests/test_issue_templates.py::test_issue_splitter_skill_defines_parent_child_contract -q`
- `uv run ruff check tests/test_issue_templates.py`
- `uv run ruff format --check tests/test_issue_templates.py`
- `uv run pytest -q tests/test_issue_templates.py` (`6 passed`)
- `uv run python scripts/dev/check_skills.py`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `git diff --check origin/main...HEAD`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4440 passed, 11 skipped, 9 warnings in 298.07s`)
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main` (`fresh: true`)

Closes #1684
