### PR TITLE
feat: summarize CI driver phase logs

### DIFF
--- a/docs/context/issue_1653_ci_runtime_slice.md
+++ b/docs/context/issue_1653_ci_runtime_slice.md
@@ -57,6 +57,20 @@ make missing step timestamps explicit in Markdown output. The post-trim sample s
 step-level durations, so PR #1700 added explicit phase timing emitted by
 `scripts/dev/ci_driver.sh` instead of relying on GitHub's step payload.
 
+The timing helper can now read saved job logs that contain those phase lines:
+
+```bash
+uv run python scripts/dev/ci_timing_summary.py \
+  --run-id <github-actions-run-id> \
+  --log output/ci_logs/fast-feedback.log \
+  --log output/ci_logs/smoke-artifacts.log \
+  --top 10
+```
+
+This keeps the measurement-first #1653 workflow additive: the command ranks repository-owned
+`ci_driver phase_end` durations without changing CI job structure, test selection, or required
+checks.
+
 `fast-feedback` and `smoke-artifacts` both repeat checkout, uv setup, Python setup, system package
 installation, dependency sync, and artifact migration. Because GitHub did not expose step durations
 for the sampled runs, the current evidence cannot yet quantify repeated setup or artifact-generation

--- a/scripts/dev/ci_timing_summary.py
+++ b/scripts/dev/ci_timing_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -192,9 +193,13 @@ def _escape_md_table_cell(value: str) -> str:
 def _parse_phase_end_fields(raw_fields: str) -> dict[str, str]:
     """Parse shell-style key=value fields emitted by ci_driver phase_end logs."""
     parsed: dict[str, str] = {}
-    for token in raw_fields.split():
+    try:
+        tokens = shlex.split(raw_fields, comments=False, posix=True)
+    except ValueError:
+        return parsed
+    for token in tokens:
         key, separator, value = token.partition("=")
-        if not separator:
+        if not separator or not key:
             continue
         parsed[key] = value
     return parsed
@@ -229,6 +234,8 @@ def _load_phase_timings_from_logs(paths: list[Path]) -> list[PhaseTiming]:
     """Load repository phase timings from saved CI log files."""
     timings: list[PhaseTiming] = []
     for path in paths:
