### PR TITLE
feat: add issue 1475 ORCA residual Slurm prep (#1475)

### DIFF
--- a/SLURM/Auxme/issue_1475_orca_residual_bc.sl
+++ b/SLURM/Auxme/issue_1475_orca_residual_bc.sl
@@ -54,11 +54,11 @@ cleanup() {
 trap cleanup EXIT
 
 run_in_allocation() {
-  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
+  if [[ "${ISSUE1475_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
     log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores --gpus-per-node=1 "$@"
   else
-    log "srun unavailable or not in a Slurm job; running directly."
+    log "Running directly inside the batch allocation; set ISSUE1475_USE_SRUN=1 to opt into srun."
     "$@"
   fi
 }

--- a/SLURM/Auxme/issue_1475_orca_residual_bc.sl
+++ b/SLURM/Auxme/issue_1475_orca_residual_bc.sl
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=issue1475-orca-bc
+#SBATCH --account=mitarbeiter
+#SBATCH --partition=a30
+#SBATCH --qos=a30-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=64G
+#SBATCH --time=12:00:00
+#SBATCH --gres=gpu:1
+#SBATCH --output=output/slurm/%j-issue1475-orca-residual-bc.out
+#SBATCH --error=output/slurm/%j-issue1475-orca-residual-bc.err
+
+set -euo pipefail
+
+PROJECT_ROOT=$(git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null || echo "${SLURM_SUBMIT_DIR:-$(pwd)}")
+LOCAL_OUTPUT_ROOT=${PROJECT_ROOT}/output/slurm
+RESULTS_ROOT=${ISSUE1475_RESULTS_DIR:-${LOCAL_OUTPUT_ROOT}/issue1475-orca-residual-bc-job-${SLURM_JOB_ID:-local}}
+WORKDIR=${SLURM_TMPDIR:-/tmp/${USER}/issue1475-orca-residual-bc-${SLURM_JOB_ID:-local}}
+LINEAGE_CONFIG=${ISSUE1475_LINEAGE_CONFIG:-configs/training/orca_residual/orca_residual_bc_issue_1428.yaml}
+BC_CONFIG=${ISSUE1475_BC_CONFIG:-configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml}
+TRAINING_ENV_CONFIG=${ISSUE1475_TRAINING_ENV_CONFIG:-configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml}
+SCENARIO_CONFIG=${ISSUE1475_SCENARIO_CONFIG:-configs/scenarios/single/planner_sanity_simple.yaml}
+SOURCE_POLICY_ID=${ISSUE1475_SOURCE_POLICY_ID:-ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417}
+DATASET_ID=${ISSUE1475_DATASET_ID:-issue_1428_orca_residual_bc_smoke}
+POLICY_OUTPUT_ID=${ISSUE1475_POLICY_OUTPUT_ID:-issue_1428_orca_residual_bc_policy_smoke}
+EPISODES=${ISSUE1475_EPISODES:-3}
+SEEDS=${ISSUE1475_SEEDS:-"111:112:113"}
+CANDIDATE=${ISSUE1475_CANDIDATE:-orca_residual_guarded_ppo_v0}
+RUN_NOMINAL=${ISSUE1475_RUN_NOMINAL:-0}
+LOG_LEVEL=${ISSUE1475_LOG_LEVEL:-WARNING}
+RUN_OUTPUT_DIR=""
+
+log() {
+  echo "[issue1475-orca-bc] $*"
+}
+
+die() {
+  echo "[issue1475-orca-bc] $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "${RUN_OUTPUT_DIR}" && -d "${RUN_OUTPUT_DIR}" ]]; then
+    mkdir -p "${RESULTS_ROOT}"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --partial --prune-empty-dirs "${RUN_OUTPUT_DIR}/" "${RESULTS_ROOT}/" || true
+    else
+      cp -r "${RUN_OUTPUT_DIR}/." "${RESULTS_ROOT}/" || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+run_in_allocation() {
+  if command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    log "Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
+    srun --cpu_bind=cores --gpus-per-node=1 "$@"
+  else
+    log "srun unavailable or not in a Slurm job; running directly."
+    "$@"
+  fi
+}
+
+if ! git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  die "PROJECT_ROOT is not inside a git worktree: ${PROJECT_ROOT}"
+fi
+
+cd "${PROJECT_ROOT}"
+
+for path in "${LINEAGE_CONFIG}" "${BC_CONFIG}" "${TRAINING_ENV_CONFIG}" "${SCENARIO_CONFIG}"; do
+  [[ -f "${path}" ]] || die "Required path not found: ${path}"
+done
+
+mkdir -p "${WORKDIR}" "${LOCAL_OUTPUT_ROOT}"
+export ROBOT_SF_ARTIFACT_ROOT=${WORKDIR}/results
+export UV_PROJECT_ENVIRONMENT=${ISSUE1475_UV_ENV_DIR:-${WORKDIR}/uv_env}
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-max_split_size_mb:256}
+export SDL_VIDEODRIVER=${SDL_VIDEODRIVER:-dummy}
+export MPLBACKEND=${MPLBACKEND:-Agg}
+export LOGURU_LEVEL=${LOGURU_LEVEL:-${LOG_LEVEL}}
+RUN_OUTPUT_DIR=${ROBOT_SF_ARTIFACT_ROOT}
+mkdir -p "${ROBOT_SF_ARTIFACT_ROOT}" "$(dirname "${UV_PROJECT_ENVIRONMENT}")"
+
+log "PROJECT_ROOT=${PROJECT_ROOT}"
+log "ROBOT_SF_ARTIFACT_ROOT=${ROBOT_SF_ARTIFACT_ROOT}"
+log "UV_PROJECT_ENVIRONMENT=${UV_PROJECT_ENVIRONMENT}"
+log "RESULTS_ROOT=${RESULTS_ROOT}"
+log "LINEAGE_CONFIG=${LINEAGE_CONFIG}"
+log "BC_CONFIG=${BC_CONFIG}"
+log "TRAINING_ENV_CONFIG=${TRAINING_ENV_CONFIG}"
+log "SCENARIO_CONFIG=${SCENARIO_CONFIG}"
+log "SOURCE_POLICY_ID=${SOURCE_POLICY_ID}"
+log "DATASET_ID=${DATASET_ID}"
+log "POLICY_OUTPUT_ID=${POLICY_OUTPUT_ID}"
+log "EPISODES=${EPISODES}"
+log "SEEDS=${SEEDS}"
+log "RUN_NOMINAL=${RUN_NOMINAL}"
+log "git_commit=$(git rev-parse HEAD)"
+
+uv sync --group imitation
+
+run_in_allocation \
+  uv run python scripts/validation/validate_orca_residual_lineage_packet.py \
+  --config "${LINEAGE_CONFIG}" \
+  --json
+
+SEEDS_EXPANDED="${SEEDS//,/ }"
+SEEDS_EXPANDED="${SEEDS_EXPANDED//:/ }"
+# shellcheck disable=SC2206
+SEED_ARGS=(${SEEDS_EXPANDED})
+
+run_in_allocation \
+  uv run python scripts/training/collect_expert_trajectories.py \
+  --dataset-id "${DATASET_ID}" \
+  --policy-id "${SOURCE_POLICY_ID}" \
+  --episodes "${EPISODES}" \
+  --scenario-config "${SCENARIO_CONFIG}" \
+  --training-config "${TRAINING_ENV_CONFIG}" \
+  --env-config "${BC_CONFIG}" \
+  --seeds "${SEED_ARGS[@]}"
+
+run_in_allocation \
+  uv run --group imitation python scripts/training/pretrain_from_expert.py \
+  --config "${BC_CONFIG}"
+
+MATERIALIZED_DIR="${ROBOT_SF_ARTIFACT_ROOT}/issue1475_materialized_candidate"
+MATERIALIZED_JSON="${MATERIALIZED_DIR}/materialized_candidate_manifest.json"
+POLICY_MODEL_PATH="${ROBOT_SF_ARTIFACT_ROOT}/benchmarks/expert_policies/${POLICY_OUTPUT_ID}.zip"
+run_in_allocation \
+  uv run python scripts/tools/materialize_orca_residual_candidate.py \
+  --policy-model-id "${POLICY_OUTPUT_ID}" \
+  --policy-model-path "${POLICY_MODEL_PATH}" \
+  --candidate "${CANDIDATE}" \
+  --output-dir "${MATERIALIZED_DIR}" \
+  --json
+
+RUNTIME_REGISTRY=$(python - "${MATERIALIZED_JSON}" <<'PY'
+import json
+import sys
+print(json.loads(open(sys.argv[1], encoding="utf-8").read())["runtime_registry"])
+PY
+)
+
+SMOKE_OUTPUT="${ROBOT_SF_ARTIFACT_ROOT}/policy_search/${CANDIDATE}/smoke/issue1475_smoke"
+run_in_allocation \
+  uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate "${CANDIDATE}" \
+  --candidate-registry "${RUNTIME_REGISTRY}" \
+  --stage smoke \
+  --workers 1 \
+  --output-dir "${SMOKE_OUTPUT}"
+
+python - "${SMOKE_OUTPUT}/summary.json" <<'PY'
+import json
+import sys
+summary = json.loads(open(sys.argv[1], encoding="utf-8").read())["summary"]
+success = float(summary.get("success_rate", 0.0))
+collision = float(summary.get("collision_rate", 1.0))
+if success < 1.0 or collision > 0.0:
+    raise SystemExit(
+        f"Smoke gate failed: success_rate={success:.4f} collision_rate={collision:.4f}"
+    )
+print(f"Smoke gate passed: success_rate={success:.4f} collision_rate={collision:.4f}")
+PY
+
+if [[ "${RUN_NOMINAL}" == "1" ]]; then
+  NOMINAL_OUTPUT="${ROBOT_SF_ARTIFACT_ROOT}/policy_search/${CANDIDATE}/nominal_sanity/issue1475_nominal"
+  run_in_allocation \
+    uv run python scripts/validation/run_policy_search_candidate.py \
+    --candidate "${CANDIDATE}" \
+    --candidate-registry "${RUNTIME_REGISTRY}" \
+    --stage nominal_sanity \
+    --allow-expensive-stage \
+    --workers 2 \
+    --output-dir "${NOMINAL_OUTPUT}"
+else
+  log "Skipping nominal_sanity because ISSUE1475_RUN_NOMINAL is not 1."
+fi
+
+log "ORCA-residual BC smoke chain completed. Artifacts will sync to ${RESULTS_ROOT}"

--- a/configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+++ b/configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
@@ -90,15 +90,18 @@ execution_boundary:
   dataset_command_shape: >-
     uv run python scripts/training/collect_expert_trajectories.py --policy-id
     ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
-    --dataset-id issue_1428_orca_residual_bc_dataset --episodes <bounded-smoke-episodes>
-    --training-config configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+    --dataset-id issue_1428_orca_residual_bc_smoke --episodes 3
+    --scenario-config configs/scenarios/single/planner_sanity_simple.yaml
+    --training-config
+    configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml
+    --env-config configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml
+    --seeds 111 112 113
   bc_training_command_shape: >-
     uv run python scripts/training/pretrain_from_expert.py --config
-    configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+    configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml
   smoke_candidate_command_shape: >-
     LOGURU_LEVEL=WARNING PYGAME_HIDE_SUPPORT_PROMPT=1 uv run python
     scripts/validation/run_policy_search_candidate.py --candidate orca_residual_guarded_ppo_v0
-    --stage smoke --workers 1
+    --candidate-registry <materialized-runtime-registry> --stage smoke --workers 1
   slurm_command_shape: >-
-    scripts/dev/sbatch_policy_search_sweep.sh --candidate orca_residual_guarded_ppo_v0
-    --stage nominal_sanity --config configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+    scripts/dev/sbatch_orca_residual_bc_issue1475.sh --dry-run --no-status

--- a/configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml
+++ b/configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml
@@ -1,0 +1,18 @@
+# Issue #1475 ORCA-residual BC smoke pretrain config.
+#
+# This is the concrete BC config consumed by
+# SLURM/Auxme/issue_1475_orca_residual_bc.sl.  It intentionally stays bounded to
+# the policy-search smoke scenario; nominal escalation is gated by the wrapper.
+run_id: issue_1475_orca_residual_bc_smoke
+dataset_id: issue_1428_orca_residual_bc_smoke
+policy_output_id: issue_1428_orca_residual_bc_policy_smoke
+training_config: ../ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml
+scenario_config: ../../scenarios/single/planner_sanity_simple.yaml
+scenario_id: planner_sanity_simple
+bc_epochs: 8
+batch_size: 64
+learning_rate: 0.0003
+random_seeds: [111, 112, 113]
+device: cpu
+env_overrides:
+  predictive_foresight_device: cpu

--- a/docs/context/policy_search/SLURM/005_orca_residual_bc_lineage.md
+++ b/docs/context/policy_search/SLURM/005_orca_residual_bc_lineage.md
@@ -4,9 +4,9 @@ Issue: <https://github.com/ll7/robot_sf_ll7/issues/1428>
 
 ## Boundary
 
-This handoff stages the first ORCA-residual learned-policy lineage slice. It does not submit Slurm,
-train the residual policy, or count the existing `orca_residual_guarded_ppo_v0` smoke as learned
-residual evidence.
+This handoff stages the first ORCA-residual learned-policy lineage slice. The concrete issue #1475
+smoke job is now prepared as a bounded Slurm wrapper, but this handoff still does not count the
+existing `orca_residual_guarded_ppo_v0` runtime smoke as learned residual evidence.
 
 The local preflight packet is:
 
@@ -45,15 +45,18 @@ Dataset collection:
 ```bash
 uv run python scripts/training/collect_expert_trajectories.py --policy-id \
   ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417 \
-  --dataset-id issue_1428_orca_residual_bc_dataset --episodes <bounded-smoke-episodes> \
-  --training-config configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+  --dataset-id issue_1428_orca_residual_bc_smoke --episodes 3 \
+  --scenario-config configs/scenarios/single/planner_sanity_simple.yaml \
+  --training-config configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml \
+  --env-config configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml \
+  --seeds 111 112 113
 ```
 
 Behavior-cloning training:
 
 ```bash
 uv run python scripts/training/pretrain_from_expert.py \
-  --config configs/training/orca_residual/orca_residual_bc_issue_1428.yaml
+  --config configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml
 ```
 
 Smoke evaluation after a concrete checkpoint pointer exists:
@@ -69,3 +72,23 @@ LOGURU_LEVEL=WARNING PYGAME_HIDE_SUPPORT_PROMPT=1 uv run python \
 Only submit the bounded nominal Slurm job after the local packet validates and the dataset/checkpoint
 artifact pointers are concrete. If the smoke or nominal run reports fallback/degraded status, revise
 the lineage path instead of escalating to stress/full evaluation.
+
+## Issue #1475 Slurm Wrapper
+
+Dry-run the prepared smoke job from the owning worktree:
+
+```bash
+scripts/dev/sbatch_orca_residual_bc_issue1475.sh --dry-run --no-status
+```
+
+Submit the smoke-only job from an allowed Auxme Slurm login node:
+
+```bash
+scripts/dev/sbatch_orca_residual_bc_issue1475.sh
+```
+
+The wrapper validates this lineage packet, collects three smoke episodes from the issue-791 PPO
+leader, trains `issue_1428_orca_residual_bc_policy_smoke`, materializes a run-local candidate
+registry that points at that checkpoint, and evaluates smoke before any optional nominal run. Set
+`--run-nominal` only when the smoke gate should immediately escalate to `nominal_sanity`; the
+wrapper fails closed if smoke success is below `1.0` or collision rate is above `0.0`.

--- a/scripts/dev/sbatch_orca_residual_bc_issue1475.sh
+++ b/scripts/dev/sbatch_orca_residual_bc_issue1475.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SBATCH_MAX_TIME_SCRIPT="$SCRIPT_DIR/sbatch_use_max_time.sh"
+PARTITION_STATUS_SCRIPT="$SCRIPT_DIR/auxme_partition_status.sh"
+
+PARTITION="a30"
+QOS="a30-gpu"
+TIME_LIMIT="12:00:00"
+EPISODES="3"
+SEEDS="111:112:113"
+RUN_NOMINAL="0"
+DRY_RUN=0
+SHOW_STATUS=1
+EXTRA_SBATCH_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/dev/sbatch_orca_residual_bc_issue1475.sh [options]
+
+Prepare or submit the bounded ORCA-residual BC smoke job for issue #1475.
+
+Options:
+  --partition <name>    Slurm partition (default: a30)
+  --qos <name>          Slurm QoS (default: a30-gpu)
+  --time <value>        Wall time passed to sbatch_use_max_time (default: 12:00:00)
+  --episodes <n>        Bounded smoke collection episodes (default: 3)
+  --seeds "<values>"    Colon-separated seed list (default: "111:112:113")
+  --run-nominal         Run nominal_sanity only after the smoke gate passes
+  --sbatch-arg <arg>    Extra sbatch argument
+  --no-status           Skip Auxme partition status table
+  --dry-run             Print the resolved sbatch command without submitting
+  -h, --help            Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --partition)
+      PARTITION="$2"
+      shift 2
+      ;;
+    --qos)
+      QOS="$2"
+      shift 2
+      ;;
+    --time)
+      TIME_LIMIT="$2"
+      shift 2
+      ;;
+    --episodes)
+      EPISODES="$2"
+      shift 2
+      ;;
+    --seeds)
+      SEEDS="$2"
+      shift 2
+      ;;
+    --run-nominal)
+      RUN_NOMINAL="1"
+      shift
+      ;;
+    --sbatch-arg)
+      EXTRA_SBATCH_ARGS+=("$2")
+      shift 2
+      ;;
+    --no-status)
+      SHOW_STATUS=0
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+LINEAGE_CONFIG="configs/training/orca_residual/orca_residual_bc_issue_1428.yaml"
+BC_CONFIG="configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml"
+SLURM_SCRIPT="SLURM/Auxme/issue_1475_orca_residual_bc.sl"
+
+for path in "$LINEAGE_CONFIG" "$BC_CONFIG" "$SLURM_SCRIPT"; do
+  [[ -f "$path" ]] || {
+    echo "Required path not found: $path" >&2
+    exit 2
+  }
+done
+
+uv run python scripts/validation/validate_orca_residual_lineage_packet.py \
+  --config "$LINEAGE_CONFIG" \
+  --json >/dev/null
+
+if [[ "$SHOW_STATUS" == "1" ]]; then
+  "$PARTITION_STATUS_SCRIPT" || true
+fi
+
+echo "[issue1475-submit] branch=$(git branch --show-current)" >&2
+echo "[issue1475-submit] commit=$(git rev-parse HEAD)" >&2
+echo "[issue1475-submit] lineage_config=$LINEAGE_CONFIG" >&2
+echo "[issue1475-submit] bc_config=$BC_CONFIG" >&2
+echo "[issue1475-submit] episodes=$EPISODES seeds=$SEEDS run_nominal=$RUN_NOMINAL" >&2
+
+wrapper_args=(
+  "--partition" "$PARTITION"
+  "--qos" "$QOS"
+  "--time" "$TIME_LIMIT"
+  "--sbatch-arg" "--partition=$PARTITION"
+  "--sbatch-arg" "--qos=$QOS"
+  "--sbatch-arg" "--job-name=rsf-1475-orca-bc-smoke"
+  "--sbatch-arg" "--export=ALL,ISSUE1475_EPISODES=$EPISODES,ISSUE1475_SEEDS=$SEEDS,ISSUE1475_RUN_NOMINAL=$RUN_NOMINAL"
+)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  wrapper_args+=("--dry-run")
+fi
+for arg in "${EXTRA_SBATCH_ARGS[@]}"; do
+  wrapper_args+=("--sbatch-arg" "$arg")
+done
+
+"$SBATCH_MAX_TIME_SCRIPT" "${wrapper_args[@]}" "$SLURM_SCRIPT"

