### PR TITLE
docs: add agent workflow summary schemas

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -169,7 +169,8 @@ credential, or execution environment is actually available.
 If the final audit leaves only parent, epic, decision, or research issues that are not directly
 implementable, hand exactly one parent to `issue-splitter` instead of stopping with a prose-only
 report. The splitter should produce or create one `Next Implementable Child` only after duplicate
-checks show that no equivalent child already exists.
+checks show that no equivalent child already exists. Include the companion
+`issue_split_summary.v1` shape when issue splitting determines the next route.
 
 Example compact exhausted-queue audit:
 
@@ -336,6 +337,11 @@ When the queue exhausts, also report the final implementability audit result: re
 issues, remaining open issues missing `state:*`, any labels/body updates applied after review, and
 the command or query used to confirm the queue state. Include `queue_audit.v1` rows for exhausted
 or nearly exhausted queues so future agents can compare classifications across runs.
+
+When delegated agent or worker behavior produced a reusable workflow lesson, include an
+`agent_run_self_review.v1` companion summary or link the inbox note that follows that shape. Do not
+promote a lesson into durable skill text unless the evidence is repeated, high-confidence, or
+directly explains a costly failure.
 
 ## When to use
 

--- a/.agents/skills/issue-splitter/SKILL.md
+++ b/.agents/skills/issue-splitter/SKILL.md
@@ -10,7 +10,7 @@ requires_slurm: false
 requires_benchmark_artifacts: false
 delegates_to:
 - gh-issue-creator
-output_schema: skill_run_summary.v1
+output_schema: issue_split_summary.v1
 aliases:
 - parent-to-child-issue
 ---
@@ -79,26 +79,36 @@ When the child is created, add a concise parent comment or body note:
 
 ## Output
 
+Use `.agents/skills/schemas/issue_split_summary.v1.yaml` as the compact machine-readable
+companion to the prose handoff. Keep the prose summary for readability, but include the schema
+shape when the caller needs repeatable comparison across runs.
+
 ```yaml
-parent_issue: "#..."
-mode: draft-only | created
-duplicate_check:
-  queries:
-    - "..."
-  matches:
-    - "#..."
-child_issue:
-  title: "..."
-  url: "..."
-  body_fields:
-    parent_issue: "..."
-    scope: "..."
-    non_goals: "..."
-    validation_testing: "..."
-    blocked_by: "none | ..."
-parent_update:
-  next_implementable_child: "added | skipped"
-blockers:
-  - "..."
-next_skill: gh-issue-creator | goal-issue-implementation | none
+issue_split_summary:
+  schema: issue_split_summary.v1
+  parent_issue: "#..."
+  mode: draft-only | created | duplicate-found | blocked
+  duplicate_check:
+    queries:
+      - "..."
+    matches:
+      - issue: "#..."
+        reason: "..."
+  proposed_children:
+    - title: "..."
+      issue: "#optional"
+      url: "optional"
+      readiness: ready_local | blocked_external | blocked_slurm | decision_required | duplicate | too_broad
+      blocker: none | "..."
+      scope: "..."
+      non_goals:
+        - "..."
+      validation:
+        - "..."
+  recommendation:
+    action: create_child | use_existing_child | clarify_parent | stop_blocked
+    rationale: "..."
+  parent_update:
+    next_implementable_child: added | skipped
+    note: "..."
 ```

--- a/.agents/skills/schemas/agent_run_self_review.v1.yaml
+++ b/.agents/skills/schemas/agent_run_self_review.v1.yaml
@@ -1,0 +1,27 @@
+agent_run_self_review:
+  schema: agent_run_self_review.v1
+  objective: string
+  run_scope:
+    issues:
+    - '#1234'
+    files:
+    - path
+    agents:
+    - name-or-id
+  outcome: useful | mixed | failed | incomplete
+  validation:
+  - command: string
+    result: pass | fail | skipped
+    note: string
+  blockers:
+  - string
+  reusable_lessons:
+  - class: routing | prompt-contract | skill-overhead | validation | file-scope | tooling
+    confidence: low | medium | high
+    lesson: string
+    promotion: inbox-only | promote-to-skill | promote-to-doc | no-action
+  artifact_review:
+    compact_artifacts_checked: true | false
+    local_validation_overrode_agent_summary: true | false
+    note_path: optional
+  next_action: string

