### PR TITLE
refactor: centralize local model artifact preflight

### DIFF
--- a/docs/context/issue_1638_model_path_preflight.md
+++ b/docs/context/issue_1638_model_path_preflight.md
@@ -95,6 +95,23 @@ configs under `configs/training/ppo/ablations/`. They are not benchmark-facing b
 remain out of this first preflight gate so developer-only resume experiments are not broken. They
 should still move to `resume_model_id` if those checkpoints become durable dependencies.
 
+## Issue #1847 Centralization Update
+
+Issue #1847 centralized the scanner/runtime contract in:
+
+- `robot_sf/benchmark/local_model_artifacts.py`
+
+The standalone scanner now delegates to that module instead of carrying a second YAML traversal,
+path-prefix predicate, blocklist parser, and promoted-surface parser. Runtime benchmark config
+loaders still call `validate_no_local_model_artifacts`, but the scanner and runtime validator now
+share the same local-only artifact boundary and blocklist metadata.
+
+Direct learned-baseline planners also reject relative `output/model_cache/`, `output/models/`, and
+`output/slurm/` `model_path` values when no `model_id` is configured. This keeps fallback mode from
+turning worktree-local model dependencies into apparently usable benchmark execution. Missing
+non-`output/` paths can still use the existing fallback behavior for local diagnostics; benchmark
+configs that use local `output/` model artifacts fail before planner construction.
+
 ## Validation
 
 Validation commands:

--- a/robot_sf/baselines/drl_vo.py
+++ b/robot_sf/baselines/drl_vo.py
@@ -25,6 +25,7 @@ except ImportError:  # pragma: no cover - envs without PyTorch
     torch = None  # type: ignore[assignment]
 
 from robot_sf.baselines.interface import Observation
+from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.common.math_utils import wrap_angle_pi
 from robot_sf.models import resolve_model_path
@@ -101,6 +102,11 @@ class DrlVoPlanner:
 
     def _load_model(self) -> None:
         """Load the DRL-VO policy model or enter documented fallback mode."""
