### PR TITLE
feat: add closed issue state-label hygiene guard (#1833)

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -128,8 +128,19 @@ Prioritize by:
 
 ## Queue Exhaustion Audit
 
-Before declaring the implementation queue exhausted, run one final read-only implementability audit
-over:
+Before declaring the implementation queue exhausted, first run the closed-issue state-label hygiene
+guard:
+
+```bash
+uv run python scripts/dev/closed_state_label_hygiene.py
+```
+
+This guard is read-only, avoids Project #5 writes, and exits non-zero with a
+`closed_state_label_hygiene.v1` JSON report when any closed issue still carries `state:ready`,
+`state:running`, or `state:blocked`. Treat failures as stale queue metadata to clean up or report
+before claiming that the active implementation queue is exhausted.
+
+Then run one final read-only implementability audit over:
 - open issues labeled `state:ready`,
 - open issues that lack any `state:*` label.
 

--- a/docs/context/issue_1776_state_label_routing.md
+++ b/docs/context/issue_1776_state_label_routing.md
@@ -77,3 +77,15 @@ for n in 1653 1771 1772 1775 1781 1782 1783 1784; do gh issue view "$n" --json n
 ```
 
 No Project #5 fields were changed in this pass. No new labels were created.
+
+## Reusable Closed-Issue Guard
+
+Issue #1833 added a read-only regression guard for the stale-label class found in this cleanup pass:
+
+```bash
+uv run python scripts/dev/closed_state_label_hygiene.py
+```
+
+The command checks closed issues carrying `state:ready`, `state:running`, or `state:blocked`,
+prints a `closed_state_label_hygiene.v1` JSON report, and returns non-zero when stale labels are
+present. It uses GitHub issue search only; it does not edit labels or write Project #5 metadata.

--- a/scripts/dev/closed_state_label_hygiene.py
+++ b/scripts/dev/closed_state_label_hygiene.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Audit closed issues for stale live state labels.
+
+The command is intentionally read-only: it searches GitHub issues and reports any closed issue that
+still carries labels used for active implementation routing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+LIVE_STATE_LABELS = ("state:ready", "state:running", "state:blocked")
+JSON_FIELDS = "number,title,url,state,isPullRequest,labels"
+
+
+@dataclass(frozen=True)
+class StaleIssue:
+    """Closed issue carrying one or more live state labels."""
+
+    number: int
+    title: str
+    url: str
+    state: str
+    stale_labels: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable issue summary."""
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "state": self.state,
+            "stale_labels": list(self.stale_labels),
+        }
+
+
+def _label_names(raw_labels: object) -> set[str]:
+    """Extract label names from GitHub CLI label payloads."""
+    if not isinstance(raw_labels, list):
+        return set()
+
+    names: set[str] = set()
+    for label in raw_labels:
+        if isinstance(label, str):
+            names.add(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.add(label["name"])
+    return names
+
+
+def build_search_command(*, repo: str, label: str, limit: int) -> list[str]:
+    """Build the read-only GitHub CLI search command for one state label."""
+    return [
+        "gh",
+        "search",
+        "issues",
+        "--repo",
+        repo,
+        "--state",
+        "closed",
+        "--label",
+        label,
+        "--json",
+        JSON_FIELDS,
+        "--limit",
+        str(limit),
+    ]
+
+
+def collect_stale_issues(
+    rows_by_label: dict[str, list[dict[str, object]]],
+    *,
+    watched_labels: tuple[str, ...] = LIVE_STATE_LABELS,
+) -> list[StaleIssue]:
+    """Aggregate closed issues carrying watched live state labels.
+
+    Returns:
+        Stale issue summaries sorted by issue number.
+    """
+    watched = set(watched_labels)
+    issue_rows: dict[int, dict[str, object]] = {}
+    issue_labels: dict[int, set[str]] = {}
+
+    for search_label, rows in rows_by_label.items():
+        for row in rows:
+            if row.get("isPullRequest") is True:
+                continue
+            if str(row.get("state", "")).lower() != "closed":
+                continue
+
+            try:
+                number = int(row["number"])
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            matching_labels = _label_names(row.get("labels")) & watched
+            if search_label in watched:
+                matching_labels.add(search_label)
+            if not matching_labels:
+                continue
+
+            issue_rows.setdefault(number, row)
+            issue_labels.setdefault(number, set()).update(matching_labels)
+
+    stale: list[StaleIssue] = []
+    for number in sorted(issue_rows):
+        row = issue_rows[number]
+        stale.append(
+            StaleIssue(
+                number=number,
+                title=str(row.get("title", "")),
+                url=str(row.get("url", "")),
+                state=str(row.get("state", "")),
+                stale_labels=tuple(sorted(issue_labels[number])),
+            )
+        )
+    return stale
+
+
+def build_report(
+    *,
+    repo: str,
+    checked_labels: tuple[str, ...],
+    stale_issues: list[StaleIssue],
+) -> dict[str, Any]:
+    """Build the machine-readable audit report."""
+    return {
+        "schema": "closed_state_label_hygiene.v1",
+        "ok": not stale_issues,
+        "read_only": True,
+        "project_writes": False,
+        "repo": repo,
+        "checked_labels": list(checked_labels),
+        "stale_count": len(stale_issues),
+        "issues": [issue.to_payload() for issue in stale_issues],
+        "failure_summary": {
+            "reason": "closed_issues_with_live_state_labels",
+            "count": len(stale_issues),
+        }
+        if stale_issues
+        else None,
+    }
+
+
+def fetch_closed_issues_by_label(
+    *,
+    repo: str,
+    labels: tuple[str, ...],
+    limit: int,
+) -> dict[str, list[dict[str, object]]]:
+    """Fetch closed issues for each label with read-only GitHub search commands."""
+    rows_by_label: dict[str, list[dict[str, object]]] = {}
+    for label in labels:
+        command = build_search_command(repo=repo, label=label, limit=limit)
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        payload = json.loads(result.stdout or "[]")
+        if not isinstance(payload, list):
+            raise ValueError(f"Expected a JSON list from {' '.join(command)}")
+        rows_by_label[label] = [row for row in payload if isinstance(row, dict)]
+    return rows_by_label
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository as OWNER/REPO.")
+    parser.add_argument(
+        "--label",
+        action="append",
+        dest="labels",
+        help="State label to check. May be repeated. Defaults to live state labels.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=1000,
+        help="Maximum search results to fetch per label.",
+    )
+    return parser
+
+
+def _dump_json(payload: dict[str, Any]) -> None:
+    """Print stable JSON to stdout."""
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    labels = tuple(args.labels) if args.labels else LIVE_STATE_LABELS
+
+    try:
+        rows_by_label = fetch_closed_issues_by_label(
+            repo=args.repo,
+            labels=labels,
+            limit=args.limit,
+        )
+        stale_issues = collect_stale_issues(rows_by_label, watched_labels=labels)
+        report = build_report(repo=args.repo, checked_labels=labels, stale_issues=stale_issues)
+    except (json.JSONDecodeError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        _dump_json(
+            {
+                "schema": "closed_state_label_hygiene.v1",
+                "ok": False,
+                "read_only": True,
+                "project_writes": False,
+                "repo": args.repo,
+                "checked_labels": list(labels),
+                "stale_count": None,
+                "issues": [],
+                "error": str(exc),
+            }
+        )
+        return 2
+
+    _dump_json(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dev/closed_state_label_hygiene.py
+++ b/scripts/dev/closed_state_label_hygiene.py
@@ -73,6 +73,28 @@ def build_search_command(*, repo: str, label: str, limit: int) -> list[str]:
     ]
 
 
+def _run_search_command(command: list[str]) -> list[dict[str, object]]:
+    """Run one read-only GitHub search command and return object rows."""
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("GitHub CLI 'gh' was not found; install gh or add it to PATH.") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        details = f": {stderr}" if stderr else ""
+        raise RuntimeError(f"GitHub CLI command failed ({' '.join(command)}){details}") from exc
+
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Failed to parse GitHub CLI JSON output ({' '.join(command)}): {exc.msg}"
+        ) from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected a JSON list from {' '.join(command)}")
+    return [row for row in payload if isinstance(row, dict)]
+
+
 def collect_stale_issues(
     rows_by_label: dict[str, list[dict[str, object]]],
     *,
@@ -158,11 +180,7 @@ def fetch_closed_issues_by_label(
     rows_by_label: dict[str, list[dict[str, object]]] = {}
     for label in labels:
         command = build_search_command(repo=repo, label=label, limit=limit)
-        result = subprocess.run(command, check=True, capture_output=True, text=True)
-        payload = json.loads(result.stdout or "[]")
-        if not isinstance(payload, list):
-            raise ValueError(f"Expected a JSON list from {' '.join(command)}")
-        rows_by_label[label] = [row for row in payload if isinstance(row, dict)]
+        rows_by_label[label] = _run_search_command(command)
     return rows_by_label
 
 
@@ -203,7 +221,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         stale_issues = collect_stale_issues(rows_by_label, watched_labels=labels)
         report = build_report(repo=args.repo, checked_labels=labels, stale_issues=stale_issues)
-    except (json.JSONDecodeError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
         _dump_json(
             {
                 "schema": "closed_state_label_hygiene.v1",

--- a/tests/dev/test_closed_state_label_hygiene.py
+++ b/tests/dev/test_closed_state_label_hygiene.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pytest
 
@@ -143,3 +144,45 @@ def test_main_returns_nonzero_json_summary_without_live_github(
     assert payload["ok"] is False
     assert payload["stale_count"] == 1
     assert payload["issues"][0]["number"] == 12
+
+
+def test_run_search_command_reports_missing_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing gh should produce an actionable runtime error."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="GitHub CLI 'gh' was not found"):
+        closed_state_label_hygiene._run_search_command(["gh", "search", "issues"])
+
+
+def test_run_search_command_preserves_captured_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Captured gh stderr should appear in the machine-readable error path."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=("gh", "search", "issues"),
+            stderr="authentication required",
+        )
+
+    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="authentication required"):
+        closed_state_label_hygiene._run_search_command(["gh", "search", "issues"])
+
+
+def test_run_search_command_reports_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed gh output should be diagnosed before row filtering."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=("gh",), returncode=0, stdout="not-json")
+
+    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Failed to parse GitHub CLI JSON output"):
+        closed_state_label_hygiene._run_search_command(["gh", "search", "issues"])

--- a/tests/dev/test_closed_state_label_hygiene.py
+++ b/tests/dev/test_closed_state_label_hygiene.py
@@ -1,0 +1,145 @@
+"""Tests for closed-issue state-label hygiene helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.dev import closed_state_label_hygiene
+
+
+def test_collect_stale_issues_aggregates_closed_issue_state_labels() -> None:
+    """Closed issues should be reported once with all stale live state labels."""
+    rows_by_label = {
+        "state:ready": [
+            {
+                "number": 12,
+                "title": "done but still queued",
+                "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+                "state": "closed",
+                "labels": [{"name": "state:ready"}, {"name": "workflow"}],
+            },
+            {
+                "number": 13,
+                "title": "open issue should not count",
+                "url": "https://github.com/ll7/robot_sf_ll7/issues/13",
+                "state": "open",
+                "labels": [{"name": "state:ready"}],
+            },
+        ],
+        "state:blocked": [
+            {
+                "number": 12,
+                "title": "done but still queued",
+                "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+                "state": "closed",
+                "labels": [{"name": "state:ready"}, {"name": "state:blocked"}],
+            }
+        ],
+    }
+
+    stale = closed_state_label_hygiene.collect_stale_issues(rows_by_label)
+
+    assert [issue.number for issue in stale] == [12]
+    assert stale[0].stale_labels == ("state:blocked", "state:ready")
+
+
+def test_collect_stale_issues_ignores_pull_request_rows() -> None:
+    """The guard is issue-specific even if a caller supplies PR-shaped search rows."""
+    rows_by_label = {
+        "state:ready": [
+            {
+                "number": 12,
+                "title": "closed PR with a state label",
+                "url": "https://github.com/ll7/robot_sf_ll7/pull/12",
+                "state": "closed",
+                "isPullRequest": True,
+                "labels": [{"name": "state:ready"}],
+            }
+        ],
+    }
+
+    assert closed_state_label_hygiene.collect_stale_issues(rows_by_label) == []
+
+
+def test_build_report_emits_machine_readable_failure_summary() -> None:
+    """Reports should expose a stable failure summary when stale labels exist."""
+    stale = [
+        closed_state_label_hygiene.StaleIssue(
+            number=12,
+            title="done but still queued",
+            url="https://github.com/ll7/robot_sf_ll7/issues/12",
+            state="closed",
+            stale_labels=("state:ready",),
+        )
+    ]
+
+    report = closed_state_label_hygiene.build_report(
+        repo="ll7/robot_sf_ll7",
+        checked_labels=("state:ready", "state:running", "state:blocked"),
+        stale_issues=stale,
+    )
+
+    assert report["schema"] == "closed_state_label_hygiene.v1"
+    assert report["ok"] is False
+    assert report["read_only"] is True
+    assert report["project_writes"] is False
+    assert report["stale_count"] == 1
+    assert report["issues"][0]["stale_labels"] == ["state:ready"]
+
+
+def test_build_search_command_uses_read_only_closed_issue_search() -> None:
+    """The GitHub command should only search issues and avoid Project writes."""
+    command = closed_state_label_hygiene.build_search_command(
+        repo="ll7/robot_sf_ll7",
+        label="state:ready",
+        limit=200,
+    )
+
+    assert command[:3] == ["gh", "search", "issues"]
+    assert "--state" in command
+    assert command[command.index("--state") + 1] == "closed"
+    assert "--label" in command
+    assert command[command.index("--label") + 1] == "state:ready"
+    assert "isPullRequest" in command[command.index("--json") + 1].split(",")
+    assert "--project" not in command
+    assert "edit" not in command
+
+
+def test_main_returns_nonzero_json_summary_without_live_github(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI should be testable with an injected fetcher and emit JSON on failure."""
+
+    def fake_fetch(
+        *,
+        repo: str,
+        labels: tuple[str, ...],
+        limit: int,
+    ) -> dict[str, list[dict[str, object]]]:
+        assert repo == "ll7/robot_sf_ll7"
+        assert labels == ("state:ready", "state:running", "state:blocked")
+        assert limit == 1000
+        return {
+            "state:ready": [
+                {
+                    "number": 12,
+                    "title": "done but still queued",
+                    "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+                    "state": "closed",
+                    "labels": [{"name": "state:ready"}],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(closed_state_label_hygiene, "fetch_closed_issues_by_label", fake_fetch)
+
+    exit_code = closed_state_label_hygiene.main(["--repo", "ll7/robot_sf_ll7"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["stale_count"] == 1
+    assert payload["issues"][0]["number"] == 12


### PR DESCRIPTION
## Summary
Adds a read-only closed-issue state-label hygiene guard so goal-loop audits can detect stale `state:ready`, `state:running`, or `state:blocked` labels on closed issues before declaring queues exhausted.

## Linked Issues
- Closes `#1833`
- Relates to `#1776`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Added `scripts/dev/closed_state_label_hygiene.py`, a read-only GitHub CLI-backed audit that emits `closed_state_label_hygiene.v1` JSON and exits non-zero when stale closed-issue state labels are found.
- Added focused no-network tests for aggregation, PR-row filtering, report shape, command construction, and CLI nonzero behavior.
- Documented the guard in the goal issue implementation workflow and the issue #1776 state-label routing note.

## Why It Matters
- Added value: avoids rediscovering closed work as active implementation candidates.
- Expected impact: makes stale issue-state drift observable with one reusable command instead of ad hoc `gh` queries.
- Why this is worth merging now: the stale-label class recurred after the earlier one-time cleanup in #1776.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_closed_state_label_hygiene.py tests/dev/test_queue_audit_schema_docs.py -q`
  - `rtk uv run ruff check scripts/dev/closed_state_label_hygiene.py tests/dev/test_closed_state_label_hygiene.py`
  - `rtk uv run ruff format --check scripts/dev/closed_state_label_hygiene.py tests/dev/test_closed_state_label_hygiene.py`
  - `rtk uv run python scripts/dev/check_skills.py`
  - `rtk uv run python scripts/dev/closed_state_label_hygiene.py`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Live audit returned `ok: true`, `stale_count: 0`, `read_only: true`, and `project_writes: false`.
  - Full readiness passed at `9f1bcb59ca8d9fa0772e69af297a68f0a0c18b9a`: `4622 passed, 11 skipped, 8 warnings`.
  - Freshness stamp: `output/validation/pr_ready/goal-issue-1833-closed-state-label-hygiene.json`.
- Benchmarks or smoke tests, if applicable: not applicable; workflow guard only.

## Risks / Rollout
- Compatibility risks: low; the new command is additive and read-only.
- Failure modes: GitHub CLI auth/API failures return exit code 2 with JSON error output.
- Rollback or fallback plan: remove the helper and docs pointer; existing manual `gh issue list/search` queries still work.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-issue-implementation/SKILL.md`, `docs/context/issue_1776_state_label_routing.md`.
- Relevant design or provenance notes: issue #1776 routing note and issue #1833 observed recurrence.
- Any assumptions that need to be preserved: closed issues should not carry active queue-routing state labels.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #1833.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not-applicable rationale: this is workflow hygiene, not benchmark, registry, or claim-map work.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify the command stays read-only and does not perform Project #5 or label writes.
- Known limitation: the helper reports stale labels but intentionally does not remove them automatically.
