### PR TITLE
docs: refine maintainer value authority

### DIFF
--- a/.agents/commands/gemini/analyze.toml
+++ b/.agents/commands/gemini/analyze.toml
@@ -61,7 +61,7 @@ Execution steps:
       - Conflicting requirements (e.g., one requires to use Next.js while other says to use Vue as the framework).
 
 5. Severity assignment heuristic:
-   - CRITICAL: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality.
+   - CRITICAL: Violates a hard Constitution Authority requirement (for example, a constitution-level MUST), omits a required core spec artifact, or leaves baseline-blocking functionality with zero requirement coverage.
    - HIGH: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion.
    - MEDIUM: Terminology drift, missing non-functional task coverage, underspecified edge case.
    - LOW: Style/wording improvements, minor redundancy not affecting execution order.

--- a/.agents/commands/gemini/analyze.toml
+++ b/.agents/commands/gemini/analyze.toml
@@ -15,7 +15,7 @@ Goal: Identify inconsistencies, duplications, ambiguities, and underspecified it
 
 STRICTLY READ-ONLY: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
-Constitution Authority: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/analyze`.
+Constitution Authority: The project constitution (`.specify/memory/constitution.md`) is contributor guidance plus hard contract notes. Treat conflicts with benchmark, metric, schema, reproducibility, or paper-facing contracts as CRITICAL. For softer process conflicts, report the conflict and recommend whether the spec, plan, tasks, or guidance should change.
 
 Execution steps:
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,14 +1,15 @@
 <!--
 Sync Impact Report
-Previous Version: 1.4.1 -> New Version: 1.4.2 (PATCH bump)
-Rationale: Added maintainer-values linkage, explicit honesty/transparency/reproducibility hard rule, default cheap validation for docs/instruction-only changes, and uncertainty labeling for exploratory claims.
-Modified Principles: I, IX, XIII, Governance
+Previous Version: 1.4.2 -> New Version: 1.4.3 (PATCH bump)
+Rationale: Clarified that maintainer_values.md is higher-priority current guidance while the constitution remains strict for benchmark, metric, schema, reproducibility, and paper-facing contracts.
+Modified Principles: Governance
 Added Sections: None
 Removed Sections: None
 Templates Updated:
- - ✅ maintainer_values.md: Added compact current values and hard contracts
- - ✅ dev_guide.md: Validation language remains aligned through AGENTS/docs references
- - ✅ copilot-instructions.md: Aligned quality-playbook language with risk-proportional validation
+ - ✅ AGENTS.md: Authority order now puts maintainer_values.md first
+ - ✅ maintainer_values.md: Narrowed uncertainty labeling to substantive claims and added paper-grade checklist guidance
+ - ✅ docs/context/INDEX.md: Relaxed pruning guidance for unambiguously stale context notes
+ - ✅ gemini analyze command mirror: Matched softened constitution authority wording
 Pending Template Updates: None
 Deferred TODOs: None
 All placeholder tokens resolved; no bracketed ALL_CAPS identifiers remaining.
@@ -20,8 +21,8 @@ This Constitution specifies WHAT the Robot SF repository delivers: a cohesive, r
 and engineering platform for social navigation of a robot among pedestrians. Treat it as contributor
 guidance plus hard contract notes. Benchmark, metric, schema, reproducibility, and paper-facing
 contracts remain strict; softer workflow guidance should support maintainer-directed research
-progress rather than override it. `docs/maintainer_values.md` is the compact current-values entry
-point.
+progress rather than override it. `docs/maintainer_values.md` is the highest-priority current
+maintainer-values entry point when workflow guidance conflicts.
 
 ## Core Principles
 
@@ -222,4 +223,4 @@ contracts, (3) migration guidance or deprecation plan, (4) version/date update b
 introduction of out-of-scope functionality must include justification aligning with Core Principles
 I-X or be rejected.
 
-**Version**: 1.4.2 | **Ratified**: 2025-09-19 | **Last Amended**: 2026-05-30
+**Version**: 1.4.3 | **Ratified**: 2025-09-19 | **Last Amended**: 2026-05-31

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
-Use `AGENTS.md`, `docs/maintainer_values.md`, `.specify/memory/constitution.md`, and
-`docs/dev_guide.md` to guide AI assistants.
+Use `docs/maintainer_values.md` as the highest-level current maintainer guidance, then `AGENTS.md`,
+`.specify/memory/constitution.md`, and `docs/dev_guide.md` for repository execution details.
 This document covers briefly the repository structure, coding style, testing workflow, and contributor conventions.
 Prefer reusable shell entry points under `scripts/dev/` for automation and AI skills.
 Use `.vscode/tasks.json` as thin wrappers around those scripts.
@@ -20,8 +20,9 @@ documentation, and process in proportion to risk:
   exploratory, diagnostic, blocked, or not yet benchmark evidence;
 - low-risk docs, metadata, and instruction changes use the cheaper validation path by default:
   inspect the diff and verify changed links or referenced paths where practical;
-- statements below roughly 95 percent confidence should include an uncertainty estimate, caveat, or
-  condition that would change the conclusion;
+- substantive claims, recommendations, benchmark conclusions, and prioritization judgments below
+  roughly 95 percent confidence should include a numeric uncertainty estimate, caveat, or condition
+  that would change the conclusion;
 - current maintainer direction overrides stale workflow prose. When an instruction appears to
   conflict with the user's current priority, follow the current priority, call out the conflict, and
   propose or make the smallest doc update needed to remove the drift.
@@ -29,8 +30,8 @@ documentation, and process in proportion to risk:
 ## Agent Context Stack
 Treat the following files as the repository-native context stack for Agent-style agents:
 
-- `AGENTS.md`: top-level execution rules, repo structure, and workflow defaults.
 - `docs/maintainer_values.md`: compact current values and hard contracts.
+- `AGENTS.md`: top-level execution rules, repo structure, and workflow defaults.
 - `memory/MEMORY.md`: concise repo-local memory index for stable cross-session facts and links to
   detailed topic files under `memory/`.
 - `docs/code_review.md`: benchmark-facing review criteria, provenance checks, and regression traps.

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -94,7 +94,8 @@ Then branch by task type:
 - Use `scripts/dev/` entrypoints where available.
 - Prefer aggressive exploration when status is clearly labeled as exploratory, diagnostic, blocked,
   or not yet benchmark evidence.
-- Add uncertainty estimates or caveats for statements below roughly 95 percent confidence.
+- Add numeric uncertainty estimates or caveats for substantive claims, recommendations, benchmark
+  conclusions, and prioritization judgments below roughly 95 percent confidence.
 - Preserve benchmark claims conservatively.
 - Treat planner provenance as part of correctness, not just documentation polish.
 - Distinguish observed evidence from hypothesis in findings and reports.

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -37,7 +37,8 @@ paragraphs.
 - If two notes cover the same decision, keep the newer canonical note current and mark the older
   note `Historical` or `Superseded` near the top with a pointer to the replacement.
 - If a note is issue-local and no longer reusable, keep it linked from the relevant issue-specific
-  entry only, or remove it when the issue/PR record already preserves the needed provenance.
+  entry only, or remove it from this index when the issue/PR record already preserves the needed
+  provenance.
 - If a note supports a benchmark or paper-facing claim, preserve the evidence pointer even when the
   prose is shortened.
 - Add a note to this index only when it is a current domain entry point, a durable policy boundary,

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -31,11 +31,13 @@ paragraphs.
 
 ## Pruning And Refactoring Rules
 
-- Do not delete or rewrite the full context corpus in the first pass.
+- Prune, rewrite, rename, or delete stale notes more aggressively when the reason is unambiguous,
+  the note no longer provides reusable value, and benchmark or paper-facing evidence pointers are
+  preserved.
 - If two notes cover the same decision, keep the newer canonical note current and mark the older
   note `Historical` or `Superseded` near the top with a pointer to the replacement.
 - If a note is issue-local and no longer reusable, keep it linked from the relevant issue-specific
-  entry only; do not promote it into this index.
+  entry only, or remove it when the issue/PR record already preserves the needed provenance.
 - If a note supports a benchmark or paper-facing claim, preserve the evidence pointer even when the
   prose is shortened.
 - Add a note to this index only when it is a current domain entry point, a durable policy boundary,

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -31,8 +31,10 @@ Use explicit status language:
 - `not benchmark evidence`: ran outside the benchmark contract or under fallback/degraded mode.
 - `paper-grade`: fully reproducible and suitable for paper-facing claims.
 
-When a statement is not at least 95 percent certain, include a short uncertainty estimate, caveat,
-or condition that would change the conclusion.
+For substantive claims, recommendations, benchmark conclusions, and prioritization judgments below
+roughly 95 percent confidence, include a short numeric uncertainty estimate, caveat, or condition
+that would change the conclusion. Do not spend reasoning effort quantifying ordinary status updates
+or low-impact implementation narration.
 
 ## Validation
 
@@ -43,8 +45,11 @@ Use validation proportional to risk.
 - Runtime, benchmark, metric, schema, model-provenance, and paper-facing changes need executable
   proof appropriate to the claim.
 - Low-value tests may be removed without maintainer approval when the reason is unambiguous and
-  documented. Do not assume flaky tests are common; classify each failure before broad policy
-  changes.
+  documented, provided repository coverage expectations still hold or the remaining gap is tracked.
+  Do not assume flaky tests are common; classify each failure before broad policy changes.
+- Paper-grade or benchmark-strength claims should name the exact claim, command/config/seed path,
+  artifact provenance, metric/schema mode, sample size or statistics, fallback/degraded exclusions,
+  limitations, and reproduction path before they are treated as established.
 
 ## Work Collection
 


### PR DESCRIPTION
## Summary
Refines the latest maintainer-values alignment so docs/maintainer_values.md is clearly higher-priority current guidance. Narrows uncertainty estimates to substantive claims, adds paper-grade checklist guidance, relaxes context-note pruning, and fixes stale Gemini spec-kit authority wording.

## Linked Issues
- Relates to #1714
- Relates to #1728

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Put docs/maintainer_values.md first in the top-level authority order and constitution governance wording.
- Limited the 95 percent uncertainty rule to substantive claims, recommendations, benchmark conclusions, and prioritization judgments.
- Added a compact paper-grade / benchmark-strength claim checklist.
- Relaxed docs/context pruning guidance for unambiguously stale or non-reusable notes.
- Updated the Gemini analyze command mirror to treat constitution hard authority as contract-scoped rather than blanket non-negotiable process.

## Why It Matters
- Added value: makes current maintainer preferences easier for agents to follow without over-applying process.
- Expected impact: fewer unnecessary uncertainty estimates, less stale context accumulation, and less rigid spec-kit behavior.
- Why this is worth merging now: it resolves the latest audit decisions while the instruction stack is already being cleaned up.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `uv run python - <<PY ... tomllib.loads(...) ... PY` for `.agents/commands/gemini/analyze.toml`
  - `test -f` checks for referenced top-level docs and context index paths
  - `git grep` check for stale `non-negotiable`, `automatically CRITICAL`, and old context pruning wording in active instruction surfaces
  - `git status --ignored --short -uall output` artifact inspection
- Evidence that the change works here: edited TOML parses successfully and stale mirror wording no longer appears in the active instruction surfaces.
- Benchmarks or smoke tests, if applicable: not applicable; docs/instruction-only branch. Full `pr_ready_check` was intentionally not run under the cheaper official path.

## Risks / Rollout
- Compatibility risks: low; changes are instruction text only.
- Failure modes: an agent may still find older historical context notes with stricter wording, but the active authority order now points it back to maintainer values.
- Rollback or fallback plan: revert the docs commit if the wording makes agent behavior worse.

## Docs / Provenance
- Updated docs: AGENTS.md, docs/maintainer_values.md, docs/ai/repo_overview.md, docs/context/INDEX.md, .specify/memory/constitution.md, .agents/commands/gemini/analyze.toml
- Relevant design or provenance notes: latest maintainer-values audit discussion in this thread.
- Any assumptions that need to be preserved: docs-only and instruction-only changes can use cheap validation by default.

## Follow-Up Issues
- Deferred work: broader docs/ai consolidation remains separate from this narrow patch.
- Issues opened for follow-up: none in this patch. Existing related follow-ups include #1714 and #1728.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the paper-grade checklist is compact enough to be universally useful.
- Any known limitations: this does not consolidate docs/ai or remove stale Claude/spec-kit surfaces beyond the specific Gemini mirror drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance framework (Constitution v1.4.3) with revised priority hierarchy for maintenance guidance.
  * Enhanced validation requirements for claims and benchmarks, now requiring numeric uncertainty estimates when confidence is below ~95%.
  * Refined contract conflict handling to differentiate critical infrastructure conflicts from process-level recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->