+        if self.config.model_id is None:
+            validate_no_local_model_path_value(
+                self.config.model_path,
+                owner="DrlVoPlannerConfig",
+            )
         if torch is None:
             warn_soft_degrade(
                 "DRL-VO",

--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -40,6 +40,7 @@ except ImportError:  # pragma: no cover - envs without SB3 installed
     PPO = None  # type: ignore
 
 from robot_sf.baselines.interface import Observation
+from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.models import resolve_model_path
 from robot_sf.planner.predictive_foresight import (
@@ -134,6 +135,11 @@ class PPOPlanner:
 
     def _load_model(self) -> None:
         """Load the PPO model from disk or enter fallback mode."""
+        if self.config.model_id is None:
+            validate_no_local_model_path_value(
+                self.config.model_path,
+                owner="PPOPlannerConfig",
+            )
         if PPO is None:  # pragma: no cover - missing sb3 at runtime
             warn_soft_degrade(
                 "PPO",

--- a/robot_sf/baselines/sac.py
+++ b/robot_sf/baselines/sac.py
@@ -15,6 +15,7 @@ except ImportError:  # pragma: no cover - runtime-only dependency
     SAC = None  # type: ignore
 
 from robot_sf.baselines.interface import Observation
+from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.models import resolve_model_path
 from robot_sf.sensor.socnav_observation import SOCNAV_POSITION_CAP_M
@@ -68,6 +69,11 @@ class SACPlanner:
 
     def _load_model(self) -> None:
         """Load the configured SAC checkpoint or enter explicit fallback mode."""
+        if self.config.model_id is None:
+            validate_no_local_model_path_value(
+                self.config.model_path,
+                owner="SACPlannerConfig",
+            )
         if SAC is None:  # pragma: no cover - runtime dependency
             if self.config.fallback_to_goal:
                 warn_soft_degrade(

--- a/robot_sf/benchmark/local_model_artifacts.py
+++ b/robot_sf/benchmark/local_model_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -10,6 +11,8 @@ import yaml
 LOCAL_MODEL_KEYS = {"model_path", "resume_from"}
 LOCAL_MODEL_PREFIXES = ("output/model_cache/", "output/models/", "output/slurm/")
 DEFAULT_BLOCKLIST_PATH = Path("configs/baselines/local_model_artifact_blocklist.yaml")
+DEFAULT_PROMOTED_SURFACES_PATH = Path("configs/benchmarks/promoted_config_surfaces.yaml")
+PROMOTED_BLOCKED_STATUS = "promoted_blocked"
 
 
 class BlocklistMetadata(NamedTuple):
@@ -17,6 +20,18 @@ class BlocklistMetadata(NamedTuple):
 
     reasons: dict[tuple[str, str, str], str]
     follow_up_issue: str
+
+
+@dataclass(frozen=True)
+class LocalModelReference:
+    """One classified local model path found in a YAML config."""
+
+    path: str
+    field: str
+    value: str
+    status: str
+    reason: str
+    surface: str = "local_experimental"
 
 
 def is_local_output_model_path(value: Any) -> bool:
@@ -63,43 +78,294 @@ def iter_local_model_references(
     return references
 
 
-def _load_blocklist(path: Path) -> BlocklistMetadata:
+def _load_yaml_mapping(path: Path, *, strict: bool) -> dict[str, Any]:
+    """Load a YAML file as a mapping, optionally raising on malformed payloads.
+
+    Returns:
+        Parsed YAML mapping, or an empty mapping for lenient malformed input.
+    """
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if isinstance(payload, dict):
+        return payload
+    if strict:
+        raise ValueError(f"{path}: expected top-level mapping")
+    return {}
+
+
+def _parse_blocklist_entry(
+    entry: Any,
+    *,
+    path: Path,
+    index: int,
+    strict: bool,
+) -> tuple[str, str, str, str] | None:
+    """Parse one blocklist entry into normalized fields.
+
+    Returns:
+        Tuple of ``(config_path, field, value, reason)`` when the entry is valid.
+    """
+    if not isinstance(entry, dict):
+        if strict:
+            raise ValueError(f"{path}: blocked_references[{index}] must be a mapping")
+        return None
+    config_path = str(entry.get("path") or "").strip()
+    field = str(entry.get("field") or "").strip()
+    value = str(entry.get("value") or "").strip()
+    reason = str(entry.get("reason") or "").strip()
+    if config_path and field and value and reason:
+        return config_path, field, value, reason
+    if strict:
+        raise ValueError(
+            f"{path}: blocked_references[{index}] requires path, field, value, and reason"
+        )
+    return None
+
+
+def load_blocklist(path: Path, *, strict: bool = False) -> BlocklistMetadata:
     """Load known blocked local artifacts keyed by config path, field, and value.
+
+    Args:
+        path: YAML blocklist path.
+        strict: Whether malformed blocklists should raise. Runtime benchmark loading keeps this
+            false to preserve the historical fail-closed local-artifact check even when the
+            optional blocklist is absent; scanner/CI entry points use strict mode.
 
     Returns:
         Blocklist metadata with ``(path, field, value)`` blocker reasons.
     """
     if not path.exists():
         return BlocklistMetadata({}, "")
-    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    follow_up_issue = ""
-    if isinstance(payload, dict):
-        follow_up_issue = str(payload.get("follow_up_issue") or "").strip()
+    payload = _load_yaml_mapping(path, strict=strict)
+    if strict and payload.get("version") != 1:
+        raise ValueError(f"{path}: version must be 1")
+    follow_up_issue = str(payload.get("follow_up_issue") or "").strip()
     entries = payload.get("blocked_references") if isinstance(payload, dict) else None
     if not isinstance(entries, list):
+        if strict:
+            raise ValueError(f"{path}: blocked_references must be a list")
         return BlocklistMetadata({}, follow_up_issue)
     blocklist: dict[tuple[str, str, str], str] = {}
-    for entry in entries:
-        if not isinstance(entry, dict):
+    for index, entry in enumerate(entries):
+        parsed = _parse_blocklist_entry(entry, path=path, index=index, strict=strict)
+        if parsed is None:
             continue
-        config_path = str(entry.get("path") or "").strip()
-        field = str(entry.get("field") or "").strip()
-        value = str(entry.get("value") or "").strip()
-        reason = str(entry.get("reason") or "").strip()
-        if config_path and field and value and reason:
-            blocklist[(config_path, field, value)] = reason
+        config_path, field, value, reason = parsed
+        blocklist[(config_path, field, value)] = reason
     return BlocklistMetadata(blocklist, follow_up_issue)
 
 
-def _path_lookup_candidates(path: Path) -> list[str]:
-    """Return stable path spellings for blocklist matching."""
+def _parse_promoted_surface_entry(
+    entry: Any,
+    *,
+    path: Path,
+    index: int,
+    strict: bool,
+) -> tuple[str, str] | None:
+    """Parse one promoted-surface manifest entry.
+
+    Returns:
+        Tuple of ``(config_path, reason)`` when the entry is valid.
+    """
+    if isinstance(entry, str):
+        config_path = entry.strip()
+        reason = "Benchmark-promoted config surface."
+    elif isinstance(entry, dict):
+        config_path = str(entry.get("path") or "").strip()
+        reason = str(entry.get("reason") or "").strip()
+    else:
+        if strict:
+            raise ValueError(f"{path}: promoted_configs[{index}] must be a mapping or string")
+        return None
+    if config_path and reason:
+        return config_path, reason
+    if strict:
+        raise ValueError(f"{path}: promoted_configs[{index}] requires path and reason")
+    return None
+
+
+def load_promoted_surfaces(path: Path, *, strict: bool = True) -> dict[str, str]:
+    """Load benchmark-promoted config paths and their reasons.
+
+    Args:
+        path: YAML promoted-surface manifest path.
+        strict: Whether malformed manifests should raise.
+
+    Returns:
+        Mapping from config path spelling to promotion reason.
+    """
+    if not path.exists():
+        if strict:
+            raise FileNotFoundError(path)
+        return {}
+    payload = _load_yaml_mapping(path, strict=strict)
+    if strict and payload.get("version") != 1:
+        raise ValueError(f"{path}: version must be 1")
+    entries = payload.get("promoted_configs")
+    if not isinstance(entries, list):
+        if strict:
+            raise ValueError(f"{path}: promoted_configs must be a list")
+        return {}
+
+    surfaces: dict[str, str] = {}
+    for index, entry in enumerate(entries):
+        parsed = _parse_promoted_surface_entry(entry, path=path, index=index, strict=strict)
+        if parsed is None:
+            continue
+        config_path, reason = parsed
+        surfaces[config_path] = reason
+    return surfaces
+
+
+def path_lookup_candidates(
+    path: Path,
+    *,
+    repo_root: Path | None = None,
+    cwd: Path | None = None,
+    include_name: bool = False,
+) -> list[str]:
+    """Return stable path spellings for config-surface and blocklist matching."""
     candidates = [path.as_posix()]
-    if path.is_absolute():
+    resolved = path.resolve()
+    if repo_root is not None:
         try:
-            candidates.append(path.relative_to(Path.cwd()).as_posix())
+            candidates.append(resolved.relative_to(repo_root.resolve()).as_posix())
         except ValueError:
             pass
+    if path.is_absolute():
+        base = cwd.resolve() if cwd is not None else Path.cwd().resolve()
+        try:
+            candidates.append(resolved.relative_to(base).as_posix())
+        except ValueError:
+            pass
+    if include_name:
+        candidates.append(path.name)
     return list(dict.fromkeys(candidates))
+
+
+def display_path(path: Path, *, repo_root: Path | None = None) -> str:
+    """Return a stable display path, preferring a repository-relative spelling."""
+    if repo_root is not None:
+        try:
+            return path.resolve().relative_to(repo_root.resolve()).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def iter_yaml_files(paths: list[Path]) -> list[Path]:
+    """Expand scan roots into sorted YAML files.
+
+    Args:
+        paths: YAML files or directories to scan.
+
+    Returns:
+        YAML files to inspect.
+    """
+    files: set[Path] = set()
+    for path in paths:
+        if path.is_dir():
+            files.update(path.rglob("*.yaml"))
+            files.update(path.rglob("*.yml"))
+        elif path.suffix.lower() in {".yaml", ".yml"}:
+            files.add(path)
+    return sorted(files)
+
+
+def classify_local_model_references(
+    scan_paths: list[Path],
+    *,
+    repo_root: Path,
+    blocklist_path: Path = DEFAULT_BLOCKLIST_PATH,
+    promoted_surfaces_path: Path = DEFAULT_PROMOTED_SURFACES_PATH,
+) -> list[LocalModelReference]:
+    """Inspect YAML configs and classify local model references.
+
+    Args:
+        scan_paths: YAML files or directories to scan.
+        repo_root: Repository root used for path display and repo-relative manifests.
+        blocklist_path: Explicit blocker manifest for unresolved local artifacts.
+        promoted_surfaces_path: Manifest of configs that must never use local artifact paths.
+
+    Returns:
+        Classified local artifact references.
+    """
+    blocklist = load_blocklist(blocklist_path, strict=True)
+    promoted_surfaces = load_promoted_surfaces(promoted_surfaces_path, strict=True)
+    follow_up_issue = blocklist.follow_up_issue or "https://github.com/ll7/robot_sf_ll7/issues/1764"
+    expanded_scan_paths = list(scan_paths)
+    expanded_scan_paths.extend(
+        path if path.is_absolute() else repo_root / path
+        for path in (Path(path) for path in promoted_surfaces)
+    )
+
+    rows: list[LocalModelReference] = []
+    for yaml_path in iter_yaml_files(expanded_scan_paths):
+        if yaml_path.resolve() == blocklist_path.resolve():
+            continue
+        rel_path = display_path(yaml_path, repo_root=repo_root)
+        lookup_paths = path_lookup_candidates(
+            yaml_path,
+            repo_root=repo_root,
+            cwd=Path.cwd(),
+            include_name=True,
+        )
+        promoted_reason = next(
+            (
+                promoted_surfaces[candidate]
+                for candidate in lookup_paths
+                if candidate in promoted_surfaces
+            ),
+            "",
+        )
+        payload = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        for field, value in iter_local_model_references(payload):
+            if promoted_reason:
+                rows.append(
+                    LocalModelReference(
+                        rel_path,
+                        field,
+                        value,
+                        PROMOTED_BLOCKED_STATUS,
+                        (
+                            f"{promoted_reason} Replace the local output/ reference with a "
+                            "durable model_id or artifact pointer before using it as a promoted "
+                            f"benchmark config. Follow-up: {follow_up_issue}"
+                        ),
+                        "benchmark_promoted",
+                    )
+                )
+                continue
+            reason = blocklist.reasons.get((rel_path, field, value))
+            if reason:
+                rows.append(LocalModelReference(rel_path, field, value, "blocked", reason))
+            else:
+                rows.append(
+                    LocalModelReference(
+                        rel_path,
+                        field,
+                        value,
+                        "unblocked",
+                        "replace with model_id or add an explicit artifact-promotion blocker",
+                        "local_experimental",
+                    )
+                )
+    return rows
+
+
+def validate_no_local_model_path_value(
+    value: Any,
+    *,
+    field: str = "model_path",
+    owner: str = "planner config",
+) -> None:
+    """Raise when a direct planner model path points at local ``output/`` artifacts."""
+    if not is_local_output_model_path(value):
+        return
+    raise ValueError(
+        f"{owner}:{field} points at local-only model artifact {str(value).strip()!r}. "
+        "Local output/ artifacts are not durable across checkouts; use model_id or a "
+        "tracked/durable artifact pointer instead."
+    )
 
 
 def validate_no_local_model_artifacts(
@@ -122,8 +388,8 @@ def validate_no_local_model_artifacts(
     if not references:
         return
 
-    blocklist = _load_blocklist(blocklist_path)
-    lookup_paths = _path_lookup_candidates(config_path)
+    blocklist = load_blocklist(blocklist_path)
+    lookup_paths = path_lookup_candidates(config_path, cwd=Path.cwd())
     display_path = lookup_paths[-1]
     messages: list[str] = []
     for field, value in references:

--- a/scripts/validation/check_local_model_artifacts.py
+++ b/scripts/validation/check_local_model_artifacts.py
@@ -10,164 +10,18 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-import yaml
+from robot_sf.benchmark.local_model_artifacts import (
+    PROMOTED_BLOCKED_STATUS,
+    LocalModelReference,
+    classify_local_model_references,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCAN_ROOTS = (REPO_ROOT / "configs/baselines",)
 DEFAULT_BLOCKLIST = REPO_ROOT / "configs/baselines/local_model_artifact_blocklist.yaml"
 DEFAULT_PROMOTED_SURFACES = REPO_ROOT / "configs/benchmarks/promoted_config_surfaces.yaml"
-LOCAL_MODEL_KEYS = {"model_path", "resume_from"}
-PROMOTED_BLOCKED_STATUS = "promoted_blocked"
-
-
-@dataclass(frozen=True)
-class LocalModelReference:
-    """One local model path found in a YAML config."""
-
-    path: str
-    field: str
-    value: str
-    status: str
-    reason: str
-    surface: str = "local_experimental"
-
-
-def _load_yaml(path: Path) -> Any:
-    """Load a YAML file and return the parsed payload."""
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
-
-
-def _is_output_model_path(value: Any) -> bool:
-    """Return whether a scalar points at a local output model artifact."""
-    if not isinstance(value, str):
-        return False
-    normalized = value.strip()
-    return normalized.startswith(("output/model_cache/", "output/models/", "output/slurm/"))
-
-
-def _iter_yaml_files(paths: list[Path]) -> list[Path]:
-    """Expand scan roots into sorted YAML files.
-
-    Returns:
-        list[Path]: YAML files to inspect.
-    """
-    files: set[Path] = set()
-    for path in paths:
-        if path.is_dir():
-            files.update(path.rglob("*.yaml"))
-            files.update(path.rglob("*.yml"))
-        elif path.suffix.lower() in {".yaml", ".yml"}:
-            files.add(path)
-    return sorted(files)
-
-
-def _path_lookup_candidates(path: Path) -> list[str]:
-    """Return stable path spellings for config-surface matching."""
-    candidates = [path.as_posix()]
-    resolved = path.resolve()
-    try:
-        candidates.append(resolved.relative_to(REPO_ROOT).as_posix())
-    except ValueError:
-        pass
-    if path.is_absolute():
-        try:
-            candidates.append(resolved.relative_to(Path.cwd().resolve()).as_posix())
-        except ValueError:
-            pass
-    candidates.append(path.name)
-    return list(dict.fromkeys(candidates))
-
-
-def _display_path(path: Path) -> str:
-    """Return the repository-relative path when available."""
-    try:
-        return path.resolve().relative_to(REPO_ROOT).as_posix()
-    except ValueError:
-        return path.as_posix()
-
-
-def _load_promoted_surfaces(path: Path) -> dict[str, str]:
-    """Load benchmark-promoted config paths and their reasons."""
-    if not path.exists():
-        return {}
-    payload = _load_yaml(path)
-    if not isinstance(payload, dict):
-        raise ValueError(f"{path}: expected top-level mapping")
-    if payload.get("version") != 1:
-        raise ValueError(f"{path}: version must be 1")
-    entries = payload.get("promoted_configs")
-    if not isinstance(entries, list):
-        raise ValueError(f"{path}: promoted_configs must be a list")
-
-    surfaces: dict[str, str] = {}
-    for index, entry in enumerate(entries):
-        if isinstance(entry, str):
-            config_path = entry.strip()
-            reason = "Benchmark-promoted config surface."
-        elif isinstance(entry, dict):
-            config_path = str(entry.get("path") or "").strip()
-            reason = str(entry.get("reason") or "").strip()
-        else:
-            raise ValueError(f"{path}: promoted_configs[{index}] must be a mapping or string")
-        if not config_path or not reason:
-            raise ValueError(f"{path}: promoted_configs[{index}] requires path and reason")
-        surfaces[config_path] = reason
-    return surfaces
-
-
-def _find_local_references(
-    payload: Any, *, path_parts: tuple[str, ...] = ()
-) -> list[tuple[str, str]]:
-    """Return dotted-field/value pairs for local model references."""
-    references: list[tuple[str, str]] = []
-    if isinstance(payload, dict):
-        for key, value in payload.items():
-            key_str = str(key)
-            next_parts = (*path_parts, key_str)
-            if key_str in LOCAL_MODEL_KEYS and _is_output_model_path(value):
-                references.append((".".join(next_parts), str(value).strip()))
-            references.extend(_find_local_references(value, path_parts=next_parts))
-    elif isinstance(payload, list):
-        for index, value in enumerate(payload):
-            references.extend(_find_local_references(value, path_parts=(*path_parts, str(index))))
-    return references
-
-
-def _load_blocklist(path: Path) -> dict[tuple[str, str, str], str]:
-    """Load the explicit local-artifact blocklist.
-
-    Returns:
-        dict[tuple[str, str, str], str]: Mapping from ``(path, field, value)`` to reason.
-    """
-    if not path.exists():
-        return {}
-    payload = _load_yaml(path)
-    if not isinstance(payload, dict):
-        raise ValueError(f"{path}: expected top-level mapping")
-    if payload.get("version") != 1:
-        raise ValueError(f"{path}: version must be 1")
-    entries = payload.get("blocked_references")
-    if not isinstance(entries, list):
-        raise ValueError(f"{path}: blocked_references must be a list")
-
-    blocklist: dict[tuple[str, str, str], str] = {}
-    for index, entry in enumerate(entries):
-        if not isinstance(entry, dict):
-            raise ValueError(f"{path}: blocked_references[{index}] must be a mapping")
-        config_path = str(entry.get("path") or "").strip()
-        field = str(entry.get("field") or "").strip()
-        value = str(entry.get("value") or "").strip()
-        reason = str(entry.get("reason") or "").strip()
-        if not config_path or not field or not value or not reason:
-            raise ValueError(
-                f"{path}: blocked_references[{index}] requires path, field, value, and reason"
-            )
-        blocklist[(config_path, field, value)] = reason
-    return blocklist
 
 
 def check_local_model_artifacts(
@@ -182,61 +36,12 @@ def check_local_model_artifacts(
         list[LocalModelReference]: Classified references. ``status=unblocked`` rows should fail
         preflight; ``status=blocked`` rows are intentionally explicit follow-up work.
     """
-    blocklist = _load_blocklist(blocklist_path)
-    promoted_surfaces = _load_promoted_surfaces(promoted_surfaces_path)
-    expanded_scan_paths = list(scan_paths)
-    expanded_scan_paths.extend(
-        path if path.is_absolute() else REPO_ROOT / path
-        for path in (Path(path) for path in promoted_surfaces)
+    return classify_local_model_references(
+        scan_paths,
+        repo_root=REPO_ROOT,
+        blocklist_path=blocklist_path,
+        promoted_surfaces_path=promoted_surfaces_path,
     )
-    rows: list[LocalModelReference] = []
-    for yaml_path in _iter_yaml_files(expanded_scan_paths):
-        if yaml_path == blocklist_path:
-            continue
-        rel_path = _display_path(yaml_path)
-        lookup_paths = _path_lookup_candidates(yaml_path)
-        promoted_reason = next(
-            (
-                promoted_surfaces[candidate]
-                for candidate in lookup_paths
-                if candidate in promoted_surfaces
-            ),
-            "",
-        )
-        payload = _load_yaml(yaml_path)
-        for field, value in _find_local_references(payload):
-            if promoted_reason:
-                rows.append(
-                    LocalModelReference(
-                        rel_path,
-                        field,
-                        value,
-                        PROMOTED_BLOCKED_STATUS,
-                        (
-                            f"{promoted_reason} Replace the local output/ reference with a "
-                            "durable model_id or artifact pointer before using it as a promoted "
-                            "benchmark config. Follow-up: "
-                            "https://github.com/ll7/robot_sf_ll7/issues/1764"
-                        ),
-                        "benchmark_promoted",
-                    )
-                )
-                continue
-            reason = blocklist.get((rel_path, field, value))
-            if reason:
-                rows.append(LocalModelReference(rel_path, field, value, "blocked", reason))
-            else:
-                rows.append(
-                    LocalModelReference(
-                        rel_path,
-                        field,
-                        value,
-                        "unblocked",
-                        "replace with model_id or add an explicit artifact-promotion blocker",
-                        "local_experimental",
-                    )
-                )
-    return rows
 
 
 def _parse_args() -> argparse.Namespace:

--- a/tests/baselines/test_sac_planner.py
+++ b/tests/baselines/test_sac_planner.py
@@ -47,7 +47,7 @@ def _planner_without_model(*, relative_obs: bool = True) -> SACPlanner:
     """Create a SAC planner with fallback enabled and no loaded model."""
     planner = SACPlanner(
         {
-            "model_path": "output/models/sac/does_not_exist.zip",
+            "model_path": "model/does_not_exist_sac.zip",
             "fallback_to_goal": True,
             "relative_obs": relative_obs,
         }
@@ -101,7 +101,7 @@ def test_planner_handles_missing_sb3_with_fallback(monkeypatch: pytest.MonkeyPat
 
     planner = SACPlanner(
         {
-            "model_path": "output/models/sac/does_not_exist.zip",
+            "model_path": "model/does_not_exist_sac.zip",
             "fallback_to_goal": True,
         }
     )
@@ -109,6 +109,17 @@ def test_planner_handles_missing_sb3_with_fallback(monkeypatch: pytest.MonkeyPat
     meta = planner.get_metadata()
     assert meta["status"] == "fallback"
     assert meta["fallback_reason"] == "sb3_missing"
+
+
+def test_planner_rejects_local_output_model_path_even_with_fallback() -> None:
+    """Direct SAC construction should share the benchmark local-artifact boundary."""
+    with pytest.raises(ValueError, match="local-only model artifact"):
+        SACPlanner(
+            {
+                "model_path": "output/models/sac/does_not_exist.zip",
+                "fallback_to_goal": True,
+            }
+        )
 
 
 def test_planner_missing_model_fails_closed_without_fallback(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -117,6 +117,12 @@ def test_parse_algo_config_reports_blocked_local_artifact_follow_up() -> None:
     assert "DRL-VO default checkpoint" in message
 
 
+def test_build_policy_rejects_sac_default_local_output_model_path() -> None:
+    """Benchmark SAC policy construction should fail closed on local output defaults."""
+    with pytest.raises(ValueError, match="local-only model artifact"):
+        _build_policy("sac", {}, robot_kinematics="holonomic")
+
+
 def test_resolve_policy_search_candidate_runtime_merges_base_and_scenario_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/validation/test_check_local_model_artifacts.py
+++ b/tests/validation/test_check_local_model_artifacts.py
@@ -6,7 +6,9 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
+from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
 from scripts.validation.check_local_model_artifacts import (
     REPO_ROOT,
     check_local_model_artifacts,
@@ -95,6 +97,44 @@ def test_unblocked_local_model_path_fails_preflight(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0].status == "unblocked"
     assert rows[0].field == "model_path"
+
+
+def test_scanner_and_runtime_validator_share_blocklist_contract(tmp_path: Path) -> None:
+    """Scanner rows and benchmark runtime errors should agree on local-artifact blockers."""
+    config = tmp_path / "candidate.yaml"
+    blocklist = tmp_path / "blocklist.yaml"
+    promoted_surfaces = tmp_path / "promoted_surfaces.yaml"
+    config.write_text("model_path: output/model_cache/demo/model.zip\n", encoding="utf-8")
+    blocklist.write_text(
+        f"""
+version: 1
+follow_up_issue: https://github.com/ll7/robot_sf_ll7/issues/1764
+blocked_references:
+  - path: {config.as_posix()}
+    field: model_path
+    value: output/model_cache/demo/model.zip
+    reason: Synthetic local artifact is not durable.
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    promoted_surfaces.write_text("version: 1\npromoted_configs: []\n", encoding="utf-8")
+
+    rows = check_local_model_artifacts(
+        [config],
+        blocklist_path=blocklist,
+        promoted_surfaces_path=promoted_surfaces,
+    )
+
+    assert rows[0].status == "blocked"
+    assert rows[0].reason == "Synthetic local artifact is not durable."
+    with pytest.raises(ValueError, match="Synthetic local artifact is not durable") as exc_info:
+        validate_no_local_model_artifacts(
+            yaml.safe_load(config.read_text(encoding="utf-8")),
+            config_path=config,
+            blocklist_path=blocklist,
+        )
+    assert "https://github.com/ll7/robot_sf_ll7/issues/1764" in str(exc_info.value)
 
 
 def test_promoted_local_model_path_fails_even_when_blocklisted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1847.

- centralizes local `output/` model artifact scanning, blocklist parsing, promoted-surface parsing, and runtime validation in `robot_sf/benchmark/local_model_artifacts.py`
- turns `scripts/validation/check_local_model_artifacts.py` into a thin CLI wrapper over the shared contract
- makes direct PPO/SAC/DRL-VO learned-baseline model loading reject relative `output/model_cache/`, `output/models/`, and `output/slurm/` `model_path` values when no `model_id` is configured, so fallback mode cannot hide non-durable benchmark dependencies
- records the centralized contract in `docs/context/issue_1638_model_path_preflight.md`

## Validation

- `uv run pytest tests/validation/test_check_local_model_artifacts.py -q` -> 11 passed
- `uv run pytest tests/benchmark/test_map_runner_utils.py::test_parse_algo_config_rejects_local_output_model_path tests/benchmark/test_map_runner_utils.py::test_parse_algo_config_reports_blocked_local_artifact_follow_up tests/benchmark/test_map_runner_utils.py::test_build_policy_rejects_sac_default_local_output_model_path tests/baselines/test_sac_planner.py::test_planner_rejects_local_output_model_path_even_with_fallback tests/baselines/test_sac_planner.py::test_planner_handles_missing_sb3_with_fallback -q` -> 5 passed
- `uv run pytest tests/validation/test_check_local_model_artifacts.py tests/benchmark/test_map_runner_utils.py tests/baselines/test_sac_planner.py tests/baselines/test_ppo_planner.py tests/planner/test_drl_vo.py -q -k 'not drl_vo_runner_integration_policy'` -> 155 passed, 1 deselected
- `uv run ruff check robot_sf/benchmark/local_model_artifacts.py scripts/validation/check_local_model_artifacts.py robot_sf/baselines/sac.py robot_sf/baselines/ppo.py robot_sf/baselines/drl_vo.py tests/validation/test_check_local_model_artifacts.py tests/baselines/test_sac_planner.py tests/benchmark/test_map_runner_utils.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/local_model_artifacts.py scripts/validation/check_local_model_artifacts.py robot_sf/baselines/sac.py robot_sf/baselines/ppo.py robot_sf/baselines/drl_vo.py tests/validation/test_check_local_model_artifacts.py tests/baselines/test_sac_planner.py tests/benchmark/test_map_runner_utils.py` -> passed
- `uv run python scripts/validation/check_local_model_artifacts.py configs/baselines` -> reports the 7 known BLOCKED local artifacts and exits 0
- `uv run python scripts/validation/check_local_model_artifacts.py --json configs/baselines` -> wrote JSON rows successfully
- `uv run python scripts/validation/check_local_model_artifacts.py --fail-on-blocked configs/baselines` -> intentionally exits 1 on the 7 known explicit blockers
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check` -> passed
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4658 passed, 11 skipped, 10 warnings; readiness stamp `output/validation/pr_ready/issue-1847-local-model-artifact-preflight.json`

## Artifact note

`output/coverage/*` and the readiness stamp were generated by validation and remain ignored disposable local artifacts; no `output/` artifact is treated as durable evidence.

## Caveat

A broad local run including `tests/planner/test_drl_vo.py::test_drl_vo_runner_integration_policy` printed `156 passed` but the pytest process lingered after report generation, so I terminated that process group and reran the broad set with that integration cleanup case deselected. The full PR readiness gate later included the complete suite and passed cleanly.