--- a/scripts/tools/materialize_orca_residual_candidate.py
+++ b/scripts/tools/materialize_orca_residual_candidate.py
@@ -17,6 +17,7 @@ DEFAULT_CANDIDATE = "orca_residual_guarded_ppo_v0"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file as a mapping, failing when the top-level value is not a dict."""
     payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(payload, dict):
         raise TypeError(f"Expected YAML mapping: {path}")
@@ -24,6 +25,7 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
 
 def _resolve_repo_path(raw: str) -> Path:
+    """Resolve a possibly repository-relative path against ``REPO_ROOT``."""
     path = Path(raw)
     return path if path.is_absolute() else REPO_ROOT / path
 

--- a/scripts/tools/materialize_orca_residual_candidate.py
+++ b/scripts/tools/materialize_orca_residual_candidate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Materialize a run-local ORCA-residual candidate for a trained BC checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY = REPO_ROOT / "docs/context/policy_search/candidate_registry.yaml"
+DEFAULT_CANDIDATE = "orca_residual_guarded_ppo_v0"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected YAML mapping: {path}")
+    return payload
+
+
+def _resolve_repo_path(raw: str) -> Path:
+    path = Path(raw)
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy-model-id", required=True)
+    parser.add_argument(
+        "--policy-model-path",
+        type=Path,
+        required=True,
+        help="Run-local checkpoint path produced by BC pretraining.",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--candidate", default=DEFAULT_CANDIDATE)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def materialize_candidate(
+    *,
+    policy_model_id: str,
+    policy_model_path: Path,
+    output_dir: Path,
+    registry_path: Path,
+    candidate_name: str,
+) -> dict[str, Any]:
+    """Write a run-local registry and candidate config pinned to a trained policy id."""
+    registry_path = registry_path.resolve()
+    registry = _load_yaml(registry_path)
+    candidates = registry.get("candidates")
+    if not isinstance(candidates, dict) or candidate_name not in candidates:
+        raise KeyError(f"Candidate {candidate_name!r} not found in {registry_path}")
+    entry = dict(candidates[candidate_name])
+    config_raw = entry.get("candidate_config_path")
+    if not isinstance(config_raw, str) or not config_raw.strip():
+        raise ValueError(f"Candidate {candidate_name!r} has no candidate_config_path")
+
+    candidate_config_path = _resolve_repo_path(config_raw).resolve()
+    candidate = _load_yaml(candidate_config_path)
+    params = candidate.setdefault("params", {})
+    if not isinstance(params, dict):
+        raise TypeError(f"Candidate params must be a mapping: {candidate_config_path}")
+    policy_model_path = policy_model_path.resolve()
+    if not policy_model_path.is_file():
+        raise FileNotFoundError(f"Policy checkpoint not found: {policy_model_path}")
+    params["model_id"] = None
+    params["model_path"] = str(policy_model_path)
+
+    output_dir = output_dir.resolve()
+    candidate_dir = output_dir / "candidates"
+    candidate_dir.mkdir(parents=True, exist_ok=True)
+    runtime_candidate_path = candidate_dir / f"{candidate_name}.yaml"
+    runtime_registry_path = output_dir / "candidate_registry.yaml"
+    manifest_path = output_dir / "materialized_candidate_manifest.json"
+
+    runtime_candidate_path.write_text(
+        yaml.safe_dump(candidate, sort_keys=False),
+        encoding="utf-8",
+    )
+    entry["candidate_config_path"] = str(runtime_candidate_path)
+    entry["status"] = "implemented"
+    entry["training_required"] = False
+    entry["materialized_from"] = str(candidate_config_path)
+    entry["materialized_policy_model_id"] = policy_model_id
+    candidates[candidate_name] = entry
+    runtime_registry_path.write_text(
+        yaml.safe_dump(registry, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "schema_version": "orca-residual-materialized-candidate.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "candidate": candidate_name,
+        "source_candidate_config": str(candidate_config_path),
+        "runtime_candidate_config": str(runtime_candidate_path),
+        "runtime_registry": str(runtime_registry_path),
+        "policy_model_id": policy_model_id,
+        "policy_model_path": str(policy_model_path),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return manifest
+
+
+def main() -> int:
+    """Run the materializer."""
+    args = build_parser().parse_args()
+    manifest = materialize_candidate(
+        policy_model_id=args.policy_model_id,
+        policy_model_path=args.policy_model_path,
+        output_dir=args.output_dir,
+        registry_path=args.registry,
+        candidate_name=args.candidate,
+    )
+    if args.json:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+    else:
+        print(manifest["runtime_registry"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_materialize_orca_residual_candidate.py
+++ b/tests/tools/test_materialize_orca_residual_candidate.py
@@ -1,0 +1,36 @@
+"""Tests for run-local ORCA-residual candidate materialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.tools.materialize_orca_residual_candidate import materialize_candidate
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def test_materialize_candidate_pins_checkpoint_path(tmp_path: Path) -> None:
+    """Materialization should avoid mutating the checked-in candidate registry."""
+    checkpoint = tmp_path / "policy.zip"
+    checkpoint.write_text("checkpoint", encoding="utf-8")
+
+    manifest = materialize_candidate(
+        policy_model_id="issue_1428_orca_residual_bc_policy_smoke",
+        policy_model_path=checkpoint,
+        output_dir=tmp_path / "runtime",
+        registry_path=REPO_ROOT / "docs/context/policy_search/candidate_registry.yaml",
+        candidate_name="orca_residual_guarded_ppo_v0",
+    )
+
+    runtime_registry = Path(manifest["runtime_registry"])
+    runtime_candidate = Path(manifest["runtime_candidate_config"])
+    registry_payload = yaml.safe_load(runtime_registry.read_text(encoding="utf-8"))
+    candidate_payload = yaml.safe_load(runtime_candidate.read_text(encoding="utf-8"))
+
+    entry = registry_payload["candidates"]["orca_residual_guarded_ppo_v0"]
+    assert entry["candidate_config_path"] == str(runtime_candidate)
+    assert entry["training_required"] is False
+    assert candidate_payload["params"]["model_id"] is None
+    assert candidate_payload["params"]["model_path"] == str(checkpoint.resolve())


