### PR TITLE
feat: prepare issue 1470 oracle imitation Slurm traces (#1470)

### DIFF
--- a/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
+++ b/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=issue1470-oracle-traces
+#SBATCH --account=mitarbeiter
+#SBATCH --partition=a30
+#SBATCH --qos=a30-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=48G
+#SBATCH --time=06:00:00
+#SBATCH --gres=gpu:1
+#SBATCH --output=output/slurm/%j-issue1470-oracle-imitation-traces.out
+#SBATCH --error=output/slurm/%j-issue1470-oracle-imitation-traces.err
+
+set -euo pipefail
+
+PROJECT_ROOT=$(git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null || echo "${SLURM_SUBMIT_DIR:-$(pwd)}")
+LOCAL_OUTPUT_ROOT=${PROJECT_ROOT}/output/slurm
+RESULTS_ROOT=${AUXME_RESULTS_DIR:-${LOCAL_OUTPUT_ROOT}/issue1470-oracle-imitation-traces-job-${SLURM_JOB_ID:-local}}
+WORKDIR=${SLURM_TMPDIR:-/tmp/${USER}/issue1470-${SLURM_JOB_ID:-local}}
+PACKET=${ISSUE1470_PACKET:-configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml}
+REGISTRY=${ISSUE1470_CANDIDATE_REGISTRY:-docs/context/policy_search/candidate_registry.yaml}
+SPLIT=${ISSUE1470_SPLIT:-train}
+HORIZON=${ISSUE1470_HORIZON:-500}
+WORKERS=${ISSUE1470_WORKERS:-1}
+LOG_LEVEL=${ISSUE1470_LOG_LEVEL:-WARNING}
+MODULE_LIST=${AUXME_MODULES:-"gcc/13.2.0"}
+CUDA_MODULE=${AUXME_CUDA_MODULE:-cuda/12.1}
+MODULES_AVAILABLE=0
+RUN_OUTPUT_DIR=""
+
+cleanup() {
+  if [[ -n "${RUN_OUTPUT_DIR}" && -d "${RUN_OUTPUT_DIR}" ]]; then
+    mkdir -p "${RESULTS_ROOT}"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --partial --prune-empty-dirs "${RUN_OUTPUT_DIR}/" "${RESULTS_ROOT}/" || true
+    else
+      cp -r "${RUN_OUTPUT_DIR}/." "${RESULTS_ROOT}/" || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+ensure_module_command() {
+  if command -v module >/dev/null 2>&1; then
+    MODULES_AVAILABLE=1
+    return 0
+  fi
+
+  local init_script
+  for init_script in /etc/profile.d/modules.sh /usr/share/Modules/init/bash; do
+    if [[ -f "${init_script}" ]]; then
+      # shellcheck disable=SC1090
+      source "${init_script}" >/dev/null 2>&1 || true
+    fi
+    if command -v module >/dev/null 2>&1; then
+      MODULES_AVAILABLE=1
+      return 0
+    fi
+  done
+
+  echo "[issue1470] module command is unavailable; continuing without module loads." >&2
+  return 0
+}
+
+run_in_allocation() {
+  if command -v srun >/dev/null 2>&1; then
+    echo "[issue1470] Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
+    srun --cpu_bind=cores --gpus-per-node=1 "$@"
+  else
+    echo "[issue1470] srun unavailable; running directly in the batch allocation." >&2
+    "$@"
+  fi
+}
+
+if ! git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[issue1470] PROJECT_ROOT is not inside a git work tree: ${PROJECT_ROOT}" >&2
+  exit 1
+fi
+
+cd "${PROJECT_ROOT}"
+
+for path in "${PACKET}" "${REGISTRY}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "[issue1470] Required path not found: ${path}" >&2
+    exit 1
+  fi
+done
+
+ensure_module_command
+if [[ "${MODULES_AVAILABLE}" == "1" ]]; then
+  module purge
+  for mod in ${MODULE_LIST}; do
+    [[ -z "${mod}" ]] && continue
+    echo "[issue1470] Loading module ${mod}"
+    module load "${mod}"
+  done
+  if [[ -n "${CUDA_MODULE}" ]]; then
+    echo "[issue1470] Loading CUDA module ${CUDA_MODULE}"
+    module load "${CUDA_MODULE}"
+  fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "[issue1470] uv is not available in PATH." >&2
+  exit 1
+fi
+
+mkdir -p "${WORKDIR}" "${LOCAL_OUTPUT_ROOT}"
+export ROBOT_SF_ARTIFACT_ROOT=${WORKDIR}/results
+export UV_PROJECT_ENVIRONMENT=${ISSUE1470_UV_ENV_DIR:-${WORKDIR}/uv_env}
+export SDL_VIDEODRIVER=${SDL_VIDEODRIVER:-dummy}
+export MPLBACKEND=${MPLBACKEND:-Agg}
+export LOGURU_LEVEL=${LOGURU_LEVEL:-${LOG_LEVEL}}
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+RUN_OUTPUT_DIR=${ROBOT_SF_ARTIFACT_ROOT}
+TRACE_OUTPUT_DIR=${ROBOT_SF_ARTIFACT_ROOT}/oracle_imitation/issue1470_${SPLIT}_candidate_traces
+mkdir -p "${ROBOT_SF_ARTIFACT_ROOT}" "$(dirname "${UV_PROJECT_ENVIRONMENT}")" "${TRACE_OUTPUT_DIR}"
+
+echo "[issue1470] PROJECT_ROOT=${PROJECT_ROOT}"
+echo "[issue1470] ROBOT_SF_ARTIFACT_ROOT=${ROBOT_SF_ARTIFACT_ROOT}"
+echo "[issue1470] UV_PROJECT_ENVIRONMENT=${UV_PROJECT_ENVIRONMENT}"
+echo "[issue1470] RESULTS_ROOT=${RESULTS_ROOT}"
+echo "[issue1470] PACKET=${PACKET}"
+echo "[issue1470] REGISTRY=${REGISTRY}"
+echo "[issue1470] SPLIT=${SPLIT}"
+echo "[issue1470] HORIZON=${HORIZON}"
+echo "[issue1470] WORKERS=${WORKERS}"
+echo "[issue1470] commit=$(git rev-parse HEAD)"
+
+uv sync --all-extras
+
+run_in_allocation \
+  uv run python scripts/validation/validate_oracle_imitation_launch_packet.py \
+  --config "${PACKET}" \
+  --json
+
+run_in_allocation \
+  uv run python scripts/training/collect_oracle_imitation_candidate_traces.py \
+  --config "${PACKET}" \
+  --candidate-registry "${REGISTRY}" \
+  --split "${SPLIT}" \
+  --output-dir "${TRACE_OUTPUT_DIR}" \
+  --horizon "${HORIZON}" \
+  --workers "${WORKERS}" \
+  --json
+
+echo "[issue1470] Oracle candidate trace collection completed. Artifacts will sync to ${RESULTS_ROOT}"

--- a/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
+++ b/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
@@ -64,11 +64,11 @@ ensure_module_command() {
 }
 
 run_in_allocation() {
-  if command -v srun >/dev/null 2>&1; then
+  if [[ "${ISSUE1470_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "[issue1470] Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores --gpus-per-node=1 "$@"
   else
-    echo "[issue1470] srun unavailable; running directly in the batch allocation." >&2
+    echo "[issue1470] Running directly inside the batch allocation; set ISSUE1470_USE_SRUN=1 to opt into srun." >&2
     "$@"
   fi
 }

--- a/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
+++ b/SLURM/Auxme/issue_1470_oracle_imitation_traces.sl
@@ -64,7 +64,7 @@ ensure_module_command() {
 }
 
 run_in_allocation() {
-  if [[ "${ISSUE1470_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]]; then
+  if [[ "${ISSUE1470_USE_SRUN:-0}" == "1" ]] && command -v srun >/dev/null 2>&1 && [[ -n "${SLURM_JOB_ID:-}" ]] && srun --version >/dev/null 2>&1; then
     echo "[issue1470] Launching with srun on node ${SLURMD_NODENAME:-${HOSTNAME:-unknown}}."
     srun --cpu_bind=cores --gpus-per-node=1 "$@"
   else

--- a/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+++ b/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
@@ -77,5 +77,8 @@ local_preflight_command: >
   uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config
   configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json
 slurm_command_shape: >
-  Submit dataset collection only from a follow-up issue after local preflight passes and
-  concrete durable artifact aliases are assigned; do not submit Slurm from #1397.
+  scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh --dry-run --no-status
+  prepares the issue #1470 train-split source-candidate trace collection job. This trace
+  job is executable Slurm work, but it is not the final imitation NPZ dataset; downstream
+  imitation training still requires durable dataset materialization and concrete artifact
+  aliases after the trace run completes.

--- a/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
+++ b/docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md
@@ -14,10 +14,18 @@ Issue #1397 adds the pre-Slurm launch packet:
 - `scripts/validation/validate_oracle_imitation_launch_packet.py`
 - `docs/context/issue_1397_oracle_imitation_launch_packet.md`
 
-Dataset generation, hard-slice augmentation, and relabeling must still wait for a
-dedicated follow-up Slurm issue. That issue should first validate the launch packet,
-replace pending durable artifact aliases with concrete W&B aliases or run ids, then
-record generated dataset checksums before imitation training starts.
+Issue #1470 now has a concrete Slurm-prepared source-candidate trace job:
+
+```bash
+scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh --dry-run --no-status
+```
+
+Submit from an allowed Auxme Slurm login node by removing `--dry-run`. The job validates the
+launch packet, runs `hybrid_rule_v3_static_margin0_waypoint2` on the packet's exact train split,
+and writes a JSONL trace manifest under the job result root. This is executable Slurm work for
+the oracle-imitation lane, but it is not yet the final imitation NPZ dataset. Dataset
+materialization, hard-slice augmentation, relabeling, concrete durable artifact aliases, and
+checksums must still be recorded before imitation training starts.
 
 ## Suggested Phases
 

--- a/scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh
+++ b/scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SBATCH_MAX_TIME_SCRIPT="$SCRIPT_DIR/sbatch_use_max_time.sh"
+PARTITION_STATUS_SCRIPT="$SCRIPT_DIR/auxme_partition_status.sh"
+SBATCH_SCRIPT="SLURM/Auxme/issue_1470_oracle_imitation_traces.sl"
+
+PARTITION="a30"
+QOS="a30-gpu"
+TIME_LIMIT="06:00:00"
+SPLIT="train"
+HORIZON="500"
+WORKERS="1"
+SHOW_STATUS=1
+DRY_RUN=0
+EXTRA_SBATCH_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh [options]
+
+Prepare or submit the issue #1470 oracle-imitation source-candidate trace job.
+
+Options:
+  --partition <name>   Slurm partition (default: a30)
+  --qos <name>         Slurm QoS (default: a30-gpu)
+  --time <limit>       Explicit wall time passed to sbatch (default: 06:00:00)
+  --split <name>       Launch-packet split: train, validation, evaluation (default: train)
+  --horizon <n>        Episode horizon for trace collection (default: 500)
+  --workers <n>        Map-runner workers inside the allocation (default: 1)
+  --sbatch-arg <arg>   Extra sbatch argument
+  --no-status          Skip partition status table
+  --dry-run            Print resolved sbatch command without submitting
+  -h, --help           Show help
+
+Example:
+  scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh --dry-run --no-status
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --partition)
+      PARTITION="$2"
+      shift 2
+      ;;
+    --qos)
+      QOS="$2"
+      shift 2
+      ;;
+    --time)
+      TIME_LIMIT="$2"
+      shift 2
+      ;;
+    --split)
+      SPLIT="$2"
+      shift 2
+      ;;
+    --horizon)
+      HORIZON="$2"
+      shift 2
+      ;;
+    --workers)
+      WORKERS="$2"
+      shift 2
+      ;;
+    --sbatch-arg)
+      EXTRA_SBATCH_ARGS+=("$2")
+      shift 2
+      ;;
+    --no-status)
+      SHOW_STATUS=0
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      echo "Unexpected positional argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$SPLIT" in
+  train|validation|evaluation)
+    ;;
+  *)
+    echo "Unsupported split: $SPLIT" >&2
+    exit 2
+    ;;
+esac
+
+cd "$REPO_ROOT"
+
+uv run python scripts/validation/validate_oracle_imitation_launch_packet.py \
+  --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml \
+  --json >/dev/null
+
+if [[ "$SHOW_STATUS" == "1" ]]; then
+  "$PARTITION_STATUS_SCRIPT"
+fi
+
+wrapper_args=(
+  "--time" "$TIME_LIMIT"
+  "--partition" "$PARTITION"
+  "--qos" "$QOS"
+  "--sbatch-arg" "--partition=$PARTITION"
+  "--sbatch-arg" "--qos=$QOS"
+  "--sbatch-arg" "--job-name=rsf-1470-oracle-traces"
+  "--sbatch-arg" "--export=ALL,ISSUE1470_SPLIT=$SPLIT,ISSUE1470_HORIZON=$HORIZON,ISSUE1470_WORKERS=$WORKERS"
+)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  wrapper_args+=("--dry-run")
+fi
+for arg in "${EXTRA_SBATCH_ARGS[@]}"; do
+  wrapper_args+=("--sbatch-arg" "$arg")
+done
+
+"$SBATCH_MAX_TIME_SCRIPT" "${wrapper_args[@]}" "$SBATCH_SCRIPT"

