### PR TITLE
test: validate policy-search registry shape (#1772)

### DIFF
--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -116,6 +116,7 @@ Use it for three things only:
 ## Reproducible Entry Points
 
 - Candidate runner: `uv run python scripts/validation/run_policy_search_candidate.py`
+- Candidate registry validator: `uv run python scripts/validation/validate_policy_search_registry.py`
 - Candidate portfolio overview: `uv run python scripts/tools/summarize_policy_search_portfolio.py`
 - Candidate comparison: `uv run python scripts/tools/compare_policy_search_candidates.py`
 - Failure taxonomy: `uv run python scripts/tools/build_policy_search_failure_report.py`

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -1,5 +1,9 @@
 version: 1
 updated_at: 2026-05-20
+freshness:
+  policy: manual_registry_edit
+  max_age_days: 90
+  stale_action: update updated_at when candidate rows or routing contracts change
 funnel_config: configs/policy_search/funnel.yaml
 promotion_gates: configs/policy_search/promotion_gates.yaml
 
@@ -184,6 +188,8 @@ candidates:
     training_required: false
     promotion_gate: tier_b
     candidate_config_path: configs/policy_search/candidates/tentabot_value_scorer_v0.yaml
+    learned_policy_registry_id: tentabot_value_scorer_v0
+    adapter_contract: docs/context/policy_search/contracts/learned_local_policy_eligibility.md
     hypothesis: >
       A clean-room Tentabot-style primitive value scorer can reuse Robot SF's
       hybrid-rule candidate lattice and auditable route, clearance, pedestrian
@@ -559,6 +565,7 @@ candidates:
     training_required: true
     promotion_gate: tier_c
     candidate_config_path: configs/policy_search/candidates/orca_residual_guarded_ppo_v0.yaml
+    learned_policy_registry_id: orca_residual_guarded_ppo_v0
     hypothesis: >
       Unsafe PPO proposals can be reinterpreted as a bounded residual over the nominal ORCA command
       before falling through to the existing prior/fallback shield. This v0 entry wires the
@@ -575,6 +582,7 @@ candidates:
     training_required: false
     promotion_gate: tier_c
     candidate_config_path: configs/policy_search/candidates/ppo_issue791_best_v1.yaml
+    learned_policy_registry_id: ppo_issue791_best_v1
     hypothesis: >
       The repository's current best learned checkpoint from issue 791 should be the strongest
       feasible learning-only candidate: eval-aligned large-capacity PPO with predictive foresight,
@@ -619,6 +627,8 @@ candidates:
     promotion_gate: tier_b
     slurm_handoff: docs/context/policy_search/SLURM/001_learned_risk_model_v1.md
     launch_packet_config_path: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+    learned_policy_registry_id: learned_risk_model_v1
+    adapter_contract: docs/context/policy_search/contracts/learned_local_policy_eligibility.md
     hypothesis: >
       A lightweight learned risk estimator should improve candidate ranking only
       when attached to a hard safety guard.

--- a/scripts/validation/validate_policy_search_registry.py
+++ b/scripts/validation/validate_policy_search_registry.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Validate the policy-search candidate registry shape.
+
+The checker is intentionally metadata-only: it verifies that future agents can route
+candidate execution and evidence interpretation without running any candidate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_REGISTRY = Path("docs/context/policy_search/candidate_registry.yaml")
+IMPLEMENTED_STATUSES = {"implemented", "experimental_spike", "prototype"}
+SLURM_STATUSES = {"slurm_handoff_required"}
+LEARNED_FAMILIES = {
+    "learned_auxiliary_cost",
+    "learned_policy_network",
+    "learned_style_value_scorer",
+}
+
+
+@dataclass(frozen=True)
+class RegistryIssue:
+    """One policy-search registry validation issue."""
+
+    path: str
+    message: str
+
+
+def _load_yaml(path: Path) -> Any:
+    """Load a YAML file."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _is_missing(value: Any) -> bool:
+    """Return whether a value is absent for registry-contract purposes."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _repo_root_for(path: Path) -> Path:
+    """Return the nearest repository root, falling back to the registry directory."""
+    for parent in [path.resolve().parent, *path.resolve().parents]:
+        if (parent / ".git").exists():
+            return parent
+    return path.resolve().parent
+
+
+def _resolve_repo_path(repo_root: Path, raw_path: Any) -> Path | None:
+    """Resolve a repository-relative path value when it is a string."""
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    path = Path(raw_path.strip())
+    return path if path.is_absolute() else repo_root / path
+
+
+def _require_fields(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    fields: set[str],
+) -> None:
+    """Require non-empty fields in a registry row."""
+    for field in sorted(fields):
+        if _is_missing(row.get(field)):
+            issues.append(RegistryIssue(f"{prefix}.{field}", "is required"))
+
+
+def _validate_path_field(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    field: str,
+    repo_root: Path,
+) -> None:
+    """Validate that a path field points at an existing repository file."""
+    path = _resolve_repo_path(repo_root, row.get(field))
+    if path is None:
+        return
+    if not path.exists():
+        issues.append(RegistryIssue(f"{prefix}.{field}", f"path does not exist: {row[field]}"))
+
+
+def _parse_registry_date(value: Any) -> date | None:
+    """Parse a YAML date or ISO date string."""
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _validate_freshness(
+    payload: dict[str, Any],
+    *,
+    issues: list[RegistryIssue],
+    as_of: date,
+    default_max_age_days: int,
+) -> None:
+    """Validate the top-level registry freshness convention."""
+    updated_at = _parse_registry_date(payload.get("updated_at"))
+    if updated_at is None:
+        issues.append(RegistryIssue("updated_at", "must be an ISO date"))
+        return
+    if updated_at > as_of:
+        issues.append(RegistryIssue("updated_at", f"must not be in the future relative to {as_of}"))
+        return
+
+    freshness = payload.get("freshness")
+    freshness_note = ""
+    max_age_days = default_max_age_days
+    if isinstance(freshness, dict):
+        freshness_note = str(freshness.get("stale_reason") or "").strip()
+        raw_max_age = freshness.get("max_age_days")
+        if isinstance(raw_max_age, int) and raw_max_age > 0:
+            max_age_days = raw_max_age
+        elif raw_max_age is not None:
+            issues.append(RegistryIssue("freshness.max_age_days", "must be a positive integer"))
+    elif freshness is not None:
+        issues.append(RegistryIssue("freshness", "must be a mapping when present"))
+
+    age_days = (as_of - updated_at).days
+    if age_days > max_age_days and not freshness_note:
+        issues.append(
+            RegistryIssue(
+                "updated_at",
+                (
+                    f"is {age_days} days old; update it or record "
+                    "freshness.stale_reason for an intentionally stale registry"
+                ),
+            )
+        )
+
+
+def _current_utc_date() -> date:
+    """Return today's date in UTC for freshness checks."""
+    return datetime.now(UTC).date()
+
+
+def _load_known_names(
+    payload: dict[str, Any],
+    *,
+    repo_root: Path,
+) -> None:
+    """Load known promotion gates and stages into private payload keys."""
+    gates_path = _resolve_repo_path(repo_root, payload.get("promotion_gates"))
+    if gates_path is not None and gates_path.exists():
+        gates_payload = _load_yaml(gates_path)
+        gates = gates_payload.get("gates") if isinstance(gates_payload, dict) else None
+        if isinstance(gates, dict):
+            payload["_known_promotion_gates"] = set(gates)
+
+    funnel_path = _resolve_repo_path(repo_root, payload.get("funnel_config"))
+    if funnel_path is not None and funnel_path.exists():
+        funnel_payload = _load_yaml(funnel_path)
+        stages = funnel_payload.get("stages") if isinstance(funnel_payload, dict) else None
+        if isinstance(stages, dict):
+            payload["_known_stages"] = set(stages)
+
+
+def _validate_top_level(
+    payload: Any,
+    *,
+    issues: list[RegistryIssue],
+    registry_path: Path,
+    repo_root: Path,
+    as_of: date,
+    default_max_age_days: int,
+) -> dict[str, Any]:
+    """Validate top-level fields and return candidate mapping when present."""
+    if not isinstance(payload, dict):
+        issues.append(RegistryIssue("registry", "must be a mapping"))
+        return {}
+    if payload.get("version") != 1:
+        issues.append(RegistryIssue("version", "must be 1"))
+    _validate_freshness(
+        payload,
+        issues=issues,
+        as_of=as_of,
+        default_max_age_days=default_max_age_days,
+    )
+    for field in ("funnel_config", "promotion_gates"):
+        if _is_missing(payload.get(field)):
+            issues.append(RegistryIssue(field, "is required"))
+        else:
+            path = _resolve_repo_path(repo_root, payload[field])
+            if path is not None and not path.exists():
+                issues.append(RegistryIssue(field, f"path does not exist: {payload[field]}"))
+
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, dict) or not candidates:
+        issues.append(RegistryIssue("candidates", "must be a non-empty mapping"))
+        return {}
+
+    _load_known_names(payload, repo_root=repo_root)
+    del registry_path
+    return dict(candidates)
+
+
+def _validate_required_stages(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    known_stages: set[str],
+) -> None:
+    """Validate the required_stages list."""
+    stages = row.get("required_stages")
+    if not isinstance(stages, list) or not stages:
+        issues.append(RegistryIssue(f"{prefix}.required_stages", "must be a non-empty list"))
+        return
+    for index, stage in enumerate(stages):
+        if not isinstance(stage, str) or not stage.strip():
+            issues.append(RegistryIssue(f"{prefix}.required_stages[{index}]", "must be non-empty"))
+            continue
+        base_stage = stage.removesuffix("_if_promising")
+        if known_stages and stage not in known_stages and base_stage not in known_stages:
+            issues.append(
+                RegistryIssue(
+                    f"{prefix}.required_stages[{index}]",
+                    f"unknown stage: {stage}",
+                )
+            )
+
+
+def _validate_learned_link(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    repo_root: Path,
+) -> None:
+    """Validate learned-candidate registry or adapter-contract linkage."""
+    family = str(row.get("family") or "")
+    if family not in LEARNED_FAMILIES:
+        return
+    registry_id = row.get("learned_policy_registry_id")
+    adapter_contract = row.get("adapter_contract")
+    if _is_missing(registry_id) and _is_missing(adapter_contract):
+        issues.append(
+            RegistryIssue(
+                prefix,
+                "learned candidates require learned_policy_registry_id or adapter_contract",
+            )
+        )
+        return
+    if not _is_missing(adapter_contract):
+        _validate_path_field(
+            issues,
+            row,
+            prefix=prefix,
+            field="adapter_contract",
+            repo_root=repo_root,
+        )
+
+
+def _validate_slurm_row(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    repo_root: Path,
+) -> None:
+    """Validate a deferred SLURM handoff row."""
+    _require_fields(
+        issues,
+        row,
+        prefix=prefix,
+        fields={"slurm_handoff", "launch_packet_config_path", "promotion_gate"},
+    )
+    _validate_path_field(issues, row, prefix=prefix, field="slurm_handoff", repo_root=repo_root)
+    _validate_path_field(
+        issues,
+        row,
+        prefix=prefix,
+        field="launch_packet_config_path",
+        repo_root=repo_root,
+    )
+    if row.get("training_required") is not True:
+        issues.append(RegistryIssue(f"{prefix}.training_required", "must be true for SLURM handoff"))
+
+    packet_path = _resolve_repo_path(repo_root, row.get("launch_packet_config_path"))
+    if packet_path is not None and packet_path.exists():
+        packet = _load_yaml(packet_path)
+        if not isinstance(packet, dict):
+            issues.append(RegistryIssue(f"{prefix}.launch_packet_config_path", "must load mapping"))
+            return
+        for field in ("artifact_policy", "execution_boundary"):
+            if not isinstance(packet.get(field), dict):
+                issues.append(
+                    RegistryIssue(
+                        f"{prefix}.launch_packet_config_path.{field}",
+                        "is required in launch packet",
+                    )
+                )
+
+
+def _validate_candidate(
+    issues: list[RegistryIssue],
+    candidate_id: str,
+    row: Any,
+    *,
+    repo_root: Path,
+    known_gates: set[str],
+    known_stages: set[str],
+) -> None:
+    """Validate one candidate row."""
+    prefix = f"candidates.{candidate_id}"
+    if not isinstance(row, dict):
+        issues.append(RegistryIssue(prefix, "must be a mapping"))
+        return
+
+    _require_fields(
+        issues,
+        row,
+        prefix=prefix,
+        fields={"status", "family", "training_required", "hypothesis"},
+    )
+    status = str(row.get("status") or "")
+    if status in IMPLEMENTED_STATUSES:
+        _require_fields(
+            issues,
+            row,
+            prefix=prefix,
+            fields={"candidate_config_path", "promotion_gate"},
+        )
+        _validate_path_field(
+            issues,
+            row,
+            prefix=prefix,
+            field="candidate_config_path",
+            repo_root=repo_root,
+        )
+        _validate_required_stages(issues, row, prefix=prefix, known_stages=known_stages)
+    elif status in SLURM_STATUSES:
+        _validate_slurm_row(issues, row, prefix=prefix, repo_root=repo_root)
+    else:
+        issues.append(RegistryIssue(f"{prefix}.status", f"unknown status: {status}"))
+
+    gate = row.get("promotion_gate")
+    if isinstance(gate, str) and known_gates and gate not in known_gates:
+        issues.append(RegistryIssue(f"{prefix}.promotion_gate", f"unknown gate: {gate}"))
+
+    family = str(row.get("family") or "")
+    if "diagnostic" in family and row.get("claim_scope") not in {None, "diagnostic_only"}:
+        issues.append(
+            RegistryIssue(
+                f"{prefix}.claim_scope",
+                "diagnostic families may only use claim_scope: diagnostic_only",
+            )
+        )
+    _validate_learned_link(issues, row, prefix=prefix, repo_root=repo_root)
+
+
+def validate_registry(
+    registry_path: Path = DEFAULT_REGISTRY,
+    *,
+    as_of: date | None = None,
+    max_age_days: int = 90,
+) -> list[RegistryIssue]:
+    """Validate a policy-search candidate registry."""
+    registry_path = Path(registry_path)
+    repo_root = _repo_root_for(registry_path)
+    issues: list[RegistryIssue] = []
+    payload = _load_yaml(registry_path)
+    payload_mapping = payload if isinstance(payload, dict) else {}
+    candidates = _validate_top_level(
+        payload,
+        issues=issues,
+        registry_path=registry_path,
+        repo_root=repo_root,
+        as_of=as_of or _current_utc_date(),
+        default_max_age_days=max_age_days,
+    )
+    known_gates = payload_mapping.get("_known_promotion_gates", set())
+    known_stages = payload_mapping.get("_known_stages", set())
+    for candidate_id, row in candidates.items():
+        _validate_candidate(
+            issues,
+            str(candidate_id),
+            row,
+            repo_root=repo_root,
+            known_gates=known_gates,
+            known_stages=known_stages,
+        )
+    return issues
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "registry",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_REGISTRY,
+        help="Policy-search candidate registry YAML.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON issues.")
+    parser.add_argument(
+        "--as-of",
+        type=date.fromisoformat,
+        default=_current_utc_date(),
+        help="Freshness reference date in YYYY-MM-DD form.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=90,
+        help="Default freshness window when registry freshness.max_age_days is absent.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the registry validator."""
+    args = _parse_args()
+    issues = validate_registry(
+        args.registry,
+        as_of=args.as_of,
+        max_age_days=args.max_age_days,
+    )
+    if args.json:
+        print(json.dumps([issue.__dict__ for issue in issues], indent=2, sort_keys=True))
+    else:
+        if not issues:
+            print(f"OK: {args.registry} satisfies the policy-search registry contract.")
+        for issue in issues:
+            print(f"ERROR: {issue.path}: {issue.message}")
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/validate_policy_search_registry.py
+++ b/scripts/validation/validate_policy_search_registry.py
@@ -52,10 +52,11 @@ def _is_missing(value: Any) -> bool:
 
 def _repo_root_for(path: Path) -> Path:
     """Return the nearest repository root, falling back to the registry directory."""
-    for parent in [path.resolve().parent, *path.resolve().parents]:
+    registry_dir = path.resolve().parent
+    for parent in (registry_dir, *registry_dir.parents):
         if (parent / ".git").exists():
             return parent
-    return path.resolve().parent
+    return registry_dir
 
 
 def _resolve_repo_path(repo_root: Path, raw_path: Any) -> Path | None:
@@ -158,28 +159,32 @@ def _load_known_names(
     payload: dict[str, Any],
     *,
     repo_root: Path,
-) -> None:
-    """Load known promotion gates and stages into private payload keys."""
+) -> tuple[set[str], set[str]]:
+    """Load known promotion gates and stages from registry support files."""
+    known_gates: set[str] = set()
+    known_stages: set[str] = set()
+
     gates_path = _resolve_repo_path(repo_root, payload.get("promotion_gates"))
     if gates_path is not None and gates_path.exists():
         gates_payload = _load_yaml(gates_path)
         gates = gates_payload.get("gates") if isinstance(gates_payload, dict) else None
         if isinstance(gates, dict):
