### PR TITLE
docs: audit legacy benchmark track metadata

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -138,7 +138,7 @@ knowledge, not every transient iteration detail.
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
 * Issue #1612 parallel observation-space benchmark tracks:
   [issue_1612_observation_track_architecture.md](issue_1612_observation_track_architecture.md)
-* Issue #1721 legacy benchmark-track metadata audit:
+* Issue #1721 Legacy Benchmark-Track Metadata Audit:
   [issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md)
 * Issue #1659 LiDAR occupancy adapter:
   [issue_1659_lidar_occupancy_adapter.md](issue_1659_lidar_occupancy_adapter.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -138,6 +138,8 @@ knowledge, not every transient iteration detail.
   [issue_1246_observation_levels.md](issue_1246_observation_levels.md)
 * Issue #1612 parallel observation-space benchmark tracks:
   [issue_1612_observation_track_architecture.md](issue_1612_observation_track_architecture.md)
+* Issue #1721 legacy benchmark-track metadata audit:
+  [issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md)
 * Issue #1659 LiDAR occupancy adapter:
   [issue_1659_lidar_occupancy_adapter.md](issue_1659_lidar_occupancy_adapter.md)
 * Issue #1653 CI runtime slice:

--- a/docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/README.md
+++ b/docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/README.md
@@ -50,3 +50,6 @@ uv run python scripts/tools/analyze_scenario_seed_sensitivity.py \
 This is derived diagnostic evidence for scenario prioritization. It is not causal mechanism proof
 and is not paper-facing significance evidence. The source campaign is exploratory candidate evidence
 with `paper_facing=false`, and SNQI is not used for this issue's planner selection or classification.
+The source Issue #1454 bundle predates explicit `benchmark_track` and `track_schema_version`
+metadata, so this derived evidence inherits `legacy_track_unknown` status per
+`docs/context/issue_1721_benchmark_track_metadata_audit.md`.

--- a/docs/context/issue_1454_s10_h500_candidate_comparison.md
+++ b/docs/context/issue_1454_s10_h500_candidate_comparison.md
@@ -118,6 +118,11 @@ ahead after the S10 rerun.
 - SNQI diagnostics for this campaign report contract status `fail`, including negative rank
   alignment. Use direct success, collision, and near-miss metrics for claims; treat SNQI as
   diagnostic only.
+- The compact campaign evidence predates explicit `benchmark_track` and `track_schema_version`
+  metadata. Treat it as `legacy_track_unknown` per
+  [issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md):
+  valid for this historical S10/h500 surface, but not safe to aggregate with track-aware result rows
+  or compare across observation tracks.
 - The h500 surface should not replace fixed h100 in issue #1454 without an explicit scope decision.
   The fixed h100 Stage A gate remains failed at campaign level because `socnav_bench` failed closed.
 

--- a/docs/context/issue_1542_manuscript_claim_evidence_map.md
+++ b/docs/context/issue_1542_manuscript_claim_evidence_map.md
@@ -20,6 +20,13 @@ Verdict categories:
 - `insufficient`: evidence exists but is too weak/narrow for the claim.
 - `not_ready`: evidence collection or validation is incomplete.
 
+Observation-track metadata boundary: most historical benchmark evidence cited by this map predates
+first-class `benchmark_track` and `track_schema_version` metadata. Unless an evidence row
+explicitly records both fields, treat it as `legacy_track_unknown`: useful for within-surface
+interpretation, but not safe to aggregate with track-aware results or compare across observation
+tracks. See
+[issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md).
+
 ## Claim Area 1: AMV Benchmark Evidence
 
 ### Candidate Claim

--- a/docs/context/issue_1545_power_aware_seed_budget_planning.md
+++ b/docs/context/issue_1545_power_aware_seed_budget_planning.md
@@ -27,6 +27,11 @@ Canonical benchmark contract references:
 - SNQI remains diagnostic-only on the cited h500 surface because the durable summary records
   `snqi_contract_status="fail"` for the S10/h500 candidate campaign and only `warn` for the Stage A
   fixed-h100 surface.
+- The cited compact benchmark bundles predate explicit `benchmark_track` and
+  `track_schema_version` metadata unless a row says otherwise. Treat them as
+  `legacy_track_unknown` per
+  [issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md), and
+  do not aggregate them with track-aware result rows.
 
 ## Evidence Basis
 

--- a/docs/context/issue_1608_seed_sensitivity_analysis.md
+++ b/docs/context/issue_1608_seed_sensitivity_analysis.md
@@ -91,6 +91,13 @@ The result also should not be reused as paper-facing significance evidence. The 
 campaign is an exploratory candidate surface, and SNQI is not used here because the source bundle
 marks SNQI ordering as diagnostic only.
 
+Observation-track metadata boundary: the source Issue #1454 bundle predates explicit
+`benchmark_track` and `track_schema_version` metadata. This derived analysis therefore inherits
+`legacy_track_unknown` status per
+[issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md). Use it
+within the historical S10/h500 surface only; do not aggregate it with track-aware result rows or use
+it for cross-observation-track comparisons.
+
 ## Validation
 
 - `uv run pytest tests/tools/test_analyze_scenario_seed_sensitivity.py -q`

--- a/docs/context/issue_1721_benchmark_track_metadata_audit.md
+++ b/docs/context/issue_1721_benchmark_track_metadata_audit.md
@@ -1,0 +1,80 @@
+# Issue #1721 Benchmark Track Metadata Audit
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1721>
+
+Date: 2026-05-30
+
+## Goal
+
+Audit tracked benchmark evidence summaries, reports, and compact context evidence for explicit
+`benchmark_track` and `track_schema_version` metadata now that observation-track identity is part
+of benchmark comparability.
+
+This note preserves historical evidence as-is. It does not rerun benchmarks, rewrite old result
+files, infer missing metadata, or change planner rankings.
+
+## Classification Terms
+
+- `track_known`: the artifact or source contract explicitly records `benchmark_track` and
+  `track_schema_version`, or the note is a current track-aware specification/test surface.
+- `legacy_track_unknown`: the artifact contains benchmark results or derived benchmark analysis but
+  predates explicit track metadata. It can support bounded historical interpretation, but it must
+  not be aggregated with track-aware rows or used for cross-observation-track comparisons.
+- `not_applicable`: the artifact is a design note, launch packet, blocked/unavailable row,
+  diagnostic stub, CARLA replay parity surface, or non-benchmark evidence where observation-track
+  aggregation is not the evidence claim.
+
+## Method
+
+Static audit commands:
+
+```bash
+rg "benchmark_track|track_schema_version" docs/context docs/context/evidence configs scripts
+rg -l "benchmark_success|campaign_summary|scenario_seed|success_rate|collision|snqi|paper_facing|paired|AMV|seed" \
+  docs/context docs/context/evidence -g '*.md' -g '*.json' -g '*.csv' -g '*.yaml'
+```
+
+Observed result: no tracked files under `docs/context/evidence/` currently contain
+`benchmark_track` or `track_schema_version`. The track-aware contract is present in
+`docs/benchmark_spec.md`, `docs/context/issue_1612_observation_track_architecture.md`, current
+benchmark tests, and current benchmark/runtime code, but the preserved compact evidence bundles
+listed below were produced before that metadata became part of benchmark identity.
+
+## Inventory
+
+| Surface | Evidence kind | Classification | Why | Action |
+|---|---|---|---|---|
+| `docs/benchmark_spec.md` | current benchmark specification | `track_known` | Defines `benchmark_track` and `track_schema_version` as part of track-aware runs and aggregation boundaries. | Use as the current rule anchor. |
+| `docs/context/issue_1612_observation_track_architecture.md` | observation-track architecture note | `track_known` | Defines track metadata fields, aggregation fence, and diagnostic cross-track reporting boundary. | Use as the current interpretation anchor. |
+| `tests/test_cli_run.py`, `tests/test_runner_resume.py`, `tests/test_cli_aggregate.py`, `tests/test_cli_table.py`, `tests/test_ranking.py`, `tests/benchmark/test_lidar_observation_track.py` | current track-aware tests | `track_known` | Exercise metadata emission, resume identity, fail-closed mixed-track aggregation, and diagnostic cross-track labels. | Use as validation evidence for new runs, not as historical evidence metadata. |
+| `docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/` | compact AMV primary nominal/stress evidence | `legacy_track_unknown` | Benchmark summaries and tables predate explicit track metadata; static search found no track keys. | Keep cited with AMV/SNQI and unknown-track caveats. |
+| `docs/context/evidence/issue_1353_broader_amv_2026-05-26/` | broader AMV nominal/stress/cross-kinematics evidence | `legacy_track_unknown` | Benchmark summaries and tables predate explicit track metadata; static search found no track keys. | Keep cited with AMV/SNQI, SocNav unavailable, and unknown-track caveats. |
+| `docs/context/evidence/issue_1454_stage_a_fixed_h100_2026-05-22/` | S10 fixed-h100 benchmark evidence | `legacy_track_unknown` | Benchmark summaries and reports predate explicit track metadata; static search found no track keys. | Use only inside its historical fixed-h100 scope. |
+| `docs/context/evidence/issue_1454_s10_h500_candidates_2026-05-23/` | S10/h500 candidate benchmark evidence | `legacy_track_unknown` | Benchmark summaries, seed rows, and campaign tables predate explicit track metadata; static search found no track keys. | Keep challenger and seed-analysis claims bounded to this historical surface. |
+| `docs/context/evidence/issue_1462_s10_h500_failure_modes_2026-05-24/` | derived S10/h500 failure-mode summary | `legacy_track_unknown` | Derived from the issue #1454 S10/h500 candidate bundle, so it inherits unknown-track status. | Do not treat as new track-known evidence. |
+| `docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/` | derived seed-sensitivity analysis | `legacy_track_unknown` | Derived from the issue #1454 S10/h500 candidate bundle, so it inherits unknown-track status despite being generated after track architecture work. | Cite as diagnostic prioritization only. |
+| `docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/` | compact cross-kinematics smoke/probe evidence | `legacy_track_unknown` | Benchmark summaries and tables predate explicit track metadata; static search found no track keys. | Use only as compatibility smoke/probe evidence. |
+| `docs/context/evidence/camera_ready_all_planners_2026-05-04/` and `docs/context/evidence/issue_1023_*_2026-05-06/` | older camera-ready and scenario-horizon compact evidence | `legacy_track_unknown` | Benchmark summaries and reports predate explicit track metadata; static search found no track keys. | Do not mix with track-aware result rows. |
+| CARLA replay, route-clearance, setup-smoke, launch-packet, and blocked/unavailable evidence bundles | non-benchmark or non-aggregation evidence | `not_applicable` | These surfaces are not making observation-track benchmark aggregation claims. | Preserve their existing caveats; no track caveat needed unless reused as benchmark rows. |
+
+## Claim Caveat
+
+Any current note that cites the `legacy_track_unknown` benchmark bundles above should include this
+boundary:
+
+> Unless a cited evidence row explicitly records `benchmark_track` and `track_schema_version`, treat
+> it as `legacy_track_unknown`: useful for within-surface historical interpretation, but not safe to
+> aggregate with track-aware results or compare across observation tracks.
+
+This caveat is now reflected in the current manuscript evidence map, seed-budget planning note,
+S10/h500 candidate comparison note, and issue #1608 seed-sensitivity note.
+
+## Validation
+
+- `rg "benchmark_track|track_schema_version" docs/context docs/context/evidence configs scripts`
+- Manual link and caveat review for:
+  - `docs/context/issue_1542_manuscript_claim_evidence_map.md`
+  - `docs/context/issue_1545_power_aware_seed_budget_planning.md`
+  - `docs/context/issue_1454_s10_h500_candidate_comparison.md`
+  - `docs/context/issue_1608_seed_sensitivity_analysis.md`
+  - `docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/README.md`

--- a/docs/context/issue_1721_benchmark_track_metadata_audit.md
+++ b/docs/context/issue_1721_benchmark_track_metadata_audit.md
@@ -1,4 +1,4 @@
-# Issue #1721 Benchmark Track Metadata Audit
+# Issue #1721 Benchmark Track Metadata Audit (2026-05-30)
 
 Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1721>
 
@@ -34,11 +34,13 @@ rg -l "benchmark_success|campaign_summary|scenario_seed|success_rate|collision|s
   docs/context docs/context/evidence -g '*.md' -g '*.json' -g '*.csv' -g '*.yaml'
 ```
 
-Observed result: no tracked files under `docs/context/evidence/` currently contain
-`benchmark_track` or `track_schema_version`. The track-aware contract is present in
-`docs/benchmark_spec.md`, `docs/context/issue_1612_observation_track_architecture.md`, current
-benchmark tests, and current benchmark/runtime code, but the preserved compact evidence bundles
-listed below were produced before that metadata became part of benchmark identity.
+Observed result: the preserved compact evidence rows and summaries under
+`docs/context/evidence/` do not record explicit `benchmark_track` or `track_schema_version`
+metadata. PR-introduced caveat text may mention those field names, but it does not turn legacy rows
+into track-known evidence. The track-aware contract is present in `docs/benchmark_spec.md`,
+`docs/context/issue_1612_observation_track_architecture.md`, current benchmark tests, and current
+benchmark/runtime code, but the preserved compact evidence bundles listed below were produced before
+that metadata became part of benchmark identity.
 
 ## Inventory
 


### PR DESCRIPTION
## Summary

- Adds a dedicated issue #1721 audit note that classifies tracked benchmark evidence as `track_known`, `legacy_track_unknown`, or `not_applicable`.
- Records the static-search finding that current compact evidence under `docs/context/evidence/` has no explicit `benchmark_track` / `track_schema_version` keys.
- Adds unknown-track caveats to current claim/report notes that still cite legacy pre-track evidence.

Closes #1721

## Validation

- `rg "benchmark_track|track_schema_version" docs/context docs/context/evidence configs scripts`
- `git diff --check`
- `scripts/dev/check_docs_proof_consistency_diff.sh`
- Manual path existence checks for changed context-note links

## Artifact / Output Review

- `git status --ignored --short -uall output` produced no output.
- The worktree `.venv/` was created by the docs consistency check bootstrap and remains ignored/untracked.

## Notes

- PR opened ready for review, not draft.
- Historical evidence files are preserved as-is; no old result metadata was inferred or rewritten.