### PR TITLE
feat: add 2p4 static escape diagnostic

### DIFF
--- a/configs/policy_search/candidates/hybrid_rule_v3_progress_2p4_static_escape_probe.yaml
+++ b/configs/policy_search/candidates/hybrid_rule_v3_progress_2p4_static_escape_probe.yaml
@@ -1,0 +1,24 @@
+name: hybrid_rule_v3_progress_2p4_static_escape_probe
+algo: hybrid_rule_local_planner
+base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
+params:
+  max_linear_speed: 2.4
+  max_linear_accel: 2.4
+  goal_progress_weight: 5.0
+  speed_preference_weight: 0.9
+  static_clearance_escape_enabled: true
+  static_clearance_escape_min_clearance: 1.0
+  static_clearance_escape_max_speed: 0.3
+  static_clearance_escape_tolerance: 0.05
+  static_recenter_enabled: true
+  static_recenter_weight: 0.7
+  static_recenter_probe_speed: 0.3
+  static_corridor_transit_enabled: true
+  static_corridor_transit_initial_band: 0.08
+  static_corridor_transit_tolerance: 0.08
+  static_corridor_transit_min_progress_3s: 0.1
+  static_corridor_transit_weight: 0.5
+scenario_overrides:
+  francis2023_perpendicular_traffic:
+    very_slow_speed: 0.6
+    static_clearance_escape_max_speed: 0.6

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -168,6 +168,23 @@ candidates:
       - nominal_sanity
       - stress_slice
 
+  hybrid_rule_v3_progress_2p4_static_escape_probe:
+    status: experimental_spike
+    family: hybrid_rule_based
+    training_required: false
+    claim_scope: diagnostic_only
+    promotion_gate: tier_b
+    candidate_config_path: configs/policy_search/candidates/hybrid_rule_v3_progress_2p4_static_escape_probe.yaml
+    issue: 1834
+    hypothesis: >
+      Keeping the 2.4 m/s progress envelope while enabling the static-escape
+      and recenter probes from the faster static-escape candidate may convert
+      some low-progress stalls without adopting the 3.0 m/s fast-progress speed
+      envelope.
+    required_stages:
+      - smoke
+      - nominal_sanity
+
   risk_dwa_camera_ready:
     status: implemented
     family: classical_baseline

--- a/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_sanity.md
+++ b/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_sanity.md
@@ -15,8 +15,8 @@ Keeping the 2.4 m/s progress envelope while enabling the static-escape and recen
 - Algorithm: `hybrid_rule_local_planner`
 - Scenario matrix: `configs/policy_search/nominal_sanity_matrix.yaml`
 - Seed manifest: `configs/policy_search/nominal_sanity_seeds.yaml`
-- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_issue1834_final/summary.json`
-- Git commit: `fd66bceb514418f6250bbdc601962c2478dd9b99`
+- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_pr1837_current_head/summary.json`
+- Git commit: `2a14055d5621522f6663b20d72784bd37b3b14e5`
 
 ## Aggregate Results
 
@@ -39,13 +39,13 @@ Keeping the 2.4 m/s progress envelope while enabling the static-escape and recen
 
 ## Issue 1834 Interpretation
 
-This probe is diagnostic-only and should not be promoted from the nominal-sanity result. It preserves
-the original `hybrid_rule_v3_progress_2p4` nominal success rate recorded in
+This current-head rerun keeps the probe diagnostic-only and should not be used for promotion. It
+preserves the original `hybrid_rule_v3_progress_2p4` nominal success rate recorded in
 `docs/context/policy_search/experiment_ledger.md` (`0.2222`) and keeps collision rate at `0.0000`,
 but it increases nominal near-miss rate from the ledger value (`0.1667`) to `0.2778` while
 `timeout_low_progress` remains the dominant failure mode. The bounded static-escape/recenter
-mechanism is therefore wired and runnable, but it has not yet repaired the 2.4 m/s progress
-regression.
+mechanism is wired and runnable at PR head `2a14055d5621522f6663b20d72784bd37b3b14e5`, but it has
+not repaired the 2.4 m/s progress regression.
 
 ## Claim Boundary
 