-            payload["_known_promotion_gates"] = set(gates)
+            known_gates = set(gates)
 
     funnel_path = _resolve_repo_path(repo_root, payload.get("funnel_config"))
     if funnel_path is not None and funnel_path.exists():
         funnel_payload = _load_yaml(funnel_path)
         stages = funnel_payload.get("stages") if isinstance(funnel_payload, dict) else None
         if isinstance(stages, dict):
-            payload["_known_stages"] = set(stages)
+            known_stages = set(stages)
+
+    return known_gates, known_stages
 
 
 def _validate_top_level(
     payload: Any,
     *,
     issues: list[RegistryIssue],
-    registry_path: Path,
     repo_root: Path,
     as_of: date,
     default_max_age_days: int,
@@ -209,8 +214,6 @@ def _validate_top_level(
         issues.append(RegistryIssue("candidates", "must be a non-empty mapping"))
         return {}
 
-    _load_known_names(payload, repo_root=repo_root)
-    del registry_path
     return dict(candidates)
 
 
@@ -294,7 +297,9 @@ def _validate_slurm_row(
         repo_root=repo_root,
     )
     if row.get("training_required") is not True:
-        issues.append(RegistryIssue(f"{prefix}.training_required", "must be true for SLURM handoff"))
+        issues.append(
+            RegistryIssue(f"{prefix}.training_required", "must be true for SLURM handoff")
+        )
 
     packet_path = _resolve_repo_path(repo_root, row.get("launch_packet_config_path"))
     if packet_path is not None and packet_path.exists():
@@ -384,13 +389,11 @@ def validate_registry(
     candidates = _validate_top_level(
         payload,
         issues=issues,
-        registry_path=registry_path,
         repo_root=repo_root,
         as_of=as_of or _current_utc_date(),
         default_max_age_days=max_age_days,
     )
-    known_gates = payload_mapping.get("_known_promotion_gates", set())
-    known_stages = payload_mapping.get("_known_stages", set())
+    known_gates, known_stages = _load_known_names(payload_mapping, repo_root=repo_root)
     for candidate_id, row in candidates.items():
         _validate_candidate(
             issues,

--- a/tests/validation/test_validate_policy_search_registry.py
+++ b/tests/validation/test_validate_policy_search_registry.py
@@ -1,0 +1,167 @@
+"""Tests for the policy-search candidate registry validator."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from textwrap import dedent
+
+from scripts.validation.validate_policy_search_registry import validate_registry
+
+
+def _write(path: Path, text: str) -> None:
+    """Write a dedented YAML fixture."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(text).strip() + "\n", encoding="utf-8")
+
+
+def _write_support_files(root: Path) -> None:
+    """Write common registry support files."""
+    _write(
+        root / "configs/policy_search/funnel.yaml",
+        """
+        stages:
+          smoke: {}
+          nominal_sanity: {}
+        """,
+    )
+    _write(
+        root / "configs/policy_search/promotion_gates.yaml",
+        """
+        gates:
+          tier_b: {}
+        """,
+    )
+    _write(root / "configs/policy_search/candidates/demo.yaml", "name: demo\n")
+    _write(root / "docs/context/policy_search/SLURM/demo.md", "# Handoff\n")
+    _write(
+        root / "configs/training/demo_launch.yaml",
+        """
+        artifact_policy:
+          checkpoints_in_git: false
+        execution_boundary:
+          full_training_in_this_issue: false
+        """,
+    )
+
+
+def _valid_registry_text() -> str:
+    """Return a minimal valid registry fixture."""
+    return """
+    version: 1
+    updated_at: 2026-05-20
+    freshness:
+      max_age_days: 90
+    funnel_config: configs/policy_search/funnel.yaml
+    promotion_gates: configs/policy_search/promotion_gates.yaml
+    candidates:
+      demo_candidate:
+        status: implemented
+        family: hybrid_rule_based
+        training_required: false
+        promotion_gate: tier_b
+        candidate_config_path: configs/policy_search/candidates/demo.yaml
+        hypothesis: Demo candidate.
+        required_stages: [smoke]
+      learned_candidate:
+        status: implemented
+        family: learned_policy_network
+        training_required: false
+        promotion_gate: tier_b
+        candidate_config_path: configs/policy_search/candidates/demo.yaml
+        learned_policy_registry_id: learned_candidate
+        hypothesis: Demo learned candidate.
+        required_stages: [smoke]
+      deferred_candidate:
+        status: slurm_handoff_required
+        family: learned_auxiliary_cost
+        training_required: true
+        promotion_gate: tier_b
+        slurm_handoff: docs/context/policy_search/SLURM/demo.md
+        launch_packet_config_path: configs/training/demo_launch.yaml
+        learned_policy_registry_id: deferred_candidate
+        hypothesis: Demo deferred candidate.
+    """
+
+
+def test_checked_in_policy_search_registry_validates() -> None:
+    """The tracked policy-search registry should satisfy the metadata contract."""
+    repo_root = Path(__file__).parents[2]
+
+    issues = validate_registry(
+        repo_root / "docs/context/policy_search/candidate_registry.yaml",
+        as_of=date(2026, 5, 31),
+    )
+
+    assert issues == []
+
+
+def test_valid_registry_fixture_passes(tmp_path: Path) -> None:
+    """A representative implemented, learned, and SLURM registry can pass."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(registry, _valid_registry_text())
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31))
+
+    assert issues == []
+
+
+def test_missing_implemented_fields_are_reported(tmp_path: Path) -> None:
+    """Implemented candidates need config, gate, and stage routing fields."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(
+        registry,
+        """
+        version: 1
+        updated_at: 2026-05-20
+        funnel_config: configs/policy_search/funnel.yaml
+        promotion_gates: configs/policy_search/promotion_gates.yaml
+        candidates:
+          bad_candidate:
+            status: implemented
+            family: hybrid_rule_based
+            training_required: false
+            hypothesis: Missing routing fields.
+        """,
+    )
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31))
+    paths = {issue.path for issue in issues}
+
+    assert "candidates.bad_candidate.candidate_config_path" in paths
+    assert "candidates.bad_candidate.promotion_gate" in paths
+    assert "candidates.bad_candidate.required_stages" in paths
+
+
+def test_stale_updated_at_requires_explanation(tmp_path: Path) -> None:
+    """Stale registries should be updated or explicitly explained."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(registry, _valid_registry_text().replace("2026-05-20", "2026-01-01"))
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31), max_age_days=30)
+
+    assert any(issue.path == "updated_at" and "days old" in issue.message for issue in issues)
+
+
+def test_learned_candidate_requires_registry_or_adapter_link(tmp_path: Path) -> None:
+    """Learned candidates need a registry id or adapter-contract link."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(
+        registry,
+        _valid_registry_text().replace(
+            "        learned_policy_registry_id: learned_candidate\n",
+            "",
+        ),
+    )
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31))
+
+    assert any(
+        issue.path == "candidates.learned_candidate"
+        and "learned_policy_registry_id" in issue.message
+        for issue in issues
+    )

