### PR TITLE
feat: summarize policy-search step progress

### DIFF
--- a/scripts/validation/run_policy_search_step_diagnostics.py
+++ b/scripts/validation/run_policy_search_step_diagnostics.py
@@ -59,10 +59,13 @@ def _json_ready(value: Any) -> Any:
 
 def _optional_float(value: Any) -> float | None:
     """Return a float for numeric diagnostic values, preserving missing values."""
+    if value is None or value == "" or isinstance(value, bool):
+        return None
     try:
-        if value is None or value == "":
+        number = float(value)
+        if not np.isfinite(number):
             return None
-        return float(value)
+        return number
     except (TypeError, ValueError):
         return None
 
@@ -112,7 +115,7 @@ def _progress_bucket(
 def _step_index(row: dict[str, Any]) -> int | None:
     """Return a row's integer step index when available."""
     step = row.get("step")
-    return int(step) if isinstance(step, int) else None
+    return step if isinstance(step, int) and not isinstance(step, bool) else None
 
 
 def _collision_flag_counts(trace_rows: list[dict[str, Any]]) -> dict[str, int]:
@@ -139,7 +142,9 @@ def _goal_distance_summary(trace_rows: list[dict[str, Any]]) -> dict[str, float 
             goal_distance_values.append(pre_goal)
         if post_goal is not None:
             goal_distance_values.append(post_goal)
-        final_goal_distance = post_goal if post_goal is not None else pre_goal
+        last_goal_distance = post_goal if post_goal is not None else pre_goal
+        if last_goal_distance is not None:
+            final_goal_distance = last_goal_distance
 
     best_goal_distance = min(goal_distance_values) if goal_distance_values else None
     net_goal_progress = (
@@ -189,6 +194,8 @@ def _progress_step_summary(
             stagnant_step_count += 1
             current_stagnant_run += 1
             longest_stagnant_run = max(longest_stagnant_run, current_stagnant_run)
+        else:
+            current_stagnant_run = 0
 
     return {
         "progress_step_count": progress_step_count,

--- a/scripts/validation/run_policy_search_step_diagnostics.py
+++ b/scripts/validation/run_policy_search_step_diagnostics.py
@@ -57,6 +57,189 @@ def _json_ready(value: Any) -> Any:
     return str(value)
 
 
+def _optional_float(value: Any) -> float | None:
+    """Return a float for numeric diagnostic values, preserving missing values."""
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_summary_float(value: Any) -> str:
+    """Format optional floats for the Markdown report."""
+    number = _optional_float(value)
+    return "n/a" if number is None else f"{number:.4f}"
+
+
+def _empty_trace_progress_summary() -> dict[str, Any]:
+    """Return the stable progress-summary shape for an empty trace."""
+    return {
+        "steps_observed": 0,
+        "initial_goal_distance": None,
+        "final_goal_distance": None,
+        "best_goal_distance": None,
+        "net_goal_progress": None,
+        "best_goal_progress": None,
+        "progress_step_count": 0,
+        "regression_step_count": 0,
+        "stagnant_step_count": 0,
+        "longest_stagnant_run": 0,
+        "closest_robot_ped_distance": None,
+        "closest_robot_ped_step": None,
+        "collision_flag_counts": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+    }
+
+
+def _progress_bucket(
+    pre_goal: float | None,
+    post_goal: float | None,
+    *,
+    stagnation_epsilon: float,
+) -> str | None:
+    """Classify one step as progress, regression, stagnant, or unavailable."""
+    if pre_goal is None or post_goal is None:
+        return None
+    step_progress = pre_goal - post_goal
+    if step_progress > stagnation_epsilon:
+        return "progress"
+    if step_progress < -stagnation_epsilon:
+        return "regression"
+    return "stagnant"
+
+
+def _step_index(row: dict[str, Any]) -> int | None:
+    """Return a row's integer step index when available."""
+    step = row.get("step")
+    return int(step) if isinstance(step, int) else None
+
+
+def _collision_flag_counts(trace_rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Count per-step collision flags emitted by the environment."""
+    return {
+        "pedestrian": sum(1 for row in trace_rows if row.get("is_pedestrian_collision")),
+        "obstacle": sum(1 for row in trace_rows if row.get("is_obstacle_collision")),
+        "robot": sum(1 for row in trace_rows if row.get("is_robot_collision")),
+    }
+
+
+def _goal_distance_summary(trace_rows: list[dict[str, Any]]) -> dict[str, float | None]:
+    """Summarize initial, final, best, and derived goal-distance progress."""
+    goal_distance_values: list[float] = []
+    initial_goal_distance: float | None = None
+    final_goal_distance: float | None = None
+
+    for row in trace_rows:
+        pre_goal = _optional_float(row.get("goal_distance"))
+        post_goal = _optional_float(row.get("post_step_goal_distance"))
+        if initial_goal_distance is None:
+            initial_goal_distance = pre_goal if pre_goal is not None else post_goal
+        if pre_goal is not None:
+            goal_distance_values.append(pre_goal)
+        if post_goal is not None:
+            goal_distance_values.append(post_goal)
+        final_goal_distance = post_goal if post_goal is not None else pre_goal
+
+    best_goal_distance = min(goal_distance_values) if goal_distance_values else None
+    net_goal_progress = (
+        initial_goal_distance - final_goal_distance
+        if initial_goal_distance is not None and final_goal_distance is not None
+        else None
+    )
+    best_goal_progress = (
+        initial_goal_distance - best_goal_distance
+        if initial_goal_distance is not None and best_goal_distance is not None
+        else None
+    )
+    return {
+        "initial_goal_distance": initial_goal_distance,
+        "final_goal_distance": final_goal_distance,
+        "best_goal_distance": best_goal_distance,
+        "net_goal_progress": net_goal_progress,
+        "best_goal_progress": best_goal_progress,
+    }
+
+
+def _progress_step_summary(
+    trace_rows: list[dict[str, Any]],
+    *,
+    stagnation_epsilon: float,
+) -> dict[str, int]:
+    """Count step-level progress, regression, and stagnation streaks."""
+    progress_step_count = 0
+    regression_step_count = 0
+    stagnant_step_count = 0
+    current_stagnant_run = 0
+    longest_stagnant_run = 0
+
+    for row in trace_rows:
+        bucket = _progress_bucket(
+            _optional_float(row.get("goal_distance")),
+            _optional_float(row.get("post_step_goal_distance")),
+            stagnation_epsilon=stagnation_epsilon,
+        )
+        if bucket == "progress":
+            progress_step_count += 1
+            current_stagnant_run = 0
+        elif bucket == "regression":
+            regression_step_count += 1
+            current_stagnant_run = 0
+        elif bucket == "stagnant":
+            stagnant_step_count += 1
+            current_stagnant_run += 1
+            longest_stagnant_run = max(longest_stagnant_run, current_stagnant_run)
+
+    return {
+        "progress_step_count": progress_step_count,
+        "regression_step_count": regression_step_count,
+        "stagnant_step_count": stagnant_step_count,
+        "longest_stagnant_run": longest_stagnant_run,
+    }
+
+
+def _closest_robot_ped_summary(trace_rows: list[dict[str, Any]]) -> dict[str, float | int | None]:
+    """Find the closest robot-pedestrian clearance observed in a trace."""
+    closest_robot_ped_distance: float | None = None
+    closest_robot_ped_step: int | None = None
+
+    for row in trace_rows:
+        step_index = _step_index(row)
+        for field in ("min_robot_ped_distance", "post_step_min_robot_ped_distance"):
+            distance = _optional_float(row.get(field))
+            if distance is None:
+                continue
+            if closest_robot_ped_distance is None or distance < closest_robot_ped_distance:
+                closest_robot_ped_distance = distance
+                closest_robot_ped_step = step_index
+
+    return {
+        "closest_robot_ped_distance": closest_robot_ped_distance,
+        "closest_robot_ped_step": closest_robot_ped_step,
+    }
+
+
+def _trace_progress_summary(
+    trace_rows: list[dict[str, Any]],
+    *,
+    stagnation_epsilon: float = 1e-6,
+) -> dict[str, Any]:
+    """Summarize per-step progress, stagnation, clearance, and collision flags."""
+    if not trace_rows:
+        return _empty_trace_progress_summary()
+
+    return {
+        "steps_observed": len(trace_rows),
+        **_goal_distance_summary(trace_rows),
+        **_progress_step_summary(
+            trace_rows,
+            stagnation_epsilon=stagnation_epsilon,
+        ),
+        **_closest_robot_ped_summary(trace_rows),
+        "collision_flag_counts": _collision_flag_counts(trace_rows),
+    }
+
+
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -291,6 +474,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                 planner_summary = diagnostics()
         env.close()
 
+    progress_summary = _trace_progress_summary(trace_rows)
     trace_payload = {
         "candidate": args.candidate,
         "stage": args.stage,
@@ -302,6 +486,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "algo_config": _json_ready(effective_cfg),
         "algorithm_metadata": _json_ready(algo_meta),
         "planner_summary": _json_ready(planner_summary),
+        "progress_summary": _json_ready(progress_summary),
         "done_info": _json_ready(done_info),
         "steps": trace_rows,
     }
@@ -332,6 +517,23 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "## Outcome",
         "",
         f"- Done info: `{_json_ready(done_info)}`",
+        "",
+        "## Progress/Risk Summary",
+        "",
+        f"- Net goal progress: `{_format_summary_float(progress_summary['net_goal_progress'])}`",
+        f"- Best goal progress: `{_format_summary_float(progress_summary['best_goal_progress'])}`",
+        f"- Initial goal distance: `{_format_summary_float(progress_summary['initial_goal_distance'])}`",
+        f"- Final goal distance: `{_format_summary_float(progress_summary['final_goal_distance'])}`",
+        f"- Best goal distance: `{_format_summary_float(progress_summary['best_goal_distance'])}`",
+        f"- Progress/regression/stagnant steps: "
+        f"`{progress_summary['progress_step_count']}` / "
+        f"`{progress_summary['regression_step_count']}` / "
+        f"`{progress_summary['stagnant_step_count']}`",
+        f"- Longest stagnant run: `{progress_summary['longest_stagnant_run']}`",
+        f"- Closest robot-ped distance: "
+        f"`{_format_summary_float(progress_summary['closest_robot_ped_distance'])}` "
+        f"at step `{progress_summary['closest_robot_ped_step']}`",
+        f"- Collision flag counts: `{progress_summary['collision_flag_counts']}`",
         "",
         "## Step Summary",
         "",
@@ -365,6 +567,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                 "seed": seed,
                 "decision_counts": dict(decision_counter),
                 "selected_head_counts": dict(selected_head_counter),
+                "progress_summary": _json_ready(progress_summary),
                 "done_info": _json_ready(done_info),
             },
             indent=2,

--- a/tests/validation/test_run_policy_search_step_diagnostics.py
+++ b/tests/validation/test_run_policy_search_step_diagnostics.py
@@ -96,3 +96,56 @@ def test_trace_progress_summary_handles_empty_trace() -> None:
             "robot": 0,
         },
     }
+
+
+def test_trace_progress_summary_ignores_invalid_numeric_values() -> None:
+    """Invalid diagnostic numbers should not poison progress or clearance summaries."""
+    rows = [
+        {
+            "step": 0,
+            "goal_distance": 10.0,
+            "post_step_goal_distance": 9.0,
+            "min_robot_ped_distance": 2.0,
+            "post_step_min_robot_ped_distance": 1.5,
+        },
+        {
+            "step": True,
+            "goal_distance": float("nan"),
+            "post_step_goal_distance": float("inf"),
+            "min_robot_ped_distance": True,
+            "post_step_min_robot_ped_distance": "",
+        },
+        {
+            "step": 2,
+            "goal_distance": None,
+            "post_step_goal_distance": None,
+            "min_robot_ped_distance": 1.2,
+            "post_step_min_robot_ped_distance": 1.1,
+        },
+    ]
+
+    summary = _trace_progress_summary(rows)
+
+    assert summary["initial_goal_distance"] == pytest.approx(10.0)
+    assert summary["final_goal_distance"] == pytest.approx(9.0)
+    assert summary["best_goal_distance"] == pytest.approx(9.0)
+    assert summary["progress_step_count"] == 1
+    assert summary["regression_step_count"] == 0
+    assert summary["stagnant_step_count"] == 0
+    assert summary["longest_stagnant_run"] == 0
+    assert summary["closest_robot_ped_distance"] == pytest.approx(1.1)
+    assert summary["closest_robot_ped_step"] == 2
+
+
+def test_trace_progress_summary_missing_steps_break_stagnant_runs() -> None:
+    """Unavailable progress data should split contiguous stagnant step runs."""
+    rows = [
+        {"step": 0, "goal_distance": 5.0, "post_step_goal_distance": 5.0},
+        {"step": 1, "goal_distance": None, "post_step_goal_distance": None},
+        {"step": 2, "goal_distance": 4.0, "post_step_goal_distance": 4.0},
+    ]
+
+    summary = _trace_progress_summary(rows)
+
+    assert summary["stagnant_step_count"] == 2
+    assert summary["longest_stagnant_run"] == 1

--- a/tests/validation/test_run_policy_search_step_diagnostics.py
+++ b/tests/validation/test_run_policy_search_step_diagnostics.py
@@ -1,0 +1,98 @@
+"""Tests for policy-search step diagnostics helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.validation.run_policy_search_step_diagnostics import _trace_progress_summary
+
+
+def test_trace_progress_summary_exposes_progress_stagnation_and_risk() -> None:
+    """Step diagnostics should summarize progress and clearance without scanning every row."""
+    rows = [
+        {
+            "step": 0,
+            "goal_distance": 10.0,
+            "post_step_goal_distance": 9.5,
+            "min_robot_ped_distance": 1.2,
+            "post_step_min_robot_ped_distance": 0.9,
+            "is_pedestrian_collision": False,
+            "is_obstacle_collision": False,
+            "is_robot_collision": False,
+        },
+        {
+            "step": 1,
+            "goal_distance": 9.5,
+            "post_step_goal_distance": 9.5,
+            "min_robot_ped_distance": 0.8,
+            "post_step_min_robot_ped_distance": 0.7,
+            "is_pedestrian_collision": False,
+            "is_obstacle_collision": False,
+            "is_robot_collision": False,
+        },
+        {
+            "step": 2,
+            "goal_distance": 9.5,
+            "post_step_goal_distance": 9.5,
+            "min_robot_ped_distance": 0.72,
+            "post_step_min_robot_ped_distance": 0.65,
+            "is_pedestrian_collision": True,
+            "is_obstacle_collision": False,
+            "is_robot_collision": False,
+        },
+        {
+            "step": 3,
+            "goal_distance": 9.5,
+            "post_step_goal_distance": 9.8,
+            "min_robot_ped_distance": None,
+            "post_step_min_robot_ped_distance": 0.6,
+            "is_pedestrian_collision": False,
+            "is_obstacle_collision": True,
+            "is_robot_collision": False,
+        },
+    ]
+
+    summary = _trace_progress_summary(rows)
+
+    assert summary["steps_observed"] == 4
+    assert summary["initial_goal_distance"] == pytest.approx(10.0)
+    assert summary["final_goal_distance"] == pytest.approx(9.8)
+    assert summary["best_goal_distance"] == pytest.approx(9.5)
+    assert summary["net_goal_progress"] == pytest.approx(0.2)
+    assert summary["best_goal_progress"] == pytest.approx(0.5)
+    assert summary["progress_step_count"] == 1
+    assert summary["regression_step_count"] == 1
+    assert summary["stagnant_step_count"] == 2
+    assert summary["longest_stagnant_run"] == 2
+    assert summary["closest_robot_ped_distance"] == pytest.approx(0.6)
+    assert summary["closest_robot_ped_step"] == 3
+    assert summary["collision_flag_counts"] == {
+        "pedestrian": 1,
+        "obstacle": 1,
+        "robot": 0,
+    }
+
+
+def test_trace_progress_summary_handles_empty_trace() -> None:
+    """Empty traces should still produce a stable report payload."""
+    summary = _trace_progress_summary([])
+
+    assert summary == {
+        "steps_observed": 0,
+        "initial_goal_distance": None,
+        "final_goal_distance": None,
+        "best_goal_distance": None,
+        "net_goal_progress": None,
+        "best_goal_progress": None,
+        "progress_step_count": 0,
+        "regression_step_count": 0,
+        "stagnant_step_count": 0,
+        "longest_stagnant_run": 0,
+        "closest_robot_ped_distance": None,
+        "closest_robot_ped_step": None,
+        "collision_flag_counts": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0,
+        },
+    }


### PR DESCRIPTION
## Summary

- Add a compact `progress_summary` to `run_policy_search_step_diagnostics.py` trace JSON.
- Include the same progress/stagnation/clearance summary in the Markdown report and CLI JSON output.
- Add focused tests for progress, regression, stagnant runs, closest robot-ped distance, collision flags, and empty traces.

Closes #1809.

## Validation

- `uv run ruff check scripts/validation/run_policy_search_step_diagnostics.py tests/validation/test_run_policy_search_step_diagnostics.py`
- `uv run ruff format --check scripts/validation/run_policy_search_step_diagnostics.py tests/validation/test_run_policy_search_step_diagnostics.py`
- `uv run pytest -q tests/validation/test_run_policy_search_step_diagnostics.py` (2 passed)
- `git diff --check`
- `LOGURU_LEVEL=WARNING DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/run_policy_search_step_diagnostics.py --candidate risk_surface_dwa_v0 --stage smoke --horizon 20 --output-dir output/policy_search/risk_surface_dwa_v0/step_diagnostics/progress_summary_20260531 --candidate-registry docs/context/policy_search/candidate_registry.yaml`

## Smoke interpretation

The short diagnostic emitted `progress_summary` with 20 observed steps, 0.0 net/best progress, 20 stagnant steps, and no collision flags. That makes the current `risk_surface_dwa_v0` failure easier to classify without scanning every trace row. This PR changes reporting only; it does not change planner behavior.

Ignored `output/coverage/*` and `output/policy_search/*` artifacts were generated locally and left untracked.
