### PR TITLE
ci: time setup phases (#1653)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
           sudo apt-get install -y --no-install-recommends ffmpeg libglib2.0-0 libgl1 fonts-dejavu-core jq
 
       - name: Sync dependencies (locked)
-        run: uv sync --all-extras --frozen
+        run: bash scripts/dev/ci_step_timer.sh "Sync dependencies (locked)" uv sync --all-extras --frozen
 
       - name: Migrate legacy artifacts into canonical root
-        run: uv run python scripts/tools/migrate_artifacts.py
+        run: bash scripts/dev/ci_step_timer.sh "Migrate legacy artifacts into canonical root" uv run python scripts/tools/migrate_artifacts.py
 
       - name: Lint
         run: scripts/dev/ci_driver.sh lint
@@ -146,10 +146,10 @@ jobs:
           sudo apt-get install -y --no-install-recommends ffmpeg libglib2.0-0 libgl1 fonts-dejavu-core jq
 
       - name: Sync dependencies (locked)
-        run: uv sync --all-extras --frozen
+        run: bash scripts/dev/ci_step_timer.sh "Sync dependencies (locked)" uv sync --all-extras --frozen
 
       - name: Migrate legacy artifacts into canonical root
-        run: uv run python scripts/tools/migrate_artifacts.py
+        run: bash scripts/dev/ci_step_timer.sh "Migrate legacy artifacts into canonical root" uv run python scripts/tools/migrate_artifacts.py
 
       - name: Validation smoke tests
         run: scripts/dev/ci_driver.sh smoke

--- a/docs/context/issue_1653_ci_runtime_slice.md
+++ b/docs/context/issue_1653_ci_runtime_slice.md
@@ -53,15 +53,17 @@ for sampled runs do not include step timestamps. The timing helper therefore pro
 
 PR #1681 updated `scripts/dev/ci_timing_summary.py` to report slowest jobs as a fallback and to
 make missing step timestamps explicit in Markdown output. The post-trim sample still has no
-step-level durations, so this branch adds explicit phase timing emitted by
+step-level durations, so PR #1700 added explicit phase timing emitted by
 `scripts/dev/ci_driver.sh` instead of relying on GitHub's step payload.
 
 `fast-feedback` and `smoke-artifacts` both repeat checkout, uv setup, Python setup, system package
 installation, dependency sync, and artifact migration. Because GitHub did not expose step durations
 for the sampled runs, the current evidence cannot yet quantify repeated setup or artifact-generation
-cost. The new phase timing covers the repository-owned `ci_driver.sh` phases first; setup-step
-timing should be added at workflow level only if the next CI logs show that repository phases are
-not the main cost.
+cost. The new phase timing covers the repository-owned `ci_driver.sh` phases first. This branch also
+adds workflow-level timing around dependency sync and artifact migration in both `fast-feedback` and
+`smoke-artifacts` using `scripts/dev/ci_step_timer.sh` so repeated setup costs surface directly in
+CI logs. If repository phases remain dominant, the next probe should inspect required test grouping
+or sharding without weakening coverage.
 
 ## Local Slowest Tests
 
@@ -111,7 +113,7 @@ The aggregate `ci` job remains unchanged. It still gates on both `fast-feedback`
 | candidate | risk | evidence needed before implementation |
 | --- | --- | --- |
 | Add phase timing around `lint`, `typecheck`, `test`, `smoke`, and `artifact-policy` in `scripts/dev/ci_driver.sh` | low, implemented in this branch | CI log shows per-phase durations without changing pass/fail semantics |
-| Add timing around dependency sync and artifact migration in both CI jobs | low | CI log identifies whether repeated setup is material compared with test time |
+| Add timing around dependency sync and artifact migration in both CI jobs | low, **done** | CI log identifies whether repeated setup is material compared with test time |
 | Split slow example smoke tests into a separately timed subgroup while keeping them required | medium | Before/after CI run shows earlier failure signal or lower p90 without reducing coverage |
 | Investigate whether docs-only PRs can use a reduced gate | medium-high | Maintainer decision plus path filter proof that benchmark, planner, workflow, config, and code changes still run full gates |
 

--- a/scripts/dev/ci_step_timer.sh
+++ b/scripts/dev/ci_step_timer.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: scripts/dev/ci_step_timer.sh <label> <command> [args...]" >&2
+  exit 2
+fi
+
+label="$1"
+shift
+
+echo "::group::${label}"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+start_seconds="$(date +%s)"
+echo "ci_step_timer step_start label=${label} started_at=${started_at}"
+
+set +e
+"$@"
+status=$?
+
+completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+end_seconds="$(date +%s)"
+duration=$((end_seconds - start_seconds))
+echo "ci_step_timer step_end label=${label} status=${status} duration_seconds=${duration} completed_at=${completed_at}"
+echo "::notice title=${label} timing::status=${status} duration_seconds=${duration}"
+echo "::endgroup::"
+
+set -e
+exit "${status}"

--- a/scripts/dev/ci_step_timer.sh
+++ b/scripts/dev/ci_step_timer.sh
@@ -12,7 +12,7 @@ shift
 echo "::group::${label}"
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 start_seconds="$(date +%s)"
-echo "ci_step_timer step_start label=${label} started_at=${started_at}"
+echo "ci_step_timer step_start label=\"${label}\" started_at=${started_at}"
 
 set +e
 "$@"
@@ -21,8 +21,8 @@ status=$?
 completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 end_seconds="$(date +%s)"
 duration=$((end_seconds - start_seconds))
-echo "ci_step_timer step_end label=${label} status=${status} duration_seconds=${duration} completed_at=${completed_at}"
-echo "::notice title=${label} timing::status=${status} duration_seconds=${duration}"
+echo "ci_step_timer step_end label=\"${label}\" status=${status} duration_seconds=${duration} completed_at=${completed_at}"
+echo "::notice title=\"${label}\" timing::status=${status} duration_seconds=${duration}"
 echo "::endgroup::"
 
 set -e

--- a/tests/dev/test_ci_step_timer.py
+++ b/tests/dev/test_ci_step_timer.py
@@ -7,28 +7,33 @@ from pathlib import Path
 
 
 def test_ci_step_timer_shell_syntax():
+    """Validate that the CI step timer helper passes bash syntax checks."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
     assert script.exists(), "ci_step_timer.sh helper is missing"
-    assert subprocess.run(["bash", "-n", str(script)], check=True).returncode == 0
+    assert subprocess.run(["bash", "-n", str(script)], check=False).returncode == 0
 
 
 def test_ci_step_timer_requires_label_and_command():
+    """Ensure the helper exits with usage info when arguments are missing."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
     result = subprocess.run(
         ["bash", str(script)],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 2
     assert "Usage:" in result.stderr
 
 
 def test_ci_step_timer_propagates_failure():
+    """Verify that a failing command is reflected in the reported status."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
     result = subprocess.run(
         ["bash", str(script), "failing-check", "false"],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 1
     assert "failing-check" in result.stdout
@@ -36,13 +41,15 @@ def test_ci_step_timer_propagates_failure():
 
 
 def test_ci_step_timer_reports_success_duration():
+    """Check that a successful step is reported with zero exit status and duration."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
     result = subprocess.run(
         ["bash", str(script), "echo-test", "echo", "hello"],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 0
     assert "echo-test" in result.stdout
     assert "hello" in result.stdout
-    assert "ci_step_timer step_end label=echo-test status=0 duration_seconds=" in result.stdout
+    assert 'ci_step_timer step_end label="echo-test" status=0 duration_seconds=' in result.stdout

--- a/tests/dev/test_ci_step_timer.py
+++ b/tests/dev/test_ci_step_timer.py
@@ -1,0 +1,48 @@
+"""Tiny sanity check for the CI step timer helper."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_ci_step_timer_shell_syntax():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    assert script.exists(), "ci_step_timer.sh helper is missing"
+    assert subprocess.run(["bash", "-n", str(script)], check=True).returncode == 0
+
+
+def test_ci_step_timer_requires_label_and_command():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
+
+
+def test_ci_step_timer_propagates_failure():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    result = subprocess.run(
+        ["bash", str(script), "failing-check", "false"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "failing-check" in result.stdout
+    assert "::endgroup::" in result.stdout
+
+
+def test_ci_step_timer_reports_success_duration():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    result = subprocess.run(
+        ["bash", str(script), "echo-test", "echo", "hello"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "echo-test" in result.stdout
+    assert "hello" in result.stdout
+    assert "ci_step_timer step_end label=echo-test status=0 duration_seconds=" in result.stdout


### PR DESCRIPTION
## Summary
Adds explicit CI log timing around dependency sync and artifact migration in both CI jobs so #1653
can quantify repeated setup costs before changing test selection or workflow coverage.

## Linked Issues
- Relates to #1653

## What Changed
- Added `scripts/dev/ci_step_timer.sh`, a small wrapper that preserves the wrapped command exit code
  and emits grouped `ci_step_timer` start/end log lines plus a GitHub Actions notice.
- Wrapped `uv sync --all-extras --frozen` and `scripts/tools/migrate_artifacts.py` in both
  `fast-feedback` and `smoke-artifacts`.
- Added focused tests for helper syntax, usage errors, failure propagation, and success logging.
- Updated `docs/context/issue_1653_ci_runtime_slice.md` to mark this low-risk timing slice done.

## Why It Matters
- Added value: CI logs will show whether repeated dependency sync or artifact migration materially
  contributes to CI wall time.
- Expected impact: safer follow-up tuning because the next #1653 decision can use concrete setup
  timing rather than guesswork.
- Why this is worth merging now: it preserves the validation contract and only adds instrumentation.

## Validation / Proof
- Commands run:
  - `bash -n scripts/dev/ci_step_timer.sh`
  - `uv run pytest tests/dev/test_ci_step_timer.py -v`
  - YAML parse of `.github/workflows/ci.yml` with PyYAML
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
- Evidence that the change works here:
  - Helper tests passed: `4 passed`.
  - The workflow YAML parses.
  - The helper tests verify failure propagation and success log output.
- Benchmarks or smoke tests, if applicable:
  - Not applicable; instrumentation-only CI workflow change.
  - Full `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` intentionally not run before PR;
    GitHub CI is the meaningful execution proof for this workflow branch.

## Risks / Rollout
- Compatibility risks: low; job names, required checks, test selection, artifact policy, and
  benchmark semantics are unchanged.
- Failure modes: CI shell/YAML mistake; mitigated by helper tests and YAML parse.
- Rollback or fallback plan: revert the helper and workflow wrapper commit.

## Docs / Provenance
- Updated docs:
  - `docs/context/issue_1653_ci_runtime_slice.md`
- Relevant design or provenance notes:
  - Existing #1653 timing baseline and candidate quick-win table.
- Any assumptions that need to be preserved:
  - This is instrumentation only; it is not evidence of a runtime speedup until CI logs are
    inspected after this PR runs.

## Follow-Up Issues
- Deferred work:
  - Inspect this PR's CI logs to decide whether setup, repository phases, or tests dominate the
    next #1653 slice.
- Issues opened for follow-up:
  - None.

## Reviewer Notes
- Anything a reviewer should verify closely:
  - The `ci_step_timer` log output in the first CI run on this PR.
- Any known limitations:
  - `actionlint` was not available locally; validation used YAML parsing plus GitHub CI.