--- a/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_sanity.md
+++ b/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_sanity.md
@@ -1,0 +1,68 @@
+# Candidate Report: hybrid_rule_v3_progress_2p4_static_escape_probe (nominal_sanity)
+
+## Decision
+
+revise
+
+## Hypothesis
+
+Keeping the 2.4 m/s progress envelope while enabling the static-escape and recenter probes from the faster static-escape candidate may convert some low-progress stalls without adopting the 3.0 m/s fast-progress speed envelope.
+
+
+## Evaluation Scope
+
+- Stage: `nominal_sanity`
+- Algorithm: `hybrid_rule_local_planner`
+- Scenario matrix: `configs/policy_search/nominal_sanity_matrix.yaml`
+- Seed manifest: `configs/policy_search/nominal_sanity_seeds.yaml`
+- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_issue1834_final/summary.json`
+- Git commit: `fd66bceb514418f6250bbdc601962c2478dd9b99`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 18 | 0.2222 | 0.0000 | 0.2778 | 4.1995 | 1.6116 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| classic | 12 | 0.0833 | 0.0000 | 0.4167 |
+| francis2023 | 3 | 0.0000 | 0.0000 | 0.0000 |
+| nominal | 3 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- `near_miss_intrusive`: `4`
+- `timeout_low_progress`: `10`
+
+## Issue 1834 Interpretation
+
+This probe is diagnostic-only and should not be promoted from the nominal-sanity result. It preserves
+the original `hybrid_rule_v3_progress_2p4` nominal success rate recorded in
+`docs/context/policy_search/experiment_ledger.md` (`0.2222`) and keeps collision rate at `0.0000`,
+but it increases nominal near-miss rate from the ledger value (`0.1667`) to `0.2778` while
+`timeout_low_progress` remains the dominant failure mode. The bounded static-escape/recenter
+mechanism is therefore wired and runnable, but it has not yet repaired the 2.4 m/s progress
+regression.
+
+## Claim Boundary
+
+This report is diagnostic-only wiring or stage evidence. Treat aggregate metrics and baseline deltas as arithmetic context, not benchmark-strength evidence for comfort, near-miss behavior, generalization, or planner superiority.
+
+## Baseline Deltas
+
+_Diagnostic-only arithmetic context; not a benchmark comparison claim._
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.2080 | -0.2411 | n/a |
+| orca | +0.0378 | -0.0355 | n/a |
+| ppo | -0.0260 | -0.0993 | n/a |
+
+## Family Override Runs
+
+- `classic`: success `0.0833`, collision `0.0000`
+- `francis2023`: success `0.0000`, collision `0.0000`
+- `nominal`: success `1.0000`, collision `0.0000`

--- a/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_smoke.md
@@ -15,8 +15,8 @@ Keeping the 2.4 m/s progress envelope while enabling the static-escape and recen
 - Algorithm: `hybrid_rule_local_planner`
 - Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
 - Seed manifest: `suite default`
-- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_smoke_issue1834/summary.json`
-- Git commit: `fd66bceb514418f6250bbdc601962c2478dd9b99`
+- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_smoke_pr1837_current_head/summary.json`
+- Git commit: `2a14055d5621522f6663b20d72784bd37b3b14e5`
 
 ## Aggregate Results
 

--- a/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_smoke.md
+++ b/docs/context/policy_search/reports/2026-05-31_hybrid_rule_v3_progress_2p4_static_escape_probe_smoke.md
@@ -1,0 +1,53 @@
+# Candidate Report: hybrid_rule_v3_progress_2p4_static_escape_probe (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+Keeping the 2.4 m/s progress envelope while enabling the static-escape and recenter probes from the faster static-escape candidate may convert some low-progress stalls without adopting the 3.0 m/s fast-progress speed envelope.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `hybrid_rule_local_planner`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_smoke_issue1834/summary.json`
+- Git commit: `fd66bceb514418f6250bbdc601962c2478dd9b99`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.8700 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- No failures recorded.
+
+## Claim Boundary
+
+This report is diagnostic-only wiring or stage evidence. Treat aggregate metrics and baseline deltas as arithmetic context, not benchmark-strength evidence for comfort, near-miss behavior, generalization, or planner superiority.
+
+## Baseline Deltas
+
+_Diagnostic-only arithmetic context; not a benchmark comparison claim._
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |
+
+## Family Override Runs
+
+- `nominal`: success `1.0000`, collision `0.0000`

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -96,6 +96,36 @@ def test_adaptive_proxemic_selector_candidate_is_diagnostic_only() -> None:
     )
 
 