### PR DESCRIPTION
## Summary
Adds a concrete Auxme Slurm wrapper and launch helper for the Issue #1475 ORCA-residual BC smoke workflow, plus the runtime candidate materializer needed to evaluate the trained residual policy without mutating the checked-in registry.

## Linked Issues
- Relates to #1475
- Relates to #1428

## Stack / Dependency
- Base dependency: main
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `SLURM/Auxme/issue_1475_orca_residual_bc.sl` and `scripts/dev/sbatch_orca_residual_bc_issue1475.sh` for a dry-runable/submit-ready smoke training job.
- Added `configs/training/orca_residual/orca_residual_bc_issue_1475_smoke_pretrain.yaml` and updated the existing ORCA-residual lineage packet command shapes.
- Added `scripts/tools/materialize_orca_residual_candidate.py` and tests so the trained checkpoint is materialized into a run-local candidate registry.
- Updated `docs/context/policy_search/SLURM/005_orca_residual_bc_lineage.md` with the Issue #1475 wrapper and caveats.
- Review fix: the Slurm wrapper now runs directly inside the batch allocation by default; `ISSUE1475_USE_SRUN=1` is required to opt into `srun`.

## Why It Matters
- Added value: prepares a meaningful Slurm training job for the bounded ORCA-residual BC path instead of leaving Issue #1475 as only a launch-packet placeholder.
- Expected impact: an Auxme submitter can now start the smoke pretraining job from this branch with `scripts/dev/sbatch_orca_residual_bc_issue1475.sh`.
- Why this is worth merging now: local submission is disallowed on this machine, but the repository-side infrastructure, validation, dry-run command, and runtime candidate wiring are ready.

