### PR TITLE
fix: make PR readiness final mode head-aware

### DIFF
--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -27,9 +27,12 @@ classified.
 - Current branch head differs from stale readiness stamps (freshness required).
 
 Freshness check:
-- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main`
-- If stale/failing, rerun `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`; the wrapper
-  records freshness after all gates pass.
+- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree`
+- If stale/failing, rerun
+  `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`; the wrapper records
+  clean committed-HEAD freshness after all gates pass.
+- Use plain `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` only for interim dirty-tree
+  feedback before PR handoff.
 
 ## Workflow
 

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -148,8 +148,12 @@ Use the repository gates before higher-risk PRs are opened:
 - `scripts/dev/ruff_fix_format.sh`
 - `scripts/dev/run_tests_parallel.sh`
 - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
+- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
 
-The standard readiness flow is fail-fast and failed-first by default. If a failure appears, assess test value first before changing or removing tests.
+The standard readiness flow is fail-fast and failed-first by default. Use the plain command for
+interim feedback while the tree may still be dirty. Use `PR_READY_MODE=final` before PR handoff;
+it fails instead of recording final readiness when non-ignored files are uncommitted. If a failure
+appears, assess test value first before changing or removing tests.
 
 For docs-only and low-risk instruction branches, use the cheaper official path by default: inspect
 the diff, verify referenced paths where practical, and state in the PR when the full readiness gate

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -193,6 +193,7 @@ scripts/dev/run_ci_local.sh
 scripts/dev/check_docs_proof_consistency_diff.sh
 scripts/dev/sbatch_use_max_time.sh SLURM/Auxme/auxme_gpu.sl
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 uv run python scripts/dev/complexity_runtime_baseline.py --top 10 robot_sf scripts tests
 uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run-id> --top 10
 scripts/dev/gh_comment.sh pr --current <<'EOF'
@@ -211,9 +212,15 @@ share the same phase definitions (`lint`, `typecheck`, `test`, `smoke`, and
 `scripts/dev/run_ci_local.sh --no-setup lint test` for faster repeat local feedback.
 
 Before opening a PR, fetch the latest `origin/main`, integrate it into the feature branch with
-either merge or rebase, and only then run `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
-The `BASE_REF` value tells the readiness gate what to compare against; it does not update the
-feature branch by itself, so validation from before the latest-main sync is stale for PR creation.
+either merge or rebase, and only then run
+`PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
+Final mode refuses to write readiness evidence unless the non-ignored worktree is clean, so the
+stamp represents committed `HEAD` rather than an interim dirty-tree check. Plain
+`BASE_REF=origin/main scripts/dev/pr_ready_check.sh` remains useful for local feedback while edits
+are in progress; if it records a dirty-tree stamp, treat that stamp as interim and rerun final mode
+after committing. The `BASE_REF` value tells the readiness gate what to compare against; it does
+not update the feature branch by itself, so validation from before the latest-main sync is stale for
+PR creation.
 Do not wait until PR creation to pick up `main` branch improvements on long-lived feature branches;
 merge latest `origin/main` into the current branch when active work starts, then sync again before
 opening the PR.

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -19,9 +19,11 @@ worktree_state() {
   fi
 }
 
-case "${PR_READY_MODE,,}" in
+pr_ready_mode_lower=$(printf '%s' "$PR_READY_MODE" | tr '[:upper:]' '[:lower:]')
+case "$pr_ready_mode_lower" in
   "")
-    case "${PR_READY_FINAL,,}" in
+    pr_ready_final_lower=$(printf '%s' "$PR_READY_FINAL" | tr '[:upper:]' '[:lower:]')
+    case "$pr_ready_final_lower" in
       1|true|yes|on) pr_ready_final=1 ;;
       0|false|no|off) pr_ready_final=0 ;;
       *)

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -8,10 +8,54 @@ source "$SCRIPT_DIR/common_setup.sh"
 export BASE_REF="${BASE_REF:-origin/main}"
 export MIN_COVERAGE="${MIN_COVERAGE:-80}"
 export GOAL_COVERAGE="${GOAL_COVERAGE:-100}"
