### PR TITLE
docs: add queue exhaustion audit example

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -137,6 +137,34 @@ hardware, SLURM, CARLA, private artifacts, checkpoint aliases, datasets, or a cl
 mark it blocked or send it to issue clarification instead of counting the queue as empty. Keep this
 audit read-only until the orchestrator has reviewed the proposed label/body changes.
 
+This audit is an illustrative handoff, not a new machine-readable schema. Keep it compact enough
+for the next agent or maintainer to act on directly:
+
+```md
+Queue exhaustion audit:
+- Query used: `gh issue list --state open --label state:ready --limit 100 --json number,title,labels,url`
+- Remaining ready issues:
+  - `#1457` needs SLURM capacity and durable artifact destination; classify as blocked on
+    `resource:slurm`.
+  - `#1512` is implementable only after the benchmark fallback policy note is refreshed; send to
+    `gh-issue-clarifier`.
+  - `#1530` is too broad for one PR; best split candidate because it combines docs, validator
+    behavior, and Project #5 metadata.
+- Open issues without `state:*`: 7 found via
+  `gh issue list --state open --limit 100 --json number,title,labels,url`; no writes applied.
+- Proposed next action: open/split a child issue for the validator-only part of `#1530`, then
+  revisit the queue after maintainer review.
+- Labels/body writes: none; read-only audit only.
+```
+
+Route remaining issues by their blocker:
+- Use `gh-issue-clarifier` when the issue intent, proof path, acceptance criteria, or ownership is
+  unclear.
+- Use `gh-issue-creator` or an explicit issue-splitting pass when one ready issue mixes multiple
+  independently reviewable PRs.
+- Mark the run `blocked` instead of exhausted when the next issue requires unavailable hardware,
+  private artifacts, credentials, live external services, or unapproved Project writes.
+
 ## Process
 
 1. Select one issue (`gh-issue-sequencer` output or explicit user target).


### PR DESCRIPTION
## Summary
Adds an illustrative exhausted-queue audit example to the goal-issue-implementation skill docs.

## Linked Issues
- Closes #1688

## What Changed
- Expanded .agents/skills/goal-issue-implementation/SKILL.md with a compact read-only queue exhaustion audit handoff example.
- Clarified when remaining issues should route to issue clarification, issue splitting, or blocked status instead of being counted as exhausted.
- Kept this explicitly illustrative rather than introducing a new machine-readable schema.

## Why It Matters
- Added value: future exhausted-queue handoffs include the query, remaining issue classes, and best split candidate.
- Expected impact: agent runs should produce more actionable queue-end reports.
- Why this is worth merging now: it sharpens existing workflow guidance without changing eligibility semantics or Project #5 writes.

## Validation / Proof
- uv run python scripts/dev/check_skills.py
- python path existence check for .agents/skills/goal-issue-implementation/SKILL.md, docs/context/goal_driven_agent_loops_2026-05-13.md, and docs/context/issue_713_batch_first_issue_workflow.md
- git diff --check
- PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh

Evidence: after fresh-worktree uv sync --all-extras, post-commit readiness passed at fd9cd591 with 4439 passed, 11 skipped, 9 warnings.

## Risks / Rollout
- Compatibility risks: low; docs-only skill guidance.
- Failure modes: example could be mistaken for a strict schema, so the text states it is illustrative.
- Rollback or fallback plan: revert the single skill-doc commit.

## Docs / Provenance
- Updated docs: .agents/skills/goal-issue-implementation/SKILL.md.
- Relevant design or provenance notes: follows issue #1688 scope; no generated skill index drift after validation.
- Assumptions: no Project #5 field writes or issue labels were changed.

## Follow-Up Issues
- Deferred work: none.

## Reviewer Notes
- Please verify the example remains compact and does not imply a mandatory queue_audit.v1 schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added illustrative queue exhaustion audit example to skill documentation, including issue classifications (resource-capability blocked, clarifier, split PR candidates), audit query examples, and explicit routing rules for issue triage and next actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ll7/robot_sf_ll7/pull/1712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->