### PR TITLE
Require registry observation-track metadata

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -167,6 +167,9 @@ easier:
 
 Use `robot_sf.models.upsert_registry_entry(...)` to auto-populate or update the
 registry from training pipelines.
+Benchmark-promoted learned checkpoints must also include `benchmark_promotion`
+observation-track metadata; see `model/registry.md` and
+`docs/context/issue_1612_observation_track_architecture.md`.
 
 ### One‑liner quality gates (CLI):
 

--- a/docs/model_registry_publication.md
+++ b/docs/model_registry_publication.md
@@ -45,7 +45,22 @@ github_release:
   sha256: <sha256>
   size_bytes: <bytes>
   metadata_asset: <model_id>-metadata.json
+benchmark_promotion:
+  claim_boundary: benchmark_promoted
+  benchmark_track: grid_socnav_v1
+  track_schema_version: observation-track.v1
+  observation_level: tracked_agents_no_noise
+  observation_mode: socnav_state
+  allowed_observation_keys: [robot_state, goal, tracked_agents]
+  goal_encoding: current route goal in planner observation
+  sensor_geometry: tracked-agent state, no LiDAR ray geometry
+  privileged_input_status: no evaluation-time privileged inputs
+  reference: docs/context/issue_1612_observation_track_architecture.md
 ```
+
+Use a non-benchmark boundary such as `research_only` or `smoke_only` plus
+`non_benchmark_reason` when the entry is preserved for analysis or launch checks but is not eligible
+for benchmark claims.
 
 ## How
 

--- a/model/registry.md
+++ b/model/registry.md
@@ -25,7 +25,32 @@ notebooks to insert/update entries without manual YAML editing.
   exists on the current machine.
 - `replacement_model_id`: optional migration target surfaced in local-only
   resolution errors.
+- `benchmark_promotion` (required for benchmark-promoted learned checkpoints): observation-track
+  claim boundary and policy input contract.
 - `tags` / `notes`: free-form metadata for discovery.
+
+### Benchmark promotion metadata
+
+Learned checkpoints promoted for benchmark claims must include `benchmark_promotion` so LiDAR,
+grid/SocNav, privileged-state, and adapter-derived policies cannot be confused in reports. The
+vocabulary follows `docs/context/issue_1612_observation_track_architecture.md`.
+
+Required for `claim_boundary: benchmark_promoted` or `benchmark_candidate`:
+
+- `benchmark_track`: stable aggregation lane such as `grid_socnav_v1` or `lidar_2d_v1`.
+- `track_schema_version`: schema slug such as `observation-track.v1`.
+- `observation_level`: benchmark observation-level vocabulary from
+  `robot_sf/benchmark/observation_levels.py`.
+- `observation_mode`: active environment or policy observation mode, such as `socnav_state`,
+  `sensor_fusion_state`, or a documented learned-policy dict contract.
+- `allowed_observation_keys`: concrete policy input keys allowed at evaluation time.
+- `goal_encoding`: how the current route or goal enters the observation.
+- `sensor_geometry`: grid, ray, stack, range, or other sensor-shape details that define the track.
+- `privileged_input_status`: explicit statement about evaluation-time privileged inputs.
+
+Research-only, smoke-only, legacy, or otherwise non-benchmark entries may omit those track fields
+only when `benchmark_promotion.claim_boundary` is one of `research_only`, `smoke_only`,
+`legacy_non_track`, or `not_for_benchmark` and `non_benchmark_reason` explains the claim boundary.
 
 ### Minimal schema (YAML)
 
@@ -50,6 +75,17 @@ models:
       url: https://github.com/owner/repo/releases/download/artifact/models-YYYY-MM-registry-v1/my_model_id-model.zip
       sha256: ...
       size_bytes: 123
+    benchmark_promotion:
+      claim_boundary: benchmark_promoted
+      benchmark_track: grid_socnav_v1
+      track_schema_version: observation-track.v1
+      observation_level: tracked_agents_no_noise
+      observation_mode: socnav_state
+      allowed_observation_keys: [robot_state, goal, tracked_agents]
+      goal_encoding: current route goal in planner observation
+      sensor_geometry: tracked-agent state, no LiDAR ray geometry
+      privileged_input_status: no evaluation-time privileged inputs
+      reference: docs/context/issue_1612_observation_track_architecture.md
     local_only: false
     replacement_model_id: my_model_id_v2
     tags: ["ppo", "socnav"]

--- a/model/registry.yaml
+++ b/model/registry.yaml
@@ -22,6 +22,43 @@ models:
   - predictive-foresight
   - promoted
   - canonical-baseline
+  benchmark_promotion:
+    claim_boundary: benchmark_promoted
+    benchmark_track: grid_socnav_v1
+    track_schema_version: observation-track.v1
+    observation_level: tracked_agents_no_noise
+    observation_mode: dict
+    allowed_observation_keys:
+    - occupancy_grid
+    - occupancy_grid_meta_origin
+    - occupancy_grid_meta_resolution
+    - occupancy_grid_meta_width
+    - occupancy_grid_meta_height
+    - robot_position
+    - robot_heading
+    - robot_velocity_xy
+    - robot_speed
+    - robot_angular_velocity
+    - robot_radius
+    - goal_current
+    - goal_next
+    - pedestrians_positions
+    - pedestrians_velocities
+    - pedestrians_radius
+    - pedestrians_count
+    - map_size
+    - sim_timestep
+    - predictive_min_clearance
+    - predictive_ttc_risk
+    - predictive_crossing_count
+    - predictive_gap_scores
+    - predictive_flow_alignment
+    - predictive_uncertainty
+    goal_encoding: current route goal encoded in the PPO dict observation as goal_current
+    sensor_geometry: local occupancy-grid/SocNav state with predictive foresight features; no LiDAR
+      ray geometry
+    privileged_input_status: no evaluation-time privileged inputs
+    reference: docs/context/issue_1612_observation_track_architecture.md
   notes:
   - Promoted on 2026-04-28 as the canonical PPO benchmark baseline; replaces BR-06
     v3 as the default for configs/baselines/ppo_15m_grid_socnav.yaml.
@@ -463,6 +500,10 @@ models:
   - xl
   - ego-conditioned
   - promoted
+  benchmark_promotion:
+    claim_boundary: not_for_benchmark
+    non_benchmark_reason: Auxiliary predictive-foresight checkpoint, not a standalone learned
+      navigation policy or benchmark-promoted local planner.
   notes:
   - 'Dataset: output/tmp/predictive_planner/pipeline/predictive_br07_all_maps_randomized_xl_ego_20260309T141432Z/datasets/predictive_rollouts_mixed.npz'
   - 'Training summary uploaded to W&B run file: training_summary.json'

--- a/robot_sf/models/__init__.py
+++ b/robot_sf/models/__init__.py
@@ -1,19 +1,23 @@
 """Helpers for managing trained policy artifacts."""
 
 from robot_sf.models.registry import (
+    RegistryIssue,
     find_latest_wandb_model,
     get_registry_entry,
     load_registry,
     resolve_latest_wandb_model,
     resolve_model_path,
     upsert_registry_entry,
+    validate_registry_entry_benchmark_promotion,
 )
 
 __all__ = [
+    "RegistryIssue",
     "find_latest_wandb_model",
     "get_registry_entry",
     "load_registry",
     "resolve_latest_wandb_model",
     "resolve_model_path",
     "upsert_registry_entry",
+    "validate_registry_entry_benchmark_promotion",
 ]

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -21,6 +21,37 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional depend
 
 DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")
 _LOGGED_CACHED_MODEL_ARTIFACTS: set[Path] = set()
+BENCHMARK_PROMOTED_CLAIM_BOUNDARIES = {
+    "benchmark_promoted",
+    "benchmark_candidate",
+}
+NON_BENCHMARK_CLAIM_BOUNDARIES = {
+    "research_only",
+    "smoke_only",
+    "legacy_non_track",
+    "not_for_benchmark",
+}
+BENCHMARK_PROMOTION_CLAIM_BOUNDARIES = (
+    BENCHMARK_PROMOTED_CLAIM_BOUNDARIES | NON_BENCHMARK_CLAIM_BOUNDARIES
+)
+BENCHMARK_PROMOTION_REQUIRED_OBSERVATION_FIELDS = {
+    "benchmark_track",
+    "track_schema_version",
+    "observation_level",
+    "observation_mode",
+    "allowed_observation_keys",
+    "goal_encoding",
+    "sensor_geometry",
+    "privileged_input_status",
+}
+LEARNED_POLICY_REGISTRY_TAGS = {
+    "ppo",
+    "learned-policy",
+    "learned-checkpoint",
+    "rl-policy",
+    "imitation-policy",
+    "predictive",
+}
 
 
 def _local_only_resolution_error(
@@ -54,6 +85,107 @@ class WandbLatestModel:
     state: str | None
     created_at: str | None
     file_name: str
+
+
+@dataclass(frozen=True)
+class RegistryIssue:
+    """One model-registry validation issue."""
+
+    path: str
+    message: str
+
+
+def _is_missing(value: Any) -> bool:
+    """Return whether a registry value is absent for contract validation."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _registry_tags(entry: dict[str, Any]) -> set[str]:
+    """Return normalized registry tags."""
+    raw_tags = entry.get("tags")
+    if not isinstance(raw_tags, list):
+        return set()
+    return {str(tag).strip().lower() for tag in raw_tags if str(tag).strip()}
+
+
+def _is_promoted_learned_policy(entry: dict[str, Any]) -> bool:
+    """Return whether a registry row is a promoted learned-policy checkpoint."""
+    tags = _registry_tags(entry)
+    return "promoted" in tags and bool(tags & LEARNED_POLICY_REGISTRY_TAGS)
+
+
+def _require_benchmark_promotion_field(
+    issues: list[RegistryIssue],
+    promotion: dict[str, Any],
+    field: str,
+) -> None:
+    """Require one non-empty benchmark-promotion field."""
+    if _is_missing(promotion.get(field)):
+        issues.append(RegistryIssue(f"benchmark_promotion.{field}", "is required"))
+
+
+def validate_registry_entry_benchmark_promotion(entry: dict[str, Any]) -> list[RegistryIssue]:
+    """Validate observation-track metadata for benchmark promotion.
+
+    Promoted learned-policy checkpoints must declare a benchmark-promotion block with the
+    observation-track contract needed to compare their benchmark rows. Research, smoke, legacy, and
+    non-benchmark entries can remain in the registry when they declare an explicit claim boundary.
+
+    Returns:
+        list[RegistryIssue]: Validation issues, empty when the entry satisfies this contract.
+    """
+    issues: list[RegistryIssue] = []
+    promotion_raw = entry.get("benchmark_promotion")
+    if promotion_raw is None:
+        if _is_promoted_learned_policy(entry):
+            issues.append(
+                RegistryIssue(
+                    "benchmark_promotion",
+                    "promoted learned-policy checkpoints require observation-track metadata",
+                )
+            )
+        return issues
+    if not isinstance(promotion_raw, dict) or not promotion_raw:
+        return [RegistryIssue("benchmark_promotion", "must be a non-empty mapping")]
+
+    promotion = dict(promotion_raw)
+    claim_boundary = promotion.get("claim_boundary")
+    if claim_boundary not in BENCHMARK_PROMOTION_CLAIM_BOUNDARIES:
+        issues.append(
+            RegistryIssue(
+                "benchmark_promotion.claim_boundary",
+                f"must be one of {', '.join(sorted(BENCHMARK_PROMOTION_CLAIM_BOUNDARIES))}",
+            )
+        )
+        return issues
+
+    if claim_boundary in BENCHMARK_PROMOTED_CLAIM_BOUNDARIES:
+        for field in sorted(BENCHMARK_PROMOTION_REQUIRED_OBSERVATION_FIELDS):
+            _require_benchmark_promotion_field(issues, promotion, field)
+        if not _is_missing(promotion.get("allowed_observation_keys")) and not isinstance(
+            promotion.get("allowed_observation_keys"), list
+        ):
+            issues.append(
+                RegistryIssue(
+                    "benchmark_promotion.allowed_observation_keys",
+                    "must be a non-empty list",
+                )
+            )
+    elif _is_missing(promotion.get("non_benchmark_reason")):
+        issues.append(
+            RegistryIssue(
+                "benchmark_promotion.non_benchmark_reason",
+                "is required for non-benchmark claim boundaries",
+            )
+        )
+
+    return issues
 
 
 def load_registry(path: str | Path | None = None) -> dict[str, dict[str, Any]]:

--- a/scripts/validation/check_learned_policy_eligibility.py
+++ b/scripts/validation/check_learned_policy_eligibility.py
@@ -18,6 +18,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.models.registry import validate_registry_entry_benchmark_promotion
+
 ALLOWED_VERDICTS = {
     "eligible_for_adapter",
     "eligible_for_research_only",
@@ -305,6 +307,21 @@ def _validate_registry_boundary(payload: dict[str, Any], issues: list[Eligibilit
         )
 
 
+def _validate_benchmark_promotion(payload: dict[str, Any], issues: list[EligibilityIssue]) -> None:
+    """Validate optional benchmark-promotion observation-track metadata."""
+    if "benchmark_promotion" not in payload:
+        return
+    registry_like_entry = {
+        "model_id": payload.get("model_id", "candidate"),
+        "tags": ["learned-policy"],
+        "benchmark_promotion": payload.get("benchmark_promotion"),
+    }
+    issues.extend(
+        EligibilityIssue(issue.path, issue.message)
+        for issue in validate_registry_entry_benchmark_promotion(registry_like_entry)
+    )
+
+
 def validate_learned_policy_eligibility(payload: dict[str, Any]) -> list[EligibilityIssue]:
     """Return checklist-completeness and consistency issues for one candidate spec."""
     issues: list[EligibilityIssue] = []
@@ -314,6 +331,7 @@ def validate_learned_policy_eligibility(payload: dict[str, Any]) -> list[Eligibi
     _validate_action_contract(payload, issues)
     _validate_logging(payload, issues)
     _validate_registry_boundary(payload, issues)
+    _validate_benchmark_promotion(payload, issues)
     return issues
 
 

--- a/scripts/validation/check_learned_policy_eligibility.py
+++ b/scripts/validation/check_learned_policy_eligibility.py
@@ -313,7 +313,7 @@ def _validate_benchmark_promotion(payload: dict[str, Any], issues: list[Eligibil
         return
     registry_like_entry = {
         "model_id": payload.get("model_id", "candidate"),
-        "tags": ["learned-policy"],
+        "tags": ["learned-policy", "promoted"],
         "benchmark_promotion": payload.get("benchmark_promotion"),
     }
     issues.extend(

--- a/tests/benchmark/test_ppo_baseline_contract.py
+++ b/tests/benchmark/test_ppo_baseline_contract.py
@@ -73,6 +73,20 @@ def test_canonical_ppo_baseline_points_at_promoted_artifact_path(
     assert canonical_entry["wandb_artifact_path"].endswith("-best-success:v9")
 
 
+def test_canonical_ppo_baseline_declares_observation_track_metadata(canonical_entry: dict) -> None:
+    """The benchmark-promoted PPO checkpoint should declare its track-level input contract."""
+    promotion = canonical_entry["benchmark_promotion"]
+
+    assert promotion["claim_boundary"] == "benchmark_promoted"
+    assert promotion["benchmark_track"] == "grid_socnav_v1"
+    assert promotion["observation_level"] == "tracked_agents_no_noise"
+    assert promotion["observation_mode"] == "dict"
+    assert "occupancy_grid" in promotion["allowed_observation_keys"]
+    assert "predictive_min_clearance" in promotion["allowed_observation_keys"]
+    assert promotion["privileged_input_status"] == "no evaluation-time privileged inputs"
+    assert "docs/context/issue_1612_observation_track_architecture.md" in promotion["reference"]
+
+
 def test_issue_576_closeout_config_has_resolved_provenance(
     repo_root: Path, issue_576_entry: dict
 ) -> None:

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -206,6 +206,49 @@ models:
         registry.load_registry(registry_path)
 
 
+def test_promoted_learned_policy_requires_observation_track_metadata() -> None:
+    """Benchmark-promoted learned checkpoints must declare their observation contract."""
+    entry = {
+        "model_id": "promoted_ppo",
+        "tags": ["ppo", "promoted"],
+        "benchmark_promotion": {"claim_boundary": "benchmark_promoted"},
+    }
+
+    issues = registry.validate_registry_entry_benchmark_promotion(entry)
+    paths = {issue.path for issue in issues}
+
+    assert "benchmark_promotion.benchmark_track" in paths
+    assert "benchmark_promotion.allowed_observation_keys" in paths
+    assert "benchmark_promotion.privileged_input_status" in paths
+
+
+def test_research_only_registry_boundary_is_allowed_with_reason() -> None:
+    """Non-benchmark learned checkpoints can stay in the registry with a clear claim boundary."""
+    entry = {
+        "model_id": "lidar_smoke_candidate",
+        "tags": ["learned-policy", "candidate"],
+        "benchmark_promotion": {
+            "claim_boundary": "smoke_only",
+            "non_benchmark_reason": "LiDAR launch packet only; no benchmark claim.",
+        },
+    }
+
+    assert registry.validate_registry_entry_benchmark_promotion(entry) == []
+
+
+def test_repository_registry_benchmark_promotion_metadata_is_valid() -> None:
+    """Tracked registry entries should satisfy benchmark-promotion claim boundaries."""
+    registry_path = Path(__file__).resolve().parents[2] / "model" / "registry.yaml"
+    entries = registry.load_registry(registry_path)
+
+    issues = {
+        model_id: registry.validate_registry_entry_benchmark_promotion(entry)
+        for model_id, entry in entries.items()
+    }
+
+    assert {model_id: row_issues for model_id, row_issues in issues.items() if row_issues} == {}
+
+
 def test_get_registry_entry_raises_for_unknown_model(tmp_path: Path) -> None:
     """Unknown model ids should raise a clear KeyError."""
     registry_path = tmp_path / "registry.yaml"

--- a/tests/validation/test_check_learned_policy_eligibility.py
+++ b/tests/validation/test_check_learned_policy_eligibility.py
@@ -163,6 +163,16 @@ def test_benchmark_promotion_requires_observation_track_metadata() -> None:
     assert "benchmark_promotion.allowed_observation_keys" in paths
 
 
+def test_benchmark_promotion_null_is_reported() -> None:
+    """A null promotion block should not bypass benchmark metadata validation."""
+    spec = _eligible_spec()
+    spec["benchmark_promotion"] = None
+
+    issues = validate_learned_policy_eligibility(spec)
+
+    assert any(issue.path == "benchmark_promotion" for issue in issues)
+
+
 def test_research_only_promotion_boundary_can_pass_without_track_fields() -> None:
     """Research-only candidates should declare the boundary without pretending to be benchmark rows."""
     spec = _eligible_spec()

--- a/tests/validation/test_check_learned_policy_eligibility.py
+++ b/tests/validation/test_check_learned_policy_eligibility.py
@@ -76,6 +76,23 @@ def _eligible_spec() -> dict[str, object]:
             "unsupported_observation_policy": "fail closed before benchmark run",
             "guard_activation_policy": "report as caveat, not success evidence",
         },
+        "benchmark_promotion": {
+            "claim_boundary": "benchmark_promoted",
+            "benchmark_track": "grid_socnav_v1",
+            "track_schema_version": "observation-track.v1",
+            "observation_level": "tracked_agents_no_noise",
+            "observation_mode": "socnav_state",
+            "allowed_observation_keys": [
+                "robot_state",
+                "goal",
+                "tracked_agents",
+                "occupancy_grid",
+            ],
+            "goal_encoding": "current route goal included in planner observation",
+            "sensor_geometry": "local occupancy-grid/SocNav state, no LiDAR ray geometry",
+            "privileged_input_status": "no evaluation-time privileged inputs",
+            "reference": "docs/context/issue_1612_observation_track_architecture.md",
+        },
     }
 
 
@@ -125,6 +142,35 @@ def test_training_only_or_oracle_can_record_forbidden_fields() -> None:
     spec["observation_fields"]["forbidden_evaluation_time"] = [
         "future collision label",
     ]
+    spec["benchmark_promotion"] = {
+        "claim_boundary": "research_only",
+        "non_benchmark_reason": "Oracle-training spec is not a benchmark-promoted checkpoint.",
+    }
+
+    assert validate_learned_policy_eligibility(spec) == []
+
+
+def test_benchmark_promotion_requires_observation_track_metadata() -> None:
+    """Learned checkpoints cannot be promoted without explicit observation-track metadata."""
+    spec = _eligible_spec()
+    spec["benchmark_promotion"] = {"claim_boundary": "benchmark_promoted"}
+
+    issues = validate_learned_policy_eligibility(spec)
+    paths = {issue.path for issue in issues}
+
+    assert "benchmark_promotion.benchmark_track" in paths
+    assert "benchmark_promotion.observation_level" in paths
+    assert "benchmark_promotion.allowed_observation_keys" in paths
+
+
+def test_research_only_promotion_boundary_can_pass_without_track_fields() -> None:
+    """Research-only candidates should declare the boundary without pretending to be benchmark rows."""
+    spec = _eligible_spec()
+    spec["verdict"] = "eligible_for_research_only"
+    spec["benchmark_promotion"] = {
+        "claim_boundary": "research_only",
+        "non_benchmark_reason": "Adapter smoke only; not benchmark promotion evidence.",
+    }
 
     assert validate_learned_policy_eligibility(spec) == []
 


### PR DESCRIPTION
## Summary

- add benchmark-promotion observation-track validation for model-registry entries
- extend learned-policy eligibility metadata checks to validate `benchmark_promotion` blocks
- migrate the canonical PPO baseline with concrete grid/SocNav dict input keys and mark the promoted predictive checkpoint as not a standalone benchmark policy
- document the registry vocabulary and publication guidance for benchmark vs non-benchmark claim boundaries

Closes #1704.

## Validation

- `uv run ruff check robot_sf/models/registry.py robot_sf/models/__init__.py scripts/validation/check_learned_policy_eligibility.py tests/models/test_registry.py tests/validation/test_check_learned_policy_eligibility.py tests/benchmark/test_ppo_baseline_contract.py`
- `uv run ruff format --check robot_sf/models/registry.py robot_sf/models/__init__.py scripts/validation/check_learned_policy_eligibility.py tests/models/test_registry.py tests/validation/test_check_learned_policy_eligibility.py tests/benchmark/test_ppo_baseline_contract.py`
- `uv run pytest tests/models/test_registry.py tests/validation/test_check_learned_policy_eligibility.py tests/benchmark/test_ppo_baseline_contract.py` (39 passed)
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4448 passed, 11 skipped, 8 warnings in 283.70s; coverage goal warnings only)

## Notes

- Stacked on #1708 / `issue-1702-observation-track-metadata` because the registry contract builds on the observation-track schema work.
- Qwen Code review was attempted with plus and flash model names but non-interactive auth was unavailable/retired; Gemini auto and OpenCode Go review findings were applied.