--- a/scripts/training/collect_oracle_imitation_candidate_traces.py
+++ b/scripts/training/collect_oracle_imitation_candidate_traces.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Collect launch-packet oracle candidate traces for imitation dataset staging."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.training.oracle_imitation_launch_packet import (
+    load_launch_packet,
+    validate_launch_packet,
+)
+from robot_sf.training.scenario_loader import load_scenarios
+from scripts.validation.policy_search_common import summarize_policy_search_records
+from scripts.validation.run_policy_search_candidate import (
+    _group_scenarios_by_config_overrides,
+    _load_records,
+    _prepare_scenarios_for_inline_run,
+    _write_records,
+    load_candidate_definition,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PACKET = Path("configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml")
+DEFAULT_REGISTRY = Path("docs/context/policy_search/candidate_registry.yaml")
+EPISODE_ID_RE = re.compile(r"^(?P<split>[a-z_]+)__(?P<scenario>.+)__seed(?P<seed>\d+)$")
+
+
+def _git_hash() -> str | None:
+    """Return the current Git SHA when available."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _scenario_id(scenario: dict[str, Any]) -> str:
+    """Return the stable scenario id used by policy-search manifests."""
+    return str(
+        scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "unknown"
+    )
+
+
+def _parse_episode_id(episode_id: str, *, split: str) -> tuple[str, int]:
+    """Parse one launch-packet episode id into `(scenario_id, seed)`.
+
+    Args:
+        episode_id: Launch-packet episode id shaped like `train__scenario__seed201`.
+        split: Expected split prefix.
+
+    Returns:
+        Scenario id and integer seed.
+
+    Raises:
+        ValueError: If the id does not match the packet contract.
+    """
+    match = EPISODE_ID_RE.match(episode_id)
+    if match is None:
+        raise ValueError(f"invalid launch-packet episode id: {episode_id!r}")
+    actual_split = match.group("split")
+    if actual_split != split:
+        raise ValueError(
+            f"episode id split mismatch for {episode_id!r}: expected {split!r}, got {actual_split!r}"
+        )
+    return match.group("scenario"), int(match.group("seed"))
+
+
+def build_split_scenarios(
+    packet: dict[str, Any], *, split: str, repo_root: Path
+) -> list[dict[str, Any]]:
+    """Build exact scenario rows from a launch packet split.
+
+    The packet's `scenario_source` can include more scenarios than one split uses.  This helper
+    follows `episode_ids_by_split` so train/validation/evaluation rows stay explicit.
+
+    Args:
+        packet: Parsed launch packet.
+        split: Split name to materialize.
+        repo_root: Repository root for resolving scenario paths.
+
+    Returns:
+        Scenario mappings with a single `seeds` entry per packet episode.
+    """
+    episode_ids_by_split = packet.get("episode_ids_by_split")
+    if not isinstance(episode_ids_by_split, dict) or split not in episode_ids_by_split:
+        raise ValueError(f"launch packet is missing episode_ids_by_split.{split}")
+    raw_episode_ids = episode_ids_by_split[split]
+    if not isinstance(raw_episode_ids, list) or not raw_episode_ids:
+        raise ValueError(f"episode_ids_by_split.{split} must be a non-empty list")
+
+    scenario_source = packet.get("scenario_source")
+    if not isinstance(scenario_source, str) or not scenario_source.strip():
+        raise ValueError("launch packet scenario_source must be a non-empty path")
+    scenario_path = Path(scenario_source)
+    if not scenario_path.is_absolute():
+        scenario_path = repo_root / scenario_path
+    scenario_path = scenario_path.resolve()
+
+    source_scenarios = load_scenarios(scenario_path)
+    scenarios_by_id = {
+        _scenario_id(dict(scenario)): dict(scenario) for scenario in source_scenarios
+    }
+
+    split_scenarios: list[dict[str, Any]] = []
+    for raw_episode_id in raw_episode_ids:
+        if not isinstance(raw_episode_id, str) or not raw_episode_id.strip():
+            raise ValueError(f"episode_ids_by_split.{split} contains a non-string episode id")
+        scenario_id, seed = _parse_episode_id(raw_episode_id, split=split)
+        if scenario_id not in scenarios_by_id:
+            raise ValueError(
+                f"episode {raw_episode_id!r} references scenario {scenario_id!r}, "
+                f"but {scenario_path} does not provide it"
+            )
+        scenario = deepcopy(scenarios_by_id[scenario_id])
+        scenario["seeds"] = [seed]
+        metadata = scenario.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            metadata["oracle_imitation_episode_id"] = raw_episode_id
+            metadata["oracle_imitation_split"] = split
+        split_scenarios.append(scenario)
+
+    return _prepare_scenarios_for_inline_run(split_scenarios, scenario_root=scenario_path.parent)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write pretty JSON to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML mapping."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected YAML mapping: {path}")
+    return payload
+
+
+def collect_candidate_traces(  # noqa: PLR0913
+    *,
+    packet_path: Path,
+    candidate_registry: Path,
+    split: str,
+    output_dir: Path,
+    horizon: int,
+    dt: float,
+    workers: int,
+    benchmark_profile: str,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    """Run packet-selected scenarios through the source candidate and write trace artifacts."""
+    repo_root = REPO_ROOT
+    packet_path = (
+        (repo_root / packet_path).resolve() if not packet_path.is_absolute() else packet_path
+    )
+    registry_path = (
+        (repo_root / candidate_registry).resolve()
+        if not candidate_registry.is_absolute()
+        else candidate_registry
+    )
+    output_dir = output_dir.resolve()
+
+    validation_report = validate_launch_packet(packet_path, repo_root=repo_root)
+    packet = load_launch_packet(packet_path)
+    source_candidate = str(packet["source_candidate"])
+    scenarios = build_split_scenarios(packet, split=split, repo_root=repo_root)
+    entry, candidate_payload, candidate_config, candidate_config_path = load_candidate_definition(
+        registry_path,
+        source_candidate,
+    )
+    default_algo = str(candidate_payload.get("algo", "")).strip().lower()
+    if not default_algo:
+        raise ValueError(f"candidate {source_candidate!r} is missing algo")
+
+    grouped = _group_scenarios_by_config_overrides(
+        scenarios,
+        candidate_payload=candidate_payload,
+        candidate_config=candidate_config,
+        default_algo=default_algo,
+        config_anchor=candidate_config_path.parent,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    all_records: list[dict[str, Any]] = []
+    group_summaries: dict[str, Any] = {}
+    failures: list[dict[str, Any]] = []
+
+    for group_name, group in sorted(grouped.items()):
+        group_dir = output_dir / "groups" / group_name
+        group_dir.mkdir(parents=True, exist_ok=True)
+        algo_config_path = group_dir / "algo.yaml"
+        jsonl_path = group_dir / "episodes.jsonl"
+        algo_config_path.write_text(
+            yaml.safe_dump(group["config"], sort_keys=False),
+            encoding="utf-8",
+        )
+        if jsonl_path.exists():
+            jsonl_path.unlink()
+        batch_summary = run_map_batch(
+            group["scenarios"],
+            jsonl_path,
+            schema_path=Path("robot_sf/benchmark/schemas/episode.schema.v1.json"),
+            algo=str(group["algo"]),
+            algo_config_path=str(algo_config_path),
+            horizon=int(horizon),
+            dt=float(dt),
+            workers=int(workers),
+            resume=False,
+            benchmark_profile=benchmark_profile,
+        )
+        records = _load_records(jsonl_path) if jsonl_path.exists() else []
+        all_records.extend(records)
+        group_summaries[group_name] = {
+            "algo": group["algo"],
+            "algo_config_path": str(algo_config_path),
+            "jsonl_path": str(jsonl_path),
+            "scenario_count": len(group["scenarios"]),
+            "batch_summary": batch_summary,
+            "summary": summarize_policy_search_records(records),
+        }
+        if int(batch_summary.get("failed_jobs", 0) or 0) > 0:
+            failures.extend(batch_summary.get("failures", []))
+
+    combined_jsonl = output_dir / f"{split}__{source_candidate}__combined.jsonl"
+    _write_records(combined_jsonl, all_records)
+    summary = summarize_policy_search_records(all_records)
+    expected_episodes = len(scenarios)
+    if len(all_records) != expected_episodes:
+        failures.append(
+            {
+                "error": "episode_count_mismatch",
+                "expected": expected_episodes,
+                "actual": len(all_records),
+            }
+        )
+
+    manifest = {
+        "schema_version": "oracle-imitation-candidate-traces.v1",
+        "created_at": datetime.now(UTC).isoformat(),
+        "git_hash": _git_hash(),
+        "launch_packet": str(packet_path),
+        "launch_packet_validation": validation_report,
+        "candidate_registry": str(registry_path),
+        "candidate": source_candidate,
+        "candidate_entry": entry,
+        "candidate_config_path": str(candidate_config_path),
+        "split": split,
+        "scenario_count": len(scenarios),
+        "horizon": int(horizon),
+        "dt": float(dt),
+        "workers": int(workers),
+        "benchmark_profile": benchmark_profile,
+        "combined_jsonl": str(combined_jsonl),
+        "summary": summary,
+        "group_summaries": group_summaries,
+        "failures": failures,
+        "dataset_boundary": (
+            "This trace collection is not the final imitation NPZ dataset. It proves the "
+            "launch-packet source candidate can run on the selected split and preserves JSONL "
+            "episode evidence for downstream dataset materialization."
+        ),
+    }
+    manifest_path = output_dir / "oracle_candidate_trace_manifest.json"
+    _write_json(manifest_path, manifest)
+    manifest["manifest_path"] = str(manifest_path)
+
+    if failures and not allow_partial:
+        raise RuntimeError(
+            f"oracle candidate trace collection failed closed with {len(failures)} failure(s); "
+            f"see {manifest_path}"
+        )
+    return manifest
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--candidate-registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--split", choices=("train", "validation", "evaluation"), default="train")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--horizon", type=int, default=500)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--benchmark-profile", default="testing")
+    parser.add_argument("--allow-partial", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    manifest = collect_candidate_traces(
+        packet_path=args.config,
+        candidate_registry=args.candidate_registry,
+        split=args.split,
+        output_dir=args.output_dir,
+        horizon=args.horizon,
+        dt=args.dt,
+        workers=args.workers,
+        benchmark_profile=args.benchmark_profile,
+        allow_partial=bool(args.allow_partial),
+    )
+    if args.json:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+    else:
+        print(f"manifest={manifest['manifest_path']}")
+        print(f"combined_jsonl={manifest['combined_jsonl']}")
+        print(f"episodes={manifest['summary'].get('episodes', 0)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/training/test_oracle_imitation_candidate_traces.py
+++ b/tests/training/test_oracle_imitation_candidate_traces.py
@@ -1,0 +1,68 @@
+"""Tests for oracle-imitation candidate trace launch-packet selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.training.oracle_imitation_launch_packet import load_launch_packet
+from scripts.training.collect_oracle_imitation_candidate_traces import (
+    _parse_episode_id,
+    build_split_scenarios,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKET = REPO_ROOT / "configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml"
+
+
+def test_parse_episode_id_requires_split() -> None:
+    """Episode ids must preserve the requested launch-packet split."""
+    assert _parse_episode_id("train__planner_sanity_simple__seed201", split="train") == (
+        "planner_sanity_simple",
+        201,
+    )
+
+    with pytest.raises(ValueError, match="split mismatch"):
+        _parse_episode_id("validation__planner_sanity_simple__seed101", split="train")
+
+
+def test_build_split_scenarios_uses_exact_packet_rows() -> None:
+    """Train trace collection should use only the packet's declared train rows."""
+    packet = load_launch_packet(PACKET)
+
+    scenarios = build_split_scenarios(packet, split="train", repo_root=REPO_ROOT)
+
+    assert [scenario["name"] for scenario in scenarios] == [
+        "planner_sanity_simple",
+        "classic_head_on_corridor_low",
+        "classic_crossing_low",
+        "classic_doorway_low",
+        "classic_overtaking_low",
+        "francis2023_following_human",
+    ]
+    assert [scenario["seeds"] for scenario in scenarios] == [
+        [201],
+        [202],
+        [203],
+        [204],
+        [205],
+        [206],
+    ]
+    assert scenarios[0]["metadata"]["oracle_imitation_episode_id"] == (
+        "train__planner_sanity_simple__seed201"
+    )
+
+
+def test_build_validation_split_uses_validation_subset_only() -> None:
+    """Validation trace collection should not inherit the full scenario source."""
+    packet = load_launch_packet(PACKET)
+
+    scenarios = build_split_scenarios(packet, split="validation", repo_root=REPO_ROOT)
+
+    assert [scenario["name"] for scenario in scenarios] == [
+        "planner_sanity_simple",
+        "classic_crossing_low",
+        "classic_doorway_low",
+    ]
+    assert [scenario["seeds"] for scenario in scenarios] == [[101], [102], [103]]


### PR DESCRIPTION
## Summary
Prepares a concrete Slurm-executable source-candidate trace job for issue #1470. The branch makes the runnable state explicit: submit from an allowed Auxme node with `scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh` after reviewing the dry-run command.

## Linked Issues
- Relates to #1470
- Relates to #1397

## Stack / Dependency
- Base dependency: main
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/training/collect_oracle_imitation_candidate_traces.py`, which validates the oracle-imitation launch packet, selects exact split rows from `episode_ids_by_split`, runs the registered source candidate, and writes JSONL trace artifacts plus a manifest.
- Added `SLURM/Auxme/issue_1470_oracle_imitation_traces.sl` and `scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh`.
- Updated the launch packet and Slurm context note to state the ready command and the boundary: this is source-candidate trace collection, not the final imitation NPZ dataset.
- Added focused tests for packet episode-id parsing and split-scenario selection.

## Why It Matters
- Added value: turns #1470 from a launch-packet handoff into a branch with an actual Slurm job that can be executed from the intended worktree state.
- Expected impact: produces durable-job-result JSONL traces for `hybrid_rule_v3_static_margin0_waypoint2` on the packet train split, which is the next concrete step before dataset materialization.
- Why this is worth merging now: the previous command shape pointed at `collect_expert_trajectories.py`, which assumes PPO checkpoints and would not honestly run the non-learning source candidate named by the packet.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json`
  - `bash -n SLURM/Auxme/issue_1470_oracle_imitation_traces.sl`
  - `bash -n scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh`
  - `uv run ruff check --fix scripts/training/collect_oracle_imitation_candidate_traces.py tests/training/test_oracle_imitation_candidate_traces.py`
  - `uv run ruff check scripts/training/collect_oracle_imitation_candidate_traces.py tests/training/test_oracle_imitation_candidate_traces.py`
  - `uv run pytest -q tests/training/test_oracle_imitation_candidate_traces.py`
  - `scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh --dry-run --no-status`
  - `LOGURU_LEVEL=WARNING SDL_VIDEODRIVER=dummy MPLBACKEND=Agg uv run python scripts/training/collect_oracle_imitation_candidate_traces.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --split validation --output-dir output/tmp/issue1470_trace_smoke --horizon 3 --workers 1 --json`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed on `45b7f3d48d801aa92067990f7f0dbbdaf26b6e73` with `4686 passed, 11 skipped, 8 warnings`, clean tree stamp.
- Slurm dry-run command resolved to `sbatch --time=06:00:00 --partition=a30 --qos=a30-gpu --job-name=rsf-1470-oracle-traces --export=ALL,ISSUE1470_SPLIT=train,ISSUE1470_HORIZON=500,ISSUE1470_WORKERS=1 SLURM/Auxme/issue_1470_oracle_imitation_traces.sl`.
- Local trace smoke wrote 3 validation-split rows with no failures at horizon 3.

## Risks / Rollout
- Compatibility risks: the job uses the policy-search candidate runner and produces JSONL traces, not the final imitation-training NPZ dataset.
- Failure modes: candidate runtime failures, missing scenario assets, or partial row collection fail closed unless `--allow-partial` is explicitly used.
- Rollback or fallback plan: revert the driver/wrapper additions; no checked-in registry state is mutated.

## Docs / Provenance
- Updated docs: `docs/context/policy_search/SLURM/003_imitation_oracle_dataset_campaign.md`
- Relevant design or provenance notes: the manifest records launch packet, candidate registry, candidate config, commit, split, summary, group summaries, and the dataset boundary.
- Any assumptions that need to be preserved: generated JSONL, manifests, coverage, and Slurm logs remain ignored under `output/` or copied job result roots until deliberately promoted.

## Downstream Propagation
- Parent issue updated: no
- Claim map / benchmark report updated: NA
- Registry or config index updated: launch packet command shape updated
- Context index / memory note updated: no
- Follow-up issue opened for deferred propagation: no
- Not-applicable rationale: this branch prepares executable Slurm work; benchmark or imitation-training claims require the future Slurm run and durable dataset materialization.

## Follow-Up Issues
- Deferred work: submit from an allowed Auxme Slurm node, promote resulting traces/manifests if useful, then implement final NPZ dataset materialization/checksum publication before imitation training.
- Issues opened for follow-up: none

## Reviewer Notes
- Review the boundary language carefully: this PR intentionally does not claim final dataset completion. It prepares the next executable Slurm job state for #1470.