### PR TITLE
feat: add policy stack arbitration trace packet

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -582,6 +582,9 @@ knowledge, not every transient iteration detail.
 * [Issue #871 Policy Stack Topology Smoke](issue_871_policy_stack_topology_smoke.md)
   records the `corridor_following` atomic topology smoke that proves `policy_stack_v1` can reach a
   topology-heavy goal through the normal map-runner path with proposal diagnostics intact.
+* [Issue #1751 Policy Stack Arbitration Trace Packet](issue_1751_policy_stack_arbitration_trace.md)
+  defines the diagnostic-only `policy_stack_v1.arbitration_trace_packet.v1` contract for future
+  learned-arbiter data collection, plus the compact validation smoke command.
 * [Issue #884 Classic Merging Diagnostics](issue_884_classic_merging_diagnostics.md)
   records source-level hybrid-rule rejection diagnostics, rejected classic-merging recovery
   mechanisms, and the later #1034 targeted recovery result.

--- a/docs/context/issue_1751_policy_stack_arbitration_trace.md
+++ b/docs/context/issue_1751_policy_stack_arbitration_trace.md
@@ -1,0 +1,85 @@
+# Issue 1751 Policy Stack Arbitration Trace Packet
+
+Related issue: [#1751](https://github.com/ll7/robot_sf_ll7/issues/1751)
+Parent assessment PR: [#1749](https://github.com/ll7/robot_sf_ll7/pull/1749)
+Contract predecessor: [issue_926_policy_stack_v1_contract.md](issue_926_policy_stack_v1_contract.md)
+Runtime predecessor: [issue_1004_policy_stack_v1_runtime.md](issue_1004_policy_stack_v1_runtime.md)
+
+## Decision
+
+`policy_stack_v1` now exposes a diagnostic-only arbitration trace packet:
+
+```text
+policy_stack_v1.arbitration_trace_packet.v1
+```
+
+This packet is a data-contract preflight for future learned arbitration. It does not train, enable,
+or ship a learned arbiter.
+
+## Proposal And Command Contract
+
+The packet records:
+
+- configured `proposal_sources`;
+- action space: `unicycle_vw`;
+- command fields: `linear_velocity_m_s`, `angular_velocity_rad_s`;
+- configured maximum linear and angular command bounds;
+- source status vocabulary: `native`, `adapter`, `fallback`, `degraded`, `failed`,
+  `not_available`, `rejected`;
+- executable proposal statuses: `native`, `adapter`, `fallback`, `degraded`.
+
+Per-step trace diagnostics include the selected proposal, proposal status counts, proposal commands,
+rejection reasons, risk-score components, and `candidate_ranking` sorted by total score. The new
+`last_decision()` accessor returns the most recent step decision for tooling that wants one packet
+without parsing the whole episode diagnostics payload.
+
+## Observation And Leakage Boundary
+
+Inference-available features are limited to:
+
+- `robot.position`
+- `robot.heading`
+- `goal.current`
+- `goal.next`
+- `pedestrians.positions`
+
+Leakage exclusions are explicit:
+
+- `future_trajectory`
+- `simulator_collision_label`
+- `episode_success_label`
+- `route_outcome_label`
+- `benchmark_metric_rollups`
+
+Any future learned arbiter must keep those exclusions unless a later issue changes the observation
+contract with its own proof.
+
+## Switching And Dwell
+
+The v1 trace records one arbitration decision per planner step. `min_dwell_steps=1` is declared as
+the current trace-level minimum, and dwell enforcement is marked
+`not_enforced_in_v1_trace`. A learned arbiter may not silently infer a stronger dwell guarantee from
+this packet; any future dwell constraint must be implemented and recorded explicitly.
+
+## Fallback Policy
+
+Fallback and degraded proposals are caveat labels. `failed`, `not_available`, and `rejected`
+proposals are non-executable diagnostic labels. None of these are successful training targets unless
+a future data-preparation issue explicitly filters or labels them.
+
+## Smoke Command
+
+The compact shape check is:
+
+```bash
+uv run python scripts/validation/validate_policy_stack_trace_packet.py
+```
+
+To inspect the packet JSON:
+
+```bash
+uv run python scripts/validation/validate_policy_stack_trace_packet.py --json
+```
+
+The smoke uses an in-process fixture, not a benchmark run, so it proves packet shape without
+changing benchmark metrics.

--- a/robot_sf/planner/policy_stack_v1.py
+++ b/robot_sf/planner/policy_stack_v1.py
@@ -30,6 +30,21 @@ _STATUS_KEYS = (
     "rejected",
 )
 _COMMAND_STATUSES = {"native", "adapter", "fallback", "degraded"}
+ARBITRATION_TRACE_SCHEMA = "policy_stack_v1.arbitration_trace_packet.v1"
+_INFERENCE_AVAILABLE_FEATURES = (
+    "robot.position",
+    "robot.heading",
+    "goal.current",
+    "goal.next",
+    "pedestrians.positions",
+)
+_LEAKAGE_EXCLUSIONS = (
+    "future_trajectory",
+    "simulator_collision_label",
+    "episode_success_label",
+    "route_outcome_label",
+    "benchmark_metric_rollups",
+)
 
 
 @dataclass(frozen=True)
@@ -164,6 +179,23 @@ class PolicyStackV1Adapter:
 
         failed_count = step_status_counts["failed"]
         unavailable_count = step_status_counts["not_available"]
+        candidate_ranking = [
+            {
+                "proposal_key": proposal.key,
+                "status": proposal.status,
+                "rank": rank,
+                "score_total": float(scores[proposal.key]["total"]),
+                "command": [
+                    float(proposal.command[0]),
+                    float(proposal.command[1]),
+                ],
+            }
+            for rank, proposal in enumerate(
+                sorted(candidates, key=lambda item: scores[item.key]["total"], reverse=True),
+                start=1,
+            )
+            if proposal.command is not None
+        ]
 
         self._steps += 1
         _accumulate_counts(self._status_counts, step_status_counts)
@@ -185,10 +217,19 @@ class PolicyStackV1Adapter:
             "proposal_status_counts": dict(step_status_counts),
             "proposal_statuses": proposal_statuses,
             "proposal_commands": proposal_commands,
+            "candidate_ranking": candidate_ranking,
             "risk_score_components": {key: dict(value) for key, value in scores.items()},
             "rejection_reasons": rejection_reasons,
         }
         return float(command[0]), float(command[1])
+
+    def last_decision(self) -> dict[str, Any] | None:
+        """Return the most recent step decision packet.
+
+        Returns:
+            JSON-safe step decision, or ``None`` before the first planner step.
+        """
+        return deepcopy(self._last_step) if self._last_step is not None else None
 
     def diagnostics(self) -> dict[str, Any]:
         """Return JSON-safe episode diagnostics for benchmark metadata."""
@@ -201,6 +242,52 @@ class PolicyStackV1Adapter:
             "rejected_count": int(self._rejected_count),
             "shield_intervention_count": int(self._shield_intervention_count),
             "last_step": deepcopy(self._last_step) if self._last_step is not None else None,
+        }
+
+    def arbitration_trace_packet(self) -> dict[str, Any]:
+        """Return a JSON-safe packet for future learned-arbiter data collection.
+
+        Returns:
+            Trace packet with proposal, action, observation, cadence, and status contracts.
+        """
+        diagnostics = self.diagnostics()
+        return {
+            "schema_version": ARBITRATION_TRACE_SCHEMA,
+            "planner_key": "policy_stack_v1",
+            "packet_mode": "diagnostic_trace_only",
+            "training_enabled": False,
+            "proposal_sources": list(self.config.proposal_sources),
+            "command_contract": {
+                "action_space": "unicycle_vw",
+                "command_fields": ["linear_velocity_m_s", "angular_velocity_rad_s"],
+                "max_linear_speed": float(self.config.max_linear_speed),
+                "max_angular_speed": float(self.config.max_angular_speed),
+                "source_statuses": list(_STATUS_KEYS),
+                "executable_statuses": sorted(_COMMAND_STATUSES),
+            },
+            "observation_contract": {
+                "inference_available_features": list(_INFERENCE_AVAILABLE_FEATURES),
+                "leakage_exclusions": list(_LEAKAGE_EXCLUSIONS),
+            },
+            "switching_contract": {
+                "cadence": "one_arbitration_decision_per_planner_step",
+                "min_dwell_steps": 1,
+                "dwell_enforcement": "not_enforced_in_v1_trace",
+                "future_learned_arbiter_constraint": (
+                    "learned arbiters must record and enforce any dwell constraint explicitly"
+                ),
+            },
+            "status_policy": {
+                "fallback_statuses": ["fallback"],
+                "degraded_statuses": ["degraded"],
+                "not_available_statuses": ["not_available"],
+                "non_executable_statuses": ["failed", "not_available", "rejected"],
+                "training_use": (
+                    "fallback, degraded, failed, not_available, and rejected proposals are "
+                    "diagnostic labels, not successful training targets unless explicitly filtered"
+                ),
+            },
+            "trace": diagnostics,
         }
 
     def _collect_proposals(self, observation: dict[str, Any]) -> list[_Proposal]:
@@ -509,6 +596,7 @@ def _accumulate_counts(target: dict[str, int], delta: dict[str, int]) -> None:
 
 
 __all__ = [
+    "ARBITRATION_TRACE_SCHEMA",
     "PolicyStackV1Adapter",
     "PolicyStackV1BuildConfig",
     "PolicyStackV1Config",

--- a/robot_sf/planner/policy_stack_v1.py
+++ b/robot_sf/planner/policy_stack_v1.py
@@ -167,6 +167,7 @@ class PolicyStackV1Adapter:
             selected_mode = "fallback"
             shield_intervened = True
             step_status_counts["fallback"] += 1
+            proposal_commands["shield_stop"] = [0.0, 0.0]
             rejection_reasons["shield_stop"] = (
                 f"hard stop clearance below {float(self.config.hard_stop_clearance):.3f} m"
             )
@@ -209,6 +210,8 @@ class PolicyStackV1Adapter:
         self._last_step = {
             "selected_proposal_key": selected_key,
             "selected_mode": selected_mode,
+            "selected_command": [float(command[0]), float(command[1])],
+            "executed_command": [float(command[0]), float(command[1])],
             "candidate_count": len(candidates),
             "rejected_count": rejected_count,
             "failed_count": failed_count,

--- a/scripts/validation/validate_policy_stack_trace_packet.py
+++ b/scripts/validation/validate_policy_stack_trace_packet.py
@@ -1,0 +1,157 @@
+"""Validate the policy_stack_v1 arbitration trace packet shape."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.planner.policy_stack_v1 import (
+    ARBITRATION_TRACE_SCHEMA,
+    PolicyStackV1Adapter,
+    PolicyStackV1Config,
+)
+
+EXPECTED_INFERENCE_FEATURES = {
+    "robot.position",
+    "robot.heading",
+    "goal.current",
+    "goal.next",
+    "pedestrians.positions",
+}
+EXPECTED_LEAKAGE_EXCLUSIONS = {
+    "future_trajectory",
+    "simulator_collision_label",
+    "episode_success_label",
+    "route_outcome_label",
+    "benchmark_metric_rollups",
+}
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _fixture_observation() -> dict[str, Any]:
+    """Return a tiny inference-available observation fixture.
+
+    Returns:
+        Observation payload containing only fields allowed in the arbitration trace contract.
+    """
+    return {
+        "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+        "goal": {"current": [1.0, 0.0]},
+        "pedestrians": {"positions": []},
+    }
+
+
+def validate_packet(packet: dict[str, Any]) -> list[str]:
+    """Validate the trace packet shape and return human-readable errors.
+
+    Returns:
+        List of validation errors. Empty means valid.
+    """
+    errors: list[str] = []
+    if packet.get("schema_version") != ARBITRATION_TRACE_SCHEMA:
+        errors.append("schema_version mismatch")
+    if packet.get("training_enabled") is not False:
+        errors.append("training_enabled must remain false for the trace preflight")
+    if not packet.get("proposal_sources"):
+        errors.append("proposal_sources must be non-empty")
+    errors.extend(_validate_contract_sections(packet))
+    errors.extend(_validate_trace_section(packet))
+    return errors
+
+
+def _validate_contract_sections(packet: dict[str, Any]) -> list[str]:
+    """Validate packet contract sections.
+
+    Returns:
+        List of contract-section errors.
+    """
+    errors: list[str] = []
+    command_contract = packet.get("command_contract")
+    if not isinstance(command_contract, dict):
+        errors.append("command_contract must be present")
+    elif command_contract.get("action_space") != "unicycle_vw":
+        errors.append("command_contract.action_space must be unicycle_vw")
+    observation_contract = packet.get("observation_contract")
+    if not isinstance(observation_contract, dict):
+        errors.append("observation_contract must be present")
+    else:
+        features = set(observation_contract.get("inference_available_features", []))
+        exclusions = set(observation_contract.get("leakage_exclusions", []))
+        if features != EXPECTED_INFERENCE_FEATURES:
+            errors.append("observation_contract.inference_available_features changed")
+        if exclusions != EXPECTED_LEAKAGE_EXCLUSIONS:
+            errors.append("observation_contract.leakage_exclusions changed")
+    status_policy = packet.get("status_policy")
+    if not isinstance(status_policy, dict):
+        errors.append("status_policy must be present")
+    elif "not_available" not in status_policy.get("not_available_statuses", []):
+        errors.append("status_policy must identify not_available statuses")
+    elif set(status_policy.get("non_executable_statuses", [])) != {
+        "failed",
+        "not_available",
+        "rejected",
+    }:
+        errors.append("status_policy.non_executable_statuses changed")
+    return errors
+
+
+def _validate_trace_section(packet: dict[str, Any]) -> list[str]:
+    """Validate packet trace section.
+
+    Returns:
+        List of trace-section errors.
+    """
+    errors: list[str] = []
+    trace = packet.get("trace")
+    if not isinstance(trace, dict):
+        errors.append("trace must be present")
+    elif not isinstance(trace.get("last_step"), dict):
+        errors.append("trace.last_step must be present after one planner step")
+    else:
+        ranking = trace["last_step"].get("candidate_ranking")
+        if not isinstance(ranking, list) or not ranking:
+            errors.append("trace.last_step.candidate_ranking must be non-empty")
+    return errors
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the trace packet validator CLI parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print the trace packet as JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run a tiny trace-packet smoke validation.
+
+    Returns:
+        Exit code 0 when valid, 2 when the packet shape is invalid.
+    """
+    args = build_arg_parser().parse_args(argv)
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal", "missing_optional"),
+            optional_sources=("missing_optional",),
+        )
+    )
+    stack.plan(_fixture_observation())
+    packet = stack.arbitration_trace_packet()
+    errors = validate_packet(packet)
+    if args.json:
+        print(json.dumps(packet, indent=2, sort_keys=True))
+    elif errors:
+        print("\n".join(errors))
+    else:
+        print("OK policy_stack_v1 arbitration trace packet is valid")
+    return 2 if errors else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/scripts/validation/validate_policy_stack_trace_packet.py
+++ b/scripts/validation/validate_policy_stack_trace_packet.py
@@ -87,9 +87,21 @@ def _validate_contract_sections(packet: dict[str, Any]) -> list[str]:
     status_policy = packet.get("status_policy")
     if not isinstance(status_policy, dict):
         errors.append("status_policy must be present")
-    elif "not_available" not in status_policy.get("not_available_statuses", []):
+    else:
+        errors.extend(_validate_status_policy(status_policy))
+    return errors
+
+
+def _validate_status_policy(status_policy: dict[str, Any]) -> list[str]:
+    """Validate fallback/degraded and non-executable status policy labels."""
+    errors: list[str] = []
+    if set(status_policy.get("fallback_statuses", [])) != {"fallback"}:
+        errors.append("status_policy.fallback_statuses changed")
+    if set(status_policy.get("degraded_statuses", [])) != {"degraded"}:
+        errors.append("status_policy.degraded_statuses changed")
+    if "not_available" not in status_policy.get("not_available_statuses", []):
         errors.append("status_policy must identify not_available statuses")
-    elif set(status_policy.get("non_executable_statuses", [])) != {
+    if set(status_policy.get("non_executable_statuses", [])) != {
         "failed",
         "not_available",
         "rejected",
@@ -114,7 +126,19 @@ def _validate_trace_section(packet: dict[str, Any]) -> list[str]:
         ranking = trace["last_step"].get("candidate_ranking")
         if not isinstance(ranking, list) or not ranking:
             errors.append("trace.last_step.candidate_ranking must be non-empty")
+        executed_command = trace["last_step"].get("executed_command")
+        if not _is_command_pair(executed_command):
+            errors.append("trace.last_step.executed_command must be a two-value command")
     return errors
+
+
+def _is_command_pair(value: object) -> bool:
+    """Return whether a value is a JSON-style two-number command pair."""
+    return (
+        isinstance(value, list)
+        and len(value) == 2
+        and all(isinstance(item, int | float) for item in value)
+    )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -149,6 +149,7 @@ def test_policy_stack_arbitration_trace_packet_contract() -> None:
     ]
     assert packet["trace"]["last_step"]["proposal_status_counts"]["not_available"] == 1
     assert packet["trace"]["last_step"]["candidate_ranking"][0]["proposal_key"] == "goal"
+    assert packet["trace"]["last_step"]["executed_command"] == [1.0, 0.0]
     assert stack.last_decision() == packet["trace"]["last_step"]
     json.dumps(packet, allow_nan=False)
 
@@ -226,6 +227,13 @@ def test_policy_stack_hard_shield_stops_unsafe_moving_command_and_resets() -> No
     assert diagnostics["shield_intervention_count"] == 1
     assert diagnostics["last_step"]["shield_intervened"] is True
     assert diagnostics["last_step"]["selected_proposal_key"] == "shield_stop"
+    assert diagnostics["last_step"]["selected_command"] == [0.0, 0.0]
+    assert diagnostics["last_step"]["executed_command"] == [0.0, 0.0]
+    assert diagnostics["last_step"]["proposal_commands"]["shield_stop"] == [0.0, 0.0]
+
+    packet = stack.arbitration_trace_packet()
+    assert packet["trace"]["last_step"]["selected_proposal_key"] == "shield_stop"
+    assert packet["trace"]["last_step"]["executed_command"] == [0.0, 0.0]
 
     stack.reset()
     assert stack.diagnostics()["steps"] == 0

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -95,6 +95,7 @@ def test_policy_stack_selects_goal_and_records_two_proposal_modes() -> None:
     assert last["proposal_status_counts"]["native"] == 1
     assert last["proposal_status_counts"]["adapter"] == 1
     assert set(last["risk_score_components"]) == {"goal", "risk_dwa"}
+    assert last["candidate_ranking"][0]["proposal_key"] == "goal"
     json.dumps(diagnostics, allow_nan=False)
 
 
@@ -119,6 +120,37 @@ def test_policy_stack_records_failed_and_not_available_without_fallback_success(
     assert last["unavailable_count"] == 1
     assert "risk solver failed" in last["rejection_reasons"]["risk_dwa"]
     assert "not available" in last["rejection_reasons"]["missing_optional"]
+
+
+def test_policy_stack_arbitration_trace_packet_contract() -> None:
+    """Trace packets should define the future arbiter contract without enabling training."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal", "missing_optional"),
+            optional_sources=("missing_optional",),
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+
+    stack.plan(_obs())
+    packet = stack.arbitration_trace_packet()
+
+    assert packet["schema_version"] == "policy_stack_v1.arbitration_trace_packet.v1"
+    assert packet["training_enabled"] is False
+    assert packet["proposal_sources"] == ["goal", "missing_optional"]
+    assert packet["command_contract"]["action_space"] == "unicycle_vw"
+    assert packet["switching_contract"]["min_dwell_steps"] == 1
+    assert "future_trajectory" in packet["observation_contract"]["leakage_exclusions"]
+    assert "not_available" in packet["status_policy"]["not_available_statuses"]
+    assert packet["status_policy"]["non_executable_statuses"] == [
+        "failed",
+        "not_available",
+        "rejected",
+    ]
+    assert packet["trace"]["last_step"]["proposal_status_counts"]["not_available"] == 1
+    assert packet["trace"]["last_step"]["candidate_ranking"][0]["proposal_key"] == "goal"
+    assert stack.last_decision() == packet["trace"]["last_step"]
+    json.dumps(packet, allow_nan=False)
 
 
 def test_policy_stack_rejects_nonfinite_adapter_command_before_scoring() -> None:

--- a/tests/validation/test_validate_policy_stack_trace_packet.py
+++ b/tests/validation/test_validate_policy_stack_trace_packet.py
@@ -1,0 +1,34 @@
+"""Tests for policy_stack_v1 arbitration trace packet validation."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.validation import validate_policy_stack_trace_packet as validator
+
+
+def test_validate_policy_stack_trace_packet_cli(capsys) -> None:
+    """The CLI should prove the tiny trace packet shape without benchmark metrics."""
+    exit_code = validator.main([])
+
+    assert exit_code == 0
+    assert "OK policy_stack_v1 arbitration trace packet is valid" in capsys.readouterr().out
+
+
+def test_validate_policy_stack_trace_packet_json(capsys) -> None:
+    """The JSON mode should expose a complete packet for docs and fixtures."""
+    exit_code = validator.main(["--json"])
+
+    assert exit_code == 0
+    packet = json.loads(capsys.readouterr().out)
+    assert packet["schema_version"] == "policy_stack_v1.arbitration_trace_packet.v1"
+    assert packet["training_enabled"] is False
+    assert packet["command_contract"]["action_space"] == "unicycle_vw"
+    assert set(packet["observation_contract"]["inference_available_features"]) == (
+        validator.EXPECTED_INFERENCE_FEATURES
+    )
+    assert set(packet["observation_contract"]["leakage_exclusions"]) == (
+        validator.EXPECTED_LEAKAGE_EXCLUSIONS
+    )
+    assert packet["trace"]["last_step"]["selected_proposal_key"] == "goal"
+    assert packet["trace"]["last_step"]["candidate_ranking"][0]["rank"] == 1


### PR DESCRIPTION
## Summary
- Adds `policy_stack_v1.arbitration_trace_packet.v1` as a diagnostic-only trace packet for future learned-arbiter data collection.
- Records proposal sources, command/action contract, inference-available observation features, leakage exclusions, switching/dwell boundary, fallback/non-executable status policy, and ranked candidate trace.
- Adds `last_decision()` plus `scripts/validation/validate_policy_stack_trace_packet.py` as a compact smoke command that proves packet shape without changing benchmark metrics.

## Validation
- `uv run pytest tests/planner/test_policy_stack_v1.py tests/validation/test_validate_policy_stack_trace_packet.py -q`
- `uv run pytest tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner -q`
- `uv run ruff check robot_sf/planner/policy_stack_v1.py scripts/validation/validate_policy_stack_trace_packet.py tests/planner/test_policy_stack_v1.py tests/validation/test_validate_policy_stack_trace_packet.py`
- `uv run python scripts/validation/validate_policy_stack_trace_packet.py`
- `uv run python scripts/validation/validate_policy_stack_trace_packet.py --json | python -m json.tool`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`

Closes #1751
