### PR TITLE
feat: add Decision Transformer dataset preflight

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -501,6 +501,9 @@ knowledge, not every transient iteration detail.
 * [Issue #749 BC-Preinitialized PPO Launch Packet](issue_749_bc_preinit_ppo_launch_packet.md)
   defines the config-first launch path and artifact boundary for the deferred BC warm-start PPO
   challenger experiment.
+* [Issue #1752 Decision Transformer Dataset Preflight](issue_1752_decision_transformer_dataset_preflight.md)
+  records the reward/terminal/return-to-go trajectory schema, manifest metadata, validator CLI, and
+  tiny dry-run proof needed before any future Decision Transformer training campaign.
 * [Issue #1209 Imitation Observation Contract](issue_1209_imitation_observation_contract.md)
   records the BR-06 checkpoint-compatible observation-contract fix and validation path that
   unblocks #1108's BC warm-start launch.

--- a/docs/context/issue_1752_decision_transformer_dataset_preflight.md
+++ b/docs/context/issue_1752_decision_transformer_dataset_preflight.md
@@ -1,0 +1,130 @@
+# Issue 1752 Decision Transformer Dataset Preflight
+
+Related issue: [#1752](https://github.com/ll7/robot_sf_ll7/issues/1752)
+Parent feasibility PR: [#1750](https://github.com/ll7/robot_sf_ll7/pull/1750)
+Fallback policy: [issue_691_benchmark_fallback_policy.md](issue_691_benchmark_fallback_policy.md)
+
+## Decision
+
+The expert trajectory collector now emits a Decision-Transformer-ready preflight schema while
+remaining backwards-compatible for existing BC consumers that read only observations/actions.
+
+Schema marker:
+
+```text
+trajectory_dataset.v2.decision_transformer_preflight
+```
+
+The collector still does not train a Decision Transformer. It only proves that Robot SF can produce
+and validate the missing offline sequence labels that issue #1622 identified as a blocker.
+
+## Dataset Fields
+
+`scripts/training/collect_expert_trajectories.py` now writes these NPZ arrays:
+
+- `positions`
+- `actions`
+- `observations`
+- `rewards`
+- `terminated`
+- `truncated`
+- `return_to_go`
+- `episode_ids`
+- `scenario_ids`
+- `seeds`
+
+Reward convention: `environment_step_reward`.
+Return convention: `undiscounted_future_return_to_go`.
+
+The return-to-go value at step `t` is the undiscounted sum of rewards from `t` through the end of
+that recorded episode. The terminal flags are stored separately so a future offline-RL loader can
+distinguish environment termination from truncation.
+
+## Manifest Fields
+
+Trajectory dataset manifests now receive additive metadata:
+
+- `dataset_schema`
+- `trajectory_fields`
+- `splits`
+- `reward_convention`
+- `return_convention`
+- `status_policy`
+- `dataset_sha256`
+- `durable_artifact_uri_policy`
+
+The `splits.train` section records episode IDs, scenario IDs, and seeds. The issue #1752 slice uses
+a single `train` split because it is a preflight producer; fair BC/PPO/oracle comparison splits are
+still future experiment-design work.
+
+The status policy explicitly lists excluded non-success statuses:
+
+- `readiness_status`: `fallback`, `degraded`
+- `availability_status`: `not_available`
+
+Rows with those statuses must be excluded or explicitly labeled before any future training use.
+
+## Validator
+
+`robot_sf.benchmark.validation.trajectory_dataset.TrajectoryDatasetValidator` now has an explicit
+Decision Transformer preflight mode. Legacy BC-style NPZ datasets still validate against the base
+`positions` / `actions` / `observations` schema unless DT mode is requested or the dataset metadata
+declares `trajectory_dataset.v2.decision_transformer_preflight`. In DT mode, the validator requires
+reward, terminal, truncation, and return-to-go arrays. It also quarantines datasets when per-episode
+trajectory lengths are misaligned or when fallback/degraded/not-available status rows are present
+without an explicit status policy.
+
+The new CLI is:
+
+```bash
+uv run python scripts/validation/validate_trajectory_dataset.py \
+  --dataset-id dt1752_dry \
+  --min-episodes 1 \
+  --fail-on-quarantine
+```
+
+For ad-hoc legacy NPZ files that do not yet declare the schema, add
+`--require-decision-transformer-fields` to force the stricter preflight.
+
+## Proof
+
+Focused tests:
+
+```bash
+uv run pytest \
+  tests/training/test_collect_expert_trajectories_dt_preflight.py \
+  tests/integration/test_expert_trajectory_dataset.py \
+  tests/test_benchmark_imitation_manifest.py \
+  tests/validation/test_validate_trajectory_dataset_cli.py \
+  -q
+```
+
+Lint:
+
+```bash
+uv run ruff check \
+  scripts/training/collect_expert_trajectories.py \
+  scripts/validation/validate_trajectory_dataset.py \
+  robot_sf/benchmark/validation/trajectory_dataset.py \
+  tests/training/test_collect_expert_trajectories_dt_preflight.py \
+  tests/integration/test_expert_trajectory_dataset.py \
+  tests/test_benchmark_imitation_manifest.py \
+  tests/validation/test_validate_trajectory_dataset_cli.py
+```
+
+Tiny executable preflight:
+
+```bash
+LOGURU_LEVEL=WARNING uv run python scripts/training/collect_expert_trajectories.py \
+  --dataset-id dt1752_dry \
+  --policy-id ppo_expert_v1 \
+  --episodes 1 \
+  --dry-run \
+  --scenario-config configs/scenarios/classic_interactions.yaml \
+  --seeds 1752
+```
+
+Observed result: the generated manifest under `output/benchmarks/expert_trajectories/` recorded
+`quality_status=validated`, one episode, split seed `1752`, non-empty `dataset_sha256`, and the
+schema/status-policy metadata above. The generated `output/` files are local proof artifacts only,
+not durable training dependencies.

--- a/robot_sf/benchmark/validation/trajectory_dataset.py
+++ b/robot_sf/benchmark/validation/trajectory_dataset.py
@@ -11,7 +11,21 @@ import numpy as np
 from robot_sf.common import TrajectoryQuality
 
 MAX_DATASET_SIZE_BYTES = 25 * 1024**3
-REQUIRED_ARRAYS = ("positions", "actions", "observations")
+BASE_REQUIRED_ARRAYS = (
+    "positions",
+    "actions",
+    "observations",
+)
+DECISION_TRANSFORMER_SCHEMA = "trajectory_dataset.v2.decision_transformer_preflight"
+DECISION_TRANSFORMER_REQUIRED_ARRAYS = (
+    *BASE_REQUIRED_ARRAYS,
+    "rewards",
+    "terminated",
+    "truncated",
+    "return_to_go",
+)
+EXCLUDED_READINESS_STATUSES = {"fallback", "degraded"}
+EXCLUDED_AVAILABILITY_STATUSES = {"not_available"}
 
 
 @dataclass(slots=True)
@@ -34,7 +48,12 @@ class TrajectoryDatasetValidator:
         self.dataset_path = Path(dataset_path).resolve()
         self.dataset_id = self.dataset_path.stem
 
-    def validate(self, *, minimum_episodes: int = 200) -> TrajectoryDatasetValidationResult:
+    def validate(
+        self,
+        *,
+        minimum_episodes: int = 200,
+        require_decision_transformer_fields: bool | None = None,
+    ) -> TrajectoryDatasetValidationResult:
         """Validate dataset integrity and return a structured report.
 
         Returns:
@@ -50,7 +69,11 @@ class TrajectoryDatasetValidator:
 
         file_size = self.dataset_path.stat().st_size
         if self.dataset_path.suffix.lower() == ".npz":
-            result = self._validate_npz(file_size, minimum_episodes)
+            result = self._validate_npz(
+                file_size,
+                minimum_episodes,
+                require_decision_transformer_fields=require_decision_transformer_fields,
+            )
         else:
             result = self._validate_jsonl(file_size, minimum_episodes)
         return result
@@ -59,6 +82,8 @@ class TrajectoryDatasetValidator:
         self,
         file_size: int,
         minimum_episodes: int,
+        *,
+        require_decision_transformer_fields: bool | None,
     ) -> TrajectoryDatasetValidationResult:
         """Validate an `.npz` trajectory dataset payload.
 
@@ -69,21 +94,40 @@ class TrajectoryDatasetValidator:
             files = data.files
             arrays = {name: data[name] for name in files}
 
-        missing_arrays = [name for name in REQUIRED_ARRAYS if name not in arrays]
         episode_count = self._extract_episode_count(arrays)
         metadata = self._extract_metadata(arrays)
         coverage = metadata.get("scenario_coverage", {})
+        require_dt = self._requires_decision_transformer_fields(
+            arrays,
+            metadata,
+            require_decision_transformer_fields,
+        )
+        required_arrays = (
+            DECISION_TRANSFORMER_REQUIRED_ARRAYS if require_dt else BASE_REQUIRED_ARRAYS
+        )
+        missing_arrays = [name for name in required_arrays if name not in arrays]
+        alignment_issues = self._episode_alignment_issues(arrays, required_arrays)
+        status_report = self._status_report(arrays, metadata)
 
         report = {
             "file_size": file_size,
             "present_arrays": sorted(arrays.keys()),
+            "required_arrays": list(required_arrays),
+            "decision_transformer_preflight": require_dt,
             "missing_arrays": missing_arrays,
             "episode_count": episode_count,
             "metadata": metadata,
+            "alignment_issues": alignment_issues,
+            "status_report": status_report,
         }
 
         quality = self._determine_quality(
-            episode_count, missing_arrays, file_size, minimum_episodes
+            episode_count,
+            missing_arrays,
+            file_size,
+            minimum_episodes,
+            alignment_issues=alignment_issues,
+            unlabeled_excluded_rows=int(status_report["unlabeled_excluded_rows"]),
         )
         return TrajectoryDatasetValidationResult(
             dataset_id=self.dataset_id,
@@ -127,6 +171,9 @@ class TrajectoryDatasetValidator:
         missing_arrays: list[str],
         file_size: int,
         minimum_episodes: int,
+        *,
+        alignment_issues: list[dict[str, Any]] | None = None,
+        unlabeled_excluded_rows: int = 0,
     ) -> TrajectoryQuality:
         """Determine dataset quality based on size and completeness.
 
@@ -135,11 +182,115 @@ class TrajectoryDatasetValidator:
         """
         if file_size > MAX_DATASET_SIZE_BYTES:
             return TrajectoryQuality.QUARANTINED
-        if missing_arrays:
+        if missing_arrays or alignment_issues or unlabeled_excluded_rows:
             return TrajectoryQuality.QUARANTINED
         if episode_count >= minimum_episodes:
             return TrajectoryQuality.VALIDATED
         return TrajectoryQuality.DRAFT
+
+    @staticmethod
+    def _requires_decision_transformer_fields(
+        arrays: dict[str, Any],
+        metadata: dict[str, Any],
+        explicit: bool | None,
+    ) -> bool:
+        """Return whether validation should enforce the Decision Transformer schema.
+
+        Returns:
+            True when explicit mode, metadata, or DT-specific arrays request the stricter schema.
+        """
+        if explicit is not None:
+            return bool(explicit)
+        if metadata.get("dataset_schema") == DECISION_TRANSFORMER_SCHEMA:
+            return True
+        return any(name in arrays for name in DECISION_TRANSFORMER_REQUIRED_ARRAYS[3:])
+
+    @staticmethod
+    def _episode_alignment_issues(
+        arrays: dict[str, Any],
+        required_arrays: tuple[str, ...],
+    ) -> list[dict[str, Any]]:
+        """Return per-episode length mismatches across trajectory arrays."""
+        if any(name not in arrays for name in required_arrays):
+            return []
+
+        episode_count = min(len(arrays[name]) for name in required_arrays)
+        issues: list[dict[str, Any]] = []
+        for episode_index in range(episode_count):
+            lengths: dict[str, int] = {}
+            for name in required_arrays:
+                value = arrays[name][episode_index]
+                try:
+                    lengths[name] = len(value)
+                except TypeError:
+                    lengths[name] = 1
+            expected = lengths["actions"]
+            mismatched = {
+                name: length for name, length in lengths.items() if length != expected
+            }
+            if mismatched:
+                issues.append(
+                    {
+                        "episode_index": episode_index,
+                        "expected_steps": expected,
+                        "lengths": lengths,
+                    }
+                )
+        return issues
+
+    @staticmethod
+    def _status_report(arrays: dict[str, Any], metadata: dict[str, Any]) -> dict[str, Any]:
+        """Summarize fallback/degraded/not-available rows for fail-closed preflights.
+
+        Returns:
+            Status counters and samples used to quarantine unlabeled excluded rows.
+        """
+        readiness_values = TrajectoryDatasetValidator._status_values(
+            arrays.get("readiness_status")
+        )
+        availability_values = TrajectoryDatasetValidator._status_values(
+            arrays.get("availability_status")
+        )
+        excluded_samples: list[dict[str, Any]] = []
+        excluded_rows = 0
+        row_count = max(len(readiness_values), len(availability_values))
+        for index in range(row_count):
+            readiness = readiness_values[index] if index < len(readiness_values) else ""
+            availability = availability_values[index] if index < len(availability_values) else ""
+            if (
+                readiness in EXCLUDED_READINESS_STATUSES
+                or availability in EXCLUDED_AVAILABILITY_STATUSES
+            ):
+                excluded_rows += 1
+                if len(excluded_samples) < 10:
+                    excluded_samples.append(
+                        {
+                            "row_index": index,
+                            "readiness_status": readiness,
+                            "availability_status": availability,
+                        }
+                    )
+
+        status_policy = metadata.get("status_policy")
+        has_label_policy = isinstance(status_policy, dict) and bool(status_policy.get("handling"))
+        return {
+            "excluded_rows": excluded_rows,
+            "excluded_samples": excluded_samples,
+            "unlabeled_excluded_rows": 0 if has_label_policy else excluded_rows,
+            "status_policy_present": has_label_policy,
+        }
+
+    @staticmethod
+    def _status_values(raw: Any) -> list[str]:
+        """Flatten optional status arrays into normalized lowercase strings.
+
+        Returns:
+            Normalized status values from the array payload.
+        """
+        if raw is None:
+            return []
+        array = np.asarray(raw, dtype=object).reshape(-1)
+        return [str(value).strip().lower() for value in array]
 
     @staticmethod
     def _extract_episode_count(arrays: dict[str, Any]) -> int:

--- a/robot_sf/benchmark/validation/trajectory_dataset.py
+++ b/robot_sf/benchmark/validation/trajectory_dataset.py
@@ -214,9 +214,25 @@ class TrajectoryDatasetValidator:
         if any(name not in arrays for name in required_arrays):
             return []
 
-        episode_count = min(len(arrays[name]) for name in required_arrays)
         issues: list[dict[str, Any]] = []
+        top_level_lengths = {name: len(arrays[name]) for name in required_arrays}
+        episode_count = int(arrays.get("episode_count", np.array(min(top_level_lengths.values()))))
+        top_level_mismatches = {
+            name: length for name, length in top_level_lengths.items() if length != episode_count
+        }
+        if top_level_mismatches:
+            issues.append(
+                {
+                    "episode_index": None,
+                    "expected_episodes": episode_count,
+                    "array_episode_counts": top_level_lengths,
+                }
+            )
+
+        comparable_episode_count = min(top_level_lengths.values())
         for episode_index in range(episode_count):
+            if episode_index >= comparable_episode_count:
+                break
             lengths: dict[str, int] = {}
             for name in required_arrays:
                 value = arrays[name][episode_index]
@@ -225,9 +241,7 @@ class TrajectoryDatasetValidator:
                 except TypeError:
                     lengths[name] = 1
             expected = lengths["actions"]
-            mismatched = {
-                name: length for name, length in lengths.items() if length != expected
-            }
+            mismatched = {name: length for name, length in lengths.items() if length != expected}
             if mismatched:
                 issues.append(
                     {
@@ -245,9 +259,7 @@ class TrajectoryDatasetValidator:
         Returns:
             Status counters and samples used to quarantine unlabeled excluded rows.
         """
-        readiness_values = TrajectoryDatasetValidator._status_values(
-            arrays.get("readiness_status")
-        )
+        readiness_values = TrajectoryDatasetValidator._status_values(arrays.get("readiness_status"))
         availability_values = TrajectoryDatasetValidator._status_values(
             arrays.get("availability_status")
         )

--- a/scripts/training/collect_expert_trajectories.py
+++ b/scripts/training/collect_expert_trajectories.py
@@ -8,6 +8,7 @@ persists a manifest using the imitation helpers for downstream workflows.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import shlex
 import subprocess
 import sys
@@ -45,6 +46,15 @@ from scripts.training.train_ppo import _apply_env_overrides
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
+
+DEFAULT_DATASET_SPLIT = "train"
+DECISION_TRANSFORMER_REWARD_CONVENTION = "environment_step_reward"
+DECISION_TRANSFORMER_RETURN_CONVENTION = "undiscounted_future_return_to_go"
+DECISION_TRANSFORMER_STATUS_POLICY = {
+    "readiness_status_excluded": ["fallback", "degraded"],
+    "availability_status_excluded": ["not_available"],
+    "handling": "exclude_or_explicitly_label_before_training",
+}
 
 
 def _resolve_scenario_config(
@@ -119,6 +129,17 @@ def _command_line() -> str:
     return " ".join(shlex.quote(arg) for arg in sys.argv)
 
 
+def _file_sha256(path: Path) -> str | None:
+    """Return a SHA-256 checksum for a written file when it exists."""
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _zero_action(space: Any) -> np.ndarray:
     """Create a zero-valued action compatible with an action space.
 
@@ -133,13 +154,29 @@ def _zero_action(space: Any) -> np.ndarray:
     return np.zeros(shape, dtype=dtype)
 
 
+def _return_to_go(rewards: Sequence[float]) -> list[float]:
+    """Compute undiscounted return-to-go values for one episode."""
+    running_total = 0.0
+    returns: list[float] = []
+    for reward in reversed(rewards):
+        running_total += float(reward)
+        returns.append(running_total)
+    returns.reverse()
+    return returns
+
+
+def _episode_id(dataset_id: str, scenario_label: str, episode_index: int) -> str:
+    """Build a stable episode id for dataset and manifest split metadata."""
+    return f"{dataset_id}:{scenario_label}:episode_{episode_index:06d}"
+
+
 def _record_episode(
     env: Any,
     *,
     policy: PPO | None,
     dry_run: bool,
     observation_adapter: Callable[[Mapping[str, Any]], Any] | None = None,
-) -> tuple[list[Any], list[Any], list[Any]]:
+) -> dict[str, list[Any]]:
     """Record one episode using policy-compatible observations.
 
     Args:
@@ -150,7 +187,7 @@ def _record_episode(
             policy inference and dataset storage.
 
     Returns:
-        Episode positions, actions, and adapted observations.
+        Episode trajectory fields, including Decision-Transformer-ready reward labels.
     """
     raw_obs, _ = env.reset()
     obs = observation_adapter(raw_obs) if observation_adapter is not None else raw_obs
@@ -158,6 +195,9 @@ def _record_episode(
     positions: list[Any] = []
     actions: list[Any] = []
     observations: list[Any] = []
+    rewards: list[float] = []
+    terminated_flags: list[bool] = []
+    truncated_flags: list[bool] = []
     steps = 0
     max_steps = env.state.max_sim_steps
 
@@ -166,18 +206,29 @@ def _record_episode(
             action = _zero_action(env.action_space)
         else:
             action, _ = policy.predict(obs, deterministic=True)
-        raw_next_obs, _reward, terminated, truncated, _info = env.step(action)
+        raw_next_obs, reward, terminated, truncated, _info = env.step(action)
         next_obs = (
             observation_adapter(raw_next_obs) if observation_adapter is not None else raw_next_obs
         )
         positions.append(tuple(env.state.nav.pos))
         actions.append(np.asarray(action, dtype=float))
         observations.append(next_obs)
+        rewards.append(float(reward))
+        terminated_flags.append(bool(terminated))
+        truncated_flags.append(bool(truncated))
         obs = next_obs
         done = bool(terminated or truncated)
         steps += 1
 
-    return positions, actions, observations
+    return {
+        "positions": positions,
+        "actions": actions,
+        "observations": observations,
+        "rewards": rewards,
+        "terminated": terminated_flags,
+        "truncated": truncated_flags,
+        "return_to_go": _return_to_go(rewards),
+    }
 
 
 def _record_dataset(
@@ -189,7 +240,7 @@ def _record_dataset(
     scenario: Mapping[str, Any],
     scenario_path: Path,
     observation_adapter: Callable[[Mapping[str, Any]], Any] | None = None,
-) -> tuple[dict[str, list[np.ndarray]], dict[str, int]]:
+) -> tuple[dict[str, list[np.ndarray]], dict[str, int], dict[str, Any]]:
     """Record all requested episodes for one scenario.
 
     Args:
@@ -208,8 +259,22 @@ def _record_dataset(
         "positions": [],
         "actions": [],
         "observations": [],
+        "rewards": [],
+        "terminated": [],
+        "truncated": [],
+        "return_to_go": [],
+        "episode_ids": [],
+        "scenario_ids": [],
+        "seeds": [],
     }
     coverage: dict[str, int] = {}
+    split_metadata: dict[str, Any] = {
+        DEFAULT_DATASET_SPLIT: {
+            "episode_ids": [],
+            "scenario_ids": [],
+            "seeds": [],
+        }
+    }
 
     for episode in range(config.episodes):
         seed = int(config.random_seeds[episode % len(config.random_seeds)])
@@ -217,7 +282,7 @@ def _record_dataset(
         _apply_env_overrides(env_config, config.env_overrides)
         env = make_robot_env(config=env_config, seed=seed, **config.env_factory_kwargs)
         try:
-            positions, actions, observations = _record_episode(
+            episode_record = _record_episode(
                 env,
                 policy=policy,
                 dry_run=dry_run,
@@ -225,11 +290,25 @@ def _record_dataset(
             )
         finally:
             env.close()
-        dataset["positions"].append(np.asarray(positions, dtype=object))
-        dataset["actions"].append(np.asarray(actions, dtype=object))
-        dataset["observations"].append(np.asarray(observations, dtype=object))
+        episode_id = _episode_id(config.dataset_id, scenario_label, episode)
+        dataset["positions"].append(np.asarray(episode_record["positions"], dtype=object))
+        dataset["actions"].append(np.asarray(episode_record["actions"], dtype=object))
+        dataset["observations"].append(np.asarray(episode_record["observations"], dtype=object))
+        dataset["rewards"].append(np.asarray(episode_record["rewards"], dtype=float))
+        dataset["terminated"].append(np.asarray(episode_record["terminated"], dtype=bool))
+        dataset["truncated"].append(np.asarray(episode_record["truncated"], dtype=bool))
+        dataset["return_to_go"].append(np.asarray(episode_record["return_to_go"], dtype=float))
+        dataset["episode_ids"].append(np.asarray([episode_id], dtype=object))
+        dataset["scenario_ids"].append(np.asarray([scenario_label], dtype=object))
+        dataset["seeds"].append(np.asarray([seed], dtype=int))
+        split_metadata[DEFAULT_DATASET_SPLIT]["episode_ids"].append(episode_id)
+        split_metadata[DEFAULT_DATASET_SPLIT]["scenario_ids"].append(scenario_label)
+        split_metadata[DEFAULT_DATASET_SPLIT]["seeds"].append(seed)
         coverage[scenario_label] = coverage.get(scenario_label, 0) + 1
-    return dataset, coverage
+    split_metadata[DEFAULT_DATASET_SPLIT]["scenario_ids"] = sorted(
+        set(split_metadata[DEFAULT_DATASET_SPLIT]["scenario_ids"])
+    )
+    return dataset, coverage, split_metadata
 
 
 def _write_dataset(
@@ -249,9 +328,7 @@ def _write_dataset(
     path.parent.mkdir(parents=True, exist_ok=True)
     np.savez(
         path,
-        positions=np.array(arrays["positions"], dtype=object),
-        actions=np.array(arrays["actions"], dtype=object),
-        observations=np.array(arrays["observations"], dtype=object),
+        **{name: np.array(values, dtype=object) for name, values in sorted(arrays.items())},
         episode_count=np.array(episode_count),
         metadata=metadata,
     )
@@ -390,7 +467,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         observation_contract = observation_contract_from_space(policy.observation_space)
         observation_adapter = resolve_policy_obs_adapter(policy)
 
-    arrays, coverage = _record_dataset(
+    arrays, coverage, split_metadata = _record_dataset(
         collection_config,
         policy=policy,
         dry_run=args.dry_run,
@@ -417,6 +494,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         "env_factory_kwargs": dict(collection_config.env_factory_kwargs),
         "random_seeds": list(collection_config.random_seeds),
         "scenario_coverage": coverage,
+        "dataset_schema": "trajectory_dataset.v2.decision_transformer_preflight",
+        "trajectory_fields": sorted(arrays.keys()),
+        "splits": split_metadata,
+        "reward_convention": DECISION_TRANSFORMER_REWARD_CONVENTION,
+        "return_convention": DECISION_TRANSFORMER_RETURN_CONVENTION,
+        "status_policy": DECISION_TRANSFORMER_STATUS_POLICY,
+        "durable_artifact_uri_policy": (
+            "worktree-local output paths are not durable; promote required datasets to an "
+            "explicit artifact store and record that URI before training depends on them"
+        ),
         "training_config": str(training_config_path) if training_config_path else None,
         "observation_contract": observation_contract,
         "command": _command_line(),
@@ -426,9 +513,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     }
 
     _write_dataset(dataset_path, arrays, len(arrays["positions"]), metadata)
+    metadata["dataset_sha256"] = _file_sha256(dataset_path)
 
     validator = TrajectoryDatasetValidator(dataset_path)
-    validation_result = validator.validate(minimum_episodes=collection_config.episodes)
+    validation_result = validator.validate(
+        minimum_episodes=collection_config.episodes,
+        require_decision_transformer_fields=True,
+    )
 
     dataset_artifact = common.TrajectoryDatasetArtifact(
         dataset_id=collection_config.dataset_id,

--- a/scripts/validation/validate_trajectory_dataset.py
+++ b/scripts/validation/validate_trajectory_dataset.py
@@ -1,0 +1,108 @@
+"""Validate expert trajectory datasets from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf import common
+from robot_sf.benchmark.validation.trajectory_dataset import TrajectoryDatasetValidator
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the trajectory dataset validator CLI parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset-id",
+        "--dataset",
+        dest="dataset_id",
+        help="Dataset id under the canonical trajectory dataset directory.",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        help="Explicit dataset path. Use instead of --dataset-id for ad-hoc files.",
+    )
+    parser.add_argument(
+        "--min-episodes",
+        type=int,
+        default=200,
+        help="Minimum episode count required for a validated-quality dataset.",
+    )
+    parser.add_argument(
+        "--fail-on-quarantine",
+        action="store_true",
+        help="Return exit code 2 when validation classifies the dataset as quarantined.",
+    )
+    parser.add_argument(
+        "--require-decision-transformer-fields",
+        action="store_true",
+        help=(
+            "Require reward, terminated, truncated, and return_to_go arrays even when the "
+            "dataset metadata does not declare the Decision Transformer preflight schema."
+        ),
+    )
+    return parser
+
+
+def _resolve_dataset_path(dataset_id: str | None, path: Path | None) -> Path:
+    """Resolve the dataset path from CLI arguments.
+
+    Returns:
+        Concrete dataset path for validation.
+
+    Raises:
+        ValueError: If neither or both path selectors are provided.
+    """
+    if bool(dataset_id) == bool(path):
+        raise ValueError("Provide exactly one of --dataset-id/--dataset or --path.")
+    if path is not None:
+        return path
+    assert dataset_id is not None
+    return common.get_trajectory_dataset_path(dataset_id)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate a trajectory dataset and print a JSON report.
+
+    Returns:
+        Process exit code.
+    """
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        dataset_path = _resolve_dataset_path(args.dataset_id, args.path)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    result = TrajectoryDatasetValidator(dataset_path).validate(
+        minimum_episodes=int(args.min_episodes),
+        require_decision_transformer_fields=(
+            True if args.require_decision_transformer_fields else None
+        ),
+    )
+    payload = {
+        "dataset_id": result.dataset_id,
+        "dataset_path": str(result.dataset_path),
+        "episode_count": result.episode_count,
+        "scenario_coverage": result.scenario_coverage,
+        "quality_status": result.quality_status.value,
+        "integrity_report": result.integrity_report,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if args.fail_on_quarantine and result.quality_status == common.TrajectoryQuality.QUARANTINED:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/integration/test_expert_trajectory_dataset.py
+++ b/tests/integration/test_expert_trajectory_dataset.py
@@ -18,12 +18,24 @@ def _write_npz_dataset(path, episode_count: int) -> None:
     positions = np.zeros((episode_count, 4, 2), dtype=float)
     actions = np.zeros((episode_count, 4, 2), dtype=float)
     observations = np.zeros((episode_count, 4, 5), dtype=float)
-    metadata = {"scenario_coverage": {"classic_interactions": episode_count}}
+    rewards = np.ones((episode_count, 4), dtype=float)
+    terminated = np.zeros((episode_count, 4), dtype=bool)
+    terminated[:, -1] = True
+    truncated = np.zeros((episode_count, 4), dtype=bool)
+    return_to_go = np.tile(np.array([4.0, 3.0, 2.0, 1.0]), (episode_count, 1))
+    metadata = {
+        "scenario_coverage": {"classic_interactions": episode_count},
+        "status_policy": {"handling": "exclude_or_explicitly_label_before_training"},
+    }
     np.savez(
         path,
         positions=positions,
         actions=actions,
         observations=observations,
+        rewards=rewards,
+        terminated=terminated,
+        truncated=truncated,
+        return_to_go=return_to_go,
         episode_count=np.array(episode_count),
         metadata=metadata,
     )
@@ -44,6 +56,7 @@ def test_validate_npz_dataset(tmp_path):
     assert result.dataset_id == "expert_dataset"
     assert result.quality_status == common.TrajectoryQuality.VALIDATED
     assert result.integrity_report["missing_arrays"] == []
+    assert result.integrity_report["alignment_issues"] == []
     assert result.integrity_report["episode_count"] == 8
     coverage = result.scenario_coverage
     assert coverage.get("classic_interactions") == 8
@@ -64,6 +77,82 @@ def test_incomplete_dataset_quarantines(tmp_path):
 
     assert result.quality_status == common.TrajectoryQuality.QUARANTINED
     assert "actions" in result.integrity_report["missing_arrays"]
+
+
+def test_legacy_bc_dataset_without_reward_labels_remains_valid(tmp_path):
+    """Base BC trajectory validation stays compatible unless DT fields are required."""
+    dataset_path = tmp_path / "legacy_bc.npz"
+    positions = np.zeros((2, 3, 2), dtype=float)
+    actions = np.zeros((2, 3, 2), dtype=float)
+    observations = np.zeros((2, 3, 5), dtype=float)
+    np.savez(
+        dataset_path,
+        positions=positions,
+        actions=actions,
+        observations=observations,
+        episode_count=np.array(2),
+        metadata={"scenario_coverage": {"classic_interactions": 2}},
+    )
+
+    validator = TrajectoryDatasetValidator(dataset_path)
+    legacy_result = validator.validate(minimum_episodes=2)
+    dt_result = validator.validate(
+        minimum_episodes=2,
+        require_decision_transformer_fields=True,
+    )
+
+    assert legacy_result.quality_status == common.TrajectoryQuality.VALIDATED
+    assert legacy_result.integrity_report["decision_transformer_preflight"] is False
+    assert dt_result.quality_status == common.TrajectoryQuality.QUARANTINED
+    assert "rewards" in dt_result.integrity_report["missing_arrays"]
+
+
+def test_reward_label_misalignment_quarantines(tmp_path):
+    """Decision Transformer preflight labels must align step-for-step."""
+    dataset_path = tmp_path / "misaligned_rewards.npz"
+    positions = np.zeros((1, 3, 2), dtype=float)
+    actions = np.zeros((1, 3, 2), dtype=float)
+    observations = np.zeros((1, 3, 5), dtype=float)
+    rewards = np.zeros((1, 2), dtype=float)
+    terminated = np.zeros((1, 3), dtype=bool)
+    truncated = np.zeros((1, 3), dtype=bool)
+    return_to_go = np.zeros((1, 3), dtype=float)
+    np.savez(
+        dataset_path,
+        positions=positions,
+        actions=actions,
+        observations=observations,
+        rewards=rewards,
+        terminated=terminated,
+        truncated=truncated,
+        return_to_go=return_to_go,
+        episode_count=np.array(1),
+        metadata={"scenario_coverage": {"classic_interactions": 1}},
+    )
+
+    result = TrajectoryDatasetValidator(dataset_path).validate(minimum_episodes=1)
+
+    assert result.quality_status == common.TrajectoryQuality.QUARANTINED
+    assert result.integrity_report["alignment_issues"][0]["episode_index"] == 0
+    assert result.integrity_report["alignment_issues"][0]["lengths"]["rewards"] == 2
+
+
+def test_unlabeled_fallback_rows_quarantine_dataset(tmp_path):
+    """Fallback/degraded/not_available rows need an explicit exclusion policy."""
+    dataset_path = tmp_path / "fallback_rows.npz"
+    _write_npz_dataset(dataset_path, episode_count=1)
+    with np.load(dataset_path, allow_pickle=True) as data:
+        payload = {name: data[name] for name in data.files}
+    payload["readiness_status"] = np.array(["fallback"], dtype=object)
+    payload["metadata"] = {"scenario_coverage": {"classic_interactions": 1}}
+    np.savez(dataset_path, **payload)
+
+    result = TrajectoryDatasetValidator(dataset_path).validate(minimum_episodes=1)
+
+    assert result.quality_status == common.TrajectoryQuality.QUARANTINED
+    status_report = result.integrity_report["status_report"]
+    assert status_report["excluded_rows"] == 1
+    assert status_report["unlabeled_excluded_rows"] == 1
 
 
 def test_jsonl_dataset_drafts_when_small(tmp_path):

--- a/tests/integration/test_expert_trajectory_dataset.py
+++ b/tests/integration/test_expert_trajectory_dataset.py
@@ -137,6 +137,38 @@ def test_reward_label_misalignment_quarantines(tmp_path):
     assert result.integrity_report["alignment_issues"][0]["lengths"]["rewards"] == 2
 
 
+def test_missing_reward_episode_quarantines(tmp_path):
+    """Decision Transformer preflight labels must align episode-for-episode."""
+    dataset_path = tmp_path / "missing_reward_episode.npz"
+    positions = np.zeros((2, 3, 2), dtype=float)
+    actions = np.zeros((2, 3, 2), dtype=float)
+    observations = np.zeros((2, 3, 5), dtype=float)
+    rewards = np.zeros((1, 3), dtype=float)
+    terminated = np.zeros((2, 3), dtype=bool)
+    truncated = np.zeros((2, 3), dtype=bool)
+    return_to_go = np.zeros((1, 3), dtype=float)
+    np.savez(
+        dataset_path,
+        positions=positions,
+        actions=actions,
+        observations=observations,
+        rewards=rewards,
+        terminated=terminated,
+        truncated=truncated,
+        return_to_go=return_to_go,
+        episode_count=np.array(2),
+        metadata={"scenario_coverage": {"classic_interactions": 2}},
+    )
+
+    result = TrajectoryDatasetValidator(dataset_path).validate(minimum_episodes=2)
+
+    assert result.quality_status == common.TrajectoryQuality.QUARANTINED
+    issue = result.integrity_report["alignment_issues"][0]
+    assert issue["episode_index"] is None
+    assert issue["expected_episodes"] == 2
+    assert issue["array_episode_counts"]["rewards"] == 1
+
+
 def test_unlabeled_fallback_rows_quarantine_dataset(tmp_path):
     """Fallback/degraded/not_available rows need an explicit exclusion policy."""
     dataset_path = tmp_path / "fallback_rows.npz"

--- a/tests/integration/test_ppo_pretraining_pipeline.py
+++ b/tests/integration/test_ppo_pretraining_pipeline.py
@@ -357,7 +357,7 @@ def test_collect_trajectories_filters_to_policy_observation_space(tmp_path, monk
         collector,
         "TrajectoryDatasetValidator",
         lambda _path: SimpleNamespace(
-            validate=lambda minimum_episodes: SimpleNamespace(
+            validate=lambda minimum_episodes, **_kwargs: SimpleNamespace(
                 episode_count=minimum_episodes,
                 scenario_coverage={"demo": minimum_episodes},
                 integrity_report={},
@@ -470,7 +470,7 @@ def test_collect_trajectories_merges_training_then_env_contract(tmp_path, monkey
         collector,
         "TrajectoryDatasetValidator",
         lambda _path: SimpleNamespace(
-            validate=lambda minimum_episodes: SimpleNamespace(
+            validate=lambda minimum_episodes, **_kwargs: SimpleNamespace(
                 episode_count=minimum_episodes,
                 scenario_coverage={"demo": minimum_episodes},
                 integrity_report={},

--- a/tests/test_benchmark_imitation_manifest.py
+++ b/tests/test_benchmark_imitation_manifest.py
@@ -108,6 +108,15 @@ def test_trajectory_manifest_serialization_handles_metadata() -> None:
         "collected_at": datetime(2025, 11, 14, 12, 30, tzinfo=UTC),
         "source_path": Path("logs/collector.log"),
         "notes": ["steady", Path("calibration.csv")],
+        "dataset_sha256": "abc123",
+        "reward_convention": "environment_step_reward",
+        "return_convention": "undiscounted_future_return_to_go",
+        "splits": {"train": {"episode_ids": ["traj_v1:demo:episode_000000"]}},
+        "status_policy": {
+            "handling": "exclude_or_explicitly_label_before_training",
+            "readiness_status_excluded": ["fallback", "degraded"],
+            "availability_status_excluded": ["not_available"],
+        },
     }
     artifact = TrajectoryDatasetArtifact(
         dataset_id="traj_v1",
@@ -128,6 +137,13 @@ def test_trajectory_manifest_serialization_handles_metadata() -> None:
     assert record["metadata"]["collected_at"].startswith("2025-11-14T12:30")
     assert record["metadata"]["source_path"] == "logs/collector.log"
     assert record["metadata"]["notes"][1] == "calibration.csv"
+    assert record["metadata"]["dataset_sha256"] == "abc123"
+    assert record["metadata"]["reward_convention"] == "environment_step_reward"
+    assert record["metadata"]["splits"]["train"]["episode_ids"][0].startswith("traj_v1:")
+    assert record["metadata"]["status_policy"]["readiness_status_excluded"] == [
+        "fallback",
+        "degraded",
+    ]
 
 
 def test_training_run_manifest_writes_to_runs_folder(

--- a/tests/training/test_collect_expert_trajectories_dt_preflight.py
+++ b/tests/training/test_collect_expert_trajectories_dt_preflight.py
@@ -75,6 +75,4 @@ def test_write_dataset_persists_decision_transformer_arrays(tmp_path) -> None:
         stored_metadata = data["metadata"].item()
 
     assert stored_metadata["reward_convention"] == "environment_step_reward"
-    assert stored_metadata["status_policy"]["availability_status_excluded"] == [
-        "not_available"
-    ]
+    assert stored_metadata["status_policy"]["availability_status_excluded"] == ["not_available"]

--- a/tests/training/test_collect_expert_trajectories_dt_preflight.py
+++ b/tests/training/test_collect_expert_trajectories_dt_preflight.py
@@ -1,0 +1,80 @@
+"""Tests for Decision Transformer trajectory preflight fields."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+from gymnasium import spaces
+
+from scripts.training import collect_expert_trajectories as collector
+
+
+class _FakeEnv:
+    """Small deterministic env for collector unit tests."""
+
+    action_space = spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+    def __init__(self) -> None:
+        self.state = SimpleNamespace(max_sim_steps=3, nav=SimpleNamespace(pos=(0.0, 0.0)))
+        self._step = 0
+
+    def reset(self):
+        self._step = 0
+        return {"obs": np.array([0.0], dtype=np.float32)}, {}
+
+    def step(self, action):
+        self._step += 1
+        self.state.nav.pos = (float(self._step), float(self._step + 1))
+        reward = float(self._step)
+        terminated = self._step == 3
+        truncated = False
+        return {"obs": np.array([self._step], dtype=np.float32)}, reward, terminated, truncated, {}
+
+
+def test_record_episode_exports_reward_terminal_and_return_to_go_fields() -> None:
+    """Recorded episodes include the labels needed by offline sequence models."""
+    record = collector._record_episode(_FakeEnv(), policy=None, dry_run=True)
+
+    assert record["rewards"] == [1.0, 2.0, 3.0]
+    assert record["terminated"] == [False, False, True]
+    assert record["truncated"] == [False, False, False]
+    assert record["return_to_go"] == [6.0, 5.0, 3.0]
+    assert len(record["actions"]) == len(record["observations"]) == 3
+
+
+def test_write_dataset_persists_decision_transformer_arrays(tmp_path) -> None:
+    """The NPZ payload keeps reward, terminal, and return labels alongside BC fields."""
+    dataset_path = tmp_path / "dt_preflight.npz"
+    arrays = {
+        "positions": [np.array([(1.0, 2.0), (2.0, 3.0)], dtype=object)],
+        "actions": [np.zeros((2, 2), dtype=float)],
+        "observations": [np.array([{"obs": 1}, {"obs": 2}], dtype=object)],
+        "rewards": [np.array([1.0, -0.5], dtype=float)],
+        "terminated": [np.array([False, True], dtype=bool)],
+        "truncated": [np.array([False, False], dtype=bool)],
+        "return_to_go": [np.array([0.5, -0.5], dtype=float)],
+        "episode_ids": [np.array(["demo:episode_000000"], dtype=object)],
+        "scenario_ids": [np.array(["demo"], dtype=object)],
+        "seeds": [np.array([11], dtype=int)],
+    }
+    metadata = {
+        "dataset_schema": "trajectory_dataset.v2.decision_transformer_preflight",
+        "reward_convention": collector.DECISION_TRANSFORMER_REWARD_CONVENTION,
+        "return_convention": collector.DECISION_TRANSFORMER_RETURN_CONVENTION,
+        "status_policy": collector.DECISION_TRANSFORMER_STATUS_POLICY,
+    }
+
+    collector._write_dataset(dataset_path, arrays, episode_count=1, metadata=metadata)
+
+    with np.load(dataset_path, allow_pickle=True) as data:
+        assert data["rewards"][0].tolist() == [1.0, -0.5]
+        assert data["terminated"][0].tolist() == [False, True]
+        assert data["truncated"][0].tolist() == [False, False]
+        assert data["return_to_go"][0].tolist() == [0.5, -0.5]
+        stored_metadata = data["metadata"].item()
+
+    assert stored_metadata["reward_convention"] == "environment_step_reward"
+    assert stored_metadata["status_policy"]["availability_status_excluded"] == [
+        "not_available"
+    ]

--- a/tests/validation/test_validate_trajectory_dataset_cli.py
+++ b/tests/validation/test_validate_trajectory_dataset_cli.py
@@ -1,0 +1,77 @@
+"""Tests for the trajectory dataset validation CLI."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from scripts.validation import validate_trajectory_dataset
+
+
+def _write_dataset(path, *, include_rewards: bool = True) -> None:
+    """Write a tiny trajectory dataset fixture."""
+    payload = {
+        "positions": np.zeros((1, 2, 2), dtype=float),
+        "actions": np.zeros((1, 2, 2), dtype=float),
+        "observations": np.zeros((1, 2, 3), dtype=float),
+        "episode_count": np.array(1),
+        "metadata": {
+            "scenario_coverage": {"demo": 1},
+            "status_policy": {"handling": "exclude_or_explicitly_label_before_training"},
+        },
+    }
+    if include_rewards:
+        payload.update(
+            {
+                "rewards": np.array([[1.0, 2.0]], dtype=float),
+                "terminated": np.array([[False, True]], dtype=bool),
+                "truncated": np.array([[False, False]], dtype=bool),
+                "return_to_go": np.array([[3.0, 2.0]], dtype=float),
+            }
+        )
+    np.savez(path, **payload)
+
+
+def test_validate_trajectory_dataset_cli_reports_validated(tmp_path, capsys) -> None:
+    """CLI prints JSON validation output for a complete dataset."""
+    dataset_path = tmp_path / "complete.npz"
+    _write_dataset(dataset_path)
+
+    exit_code = validate_trajectory_dataset.main(
+        [
+            "--path",
+            str(dataset_path),
+            "--min-episodes",
+            "1",
+            "--fail-on-quarantine",
+            "--require-decision-transformer-fields",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["quality_status"] == "validated"
+    assert payload["integrity_report"]["missing_arrays"] == []
+
+
+def test_validate_trajectory_dataset_cli_fails_on_quarantine(tmp_path, capsys) -> None:
+    """CLI can fail closed for datasets missing Decision Transformer labels."""
+    dataset_path = tmp_path / "missing_rewards.npz"
+    _write_dataset(dataset_path, include_rewards=False)
+
+    exit_code = validate_trajectory_dataset.main(
+        [
+            "--path",
+            str(dataset_path),
+            "--min-episodes",
+            "1",
+            "--fail-on-quarantine",
+            "--require-decision-transformer-fields",
+        ]
+    )
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["quality_status"] == "quarantined"
+    assert "rewards" in payload["integrity_report"]["missing_arrays"]


### PR DESCRIPTION
## Summary
- Extends `collect_expert_trajectories.py` with Decision-Transformer-ready trajectory labels: rewards, terminated/truncated flags, return-to-go, episode IDs, scenario IDs, seeds, split metadata, checksum, and status policy.
- Adds schema-aware trajectory validation so DT preflights fail closed while legacy BC-style datasets remain compatible by default.
- Adds `scripts/validation/validate_trajectory_dataset.py` plus focused tests and a context note documenting the schema and dry-run proof.

## Validation
- `uv run pytest tests/training/test_collect_expert_trajectories_dt_preflight.py tests/integration/test_expert_trajectory_dataset.py tests/test_benchmark_imitation_manifest.py tests/validation/test_validate_trajectory_dataset_cli.py -q`
- `uv run ruff check scripts/training/collect_expert_trajectories.py scripts/validation/validate_trajectory_dataset.py robot_sf/benchmark/validation/trajectory_dataset.py tests/training/test_collect_expert_trajectories_dt_preflight.py tests/integration/test_expert_trajectory_dataset.py tests/test_benchmark_imitation_manifest.py tests/validation/test_validate_trajectory_dataset_cli.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`
- `LOGURU_LEVEL=WARNING uv run python scripts/training/collect_expert_trajectories.py --dataset-id dt1752_dry --policy-id ppo_expert_v1 --episodes 1 --dry-run --scenario-config configs/scenarios/classic_interactions.yaml --seeds 1752`
- `LOGURU_LEVEL=WARNING uv run python scripts/validation/validate_trajectory_dataset.py --dataset-id dt1752_dry --min-episodes 1 --fail-on-quarantine --require-decision-transformer-fields`

Generated dry-run files under `output/benchmarks/expert_trajectories/` were used as local proof artifacts only and are not committed.

Closes #1752
