### PR TITLE
feat: expose risk-surface DWA exploratory candidate (#1780)

### DIFF
--- a/configs/algos/risk_surface_dwa_v0.yaml
+++ b/configs/algos/risk_surface_dwa_v0.yaml
@@ -1,0 +1,35 @@
+# Deterministic risk-surface producer wrapped around Risk-DWA.
+# Exploratory smoke-only candidate: not learned-risk benchmark evidence.
+allow_testing_algorithms: true
+risk_surface:
+  resolution: 0.25
+  width: 4.0
+  height: 4.0
+  frame: ego
+  risk_threshold: 0.5
+  producer_id: deterministic_pedestrian_fixture_v0
+risk_dwa:
+  max_linear_speed: 1.2
+  max_angular_speed: 1.2
+  rollout_dt: 0.2
+  rollout_steps: 8
+  goal_tolerance: 0.25
+  linear_candidates: [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2]
+  angular_candidates: [-1.2, -0.8, -0.4, 0.0, 0.4, 0.8, 1.2]
+  goal_progress_weight: 4.0
+  heading_weight: 0.8
+  ped_clearance_weight: 1.6
+  obstacle_clearance_weight: 1.2
+  smoothness_weight: 0.15
+  ttc_weight: 0.3
+  safe_distance: 0.35
+  near_distance: 0.7
+  obstacle_threshold: 0.5
+  obstacle_search_cells: 12
+  near_field_distance: 2.5
+  density_norm_count: 8.0
+  near_field_speed_cap: 0.6
+  progress_escape_enabled: true
+  progress_escape_distance: 1.0
+  progress_escape_speed: 0.55
+  progress_escape_heading_gain: 1.6

--- a/configs/policy_search/candidates/risk_surface_dwa_v0.yaml
+++ b/configs/policy_search/candidates/risk_surface_dwa_v0.yaml
@@ -1,0 +1,4 @@
+name: risk_surface_dwa_v0
+algo: risk_surface_dwa
+base_config_path: configs/algos/risk_surface_dwa_v0.yaml
+params: {}

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -178,6 +178,20 @@ candidates:
       - smoke
       - nominal_sanity
 
+  risk_surface_dwa_v0:
+    status: experimental_spike
+    family: local_risk_surface
+    training_required: false
+    promotion_gate: tier_b
+    candidate_config_path: configs/policy_search/candidates/risk_surface_dwa_v0.yaml
+    hypothesis: >
+      A deterministic local risk-surface producer can expose pedestrian proximity as an
+      occupancy-compatible ego grid and let the existing Risk-DWA planner consume that surface
+      through the normal policy-search smoke path. This is a prototype interface proof only, not
+      learned-risk model or benchmark-strength evidence.
+    required_stages:
+      - smoke
+
   tentabot_value_scorer_v0:
     status: experimental_spike
     family: learned_style_value_scorer

--- a/docs/context/policy_search/reports/2026-05-31_risk_surface_dwa_v0_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-31_risk_surface_dwa_v0_smoke.md
@@ -1,0 +1,43 @@
+# Candidate Report: risk_surface_dwa_v0 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+A deterministic local risk-surface producer can expose pedestrian proximity as an occupancy-compatible ego grid and let the existing Risk-DWA planner consume that surface through the normal policy-search smoke path. This is a prototype interface proof only, not learned-risk model or benchmark-strength evidence.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `risk_surface_dwa`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/risk_surface_dwa_v0/smoke/latest/summary.json`
+- Git commit: `ae01fb0a3b7888bf789753a35be4428ff71c4a98`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 0.0000 | 0.0000 | 0.0000 | n/a | 0.0000 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 0.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- `overconservative_stop`: `1`
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | -0.0142 | -0.2411 | n/a |
+| orca | -0.1844 | -0.0355 | n/a |
+| ppo | -0.2482 | -0.0993 | n/a |

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -44,6 +44,7 @@ _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "prediction_planner": "learning",
     "predictive_mppi": "learning",
     "risk_dwa": "classical",
+    "risk_surface_dwa": "classical",
     "hybrid_rule_local_planner": "classical",
     "safety_barrier": "classical",
     "grid_route": "classical",
@@ -95,6 +96,7 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "prediction_planner": "predictive_model_based_adapter",
     "predictive_mppi": "predictive_sequence_optimizer",
     "risk_dwa": "risk_aware_dynamic_window",
+    "risk_surface_dwa": "deterministic_local_risk_surface_dwa",
     "hybrid_rule_local_planner": "hybrid_rule_deterministic_local_planner",
     "safety_barrier": "native_barrier_style_safety_filter",
     "grid_route": "occupancy_grid_route_tracking",
@@ -156,6 +158,15 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
     "stream_gap": _DEFAULT_OBSERVATION_SPEC,
     "gap_prediction": _DEFAULT_OBSERVATION_SPEC,
     "risk_dwa": _DEFAULT_OBSERVATION_SPEC,
+    "risk_surface_dwa": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "pedestrians", "local_risk_surface"),
+        "notes": (
+            "Exploratory deterministic risk-surface producer consumes structured SocNav state, "
+            "derives an ego-frame occupancy-compatible risk grid, and wraps risk_dwa."
+        ),
+    },
     "mppi_social": _DEFAULT_OBSERVATION_SPEC,
     "hybrid_portfolio": _DEFAULT_OBSERVATION_SPEC,
     "hybrid_orca_sampler": _DEFAULT_OBSERVATION_SPEC,
