### PR TITLE
feat: expose planner summary in step diagnostics

### DIFF
--- a/scripts/validation/run_policy_search_step_diagnostics.py
+++ b/scripts/validation/run_policy_search_step_diagnostics.py
@@ -247,6 +247,41 @@ def _trace_progress_summary(
     }
 
 
+def _format_planner_summary_lines(planner_summary: Any) -> list[str]:
+    """Return Markdown lines for the aggregate planner diagnostics summary."""
+    summary = _json_ready(planner_summary)
+    lines = ["## Planner Summary", ""]
+    if summary is None:
+        return [*lines, "- Planner summary: `null`"]
+    if not isinstance(summary, dict):
+        return [*lines, f"- Planner summary: `{summary}`"]
+    if not summary:
+        return [*lines, "- Planner summary: `{}`"]
+    for key, value in sorted(summary.items()):
+        if isinstance(value, (dict, list)):
+            rendered = json.dumps(value, sort_keys=True)
+        else:
+            rendered = str(value)
+        lines.append(f"- `{key}`: `{rendered}`")
+    return lines
+
+
+def _diagnostics_stdout_payload(
+    *,
+    metadata: dict[str, Any],
+    progress_summary: dict[str, Any],
+    planner_summary: Any,
+    done_info: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the stable machine-readable diagnostics CLI payload."""
+    return {
+        **_json_ready(metadata),
+        "progress_summary": _json_ready(progress_summary),
+        "planner_summary": _json_ready(planner_summary),
+        "done_info": _json_ready(done_info),
+    }
+
+
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -525,6 +560,8 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "",
         f"- Done info: `{_json_ready(done_info)}`",
         "",
+        *_format_planner_summary_lines(planner_summary),
+        "",
         "## Progress/Risk Summary",
         "",
         f"- Net goal progress: `{_format_summary_float(progress_summary['net_goal_progress'])}`",
@@ -564,22 +601,21 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
     report_path = output_dir / "report.md"
     report_path.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
 
-    print(
-        json.dumps(
-            {
-                "trace": str(trace_path),
-                "report": str(report_path),
-                "scenario_id": _scenario_id(scenario),
-                "family": family,
-                "seed": seed,
-                "decision_counts": dict(decision_counter),
-                "selected_head_counts": dict(selected_head_counter),
-                "progress_summary": _json_ready(progress_summary),
-                "done_info": _json_ready(done_info),
-            },
-            indent=2,
-        )
+    payload = _diagnostics_stdout_payload(
+        metadata={
+            "trace": trace_path,
+            "report": report_path,
+            "scenario_id": _scenario_id(scenario),
+            "family": family,
+            "seed": seed,
+            "decision_counts": dict(decision_counter),
+            "selected_head_counts": dict(selected_head_counter),
+        },
+        progress_summary=progress_summary,
+        planner_summary=planner_summary,
+        done_info=done_info,
     )
+    print(json.dumps(payload, indent=2))
     return 0
 
 

--- a/tests/validation/test_run_policy_search_step_diagnostics.py
+++ b/tests/validation/test_run_policy_search_step_diagnostics.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.validation.run_policy_search_step_diagnostics import _trace_progress_summary
+from scripts.validation.run_policy_search_step_diagnostics import (
+    _diagnostics_stdout_payload,
+    _format_planner_summary_lines,
+    _trace_progress_summary,
+)
 
 
 def test_trace_progress_summary_exposes_progress_stagnation_and_risk() -> None:
@@ -149,3 +153,41 @@ def test_trace_progress_summary_missing_steps_break_stagnant_runs() -> None:
 
     assert summary["stagnant_step_count"] == 2
     assert summary["longest_stagnant_run"] == 1
+
+
+def test_planner_summary_lines_render_nested_diagnostics() -> None:
+    """Markdown reports should expose planner summaries without opening trace JSON."""
+    lines = _format_planner_summary_lines(
+        {
+            "calls": 4,
+            "selected_sources": {"route_guide": 2, "dynamic_window": 2},
+        }
+    )
+
+    assert lines == [
+        "## Planner Summary",
+        "",
+        "- `calls`: `4`",
+        '- `selected_sources`: `{"dynamic_window": 2, "route_guide": 2}`',
+    ]
+
+
+def test_stdout_payload_includes_planner_summary(tmp_path) -> None:
+    """Machine-readable stdout should surface the aggregate planner diagnostics."""
+    payload = _diagnostics_stdout_payload(
+        metadata={
+            "trace": tmp_path / "trace.json",
+            "report": tmp_path / "report.md",
+            "scenario_id": "planner_sanity_simple",
+            "family": "nominal",
+            "seed": 111,
+            "decision_counts": {"fallback": 1},
+            "selected_head_counts": {"risk_dwa": 1},
+        },
+        progress_summary={"steps_observed": 1},
+        planner_summary={"fallback_count": 1},
+        done_info={"success": False},
+    )
+
+    assert payload["planner_summary"] == {"fallback_count": 1}
+    assert payload["progress_summary"] == {"steps_observed": 1}


### PR DESCRIPTION
## Summary
Exposes `planner_summary` in the step-diagnostics stdout JSON and Markdown report so one-shot planner diagnostics no longer require opening `trace.json` for aggregate planner signals.

## Linked Issues
- Closes `#1840`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added JSON-safe formatting helpers for planner summaries in `scripts/validation/run_policy_search_step_diagnostics.py`.
- Added a concise `## Planner Summary` section to generated reports.
- Included `planner_summary` in the final machine-readable stdout payload while keeping existing `trace.json` content compatible.
- Added focused unit coverage for nested summary rendering and stdout payload shape.

## Why It Matters
- Added value: planner aggregate diagnostics are visible in the same report/stdout surfaces used by smoke and nominal search-policy probes.
- Expected impact: faster triage for exploratory local-planner candidates without changing planner semantics.
- Why this is worth merging now: recent planner-search work is producing many one-shot diagnostics, and this removes a small but repeated inspection step.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/validation/test_run_policy_search_step_diagnostics.py -q`
  - `uv run ruff check scripts/validation/run_policy_search_step_diagnostics.py tests/validation/test_run_policy_search_step_diagnostics.py`
  - `uv run ruff format scripts/validation/run_policy_search_step_diagnostics.py tests/validation/test_run_policy_search_step_diagnostics.py --check`
  - `git diff --check`
  - `LOGURU_LEVEL=ERROR uv run python scripts/validation/run_policy_search_step_diagnostics.py --candidate topology_guided_hybrid_rule_v0 --stage smoke --output-dir /tmp/issue1840_step_diag > /tmp/issue1840_step_diag/stdout.json`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted tests passed: `6 passed`.
  - Real smoke diagnostics produced `planner_summary` in stdout, `planner_summary` in trace, and `## Planner Summary` in report.
  - Full readiness passed: `4626 passed, 11 skipped`.
- Benchmarks or smoke tests, if applicable:
  - Smoke diagnostics command above was used only to verify output surfaces, not to make a planner-performance claim.

## Risks / Rollout
- Compatibility risks: low; `trace.json` remains backward-compatible and existing stdout fields are preserved.
- Failure modes: planners with missing summaries render an explicit null/empty section.
- Rollback or fallback plan: revert the helper/report/stdout additions; trace-level summary remains available.

## Docs / Provenance
- Updated docs: none; CLI output behavior is covered by tests and PR proof.
- Relevant design or provenance notes: issue #1840 records the output-surface gap.
- Any assumptions that need to be preserved: this does not change planner diagnostic content or semantics.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: workflow output-surface change only; no benchmark, registry, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify that stdout remains machine-readable and that the report section is concise enough for repeated diagnostic runs.
- Known limitations: planner summaries are only as informative as the planner-provided diagnostics.
