### PR TITLE
chore: add shared venv worktree validation helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@ When working in a linked Git worktree, detect bootstrap state before running exp
   `ln -s "$MAIN_REPO_ROOT/local.machine.md" .`
 - After the machine-context symlink is in place, run `uv sync --all-extras`, then
   `source .venv/bin/activate` before using Python tooling.
+- For quick targeted validation from a sibling worktree that intentionally reuses the main
+  checkout virtualenv, prefer `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>` so
+  `PYTHONPATH` is pinned to the active worktree while `UV_PROJECT_ENVIRONMENT` points at the shared
+  `.venv`. Use a full local `.venv` and final PR readiness for merge proof.
 - If the current branch is not `main`, fetch the latest `origin/main` and merge it into the current
   branch early in the work cycle so the branch benefits from repository-wide fixes and workflow
   improvements before local changes diverge. Typical command sequence:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -96,6 +96,25 @@ git fetch origin main
 git merge origin/main
 ```
 
+### Targeted shared-venv worktree validation
+
+For quick, targeted checks in a sibling worktree, you can reuse the main checkout virtualenv while
+pinning imports to the current worktree:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
+scripts/dev/run_worktree_shared_venv.sh --venv ../robot_sf_ll7/.venv -- ruff check scripts/dev
+```
+
+The helper runs from `git rev-parse --show-toplevel`, prepends that root to `PYTHONPATH`, sets
+`UV_PROJECT_ENVIRONMENT` to the shared `.venv`, and sets `UV_NO_SYNC=1`. This is intended for fast
+local feedback when dependencies are already current. It should fail if the shared virtualenv is
+missing instead of silently installing into the wrong checkout.
+
+Use a normal worktree-local `uv sync --all-extras` and
+`PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` for final PR proof,
+dependency changes, generated lockfile validation, or any run where environment isolation matters.
+
 ### Critical dependencies and setup: Fast-pysf integration
 
 The `fast-pysf/` directory contains the optimized SocialForce physics engine and is now integrated as a **git subtree** (previously a submodule). After cloning the repository, the fast-pysf code is automatically available—no additional initialization steps required.