## Validation / Proof
- Commands run before review fixes:
  - `uv sync --all-extras`
  - `uv run python scripts/validation/validate_orca_residual_lineage_packet.py --config configs/training/orca_residual/orca_residual_bc_issue_1428.yaml --json`
  - `uv run pytest -q tests/training/test_orca_residual_lineage_packet.py tests/tools/test_materialize_orca_residual_candidate.py`
  - `uv run ruff check scripts/tools/materialize_orca_residual_candidate.py tests/tools/test_materialize_orca_residual_candidate.py`
  - `bash -n SLURM/Auxme/issue_1475_orca_residual_bc.sl`
  - `bash -n scripts/dev/sbatch_orca_residual_bc_issue1475.sh`
  - `scripts/dev/sbatch_orca_residual_bc_issue1475.sh --dry-run --no-status`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after merging latest `origin/main`
- Review validation on `7e42f82c99d5dc63e41476faa93382641afa9351`:
  - `git diff --check origin/main...HEAD`
  - `uv run ruff check scripts/tools/materialize_orca_residual_candidate.py tests/tools/test_materialize_orca_residual_candidate.py`
  - `uv run pytest -q tests/tools/test_materialize_orca_residual_candidate.py tests/training/test_orca_residual_lineage_packet.py` -> 9 passed
  - `bash -n SLURM/Auxme/issue_1475_orca_residual_bc.sl scripts/dev/sbatch_orca_residual_bc_issue1475.sh`
