### PR TITLE
refactor: make metadata worker bridge explicit

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -148,6 +148,8 @@ knowledge, not every transient iteration detail.
   [issue_1612_observation_track_architecture.md](issue_1612_observation_track_architecture.md)
 * Issue #1721 Legacy Benchmark-Track Metadata Audit:
   [issue_1721_benchmark_track_metadata_audit.md](issue_1721_benchmark_track_metadata_audit.md)
+* Issue #1846 metadata worker bridge:
+  [issue_1846_metadata_worker_bridge.md](issue_1846_metadata_worker_bridge.md)
 * Issue #1659 LiDAR occupancy adapter:
   [issue_1659_lidar_occupancy_adapter.md](issue_1659_lidar_occupancy_adapter.md)
 * Issue #1653 CI runtime slice:

--- a/docs/context/issue_1846_metadata_worker_bridge.md
+++ b/docs/context/issue_1846_metadata_worker_bridge.md
@@ -1,0 +1,29 @@
+# Issue #1846 Metadata Worker Bridge - 2026-05-31
+
+Related issue:
+
+- Issue #1846: <https://github.com/ll7/robot_sf_ll7/issues/1846>
+
+## Outcome
+
+Map-runner batch metadata now has an explicit worker bridge helper:
+
+- `robot_sf/benchmark/map_runner.py::_apply_worker_metadata_bridge`
+
+Both serial direct-call execution and parallel worker execution use this helper to fold each
+episode record's `algorithm_metadata` into the batch-level `algorithm_metadata_contract`. The helper
+also preserves the existing adapter-impact and kinematics-feasibility accumulators, so legacy worker
+records without `algorithm_metadata` remain valid.
+
+## Regression Guard
+
+`tests/benchmark/test_map_runner_utils.py::test_run_map_batch_parallel_preserves_runtime_metadata_bridge`
+uses the parallel map-runner path with a thread-backed executor and fake out-of-order worker
+completion. It proves that worker-returned metadata survives the serialized bridge into:
+
+- `planner_kinematics`
+- `upstream_reference`
+- `adapter_impact`
+- `kinematics_feasibility`
+
+No benchmark metrics, interpretation rules, or planner semantics were changed.

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from dataclasses import fields
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 import yaml
@@ -3713,6 +3713,46 @@ def _accumulate_batch_metadata(
     return adapter_requested_seen, adapter_native_steps, adapter_adapted_steps
 
 
+class _WorkerMetadataBridgeUpdate(NamedTuple):
+    """Normalized metadata update emitted by either direct or serialized worker paths."""
+
+    runtime_algorithm_contract: dict[str, Any]
+    adapter_requested_seen: bool
+    adapter_native_steps: int
+    adapter_adapted_steps: int
+
+
+def _apply_worker_metadata_bridge(
+    rec: dict[str, Any],
+    *,
+    feasibility_totals: dict[str, float],
+    runtime_algorithm_contract: dict[str, Any] | None,
+) -> _WorkerMetadataBridgeUpdate:
+    """Fold one worker episode record into the batch-level metadata contract.
+
+    This is the explicit bridge between per-episode worker payloads and the batch summary.  It is
+    used by both direct function-call execution and serialized worker execution so metadata-only
+    additions have one testable hop.
+
+    Returns:
+        Worker metadata update with merged runtime contract and adapter-impact deltas.
+    """
+    requested_seen, native_steps, adapted_steps = _accumulate_batch_metadata(
+        rec,
+        feasibility_totals=feasibility_totals,
+    )
+    merged_runtime_contract = _merge_runtime_algorithm_contract(
+        runtime_algorithm_contract or {},
+        rec.get("algorithm_metadata"),
+    )
+    return _WorkerMetadataBridgeUpdate(
+        runtime_algorithm_contract=merged_runtime_contract,
+        adapter_requested_seen=requested_seen,
+        adapter_native_steps=native_steps,
+        adapter_adapted_steps=adapted_steps,
+    )
+
+
 def _merge_runtime_algorithm_contract(  # noqa: C901
     base_contract: dict[str, Any],
     runtime_algorithm_metadata: Any,
@@ -4151,17 +4191,15 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         for scenario, seed in jobs:
             try:
                 rec = _run_map_job_worker((scenario, seed, fixed_params))
-                requested_seen, native_steps, adapted_steps = _accumulate_batch_metadata(
+                bridge_update = _apply_worker_metadata_bridge(
                     rec,
                     feasibility_totals=feasibility_totals,
+                    runtime_algorithm_contract=runtime_algorithm_contract,
                 )
-                adapter_samples_seen = adapter_samples_seen or requested_seen
-                adapter_native_steps += native_steps
-                adapter_adapted_steps += adapted_steps
-                runtime_algorithm_contract = _merge_runtime_algorithm_contract(
-                    runtime_algorithm_contract or {},
-                    rec.get("algorithm_metadata"),
-                )
+                adapter_samples_seen = adapter_samples_seen or bridge_update.adapter_requested_seen
+                adapter_native_steps += bridge_update.adapter_native_steps
+                adapter_adapted_steps += bridge_update.adapter_adapted_steps
+                runtime_algorithm_contract = bridge_update.runtime_algorithm_contract
                 _write_validated(out_path, schema, rec)
                 wrote += 1
             except Exception as exc:  # pragma: no cover - error path
@@ -4183,17 +4221,17 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 idx, scenario, seed = future_to_job[fut]
                 try:
                     rec = fut.result()
-                    requested_seen, native_steps, adapted_steps = _accumulate_batch_metadata(
+                    bridge_update = _apply_worker_metadata_bridge(
                         rec,
                         feasibility_totals=feasibility_totals,
+                        runtime_algorithm_contract=runtime_algorithm_contract,
                     )
-                    adapter_samples_seen = adapter_samples_seen or requested_seen
-                    adapter_native_steps += native_steps
-                    adapter_adapted_steps += adapted_steps
-                    runtime_algorithm_contract = _merge_runtime_algorithm_contract(
-                        runtime_algorithm_contract or {},
-                        rec.get("algorithm_metadata"),
+                    adapter_samples_seen = (
+                        adapter_samples_seen or bridge_update.adapter_requested_seen
                     )
+                    adapter_native_steps += bridge_update.adapter_native_steps
+                    adapter_adapted_steps += bridge_update.adapter_adapted_steps
+                    runtime_algorithm_contract = bridge_update.runtime_algorithm_contract
                     results_by_idx[idx] = rec
                 except Exception as exc:  # pragma: no cover
                     failures.append(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -35,6 +35,7 @@ from robot_sf.benchmark.map_runner import (
     _robot_kinematics_label,
     _robot_max_speed,
     _run_map_episode,
+    _run_map_job_worker,
     _scenario_robot_kinematics_label,
     _scenario_with_episode_seed_defaults,
     _select_seeds,
@@ -3723,6 +3724,164 @@ def test_run_map_batch_preserves_runtime_planner_contract_in_summary(
         result["algorithm_metadata_contract"]["upstream_reference"]["adapter_boundary"]
         == "runtime direct world velocity passthrough"
     )
+
+
+def test_run_map_batch_parallel_preserves_runtime_metadata_bridge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Serialized worker results should feed the same batch metadata bridge as serial runs."""
+    scenarios = [
+        {
+            "name": "slow",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "holonomic", "command_mode": "vx_vy"},
+        },
+        {
+            "name": "fast",
+            "metadata": {"supported": True},
+            "robot_config": {"type": "holonomic", "command_mode": "vx_vy"},
+        },
+    ]
+    out_path = tmp_path / "episodes.jsonl"
+    out_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.ProcessPoolExecutor",
+        ThreadPoolExecutor,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._write_validated",
+        lambda *args, **kwargs: None,
+    )
+
+    def _fake_worker(job):
+        """Return worker metadata out of completion order to exercise the serialized bridge."""
+        scenario, seed, _params = job
+        if scenario["name"] == "slow":
+            time.sleep(0.05)
+        return {
+            "episode_id": f"{scenario['name']}-{seed}",
+            "algorithm_metadata": {
+                "adapter_impact": {
+                    "requested": True,
+                    "native_steps": 2 if scenario["name"] == "slow" else 1,
+                    "adapted_steps": 1,
+                },
+                "kinematics_feasibility": {
+                    "commands_evaluated": 3,
+                    "infeasible_native_count": 1,
+                    "projected_count": 1,
+                    "mean_abs_delta_linear": 0.2,
+                    "mean_abs_delta_angular": 0.4,
+                    "max_abs_delta_linear": 0.5,
+                    "max_abs_delta_angular": 0.7,
+                },
+                "planner_kinematics": {
+                    "robot_kinematics": "holonomic",
+                    "execution_mode": "adapter",
+                    "planner_command_space": "holonomic_vxy_world",
+                    "benchmark_command_space": "holonomic_vxy_world",
+                    "projection_policy": "world_velocity_passthrough",
+                    "execution_detail": "direct_holonomic_world_velocity",
+                },
+                "upstream_reference": {
+                    "adapter_boundary": "parallel runtime direct world velocity passthrough"
+                },
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_job_worker", _fake_worker)
+
+    result = run_map_batch(
+        scenarios,
+        out_path,
+        schema_path=tmp_path / "schema.json",
+        algo="orca",
+        adapter_impact_eval=True,
+        workers=2,
+        resume=False,
+    )
+
+    meta = result["algorithm_metadata_contract"]
+    planner_meta = meta["planner_kinematics"]
+    assert planner_meta["planner_command_space"] == "holonomic_vxy_world"
+    assert planner_meta["benchmark_command_space"] == "holonomic_vxy_world"
+    assert planner_meta["projection_policy"] == "world_velocity_passthrough"
+    assert planner_meta["execution_detail"] == "direct_holonomic_world_velocity"
+    assert meta["upstream_reference"]["adapter_boundary"] == (
+        "parallel runtime direct world velocity passthrough"
+    )
+    assert meta["adapter_impact"]["status"] == "complete"
+    assert meta["adapter_impact"]["native_steps"] == 3
+    assert meta["adapter_impact"]["adapted_steps"] == 2
+    assert meta["kinematics_feasibility"]["commands_evaluated"] == 6
+    assert meta["kinematics_feasibility"]["projected_count"] == 2
+    assert meta["kinematics_feasibility"]["mean_abs_delta_linear"] == pytest.approx(0.2)
+
+
+def test_run_map_job_worker_forwards_metadata_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serialized map jobs should forward benchmark metadata fields into episode execution."""
+    captured: dict[str, object] = {}
+
+    def _fake_run_map_episode(scenario, seed, **kwargs):
+        """Capture worker-forwarded keyword arguments."""
+        captured["scenario"] = scenario
+        captured["seed"] = seed
+        captured.update(kwargs)
+        return {
+            "episode_id": "forwarded",
+            "algorithm_metadata": {
+                "benchmark_track": {
+                    "benchmark_track": kwargs["benchmark_track"],
+                    "track_schema_version": kwargs["track_schema_version"],
+                    "observation_level": kwargs["observation_level"],
+                    "observation_mode": kwargs["observation_mode"],
+                }
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_episode", _fake_run_map_episode)
+
+    record = _run_map_job_worker(
+        (
+            {"name": "metadata-forwarding"},
+            7,
+            {
+                "horizon": 3,
+                "dt": 0.1,
+                "record_forces": False,
+                "snqi_weights": None,
+                "snqi_baseline": None,
+                "algo": "goal",
+                "algo_config": {"max_speed": 1.0},
+                "algo_config_path": None,
+                "scenario_path": "configs/scenarios/demo.yaml",
+                "adapter_impact_eval": True,
+                "experimental_ped_impact": False,
+                "ped_impact_radius_m": 2.0,
+                "ped_impact_window_steps": 5,
+                "observation_noise": {"enabled": False},
+                "observation_mode": "socnav_state",
+                "observation_level": "tracked_agents_no_noise",
+                "benchmark_track": "lidar",
+                "track_schema_version": "track-v1",
+                "synthetic_actuation_profile": None,
+                "latency_stress_profile": None,
+            },
+        )
+    )
+
+    assert captured["scenario"] == {"name": "metadata-forwarding"}
+    assert captured["seed"] == 7
+    assert captured["observation_mode"] == "socnav_state"
+    assert captured["observation_level"] == "tracked_agents_no_noise"
+    assert captured["benchmark_track"] == "lidar"
+    assert captured["track_schema_version"] == "track-v1"
+    assert record["algorithm_metadata"]["benchmark_track"]["benchmark_track"] == "lidar"
 
 
 def test_run_map_batch_hrvo_smoke_writes_episode_jsonl(


### PR DESCRIPTION
## Summary

Closes #1846.

- adds `_apply_worker_metadata_bridge()` as the explicit map-runner bridge from per-episode worker `algorithm_metadata` into the batch-level `algorithm_metadata_contract`
- uses the same helper from serial direct-call execution and parallel worker execution
- adds regression coverage for metadata flowing both directions across the worker boundary:
  - fixed metadata params into `_run_map_episode`
  - worker-returned planner/upstream/adapter/feasibility metadata back into the batch summary
- records the contract in `docs/context/issue_1846_metadata_worker_bridge.md`

## Validation

- `uv run pytest tests/benchmark/test_map_runner_utils.py::test_run_map_job_worker_forwards_metadata_params tests/benchmark/test_map_runner_utils.py::test_run_map_batch_parallel_preserves_runtime_metadata_bridge tests/benchmark/test_map_runner_utils.py::test_run_map_batch_preserves_runtime_planner_contract_in_summary -q` -> 3 passed
- `uv run pytest tests/benchmark/test_map_runner_utils.py -q` -> 101 passed
- `uv run ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check` -> passed
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4657 passed, 11 skipped, 9 warnings; readiness stamp `output/validation/pr_ready/issue-1846-metadata-worker-bridge.json`

## Artifact note

`output/coverage/*` and the readiness stamp were generated by validation and remain ignored disposable local artifacts; no generated `output/` artifact is treated as durable evidence.

## Benchmark semantics

No metric definitions, benchmark interpretation, planner behavior, or schema requirements changed. This is metadata plumbing and regression coverage only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation for metadata worker bridge functionality in batch execution.

* **Tests**
  * Added regression tests to verify metadata preservation during parallel batch execution and metadata parameter forwarding in worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->