### PR TITLE
docs: add queue audit output schema (#1719)

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -139,6 +139,33 @@ hardware, SLURM, CARLA, private artifacts, checkpoint aliases, datasets, or a cl
 mark it blocked or send it to issue clarification instead of counting the queue as empty. Keep this
 audit read-only until the orchestrator has reviewed the proposed label/body changes.
 
+Emit the compact `queue_audit.v1` shape alongside the prose handoff when the queue is exhausted or
+nearly exhausted. Each row must include:
+
+- issue number,
+- classification,
+- `implementable_now`,
+- recommended action.
+
+Allowed classifications:
+
+- `parent_or_epic`: parent, epic, decision, or umbrella issue that should produce a child issue,
+- `analysis_only`: synthesis, interpretation, or research-only work that is not an implementation
+  PR unless the run explicitly targets synthesis,
+- `blocked_external`: requires unavailable datasets, private artifacts, external services, CARLA,
+  or non-local credentials,
+- `blocked_slurm`: requires SLURM/Auxme or another unavailable execution environment,
+- `covered_by_pr`: already has an open PR or merged change covering the scope,
+- `ready_local`: clear, bounded, locally implementable issue,
+- `ambiguous`: needs one clarification before implementation routing,
+- `too_broad`: mixes multiple independently validatable PRs,
+- `blocked_other`: blocked for a reason not covered above, with rationale.
+
+Parent, epic, and analysis-only issues must not be reported as ready implementation work unless the
+run explicitly targets clarification, splitting, or synthesis. Blocked-external and blocked-SLURM
+issues must route to `mark_blocked`, `clarify`, or `skip` until the missing artifact, service,
+credential, or execution environment is actually available.
+
 If the final audit leaves only parent, epic, decision, or research issues that are not directly
 implementable, hand exactly one parent to `issue-splitter` instead of stopping with a prose-only
 report. The splitter should produce or create one `Next Implementable Child` only after duplicate
@@ -168,11 +195,63 @@ Queue exhaustion audit
   - clarify #1235 or split #1236 before claiming the implementation queue is exhausted.
 ```
 
-This is an illustrative report shape, not a required machine-readable schema. Prefer this compact
-summary in final handoffs and PR comments when the queue is genuinely exhausted. If a remaining
-issue only needs a clearer contract, route it to issue clarification. If a remaining issue bundles
-several independently validatable changes, create child issues with `gh-issue-creator` and leave the
-parent as the coordination issue instead of treating the bundle as unimplementable.
+Companion `queue_audit.v1` example:
+
+```yaml
+queue_audit:
+  schema: queue_audit.v1
+  query_used:
+    - gh issue list --state open --label state:ready --json number,title,labels,url --limit 100
+    - gh issue list --search "repo:ll7/robot_sf_ll7 is:issue is:open -label:state:ready -label:state:blocked -label:state:hold" --json number,title,labels,url --limit 100
+  issues:
+    - issue: "#1234"
+      classification: blocked_slurm
+      implementable_now: false
+      recommended_action: mark_blocked
+      rationale: needs SLURM/Auxme allocation
+    - issue: "#1235"
+      classification: ambiguous
+      implementable_now: false
+      recommended_action: clarify
+      rationale: acceptance criteria mix benchmark claim and exploratory probe
+    - issue: "#1236"
+      classification: too_broad
+      implementable_now: false
+      recommended_action: split_parent
+      rationale: path rewrite should split into fixture migration, docs migration, and validation
+    - issue: "#1237"
+      classification: covered_by_pr
+      implementable_now: false
+      recommended_action: wait_for_pr
+      rationale: open PR #1238 covers the scope
+    - issue: "#1239"
+      classification: ready_local
+      implementable_now: true
+      recommended_action: implement
+      rationale: bounded docs/tooling change with local validation path
+    - issue: "#1240"
+      classification: parent_or_epic
+      implementable_now: false
+      recommended_action: split_parent
+      rationale: umbrella issue needs a next implementable child
+    - issue: "#1241"
+      classification: analysis_only
+      implementable_now: false
+      recommended_action: synthesize
+      rationale: asks for evidence interpretation, not code or docs implementation
+    - issue: "#1242"
+      classification: blocked_external
+      implementable_now: false
+      recommended_action: mark_blocked
+      rationale: depends on unavailable licensed dataset assets
+  best_next_action: implement #1239, or split #1236 if no ready_local row remains
+```
+
+Use the prose summary for human readability and `queue_audit.v1` for repeatable comparison across
+runs. If a remaining issue only needs a clearer contract, route it to issue clarification. If a
+remaining issue bundles several independently validatable changes, create child issues with
+`gh-issue-creator` and leave the parent as the coordination issue instead of treating the bundle as
+unimplementable.
 
 Route remaining issues by their blocker:
 - Use `gh-issue-clarifier` when the issue intent, proof path, acceptance criteria, or ownership is
@@ -255,7 +334,8 @@ For each issue completed or stopped, report:
 
 When the queue exhausts, also report the final implementability audit result: remaining ready
 issues, remaining open issues missing `state:*`, any labels/body updates applied after review, and
-the command or query used to confirm the queue state.
+the command or query used to confirm the queue state. Include `queue_audit.v1` rows for exhausted
+or nearly exhausted queues so future agents can compare classifications across runs.
 
 ## When to use
 

--- a/.agents/skills/schemas/queue_audit.v1.yaml
+++ b/.agents/skills/schemas/queue_audit.v1.yaml
@@ -1,0 +1,12 @@
+queue_audit:
+  schema: queue_audit.v1
+  query_used:
+  - gh issue list ...
+  issues:
+  - issue: '#1234'
+    classification: parent_or_epic | analysis_only | blocked_external | blocked_slurm | covered_by_pr | ready_local | ambiguous | too_broad | blocked_other
+    implementable_now: true | false
+    recommended_action: implement | split_parent | clarify | mark_blocked | wait_for_pr | synthesize | skip
+    rationale: string
+    linked_pr: '#optional'
+  best_next_action: string

--- a/docs/context/open_issue_execution_improvement_plan_2026-05-30.md
+++ b/docs/context/open_issue_execution_improvement_plan_2026-05-30.md
@@ -127,17 +127,18 @@ Use existing labels and issue-body metadata first:
 
 Only add new `state:*` labels after a specific automation or Project #5 need is documented.
 
-### Do Not Add A Separate Queue-Audit Schema First
+### Queue-Audit Schema Status
 
 `goal-issue-implementation` already requires a final read-only implementability audit before
-declaring the queue exhausted. Improve that output in place if needed. A separate
-`queue_audit.v1` schema is premature unless a script or dashboard will consume it.
+declaring the queue exhausted. Issue #1719 implements `queue_audit.v1` as a compact companion
+shape for that existing audit, not as a replacement database or Project #5 metadata layer.
 
-Better follow-up:
+Use the schema to:
 
-- add one fixture or example output to the existing skill docs;
-- make the exhausted-queue handoff include the issue query used, remaining issue classes, and the
-  best issue-splitting candidate.
+- keep the exhausted-queue handoff comparable across runs,
+- include the issue query used, remaining issue classes, and recommended action,
+- preserve the best issue-splitting candidate without classifying parent, epic, blocked, or
+  analysis-only issues as ready implementation work.
 
 ### Do Not Duplicate Agent-Run Self-Review Workflow
 

--- a/tests/dev/test_queue_audit_schema_docs.py
+++ b/tests/dev/test_queue_audit_schema_docs.py
@@ -1,0 +1,70 @@
+"""Checks for the queue_audit.v1 exhausted-queue output contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / ".agents" / "skills" / "schemas" / "queue_audit.v1.yaml"
+SKILL_PATH = REPO_ROOT / ".agents" / "skills" / "goal-issue-implementation" / "SKILL.md"
+
+CLASSIFICATIONS = {
+    "parent_or_epic",
+    "analysis_only",
+    "blocked_external",
+    "blocked_slurm",
+    "covered_by_pr",
+    "ready_local",
+    "ambiguous",
+    "too_broad",
+    "blocked_other",
+}
+
+REQUIRED_EXAMPLE_CLASSIFICATIONS = {
+    "parent_or_epic",
+    "analysis_only",
+    "blocked_external",
+    "blocked_slurm",
+    "covered_by_pr",
+    "ready_local",
+}
+
+REQUIRED_FIELDS = {
+    "issue:",
+    "classification:",
+    "implementable_now:",
+    "recommended_action:",
+}
+
+
+def test_queue_audit_schema_names_required_fields_and_classifications() -> None:
+    """The schema contract should expose the required row fields and allowed classes."""
+    schema_text = SCHEMA_PATH.read_text(encoding="utf-8")
+    schema = yaml.safe_load(schema_text)
+
+    assert schema["queue_audit"]["schema"] == "queue_audit.v1"
+    assert REQUIRED_FIELDS <= set(schema_text.split())
+    for classification in CLASSIFICATIONS:
+        assert classification in schema_text
+
+
+def test_goal_issue_implementation_documents_required_queue_audit_examples() -> None:
+    """The exhausted-queue skill docs should show the classes required by issue #1719."""
+    skill_text = SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "queue_audit.v1" in skill_text
+    for field in REQUIRED_FIELDS:
+        assert field.rstrip(":").replace("_", " ") in skill_text or field in skill_text
+    for classification in REQUIRED_EXAMPLE_CLASSIFICATIONS:
+        assert f"classification: {classification}" in skill_text
+
+
+def test_queue_audit_routing_blocks_nonimplementation_classes() -> None:
+    """Blocked and non-implementation classes must not be treated as ready work."""
+    skill_text = SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "must not be reported as ready implementation work" in skill_text
+    assert "Blocked-external and blocked-SLURM" in skill_text
+    assert "issues must route to `mark_blocked`, `clarify`, or `skip`" in skill_text


### PR DESCRIPTION
## Summary
Adds a compact `queue_audit.v1` output shape for exhausted or nearly exhausted issue queues.

## Linked Issues
- Closes #1719

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Added `.agents/skills/schemas/queue_audit.v1.yaml`.
- Updated `goal-issue-implementation` to emit `queue_audit.v1` rows alongside the prose exhausted-queue handoff.
- Added required classifications and examples for parent/epic, analysis-only, blocked-external, blocked-SLURM, covered-by-PR, and ready-local rows.
- Added tests that validate the schema fields, classification coverage, and non-implementation routing guidance.
- Updated the existing execution-improvement plan to describe the schema as a companion to the existing audit.

## Why It Matters
- Added value: exhausted-queue handoffs become comparable across runs.
- Expected impact: future agents can distinguish blocked, parent, analysis-only, PR-covered, and ready-local issues without reinterpreting prose every time.
- Why this is worth merging now: queue hygiene is currently the limiting factor for autonomous issue implementation.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_queue_audit_schema_docs.py -v`
  - `uv run python scripts/dev/check_skills.py`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Evidence that the change works here: the new focused tests assert required fields, classifications, example coverage, and blocked/non-implementation routing guidance.
- Benchmarks or smoke tests, if applicable: not applicable; workflow documentation/schema change only.

## Risks / Rollout
- Compatibility risks: low; this adds an output companion shape without replacing Project #5 metadata.
- Failure modes: agents may treat the YAML as a strict machine schema before a parser exists; the docs call it a compact output shape and tests cover the documented contract.
- Rollback or fallback plan: remove the schema file, tests, and skill-doc section.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-issue-implementation/SKILL.md`, `docs/context/open_issue_execution_improvement_plan_2026-05-30.md`.
- Relevant design or provenance notes: keeps the schema inside the existing queue-exhaustion audit rather than creating a new queue service.
- Any assumptions that need to be preserved: parent/epic, analysis-only, blocked-external, and blocked-SLURM rows are not ready implementation work unless the run explicitly targets clarification, splitting, or synthesis.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Gemini read-only review initially flagged missing validation/example coverage; the final patch adds tests and the missing examples.
- Ignored local artifacts: `.venv/`, `.pytest_cache/`, and `output/coverage/*` were created by validation and remain untracked.