+def test_progress_2p4_static_escape_probe_candidate_is_diagnostic_only() -> None:
+    """Issue #1834 candidate should merge 2.4 m/s progress with static-escape probes."""
+    registry_path = Path(__file__).parents[2] / "docs/context/policy_search/candidate_registry.yaml"
+
+    entry, payload, merged, config_path = load_candidate_definition(
+        registry_path,
+        "hybrid_rule_v3_progress_2p4_static_escape_probe",
+    )
+
+    assert entry["status"] == "experimental_spike"
+    assert entry["claim_scope"] == "diagnostic_only"
+    assert entry["issue"] == 1834
+    assert payload["algo"] == "hybrid_rule_local_planner"
+    assert merged["planner_variant"] == "hybrid_rule_v3_teb_like_rollout"
+    assert merged["route_guide_enabled"] is True
+    assert merged["max_linear_speed"] == pytest.approx(2.4)
+    assert merged["max_linear_accel"] == pytest.approx(2.4)
+    assert merged["static_clearance_escape_enabled"] is True
+    assert merged["static_recenter_enabled"] is True
+    assert merged["static_corridor_transit_enabled"] is True
+    assert merged["static_clearance_escape_max_speed"] == pytest.approx(0.3)
+    assert merged["static_recenter_weight"] == pytest.approx(0.7)
+    assert (
+        config_path
+        == Path(
+            "configs/policy_search/candidates/hybrid_rule_v3_progress_2p4_static_escape_probe.yaml"
+        ).resolve()
+    )
+
+
 def test_split_scenarios_by_family_uses_name_when_scenario_id_is_missing() -> None:
     """Scenario names should drive family inference when scenario_id is absent."""
     grouped = split_scenarios_by_family(


### PR DESCRIPTION
## Summary
- Add `hybrid_rule_v3_progress_2p4_static_escape_probe` as a diagnostic-only policy-search candidate for #1834.
- Reuse the 2.4 m/s progress envelope with static-escape/recenter probes from the faster static-escape family.
- Record smoke and nominal-sanity reports, including the negative nominal interpretation.

Closes #1834.

## Observed Result
- Smoke: pass, 1/1 success, 0 collision, 0 near miss.
- Nominal sanity: revise, 18 episodes, success `0.2222`, collision `0.0000`, near miss `0.2778`, `timeout_low_progress: 10`.
- Interpretation: this wires a runnable diagnostic probe, but it does **not** repair the 2.4 m/s progress regression. It preserves the old 2p4 nominal success rate (`0.2222`) and zero collisions, but near misses worsen versus the ledger value (`0.1667` -> `0.2778`).

## Validation
- `uv run pytest tests/validation/test_run_policy_search_candidate.py -k "progress_2p4_static_escape_probe" -q`
- `uv run ruff check tests/validation/test_run_policy_search_candidate.py`
- `uv run ruff format tests/validation/test_run_policy_search_candidate.py --check`
- `uv run python scripts/validation/validate_policy_search_registry.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `LOGURU_LEVEL=WARNING uv run python scripts/validation/run_policy_search_candidate.py --candidate hybrid_rule_v3_progress_2p4_static_escape_probe --stage smoke --workers 1 --output-dir output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_smoke_issue1834`
- `LOGURU_LEVEL=WARNING uv run python scripts/validation/run_policy_search_candidate.py --candidate hybrid_rule_v3_progress_2p4_static_escape_probe --stage nominal_sanity --workers 1 --output-dir output/policy_search/hybrid_rule_v3_progress_2p4_static_escape_probe_nominal_issue1834_final`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4618 passed, 11 skipped)

## Notes
- This is intentionally diagnostic-only; no benchmark-strength or promotion claim is made.
- Generated `output/*` artifacts remain ignored and disposable; tracked reports point to the exact local output paths used for this validation.
