### PR TITLE
feat: add ego-up manual camera hook

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -429,8 +429,8 @@ knowledge, not every transient iteration detail.
   `hybrid_rule_v3_fast_progress_static_escape_continuous`, promotion-gate outcome, comparator
   deltas, remaining failure taxonomy, and artifact persistence boundary.
 * [Issue #1152 Manual-Control Mode Experiments](issue_1152_manual_control_modes.md)
-  records the first post-MVP steering-mode bundle, artifact-filterability contract, and fail-closed
-  `ego_up_view_v1` renderer-hook blocker.
+  records the first post-MVP steering-mode bundle, artifact-filterability contract, and issue #1604
+  `ego_up_view_v1` renderer-hook implementation proof.
 
 ## Manual Control Notes
 

--- a/docs/context/issue_1152_manual_control_modes.md
+++ b/docs/context/issue_1152_manual_control_modes.md
@@ -20,16 +20,17 @@ and `--robot-action-space` through `scripts/manual_control/validate_modes.py`. T
 interactive runners the same validated selector path without making the pure mapper tests depend on
 Pygame.
 
-## Ego-up blocker
+## Ego-up renderer hook
 
-`ego_up_view_v1` is registry-visible but intentionally fails closed. The stacked #1151 foundation
-contains pure mode, recording, replay, and export primitives, but it does not yet expose an
-interactive renderer camera-transform hook that can make a robot-centered, robot-up view executable.
+Issue #1604 removes the `ego_up_view_v1` fail-closed blocker by adding a renderer-facing camera
+hook to `SimulationView` and replay support through `LazySimulationView`. Manual-control sessions
+now configure the environment renderer with `set_manual_view_mode("ego_up")`, which centers the
+camera on the robot and rotates world coordinates so the robot heading points toward screen up.
 
-The current blocker text is stored in `robot_sf/manual_control/modes.py` and is surfaced through
-`ManualControlRuntimeConfig.from_strings(view_mode="ego_up")`. A later runner/rendering issue should
-replace the fail-closed state with an implemented `ManualViewModeSpec` only after the camera
-transform is exercised by a real or headless rendering smoke.
+The fixed-map path remains backward-compatible: renderers without a manual camera hook are allowed
+for `fixed_map`, and `SimulationView` falls back to the original scale-plus-offset transform when no
+ego-up camera center/rotation is active. `robot_static` remains intentionally fail-closed until a
+separate renderer mode is implemented.
 
 ## Validation path
 
@@ -39,6 +40,16 @@ Targeted proof for this issue should cover:
 - mode-registry and unsupported action-space validation,
 - session manifest and JSONL recording mode metadata,
 - CLI mode-selection smoke via `scripts/manual_control/validate_modes.py`.
+- for issue #1604 specifically: ego-up mode-registry support, unsupported-renderer fail-closed
+  behavior, `LazySimulationView` replay/forwarding, manual runner renderer wiring, and the
+  `SimulationView` transform that maps robot heading to screen up.
 
 Before PR handoff, run the targeted manual-control tests and then the repository PR readiness check
-against the stacked #1151 base.
+against the current `origin/main` base.
+
+Issue #1604 targeted validation on 2026-05-30:
+
+- `uv run pytest -q tests/test_manual_control_modes.py tests/test_manual_control_pygame_runner.py tests/test_lazy_pygame_init.py tests/visuals/test_sim_view_coverage_paths.py::test_sim_view_ego_up_camera_transform_centers_robot_and_rotates_heading tests/visuals/test_sim_view_coverage_paths.py::test_sim_view_default_camera_transform_keeps_existing_affine_scaling`
+  passed with `34 passed`.
+- `uv run ruff check robot_sf/manual_control robot_sf/render tests/test_manual_control_modes.py tests/test_manual_control_pygame_runner.py tests/test_lazy_pygame_init.py tests/visuals/test_sim_view_coverage_paths.py`
+  passed.

--- a/robot_sf/manual_control/modes.py
+++ b/robot_sf/manual_control/modes.py
@@ -70,11 +70,6 @@ VIEW_MODE_REGISTRY: dict[ManualViewMode, ManualViewModeSpec] = {
     ManualViewMode.EGO_UP: ManualViewModeSpec(
         mode=ManualViewMode.EGO_UP,
         overlay_label="Ego-up view: robot-centered camera with robot facing up",
-        implemented=False,
-        blocker=(
-            "ego_up_view_v1 requires an interactive renderer camera transform hook; "
-            "the current manual-control foundation exposes pure mode metadata only"
-        ),
     ),
     ManualViewMode.ROBOT_STATIC: ManualViewModeSpec(
         mode=ManualViewMode.ROBOT_STATIC,
@@ -186,3 +181,24 @@ def ensure_supported_mvp_mode(
         raise NotImplementedError(
             f"manual control mode is not implemented: {control_mode}"
         ) from exc
+
+
+def configure_manual_view_renderer(renderer: object, view_mode: str | ManualViewMode) -> None:
+    """Apply manual-view camera settings to a renderer, failing closed when unsupported."""
+    parsed = parse_manual_view_mode(view_mode)
+    view_spec = view_mode_spec(parsed)
+    if not view_spec.implemented:
+        blocker = f"; blocker: {view_spec.blocker}" if view_spec.blocker else ""
+        raise NotImplementedError(
+            f"manual view mode is not implemented: {view_spec.mode.value}{blocker}"
+        )
+    configure = getattr(renderer, "set_manual_view_mode", None)
+    if parsed == ManualViewMode.FIXED_MAP:
+        if callable(configure):
+            configure(parsed)
+        return
+    if not callable(configure):
+        raise NotImplementedError(
+            f"manual view mode requires a renderer camera transform hook: {parsed.value}"
+        )
+    configure(parsed)

--- a/robot_sf/manual_control/pygame_runner.py
+++ b/robot_sf/manual_control/pygame_runner.py
@@ -22,6 +22,7 @@ from robot_sf.manual_control.input_mapping import (
     mapper_for_manual_mode,
 )
 from robot_sf.manual_control.manifest import ManualSessionManifest, write_manual_session_manifest
+from robot_sf.manual_control.modes import configure_manual_view_renderer
 from robot_sf.manual_control.recording import (
     ManualControlRecord,
     ManualJsonlRecorder,
@@ -345,13 +346,17 @@ class ManualPygameRunner:
         Any
             Gymnasium-compatible Robot SF environment.
         """
-        return self.env_factory(
+        env = self.env_factory(
             seed=self.settings.seed,
             debug=self.settings.render,
             scenario_name=self.settings.scenario_id,
             algorithm_name="manual_control",
             recording_enabled=False,
         )
+        sim_ui = getattr(env, "sim_ui", None)
+        if sim_ui is not None:
+            configure_manual_view_renderer(sim_ui, runtime_config.view_mode)
+        return env
 
     def _build_baseline(self) -> PolicyBaseline:
         """Freeze the policy-to-beat metadata for this session.

--- a/robot_sf/render/lazy_sim_view.py
+++ b/robot_sf/render/lazy_sim_view.py
@@ -16,6 +16,7 @@ class LazySimulationView:
         """Store view construction arguments without importing pygame."""
         object.__setattr__(self, "_view_kwargs", dict(view_kwargs))
         object.__setattr__(self, "_pending_attrs", {})
+        object.__setattr__(self, "_pending_manual_view_mode", None)
         object.__setattr__(self, "_view", None)
         object.__setattr__(self, "record_video", bool(view_kwargs.get("record_video", False)))
         object.__setattr__(self, "video_path", view_kwargs.get("video_path"))
@@ -42,7 +43,11 @@ class LazySimulationView:
         view = sim_view_module.SimulationView(**self._view_kwargs)
         for name, value in self._pending_attrs.items():
             setattr(view, name, value)
+        pending_manual_view_mode = self._pending_manual_view_mode
+        if pending_manual_view_mode is not None:
+            view.set_manual_view_mode(pending_manual_view_mode)
         object.__setattr__(self, "_pending_attrs", {})
+        object.__setattr__(self, "_pending_manual_view_mode", None)
         object.__setattr__(self, "_view", view)
         return view
 
@@ -94,6 +99,14 @@ class LazySimulationView:
             Any: Result returned by ``SimulationView.render``.
         """
         return self._ensure_view().render(*args, **kwargs)
+
+    def set_manual_view_mode(self, view_mode: Any) -> None:
+        """Store or forward manual-control camera mode selection."""
+        view = self._view
+        if view is None:
+            object.__setattr__(self, "_pending_manual_view_mode", view_mode)
+            return
+        view.set_manual_view_mode(view_mode)
 
     def exit_simulation(self, *args: Any, **kwargs: Any) -> Any:
         """Close the materialized view, or no-op if rendering never started.

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from dataclasses import dataclass, field
-from math import cos, sin
+from math import cos, pi, sin
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
@@ -171,6 +171,7 @@ class SimulationView:
     caption: str = "RobotSF Simulation"
     focus_on_robot: bool = True
     focus_on_ego_ped: bool = False
+    manual_view_mode: str = "fixed_map"
     record_video: bool = False
     video_path: str | None = None
     video_fps: float | None = None
@@ -232,6 +233,8 @@ class SimulationView:
     _ped_last_directions: list[tuple[float, float]] = field(init=False, default_factory=list)
     _prev_robot_pose_xy: tuple[float, float] | None = field(init=False, default=None)
     _prev_robot_speed_vec: np.ndarray | None = field(init=False, default=None)
+    _camera_center_world: tuple[float, float] | None = field(init=False, default=None)
+    _camera_rotation_rad: float | None = field(init=False, default=None)
     # Telemetry pane state
     show_telemetry_panel: bool = field(default=False)
     telemetry_session: object | None = field(default=None)
@@ -581,9 +584,27 @@ class SimulationView:
         Returns:
             tuple[float, float]: Scaled and offset-adjusted (x, y) coordinates.
         """
+        if self._camera_center_world is not None and self._camera_rotation_rad is not None:
+            dx = float(tup[0]) - self._camera_center_world[0]
+            dy = float(tup[1]) - self._camera_center_world[1]
+            rotation_cos = cos(self._camera_rotation_rad)
+            rotation_sin = sin(self._camera_rotation_rad)
+            x = (dx * rotation_cos - dy * rotation_sin) * self.scaling + self.width / 2
+            y = (dx * rotation_sin + dy * rotation_cos) * self.scaling + self.height / 2
+            return (x, y)
         x = tup[0] * self.scaling + self.offset[0]
         y = tup[1] * self.scaling + self.offset[1]
         return (x, y)
+
+    def set_manual_view_mode(self, view_mode: object) -> None:
+        """Configure the renderer camera mode used by manual-control sessions."""
+        normalized = str(getattr(view_mode, "value", view_mode))
+        if normalized not in {"fixed_map", "ego_up"}:
+            raise NotImplementedError(f"manual view mode is not implemented: {normalized}")
+        self.manual_view_mode = normalized
+        if normalized == "fixed_map":
+            self._camera_center_world = None
+            self._camera_rotation_rad = None
 
     def exit_simulation(self, return_frames: bool = False):
         """Exit the simulation.
@@ -734,6 +755,15 @@ class SimulationView:
 
     def _move_camera(self, state: VisualizableSimState):
         """Moves the camera based on the focused object."""
+        self._camera_center_world = None
+        self._camera_rotation_rad = None
+        if self.manual_view_mode == "ego_up":
+            (r_x, r_y), theta = state.robot_pose
+            self._camera_center_world = (float(r_x), float(r_y))
+            self._camera_rotation_rad = -pi / 2.0 - float(theta)
+            self.offset[0] = self.width / 2 - float(r_x) * self.scaling
+            self.offset[1] = self.height / 2 - float(r_y) * self.scaling
+            return
         if self.focus_on_robot:
             r_x, r_y = state.robot_pose[0]
             self.offset[0] = int(r_x * self.scaling - self.width / 2) * -1

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -590,8 +590,12 @@ class SimulationView:
         if self._camera_center_world is not None and self._camera_rotation_rad is not None:
             dx = float(tup[0]) - self._camera_center_world[0]
             dy = float(tup[1]) - self._camera_center_world[1]
-            x = (dx * self._camera_rotation_cos - dy * self._camera_rotation_sin) * self.scaling + self.width / 2
-            y = (dx * self._camera_rotation_sin + dy * self._camera_rotation_cos) * self.scaling + self.height / 2
+            x = (
+                dx * self._camera_rotation_cos - dy * self._camera_rotation_sin
+            ) * self.scaling + self.width / 2
+            y = (
+                dx * self._camera_rotation_sin + dy * self._camera_rotation_cos
+            ) * self.scaling + self.height / 2
             return (x, y)
         x = tup[0] * self.scaling + self.offset[0]
         y = tup[1] * self.scaling + self.offset[1]

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -235,6 +235,9 @@ class SimulationView:
     _prev_robot_speed_vec: np.ndarray | None = field(init=False, default=None)
     _camera_center_world: tuple[float, float] | None = field(init=False, default=None)
     _camera_rotation_rad: float | None = field(init=False, default=None)
+    _camera_rotation_cos: float | None = field(init=False, default=None)
+    _camera_rotation_sin: float | None = field(init=False, default=None)
+    _prev_offset_for_ego_up: tuple[float, float] | None = field(init=False, default=None)
     # Telemetry pane state
     show_telemetry_panel: bool = field(default=False)
     telemetry_session: object | None = field(default=None)
@@ -587,10 +590,8 @@ class SimulationView:
         if self._camera_center_world is not None and self._camera_rotation_rad is not None:
             dx = float(tup[0]) - self._camera_center_world[0]
             dy = float(tup[1]) - self._camera_center_world[1]
-            rotation_cos = cos(self._camera_rotation_rad)
-            rotation_sin = sin(self._camera_rotation_rad)
-            x = (dx * rotation_cos - dy * rotation_sin) * self.scaling + self.width / 2
-            y = (dx * rotation_sin + dy * rotation_cos) * self.scaling + self.height / 2
+            x = (dx * self._camera_rotation_cos - dy * self._camera_rotation_sin) * self.scaling + self.width / 2
+            y = (dx * self._camera_rotation_sin + dy * self._camera_rotation_cos) * self.scaling + self.height / 2
             return (x, y)
         x = tup[0] * self.scaling + self.offset[0]
         y = tup[1] * self.scaling + self.offset[1]
@@ -601,10 +602,20 @@ class SimulationView:
         normalized = str(getattr(view_mode, "value", view_mode))
         if normalized not in {"fixed_map", "ego_up"}:
             raise NotImplementedError(f"manual view mode is not implemented: {normalized}")
+        if normalized == "ego_up":
+            self._prev_offset_for_ego_up = (float(self.offset[0]), float(self.offset[1]))
+            self.manual_view_mode = normalized
+            return
+        # fixed_map restores any previously saved pan offset.
         self.manual_view_mode = normalized
-        if normalized == "fixed_map":
-            self._camera_center_world = None
-            self._camera_rotation_rad = None
+        self._camera_center_world = None
+        self._camera_rotation_rad = None
+        self._camera_rotation_cos = None
+        self._camera_rotation_sin = None
+        if self._prev_offset_for_ego_up is not None:
+            self.offset[0] = self._prev_offset_for_ego_up[0]
+            self.offset[1] = self._prev_offset_for_ego_up[1]
+            self._prev_offset_for_ego_up = None
 
     def exit_simulation(self, return_frames: bool = False):
         """Exit the simulation.
@@ -757,12 +768,14 @@ class SimulationView:
         """Moves the camera based on the focused object."""
         self._camera_center_world = None
         self._camera_rotation_rad = None
+        self._camera_rotation_cos = None
+        self._camera_rotation_sin = None
         if self.manual_view_mode == "ego_up":
             (r_x, r_y), theta = state.robot_pose
             self._camera_center_world = (float(r_x), float(r_y))
             self._camera_rotation_rad = -pi / 2.0 - float(theta)
-            self.offset[0] = self.width / 2 - float(r_x) * self.scaling
-            self.offset[1] = self.height / 2 - float(r_y) * self.scaling
+            self._camera_rotation_cos = cos(self._camera_rotation_rad)
+            self._camera_rotation_sin = sin(self._camera_rotation_rad)
             return
         if self.focus_on_robot:
             r_x, r_y = state.robot_pose[0]
@@ -1685,6 +1698,8 @@ class SimulationView:
         :param grid_increment: The increment of the grid in pixels.
         :param grid_color: The color of the grid lines.
         """
+        if self.manual_view_mode == "ego_up":
+            return
         scaled_grid_size = grid_increment * self.scaling
         font = pygame.font.Font(None, 24)
         # draw the vertical lines

--- a/tests/test_lazy_pygame_init.py
+++ b/tests/test_lazy_pygame_init.py
@@ -85,7 +85,11 @@ def test_lazy_simulation_view_replays_pending_attributes(monkeypatch) -> None:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self.render_calls = []
+            self.manual_view_modes = []
             created["view"] = self
+
+        def set_manual_view_mode(self, view_mode):
+            self.manual_view_modes.append(view_mode)
 
         def render(self, *args, **kwargs):
             self.render_calls.append((args, kwargs))
@@ -99,6 +103,7 @@ def test_lazy_simulation_view_replays_pending_attributes(monkeypatch) -> None:
 
     view = LazySimulationView(record_video=True, width=320, height=200)
     view.observation_space_mode = "grid"
+    view.set_manual_view_mode("ego_up")
 
     assert bool(view)
     assert view.materialized is False
@@ -109,6 +114,7 @@ def test_lazy_simulation_view_replays_pending_attributes(monkeypatch) -> None:
     materialized = created["view"]
     assert materialized.kwargs["width"] == 320
     assert materialized.observation_space_mode == "grid"
+    assert materialized.manual_view_modes == ["ego_up"]
     assert materialized.render_calls == [(("state",), {"target_fps": 12})]
 
 
@@ -148,6 +154,36 @@ def test_lazy_simulation_view_propagates_tracked_attribute_mutations(monkeypatch
     view.height = 480
 
     assert materialized.height == 480
+
+
+def test_lazy_simulation_view_forwards_manual_view_mode_after_materialization(monkeypatch) -> None:
+    """Manual view mode changes should forward to an already materialized SimulationView."""
+    from robot_sf.render.lazy_sim_view import LazySimulationView
+
+    created = {}
+
+    class FakeSimulationView:
+        def __init__(self, **_kwargs):
+            self.manual_view_modes = []
+            created["view"] = self
+
+        def set_manual_view_mode(self, view_mode):
+            self.manual_view_modes.append(view_mode)
+
+        def render(self):
+            return "rendered"
+
+    def fake_import_module(name: str):
+        assert name == "robot_sf.render.sim_view"
+        return SimpleNamespace(SimulationView=FakeSimulationView)
+
+    monkeypatch.setattr("robot_sf.render.lazy_sim_view.importlib.import_module", fake_import_module)
+
+    view = LazySimulationView(record_video=False)
+    assert view.render() == "rendered"
+    view.set_manual_view_mode("ego_up")
+
+    assert created["view"].manual_view_modes == ["ego_up"]
 
 
 def test_pysocialforce_visualization_export_remains_available() -> None:

--- a/tests/test_manual_control_config.py
+++ b/tests/test_manual_control_config.py
@@ -26,11 +26,22 @@ def test_runtime_config_records_mode_versions_and_overlay_labels():
 
 def test_runtime_config_rejects_unsupported_view_mode():
     """Unsupported view modes should fail closed before a runner starts."""
-    with pytest.raises(NotImplementedError, match="ego_up"):
+    with pytest.raises(NotImplementedError, match="robot_static"):
         ManualControlRuntimeConfig.from_strings(
             control_mode="keyboard_cruise",
-            view_mode="ego_up",
+            view_mode="robot_static",
         )
+
+
+def test_runtime_config_accepts_ego_up_view_mode():
+    """Ego-up is selectable now that the renderer exposes a camera transform hook."""
+    config = ManualControlRuntimeConfig.from_strings(
+        control_mode="keyboard_cruise",
+        view_mode="ego_up",
+    )
+
+    assert config.view_mode == "ego_up"
+    assert "robot-centered" in config.overlay_metadata()["view_overlay_label"]
 
 
 def test_validate_modes_cli_prints_selected_mode_metadata():

--- a/tests/test_manual_control_modes.py
+++ b/tests/test_manual_control_modes.py
@@ -6,6 +6,7 @@ from robot_sf.manual_control.modes import (
     CONTROL_MODE_REGISTRY,
     ManualControlMode,
     ManualViewMode,
+    configure_manual_view_renderer,
     control_mode_for_input_mapping_version,
     ensure_supported_manual_mode,
     ensure_supported_mvp_mode,
@@ -31,12 +32,12 @@ def test_ensure_supported_mvp_mode_rejects_unimplemented_control_mode():
         )
 
 
-def test_ensure_supported_mvp_mode_rejects_unimplemented_view_mode():
+def test_ensure_supported_mvp_mode_rejects_robot_static_until_camera_hook_exists():
     """Stretch view modes should fail closed until implemented."""
-    with pytest.raises(NotImplementedError, match="ego_up"):
+    with pytest.raises(NotImplementedError, match="robot_static"):
         ensure_supported_mvp_mode(
             control_mode=ManualControlMode.KEYBOARD_HOLD,
-            view_mode=ManualViewMode.EGO_UP,
+            view_mode=ManualViewMode.ROBOT_STATIC,
         )
 
 
@@ -61,17 +62,42 @@ def test_input_mapping_versions_resolve_back_to_control_modes() -> None:
         control_mode_for_input_mapping_version("joystick_arcade_v1")
 
 
-def test_ego_up_view_fails_closed_with_documented_blocker():
-    """Ego-up should be explicit but blocked until the renderer exposes camera hooks."""
+def test_ego_up_view_is_supported_by_mode_registry():
+    """Ego-up should be selectable now that the renderer exposes camera hooks."""
     spec = view_mode_spec(ManualViewMode.EGO_UP)
 
-    assert spec.implemented is False
-    assert "renderer camera transform hook" in str(spec.blocker)
-    with pytest.raises(NotImplementedError, match="renderer camera transform hook"):
-        ensure_supported_manual_mode(
-            control_mode=ManualControlMode.KEYBOARD_CRUISE,
-            view_mode=ManualViewMode.EGO_UP,
-        )
+    assert spec.implemented is True
+    assert spec.blocker is None
+    ensure_supported_manual_mode(
+        control_mode=ManualControlMode.KEYBOARD_CRUISE,
+        view_mode=ManualViewMode.EGO_UP,
+    )
+
+
+def test_ego_up_renderer_adapter_requires_camera_transform_hook():
+    """Ego-up should still fail closed when a renderer cannot apply the camera transform."""
+    with pytest.raises(NotImplementedError, match="camera transform hook"):
+        configure_manual_view_renderer(object(), ManualViewMode.EGO_UP)
+
+
+def test_fixed_map_renderer_adapter_allows_renderers_without_camera_hook():
+    """Fixed-map remains compatible with renderers that have no manual camera hook."""
+    configure_manual_view_renderer(object(), ManualViewMode.FIXED_MAP)
+
+
+def test_ego_up_renderer_adapter_configures_supported_renderer():
+    """Supported renderers receive the selected manual view mode."""
+
+    class _Renderer:
+        configured_mode = None
+
+        def set_manual_view_mode(self, mode):
+            self.configured_mode = mode
+
+    renderer = _Renderer()
+    configure_manual_view_renderer(renderer, ManualViewMode.EGO_UP)
+
+    assert renderer.configured_mode == ManualViewMode.EGO_UP
 
 
 def test_ensure_supported_mvp_mode_accepts_supported_string_inputs():

--- a/tests/test_manual_control_pygame_runner.py
+++ b/tests/test_manual_control_pygame_runner.py
@@ -78,6 +78,19 @@ class _FakeEnv:
         self.exit_count += 1
 
 
+class _FakeManualView:
+    """Renderer test double that records manual view mode configuration."""
+
+    def __init__(self) -> None:
+        self.configured_mode = None
+        self.font = _FakeFont()
+        self.screen = _FakeScreen()
+        self._use_display = False
+
+    def set_manual_view_mode(self, mode) -> None:
+        self.configured_mode = mode
+
+
 class _FakeKey:
     @staticmethod
     def name(key) -> str:
@@ -258,6 +271,34 @@ def test_pygame_runner_countdown_render_overlay_and_keyup(tmp_path):
     assert screen.blits
     assert _FakeDisplay.updates >= 1
     assert _FakeClock.ticks
+
+
+def test_pygame_runner_configures_ego_up_renderer_view(tmp_path):
+    """Ego-up sessions should configure the env renderer before rendering."""
+    _FakeClock.ticks.clear()
+    sim_ui = _FakeManualView()
+    env = _FakeEnv(terminal_after=1, success=True, sim_ui=sim_ui)
+    settings = ManualPygameRunnerSettings(
+        scenario_id="scenario-ego-up",
+        seed=16,
+        policy_to_beat="policy-ego-up",
+        policy_to_beat_source="explicit-test",
+        output_dir=tmp_path,
+        session_id="session-ego-up",
+        countdown_steps=0,
+        max_steps=1,
+        render=True,
+        view_mode="ego_up",
+    )
+
+    ManualPygameRunner(
+        settings,
+        env_factory=lambda **_kwargs: env,
+        pygame_module=_OverlayPygame,
+        event_source=lambda: [],
+    ).run()
+
+    assert sim_ui.configured_mode == "ego_up"
     assert all(target_fps == settings.target_fps for target_fps in _FakeClock.ticks)
 
 

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -377,6 +377,25 @@ def test_sim_view_sprite_helpers_and_camera(monkeypatch, tmp_path) -> None:
     view.clear()
 
 
+def test_sim_view_ego_up_camera_transform_centers_robot_and_rotates_heading() -> None:
+    """Ego-up camera mode keeps the robot centered with its heading toward screen up."""
+    view = SimulationView(record_video=False, width=100, height=80, scaling=10)
+    view.set_manual_view_mode("ego_up")
+    view._move_camera(SimpleNamespace(robot_pose=((2.0, 3.0), 0.0)))
+
+    assert view._scale_tuple((2.0, 3.0)) == pytest.approx((50.0, 40.0))
+    assert view._scale_tuple((3.0, 3.0)) == pytest.approx((50.0, 30.0))
+
+
+def test_sim_view_default_camera_transform_keeps_existing_affine_scaling() -> None:
+    """The default camera path should preserve the existing scale-plus-offset transform."""
+    view = SimulationView(record_video=False, width=100, height=80, scaling=10)
+    view.focus_on_robot = False
+    view.offset[:] = (5, 7)
+
+    assert view._scale_tuple((2.0, 3.0)) == pytest.approx((25.0, 37.0))
+
+
 def test_robot_action_uses_speed_times_horizon_without_extra_scaling(monkeypatch) -> None:
     """Robot speed vector should use distance = speed * horizon (meters), then one screen scaling."""
     view = SimulationView(

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pygame
@@ -602,3 +603,72 @@ def test_sim_view_exit_and_telemetry_paths(monkeypatch) -> None:
     view._augment_lidar(None)
     view._augment_lidar(np.empty((0, 2, 2), dtype=np.float32))
     view._augment_lidar(5)  # type: ignore[arg-type]
+
+
+def test_sim_view_ego_up_caches_rotation_trig() -> None:
+    """Ego-up mode should cache rotation cosine/sine and clear them on fixed_map."""
+    view = SimulationView(record_video=False, width=100, height=80, scaling=10)
+    view.offset[:] = (4.0, 6.0)
+    view.set_manual_view_mode("ego_up")
+    view._move_camera(SimpleNamespace(robot_pose=((2.0, 3.0), 0.25)))
+
+    assert view._camera_center_world == pytest.approx((2.0, 3.0))
+    assert view._camera_rotation_rad == pytest.approx(-(np.pi / 2.0) - 0.25)
+    assert view._camera_rotation_cos == pytest.approx(np.cos(view._camera_rotation_rad))
+    assert view._camera_rotation_sin == pytest.approx(np.sin(view._camera_rotation_rad))
+    assert view._scale_tuple((2.0, 3.0)) == pytest.approx((50.0, 40.0))
+    assert view._scale_tuple((3.0, 3.0)) == pytest.approx(
+        (
+            view._camera_rotation_cos * 10.0 + 50.0,
+            view._camera_rotation_sin * 10.0 + 40.0,
+        )
+    )
+
+    view.set_manual_view_mode("fixed_map")
+    assert view._camera_center_world is None
+    assert view._camera_rotation_rad is None
+    assert view._camera_rotation_cos is None
+    assert view._camera_rotation_sin is None
+
+
+def test_sim_view_ego_up_preserves_manual_offset_on_mode_switch() -> None:
+    """Switching to ego_up should save the manual offset, and fixed_map should restore it."""
+    view = SimulationView(record_video=False, width=100, height=80, scaling=10)
+    view.offset[:] = (12.0, 18.0)
+
+    view.set_manual_view_mode("ego_up")
+    assert view._prev_offset_for_ego_up == pytest.approx((12.0, 18.0))
+    view._move_camera(SimpleNamespace(robot_pose=((2.0, 3.0), 0.0)))
+    # In ego_up mode, world_to-screen ignores offset; the saved offset must not leak through.
+    assert view._scale_tuple((2.0, 3.0)) == pytest.approx((50.0, 40.0))
+
+    view.set_manual_view_mode("fixed_map")
+    assert view._prev_offset_for_ego_up is None
+    assert view.offset[0] == pytest.approx(12.0)
+    assert view.offset[1] == pytest.approx(18.0)
+
+
+def test_sim_view_ego_up_skips_grid(monkeypatch) -> None:
+    """Background grid drawing should be disabled while ego_up camera rotation is active."""
+    view = SimulationView(
+        record_video=False, width=100, height=80, scaling=10, map_def=_map_def_with_routes_and_obstacles()
+    )
+    view.set_manual_view_mode("ego_up")
+
+    class DummyScreen:
+        """Record line-draw calls."""
+
+        def __init__(self) -> None:
+            self.blit_calls: list[tuple[Any, tuple[float, float]]] = []
+
+        def blit(self, source, dest, area=None):
+            self.blit_calls.append((source, dest))
+
+        def fill(self, color):
+            pass
+
+    dummy_screen = DummyScreen()
+    monkeypatch.setattr(view, "screen", dummy_screen)
+    monkeypatch.setattr(view, "offset", np.array([0.0, 0.0]))
+    view._draw_grid(grid_increment=10)
+    assert not dummy_screen.blit_calls

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -651,7 +651,11 @@ def test_sim_view_ego_up_preserves_manual_offset_on_mode_switch() -> None:
 def test_sim_view_ego_up_skips_grid(monkeypatch) -> None:
     """Background grid drawing should be disabled while ego_up camera rotation is active."""
     view = SimulationView(
-        record_video=False, width=100, height=80, scaling=10, map_def=_map_def_with_routes_and_obstacles()
+        record_video=False,
+        width=100,
+        height=80,
+        scaling=10,
+        map_def=_map_def_with_routes_and_obstacles(),
     )
     view.set_manual_view_mode("ego_up")
 


### PR DESCRIPTION
## Summary
- enable the manual-control `ego_up` view mode now that `SimulationView` exposes a renderer camera hook
- add `SimulationView.set_manual_view_mode()` with robot-centered, heading-up coordinate rotation plus lazy-view replay/forwarding
- wire manual Pygame sessions to configure the renderer and update manual-control mode/context docs

Fixes #1604

## Validation
- `git fetch origin main && git merge origin/main` -> already up to date
- `uv run pytest -q tests/test_manual_control_config.py tests/test_manual_control_modes.py tests/test_manual_control_pygame_runner.py tests/test_lazy_pygame_init.py tests/visuals/test_sim_view_coverage_paths.py::test_sim_view_ego_up_camera_transform_centers_robot_and_rotates_heading tests/visuals/test_sim_view_coverage_paths.py::test_sim_view_default_camera_transform_keeps_existing_affine_scaling` -> 38 passed
- `uv run ruff check robot_sf/manual_control robot_sf/render tests/test_manual_control_config.py tests/test_manual_control_modes.py tests/test_manual_control_pygame_runner.py tests/test_lazy_pygame_init.py tests/visuals/test_sim_view_coverage_paths.py` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check` -> passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4447 passed, 11 skipped, 8 warnings

## Notes
- Ignored `output/coverage/*` and `output/validation/pr_ready/issue-1604-ego-up-camera.json` were generated by local validation and are disposable worktree-local artifacts.
- Qwen `Step-3.7-Flash` and OpenCode Go `opencode-go/deepseek-v4-pro` completed read-only sidecar reviews with no blockers; Gemini auto hit model capacity (`429`), and Qwen `Qwen3.6-27B` was cancelled after hanging without useful output.