@@ -189,6 +208,7 @@ skills use the same commands:
 ```bash
 scripts/dev/ruff_fix_format.sh
 scripts/dev/run_tests_parallel.sh
+scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
 scripts/dev/run_ci_local.sh
 scripts/dev/check_docs_proof_consistency_diff.sh
 scripts/dev/sbatch_use_max_time.sh SLURM/Auxme/auxme_gpu.sl

--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -67,7 +67,7 @@ main_repo_root="$(cd "$git_common_dir/.." && pwd)"
 
 venv_path="${venv_override:-$main_repo_root/.venv}"
 if [[ "$venv_path" != /* ]]; then
-  venv_path="$(cd "$(dirname "$venv_path")" && pwd)/$(basename "$venv_path")"
+  venv_path="$repo_root/$venv_path"
 fi
 
 if [[ ! -x "$venv_path/bin/python" ]]; then

--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/dev/run_worktree_shared_venv.sh [options] -- <uv-run-command> [args...]
+
+Run a targeted validation command from the current checkout while reusing a shared virtualenv.
+The helper pins imports to this worktree by prepending PYTHONPATH=$PWD and sets UV_NO_SYNC=1 so
+`uv run` does not silently resync or rewrite the shared environment.
+
+Options:
+  --venv PATH   Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the main
+                checkout .venv for linked worktrees.
+  -h, --help    Show this help message.
+
+Examples:
+  scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
+  scripts/dev/run_worktree_shared_venv.sh --venv ../robot_sf_ll7/.venv -- ruff check scripts/dev
+
+Use a full local .venv plus PR_READY_MODE=final for final PR proof; this helper is for quick,
+targeted validation in sibling worktrees.
+EOF
+}
+
+venv_override=""
+cmd=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --venv)
+      if [[ $# -lt 2 ]]; then
+        echo "--venv requires a path." >&2
+        exit 2
+      fi
+      venv_override="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    --)
+      shift
+      cmd=("$@")
+      break
+      ;;
+    *)
+      cmd=("$@")
+      break
+      ;;
+  esac
+done
+
+if [[ ${#cmd[@]} -eq 0 ]]; then
+  show_help >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git_common_dir="$(git rev-parse --git-common-dir)"
+if [[ "$git_common_dir" != /* ]]; then
+  git_common_dir="$(cd "$repo_root/$git_common_dir" && pwd)"
+fi
+main_repo_root="$(cd "$git_common_dir/.." && pwd)"
+
+venv_path="${venv_override:-$main_repo_root/.venv}"
+if [[ "$venv_path" != /* ]]; then
+  venv_path="$(cd "$(dirname "$venv_path")" && pwd)/$(basename "$venv_path")"
+fi
+
+if [[ ! -x "$venv_path/bin/python" ]]; then
+  echo "Shared virtualenv not found or incomplete: $venv_path" >&2
+  echo "Create it with 'uv sync --all-extras' in the owning checkout, or use a local .venv." >&2
+  exit 2
+fi
+
+export UV_PROJECT_ENVIRONMENT="$venv_path"
+export UV_NO_SYNC=1
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+
+exec uv run "${cmd[@]}"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -13,6 +13,7 @@ PYPROJECT = ROOT / "pyproject.toml"
 RUN_TESTS_PARALLEL = ROOT / "scripts" / "dev" / "run_tests_parallel.sh"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
 PR_READY_CHECK = ROOT / "scripts" / "dev" / "pr_ready_check.sh"
+RUN_WORKTREE_SHARED_VENV = ROOT / "scripts" / "dev" / "run_worktree_shared_venv.sh"
 
 
 def test_ci_driver_smoke_uses_runtime_schema_and_output_matrix_path() -> None:
@@ -177,3 +178,61 @@ def test_pr_ready_check_exposes_final_committed_head_mode() -> None:
     assert "recording interim PR readiness from a dirty non-ignored worktree" in script_text
     assert "--require-clean-tree" in script_text
     assert "pr_ready_freshness.py" in script_text
+
+
+def test_worktree_shared_venv_helper_pins_current_checkout_imports() -> None:
+    """Shared-venv validation must import from the active worktree, not the owning checkout."""
+    script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")
+
+    assert 'repo_root="$(git rev-parse --show-toplevel)"' in script_text
+    assert 'main_repo_root="$(cd "$git_common_dir/.." && pwd)"' in script_text
+    assert 'venv_path="${venv_override:-$main_repo_root/.venv}"' in script_text
+    assert 'export UV_PROJECT_ENVIRONMENT="$venv_path"' in script_text
+    assert "export UV_NO_SYNC=1" in script_text
+    assert 'export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"' in script_text
+    assert 'exec uv run "${cmd[@]}"' in script_text
+
+
+def test_worktree_shared_venv_helper_has_valid_shell_and_help() -> None:
+    """The shared-venv helper should be shell-valid and document its safety boundary."""
+    syntax = subprocess.run(
+        ["bash", "-n", str(RUN_WORKTREE_SHARED_VENV)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+    help_result = subprocess.run(
+        [str(RUN_WORKTREE_SHARED_VENV), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert help_result.returncode == 0
+    assert "PYTHONPATH=$PWD" in help_result.stdout
+    assert "UV_PROJECT_ENVIRONMENT" in help_result.stdout
+    assert "UV_NO_SYNC=1" in help_result.stdout
+    assert "full local .venv" in help_result.stdout
+
+
+def test_worktree_shared_venv_helper_fails_for_missing_shared_env(tmp_path: Path) -> None:
+    """A missing shared env should fail before uv can fall back to an unintended checkout."""
+    missing_venv = tmp_path / "missing-venv"
+
+    result = subprocess.run(
+        [str(RUN_WORKTREE_SHARED_VENV), "--venv", str(missing_venv), "--", "python", "-V"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert f"Shared virtualenv not found or incomplete: {missing_venv}" in result.stderr
+    assert "Create it with 'uv sync --all-extras'" in result.stderr

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -236,3 +236,21 @@ def test_worktree_shared_venv_helper_fails_for_missing_shared_env(tmp_path: Path
     assert result.returncode == 2
     assert f"Shared virtualenv not found or incomplete: {missing_venv}" in result.stderr
     assert "Create it with 'uv sync --all-extras'" in result.stderr
+
+
+def test_worktree_shared_venv_helper_reports_relative_missing_env() -> None:
+    """Relative missing env paths should still use the helper's actionable error."""
+    missing_venv = Path("does/not/exist")
+
+    result = subprocess.run(
+        [str(RUN_WORKTREE_SHARED_VENV), "--venv", str(missing_venv), "--", "python", "-V"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert f"Shared virtualenv not found or incomplete: {ROOT / missing_venv}" in result.stderr
+    assert "cd:" not in result.stderr


### PR DESCRIPTION
## Summary
Adds `scripts/dev/run_worktree_shared_venv.sh`, a targeted validation wrapper for sibling worktrees that reuse a shared virtualenv while pinning imports to the active checkout.

## Linked Issues
- Closes `#1848`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Added an executable shared-venv helper that sets `UV_PROJECT_ENVIRONMENT`, `UV_NO_SYNC=1`, and prepends the current worktree root to `PYTHONPATH` before delegating to `uv run`.
- Added fail-fast handling for missing or incomplete shared virtualenv paths.
- Documented targeted shared-venv validation in `docs/dev_guide.md` and linked the pattern from `AGENTS.md` worktree guidance.
- Added script contract tests for import-root pinning, help text, shell syntax, and missing-env failure.