--- a/.agents/skills/schemas/issue_split_summary.v1.yaml
+++ b/.agents/skills/schemas/issue_split_summary.v1.yaml
@@ -1,0 +1,27 @@
+issue_split_summary:
+  schema: issue_split_summary.v1
+  parent_issue: '#1234'
+  mode: draft-only | created | duplicate-found | blocked
+  duplicate_check:
+    queries:
+    - gh issue list ...
+    matches:
+    - issue: '#1235'
+      reason: equivalent child scope already exists
+  proposed_children:
+  - title: string
+    issue: '#optional'
+    url: optional
+    readiness: ready_local | blocked_external | blocked_slurm | decision_required | duplicate | too_broad
+    blocker: none | string
+    scope: string
+    non_goals:
+    - string
+    validation:
+    - command-or-evidence-path
+  recommendation:
+    action: create_child | use_existing_child | clarify_parent | stop_blocked
+    rationale: string
+  parent_update:
+    next_implementable_child: added | skipped
+    note: string

--- a/.agents/skills/skills.yaml
+++ b/.agents/skills/skills.yaml
@@ -775,7 +775,7 @@ skills:
     - git
     delegates_to:
     - gh-issue-creator
-    output_schema: skill_run_summary.v1
+    output_schema: issue_split_summary.v1
     aliases:
     - parent-to-child-issue
   oracle-imitation-campaign:

--- a/docs/context/open_issue_execution_improvement_plan_2026-05-30.md
+++ b/docs/context/open_issue_execution_improvement_plan_2026-05-30.md
@@ -140,6 +140,10 @@ Use the schema to:
 - preserve the best issue-splitting candidate without classifying parent, epic, blocked, or
   analysis-only issues as ready implementation work.
 
+Issue splitting now has the narrower `issue_split_summary.v1` companion shape. Use it only for
+parent-to-child decomposition outputs: parent issue, duplicate-check queries, proposed child
+readiness, blockers, validation paths, and the recommended follow-up action.
+
 ### Do Not Duplicate Agent-Run Self-Review Workflow
 
 Agent workflow self-review already exists as a reusable skill and `docs/context/` is the durable
@@ -149,6 +153,11 @@ Better follow-up:
 
 - document when a self-review note is required after delegated runs;
 - keep compact lessons in existing context notes or workflow-improvement inboxes.
+
+Issue #1783 adds `agent_run_self_review.v1` for compact self-review handoffs. Use it as a
+comparison-friendly summary for objective, issue/file scope, validation, blockers, reusable lessons,
+and whether local validation overrode sparse agent output; it does not replace the existing inbox
+or context-note surfaces.
 
 ### Treat Research Priority As Maintainer Decision, Not Workflow Fact
 


### PR DESCRIPTION
## Summary
- Closes #1783.
- Adds compact `issue_split_summary.v1` and `agent_run_self_review.v1` schema examples under `.agents/skills/schemas/`.
- Wires `issue-splitter` to the dedicated issue-split schema and updates `goal-issue-implementation` to reference both companion outputs where they apply.
- Updates the open-issue execution improvement note so `queue_audit.v1`, issue splitting, and self-review summaries have separate, non-overlapping roles.

## Validation
- `uv run python scripts/dev/check_skills.py`
- `uv run python scripts/dev/generate_skills_readme.py --check`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY` for both new schema files
- `git diff --check origin/main...HEAD`

Full `scripts/dev/pr_ready_check.sh` was not run; this is a scoped workflow/schema documentation change. The only generated local artifact is the ignored worktree `.venv` bootstrap.