+export PR_READY_FINAL="${PR_READY_FINAL:-0}"
+export PR_READY_MODE="${PR_READY_MODE:-}"
+
+worktree_state() {
+  if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    printf 'dirty\n'
+  else
+    printf 'clean\n'
+  fi
+}
+
+case "${PR_READY_MODE,,}" in
+  "")
+    case "${PR_READY_FINAL,,}" in
+      1|true|yes|on) pr_ready_final=1 ;;
+      0|false|no|off) pr_ready_final=0 ;;
+      *)
+        printf 'Invalid PR_READY_FINAL value %q (expected 1|0|true|false|yes|no|on|off).\n' "$PR_READY_FINAL" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  final) pr_ready_final=1 ;;
+  interim) pr_ready_final=0 ;;
+  *)
+    printf 'Invalid PR_READY_MODE value %q (expected final|interim).\n' "$PR_READY_MODE" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$pr_ready_final" == "1" && "$(worktree_state)" != "clean" ]]; then
+  printf 'Final PR readiness requires a clean non-ignored worktree before validation.\n' >&2
+  printf 'Commit or remove local changes, or run without PR_READY_MODE=final for interim feedback.\n' >&2
+  git status --short --untracked-files=normal >&2
+  exit 2
+fi
 
 "$SCRIPT_DIR/ruff_fix_format.sh"
 "$SCRIPT_DIR/run_tests_parallel.sh"
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"
-uv run python "$SCRIPT_DIR/pr_ready_freshness.py" write --base-ref "$BASE_REF"
+
+freshness_args=(write --base-ref "$BASE_REF")
+if [[ "$pr_ready_final" == "1" ]]; then
+  freshness_args+=(--require-clean-tree)
+elif [[ "$(worktree_state)" != "clean" ]]; then
+  printf 'Warning: recording interim PR readiness from a dirty non-ignored worktree.\n' >&2
+  printf 'Use PR_READY_MODE=final BASE_REF=%q %q for final committed-HEAD PR proof.\n' "$BASE_REF" "$0" >&2
+fi
+uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"

--- a/scripts/dev/pr_ready_freshness.py
+++ b/scripts/dev/pr_ready_freshness.py
@@ -41,6 +41,17 @@ def _head_sha() -> str:
     return _run_git(["rev-parse", "HEAD"])
 
 
+def _tree_state() -> str:
+    """Return whether the current non-ignored worktree has uncommitted changes.
+
+    Returns:
+        ``"clean"`` when tracked, staged, and untracked non-ignored files are absent;
+        otherwise ``"dirty"``.
+    """
+    status = _run_git(["status", "--porcelain", "--untracked-files=normal"])
+    return "dirty" if status else "clean"
+
+
 def _sanitize_branch(branch: str) -> str:
     """Convert a branch name into a safe readiness-stamp filename stem.
 
@@ -89,19 +100,33 @@ def _write_stamp(
     branch: str,
     base_ref: str,
     head_sha: str,
+    tree_state: str,
     status: str,
+    require_clean_tree: bool,
 ) -> dict[str, Any]:
     """Write a readiness stamp for the current branch and HEAD.
 
     Returns:
         Stamp payload written to disk.
     """
+    if require_clean_tree and tree_state != "clean":
+        return {
+            "ok": False,
+            "reason": "dirty_worktree",
+            "branch": branch,
+            "base_ref": base_ref,
+            "head_sha": head_sha,
+            "tree_state": tree_state,
+            "stamp_path": str(path),
+        }
+
     payload = {
         "branch": branch,
         "base_ref": base_ref,
         "head_sha": head_sha,
         "recorded_at_utc": datetime.now(UTC).isoformat(),
         "status": status,
+        "tree_state": tree_state,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -114,6 +139,8 @@ def _freshness_result(
     branch: str,
     base_ref: str,
     head_sha: str,
+    tree_state: str | None,
+    require_clean_tree: bool,
     max_age_hours: float,
 ) -> tuple[bool, dict[str, Any]]:
     """Check whether an existing readiness stamp matches the current context.
@@ -127,8 +154,13 @@ def _freshness_result(
         "branch": branch,
         "base_ref": base_ref,
         "head_sha": head_sha,
+        "tree_state": tree_state,
+        "require_clean_tree": require_clean_tree,
         "max_age_hours": max_age_hours,
     }
+    if require_clean_tree and tree_state is not None and tree_state != "clean":
+        result["reason"] = "dirty_worktree"
+        return False, result
     if not path.exists():
         result["reason"] = "missing"
         return False, result
