### PR TITLE
feat: audit closed issue state labels

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -128,6 +128,17 @@ Prioritize by:
 
 ## Queue Exhaustion Audit
 
+First run the read-only closed-issue state-label hygiene guard:
+
+```bash
+uv run python scripts/tools/closed_issue_state_label_audit.py
+```
+
+It emits `closed_issue_state_label_audit.v1` JSON and exits non-zero when any closed issue still
+has `state:ready`, `state:running`, or `state:blocked`. Do not treat closed issues as available
+queue work. If the guard fails, report the stale labels and route a separate explicit cleanup
+action; the audit command itself does not delete labels.
+
 Before declaring the implementation queue exhausted, run one final read-only implementability audit
 over:
 - open issues labeled `state:ready`,

--- a/scripts/tools/closed_issue_state_label_audit.py
+++ b/scripts/tools/closed_issue_state_label_audit.py
@@ -1,0 +1,191 @@
+"""Audit closed GitHub issues for stale live state labels.
+
+This command is intentionally read-only. It queries closed issues for the live
+implementation queue labels and emits a stable JSON summary. A non-zero exit
+means closed issues still carry labels that can confuse agent queue routing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_LIMIT = 1000
+LIVE_STATE_LABELS: tuple[str, ...] = ("state:ready", "state:running", "state:blocked")
+
+
+@dataclass(frozen=True, slots=True)
+class StaleClosedIssue:
+    """One closed issue carrying at least one live queue state label."""
+
+    number: int
+    title: str
+    url: str
+    stale_labels: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ClosedIssueStateLabelAuditReport:
+    """Machine-readable result for the closed issue state-label audit."""
+
+    schema: str
+    repo: str
+    state: str
+    live_state_labels: tuple[str, ...]
+    read_only: bool
+    stale_issue_count: int
+    stale_label_counts: dict[str, int]
+    stale_issues: tuple[StaleClosedIssue, ...]
+    query_plan: tuple[tuple[str, ...], ...]
+    mutation_plan: tuple[dict[str, Any], ...]
+
+
+def build_query_plan(
+    *,
+    repo: str = DEFAULT_REPO,
+    labels: tuple[str, ...] = LIVE_STATE_LABELS,
+    limit: int = DEFAULT_LIMIT,
+) -> tuple[tuple[str, ...], ...]:
+    """Return the read-only gh commands used to find stale closed labels."""
+    return tuple(
+        (
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "closed",
+            "--label",
+            label,
+            "--json",
+            "number,title,labels,url",
+            "--limit",
+            str(limit),
+        )
+        for label in labels
+    )
+
+
+def _run_gh_json(command: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Run a gh JSON command and return its decoded list payload."""
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, list):
+        raise RuntimeError(f"GitHub command did not return a JSON list: {' '.join(command)}")
+    if not all(isinstance(item, dict) for item in payload):
+        raise RuntimeError(f"GitHub command returned non-object list items: {' '.join(command)}")
+    return payload
+
+
+def _label_names(issue_payload: dict[str, Any]) -> set[str]:
+    """Extract label names from a gh issue-list payload item."""
+    labels = issue_payload.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {
+        label["name"]
+        for label in labels
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+
+
+def _issue_number(issue_payload: dict[str, Any]) -> int:
+    """Return a validated issue number from a gh issue-list payload item."""
+    number = issue_payload.get("number")
+    if not isinstance(number, int):
+        raise RuntimeError(f"GitHub issue payload is missing an integer number: {issue_payload!r}")
+    return number
+
+
+def audit_closed_issue_state_labels(
+    *,
+    repo: str = DEFAULT_REPO,
+    labels: tuple[str, ...] = LIVE_STATE_LABELS,
+    limit: int = DEFAULT_LIMIT,
+    runner=None,
+) -> ClosedIssueStateLabelAuditReport:
+    """Run the read-only closed-issue stale-label audit."""
+    runner = _run_gh_json if runner is None else runner
+    query_plan = build_query_plan(repo=repo, labels=labels, limit=limit)
+    issues_by_number: dict[int, dict[str, Any]] = {}
+    stale_labels_by_number: dict[int, set[str]] = {}
+
+    for command in query_plan:
+        queried_label = command[command.index("--label") + 1]
+        for issue_payload in runner(command):
+            issue_labels = _label_names(issue_payload)
+            if queried_label not in issue_labels:
+                continue
+            number = _issue_number(issue_payload)
+            issues_by_number[number] = issue_payload
+            stale_labels_by_number.setdefault(number, set()).add(queried_label)
+
+    stale_issues = tuple(
+        StaleClosedIssue(
+            number=number,
+            title=str(issues_by_number[number].get("title") or ""),
+            url=str(issues_by_number[number].get("url") or ""),
+            stale_labels=tuple(
+                label for label in labels if label in stale_labels_by_number[number]
+            ),
+        )
+        for number in sorted(stale_labels_by_number)
+    )
+    stale_label_counts = {
+        label: sum(label in issue.stale_labels for issue in stale_issues) for label in labels
+    }
+    return ClosedIssueStateLabelAuditReport(
+        schema="closed_issue_state_label_audit.v1",
+        repo=repo,
+        state="closed",
+        live_state_labels=labels,
+        read_only=True,
+        stale_issue_count=len(stale_issues),
+        stale_label_counts=stale_label_counts,
+        stale_issues=stale_issues,
+        query_plan=query_plan,
+        mutation_plan=(),
+    )
+
+
+def _report_to_json(report: ClosedIssueStateLabelAuditReport) -> str:
+    """Serialize the audit report to stable JSON."""
+    return json.dumps(asdict(report), indent=2, sort_keys=True) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Maximum closed issues to fetch per live state label.",
+    )
+    parser.add_argument(
+        "--label",
+        dest="labels",
+        action="append",
+        choices=LIVE_STATE_LABELS,
+        help="Live state label to audit; may be repeated. Defaults to all live state labels.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    labels = tuple(args.labels) if args.labels else LIVE_STATE_LABELS
+    report = audit_closed_issue_state_labels(repo=args.repo, labels=labels, limit=args.limit)
+    print(_report_to_json(report), end="")
+    return 1 if report.stale_issue_count else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/closed_issue_state_label_audit.py
+++ b/scripts/tools/closed_issue_state_label_audit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+from collections import defaultdict
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -73,8 +74,24 @@ def build_query_plan(
 
 def _run_gh_json(command: tuple[str, ...]) -> list[dict[str, Any]]:
     """Run a gh JSON command and return its decoded list payload."""
-    completed = subprocess.run(command, check=True, capture_output=True, text=True)
-    payload = json.loads(completed.stdout)
+    try:
+        completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as err:
+        raise RuntimeError(
+            "GitHub CLI 'gh' was not found; install gh or ensure it is on PATH."
+        ) from err
+    except subprocess.CalledProcessError as err:
+        stderr = (err.stderr or "").strip()
+        details = f": {stderr}" if stderr else ""
+        raise RuntimeError(f"GitHub CLI command failed ({' '.join(command)}){details}") from err
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as err:
+        raise RuntimeError(
+            f"Failed to parse GitHub CLI JSON output ({' '.join(command)}): {err.msg}"
+        ) from err
+
     if not isinstance(payload, list):
         raise RuntimeError(f"GitHub command did not return a JSON list: {' '.join(command)}")
     if not all(isinstance(item, dict) for item in payload):
@@ -113,7 +130,7 @@ def audit_closed_issue_state_labels(
     runner = _run_gh_json if runner is None else runner
     query_plan = build_query_plan(repo=repo, labels=labels, limit=limit)
     issues_by_number: dict[int, dict[str, Any]] = {}
-    stale_labels_by_number: dict[int, set[str]] = {}
+    stale_labels_by_number: defaultdict[int, set[str]] = defaultdict(set)
 
     for command in query_plan:
         queried_label = command[command.index("--label") + 1]
@@ -123,7 +140,7 @@ def audit_closed_issue_state_labels(
                 continue
             number = _issue_number(issue_payload)
             issues_by_number[number] = issue_payload
-            stale_labels_by_number.setdefault(number, set()).add(queried_label)
+            stale_labels_by_number[number].add(queried_label)
 
     stale_issues = tuple(
         StaleClosedIssue(

--- a/tests/tools/test_closed_issue_state_label_audit.py
+++ b/tests/tools/test_closed_issue_state_label_audit.py
@@ -1,0 +1,121 @@
+"""Tests for the closed issue state-label hygiene audit."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from scripts.tools import closed_issue_state_label_audit as audit
+
+
+def test_query_plan_checks_closed_issues_for_each_live_state_label() -> None:
+    """The live GitHub query plan should be closed-issue and label-specific."""
+    plan = audit.build_query_plan(repo="owner/repo", labels=("state:ready", "state:running"))
+
+    assert plan == (
+        (
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--state",
+            "closed",
+            "--label",
+            "state:ready",
+            "--json",
+            "number,title,labels,url",
+            "--limit",
+            "1000",
+        ),
+        (
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            "owner/repo",
+            "--state",
+            "closed",
+            "--label",
+            "state:running",
+            "--json",
+            "number,title,labels,url",
+            "--limit",
+            "1000",
+        ),
+    )
+
+
+def test_audit_report_merges_duplicate_issues_and_counts_stale_labels() -> None:
+    """One closed issue can carry more than one stale live-state label."""
+    payloads: dict[str, list[dict[str, Any]]] = {
+        "state:ready": [
+            {
+                "number": 10,
+                "title": "Ready but closed",
+                "url": "https://example.test/10",
+                "labels": [{"name": "state:ready"}, {"name": "workflow"}],
+            },
+            {
+                "number": 11,
+                "title": "Ready and running but closed",
+                "url": "https://example.test/11",
+                "labels": [{"name": "state:ready"}, {"name": "state:running"}],
+            },
+        ],
+        "state:running": [
+            {
+                "number": 11,
+                "title": "Ready and running but closed",
+                "url": "https://example.test/11",
+                "labels": [{"name": "state:ready"}, {"name": "state:running"}],
+            }
+        ],
+        "state:blocked": [],
+    }
+
+    def fake_runner(command: tuple[str, ...]) -> list[dict[str, Any]]:
+        label = command[command.index("--label") + 1]
+        return payloads[label]
+
+    report = audit.audit_closed_issue_state_labels(runner=fake_runner)
+
+    assert report.schema == "closed_issue_state_label_audit.v1"
+    assert report.read_only is True
+    assert report.stale_issue_count == 2
+    assert report.stale_label_counts == {
+        "state:ready": 2,
+        "state:running": 1,
+        "state:blocked": 0,
+    }
+    assert [issue.number for issue in report.stale_issues] == [10, 11]
+    assert report.stale_issues[1].stale_labels == ("state:ready", "state:running")
+    assert report.mutation_plan == ()
+
+
+def test_cli_exits_nonzero_and_emits_machine_readable_failure_summary(monkeypatch, capsys) -> None:
+    """Stale labels should fail the command while still printing JSON."""
+
+    def fake_runner(command: tuple[str, ...]) -> list[dict[str, Any]]:
+        label = command[command.index("--label") + 1]
+        if label != "state:blocked":
+            return []
+        return [
+            {
+                "number": 12,
+                "title": "Blocked but closed",
+                "url": "https://example.test/12",
+                "labels": [{"name": "state:blocked"}],
+            }
+        ]
+
+    monkeypatch.setattr(audit, "_run_gh_json", fake_runner)
+
+    exit_code = audit.main(["--repo", "owner/repo"])
+
+    assert exit_code == 1
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["schema"] == "closed_issue_state_label_audit.v1"
+    assert summary["stale_issue_count"] == 1
+    assert summary["stale_label_counts"]["state:blocked"] == 1
+    assert summary["mutation_plan"] == []

--- a/tests/tools/test_closed_issue_state_label_audit.py
+++ b/tests/tools/test_closed_issue_state_label_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from typing import Any
 
 from scripts.tools import closed_issue_state_label_audit as audit
@@ -119,3 +120,57 @@ def test_cli_exits_nonzero_and_emits_machine_readable_failure_summary(monkeypatc
     assert summary["stale_issue_count"] == 1
     assert summary["stale_label_counts"]["state:blocked"] == 1
     assert summary["mutation_plan"] == []
+
+
+def test_run_gh_json_reports_missing_gh(monkeypatch) -> None:
+    """A missing GitHub CLI should fail with an actionable message."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(audit.subprocess, "run", fake_run)
+
+    try:
+        audit._run_gh_json(("gh", "issue", "list"))
+    except RuntimeError as err:
+        assert "GitHub CLI 'gh' was not found" in str(err)
+    else:
+        raise AssertionError("expected missing gh to raise RuntimeError")
+
+
+def test_run_gh_json_reports_captured_stderr(monkeypatch) -> None:
+    """Captured gh stderr should be preserved when a command fails."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=("gh", "issue", "list"),
+            stderr="authentication required",
+        )
+
+    monkeypatch.setattr(audit.subprocess, "run", fake_run)
+
+    try:
+        audit._run_gh_json(("gh", "issue", "list"))
+    except RuntimeError as err:
+        message = str(err)
+        assert "GitHub CLI command failed" in message
+        assert "authentication required" in message
+    else:
+        raise AssertionError("expected failing gh command to raise RuntimeError")
+
+
+def test_run_gh_json_reports_invalid_json(monkeypatch) -> None:
+    """Non-JSON gh output should fail before callers inspect the payload shape."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=("gh",), returncode=0, stdout="not-json")
+
+    monkeypatch.setattr(audit.subprocess, "run", fake_run)
+
+    try:
+        audit._run_gh_json(("gh", "issue", "list"))
+    except RuntimeError as err:
+        assert "Failed to parse GitHub CLI JSON output" in str(err)
+    else:
+        raise AssertionError("expected invalid JSON to raise RuntimeError")


### PR DESCRIPTION
## Summary
- Add a read-only `closed_issue_state_label_audit.v1` helper for closed issues that still carry live queue labels.
- Return non-zero with stable JSON when stale `state:ready`, `state:running`, or `state:blocked` labels are present.
- Document the audit in the goal issue implementation queue-exhaustion path.

Closes #1833.

## Validation
- `uv run pytest tests/tools/test_closed_issue_state_label_audit.py -q`
- `uv run ruff check scripts/tools/closed_issue_state_label_audit.py tests/tools/test_closed_issue_state_label_audit.py .agents/skills/goal-issue-implementation/SKILL.md`
- `uv run python scripts/tools/closed_issue_state_label_audit.py` (`stale_issue_count: 0`)
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4620 passed, 11 skipped)

## Notes
- The helper is audit-only; it emits an empty `mutation_plan` and does not remove labels.
- Generated `output/coverage/*` and `output/validation/pr_ready/*` artifacts are ignored and left disposable.