--- a/tests/validation/test_validate_policy_search_registry.py
+++ b/tests/validation/test_validate_policy_search_registry.py
@@ -6,7 +6,7 @@ from datetime import date
 from pathlib import Path
 from textwrap import dedent
 
-from scripts.validation.validate_policy_search_registry import validate_registry
+from scripts.validation.validate_policy_search_registry import _load_known_names, validate_registry
 
 
 def _write(path: Path, text: str) -> None:
@@ -105,6 +105,24 @@ def test_valid_registry_fixture_passes(tmp_path: Path) -> None:
     issues = validate_registry(registry, as_of=date(2026, 5, 31))
 
     assert issues == []
+
+
+def test_known_names_loader_returns_sets_without_mutating_payload(tmp_path: Path) -> None:
+    """Known stage and gate loading should not add private keys to the registry payload."""
+    _write_support_files(tmp_path)
+    payload = {
+        "funnel_config": "configs/policy_search/funnel.yaml",
+        "promotion_gates": "configs/policy_search/promotion_gates.yaml",
+    }
+
+    known_gates, known_stages = _load_known_names(payload, repo_root=tmp_path)
+
+    assert known_gates == {"tier_b"}
+    assert known_stages == {"smoke", "nominal_sanity"}
+    assert payload == {
+        "funnel_config": "configs/policy_search/funnel.yaml",
+        "promotion_gates": "configs/policy_search/promotion_gates.yaml",
+    }
 
 
 def test_missing_implemented_fields_are_reported(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1772.

- add `scripts/validation/validate_policy_search_registry.py` as a metadata-only checker for `docs/context/policy_search/candidate_registry.yaml`
- validate top-level freshness, config pointers, promotion gates, candidate config paths, required stages, SLURM launch-packet execution/artifact blocks, and learned-policy registry or adapter-contract links
- add focused tests for the checked-in registry, missing implemented routing fields, stale freshness, and learned-link gaps
- document the command in `docs/context/policy_search/README.md`

## Validation

- `uv run ruff check scripts/validation/validate_policy_search_registry.py tests/validation/test_validate_policy_search_registry.py`
- `uv run pytest -q tests/validation/test_validate_policy_search_registry.py`
- `uv run python scripts/validation/validate_policy_search_registry.py --as-of 2026-05-31`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

Full PR readiness was not run; this is a bounded validation-tooling/docs change. Ignored `output/coverage/` files were produced by pytest and intentionally left untracked.
