### PR TITLE
test: guard promoted configs from local model paths (#1775)

### DIFF
--- a/configs/benchmarks/promoted_config_surfaces.yaml
+++ b/configs/benchmarks/promoted_config_surfaces.yaml
@@ -1,0 +1,51 @@
+version: 1
+policy: issue_1775_promoted_config_local_artifact_guard
+follow_up_issue: https://github.com/ll7/robot_sf_ll7/issues/1764
+rule: >
+  A promoted config surface is a checked-in algorithm or baseline YAML that is cited by
+  camera-ready, paper-facing, or benchmark-baseline workflows as a reusable benchmark input.
+  These configs must resolve learned checkpoints through durable registry ids or artifact
+  pointers, not direct worktree-local output/ model paths.
+promoted_configs:
+  - path: configs/algos/gap_prediction_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/grid_route_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/guarded_ppo_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/hrvo_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/hybrid_portfolio_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/mppi_social_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/ppo_v3_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/prediction_planner_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/prediction_planner_camera_ready_xl_ego.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/predictive_mppi_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/risk_dwa_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/safety_barrier_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/sicnav_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/stream_gap_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/algos/teb_commitment_camera_ready.yaml
+    reason: Camera-ready benchmark algorithm config.
+  - path: configs/baselines/ppo_15m_grid_socnav.yaml
+    reason: Canonical PPO benchmark/evaluation baseline.
+  - path: configs/baselines/ppo_15m_grid_socnav_holonomic.yaml
+    reason: Strict holonomic camera-ready PPO baseline profile.
+  - path: configs/baselines/ppo_issue_576_br06_v2_15m.yaml
+    reason: Paper-baseline gate config kept for issue-576 BR-06 closeout.
+  - path: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
+    reason: Issue-791 Wave-5 leader benchmark baseline.
+  - path: configs/baselines/ppo_issue_791_eval_aligned_large_capacity_portable.yaml
+    reason: Portable issue-791 Wave-5 leader benchmark baseline.
+  - path: configs/baselines/ppo_v10_carry_forward_27dbe5xu.yaml
+    reason: Carry-forward benchmark/evaluation PPO candidate.

--- a/docs/context/issue_1638_model_path_preflight.md
+++ b/docs/context/issue_1638_model_path_preflight.md
@@ -9,6 +9,7 @@ Related issue:
 Follow-up:
 
 - Issue #1764: <https://github.com/ll7/robot_sf_ll7/issues/1764>
+- Issue #1775: <https://github.com/ll7/robot_sf_ll7/issues/1775>
 
 Related anchors:
 
@@ -55,6 +56,16 @@ The same fail-closed check is also called when benchmark algorithm configs are l
 map runner and lightweight runner. A benchmark launch that points at a blocked `output/` model path
 now fails before planner construction, with the blocklist reason and follow-up issue in the error
 trail.
+
+The promoted-config surface is explicit in:
+
+- `configs/benchmarks/promoted_config_surfaces.yaml`
+
+Configs listed there are treated as benchmark-promoted inputs because camera-ready, paper-facing,
+or benchmark-baseline workflows cite them as reusable benchmark surfaces. They fail the preflight
+whenever `model_path` or `resume_from` points into `output/`, even if that exact reference is
+listed in the local-artifact blocklist. Non-promoted local or experimental configs may remain
+blocklisted while Issue #1764 decides whether to promote, replace, or retire those artifacts.
 
 Strict audits can run:
 

--- a/model/registry.md
+++ b/model/registry.md
@@ -118,6 +118,15 @@ Treat W&B fields as experiment-lineage provenance unless the entry is intentiona
 If a paper-facing registry entry still has `commit: null`, keep the missing source commit visible as
 a provenance caveat until it is repaired.
 
+Promoted benchmark configs are listed in
+`configs/benchmarks/promoted_config_surfaces.yaml`. Those config files must use durable ids or
+artifact pointers such as `model_id`, not direct `model_path` or `resume_from` values under
+`output/`. Validate the boundary with:
+
+```bash
+uv run python scripts/validation/check_local_model_artifacts.py
+```
+
 ### Publishing preserved models
 
 Use `scripts/tools/publish_model_registry_release.py` to migrate W&B-backed model entries to GitHub

--- a/scripts/validation/check_local_model_artifacts.py
+++ b/scripts/validation/check_local_model_artifacts.py
@@ -16,9 +16,10 @@ from typing import Any
 
 import yaml
 
-DEFAULT_SCAN_ROOTS = (Path("configs/baselines"),)
-DEFAULT_BLOCKLIST = Path("configs/baselines/local_model_artifact_blocklist.yaml")
-DEFAULT_PROMOTED_SURFACES = Path("configs/benchmarks/promoted_config_surfaces.yaml")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOTS = (REPO_ROOT / "configs/baselines",)
+DEFAULT_BLOCKLIST = REPO_ROOT / "configs/baselines/local_model_artifact_blocklist.yaml"
+DEFAULT_PROMOTED_SURFACES = REPO_ROOT / "configs/benchmarks/promoted_config_surfaces.yaml"
 LOCAL_MODEL_KEYS = {"model_path", "resume_from"}
 PROMOTED_BLOCKED_STATUS = "promoted_blocked"
 
@@ -67,9 +68,14 @@ def _iter_yaml_files(paths: list[Path]) -> list[Path]:
 def _path_lookup_candidates(path: Path) -> list[str]:
     """Return stable path spellings for config-surface matching."""
     candidates = [path.as_posix()]
+    resolved = path.resolve()
+    try:
+        candidates.append(resolved.relative_to(REPO_ROOT).as_posix())
+    except ValueError:
+        pass
     if path.is_absolute():
         try:
-            candidates.append(path.relative_to(Path.cwd()).as_posix())
+            candidates.append(resolved.relative_to(Path.cwd().resolve()).as_posix())
         except ValueError:
             pass
     candidates.append(path.name)
@@ -79,7 +85,7 @@ def _path_lookup_candidates(path: Path) -> list[str]:
 def _display_path(path: Path) -> str:
     """Return the repository-relative path when available."""
     try:
-        return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
     except ValueError:
         return path.as_posix()
 
@@ -179,7 +185,10 @@ def check_local_model_artifacts(
     blocklist = _load_blocklist(blocklist_path)
     promoted_surfaces = _load_promoted_surfaces(promoted_surfaces_path)
     expanded_scan_paths = list(scan_paths)
-    expanded_scan_paths.extend(Path(path) for path in promoted_surfaces)
+    expanded_scan_paths.extend(
+        path if path.is_absolute() else REPO_ROOT / path
+        for path in (Path(path) for path in promoted_surfaces)
+    )
     rows: list[LocalModelReference] = []
     for yaml_path in _iter_yaml_files(expanded_scan_paths):
         if yaml_path == blocklist_path:

--- a/scripts/validation/check_local_model_artifacts.py
+++ b/scripts/validation/check_local_model_artifacts.py
@@ -18,7 +18,9 @@ import yaml
 
 DEFAULT_SCAN_ROOTS = (Path("configs/baselines"),)
 DEFAULT_BLOCKLIST = Path("configs/baselines/local_model_artifact_blocklist.yaml")
+DEFAULT_PROMOTED_SURFACES = Path("configs/benchmarks/promoted_config_surfaces.yaml")
 LOCAL_MODEL_KEYS = {"model_path", "resume_from"}
+PROMOTED_BLOCKED_STATUS = "promoted_blocked"
 
 
 @dataclass(frozen=True)
@@ -30,6 +32,7 @@ class LocalModelReference:
     value: str
     status: str
     reason: str
+    surface: str = "local_experimental"
 
 
 def _load_yaml(path: Path) -> Any:
@@ -59,6 +62,55 @@ def _iter_yaml_files(paths: list[Path]) -> list[Path]:
         elif path.suffix.lower() in {".yaml", ".yml"}:
             files.add(path)
     return sorted(files)
+
+
+def _path_lookup_candidates(path: Path) -> list[str]:
+    """Return stable path spellings for config-surface matching."""
+    candidates = [path.as_posix()]
+    if path.is_absolute():
+        try:
+            candidates.append(path.relative_to(Path.cwd()).as_posix())
+        except ValueError:
+            pass
+    candidates.append(path.name)
+    return list(dict.fromkeys(candidates))
+
+
+def _display_path(path: Path) -> str:
+    """Return the repository-relative path when available."""
+    try:
+        return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_promoted_surfaces(path: Path) -> dict[str, str]:
+    """Load benchmark-promoted config paths and their reasons."""
+    if not path.exists():
+        return {}
+    payload = _load_yaml(path)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected top-level mapping")
+    if payload.get("version") != 1:
+        raise ValueError(f"{path}: version must be 1")
+    entries = payload.get("promoted_configs")
+    if not isinstance(entries, list):
+        raise ValueError(f"{path}: promoted_configs must be a list")
+
+    surfaces: dict[str, str] = {}
+    for index, entry in enumerate(entries):
+        if isinstance(entry, str):
+            config_path = entry.strip()
+            reason = "Benchmark-promoted config surface."
+        elif isinstance(entry, dict):
+            config_path = str(entry.get("path") or "").strip()
+            reason = str(entry.get("reason") or "").strip()
+        else:
+            raise ValueError(f"{path}: promoted_configs[{index}] must be a mapping or string")
+        if not config_path or not reason:
+            raise ValueError(f"{path}: promoted_configs[{index}] requires path and reason")
+        surfaces[config_path] = reason
+    return surfaces
 
 
 def _find_local_references(
@@ -116,6 +168,7 @@ def check_local_model_artifacts(
     scan_paths: list[Path],
     *,
     blocklist_path: Path = DEFAULT_BLOCKLIST,
+    promoted_surfaces_path: Path = DEFAULT_PROMOTED_SURFACES,
 ) -> list[LocalModelReference]:
     """Inspect YAML configs and classify local model references.
 
@@ -124,13 +177,42 @@ def check_local_model_artifacts(
         preflight; ``status=blocked`` rows are intentionally explicit follow-up work.
     """
     blocklist = _load_blocklist(blocklist_path)
+    promoted_surfaces = _load_promoted_surfaces(promoted_surfaces_path)
+    expanded_scan_paths = list(scan_paths)
+    expanded_scan_paths.extend(Path(path) for path in promoted_surfaces)
     rows: list[LocalModelReference] = []
-    for yaml_path in _iter_yaml_files(scan_paths):
+    for yaml_path in _iter_yaml_files(expanded_scan_paths):
         if yaml_path == blocklist_path:
             continue
-        rel_path = yaml_path.as_posix()
+        rel_path = _display_path(yaml_path)
+        lookup_paths = _path_lookup_candidates(yaml_path)
+        promoted_reason = next(
+            (
+                promoted_surfaces[candidate]
+                for candidate in lookup_paths
+                if candidate in promoted_surfaces
+            ),
+            "",
+        )
         payload = _load_yaml(yaml_path)
         for field, value in _find_local_references(payload):
+            if promoted_reason:
+                rows.append(
+                    LocalModelReference(
+                        rel_path,
+                        field,
+                        value,
+                        PROMOTED_BLOCKED_STATUS,
+                        (
+                            f"{promoted_reason} Replace the local output/ reference with a "
+                            "durable model_id or artifact pointer before using it as a promoted "
+                            "benchmark config. Follow-up: "
+                            "https://github.com/ll7/robot_sf_ll7/issues/1764"
+                        ),
+                        "benchmark_promoted",
+                    )
+                )
+                continue
             reason = blocklist.get((rel_path, field, value))
             if reason:
                 rows.append(LocalModelReference(rel_path, field, value, "blocked", reason))
@@ -142,6 +224,7 @@ def check_local_model_artifacts(
                         value,
                         "unblocked",
                         "replace with model_id or add an explicit artifact-promotion blocker",
+                        "local_experimental",
                     )
                 )
     return rows
@@ -163,6 +246,12 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_BLOCKLIST,
         help="Explicit blocklist for known local-only artifact references.",
     )
+    parser.add_argument(
+        "--promoted-surfaces",
+        type=Path,
+        default=DEFAULT_PROMOTED_SURFACES,
+        help="YAML file listing benchmark-promoted config surfaces that must never use output/ model paths.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON rows.")
     parser.add_argument(
         "--fail-on-blocked",
@@ -175,7 +264,11 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     """Run the local model artifact preflight."""
     args = _parse_args()
-    rows = check_local_model_artifacts(args.paths, blocklist_path=args.blocklist)
+    rows = check_local_model_artifacts(
+        args.paths,
+        blocklist_path=args.blocklist,
+        promoted_surfaces_path=args.promoted_surfaces,
+    )
     if args.json:
         print(json.dumps([row.__dict__ for row in rows], indent=2, sort_keys=True))
     else:
@@ -185,7 +278,7 @@ def main() -> int:
             print(f"{row.status.upper()}: {row.path}:{row.field}: {row.value}")
             print(f"  reason: {row.reason}")
 
-    has_unblocked = any(row.status == "unblocked" for row in rows)
+    has_unblocked = any(row.status in {"unblocked", PROMOTED_BLOCKED_STATUS} for row in rows)
     has_blocked = any(row.status == "blocked" for row in rows)
     return 1 if has_unblocked or (args.fail_on_blocked and has_blocked) else 0
 

--- a/tests/validation/test_check_local_model_artifacts.py
+++ b/tests/validation/test_check_local_model_artifacts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from scripts.validation.check_local_model_artifacts import (
+    REPO_ROOT,
     check_local_model_artifacts,
     main,
 )
@@ -30,6 +31,58 @@ def test_checked_in_promoted_surfaces_have_no_local_output_model_paths() -> None
     rows = check_local_model_artifacts([])
 
     assert rows == []
+
+
+def test_default_cli_paths_are_stable_from_subdirectory(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default repo config surfaces should resolve even when invoked below the repo root."""
+    monkeypatch.chdir(REPO_ROOT / "scripts")
+    monkeypatch.setattr("sys.argv", ["check_local_model_artifacts.py"])
+
+    assert main() == 0
+    stdout = capsys.readouterr().out
+    assert "configs/baselines/" in stdout
+    assert "../configs" not in stdout
+
+
+def test_promoted_surface_paths_expand_from_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repo-relative promoted surfaces should not depend on the caller's current directory."""
+    config = tmp_path / "configs" / "promoted.yaml"
+    promoted_surfaces = tmp_path / "configs" / "promoted_config_surfaces.yaml"
+    caller_cwd = tmp_path / "scripts"
+    config.parent.mkdir()
+    caller_cwd.mkdir()
+    config.write_text("model_path: output/model_cache/demo/model.zip\n", encoding="utf-8")
+    promoted_surfaces.write_text(
+        """
+version: 1
+promoted_configs:
+  - path: configs/promoted.yaml
+    reason: Synthetic promoted config.
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(caller_cwd)
+    monkeypatch.setattr(
+        "scripts.validation.check_local_model_artifacts.REPO_ROOT",
+        tmp_path,
+    )
+
+    rows = check_local_model_artifacts(
+        [],
+        blocklist_path=tmp_path / "missing.yaml",
+        promoted_surfaces_path=promoted_surfaces,
+    )
+
+    assert len(rows) == 1
+    assert rows[0].path == "configs/promoted.yaml"
+    assert rows[0].status == "promoted_blocked"
 
 
 def test_unblocked_local_model_path_fails_preflight(tmp_path: Path) -> None:

--- a/tests/validation/test_check_local_model_artifacts.py
+++ b/tests/validation/test_check_local_model_artifacts.py
@@ -25,6 +25,13 @@ def test_checked_in_baseline_local_paths_are_explicitly_blocked() -> None:
     }.isdisjoint({row.path for row in rows})
 
 
+def test_checked_in_promoted_surfaces_have_no_local_output_model_paths() -> None:
+    """Promoted benchmark config surfaces should resolve through durable ids or pointers."""
+    rows = check_local_model_artifacts([])
+
+    assert rows == []
+
+
 def test_unblocked_local_model_path_fails_preflight(tmp_path: Path) -> None:
     """A new output model path should fail unless it is explicitly blocklisted."""
     config = tmp_path / "candidate.yaml"
@@ -35,6 +42,72 @@ def test_unblocked_local_model_path_fails_preflight(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0].status == "unblocked"
     assert rows[0].field == "model_path"
+
+
+def test_promoted_local_model_path_fails_even_when_blocklisted(tmp_path: Path) -> None:
+    """Promoted benchmark config surfaces cannot be softened by the local blocker list."""
+    config = tmp_path / "promoted.yaml"
+    blocklist = tmp_path / "blocklist.yaml"
+    promoted_surfaces = tmp_path / "promoted_surfaces.yaml"
+    config.write_text("model_path: output/model_cache/demo/model.zip\n", encoding="utf-8")
+    blocklist.write_text(
+        f"""
+version: 1
+blocked_references:
+  - path: {config.as_posix()}
+    field: model_path
+    value: output/model_cache/demo/model.zip
+    reason: known local-only blocker
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    promoted_surfaces.write_text(
+        f"""
+version: 1
+promoted_configs:
+  - path: {config.as_posix()}
+    reason: Synthetic promoted config.
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rows = check_local_model_artifacts(
+        [config],
+        blocklist_path=blocklist,
+        promoted_surfaces_path=promoted_surfaces,
+    )
+
+    assert len(rows) == 1
+    assert rows[0].status == "promoted_blocked"
+    assert rows[0].surface == "benchmark_promoted"
+    assert "durable model_id" in rows[0].reason
+
+
+def test_promoted_model_id_config_passes_preflight(tmp_path: Path) -> None:
+    """Promoted configs may use durable model ids instead of local output paths."""
+    config = tmp_path / "promoted.yaml"
+    promoted_surfaces = tmp_path / "promoted_surfaces.yaml"
+    config.write_text("model_id: durable_registry_id\n", encoding="utf-8")
+    promoted_surfaces.write_text(
+        f"""
+version: 1
+promoted_configs:
+  - path: {config.as_posix()}
+    reason: Synthetic promoted config.
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rows = check_local_model_artifacts(
+        [config],
+        blocklist_path=tmp_path / "missing.yaml",
+        promoted_surfaces_path=promoted_surfaces,
+    )
+
+    assert rows == []
 
 
 def test_blocklist_must_name_exact_field_and_value(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1775.

- add `configs/benchmarks/promoted_config_surfaces.yaml` as the explicit benchmark-promoted config surface list
- extend `scripts/validation/check_local_model_artifacts.py` so promoted surfaces fail hard on `model_path` / `resume_from` references into `output/`, even if the same reference is listed as a known local blocker
- keep non-promoted local-only configs visible through the existing blocklist and #1764 follow-up path
- document the promoted-surface rule from `model/registry.md` and the #1638 preflight note

## Validation

- `uv run ruff check scripts/validation/check_local_model_artifacts.py tests/validation/test_check_local_model_artifacts.py`
- `uv run pytest -q tests/validation/test_check_local_model_artifacts.py`
- `uv run pytest -q tests/benchmark/test_map_runner_utils.py::test_parse_algo_config_rejects_local_output_model_path tests/benchmark/test_map_runner_utils.py::test_parse_algo_config_reports_blocked_local_artifact_follow_up`
- `uv run python scripts/validation/check_local_model_artifacts.py`
- `rg -n "^\\s*(model_path|resume_from):\\s*.*output/" configs model scripts --glob '*.yaml' --glob '*.yml'`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`

The `rg` sweep found the seven existing non-promoted baseline blockers listed in `configs/baselines/local_model_artifact_blocklist.yaml`, plus three training-only PPO warm-start `resume_from` ablation configs under `configs/training/ppo/ablations/`. No promoted surface reported a local `output/` model dependency.

Full PR readiness was not run; this is a bounded validation-tooling/docs change with targeted pytest and the new preflight command. Ignored `output/coverage/` files were produced by pytest and intentionally left untracked.
