### PR TITLE
test: add dummy learned-policy adapter fixture

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -140,6 +140,8 @@ knowledge, not every transient iteration detail.
   [issue_1613_lidar_observation_track.md](issue_1613_lidar_observation_track.md)
 * Issue #1614 LiDAR Planner Compatibility Audit (2026-05-29):
   [issue_1614_lidar_planner_compatibility.md](issue_1614_lidar_planner_compatibility.md)
+* Issue #1685 dummy learned-policy adapter fixture:
+  [issue_1685_dummy_learned_policy_adapter.md](issue_1685_dummy_learned_policy_adapter.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)
 * Issue #1255 open-issue dependency graph:

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -140,7 +140,7 @@ knowledge, not every transient iteration detail.
   [issue_1613_lidar_observation_track.md](issue_1613_lidar_observation_track.md)
 * Issue #1614 LiDAR Planner Compatibility Audit (2026-05-29):
   [issue_1614_lidar_planner_compatibility.md](issue_1614_lidar_planner_compatibility.md)
-* Issue #1685 dummy learned-policy adapter fixture:
+* Issue #1685 dummy learned-policy adapter fixture (2026-05-30):
   [issue_1685_dummy_learned_policy_adapter.md](issue_1685_dummy_learned_policy_adapter.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)

--- a/docs/context/issue_1685_dummy_learned_policy_adapter.md
+++ b/docs/context/issue_1685_dummy_learned_policy_adapter.md
@@ -51,7 +51,7 @@ Green state:
 uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py
 ```
 
-Result: `8 passed`.
+Result: `9 passed`.
 
 The focused test also calls
 `scripts.validation.check_learned_policy_eligibility.validate_learned_policy_eligibility()` on the

--- a/docs/context/issue_1685_dummy_learned_policy_adapter.md
+++ b/docs/context/issue_1685_dummy_learned_policy_adapter.md
@@ -1,0 +1,65 @@
+# Issue #1685 Dummy Learned-Policy Adapter Fixture
+
+Date: 2026-05-30
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1685>
+
+## Goal
+
+Issue #1685 adds a deterministic learned local-policy adapter fixture that exercises the Robot SF
+learned-policy boundary without loading a checkpoint, running training, or claiming benchmark
+performance.
+
+## Adapter Boundary
+
+- Adapter path: `robot_sf/planner/learned_policy_adapter.py`
+- Fixture: `DummyLearnedLocalPolicyAdapter`
+- Observation level: `lidar_2d`
+- Planner observation mode: `sensor_fusion_state`
+- Required deployment inputs: `drive_state` and `rays`
+- Action command space: `unicycle_vw`
+- Deterministic action: `{"v": 0.25, "omega": 0.0}`
+
+The fixture metadata includes checklist-style `observation_t`, observation field classifications,
+split/provenance fields, action contract fields, and per-step logging fields. The
+`claim_boundary` is `adapter_fixture_only_not_benchmark_evidence`, and `candidate_registry` keeps
+`entry_planned: false`.
+
+The fixture also exposes planner-protocol lifecycle hooks (`step`, `reset`, `configure`, and
+`close`) so adapter-boundary smoke tests can use it without pretending it is a promoted benchmark
+candidate.
+
+## Fail-Closed Behavior
+
+The adapter raises `LearnedPolicyAdapterContractError` before action emission when a request uses
+an unsupported observation level, unsupported action command space, missing required observation
+keys, or known forbidden evaluation-time keys such as `future_states`.
+
+## Validation
+
+Red state:
+
+```bash
+uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py
+```
+
+Result: collection failed because `robot_sf.planner.learned_policy_adapter` did not exist.
+
+Green state:
+
+```bash
+uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py
+```
+
+Result: `8 passed`.
+
+The focused test also calls
+`scripts.validation.check_learned_policy_eligibility.validate_learned_policy_eligibility()` on the
+adapter metadata and expects no checklist issues.
+
+## Follow-Up Boundary
+
+This fixture is not a model registry entry, durable checkpoint, training proof, benchmark claim, or
+learned-policy performance result. Future real learned adapters still need checkpoint provenance,
+runtime smoke evidence, artifact promotion decisions, and benchmark-specific validation before any
+candidate registry or paper-facing claim.

--- a/robot_sf/planner/learned_policy_adapter.py
+++ b/robot_sf/planner/learned_policy_adapter.py
@@ -32,6 +32,9 @@ class LearnedPolicyStepResult:
     action_bounds: dict[str, list[float]]
     action_projection_metadata: dict[str, Any]
 
+    _ACTION_BOUND_LOWER = 0
+    _ACTION_BOUND_UPPER = 1
+
     def to_metadata(self) -> dict[str, Any]:
         """Return a JSON-serializable diagnostic payload for this decision step."""
         return {
@@ -44,7 +47,10 @@ class LearnedPolicyStepResult:
             "observation_level": self.observation_level,
             "planner_observation_mode": self.planner_observation_mode,
             "action_bounds": {
-                key: [float(bounds[0]), float(bounds[1])]
+                key: [
+                    float(bounds[self._ACTION_BOUND_LOWER]),
+                    float(bounds[self._ACTION_BOUND_UPPER]),
+                ]
                 for key, bounds in self.action_bounds.items()
             },
             "action_projection_metadata": dict(self.action_projection_metadata),
@@ -75,6 +81,8 @@ class DummyLearnedLocalPolicyAdapter:
     )
     _action = {"v": 0.25, "omega": 0.0}
     _action_bounds = {"v": [0.0, 0.5], "omega": [-0.5, 0.5]}
+    _ACTION_BOUND_LOWER = 0
+    _ACTION_BOUND_UPPER = 1
 
     def metadata(self) -> dict[str, Any]:
         """Return checklist-style metadata for the dummy adapter fixture."""
@@ -171,7 +179,10 @@ class DummyLearnedLocalPolicyAdapter:
             observation_level=self.observation_level,
             planner_observation_mode=self.planner_observation_mode,
             action_bounds={
-                key: [float(bounds[0]), float(bounds[1])]
+                key: [
+                    float(bounds[self._ACTION_BOUND_LOWER]),
+                    float(bounds[self._ACTION_BOUND_UPPER]),
+                ]
                 for key, bounds in self._action_bounds.items()
             },
             action_projection_metadata={
@@ -222,6 +233,10 @@ class DummyLearnedLocalPolicyAdapter:
                 f"'{action_command_space}'; expected '{self.action_command_space}'"
             )
 
+        if observation is None:
+            raise LearnedPolicyAdapterContractError(
+                "observation must not be None"
+            )
         missing = [key for key in self._required_observation_inputs if key not in observation]
         if missing:
             raise LearnedPolicyAdapterContractError(

--- a/robot_sf/planner/learned_policy_adapter.py
+++ b/robot_sf/planner/learned_policy_adapter.py
@@ -1,0 +1,241 @@
+"""Learned local-policy adapter fixtures for contract-level tests.
+
+The dummy adapter in this module exists to exercise the Robot SF learned-policy
+boundary without loading a checkpoint or making a benchmark claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class LearnedPolicyAdapterContractError(ValueError):
+    """Raised when a learned-policy adapter request violates its declared contract."""
+
+
+@dataclass(frozen=True)
+class LearnedPolicyStepResult:
+    """Per-step learned-policy action and logging payload."""
+
+    action: dict[str, float]
+    raw_model_action: dict[str, float]
+    adapted_action: dict[str, float]
+    post_guard_action: dict[str, float]
+    guard_applied: bool
+    guard_or_fallback_reason: str
+    observation_level: str
+    planner_observation_mode: str
+    action_bounds: dict[str, list[float]]
+    action_projection_metadata: dict[str, Any]
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable diagnostic payload for this decision step."""
+        return {
+            "action": dict(self.action),
+            "raw_model_action": dict(self.raw_model_action),
+            "adapted_action": dict(self.adapted_action),
+            "post_guard_action": dict(self.post_guard_action),
+            "guard_applied": self.guard_applied,
+            "guard_or_fallback_reason": self.guard_or_fallback_reason,
+            "observation_level": self.observation_level,
+            "planner_observation_mode": self.planner_observation_mode,
+            "action_bounds": {
+                key: [float(bounds[0]), float(bounds[1])]
+                for key, bounds in self.action_bounds.items()
+            },
+            "action_projection_metadata": dict(self.action_projection_metadata),
+        }
+
+
+class DummyLearnedLocalPolicyAdapter:
+    """Deterministic learned-policy adapter fixture with an explicit contract.
+
+    This class intentionally does not load a model. It mirrors the observation,
+    action, and logging gates used by real learned local policies so tests can
+    exercise adapter plumbing without introducing checkpoint or training
+    provenance.
+    """
+
+    policy_id = "dummy_learned_local_policy_adapter"
+    claim_boundary = "adapter_fixture_only_not_benchmark_evidence"
+    observation_level = "lidar_2d"
+    planner_observation_mode = "sensor_fusion_state"
+    action_command_space = "unicycle_vw"
+    _required_observation_inputs = ("drive_state", "rays")
+    _forbidden_observation_inputs = (
+        "future_states",
+        "future_trajectory",
+        "future_collision_label",
+        "simulator_outcome",
+        "termination_reason",
+    )
+    _action = {"v": 0.25, "omega": 0.0}
+    _action_bounds = {"v": [0.0, 0.5], "omega": [-0.5, 0.5]}
+
+    def metadata(self) -> dict[str, Any]:
+        """Return checklist-style metadata for the dummy adapter fixture."""
+        return {
+            "policy_id": self.policy_id,
+            "claim_boundary": self.claim_boundary,
+            "verdict": "eligible_for_adapter",
+            "observation_t": "decision step t before action selection",
+            "observation_contract": {
+                "observation_level": self.observation_level,
+                "planner_observation_mode": self.planner_observation_mode,
+                "required_inputs": list(self._required_observation_inputs),
+                "deployment_observable": ["drive_state", "rays"],
+                "training_only": [],
+                "rejected_evaluation_time_inputs": list(self._forbidden_observation_inputs),
+                "normalization": "raw_fixture_values",
+            },
+            "observation_fields": {
+                "deployment_observable": ["drive_state", "rays"],
+                "training_only": [],
+                "forbidden_evaluation_time": [],
+            },
+            "split_provenance": {
+                "training_data_source": "none_dummy_fixture",
+                "validation_split": "not_applicable",
+                "test_split": "not_applicable",
+                "checkpoint_or_model_provenance": "none_no_checkpoint_loaded",
+                "privileged_training_inputs": "none",
+                "privileged_training_inputs_enter_evaluation": False,
+                "normalization_statistics": "none",
+                "normalization_statistics_fit_on_training_only": True,
+                "evidence_source": "Robot SF adapter boundary unit test",
+            },
+            "action_contract": {
+                "output_family": "velocity_command",
+                "command_space": self.action_command_space,
+                "output_keys": ["v", "omega"],
+                "frame": "robot",
+                "units": "m/s and rad/s",
+                "bounds": dict(self._action_bounds),
+                "kinematics_compatibility": "differential-drive unicycle_vw fixture",
+                "projection_policy": "none",
+                "raw_to_robot_sf_action": "copy deterministic fixture command",
+                "guard_or_projection_policy": "no guard; post_guard_action equals adapted_action",
+            },
+            "per_step_logging": {
+                "raw_model_action": "direct deterministic fixture output",
+                "adapted_action": "Robot SF action dictionary after adapter conversion",
+                "post_guard_action": "final emitted action; equal to adapted_action for fixture",
+                "guard_applied": "boolean flag",
+                "guard_or_fallback_reason": "stable string; none for fixture",
+                "observation_level": self.observation_level,
+                "planner_observation_mode": self.planner_observation_mode,
+                "action_bounds": dict(self._action_bounds),
+                "action_projection_metadata": "projection status and policy metadata",
+            },
+            "candidate_registry": {
+                "entry_planned": False,
+                "adapter_path": "robot_sf/planner/learned_policy_adapter.py",
+                "smoke_or_validation_command": (
+                    "uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py"
+                ),
+                "missing_checkpoint_policy": "not_applicable_no_checkpoint",
+                "unsupported_observation_policy": "fail closed before action emission",
+                "guard_activation_policy": "not_applicable_no_guard",
+            },
+        }
+
+    def predict(
+        self,
+        observation: Mapping[str, Any],
+        *,
+        observation_level: str | None = None,
+        action_command_space: str | None = None,
+    ) -> LearnedPolicyStepResult:
+        """Return the deterministic fixture action after contract validation."""
+        self._validate_request(
+            observation,
+            observation_level=(
+                self.observation_level if observation_level is None else observation_level
+            ),
+            action_command_space=(
+                self.action_command_space if action_command_space is None else action_command_space
+            ),
+        )
+        action = dict(self._action)
+        return LearnedPolicyStepResult(
+            action=action,
+            raw_model_action=dict(action),
+            adapted_action=dict(action),
+            post_guard_action=dict(action),
+            guard_applied=False,
+            guard_or_fallback_reason="none",
+            observation_level=self.observation_level,
+            planner_observation_mode=self.planner_observation_mode,
+            action_bounds={
+                key: [float(bounds[0]), float(bounds[1])]
+                for key, bounds in self._action_bounds.items()
+            },
+            action_projection_metadata={
+                "projected": False,
+                "projection_policy": "none",
+            },
+        )
+
+    def plan(self, observation: Mapping[str, Any]) -> tuple[float, float]:
+        """Return the deterministic command as a planner-style ``(v, omega)`` tuple."""
+        result = self.predict(observation)
+        return result.action["v"], result.action["omega"]
+
+    def step(self, obs: Mapping[str, Any]) -> dict[str, float]:
+        """Return the deterministic command as a planner-protocol action dictionary."""
+        return dict(self.predict(obs).action)
+
+    def reset(self, *, seed: int | None = None) -> None:
+        """Accept seeded planner resets; the fixture has no state to reset."""
+        del seed
+
+    def configure(self, config: Any) -> None:
+        """Accept empty configuration updates for planner-protocol compatibility."""
+        if config not in (None, {}):
+            raise LearnedPolicyAdapterContractError(
+                "dummy learned-policy fixture does not accept runtime configuration"
+            )
+
+    def close(self) -> None:
+        """Release fixture resources; no external resources are owned."""
+
+    def _validate_request(
+        self,
+        observation: Mapping[str, Any],
+        *,
+        observation_level: str,
+        action_command_space: str,
+    ) -> None:
+        """Validate the requested observation and action contract before prediction."""
+        if observation_level != self.observation_level:
+            raise LearnedPolicyAdapterContractError(
+                "unsupported observation_level "
+                f"'{observation_level}'; expected '{self.observation_level}'"
+            )
+        if action_command_space != self.action_command_space:
+            raise LearnedPolicyAdapterContractError(
+                "unsupported action_command_space "
+                f"'{action_command_space}'; expected '{self.action_command_space}'"
+            )
+
+        missing = [key for key in self._required_observation_inputs if key not in observation]
+        if missing:
+            raise LearnedPolicyAdapterContractError(
+                "missing required observation inputs: " + ", ".join(missing)
+            )
+        forbidden = [key for key in self._forbidden_observation_inputs if key in observation]
+        if forbidden:
+            raise LearnedPolicyAdapterContractError(
+                "forbidden evaluation-time observation inputs: " + ", ".join(forbidden)
+            )
+
+
+__all__ = [
+    "DummyLearnedLocalPolicyAdapter",
+    "LearnedPolicyAdapterContractError",
+    "LearnedPolicyStepResult",
+]

--- a/robot_sf/planner/learned_policy_adapter.py
+++ b/robot_sf/planner/learned_policy_adapter.py
@@ -234,9 +234,7 @@ class DummyLearnedLocalPolicyAdapter:
             )
 
         if observation is None:
-            raise LearnedPolicyAdapterContractError(
-                "observation must not be None"
-            )
+            raise LearnedPolicyAdapterContractError("observation must not be None")
         missing = [key for key in self._required_observation_inputs if key not in observation]
         if missing:
             raise LearnedPolicyAdapterContractError(

--- a/tests/planner/test_dummy_learned_policy_adapter.py
+++ b/tests/planner/test_dummy_learned_policy_adapter.py
@@ -1,0 +1,127 @@
+"""Tests for the dummy learned local-policy adapter fixture."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.planner.learned_policy_adapter import (
+    DummyLearnedLocalPolicyAdapter,
+    LearnedPolicyAdapterContractError,
+)
+from scripts.validation.check_learned_policy_eligibility import (
+    validate_learned_policy_eligibility,
+)
+
+
+def _lidar_observation() -> dict[str, object]:
+    """Return the minimal LiDAR-style observation expected by the dummy adapter."""
+    return {
+        "drive_state": [0.0, 0.0, 0.0, 0.0],
+        "rays": [2.0, 1.5, 1.0, 1.5, 2.0],
+    }
+
+
+def test_dummy_learned_policy_metadata_declares_non_benchmark_fixture_boundary() -> None:
+    """The dummy adapter should expose checklist-style metadata without overclaiming."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    metadata = adapter.metadata()
+
+    assert metadata["policy_id"] == "dummy_learned_local_policy_adapter"
+    assert metadata["claim_boundary"] == "adapter_fixture_only_not_benchmark_evidence"
+    assert metadata["verdict"] == "eligible_for_adapter"
+    assert metadata["observation_t"] == "decision step t before action selection"
+    assert metadata["observation_contract"]["observation_level"] == "lidar_2d"
+    assert metadata["observation_contract"]["required_inputs"] == ["drive_state", "rays"]
+    assert metadata["observation_fields"]["deployment_observable"] == ["drive_state", "rays"]
+    assert metadata["action_contract"]["command_space"] == "unicycle_vw"
+    assert metadata["action_contract"]["output_keys"] == ["v", "omega"]
+    assert metadata["candidate_registry"]["entry_planned"] is False
+
+
+def test_dummy_learned_policy_metadata_passes_eligibility_helper() -> None:
+    """The fixture metadata should satisfy the learned-policy checklist helper."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    assert validate_learned_policy_eligibility(adapter.metadata()) == []
+
+
+def test_dummy_learned_policy_predicts_deterministic_action_with_logging() -> None:
+    """The fixture should emit one predictable action and the required step diagnostics."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    result = adapter.predict(_lidar_observation())
+
+    assert result.action == {"v": 0.25, "omega": 0.0}
+    assert result.raw_model_action == {"v": 0.25, "omega": 0.0}
+    assert result.adapted_action == {"v": 0.25, "omega": 0.0}
+    assert result.post_guard_action == {"v": 0.25, "omega": 0.0}
+    assert result.guard_applied is False
+    assert result.guard_or_fallback_reason == "none"
+    assert result.observation_level == "lidar_2d"
+    assert result.planner_observation_mode == "sensor_fusion_state"
+    assert result.action_bounds == {"v": [0.0, 0.5], "omega": [-0.5, 0.5]}
+    assert result.action_projection_metadata == {
+        "projected": False,
+        "projection_policy": "none",
+    }
+    assert result.to_metadata()["post_guard_action"] == {"v": 0.25, "omega": 0.0}
+    assert result.to_metadata()["action_bounds"] == {"v": [0.0, 0.5], "omega": [-0.5, 0.5]}
+
+
+def test_dummy_learned_policy_plan_returns_unicycle_tuple_for_planner_smokes() -> None:
+    """Planner-style smoke tests can consume the deterministic command tuple directly."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    assert adapter.plan(_lidar_observation()) == (0.25, 0.0)
+    assert adapter.step(_lidar_observation()) == {"v": 0.25, "omega": 0.0}
+    adapter.reset(seed=7)
+    adapter.configure({})
+    adapter.configure(None)
+    adapter.close()
+
+
+@pytest.mark.parametrize(
+    ("observation", "match"),
+    [
+        ({"drive_state": [0.0]}, "missing required observation inputs: rays"),
+        ({"drive_state": [0.0], "rays": [], "future_states": []}, "forbidden"),
+    ],
+)
+def test_dummy_learned_policy_fails_closed_for_bad_observation(
+    observation: dict[str, object],
+    match: str,
+) -> None:
+    """Unsupported observation payloads should fail before returning an action."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match=match):
+        adapter.predict(observation)
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match=match):
+        adapter.plan(observation)
+
+
+def test_dummy_learned_policy_fails_closed_for_unsupported_request() -> None:
+    """Unsupported observation levels or action spaces should fail closed."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="observation_level"):
+        adapter.predict(_lidar_observation(), observation_level="oracle_full_state")
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="observation_level"):
+        adapter.predict(_lidar_observation(), observation_level="")
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="action_command_space"):
+        adapter.predict(_lidar_observation(), action_command_space="holonomic_vxy_world")
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="action_command_space"):
+        adapter.predict(_lidar_observation(), action_command_space="")
+
+
+def test_dummy_learned_policy_fails_closed_for_runtime_configuration() -> None:
+    """The fixture should not accept runtime reconfiguration that changes its contract."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="runtime configuration"):
+        adapter.configure({"action": "turn"})

--- a/tests/planner/test_dummy_learned_policy_adapter.py
+++ b/tests/planner/test_dummy_learned_policy_adapter.py
@@ -16,7 +16,7 @@ from scripts.validation.check_learned_policy_eligibility import (
 def _lidar_observation() -> dict[str, object]:
     """Return the minimal LiDAR-style observation expected by the dummy adapter."""
     return {
-        "drive_state": [0.0, 0.0, 0.0, 0.0],
+        "drive_state": [0.0, 0.0, 0.0, 0.0, 0.0],
         "rays": [2.0, 1.5, 1.0, 1.5, 2.0],
     }
 
@@ -79,6 +79,17 @@ def test_dummy_learned_policy_plan_returns_unicycle_tuple_for_planner_smokes() -
     adapter.configure({})
     adapter.configure(None)
     adapter.close()
+
+
+def test_dummy_learned_policy_fails_closed_for_none_observation() -> None:
+    """None observations should fail closed before returning an action."""
+    adapter = DummyLearnedLocalPolicyAdapter()
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="observation must not be None"):
+        adapter.predict(None)
+
+    with pytest.raises(LearnedPolicyAdapterContractError, match="observation must not be None"):
+        adapter.plan(None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds `DummyLearnedLocalPolicyAdapter`, a deterministic learned local-policy fixture with explicit observation, action, provenance, and per-step logging metadata.
- Covers fail-closed behavior for missing LiDAR inputs, rejected evaluation-time fields, unsupported observation levels, unsupported action command spaces, and runtime reconfiguration.
- Records the fixture boundary in `docs/context/issue_1685_dummy_learned_policy_adapter.md` and links it from the context index.

## Boundary

This is an adapter-boundary test fixture only. It loads no checkpoint, creates no model registry entry, runs no training, and makes no benchmark or performance claim.

## Validation

- Red: `uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py` initially failed at collection because `robot_sf.planner.learned_policy_adapter` did not exist.
- `uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py` -> `8 passed`.
- `uv run pytest -q tests/planner/test_dummy_learned_policy_adapter.py tests/validation/test_check_learned_policy_eligibility.py` -> `17 passed`.
- `uv run ruff check robot_sf/planner/learned_policy_adapter.py tests/planner/test_dummy_learned_policy_adapter.py` -> passed.
- `uv run ruff format --check robot_sf/planner/learned_policy_adapter.py tests/planner/test_dummy_learned_policy_adapter.py` -> passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh && git diff --check` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `4447 passed, 11 skipped, 9 warnings in 311.78s`.

## External Review

Read-only sidecar review used Qwen Step-3.7-Flash, Qwen3.6-27B, Gemini auto, and OpenCode Go. Accepted findings added explicit empty-string fail-closed coverage, `LearnedPolicyStepResult.to_metadata()` coverage, and planner-protocol lifecycle hooks. A workflow self-review note was written under `.git/codex-agent-runs/notes/inbox/`.

Closes #1685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dummy learned policy adapter fixture for testing learned-policy adapter boundary integration without loading models or checkpoints.

* **Documentation**
  * Added documentation for the dummy learned policy adapter fixture specification, including observation/action contracts, validation behavior, and lifecycle support.

* **Tests**
  * Added comprehensive test suite validating adapter metadata, deterministic action outputs, planner integration, and contract enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->