### PR TITLE
docs: index issue 1502 evidence bundle

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -81,6 +81,9 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   summaries, parity tables, analyzer output, and checksums for issue #1484.
 - `issue_1501_adversarial_smoke_2026-05-28/`: compact row-status, sampler-comparison, failure
   archive, and checksum evidence for the first `crossing_ttc` adversarial smoke job.
+- `issue_1502_adversarial_two_family_2026-05-31/`: compact row-status, sampler-comparison,
+  failure-archive, guided-route, and checksum evidence for the bounded two-family adversarial
+  comparison run.
 - `camera_ready_all_planners_2026-05-04/`: compact camera-ready all-planners campaign summaries and
   reports from the May 4 run.
 - `issue_1692_topology_hypothesis_probe_2026-05-30/`: compact diagnostic-only evidence for the

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -82,7 +82,7 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_1501_adversarial_smoke_2026-05-28/`: compact row-status, sampler-comparison, failure
   archive, and checksum evidence for the first `crossing_ttc` adversarial smoke job.
 - `issue_1502_adversarial_two_family_2026-05-31/`: compact row-status, sampler-comparison,
-  failure-archive, guided-route, and checksum evidence for the bounded two-family adversarial
+  failure-archive, guided-route-search, and checksum evidence for the bounded two-family adversarial
   comparison run.
 - `camera_ready_all_planners_2026-05-04/`: compact camera-ready all-planners campaign summaries and
   reports from the May 4 run.


### PR DESCRIPTION
## Summary
- Closes #1797.
- Adds the missing `issue_1502_adversarial_two_family_2026-05-31/` entry to `docs/context/evidence/README.md`.
- Keeps the change index-only; no evidence contents or benchmark interpretation changed.

## Validation
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check -- docs/context/evidence/README.md`
- `test -d docs/context/evidence/issue_1502_adversarial_two_family_2026-05-31`
- `rg -n "issue_1502_adversarial_two_family_2026-05-31" docs/context/evidence/README.md docs/context/issue_1502_adversarial_two_family_run.md`

Full `scripts/dev/pr_ready_check.sh` was not run; this is a one-file evidence-index docs fix.