## Why It Matters
- Added value: agents and contributors can run fast checks in sibling worktrees without accidentally importing from the main checkout editable install.
- Expected impact: less false confidence from targeted validation in multi-worktree issue/PR loops.
- Why this is worth merging now: the project is actively using parallel worktrees, and this closes a recurring workflow footgun with a small helper.

## Validation / Proof
- Commands run:
  - `bash -n scripts/dev/run_worktree_shared_venv.sh` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q` -> `13 passed`
  - `scripts/dev/run_worktree_shared_venv.sh -- python - <<'PY' ... import robot_sf ...` -> resolved `robot_sf` from this worktree
  - `uv run pytest tests/test_ci_script_contract.py -q` -> `13 passed`
  - `uv run ruff check tests/test_ci_script_contract.py` -> passed
  - `uv run ruff format --check tests/test_ci_script_contract.py` -> passed
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
  - `git diff --check` -> passed
  - `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `4678 passed, 11 skipped, 9 warnings`
- Evidence that the change works here: live helper smoke showed `robot_sf` importing from `issue-1848-shared-venv-worktree-validation-helper/robot_sf/__init__.py` while using a shared env.
- Benchmarks or smoke tests, if applicable: workflow helper only; no benchmark run.

## Risks / Rollout
- Compatibility risks: low; this is an additive script and docs update.
- Failure modes: if the shared env is missing or stale, the helper fails closed instead of syncing.
- Rollback or fallback plan: remove the helper and docs/tests if it causes workflow confusion.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/dev_guide.md`
- Relevant design or provenance notes: issue #1848 describes the false-import-root workflow risk.
- Any assumptions that need to be preserved: this helper is for targeted checks, not final PR proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #1848
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: additive dev workflow helper, no benchmark/report/registry propagation needed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- The key review point is the safety boundary: `UV_NO_SYNC=1` is deliberate, and final PR proof still requires a full local `.venv` plus final readiness.
- ShellCheck was not installed locally; `bash -n` covered shell syntax.