### PR TITLE
docs: add issue priority discussion workflow (#1729)

### DIFF
--- a/.agents/skills/gh-issue-sequencer/SKILL.md
+++ b/.agents/skills/gh-issue-sequencer/SKILL.md
@@ -41,19 +41,45 @@ direction and fresh evidence can override queue order.
 5. Order and apply:
    - sort by explicit maintainer direction first, then higher priority, lower uncertainty, unlock
      factor, and oldest issue number,
+   - continue autonomous ordering when the top candidate is clearly actionable,
+   - use priority discussion only when two or more plausible next issues depend on a real value
+     tradeoff that repository evidence and Project #5 fields cannot resolve,
    - apply status/priority/duration edits in one write pass,
    - run score sync once at batch end if inputs changed.
 6. If writes fail (rate limits or auth), stop writes and capture exact pending mutation details.
+
+## Priority Discussion Mode
+
+Use this mode sparingly. It exists for queue-ordering tradeoffs, not for routine approval of every
+autonomous issue selection.
+
+Ask one focused priority question only when all are true:
+
+- at least two unblocked issues are implementable now,
+- their Project #5 score or labels do not clearly decide the order,
+- the choice changes real maintainer value, risk, or unblock impact,
+- the answer cannot be inferred from recent issue comments, PR state, or canonical docs.
+
+Frame the question around concrete choices, for example:
+`Should the next PR prioritize reducing CI minutes (#A) or improving benchmark provenance (#B)?`
+
+After the maintainer answers, record the decision in the relevant issue as a short comment or
+`Maintainer priority note` body entry. If the answer changes Project #5 priority fields, batch that
+write with the normal Project #5 metadata pass and run score sync once at the end. If the answer is
+only an ordering preference, do not invent new priority-score inputs.
 
 ## Guardrails
 
 - Use MCP/interactive tools when available; use `gh` for deterministic sequencing mutations.
 - Do not interleave issue-body edits, project routing, and score sync issue-by-issue for multi-issue batches.
+- Do not ask a priority question when the next issue is already clear, when a blocker/clarification
+  question is really needed instead, or when the tradeoff is only agent convenience.
 - Use follow-up handoffs rather than retry loops when quotas are temporarily exhausted.
 
 ## Output
 
 - Ordered issue queue with one-line rationale per item.
+- Priority discussion question asked, answer recorded, or reason it was unnecessary.
 - Status and priority changes applied.
 - Unresolved blockers and next candidate issue.
 - Whether final score sync completed.

--- a/.agents/skills/issue-audit/SKILL.md
+++ b/.agents/skills/issue-audit/SKILL.md
@@ -40,7 +40,7 @@ decisions, and clear handoff state.
    - routing/Project #5 updates second,
    - one score-sync batch at the end if needed.
 
-## Priority Questions
+## Priority Discussion Mode
 
 Priority tradeoffs are allowed in this audit loop, but they should not become a confirmation gate
 for ordinary autonomous issue pickup. Ask a priority question only when the agent can name the

--- a/.agents/skills/issue-audit/SKILL.md
+++ b/.agents/skills/issue-audit/SKILL.md
@@ -40,16 +40,42 @@ decisions, and clear handoff state.
    - routing/Project #5 updates second,
    - one score-sync batch at the end if needed.
 
+## Priority Questions
+
+Priority tradeoffs are allowed in this audit loop, but they should not become a confirmation gate
+for ordinary autonomous issue pickup. Ask a priority question only when the agent can name the
+competing implementable issues and the maintainer's value judgment is the missing input.
+
+Good priority questions are single-choice tradeoffs tied to concrete issue numbers:
+
+- `Which should come first: CI-runtime reduction (#A) or benchmark-provenance cleanup (#B)?`
+- `For the next local-only PR, should we favor low-risk docs cleanup (#A) or higher-impact workflow
+  repair (#B)?`
+
+After the answer:
+
+- add a short issue comment or `Maintainer priority note` body entry on the issue whose ordering
+  changed,
+- cite the answer source when editing an issue body,
+- update Project #5 priority/status fields only when the answer changes those fields,
+- leave Project #5 score inputs advisory and quota-aware,
+- check `gh api rate_limit` before Project #5 writeback when applying several priority answers,
+  and leave exact pending mutations in the handoff if quota pressure blocks the write,
+- return to autonomous sequencing once the specific tradeoff is resolved.
+
 ## Guardrails
 
 - Ask questions only for decisions not discoverable from repo artifacts.
 - Never ask bundled multi-part questions.
+- Do not ask the user to approve every next issue; clear cases should keep moving through the
+  normal autonomous implementation loop.
 - Do not preserve stale issue statements once a decision invalidates them.
 
 ## Output
 
 - Issue and blocker addressed.
 - Question asked and answer applied.
+- Priority answer recorded and where, if priority discussion mode was used.
 - Changes made (body/labels/project state) and follow-up issues.
 - Next blocker and optional stop reason if interrupted.
 ## When to use


### PR DESCRIPTION
## Summary
Adds a lightweight priority-discussion workflow to the issue sequencing and audit skills.

## Linked Issues
- Closes #1729

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Added `Priority Discussion Mode` to `gh-issue-sequencer` with explicit criteria for when a priority question is warranted.
- Added `Priority Questions` guidance to `issue-audit` so maintainer answers are recorded as issue comments or `Maintainer priority note` body entries.
- Preserved autonomous issue pickup for clear cases and kept Project #5 score inputs advisory and quota-aware.

## Why It Matters
- Added value: agents can ask one focused tradeoff question when issue ordering depends on maintainer value judgment.
- Expected impact: fewer ad hoc planning stalls while preserving autonomous issue-to-PR flow.
- Why this is worth merging now: it gives the current issue-implementation loop a predictable escalation path for ambiguous priority choices.

## Validation / Proof
- Commands run:
  - `qwen --bare --auth-type qwen-oauth -m Step-3.7-Flash ...` (blocked by unavailable Qwen OAuth free tier)
  - `qwen --bare --auth-type qwen-oauth -m Qwen3.6-27B ...` (blocked by unavailable Qwen OAuth free tier)
  - `uv run python scripts/dev/check_skills.py`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - focused `rg` checks for priority-discussion wording
- Evidence that the change works here: skill registry validation passes, docs/proof consistency passes, and the changed skill docs include the required gating, recording, autonomy, and Project #5 quota guidance.
- Benchmarks or smoke tests, if applicable: not applicable; skill documentation change only.

## Risks / Rollout
- Compatibility risks: low; no runtime code changes.
- Failure modes: agents could overuse priority questions despite the guardrails; the docs explicitly restrict this mode to unresolved value tradeoffs.
- Rollback or fallback plan: revert the two skill-doc edits.

## Docs / Provenance
- Updated docs: `.agents/skills/gh-issue-sequencer/SKILL.md`, `.agents/skills/issue-audit/SKILL.md`.
- Relevant design or provenance notes: follows `docs/context/issue_713_batch_first_issue_workflow.md` by batching Project #5 writes and score sync.
- Any assumptions that need to be preserved: Project #5 scoring remains advisory; priority discussion is not approval for every autonomous issue selection.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Gemini read-only review found no blockers; its consistency suggestions were applied.
- Ignored local artifact: `.venv/` was created by validation/bootstrap and remains untracked.