@@ -772,6 +783,18 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "supports_adapter_commands": True,
         "default_execution_mode": "adapter",
         "default_adapter_name": "RiskDWAPlannerAdapter",
+    },
+    "risk_surface_dwa": {
+        "planner_command_space": "unicycle_vw",
+        "supports_native_commands": False,
+        "supports_adapter_commands": True,
+        "default_execution_mode": "adapter",
+        "default_adapter_name": "RiskSurfacePlannerAdapter",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "deterministic_local_risk_surface_to_risk_dwa_unicycle_vw",
+        "projection_documented": True,
+        "testing_only_adapter": True,
+        "prototype_only": True,
     },
     "hybrid_rule_local_planner": {
         "planner_command_space": "unicycle_vw",

--- a/robot_sf/benchmark/algorithm_readiness.py
+++ b/robot_sf/benchmark/algorithm_readiness.py
@@ -234,6 +234,16 @@ _ALGORITHMS: tuple[AlgorithmReadiness, ...] = (
         requires_explicit_opt_in=True,
     ),
     AlgorithmReadiness(
+        canonical_name="risk_surface_dwa",
+        tier="experimental",
+        aliases=("risk_surface_dwa", "risk_surface_dwa_v0"),
+        note=(
+            "Deterministic local risk-surface producer wrapped around risk_dwa; "
+            "prototype-only and not learned-risk benchmark evidence."
+        ),
+        requires_explicit_opt_in=True,
+    ),
+    AlgorithmReadiness(
         canonical_name="hybrid_rule_local_planner",
         tier="experimental",
         aliases=("hybrid_rule_local_planner", "hybrid_rule_v0_minimal"),

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -114,6 +114,10 @@ from robot_sf.planner.kinematics_model import (
     KinematicsModel,
     resolve_benchmark_kinematics_model,
 )
+from robot_sf.planner.learned_risk_surface import (
+    RiskSurfacePlannerAdapter,
+    build_local_risk_surface_spec,
+)
 from robot_sf.planner.lidar_occupancy import (
     LidarOccupancyPlannerAdapter,
     build_lidar_occupancy_config,
@@ -1382,6 +1386,37 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             adapter_name="RiskDWAPlannerAdapter",
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    if algo_key in {"risk_surface_dwa", "risk_surface_dwa_v0"}:
+        risk_surface_cfg = (
+            algo_config.get("risk_surface")
+            if isinstance(algo_config.get("risk_surface"), dict)
+            else {}
+        )
+        risk_dwa_cfg = (
+            algo_config.get("risk_dwa") if isinstance(algo_config.get("risk_dwa"), dict) else {}
+        )
+        adapter = RiskSurfacePlannerAdapter(
+            spec=build_local_risk_surface_spec(risk_surface_cfg),
+            planner=RiskDWAPlannerAdapter(config=build_risk_dwa_config(risk_dwa_cfg)),
+        )
+        meta["risk_surface_planner"] = {
+            "status": "enabled",
+            "producer": "deterministic_pedestrian_risk_surface",
+            "wrapped_planner": "risk_dwa",
+            "benchmark_strength": False,
+            "claim_boundary": "exploratory_smoke_only",
+        }
+        return _build_adapter_policy(
+            algo_key="risk_surface_dwa",
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="RiskSurfacePlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations="deterministic_risk_surface_fixture_not_benchmark_evidence",
         )
 
     if algo_key in {"lidar_social_force", "lidar_tracked_social_force"}:

--- a/robot_sf/planner/__init__.py
+++ b/robot_sf/planner/__init__.py
@@ -28,6 +28,7 @@ from robot_sf.planner.learned_risk_surface import (
     RiskSurfacePlannerAdapter,
     RiskSurfaceUnavailable,
     attach_risk_surface_to_observation,
+    build_local_risk_surface_spec,
     deterministic_pedestrian_risk_surface,
 )
 from robot_sf.planner.poi_sampler import POISampler
@@ -66,6 +67,7 @@ __all__ = [
     "VisibilityPlanner",
     "attach_classic_global_planner",
     "attach_risk_surface_to_observation",
+    "build_local_risk_surface_spec",
     "deterministic_pedestrian_risk_surface",
     "plot_global_plan",
     "plot_visibility_graph",

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -9,7 +9,7 @@ weights, or datasets.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any
 
 import numpy as np
@@ -254,6 +254,24 @@ def attach_risk_surface_to_observation(
     return enriched
 
 
+def build_local_risk_surface_spec(cfg: dict[str, Any] | None) -> LocalRiskSurfaceSpec:
+    """Build a local risk-surface spec from a YAML-style mapping.
+
+    Returns:
+        LocalRiskSurfaceSpec: Validated surface geometry and metadata.
+    """
+    payload = cfg if isinstance(cfg, dict) else {}
+    allowed = {field.name for field in fields(LocalRiskSurfaceSpec)}
+    filtered = {key: value for key, value in payload.items() if key in allowed}
+    origin = filtered.get("origin")
+    if origin is not None:
+        origin_values = np.asarray(origin, dtype=float).reshape(-1)
+        if origin_values.size != 2:
+            raise RiskSurfaceUnavailable("origin must contain two finite values")
+        filtered["origin"] = (float(origin_values[0]), float(origin_values[1]))
+    return LocalRiskSurfaceSpec(**filtered)
+
+
 class RiskSurfacePlannerAdapter:
     """Adapter that lets an existing local planner consume a risk surface."""
 
@@ -347,5 +365,6 @@ __all__ = [
     "RiskSurfacePlannerAdapter",
     "RiskSurfaceUnavailable",
     "attach_risk_surface_to_observation",
+    "build_local_risk_surface_spec",
     "deterministic_pedestrian_risk_surface",
 ]

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -265,10 +265,13 @@ def build_local_risk_surface_spec(cfg: dict[str, Any] | None) -> LocalRiskSurfac
     filtered = {key: value for key, value in payload.items() if key in allowed}
     origin = filtered.get("origin")
     if origin is not None:
-        origin_values = np.asarray(origin, dtype=float).reshape(-1)
-        if origin_values.size != 2:
-            raise RiskSurfaceUnavailable("origin must contain two finite values")
-        filtered["origin"] = (float(origin_values[0]), float(origin_values[1]))
+        try:
+            origin_values = np.asarray(origin, dtype=float).reshape(-1)
+            if origin_values.size != 2:
+                raise ValueError("origin must contain two finite values")
+            filtered["origin"] = (float(origin_values[0]), float(origin_values[1]))
+        except (KeyError, TypeError, ValueError, IndexError) as exc:
+            raise RiskSurfaceUnavailable("origin must contain two finite values") from exc
     return LocalRiskSurfaceSpec(**filtered)
 
 

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -143,6 +143,30 @@ def test_grid_route_metadata_marks_testing_only_route_spike() -> None:
     assert planner["adapter_name"] == "GridRoutePlannerAdapter"
 
 
+def test_risk_surface_dwa_metadata_marks_prototype_surface_adapter() -> None:
+    """Risk-surface DWA metadata should prevent learned-risk overclaiming."""
+    assert canonical_algorithm_name("risk_surface_dwa_v0") == "risk_surface_dwa"
+    meta = enrich_algorithm_metadata(
+        algo="risk_surface_dwa_v0",
+        metadata={"status": "ok"},
+        execution_mode="adapter",
+        robot_kinematics="differential_drive",
+    )
+    planner = meta["planner_kinematics"]
+    assert meta["canonical_algorithm"] == "risk_surface_dwa"
+    assert meta["baseline_category"] == "classical"
+    assert meta["policy_semantics"] == "deterministic_local_risk_surface_dwa"
+    assert meta["observation_spec"]["inputs"] == [
+        "robot_state",
+        "goal",
+        "pedestrians",
+        "local_risk_surface",
+    ]
+    assert planner["adapter_name"] == "RiskSurfacePlannerAdapter"
+    assert planner["testing_only_adapter"] is True
+    assert planner["prototype_only"] is True
+
+
 def test_safety_barrier_accepts_lidar_level_through_sensor_fusion_contract() -> None:
     """Safety-barrier LiDAR compatibility should be explicit adapter metadata, not fallback."""
     meta = enrich_algorithm_metadata(

--- a/tests/benchmark/test_algorithm_readiness_contract.py
+++ b/tests/benchmark/test_algorithm_readiness_contract.py
@@ -41,3 +41,29 @@ def test_trivial_reference_adapter_requires_explicit_experimental_opt_in() -> No
         )
         == spec
     )
+
+
+def test_risk_surface_dwa_requires_explicit_experimental_opt_in() -> None:
+    """The deterministic risk-surface planner should stay behind the testing gate."""
+    spec = get_algorithm_readiness("risk_surface_dwa_v0")
+    assert spec is not None
+    assert spec.canonical_name == "risk_surface_dwa"
+    assert spec.tier == "experimental"
+    assert spec.requires_explicit_opt_in is True
+
+    with pytest.raises(ValueError, match="allow_testing_algorithms"):
+        require_algorithm_allowed(
+            algo="risk_surface_dwa",
+            benchmark_profile="experimental",
+            ppo_paper_ready=False,
+        )
+
+    assert (
+        require_algorithm_allowed(
+            algo="risk_surface_dwa",
+            benchmark_profile="experimental",
+            ppo_paper_ready=False,
+            allow_testing_algorithms=True,
+        )
+        == spec
+    )

--- a/tests/benchmark/test_map_runner_preflight_profiles.py
+++ b/tests/benchmark/test_map_runner_preflight_profiles.py
@@ -288,6 +288,7 @@ def test_all_issue_596_testing_only_planners_remain_opt_in_gated(
     for algo in (
         "hrvo",
         "risk_dwa",
+        "risk_surface_dwa",
         "safety_barrier",
         "grid_route",
         "mppi_social",

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -379,6 +379,52 @@ def test_build_policy_nmpc_social_wires_nmpc_adapter(
     assert meta["planner_kinematics"]["execution_mode"] == "adapter"
 
 
+def test_build_policy_risk_surface_dwa_wires_surface_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exploratory risk-surface key should wrap Risk-DWA through the surface adapter."""
+
+    class _DummyAdapter:
+        """Planner adapter test double for policy wiring."""
+
+        def __init__(self, *, spec, planner) -> None:
+            self.spec = spec
+            self.planner = planner
+
+        def plan(self, _obs):
+            """Return a deterministic planner command for the wiring test."""
+            return (0.25, 0.15)
+
+        def diagnostics(self):
+            """Return diagnostics preserving the prototype claim boundary."""
+            return {"benchmark_strength": False, "status": "ok"}
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.RiskSurfacePlannerAdapter", _DummyAdapter)
+    policy, meta = _build_policy(
+        "risk_surface_dwa_v0",
+        {
+            "risk_surface": {"resolution": 0.5, "producer_id": "test_surface"},
+            "risk_dwa": {"max_linear_speed": 0.5},
+        },
+    )
+    linear, angular = policy(
+        {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [1.0, 0.0]},
+            "pedestrians": {"positions": [[0.5, 0.0]], "count": [1]},
+        }
+    )
+
+    assert (linear, angular) == (0.25, 0.15)
+    assert meta["canonical_algorithm"] == "risk_surface_dwa"
+    assert meta["policy_semantics"] == "deterministic_local_risk_surface_dwa"
+    assert meta["risk_surface_planner"]["benchmark_strength"] is False
+    assert meta["planner_kinematics"]["adapter_name"] == "RiskSurfacePlannerAdapter"
+    assert meta["planner_kinematics"]["limitations"] == (
+        "deterministic_risk_surface_fixture_not_benchmark_evidence"
+    )
+
+
 def test_build_policy_socnav_bench_forwards_allow_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -10,6 +10,7 @@ from robot_sf.planner.learned_risk_surface import (
     RiskSurfacePlannerAdapter,
     RiskSurfaceUnavailable,
     attach_risk_surface_to_observation,
+    build_local_risk_surface_spec,
     deterministic_pedestrian_risk_surface,
 )
 
@@ -106,3 +107,23 @@ def test_risk_surface_contract_rejects_invalid_resolution() -> None:
     """Invalid geometry should be rejected before any planner run."""
     with pytest.raises(RiskSurfaceUnavailable, match="resolution"):
         LocalRiskSurfaceSpec(resolution=0.0)
+
+
+def test_build_local_risk_surface_spec_accepts_yaml_style_origin() -> None:
+    """YAML mappings should build the same validated risk-surface contract."""
+    spec = build_local_risk_surface_spec(
+        {
+            "resolution": 0.5,
+            "width": 3.0,
+            "height": 2.0,
+            "origin": [-1.5, -1.0],
+            "producer_id": "test_fixture",
+            "ignored": "value",
+        }
+    )
+
+    assert spec.resolution == 0.5
+    assert spec.width == 3.0
+    assert spec.height == 2.0
+    assert spec.origin == (-1.5, -1.0)
+    assert spec.producer_id == "test_fixture"

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -127,3 +127,17 @@ def test_build_local_risk_surface_spec_accepts_yaml_style_origin() -> None:
     assert spec.height == 2.0
     assert spec.origin == (-1.5, -1.0)
     assert spec.producer_id == "test_fixture"
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        {"x": -1.5, "y": -1.0},
+        object(),
+        [0.0, 1.0, 2.0],
+    ],
+)
+def test_build_local_risk_surface_spec_rejects_malformed_origin(origin: object) -> None:
+    """Malformed origins should fail through the risk-surface domain exception."""
+    with pytest.raises(RiskSurfaceUnavailable, match="origin must contain two finite values"):
+        build_local_risk_surface_spec({"origin": origin})


### PR DESCRIPTION
## Summary

Closes #1780.

- add the experimental `risk_surface_dwa_v0` algorithm and policy-search candidate configs
- wire `risk_surface_dwa` through benchmark readiness, metadata, and `map_runner` as a testing-only prototype adapter around `RiskSurfacePlannerAdapter` + `RiskDWAPlannerAdapter`
- add a YAML-friendly `build_local_risk_surface_spec` helper and targeted contract tests for metadata, readiness gating, preflight, policy construction, and risk-surface spec parsing
- record the smoke report in `docs/context/policy_search/reports/2026-05-31_risk_surface_dwa_v0_smoke.md`

## Claim Boundary

This is exploratory interface proof, not benchmark-strength planner evidence. The smoke run executes the candidate through the policy-search path and records benchmark-strength metadata as false. The one-episode smoke passed the stage gate with no collision or near miss, but it ended at `max_steps` with `overconservative_stop`, `success_rate=0.0`, and `mean_avg_speed=0.0`.

## Validation

- `uv run ruff check robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/algorithm_readiness.py robot_sf/benchmark/map_runner.py robot_sf/planner/__init__.py robot_sf/planner/learned_risk_surface.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_algorithm_readiness_contract.py tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_map_runner_utils.py tests/planner/test_learned_risk_surface.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `uv run pytest -q tests/planner/test_learned_risk_surface.py tests/benchmark/test_algorithm_metadata_contract.py::test_risk_surface_dwa_metadata_marks_prototype_surface_adapter tests/benchmark/test_algorithm_readiness_contract.py::test_risk_surface_dwa_requires_explicit_experimental_opt_in tests/benchmark/test_map_runner_utils.py::test_build_policy_risk_surface_dwa_wires_surface_adapter tests/benchmark/test_map_runner_preflight_profiles.py::test_all_issue_596_testing_only_planners_remain_opt_in_gated`
- `uv run python scripts/validation/check_local_model_artifacts.py configs/algos/risk_surface_dwa_v0.yaml configs/policy_search/candidates/risk_surface_dwa_v0.yaml`
- `LOGURU_LEVEL=WARNING PYGAME_HIDE_SUPPORT_PROMPT=1 uv run python scripts/validation/run_policy_search_candidate.py --candidate risk_surface_dwa_v0 --stage smoke --workers 1`
- `git diff --check origin/main...HEAD`

Full PR readiness was not run; this branch used targeted planner/benchmark metadata validation plus the candidate smoke path. Ignored local artifacts under `output/coverage/` and `output/policy_search/risk_surface_dwa_v0/` are disposable run outputs and are intentionally not committed.
