### PR TITLE
refactor: centralize report grouping contracts

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -247,6 +247,8 @@ knowledge, not every transient iteration detail.
   [open_issues_training_split_audit_2026-05-30.md](open_issues_training_split_audit_2026-05-30.md)
 * Issue #1638 local model path preflight:
   [issue_1638_model_path_preflight.md](issue_1638_model_path_preflight.md)
+* Issue #1845 report grouping contracts:
+  [issue_1845_report_grouping_contracts.md](issue_1845_report_grouping_contracts.md)
 * Learned local-navigation policy registry:
   [policy_search/learned_policy_registry.md](policy_search/learned_policy_registry.md)
 * Issue #1758 Arena-Rosnav Source-Side Assessment (2026-05-30):

--- a/docs/context/issue_1845_report_grouping_contracts.md
+++ b/docs/context/issue_1845_report_grouping_contracts.md
@@ -1,0 +1,47 @@
+# Issue #1845 Report Grouping Contracts
+
+## Goal
+
+Issue #1845 centralizes the legacy-compatible grouping contract used by benchmark report surfaces.
+The implementation keeps paper/benchmark aggregation fail-closed while making human-facing reports
+share the same fallback order for legacy rows:
+
+1. `scenario_params.algo`
+2. top-level `algo`
+3. `algorithm_metadata.algorithm`
+4. fallback grouping key, usually `scenario_id`
+
+## Decision
+
+The shared helper lives in `robot_sf/benchmark/grouping.py`:
+
+* `resolve_report_group_key(...)` applies the common report fallback chain.
+* `DEFAULT_REPORT_GROUP_BY` and `DEFAULT_REPORT_FALLBACK_GROUP_BY` keep CLI defaults aligned.
+* `EFFECTIVE_REPORT_GROUP_KEY` documents the effective report key for metadata payloads.
+
+`compute_aggregates(...)` still uses its stricter aggregation resolver for benchmark-strength
+summaries, because silently grouping by `scenario_id` when algorithm metadata is missing can
+invalidate planner comparisons. Tables, rankings, distributions, Pareto plots, SNQI ablations, and
+seed-variance summaries use the shared report helper with their historical missing-row policy:
+
+* skip missing rows for table/ranking/distribution/Pareto surfaces,
+* keep an explicit `unknown` group for SNQI ablation and seed variance.
+
+## Validation
+
+Focused validation command:
+
+```bash
+uv run pytest tests/benchmark/test_report_grouping_contracts.py tests/test_aggregate.py tests/test_cli_table.py tests/test_ranking.py tests/benchmark/test_distributions.py tests/test_plots_pareto.py tests/test_snqi_ablation.py tests/test_seed_variance.py -q
+```
+
+Observed result on the issue branch: `42 passed`.
+
+The regression coverage verifies:
+
+* top-level `algo` and `algorithm_metadata.algorithm` are used before scenario fallback,
+* missing group policy is explicit (`skip`, `unknown`, or `error`),
+* legacy rows with only `algorithm_metadata.algorithm` group consistently across aggregate, table,
+  ranking, distribution, Pareto, SNQI ablation, and seed variance,
+* fully missing legacy rows still land in the `unknown` bucket for the surfaces that historically
+  preserve such rows.

