### PR TITLE
docs: add downstream propagation checklist (#1782)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -36,6 +36,17 @@ What changed, in one or two sentences.
 - Relevant design or provenance notes:
 - Any assumptions that need to be preserved:
 
+## Downstream Propagation
+- Parent issue updated or not applicable:
+- Claim map / benchmark report updated or not applicable:
+- Registry or config index updated or not applicable:
+- Context index / memory note updated or not applicable:
+- Follow-up issue opened for deferred propagation or not applicable:
+- Not-applicable rationale:
+
+For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
+propagation is deferred and name the issue or note that will carry it.
+
 ## Follow-Up Issues
 - Deferred work:
 - Issues opened for follow-up:

--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -37,11 +37,11 @@ What changed, in one or two sentences.
 - Any assumptions that need to be preserved:
 
 ## Downstream Propagation
-- Parent issue updated or not applicable:
-- Claim map / benchmark report updated or not applicable:
-- Registry or config index updated or not applicable:
-- Context index / memory note updated or not applicable:
-- Follow-up issue opened for deferred propagation or not applicable:
+- Parent issue updated (yes/no/NA):
+- Claim map / benchmark report updated (yes/no/NA):
+- Registry or config index updated (yes/no/NA):
+- Context index / memory note updated (yes/no/NA):
+- Follow-up issue opened for deferred propagation (yes/no/NA):
 - Not-applicable rationale:
 
 For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream


### PR DESCRIPTION
## Summary

Closes #1782.

- add a lightweight `Downstream Propagation` block to the default PR template
- keep the existing stack/dependency block intact
- make benchmark, registry, claim-map, and paper-facing deferrals explicit without requiring every PR to touch every surface

## Validation

- Manually inspected `.github/PULL_REQUEST_TEMPLATE/pr_default.md` for Markdown readability
- `git diff --check`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`

Full PR readiness was not run; this is a low-risk PR-template text change. The docs consistency wrapper bootstrapped an ignored `.venv/` in the worktree, which is intentionally not committed.
