### PR TITLE
docs: replace play recordings docstring placeholders

### DIFF
--- a/scripts/play_recordings.py
+++ b/scripts/play_recordings.py
@@ -1,4 +1,4 @@
-"""TODO docstring. Document this module."""
+"""Replay every saved Robot SF recording from the canonical artifact directory."""
 
 from functools import lru_cache
 from pathlib import Path
@@ -42,10 +42,11 @@ def get_specific_file(filename: str):
 
 
 def main():
+    """Load and visualize all canonical recording files in sorted order."""
+
     # Load the states from the file and view the recording
     # load_states_and_visualize(get_latest_file())
     # View all files
-    """TODO docstring. Document this function."""
     for file in get_all_files():
         load_states_and_visualize(file)
 


### PR DESCRIPTION
## Summary
- Closes #1795.
- Replaces the module and `main()` `TODO docstring` placeholders in `scripts/play_recordings.py` with accurate docstrings.
- Keeps playback behavior unchanged.

## Validation
- `uv run ruff check scripts/play_recordings.py`
- `uv run python -m py_compile scripts/play_recordings.py`
- `rg -n "TODO docstring" scripts/play_recordings.py || true`
- `git diff --check origin/main...HEAD`

Full `scripts/dev/pr_ready_check.sh` was not run; this is a one-file docstring cleanup. The only generated local artifact is the ignored worktree `.venv` bootstrap.