--- a/robot_sf/benchmark/ablation.py
+++ b/robot_sf/benchmark/ablation.py
@@ -27,6 +27,7 @@ from robot_sf.benchmark.aggregate import (
     normalize_observation_track_mode,
     observation_track_group_label,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES, compute_snqi
 
 
@@ -60,11 +61,12 @@ def _group_by(
     mode = normalize_observation_track_mode(str(track_meta["mode"]))
     groups: dict[str, list[Mapping[str, Any]]] = {}
     for rec in record_list:
-        gid = _get_nested(rec, group_by)
-        if gid is None:
-            gid = _get_nested(rec, fallback)
-        if gid is None:
-            gid = "unknown"
+        gid = resolve_report_group_key(
+            rec,
+            group_by=group_by,
+            fallback_group_by=fallback,
+            missing="unknown",
+        )
         gid = observation_track_group_label(rec, str(gid), mode=mode)
         groups.setdefault(gid, []).append(rec)
     return groups

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -26,6 +26,7 @@ import numpy as np
 from loguru import logger
 
 from robot_sf.benchmark.errors import AggregationMetadataError, EpisodeRecordInputError
+from robot_sf.benchmark.grouping import EFFECTIVE_REPORT_GROUP_KEY, resolve_report_group_key
 from robot_sf.benchmark.metrics import snqi as snqi_fn
 from robot_sf.benchmark.thresholds import validate_threshold_parameter_consistency
 
@@ -124,7 +125,7 @@ def _get_nested(d: dict[str, Any], path: str, default: Any = None) -> Any:
     return cur
 
 
-_EFFECTIVE_GROUP_KEY = "scenario_params.algo | algo | scenario_id"
+_EFFECTIVE_GROUP_KEY = EFFECTIVE_REPORT_GROUP_KEY
 _UNKNOWN_BENCHMARK_TRACK = "unspecified"
 _CAVEAT_STATUSES = {
     "degraded",
@@ -953,5 +954,6 @@ __all__ = [
     "observation_track_group_label",
     "read_jsonl",
     "resolve_benchmark_track",
+    "resolve_report_group_key",
     "write_episode_csv",
 ]

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -38,6 +38,7 @@ from robot_sf.benchmark.distributions import collect_grouped_values as _dist_col
 from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.failure_extractor import extract_failures as _extract_failures
 from robot_sf.benchmark.fallback_policy import availability_payload, benchmark_run_exit_code
+from robot_sf.benchmark.grouping import DEFAULT_REPORT_FALLBACK_GROUP_BY, DEFAULT_REPORT_GROUP_BY
 from robot_sf.benchmark.observation_levels import OBSERVATION_LEVEL_KEYS
 from robot_sf.benchmark.observation_noise import load_observation_noise_spec
 from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
@@ -1656,12 +1657,12 @@ def _add_aggregate_subparser(
     p.add_argument("--out", required=True, help="Output JSON summary path")
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument(
@@ -1837,12 +1838,12 @@ def _add_snqi_ablate_subparser(
     p.add_argument("--out", required=True, help="Output path (.md/.csv/.json)")
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument("--format", choices=["md", "csv", "json"], default="md")
@@ -1891,12 +1892,12 @@ def _add_seed_variance_subparser(
     p.add_argument("--out", required=True, help="Output JSON summary path")
     p.add_argument(
         "--group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_id",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument(
@@ -1971,12 +1972,12 @@ def _add_rank_subparser(
     p.add_argument("--out", required=True, help="Output path (md/csv/json)")
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument("--metric", default="collisions", help="Metric name under metrics.<name>")
@@ -2017,12 +2018,12 @@ def _add_table_subparser(
     p.add_argument("--out", required=True, help="Output path (md/csv/json)")
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument(
@@ -2081,12 +2082,12 @@ def _add_plot_pareto_subparser(
     p.add_argument("--y-metric", required=True, help="Metric name for Y axis")
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument("--agg", choices=["mean", "median"], default="mean")
@@ -2123,12 +2124,12 @@ def _add_plot_distributions_subparser(
     )
     p.add_argument(
         "--group-by",
-        default="scenario_params.algo",
+        default=DEFAULT_REPORT_GROUP_BY,
         help="Grouping key (dotted path). Default: scenario_params.algo",
     )
     p.add_argument(
         "--fallback-group-by",
-        default="scenario_id",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
         help="Fallback grouping key when group-by is missing. Default: scenario_id",
     )
     p.add_argument("--bins", type=int, default=30)

--- a/robot_sf/benchmark/distributions.py
+++ b/robot_sf/benchmark/distributions.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.aggregate import (
     normalize_observation_track_mode,
     observation_track_group_label,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 from robot_sf.benchmark.plotting_style import apply_latex_style
 
 Record = Mapping[str, object]
@@ -75,7 +76,12 @@ def collect_grouped_values(
     mode = normalize_observation_track_mode(str(track_meta["mode"]))
     out: dict[str, dict[str, list[float]]] = {}
     for r in record_list:
-        g = _get_dotted(r, group_by) or _get_dotted(r, fallback_group_by)
+        g = resolve_report_group_key(
+            r,
+            group_by=group_by,
+            fallback_group_by=fallback_group_by,
+            missing="skip",
+        )
         if g is None:
             continue
         g = observation_track_group_label(r, str(g), mode=mode)

--- a/robot_sf/benchmark/grouping.py
+++ b/robot_sf/benchmark/grouping.py
@@ -1,0 +1,104 @@
+"""Shared grouping helpers for benchmark report surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from robot_sf.benchmark.errors import AggregationMetadataError
+
+DEFAULT_REPORT_GROUP_BY = "scenario_params.algo"
+DEFAULT_REPORT_FALLBACK_GROUP_BY = "scenario_id"
+EFFECTIVE_REPORT_GROUP_KEY = (
+    "scenario_params.algo | algo | algorithm_metadata.algorithm | scenario_id"
+)
+
+MissingGroupPolicy = Literal["skip", "unknown", "error"]
+
+
+def get_nested(record: Mapping[str, Any], path: str, default: Any | None = None) -> Any:
+    """Read a dotted-path value from a mapping.
+
+    Returns:
+        The nested value when present, otherwise ``default``.
+    """
+    cur: Any = record
+    for part in path.split("."):
+        if isinstance(cur, Mapping) and part in cur:
+            cur = cur[part]
+        else:
+            return default
+    return cur
+
+
+def _normalize_algo(value: Any) -> str | None:
+    """Normalize algorithm identifiers to a non-empty string.
+
+    Returns:
+        Normalized string or None if empty/invalid.
+    """
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            return trimmed
+        return None
+    if value is None:
+        return None
+    return str(value)
+
+
+def resolve_report_group_key(
+    record: Mapping[str, Any],
+    *,
+    group_by: str,
+    fallback_group_by: str,
+    missing: MissingGroupPolicy = "skip",
+) -> str | None:
+    """Resolve a report grouping key with the shared legacy-row fallback contract.
+
+    Aggregate computation keeps a stricter fail-closed path because missing algorithm metadata can
+    invalidate benchmark claims. Human-facing report surfaces historically accepted legacy rows by
+    falling back to ``fallback_group_by`` or an explicit ``unknown`` bucket; this helper centralizes
+    that compatibility behavior for tables, rankings, plots, distributions, SNQI ablations, and
+    seed-variance summaries.
+
+    Args:
+        record: Episode record.
+        group_by: Primary dotted path.
+        fallback_group_by: Fallback dotted path.
+        missing: ``"skip"`` for ``None``, ``"unknown"`` for an explicit bucket, or ``"error"`` to
+            raise when neither primary nor fallback exists.
+
+    Returns:
+        Group key string, ``"unknown"``, or ``None`` depending on ``missing``.
+    """
+    if missing not in {"skip", "unknown", "error"}:
+        raise ValueError("missing must be one of {'skip', 'unknown', 'error'}")
+
+    primary_value = get_nested(record, group_by)
+    if primary_value is not None:
+        return str(primary_value)
+
+    if group_by == DEFAULT_REPORT_GROUP_BY:
+        top_level_algo = _normalize_algo(record.get("algo"))
+        if top_level_algo is not None:
+            return top_level_algo
+        metadata_algo = _normalize_algo(get_nested(record, "algorithm_metadata.algorithm"))
+        if metadata_algo is not None:
+            return metadata_algo
+
+    fallback_value = get_nested(record, fallback_group_by)
+    if fallback_value is not None:
+        return str(fallback_value)
+
+    if missing == "unknown":
+        return "unknown"
+    if missing == "error":
+        episode_id = record.get("episode_id")
+        raise AggregationMetadataError(
+            "Unable to determine report group key for episode.",
+            episode_id=str(episode_id) if episode_id is not None else None,
+            missing_fields=(group_by, fallback_group_by),
+            advice="Verify that episode records include the requested report grouping metadata.",
+        )
+    return None

--- a/robot_sf/benchmark/plots.py
+++ b/robot_sf/benchmark/plots.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.aggregate import (
     normalize_observation_track_mode,
     observation_track_group_label,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -71,9 +72,12 @@ def _group_values(
         mode = normalize_observation_track_mode(str(track_meta["mode"]))
     out: dict[str, list[float]] = {}
     for r in record_list:
-        g = _get_dotted(r, group_by)
-        if g is None:
-            g = _get_dotted(r, fallback_group_by)
+        g = resolve_report_group_key(
+            r,
+            group_by=group_by,
+            fallback_group_by=fallback_group_by,
+            missing="skip",
+        )
         val = _get_dotted(r, f"metrics.{metric}")
         if g is None or val is None:
             continue

--- a/robot_sf/benchmark/ranking.py
+++ b/robot_sf/benchmark/ranking.py
@@ -20,6 +20,7 @@ from robot_sf.benchmark.aggregate import (
     normalize_observation_track_mode,
     observation_track_group_label,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -86,9 +87,12 @@ def compute_ranking(
     mode = normalize_observation_track_mode(str(track_meta["mode"]))
     by_group: dict[str, list[float]] = {}
     for rec in record_list:
-        gid = _get_nested(rec, group_by)
-        if gid is None:
-            gid = _get_nested(rec, fallback_group_by)
+        gid = resolve_report_group_key(
+            rec,
+            group_by=group_by,
+            fallback_group_by=fallback_group_by,
+            missing="skip",
+        )
         if gid is None:
             continue
         gid = observation_track_group_label(rec, str(gid), mode=mode)

--- a/robot_sf/benchmark/report_table.py
+++ b/robot_sf/benchmark/report_table.py
@@ -16,6 +16,7 @@ from robot_sf.benchmark.aggregate import (
     observation_track_group_label,
     resolve_benchmark_track,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -48,10 +49,12 @@ def _group_key(rec: Record, group_by: str, fallback_group_by: str) -> str | None
     Returns:
         Group key string or None if missing.
     """
-    g = _get_dotted(rec, group_by)
-    if g is None:
-        g = _get_dotted(rec, fallback_group_by)
-    return None if g is None else str(g)
+    return resolve_report_group_key(
+        rec,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+        missing="skip",
+    )
 
 
 @dataclass

--- a/robot_sf/benchmark/seed_variance.py
+++ b/robot_sf/benchmark/seed_variance.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.aggregate import (
     normalize_observation_track_mode,
     observation_track_group_label,
 )
+from robot_sf.benchmark.grouping import resolve_report_group_key
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -83,11 +84,12 @@ def _group_rows(
     )
     mode = normalize_observation_track_mode(str(track_meta["mode"]))
     for rec in records:
-        g = _get_nested(rec, group_by)
-        if g is None:
-            g = _get_nested(rec, fallback_group_by)
-        if g is None:
-            g = "unknown"
+        g = resolve_report_group_key(
+            rec,
+            group_by=group_by,
+            fallback_group_by=fallback_group_by,
+            missing="unknown",
+        )
         key = observation_track_group_label(rec, str(g), mode=mode)
         groups[key].append(flatten_metrics(rec))
     return groups

--- a/tests/benchmark/test_report_grouping_contracts.py
+++ b/tests/benchmark/test_report_grouping_contracts.py
@@ -1,0 +1,168 @@
+"""Regression tests for shared benchmark report grouping contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.ablation import compute_snqi_ablation
+from robot_sf.benchmark.aggregate import compute_aggregates
+from robot_sf.benchmark.distributions import collect_grouped_values
+from robot_sf.benchmark.errors import AggregationMetadataError
+from robot_sf.benchmark.grouping import resolve_report_group_key
+from robot_sf.benchmark.plots import compute_pareto_points
+from robot_sf.benchmark.ranking import compute_ranking
+from robot_sf.benchmark.report_table import compute_table
+from robot_sf.benchmark.seed_variance import compute_seed_variance
+
+
+def _metadata_algorithm_records() -> list[dict]:
+    """Build legacy-compatible records that only identify the planner in algorithm metadata."""
+    return [
+        {
+            "episode_id": "legacy-meta-1",
+            "scenario_id": "scenario-fallback",
+            "seed": 1,
+            "algorithm_metadata": {"algorithm": "metadata-planner"},
+            "metrics": {
+                "collisions": 1.0,
+                "comfort_exposure": 0.4,
+                "success": 1.0,
+                "time_to_goal_norm": 0.3,
+            },
+        },
+        {
+            "episode_id": "legacy-meta-2",
+            "scenario_id": "scenario-fallback",
+            "seed": 2,
+            "algorithm_metadata": {"algorithm": "metadata-planner"},
+            "metrics": {
+                "collisions": 3.0,
+                "comfort_exposure": 0.6,
+                "success": 0.8,
+                "time_to_goal_norm": 0.5,
+            },
+        },
+    ]
+
+
+def test_report_group_key_uses_shared_legacy_algorithm_fallbacks() -> None:
+    """Top-level and algorithm metadata planner ids should win before scenario fallback."""
+    assert (
+        resolve_report_group_key(
+            {"algo": "top-level", "scenario_id": "scenario"},
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+        )
+        == "top-level"
+    )
+    assert (
+        resolve_report_group_key(
+            {
+                "algorithm_metadata": {"algorithm": "metadata-planner"},
+                "scenario_id": "scenario",
+            },
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+        )
+        == "metadata-planner"
+    )
+    assert (
+        resolve_report_group_key(
+            {"scenario_id": "scenario"},
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+        )
+        == "scenario"
+    )
+
+
+def test_report_group_key_missing_policy_is_explicit() -> None:
+    """Report surfaces should opt into skip, unknown, or error behavior deliberately."""
+    record = {"episode_id": "missing-group", "metrics": {"success": 1.0}}
+    assert (
+        resolve_report_group_key(
+            record,
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+            missing="skip",
+        )
+        is None
+    )
+    assert (
+        resolve_report_group_key(
+            record,
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+            missing="unknown",
+        )
+        == "unknown"
+    )
+    with pytest.raises(AggregationMetadataError):
+        resolve_report_group_key(
+            record,
+            group_by="scenario_params.algo",
+            fallback_group_by="scenario_id",
+            missing="error",
+        )
+
+
+def test_report_surfaces_share_algorithm_metadata_grouping_contract() -> None:
+    """Legacy rows with algorithm metadata should group consistently across report surfaces."""
+    records = _metadata_algorithm_records()
+    weights = {"w_success": 1.0, "w_time": 1.0, "w_collisions": 1.0}
+    baseline = {"collisions": {"med": 0.0, "p95": 4.0}}
+
+    aggregate = compute_aggregates(records, group_by="scenario_params.algo")
+    assert aggregate["metadata-planner"]["collisions"]["mean"] == 2.0
+
+    table = compute_table(records, metrics=["collisions"])
+    assert [(row.group, row.values["collisions"]) for row in table] == [("metadata-planner", 2.0)]
+
+    ranking = compute_ranking(records, metric="collisions")
+    assert [(row.group, row.mean, row.count) for row in ranking] == [("metadata-planner", 2.0, 2)]
+
+    distributions = collect_grouped_values(records, metrics=["collisions"])
+    assert distributions["metadata-planner"]["collisions"] == [1.0, 3.0]
+
+    _, pareto_labels = compute_pareto_points(records, "collisions", "comfort_exposure")
+    assert pareto_labels == ["metadata-planner"]
+
+    ablation = compute_snqi_ablation(
+        records,
+        weights=weights,
+        baseline=baseline,
+        group_by="scenario_params.algo",
+    )
+    assert [row.group for row in ablation] == ["metadata-planner"]
+
+    seed_variance = compute_seed_variance(records, group_by="scenario_params.algo")
+    assert seed_variance["metadata-planner"]["collisions"]["mean"] == 2.0
+
+
+def test_unknown_bucket_surfaces_keep_fully_missing_legacy_rows() -> None:
+    """SNQI ablation and seed variance keep an explicit bucket when all group metadata is absent."""
+    records = [
+        {
+            "episode_id": "unknown-1",
+            "seed": 1,
+            "metrics": {"success": 1.0, "time_to_goal_norm": 0.2, "collisions": 0.0},
+        },
+        {
+            "episode_id": "unknown-2",
+            "seed": 2,
+            "metrics": {"success": 0.5, "time_to_goal_norm": 0.4, "collisions": 2.0},
+        },
+    ]
+    weights = {"w_success": 1.0, "w_time": 1.0, "w_collisions": 1.0}
+    baseline = {"collisions": {"med": 0.0, "p95": 2.0}}
+
+    ablation = compute_snqi_ablation(
+        records,
+        weights=weights,
+        baseline=baseline,
+        group_by="scenario_params.algo",
+    )
+    assert [row.group for row in ablation] == ["unknown"]
+
+    seed_variance = compute_seed_variance(records, group_by="scenario_params.algo")
+    assert seed_variance["unknown"]["collisions"]["count"] == 2.0

--- a/tests/integration/test_classic_benchmark_alg_grouping.py
+++ b/tests/integration/test_classic_benchmark_alg_grouping.py
@@ -54,7 +54,10 @@ def test_smoke_aggregation_workflow():
 
     assert set(result.keys()) >= {"sf", "random", "_meta"}
     assert result["_meta"]["group_by"] == "scenario_params.algo"
-    assert result["_meta"]["effective_group_key"] == "scenario_params.algo | algo | scenario_id"
+    assert (
+        result["_meta"]["effective_group_key"]
+        == "scenario_params.algo | algo | algorithm_metadata.algorithm | scenario_id"
+    )
     assert result["_meta"]["missing_algorithms"] == ["ppo"]
     assert result["_meta"]["warnings"]
     assert any(


### PR DESCRIPTION
## Summary
Centralizes the benchmark report grouping fallback contract in `robot_sf/benchmark/grouping.py` and routes table, ranking, distribution, Pareto, SNQI ablation, and seed-variance report surfaces through it.

## Linked Issues
- Closes `#1845`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Added `resolve_report_group_key(...)` plus shared default/effective grouping constants.
- Preserved aggregate's strict fail-closed grouping resolver while documenting the effective key as `scenario_params.algo | algo | algorithm_metadata.algorithm | scenario_id`.
- Updated report surfaces and CLI defaults to use the shared report grouping contract.
- Added cross-surface regression tests for legacy rows with `algorithm_metadata.algorithm`, explicit missing policies, and `unknown` bucket behavior.
- Added `docs/context/issue_1845_report_grouping_contracts.md` and linked it from the context README.

## Why It Matters
- Added value: report surfaces no longer drift on legacy row grouping behavior.
- Expected impact: human-facing tables/plots/rankings remain compatible with older rows while benchmark-strength aggregation stays stricter.
- Why this is worth merging now: it removes duplicated fallback logic before more report surfaces and benchmark artifacts accrete around subtly different grouping semantics.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run pytest tests/benchmark/test_report_grouping_contracts.py tests/test_aggregate.py tests/test_cli_table.py tests/test_ranking.py tests/benchmark/test_distributions.py tests/test_plots_pareto.py tests/test_snqi_ablation.py tests/test_seed_variance.py -q` -> `42 passed`
  - `uv run pytest tests/benchmark/test_report_grouping_contracts.py tests/test_aggregate.py tests/integration/test_classic_benchmark_alg_grouping.py tests/test_cli_table.py tests/test_ranking.py tests/benchmark/test_distributions.py tests/test_plots_pareto.py tests/test_snqi_ablation.py tests/test_seed_variance.py tests/test_cli_seed_variance.py tests/test_cli_plot_distributions.py tests/test_cli_ranking.py tests/test_cli_snqi_ablation.py -q` -> `47 passed`
  - `uv run ruff check ...` -> passed
  - `uv run ruff format --check ...` -> passed
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
  - `git diff --check` -> passed
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `4672 passed, 11 skipped, 9 warnings`
  - `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `4672 passed, 11 skipped, 8 warnings`
- Evidence that the change works here: regression tests cover the shared fallback chain and every updated report surface.
- Benchmarks or smoke tests, if applicable: no benchmark campaign run; this is a report grouping refactor with unit/integration coverage.

## Risks / Rollout
- Compatibility risks: low; existing defaults are unchanged, and report missing-row policies are preserved.
- Failure modes: a caller expecting raw `scenario_id` fallback before `algorithm_metadata.algorithm` would now see the planner metadata group, matching the documented effective contract.
- Rollback or fallback plan: revert this PR to restore per-surface fallback implementations.

## Docs / Provenance
- Updated docs: `docs/context/issue_1845_report_grouping_contracts.md`, `docs/context/README.md`
- Relevant design or provenance notes: context note records the strict aggregate vs report-compatible grouping boundary.
- Any assumptions that need to be preserved: aggregate summaries remain fail-closed for missing planner identity; report surfaces remain compatibility-oriented.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #1845
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): yes
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: no benchmark claims, registry entries, or public report artifacts changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Please verify the intended boundary: aggregate remains strict, report surfaces share the legacy-compatible fallback helper.
- Known limitation: changed-file coverage reports warnings for some broad benchmark modules but all touched files exceed the minimum threshold and the full gate passed.