### PR TITLE
docs: add external data audit template (#1722)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1396,6 +1396,7 @@ Use the following templates for specific tasks.
 - [priority assessor skill](../.agents/skills/gh-issue-priority-assessor/SKILL.md) - Review Project #5 priority inputs against the rubric and explain plausibility
 - [PR opener skill](../.agents/skills/gh-pr-opener/SKILL.md) - Open draft PRs with the repository template, issue-scope verification, and conservative readiness freshness checks
 - [design doc template](./templates/design-doc-template.md)
+- [external data audit template](./templates/external_data_audit.md) - Record source, license, redistribution, checksum, and Robot SF use decisions before staging external assets
 - [PR template](../.github/PULL_REQUEST_TEMPLATE/pr_default.md)
 
 

--- a/docs/templates/external_data_audit.md
+++ b/docs/templates/external_data_audit.md
@@ -10,7 +10,7 @@ data unless the license and a maintainer decision explicitly allow redistributio
 - Upstream source URL:
 - Access date:
 - Upstream version, tag, commit, or release:
-- Related issue or PR:
+- Related issue or PR: none / `Issue #<id>` / `PR #<id>`
 - Intended Robot SF use:
 
 ## License And Access
@@ -67,7 +67,7 @@ data unless the license and a maintainer decision explicitly allow redistributio
 - Benchmark eligibility: not eligible / blocked until hydrated / smoke-only / benchmark candidate
 - Redistribution status: no redistribution / derived-only / raw-and-derived allowed
 - Required durable pointer:
-- Required follow-up issue:
+- Required follow-up issue: none / `Issue #<id>`
 - Reviewer notes:
 
 ## Validation Checklist

--- a/docs/templates/external_data_audit.md
+++ b/docs/templates/external_data_audit.md
@@ -1,0 +1,81 @@
+# External Data Audit Template
+
+Use this template before staging external datasets, maps, checkpoints, generated fixtures, or other
+third-party assets for Robot SF work. Keep paths repository-relative. Do not commit raw restricted
+data unless the license and a maintainer decision explicitly allow redistribution.
+
+## Summary
+
+- Dataset or asset name:
+- Upstream source URL:
+- Access date:
+- Upstream version, tag, commit, or release:
+- Related issue or PR:
+- Intended Robot SF use:
+
+## License And Access
+
+- Observed license:
+- License URL or file:
+- Access restrictions:
+- Citation requirement:
+- Citation text or BibTeX:
+- Commercial, research-only, or non-redistribution limits:
+- License compatibility decision: allowed / blocked / unclear
+- Decision rationale:
+
+## Download And Raw-File Policy
+
+- Canonical download method:
+- Required credentials or account:
+- Expected raw files:
+- Raw local cache path:
+- Raw-file tracking decision: untracked / tracked fixture / external artifact pointer
+- Raw-file redistribution decision: allowed / blocked / unclear
+- Fail-closed behavior when raw files are missing:
+
+## Derived Files And Fixtures
+
+- Derived outputs to generate:
+- Generation command or script:
+- Derived output paths:
+- Derived fixture tracking decision: untracked / tracked fixture / durable evidence copy
+- Derived redistribution decision: allowed / blocked / unclear
+- How derived files preserve license and citation metadata:
+- Difference between derived fixtures and official source data:
+
+## Checksums And Manifest
+
+- Manifest path:
+- Checksum algorithm: SHA-256
+- Raw-file checksum requirement:
+- Derived-file checksum requirement:
+- Expected manifest fields:
+  - source URL
+  - access date
+  - license
+  - raw file names and checksums
+  - derived file names and checksums
+  - generation command
+  - source commit
+  - Robot SF use decision
+- Verification command:
+
+## Robot SF Use Decision
+
+- Use status: allowed / blocked / reference-only / exploratory-only / benchmark-ready
+- Benchmark eligibility: not eligible / blocked until hydrated / smoke-only / benchmark candidate
+- Redistribution status: no redistribution / derived-only / raw-and-derived allowed
+- Required durable pointer:
+- Required follow-up issue:
+- Reviewer notes:
+
+## Validation Checklist
+
+- [ ] Source URL, access date, and version are recorded.
+- [ ] License, access restrictions, and citation requirements are recorded.
+- [ ] Raw files, derived files, and redistribution decisions are separated.
+- [ ] Checksums or an explicit checksum plan are recorded.
+- [ ] The Robot SF use decision is one of allowed, blocked, reference-only, exploratory-only, or benchmark-ready.
+- [ ] Missing artifacts fail closed with an actionable message.
+- [ ] No restricted raw data is committed unless explicitly allowed.


### PR DESCRIPTION
## Summary
Adds a reusable external data audit template for dataset and asset provenance decisions.

## Linked Issues
- Closes #1722

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Added `docs/templates/external_data_audit.md` with fields for source, license, access restrictions, citation, raw-file policy, derived fixtures, checksums, manifests, redistribution, and Robot SF use decisions.
- Linked the template from `docs/dev_guide.md`'s template list.

## Why It Matters
- Added value: external dataset and asset issues can reuse one consistent provenance checklist.
- Expected impact: fewer ambiguous license, redistribution, and checksum decisions in future external-data work.
- Why this is worth merging now: several external-data lanes are blocked or sensitive to raw-file policy, so a shared template reduces repeated issue text.

## Validation / Proof
- Commands run:
  - `sed -n '1,220p' docs/templates/external_data_audit.md`
  - `git diff --check`
  - Python assertion checking required template fields and the `docs/dev_guide.md` link
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Evidence that the change works here: the template path exists, the dev-guide link resolves by repository-relative path, and required provenance fields are present.
- Benchmarks or smoke tests, if applicable: not applicable; docs-template change only.

## Risks / Rollout
- Compatibility risks: none for runtime code.
- Failure modes: future issue authors may treat the template as a final license decision; the template keeps allowed/blocked/unclear decisions explicit to reduce that risk.
- Rollback or fallback plan: remove the template and dev-guide link.

## Docs / Provenance
- Updated docs: `docs/templates/external_data_audit.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: aligns with `docs/context/artifact_evidence_vocabulary.md` and the `data-staging-provenance` skill guardrails.
- Any assumptions that need to be preserved: raw files, derived fixtures, and redistribution decisions should remain separate.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- This PR does not stage or download any external data.
- Ignored local artifact: `.venv/` was created by validation/bootstrap and remains untracked.