- Evidence that the change works here: dry-run produced the expected `sbatch` command with `ISSUE1475_EPISODES=3`, seeds `111:112:113`, and `ISSUE1475_RUN_NOMINAL=0`. No Slurm submission was performed because this local machine forbids Slurm submission.
- Benchmarks or smoke tests, if applicable: no training job was submitted; benchmark-strength claims require Slurm run artifacts after submission.

## Risks / Rollout
- Compatibility risks: the job depends on the existing expert policy id and the Auxme Slurm environment having the expected `uv` and artifact paths.
- Failure modes: missing expert artifacts, unavailable GPU partition, or smoke collision/success gate failure should fail closed in the batch script.
- Rollback or fallback plan: revert the launcher/config/materializer additions; no checked-in registry state is mutated by the runtime materializer.

## Docs / Provenance
- Updated docs: `docs/context/policy_search/SLURM/005_orca_residual_bc_lineage.md`
- Relevant design or provenance notes: the materializer writes run-local registry/candidate files under the Slurm result directory and records a manifest for the trained checkpoint.
- Any assumptions that need to be preserved: generated Slurm outputs and checkpoints remain under ignored `output/` or runtime result directories until explicitly promoted to durable storage.

## Downstream Propagation
- Parent issue updated: yes, kept #1475 open as the Slurm execution and durable artifact follow-up
- Claim map / benchmark report updated: NA
- Registry or config index updated: yes, lineage packet command shapes updated; checked-in candidate registry intentionally unchanged.
- Context index / memory note updated: no
- Follow-up issue opened for deferred propagation: existing #1475 remains open for execution and artifact promotion
- Not-applicable rationale: this PR prepares a launchable smoke training job; benchmark-strength claims require the Slurm run artifacts after submission.

## Follow-Up Issues
- Deferred work: submit the job from an allowed Auxme Slurm login node and promote any successful checkpoint/results to durable artifact storage before making benchmark-strength claims.
- Issues opened for follow-up: none; existing #1475 remains open

## Reviewer Notes
- Review the fail-closed gates in `SLURM/Auxme/issue_1475_orca_residual_bc.sl`, especially the smoke summary success/collision checks.
- The first full readiness attempt saw a nondeterministic failure in `tests/test_robot_with_ped_obstacle_force.py::test_can_create_env`; rerunning that exact test passed. Final merge-ready still depends on CI for the current reviewed head.