### PR TITLE
docs: index ORCA-residual SLURM handoff (#1773)

### DIFF
--- a/docs/context/policy_search/SLURM/todo.md
+++ b/docs/context/policy_search/SLURM/todo.md
@@ -5,7 +5,7 @@ or other expensive execution that should not happen on the local machine.
 
 This file is a convenience index for policy-search SLURM handoff notes. It is not the execution
 status ledger. For current issue state, blocker classification, and artifact-promotion status, use
-`../../slurm_issue_batch_status_2026-05-21.md`.
+[slurm_issue_batch_status_2026-05-21.md](../../slurm_issue_batch_status_2026-05-21.md).
 
 - [Learned Risk Model v1](001_learned_risk_model_v1.md)
 - [Shielded PPO Repair Campaign](002_shielded_ppo_repair_campaign.md)

--- a/docs/context/policy_search/SLURM/todo.md
+++ b/docs/context/policy_search/SLURM/todo.md
@@ -1,10 +1,14 @@
-# SLURM TODO
+# SLURM Handoff Index
 
-These items are intentionally deferred because they require full training runs,
-extended sweeps, or other expensive execution that should not happen on the
-local laptop.
+These handoffs are intentionally deferred because they require full training runs, extended sweeps,
+or other expensive execution that should not happen on the local machine.
+
+This file is a convenience index for policy-search SLURM handoff notes. It is not the execution
+status ledger. For current issue state, blocker classification, and artifact-promotion status, use
+`../../slurm_issue_batch_status_2026-05-21.md`.
 
 - [Learned Risk Model v1](001_learned_risk_model_v1.md)
 - [Shielded PPO Repair Campaign](002_shielded_ppo_repair_campaign.md)
 - [Oracle Imitation Dataset Campaign](003_imitation_oracle_dataset_campaign.md)
 - [H500 Leader Clean Rerun](004_h500_leader_clean_rerun.md)
+- [ORCA-Residual Behavior-Cloning Lineage](005_orca_residual_bc_lineage.md)


### PR DESCRIPTION
## Summary
Updates the policy-search SLURM TODO file into an explicit handoff index, adds the missing ORCA-residual behavior-cloning handoff, and points status decisions to the canonical SLURM issue status ledger.

## Linked Issues
- Closes `#1773`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Renamed the local `SLURM/todo.md` heading to describe it as a handoff index.
- Clarified that the dated SLURM status note owns current blocker/artifact state.
- Added `005_orca_residual_bc_lineage.md` to the handoff list.

## Why It Matters
- Added value: agents following the policy-search docs will see the ORCA-residual lineage packet.
- Expected impact: less stale routing around the active ORCA-residual SLURM handoff.
- Why this is worth merging now: it keeps the index aligned with the README and SLURM status ledger.

## Validation / Proof
- Commands run:
  - `rg -n "005_orca_residual_bc_lineage|SLURM/todo|slurm_issue_batch_status" docs/context docs/README.md`
  - manual path existence check for all five `docs/context/policy_search/SLURM/*.md` handoffs and `docs/context/slurm_issue_batch_status_2026-05-21.md`
  - `git diff --check origin/main...HEAD`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Evidence that the change works here: all listed handoff files and the status ledger exist, and docs/proof consistency passed for the changed file.
- Benchmarks or smoke tests, if applicable: not applicable; docs/index-only change.

## Risks / Rollout
- Compatibility risks: low; Markdown index wording only.
- Failure modes: future handoff files can still drift if added without updating this index.
- Rollback or fallback plan: revert the single docs file if a different SLURM index source is preferred.

## Docs / Provenance
- Updated docs:
  - `docs/context/policy_search/SLURM/todo.md`
- Relevant design or provenance notes:
  - `docs/context/slurm_issue_batch_status_2026-05-21.md`
  - `docs/context/policy_search/README.md`
- Any assumptions that need to be preserved: local machines should not submit or treat SLURM training handoffs as completed evidence without durable outputs.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether `SLURM/todo.md` should remain the convenience index name long-term.
- Any known limitations: full PR readiness was not run because this is a docs-only index update; the docs proof path was used.