+        if not path.is_file():
+            raise SystemExit(f"Log file not found: {path}")
         timings.extend(
             parse_phase_timings(
                 path.read_text(encoding="utf-8"),

--- a/scripts/dev/ci_timing_summary.py
+++ b/scripts/dev/ci_timing_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 _GH_RUN_FIELDS = "databaseId,displayTitle,headBranch,status,conclusion,createdAt,updatedAt,jobs"
+_CI_PHASE_END_RE = re.compile(r"\bci_driver phase_end (?P<fields>.+)$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +37,17 @@ class JobTiming:
 
 
 @dataclass(frozen=True, slots=True)
+class PhaseTiming:
+    """Duration for one repository-owned CI driver phase."""
+
+    name: str
+    duration_seconds: float
+    status: int
+    completed_at: str
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
 class RunTimingSummary:
     """Compact timing summary for one GitHub Actions workflow run."""
 
@@ -45,6 +58,7 @@ class RunTimingSummary:
     total_seconds: float
     slowest_jobs: list[JobTiming]
     slowest_steps: list[StepTiming]
+    slowest_phases: list[PhaseTiming]
 
     def to_json(self) -> str:
         """Serialize the summary as deterministic JSON."""
@@ -104,7 +118,12 @@ def _completed_job_timings(payload: dict[str, Any]) -> list[JobTiming]:
     return timings
 
 
-def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary:
+def summarize_run(
+    payload: dict[str, Any],
+    *,
+    top: int = 10,
+    phase_timings: list[PhaseTiming] | None = None,
+) -> RunTimingSummary:
     """Summarize queue, job, total, slowest-job, and slowest-step durations."""
     jobs = _iter_dicts(payload.get("jobs"))
     created = _parse_timestamp(payload.get("createdAt"))
@@ -136,6 +155,10 @@ def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary
         _completed_job_timings(payload),
         key=lambda job: (-job.duration_seconds, job.name),
     )[:top]
+    slowest_phases = sorted(
+        phase_timings or [],
+        key=lambda phase: (-phase.duration_seconds, phase.name, phase.source),
+    )[:top]
 
     return RunTimingSummary(
         run_id=int(payload.get("databaseId") or 0),
@@ -145,6 +168,7 @@ def summarize_run(payload: dict[str, Any], *, top: int = 10) -> RunTimingSummary
         total_seconds=total_seconds,
         slowest_jobs=slowest_jobs,
         slowest_steps=slowest_steps,
+        slowest_phases=slowest_phases,
     )
 
 
@@ -165,6 +189,55 @@ def _escape_md_table_cell(value: str) -> str:
     return value.replace("|", r"\|")
 
 
+def _parse_phase_end_fields(raw_fields: str) -> dict[str, str]:
+    """Parse shell-style key=value fields emitted by ci_driver phase_end logs."""
+    parsed: dict[str, str] = {}
+    for token in raw_fields.split():
+        key, separator, value = token.partition("=")
+        if not separator:
+            continue
+        parsed[key] = value
+    return parsed
+
+
+def parse_phase_timings(text: str, *, source: str = "log") -> list[PhaseTiming]:
+    """Extract repository phase timings from ci_driver log text."""
+    timings: list[PhaseTiming] = []
+    for line in text.splitlines():
+        match = _CI_PHASE_END_RE.search(line)
+        if match is None:
+            continue
+        fields = _parse_phase_end_fields(match.group("fields"))
+        try:
+            duration = float(fields["duration_seconds"])
+            status = int(fields.get("status", "0"))
+        except (KeyError, ValueError):
+            continue
+        timings.append(
+            PhaseTiming(
+                name=fields.get("phase", ""),
+                duration_seconds=duration,
+                status=status,
+                completed_at=fields.get("completed_at", ""),
+                source=source,
+            )
+        )
+    return timings
+
+
+def _load_phase_timings_from_logs(paths: list[Path]) -> list[PhaseTiming]:
+    """Load repository phase timings from saved CI log files."""
+    timings: list[PhaseTiming] = []
+    for path in paths:
+        timings.extend(
+            parse_phase_timings(
+                path.read_text(encoding="utf-8"),
+                source=path.as_posix(),
+            )
+        )
+    return timings
+
+
 def format_markdown(summary: RunTimingSummary) -> str:
     """Format a timing summary as Markdown for issues and PR comments."""
     lines = [
@@ -178,10 +251,32 @@ def format_markdown(summary: RunTimingSummary) -> str:
         f"| job | {_format_seconds(summary.job_seconds)} |",
         f"| total | {_format_seconds(summary.total_seconds)} |",
         "",
-        "## Slowest jobs",
-        "| job | duration | started | completed |",
-        "| --- | --- | --- | --- |",
     ]
+    if summary.slowest_phases:
+        lines.extend(
+            [
+                "## Slowest repository phases",
+                "| phase | duration | status | completed | source |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for phase in summary.slowest_phases:
+            lines.append(
+                "| "
+                f"{_escape_md_table_cell(phase.name)} | "
+                f"{_format_seconds(phase.duration_seconds)} | "
+                f"{phase.status} | {phase.completed_at} | "
+                f"{_escape_md_table_cell(phase.source)} |",
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Slowest jobs",
+            "| job | duration | started | completed |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
     for job in summary.slowest_jobs:
         lines.append(
             "| "
@@ -222,9 +317,16 @@ def _load_payload_from_gh(run_id: str) -> dict[str, Any]:
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     """Parse command-line arguments for the timing summary tool."""
     parser = argparse.ArgumentParser(description="Summarize GitHub Actions CI timing.")
-    source = parser.add_mutually_exclusive_group(required=True)
+    source = parser.add_mutually_exclusive_group()
     source.add_argument("--run-id", help="GitHub Actions run id to fetch through gh.")
     source.add_argument("--run-json", type=Path, help="Saved gh run view JSON payload.")
+    parser.add_argument(
+        "--log",
+        action="append",
+        default=[],
+        type=Path,
+        help="Saved CI job log containing ci_driver phase_end lines. May be repeated.",
+    )
     parser.add_argument("--top", type=int, default=10, help="Number of slowest steps to report.")
     parser.add_argument("--json", action="store_true", help="Print deterministic JSON.")
     return parser.parse_args(argv)
@@ -235,12 +337,20 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.top <= 0:
         raise SystemExit("--top must be a positive integer")
-    payload = (
-        json.loads(args.run_json.read_text(encoding="utf-8"))
-        if args.run_json is not None
-        else _load_payload_from_gh(args.run_id)
+    if args.run_json is None and args.run_id is None and not args.log:
+        raise SystemExit("provide --run-id, --run-json, or --log")
+    if args.run_json is not None:
+        payload = json.loads(args.run_json.read_text(encoding="utf-8"))
+    elif args.run_id is not None:
+        payload = _load_payload_from_gh(args.run_id)
+    else:
+        payload = {"databaseId": 0, "displayTitle": "CI log timing summary", "jobs": []}
+
+    summary = summarize_run(
+        payload,
+        top=args.top,
+        phase_timings=_load_phase_timings_from_logs(args.log),
     )
-    summary = summarize_run(payload, top=args.top)
     sys.stdout.write(summary.to_json() if args.json else format_markdown(summary))
     sys.stdout.write("\n")
     return 0

--- a/tests/dev/test_ci_timing_summary.py
+++ b/tests/dev/test_ci_timing_summary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from scripts.dev.ci_timing_summary import (
     format_markdown,
     main,
@@ -139,6 +141,37 @@ def test_parse_phase_timings_extracts_ci_driver_phase_end_lines() -> None:
     assert phases[0].source == "fast-feedback.log"
 
 
+def test_parse_phase_timings_accepts_shell_quoted_fields() -> None:
+    """ci_driver phase_end fields may contain shell-quoted names and values."""
+    log_text = (
+        "ci_driver phase_end phase='unit tests shard 1' status='0' "
+        "duration_seconds='12.5' completed_at='2026-05-05T11:00:12Z'\n"
+    )
+
+    phases = parse_phase_timings(log_text, source="quoted.log")
+
+    assert [(phase.name, phase.duration_seconds, phase.status) for phase in phases] == [
+        ("unit tests shard 1", 12.5, 0),
+    ]
+    assert phases[0].completed_at == "2026-05-05T11:00:12Z"
+
+
+def test_parse_phase_timings_skips_malformed_shell_fields() -> None:
+    """Malformed shell syntax in one log line should not abort parsing."""
+    log_text = "\n".join(
+        [
+            "ci_driver phase_end phase='unterminated status=0 duration_seconds=12",
+            "ci_driver phase_end phase=lint status=0 duration_seconds=3 completed_at=2026-05-05T11:00:03Z",
+        ]
+    )
+
+    phases = parse_phase_timings(log_text, source="malformed.log")
+
+    assert [(phase.name, phase.duration_seconds, phase.status) for phase in phases] == [
+        ("lint", 3.0, 0),
+    ]
+
+
 def test_format_markdown_includes_repository_phase_timings() -> None:
     """Markdown summaries should surface ci_driver phase timings when logs are provided."""
     summary = summarize_run(
@@ -184,3 +217,24 @@ def test_main_accepts_log_only_timing_summary(tmp_path, capsys) -> None:
     output = capsys.readouterr().out
     assert "CI log timing summary" in output
     assert "| test | 540.0s | 0 | 2026-05-05T11:09:00Z |" in output
+
+
+def test_main_rejects_missing_log_path(tmp_path) -> None:
+    """CLI should fail cleanly before reading a missing log path."""
+    missing_log = tmp_path / "missing.log"
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--log", str(missing_log)])
+
+    assert excinfo.value.code == f"Log file not found: {missing_log}"
+
+
+def test_main_rejects_directory_log_path(tmp_path) -> None:
+    """CLI should fail cleanly when a log path points to a directory."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--log", str(log_dir)])
+
+    assert excinfo.value.code == f"Log file not found: {log_dir}"

--- a/tests/dev/test_ci_timing_summary.py
+++ b/tests/dev/test_ci_timing_summary.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import json
 
-from scripts.dev.ci_timing_summary import format_markdown, main, summarize_run
+from scripts.dev.ci_timing_summary import (
+    format_markdown,
+    main,
+    parse_phase_timings,
+    summarize_run,
+)
 
 
 def _sample_run_payload() -> dict[str, object]:
@@ -114,6 +119,43 @@ def test_format_markdown_reports_missing_step_timestamps() -> None:
     assert "No step timestamps reported" in markdown
 
 
+def test_parse_phase_timings_extracts_ci_driver_phase_end_lines() -> None:
+    """ci_driver phase_end log lines should become sortable repository phase timings."""
+    log_text = "\n".join(
+        [
+            "ci_driver phase_start phase=lint started_at=2026-05-05T11:00:00Z",
+            "ci_driver phase_end phase=lint status=0 duration_seconds=12 completed_at=2026-05-05T11:00:12Z",
+            "ci_driver phase_end phase=test status=1 duration_seconds=540 completed_at=2026-05-05T11:09:00Z",
+            "ci_driver phase_end phase=bad duration_seconds=not-a-number",
+        ]
+    )
+
+    phases = parse_phase_timings(log_text, source="fast-feedback.log")
+
+    assert [(phase.name, phase.duration_seconds, phase.status) for phase in phases] == [
+        ("lint", 12.0, 0),
+        ("test", 540.0, 1),
+    ]
+    assert phases[0].source == "fast-feedback.log"
+
+
+def test_format_markdown_includes_repository_phase_timings() -> None:
+    """Markdown summaries should surface ci_driver phase timings when logs are provided."""
+    summary = summarize_run(
+        _sample_run_payload(),
+        top=2,
+        phase_timings=parse_phase_timings(
+            "ci_driver phase_end phase=test status=0 duration_seconds=540 completed_at=2026-05-05T11:09:00Z\n",
+            source="fast-feedback.log",
+        ),
+    )
+
+    markdown = format_markdown(summary)
+
+    assert "## Slowest repository phases" in markdown
+    assert "| test | 540.0s | 0 | 2026-05-05T11:09:00Z | fast-feedback.log |" in markdown
+
+
 def test_main_reads_run_json_and_prints_markdown(tmp_path, capsys) -> None:
     """CLI should summarize saved `gh run view --json ...` output."""
     run_json = tmp_path / "run.json"
@@ -126,3 +168,19 @@ def test_main_reads_run_json_and_prints_markdown(tmp_path, capsys) -> None:
     assert "sample" in output
     assert "Unit tests" in output
     assert "Validation smoke tests" not in output
+
+
+def test_main_accepts_log_only_timing_summary(tmp_path, capsys) -> None:
+    """CLI should support a saved log when no gh run JSON is available."""
+    log_path = tmp_path / "fast-feedback.log"
+    log_path.write_text(
+        "ci_driver phase_end phase=test status=0 duration_seconds=540 completed_at=2026-05-05T11:09:00Z\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--log", str(log_path), "--top", "1"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "CI log timing summary" in output
+    assert "| test | 540.0s | 0 | 2026-05-05T11:09:00Z |" in output


### PR DESCRIPTION
## Summary
- Contributes to #1653 with a measurement-only runtime slice.
- Extends `scripts/dev/ci_timing_summary.py` with `--log` support for saved CI job logs containing `ci_driver phase_end ... duration_seconds=...` lines.
- Adds repository-owned phase timing rows to Markdown/JSON summaries while preserving existing `--run-id` and `--run-json` behavior.
- Documents the additive workflow in `docs/context/issue_1653_ci_runtime_slice.md`.

## Validation
- `uv run ruff check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py`
- `uv run ruff format --check scripts/dev/ci_timing_summary.py tests/dev/test_ci_timing_summary.py`
- `uv run pytest -q tests/dev/test_ci_timing_summary.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Synthetic log smoke: `uv run python scripts/dev/ci_timing_summary.py --log <tmp-log> --top 1`
- `git diff --check origin/main...HEAD`

Full `scripts/dev/pr_ready_check.sh` was not run; this is a scoped timing-helper and docs change. Pytest generated ignored `output/coverage/` files only; they are disposable local artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for analyzing CI phases from local log files using the `--log` parameter (repeatable).
  * Tool can now extract and report slowest repository-owned CI phases in markdown output.
  * Removed requirement to provide run ID or JSON; local logs can be analyzed standalone.

* **Documentation**
  * Added guide on using CI timing summary with local log files for phase analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->