@@ -141,6 +173,10 @@ def _freshness_result(
         return False, result
 
     result["stamp"] = stamp
+    if require_clean_tree and stamp.get("tree_state") != "clean":
+        result["reason"] = "stamp_tree_state_not_clean"
+        return False, result
+
     checks = [
         ("status", "passed", "status_not_passed"),
         ("branch", branch, "branch_mismatch"),
@@ -191,6 +227,12 @@ def _build_parser() -> argparse.ArgumentParser:
     status_parser.add_argument("--branch")
     status_parser.add_argument("--head-sha")
     status_parser.add_argument("--stamp-path")
+    status_parser.add_argument("--tree-state", choices=("clean", "dirty"))
+    status_parser.add_argument(
+        "--require-clean-tree",
+        action="store_true",
+        help="Require both the current worktree and recorded stamp to be clean.",
+    )
     status_parser.add_argument("--max-age-hours", type=float, default=24.0)
 
     write_parser = subparsers.add_parser(
@@ -201,6 +243,12 @@ def _build_parser() -> argparse.ArgumentParser:
     write_parser.add_argument("--branch")
     write_parser.add_argument("--head-sha")
     write_parser.add_argument("--stamp-path")
+    write_parser.add_argument("--tree-state", choices=("clean", "dirty"))
+    write_parser.add_argument(
+        "--require-clean-tree",
+        action="store_true",
+        help="Fail instead of writing final readiness evidence from a dirty worktree.",
+    )
     write_parser.add_argument("--status", default="passed")
 
     return parser
@@ -213,6 +261,7 @@ def main() -> int:
 
     branch = args.branch or _current_branch()
     head_sha = args.head_sha or _head_sha()
+    tree_state = args.tree_state or _tree_state()
     stamp_path = _resolve_stamp_path(args.stamp_path, branch)
 
     if args.command == "write":
@@ -221,8 +270,13 @@ def main() -> int:
             branch=branch,
             base_ref=args.base_ref,
             head_sha=head_sha,
+            tree_state=tree_state,
             status=args.status,
+            require_clean_tree=args.require_clean_tree,
         )
+        if not payload.get("ok", True):
+            _json_dump(payload)
+            return 2
         _json_dump(
             {
                 "ok": True,
@@ -237,6 +291,8 @@ def main() -> int:
         branch=branch,
         base_ref=args.base_ref,
         head_sha=head_sha,
+        tree_state=tree_state,
+        require_clean_tree=args.require_clean_tree,
         max_age_hours=args.max_age_hours,
     )
     _json_dump(payload)

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -155,8 +155,23 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     for gate in expected_gates:
         assert gate in script_text
 
-    freshness_call = 'uv run python "$SCRIPT_DIR/pr_ready_freshness.py" write'
+    freshness_call = 'uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"'
+    assert 'freshness_args=(write --base-ref "$BASE_REF")' in script_text
     assert freshness_call in script_text
     assert script_text.rfind(freshness_call) > max(
         script_text.rfind(gate) for gate in expected_gates
     )
+
+
+def test_pr_ready_check_exposes_final_committed_head_mode() -> None:
+    """Final PR proof should fail closed on dirty trees and mark clean-tree stamps."""
+    script_text = PR_READY_CHECK.read_text(encoding="utf-8")
+
+    assert "PR_READY_MODE" in script_text
+    assert "PR_READY_FINAL" in script_text
+    assert "final) pr_ready_final=1" in script_text
+    assert "interim) pr_ready_final=0" in script_text
+    assert "Final PR readiness requires a clean non-ignored worktree" in script_text
+    assert "recording interim PR readiness from a dirty non-ignored worktree" in script_text
+    assert "--require-clean-tree" in script_text
+    assert "pr_ready_freshness.py" in script_text

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -169,6 +169,8 @@ def test_pr_ready_check_exposes_final_committed_head_mode() -> None:
 
     assert "PR_READY_MODE" in script_text
     assert "PR_READY_FINAL" in script_text
+    assert ",," not in script_text
+    assert "tr '[:upper:]' '[:lower:]'" in script_text
     assert "final) pr_ready_final=1" in script_text
     assert "interim) pr_ready_final=0" in script_text
     assert "Final PR readiness requires a clean non-ignored worktree" in script_text

--- a/tests/tools/test_pr_open_readiness.py
+++ b/tests/tools/test_pr_open_readiness.py
@@ -76,6 +76,90 @@ def test_pr_ready_freshness_write_then_status_succeeds(tmp_path: Path) -> None:
     payload = json.loads(status_result.stdout)
     assert payload["fresh"] is True
     assert payload["reason"] == "fresh"
+    assert payload["stamp"]["tree_state"] in {"clean", "dirty"}
+
+
+def test_pr_ready_freshness_write_records_explicit_tree_state(tmp_path: Path) -> None:
+    """Readiness stamps should preserve whether the proof came from a dirty tree."""
+    stamp_path = tmp_path / "ready.json"
+
+    result = _run(
+        "write",
+        "--branch",
+        "codex/1844-final-readiness",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--tree-state",
+        "dirty",
+        "--stamp-path",
+        str(stamp_path),
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["stamp"]["tree_state"] == "dirty"
+
+
+def test_pr_ready_freshness_require_clean_rejects_dirty_write(tmp_path: Path) -> None:
+    """Final readiness mode must fail closed instead of recording dirty-tree proof."""
+    stamp_path = tmp_path / "ready.json"
+
+    result = _run(
+        "write",
+        "--branch",
+        "codex/1844-final-readiness",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--tree-state",
+        "dirty",
+        "--require-clean-tree",
+        "--stamp-path",
+        str(stamp_path),
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["reason"] == "dirty_worktree"
+    assert not stamp_path.exists()
+
+
+def test_pr_ready_freshness_require_clean_rejects_dirty_stamp(tmp_path: Path) -> None:
+    """Final freshness checks should not accept older interim dirty-tree stamps."""
+    stamp_path = tmp_path / "ready.json"
+    payload = {
+        "branch": "codex/1844-final-readiness",
+        "base_ref": "origin/main",
+        "head_sha": "abc123",
+        "recorded_at_utc": datetime.now(UTC).isoformat(),
+        "status": "passed",
+        "tree_state": "dirty",
+    }
+    stamp_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run(
+        "status",
+        "--branch",
+        "codex/1844-final-readiness",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--tree-state",
+        "clean",
+        "--require-clean-tree",
+        "--stamp-path",
+        str(stamp_path),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["fresh"] is False
+    assert payload["reason"] == "stamp_tree_state_not_clean"
 
 
 def test_pr_ready_freshness_rejects_mismatched_head(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds an explicit final PR-readiness mode that binds readiness evidence to a clean committed branch head while preserving the existing dirty-tree flow for interim local feedback.

## Linked Issues
- Closes `#1844`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `PR_READY_MODE=final` / `PR_READY_FINAL=1` support to `scripts/dev/pr_ready_check.sh`.
- Final mode fails before expensive gates when the non-ignored worktree is dirty, then passes `--require-clean-tree` when writing the freshness stamp.
- Default/interim mode remains usable and emits a warning when it records a dirty-tree readiness stamp.
- `scripts/dev/pr_ready_freshness.py` now records `tree_state` and can reject dirty current trees or dirty recorded stamps with `--require-clean-tree`.
- Updated PR-opener workflow docs and developer/AI docs to distinguish interim feedback from final committed-HEAD PR proof.
- Added focused tests for freshness tree-state recording, dirty write rejection, dirty-stamp rejection, and shell wrapper contract.

## Why It Matters
- Added value: agents and maintainers can tell whether readiness evidence came from committed `HEAD` or an interim dirty worktree.
- Expected impact: fewer stale or misleading PR validation claims after branch/head changes.
- Why this is worth merging now: recent PR churn showed local gates can become stale or ambiguous before PR handoff.

## Validation / Proof
- Commands run:
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` on dirty tree: failed fast with `Final PR readiness requires a clean non-ignored worktree before validation.`
  - `uv run pytest tests/tools/test_pr_open_readiness.py tests/test_ci_script_contract.py -q`
  - `uv run ruff check scripts/dev/pr_ready_freshness.py tests/tools/test_pr_open_readiness.py tests/test_ci_script_contract.py`
  - `uv run ruff format scripts/dev/pr_ready_freshness.py tests/tools/test_pr_open_readiness.py tests/test_ci_script_contract.py --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `uv sync --all-extras`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused tests passed: `17 passed`.
  - Final-mode full readiness passed on committed `HEAD`: `4659 passed, 11 skipped`.
  - Final readiness stamp recorded `tree_state: clean` for head `86fa8323705f6b40d7f3895159c35c2a4bed21fd`.
- Benchmarks or smoke tests, if applicable: NA, workflow-only change.

## Risks / Rollout
- Compatibility risks: low; default `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` remains available for interim checks.
- Failure modes: final mode can fail early when generated non-ignored files are present; this is intentional for PR handoff proof.
- Rollback or fallback plan: remove final-mode branching and tree-state checks; existing stamp behavior remains otherwise compatible.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`, `docs/ai/ai-workflow.md`, `.agents/skills/gh-pr-opener/SKILL.md`.
- Relevant design or provenance notes: issue #1844.
- Any assumptions that need to be preserved: final PR proof should use `PR_READY_MODE=final`; dirty-tree proof is interim only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via `Closes #1844`
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: workflow validation change only; no benchmark or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify that final mode remains opt-in and default interim behavior is still usable.
- Verify `tree_state` handling in `pr_ready_freshness.py` is strict only when `--require-clean-tree` is requested.
