### PR TITLE
fix: preserve risk-surface robot pose metadata

### DIFF
--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -248,7 +248,7 @@ def attach_risk_surface_to_observation(
     if not isinstance(observation, dict):
         raise RiskSurfaceUnavailable("observation must be a mapping")
     robot_position, robot_heading = _extract_robot_pose(observation)
-    robot_pose = [float(robot_position[0]), float(robot_position[1]), float(robot_heading)]
+    robot_pose = [robot_position[0], robot_position[1], robot_heading]
     enriched = dict(observation)
     meta = surface.occupancy_meta()
     if surface.spec.frame == "ego":
@@ -317,8 +317,9 @@ class RiskSurfacePlannerAdapter:
             dict[str, Any]: Observation copy enriched with the surface payload.
         """
         surface = deterministic_pedestrian_risk_surface(observation, self.spec)
-        self._last_surface = surface.diagnostics()
-        return attach_risk_surface_to_observation(observation, surface)
+        enriched = attach_risk_surface_to_observation(observation, surface)
+        self._last_surface = enriched["local_risk_surface_diagnostics"]
+        return enriched
 
     def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
         """Plan with fail-closed behavior when the surface is unavailable.

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -247,10 +247,17 @@ def attach_risk_surface_to_observation(
     """
     if not isinstance(observation, dict):
         raise RiskSurfaceUnavailable("observation must be a mapping")
+    robot_position, robot_heading = _extract_robot_pose(observation)
+    robot_pose = [float(robot_position[0]), float(robot_position[1]), float(robot_heading)]
     enriched = dict(observation)
+    meta = surface.occupancy_meta()
+    if surface.spec.frame == "ego":
+        meta["robot_pose"] = robot_pose
+    diagnostics = surface.diagnostics()
+    diagnostics["robot_pose"] = robot_pose
     enriched["occupancy_grid"] = surface.occupancy_grid()
-    enriched["occupancy_grid_meta"] = surface.occupancy_meta()
-    enriched["local_risk_surface_diagnostics"] = surface.diagnostics()
+    enriched["occupancy_grid_meta"] = meta
+    enriched["local_risk_surface_diagnostics"] = diagnostics
     return enriched
 
 

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -71,6 +71,27 @@ def test_surface_attaches_as_occupancy_payload_consumable_by_planners() -> None:
     assert enriched["local_risk_surface_diagnostics"]["producer_id"] == ("deterministic_fixture_v0")
 
 
+def test_surface_attachment_preserves_non_origin_robot_pose_for_ego_grid() -> None:
+    """Ego-frame surface metadata should let occupancy-aware planners query world rollouts."""
+    observation = {
+        "robot": {
+            "position": [5.0, -1.0],
+            "heading": [0.0],
+            "speed": [0.0],
+            "radius": [0.3],
+        },
+        "goal": {"current": [7.0, -1.0], "next": [7.0, -1.0]},
+        "pedestrians": {"positions": [], "velocities": [], "count": [0], "radius": [0.3]},
+    }
+    spec = LocalRiskSurfaceSpec(resolution=0.5, width=3.0, height=3.0)
+    surface = deterministic_pedestrian_risk_surface(observation, spec)
+
+    enriched = attach_risk_surface_to_observation(observation, surface)
+
+    assert enriched["occupancy_grid_meta"]["robot_pose"] == [5.0, -1.0, 0.0]
+    assert enriched["local_risk_surface_diagnostics"]["robot_pose"] == [5.0, -1.0, 0.0]
+
+
 def test_risk_surface_planner_adapter_produces_bounded_command_and_diagnostics() -> None:
     """A wrapped occupancy-aware planner should consume the produced surface."""
     adapter = RiskSurfacePlannerAdapter(

--- a/tests/planner/test_learned_risk_surface.py
+++ b/tests/planner/test_learned_risk_surface.py
@@ -73,6 +73,7 @@ def test_surface_attaches_as_occupancy_payload_consumable_by_planners() -> None:
 
 def test_surface_attachment_preserves_non_origin_robot_pose_for_ego_grid() -> None:
     """Ego-frame surface metadata should let occupancy-aware planners query world rollouts."""
+    expected_robot_pose = [5.0, -1.0, 0.0]
     observation = {
         "robot": {
             "position": [5.0, -1.0],
@@ -88,8 +89,16 @@ def test_surface_attachment_preserves_non_origin_robot_pose_for_ego_grid() -> No
 
     enriched = attach_risk_surface_to_observation(observation, surface)
 
-    assert enriched["occupancy_grid_meta"]["robot_pose"] == [5.0, -1.0, 0.0]
-    assert enriched["local_risk_surface_diagnostics"]["robot_pose"] == [5.0, -1.0, 0.0]
+    assert enriched["occupancy_grid_meta"]["robot_pose"] == expected_robot_pose
+    assert enriched["local_risk_surface_diagnostics"]["robot_pose"] == expected_robot_pose
+
+    adapter = RiskSurfacePlannerAdapter(spec=spec)
+    adapter.plan(observation)
+    adapter_robot_pose = (adapter.diagnostics().get("surface") or {}).get("robot_pose")
+    assert adapter_robot_pose == expected_robot_pose, (
+        "adapter diagnostics should preserve the attached non-origin robot_pose; "
+        f"got {adapter_robot_pose}"
+    )
 
 
 def test_risk_surface_planner_adapter_produces_bounded_command_and_diagnostics() -> None:


### PR DESCRIPTION
## Summary

- Preserve the observation robot pose when attaching ego-frame risk surfaces as occupancy-grid metadata.
- Add the same pose to risk-surface diagnostics so smoke reports identify the world pose bound to the ego surface.
- Add a regression test for a non-origin robot pose.

Closes #1799.

## Validation

- `uv run ruff check robot_sf/planner/learned_risk_surface.py tests/planner/test_learned_risk_surface.py`
- `uv run ruff format --check robot_sf/planner/learned_risk_surface.py tests/planner/test_learned_risk_surface.py`
- `uv run pytest -q tests/planner/test_learned_risk_surface.py` (10 passed)
- `git diff --check`

## Notes

This is a local-planner contract fix for `risk_surface_dwa_v0`; it is not benchmark-strength evidence that the exploratory planner performs well. The current claim is only that ego-frame risk-surface metadata now carries the correct world pose for occupancy-aware rollout/query code.

Ignored `output/coverage/*` artifacts were generated by pytest locally and left untracked.
