### PR TITLE
feat: add fast repeat mode to local CI wrapper

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -203,11 +203,12 @@ EOF
 ```
 
 `scripts/dev/run_ci_local.sh` is the local CI-equivalent entrypoint for the shared
-validation phases. It runs `uv sync --all-extras --frozen`, migrates legacy artifacts,
+validation phases. By default it runs `uv sync --all-extras --frozen`, migrates legacy artifacts,
 then delegates to `scripts/dev/ci_driver.sh` so local runs and `.github/workflows/ci.yml`
 share the same phase definitions (`lint`, `typecheck`, `test`, `smoke`, and
 `artifact-policy`). Pass explicit phases to scope a run, for example
-`scripts/dev/run_ci_local.sh lint test`.
+`scripts/dev/run_ci_local.sh lint test`. After dependencies are already current, use
+`scripts/dev/run_ci_local.sh --no-setup lint test` for faster repeat local feedback.
 
 Before opening a PR, fetch the latest `origin/main`, integrate it into the feature branch with
 either merge or rebase, and only then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
@@ -1031,6 +1032,8 @@ committed entry points:
 
 **Local Testing**:
 - Use `scripts/dev/run_ci_local.sh` for the canonical local CI-equivalent path.
+- Use `scripts/dev/run_ci_local.sh --no-setup <phase> ...` for repeat local phase runs after the
+  worktree has already been synced.
 - Use `scripts/dev/ci_driver.sh <phase>` for narrower local phases such as `lint`, `typecheck`,
   `test`, `smoke`, or `artifact-policy`.
 - Use `uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run-id> --top 10`

--- a/scripts/dev/run_ci_local.sh
+++ b/scripts/dev/run_ci_local.sh
@@ -7,14 +7,20 @@ source "$SCRIPT_DIR/common_setup.sh"
 
 show_help() {
   cat <<'EOF'
-Usage: scripts/dev/run_ci_local.sh [<phase> ...]
+Usage: scripts/dev/run_ci_local.sh [--no-setup] [<phase> ...]
 
 Run the canonical CI validation phases locally through the shared driver.
 When no phases are provided, the local wrapper runs every phase advertised by:
   scripts/dev/ci_driver.sh --list-phases
 
+Wrapper options:
+  --no-setup     Skip dependency sync and artifact migration for repeat local runs
+  --list-phases  List canonical CI phases without running setup
+  -h, --help     Show this help message
+
 Examples:
   scripts/dev/run_ci_local.sh
+  scripts/dev/run_ci_local.sh --no-setup lint test
   scripts/dev/run_ci_local.sh lint test
   CI_DRIVER_EVENT_NAME=workflow_dispatch scripts/dev/run_ci_local.sh smoke
 EOF
@@ -29,17 +35,45 @@ load_default_phases() {
   printf "%s\n" "${default_phases[@]}"
 }
 
-if [[ $# -gt 0 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
-  show_help
-  exit 0
-fi
+run_setup="1"
+phases=()
 
-phases=("$@")
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-setup)
+      run_setup="0"
+      shift
+      ;;
+    --list-phases)
+      "$SCRIPT_DIR/ci_driver.sh" --list-phases
+      exit 0
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    --)
+      shift
+      phases+=("$@")
+      break
+      ;;
+    *)
+      phases+=("$1")
+      shift
+      ;;
+  esac
+done
+
 if [[ ${#phases[@]} -eq 0 ]]; then
   mapfile -t phases < <(load_default_phases)
 fi
 
-uv sync --all-extras --frozen
-uv run python scripts/tools/migrate_artifacts.py
+if [[ "$run_setup" == "1" ]]; then
+  bash "$SCRIPT_DIR/ci_step_timer.sh" "Sync dependencies (locked)" uv sync --all-extras --frozen
+  bash "$SCRIPT_DIR/ci_step_timer.sh" "Migrate legacy artifacts into canonical root" \
+    uv run python scripts/tools/migrate_artifacts.py
+else
+  echo "Skipping run_ci_local setup (--no-setup)."
+fi
 
 "$SCRIPT_DIR/ci_driver.sh" "${phases[@]}"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -115,6 +115,26 @@ def test_run_ci_local_loads_default_phases_from_ci_driver() -> None:
     assert 'phases=("lint" "typecheck" "test" "smoke" "artifact-policy")' not in script_text
 
 
+def test_run_ci_local_exposes_fast_repeat_mode_with_timed_setup() -> None:
+    """Local CI repeats should be able to skip setup after dependencies are current."""
+
+    script_text = RUN_CI_LOCAL.read_text(encoding="utf-8")
+    normalized_script = " ".join(script_text.replace("\\\n", " ").split())
+
+    assert "--no-setup" in script_text
+    assert 'run_setup="1"' in script_text
+    assert 'run_setup="0"' in script_text
+    assert 'if [[ "$run_setup" == "1" ]]' in script_text
+    assert (
+        'bash "$SCRIPT_DIR/ci_step_timer.sh" "Sync dependencies (locked)" '
+        "uv sync --all-extras --frozen"
+    ) in normalized_script
+    assert (
+        'bash "$SCRIPT_DIR/ci_step_timer.sh" "Migrate legacy artifacts into canonical root" '
+        "uv run python scripts/tools/migrate_artifacts.py"
+    ) in normalized_script
+
+
 def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     """The PR-ready wrapper should record the freshness stamp its consumers require.
 


### PR DESCRIPTION
## Summary

- Add `scripts/dev/run_ci_local.sh --no-setup` for repeat local phase runs after a worktree is already synced.
- Add `--list-phases` handling in the wrapper without setup.
- Time the default dependency sync and artifact migration setup steps through `ci_step_timer.sh`.
- Document the faster repeat command in `docs/dev_guide.md`.

Closes #1801.

## Validation

- `bash -n scripts/dev/run_ci_local.sh`
- `scripts/dev/run_ci_local.sh --no-setup --list-phases`
- `scripts/dev/run_ci_local.sh --list-phases`
- `uv run ruff check tests/test_ci_script_contract.py`
- `uv run ruff format --check tests/test_ci_script_contract.py`
- `uv run pytest -q tests/test_ci_script_contract.py` (9 passed)
- `git diff --check`

## Notes

I accidentally tried `uv run ruff check scripts/dev/run_ci_local.sh tests/test_ci_script_contract.py` during local validation; Ruff reported shell-script parse errors because `run_ci_local.sh` is not Python. The shell wrapper was validated with `bash -n` and direct phase-list smoke commands instead.

Ignored `output/coverage/*` artifacts were generated by pytest locally and left untracked.
