### PR TITLE
docs: add context retrieval index (#1714)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Treat the following files as the repository-native context stack for Agent-style
   and GitHub agent sources, mirrored into tool-specific compatibility paths when possible.
 - `docs/ai/`: AI-facing overview documents for repo structure, planner-zoo state, context packing, and deferred retrieval decisions.
 
-Read only the surfaces relevant to the task. Prefer these repo-local files over ad-hoc summaries in issue comments, and avoid loading broad context-note indexes unless the task actually needs them.
+Read only the surfaces relevant to the task. Prefer these repo-local files over ad-hoc summaries in issue comments. For context-note retrieval, start with `docs/context/INDEX.md` before opening broad historical note lists.
 
 ## Local Machine Context (Gitignored)
 
@@ -110,9 +110,9 @@ detail instead of turning the index into another full instruction document.
   or successor note when a document is superseded.
 - If a touched note contains outdated or superseded statements, update them, remove them, or mark
   them clearly with a pointer to the current source of truth.
-- Keep note names and links discoverable from normal contributor entry points. Start with
-  `docs/context/README.md` and use `.agents/skills/context-note-maintainer/SKILL.md` when creating
-  or refreshing context notes.
+- Keep note names and links discoverable from normal contributor entry points. Start retrieval with
+  `docs/context/INDEX.md`; use `docs/context/README.md` and
+  `.agents/skills/context-note-maintainer/SKILL.md` when creating or refreshing context notes.
 
 ## Cross-Agent Compatibility
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 
 * **[Development Guide](./dev_guide.md)** - Primary reference for development workflows, setup, testing, quality gates, and coding standards
 * **[Runtime Requirements](./dev_runtime_requirements.md)** - Non-`uv` host tools, system packages, optional Docker/`gh-act` support, and the local capability checker
+* **[Context Retrieval Index](./context/INDEX.md)** - Lean entry point for current context-note domains, status labels, evidence bundles, and stale-note pruning rules
 * **[Context Notes Workflow](./context/README.md)** - Canonical rules for linked Markdown handoff notes, note updates vs new notes, stale-note handling, and discoverability
 * **[Open-Issues Implementation Status](./context/open_issues_implementation_status_2026-05-12.md)** - Handoff record for the May 2026 open-issues pass, including implemented slices, blocked items, and remaining follow-up surface
 * **[Open-Issues Maintainer Input Triage](./context/open_issues_maintainer_input_triage.md)** - Consolidated maintainer-decision inventory for open issues that still need scope, contract, or prioritization guidance

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -23,6 +23,7 @@ Read these first when working in this workflow:
 - [docs/dev_guide.md](../dev_guide.md)
 - [docs/README.md](../README.md)
 - [docs/ai/repo_overview.md](repo_overview.md)
+- [docs/context/INDEX.md](../context/INDEX.md)
 - [docs/context/README.md](../context/README.md)
 - [docs/context/issue_713_batch_first_issue_workflow.md](../context/issue_713_batch_first_issue_workflow.md)
 - [docs/context/issue_728_coding_agents_compatibility.md](../context/issue_728_coding_agents_compatibility.md)
@@ -171,7 +172,7 @@ Treat it as a reviewer-lens pass, not another full test suite:
   local paths in tracked evidence, and durable evidence files that still point at ignored
   `output/` artifacts.
 - docs/context changes: align PR-body validation, context-note validation, and exact proof output;
-  add required `docs/README.md` and `docs/context/README.md` links.
+  add required `docs/README.md`, `docs/context/INDEX.md`, and `docs/context/README.md` links.
 - schema, parser, path, JSON, artifact, and public-helper changes: check malformed payloads,
   missing values, wrong shapes, directories, absolute paths, traversal, `NaN`, `inf`, and negative
   sentinels.

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -34,7 +34,7 @@ Then branch by task type:
 - planner family support: `docs/benchmark_planner_family_coverage.md`
 - training/eval workflow: `docs/AGENT_INDEX.md`, `docs/training/`
 - end-to-end AI workflow: `docs/ai/ai-workflow.md`
-- issue execution history and handoff knowledge base: `docs/context/`
+- issue execution history and handoff knowledge base: start with `docs/context/INDEX.md`
 - context note workflow: `docs/context/README.md`
 
 ## Key Repository Areas
@@ -54,8 +54,10 @@ Then branch by task type:
 - `output/`: git-ignored canonical artifact root
 - `docs/context/evidence/`: small tracked evidence bundles promoted from generated outputs when
   they support durable benchmark or context decisions
-- `docs/context/`: linked execution notes, issue-specific evidence logs, and agent handoff context;
-  keep this tree indexed, pruned, and treated as a retrieval surface rather than a bulk dump
+- `docs/context/INDEX.md`: lean retrieval surface for linked execution notes, issue-specific
+  evidence logs, and agent handoff context
+- `docs/context/`: underlying note tree; keep it indexed, pruned, and treated as a retrieval
+  surface rather than a bulk dump
 - `memory/`: repo-local Markdown memory tree for stable cross-session facts and concise retrieval
 
 ### Existing agent workflow surfaces

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -1,0 +1,77 @@
+# Context Retrieval Index
+
+Status: first-pass retrieval surface for GitHub issue #1714.
+
+Use this file before browsing the full `docs/context/` tree. The directory has hundreds of
+issue-scoped notes plus tracked evidence bundles; broad reads should start from the smallest
+current surface below, then expand only when the task needs more detail.
+
+This Markdown-first catalog preserves the retrieval boundary described in
+[docs/ai/retrieval_deferral.md](../ai/retrieval_deferral.md): no database, vector store, or MCP
+retrieval layer is introduced until repository evidence justifies that extra infrastructure.
+
+## Retrieval Rules
+
+1. Start with the task domain, not the newest note.
+2. Prefer canonical or current notes over historical execution logs.
+3. Open predecessor, successor, or evidence links only when a claim depends on them.
+4. Treat `output/` paths mentioned in old notes as local-only unless a tracked manifest, release,
+   W&B artifact, or `docs/context/evidence/` copy is linked.
+5. If a touched note is stale or superseded, update the status line or point it at the current
+   source of truth before adding more prose.
+
+## Status Vocabulary
+
+Use these status labels when adding or refreshing notes:
+
+- `canonical`: the preferred current entry point for a domain or issue family.
+- `current`: still accurate for its issue or bounded investigation.
+- `historical`: useful background, but not the current decision surface.
+- `superseded`: kept only for traceability; must link to the replacement note.
+- `blocked`: work cannot proceed without named artifacts, hardware, data, or maintainer input.
+- `evidence`: compact tracked proof under `docs/context/evidence/`.
+
+## Domain Entry Points
+
+| Domain | Start Here | Why |
+| --- | --- | --- |
+| Agent issue loops and GitHub workflow | [goal_driven_agent_loops_2026-05-13.md](goal_driven_agent_loops_2026-05-13.md), [issue_713_batch_first_issue_workflow.md](issue_713_batch_first_issue_workflow.md) | Canonical loop boundaries, queue policy, and API batching rules. |
+| Open-issue execution state | [open_issue_execution_improvement_plan_2026-05-30.md](open_issue_execution_improvement_plan_2026-05-30.md), [open_issues_training_split_audit_2026-05-30.md](open_issues_training_split_audit_2026-05-30.md) | Current issue-queue audit and training/resource split context. |
+| Context-note maintenance | [README.md](README.md) | Contribution rules for creating, updating, linking, and pruning notes. |
+| Benchmark fallback and claim safety | [issue_691_benchmark_fallback_policy.md](issue_691_benchmark_fallback_policy.md), [issue_1436_reproducibility_flaky_acceptance.md](issue_1436_reproducibility_flaky_acceptance.md) | Fail-closed fallback policy and validation rerun boundaries. |
+| Observation tracks and learned policies | [issue_1612_observation_track_architecture.md](issue_1612_observation_track_architecture.md), [issue_1618_learned_policy_adapter_interface.md](issue_1618_learned_policy_adapter_interface.md), [issue_1685_dummy_learned_policy_adapter.md](issue_1685_dummy_learned_policy_adapter.md) | Current observation-track architecture, adapter boundary, and dummy fixture proof. |
+| Model and artifact provenance | [artifact_evidence_vocabulary.md](artifact_evidence_vocabulary.md), [../model_registry_publication.md](../model_registry_publication.md) | Shared language for exploratory outputs, durable evidence, releases, and promoted models. |
+| Policy-search portfolio | [policy_search/README.md](policy_search/README.md), [policy_search/candidate_registry.yaml](policy_search/candidate_registry.yaml), [policy_search/learned_policy_registry.md](policy_search/learned_policy_registry.md) | Subtree-specific index and registries for policy candidates and learned policy evidence. |
+| CI and validation runtime | [issue_1653_ci_runtime_slice.md](issue_1653_ci_runtime_slice.md) | Current timing baseline, implemented instrumentation, and next CI-runtime targets. |
+| Root layout and repository hygiene | [issue_1690_root_layout_inventory.md](issue_1690_root_layout_inventory.md), [issue_1583_high_risk_root_boundaries.md](issue_1583_high_risk_root_boundaries.md) | Root layout inventory and high-risk path boundaries. |
+| Simulation trace and visualization workbench | [issue_1689_simulation_trace_export_schema.md](issue_1689_simulation_trace_export_schema.md), [open_issue_execution_improvement_plan_2026-05-30.md](open_issue_execution_improvement_plan_2026-05-30.md) | Trace export schema plus current workbench sequencing and deferred viewer boundary. |
+| AMV, CARLA, and external data blockers | [slurm_issue_batch_status_2026-05-21.md](slurm_issue_batch_status_2026-05-21.md), [issue_1584_socnav_unavailable_row_policy.md](issue_1584_socnav_unavailable_row_policy.md), [issue_1111_carla_setup_smoke.md](issue_1111_carla_setup_smoke.md) | Resource-gated issue status, unavailable-row policy, and CARLA setup boundary. |
+
+## Evidence Bundles
+
+Use [evidence/README.md](evidence/README.md) for small tracked evidence copies. Evidence bundles
+are review aids, not replacements for canonical configs, commands, seeds, commit SHAs, or durable
+artifact pointers.
+
+Current high-signal bundles include:
+
+- `evidence/issue_1608_seed_sensitivity_2026-05-30/`
+- `evidence/issue_1674_topology_hypothesis_diagnostics_2026-05-30/`
+- `evidence/issue_1692_topology_hypothesis_probe_2026-05-30/`
+
+## Pruning And Refactoring Rules
+
+- Do not delete historical notes just because they are old; mark them `historical` or `superseded`
+  when they still explain a decision trail.
+- Prefer one canonical note per active issue family, with older notes linking forward.
+- Move repeated operational instructions into `AGENTS.md`, `docs/dev_guide.md`, `.agents/skills/`,
+  or `docs/ai/` when they are no longer issue-specific.
+- Keep large generated artifacts out of this tree. Promote only compact, reviewable summaries or
+  manifests into `docs/context/evidence/`.
+- When a note only points at unavailable local `output/` files and has no durable pointer, classify
+  it as historical or blocked instead of treating it as reusable evidence.
+
+## Adding A New Index Row
+
+Add a row here when a note becomes a stable entry point for future agents. Include the domain, the
+smallest useful starting file, and why it should be read before lower-level history.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -3,6 +3,10 @@
 `docs/context/` is the repository's Markdown knowledge base for issue execution history, durable
 agent handoff, and reusable reasoning that should not be trapped in chat or PR text.
 
+For retrieval, start with [INDEX.md](INDEX.md). This README defines how to create and maintain
+notes; the index is the lean entry point for finding current, domain-relevant context without
+bulk-reading the whole history.
+
 Use this directory for non-trivial insights, decisions, tradeoffs, validation notes, and execution
 context that future contributors or agents are likely to need again.
 


### PR DESCRIPTION
## Summary
Adds a lean Markdown-first retrieval index for `docs/context/` and updates agent/documentation entry
points to start from it before opening broad historical note lists.

## Linked Issues
- Closes #1714

## What Changed
- Added `docs/context/INDEX.md` with retrieval rules, status vocabulary, domain entry points,
  evidence bundle pointers, and stale-note pruning/refactoring rules.
- Reframed `docs/context/README.md` as the note-maintenance workflow while pointing retrieval to
  the new index.
- Updated `AGENTS.md`, `docs/README.md`, `docs/ai/repo_overview.md`, and
  `docs/ai/ai-workflow.md` so agents and contributors discover the new retrieval surface.

## Why It Matters
- Added value: agents can find current context-note surfaces without bulk-reading the full
  `docs/context/` history.
- Expected impact: lower token/context overhead for issue, benchmark, and workflow investigations.
- Why this is worth merging now: it satisfies the first-pass #1714 architecture without introducing
  a retrieval database, generated catalog, or vector/MCP infrastructure.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - explicit shell path-existence check for every new `docs/context/INDEX.md` link
- Evidence that the change works here:
  - Qwen Step review: no blockers; confirmed issue acceptance criteria and suggested the
    retrieval-deferral provenance link.
  - OpenCode Go review: no blockers; confirmed docs-only scope and valid links.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; docs-only retrieval architecture.
  - Full `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` intentionally not run for this
    low-risk docs-only branch.

## Risks / Rollout
- Compatibility risks: low; no runtime code, configs, schemas, or benchmark semantics changed.
- Failure modes: the hand-curated index can drift as context notes move or are superseded.
- Rollback or fallback plan: revert the docs commit; existing `docs/context/README.md` links remain
  available in history.

## Docs / Provenance
- Updated docs:
  - `docs/context/INDEX.md`
  - `docs/context/README.md`
  - `AGENTS.md`
  - `docs/README.md`
  - `docs/ai/repo_overview.md`
  - `docs/ai/ai-workflow.md`
- Relevant design or provenance notes:
  - `docs/ai/retrieval_deferral.md`
- Any assumptions that need to be preserved:
  - This is a Markdown-first catalog, not a generated or database-backed retrieval layer.

## Follow-Up Issues
- Deferred work:
  - Optional future validation hook for checking `docs/context/INDEX.md` links if index drift
    becomes costly.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - Whether the first-pass domain table covers the right high-value context surfaces.
- Any known limitations:
  - The index is intentionally not exhaustive; it is a starting surface for current context.
