### PR TITLE
docs: update AMV actuation claim boundary

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -233,7 +233,7 @@ knowledge, not every transient iteration detail.
   [issue_1484_broader_cross_kinematics_launch.md](issue_1484_broader_cross_kinematics_launch.md)
 * Issue #1546 AMV actuation-envelope stress slice:
   [issue_1546_amv_actuation_envelope_stress_slice.md](issue_1546_amv_actuation_envelope_stress_slice.md)
-* Issue #1556 synthetic AMV actuation stress slice:
+* Issue #1556 synthetic AMV actuation stress slice and #1570 claim boundary:
   [issue_1556_amv_actuation_stress_slice.md](issue_1556_amv_actuation_stress_slice.md)
 * Issue #1606 Full Classic placeholder retirement:
   [issue_1606_full_classic_placeholder_retirement.md](issue_1606_full_classic_placeholder_retirement.md)

--- a/docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/README.md
+++ b/docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/README.md
@@ -45,6 +45,18 @@ for issue-facing handoff without mirroring the generated campaign artifacts into
    metadata blocks in the scenario matrix.
 5. Adapter diagnostics remain caveated: ORCA required command projection for most steps in this
    smoke, and the `social_force` campaign row still reports unknown command-space/projection-policy
-   metadata in the underlying campaign output. Follow-up issue #1572 tracks that metadata cleanup.
+   metadata in the underlying campaign output.
+
+## Post-Smoke Claim-Map Update
+
+Issue #1572 and its decision split #1582 are now closed. PR #1580 implemented the conservative
+metadata contract for future synthetic actuation summaries: slice-local synthetic AMV overrides,
+compact scenario AMV rows, and explicit planner command-space/projection metadata. That repair makes
+future diagnostics easier to interpret, but it does not rewrite this historical smoke campaign and
+does not promote the Issue #1569 evidence beyond `synthetic diagnostic` / `non-paper-facing`
+status.
+
+Issue #1570 records this bundle as compact smoke evidence only. Calibrated or paper-facing AMV
+actuation claims remain blocked on Issue #1559.
 
 See `summary.json` for the compact planner-level snapshot promoted from the local campaign.

--- a/docs/context/issue_1542_manuscript_claim_evidence_map.md
+++ b/docs/context/issue_1542_manuscript_claim_evidence_map.md
@@ -1,8 +1,13 @@
 # Issue #1542 Manuscript Claim Evidence Map
 
-Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1542>
+Related issues:
+
+- <https://github.com/ll7/robot_sf_ll7/issues/1542>
+- AMV actuation boundary update: <https://github.com/ll7/robot_sf_ll7/issues/1570>
 
 Date: 2026-05-26
+
+Latest AMV claim-boundary update: Issue #1570 on 2026-05-31.
 
 ## Purpose
 
@@ -44,6 +49,14 @@ tracks. See
   [issue_1353_broader_amv_preflight.md](issue_1353_broader_amv_preflight.md)
 - Broader baseline evidence:
   [issue_1353_broader_amv_2026-05-26/](evidence/issue_1353_broader_amv_2026-05-26/)
+- Synthetic actuation stress design:
+  [issue_1546_amv_actuation_envelope_stress_slice.md](issue_1546_amv_actuation_envelope_stress_slice.md)
+- Synthetic actuation implementation and smoke verdict:
+  [issue_1556_amv_actuation_stress_slice.md](issue_1556_amv_actuation_stress_slice.md)
+- Compact actuation smoke evidence:
+  [issue_1569_amv_actuation_smoke_2026-05-27/](evidence/issue_1569_amv_actuation_smoke_2026-05-27/)
+- Paper-facing actuation calibration gate: issue
+  [#1559](https://github.com/ll7/robot_sf_ll7/issues/1559)
 - Primary configs:
   - `configs/benchmarks/issue_1344_paired_nominal_v1_primary.yaml`
   - `configs/benchmarks/issue_1344_paired_stress_primary.yaml`
@@ -56,6 +69,11 @@ tracks. See
 
 `stress` + `full_matrix` (broader baselines)
 
+Synthetic actuation slice tier: `diagnostic_smoke` / `not paper-facing`. The Issue #1569 compact
+smoke proves that the synthetic actuation-envelope slice is executable locally and emits actuation
+diagnostics, but it is not calibrated AMV evidence and does not upgrade this claim area to
+paper-facing.
+
 ### Metrics Used
 
 - Success rate
@@ -63,11 +81,15 @@ tracks. See
 - Near-miss rate (implicitly tracked, not durably preserved in all summaries)
 - SNQI v3 (baseline, weights, diagnostics)
 - Mean minimum distance
-- AMV coverage dimensions (observed as unavailable/missing in #1344 and #1353 nominal/stress)
+- AMV coverage dimensions (observed as unavailable/missing in Issue #1344 and Issue #1353
+  nominal/stress)
+- Synthetic actuation diagnostics for Issue #1556/Issue #1569 only: `command_clip_fraction`,
+  `yaw_rate_saturation_fraction`, `signed_braking_peak_m_s2`, planner command-space/projection
+  metadata, and compact scenario AMV rows.
 
 ### Key Results
 
-**Primary protocol (#1344):**
+**Primary protocol (Issue #1344):**
 
 | Planner | Nominal success | Stress success | Nominal collisions | Stress collisions | Nominal SNQI | Stress SNQI |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -75,7 +97,7 @@ tracks. See
 | `orca` | 0.2500 | 0.1667 | 0.0833 | 0.0764 | -0.2999 | -0.2466 |
 | `social_force` | 0.0000 | 0.0000 | 0.0000 | 0.2500 | -1.0435 | -0.8591 |
 
-**Broader baselines (#1353 2026-05-26):**
+**Broader baselines (Issue #1353, 2026-05-26):**
 
 | Surface | Total runs | Successful rows | Core rows | Episodes | Campaign success | AMV coverage | SNQI contract |
 | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
@@ -89,28 +111,59 @@ tracks. See
 - `socnav_bench` is `not_available` in both surfaces (accepted unavailable row, not successful
   evidence)
 
-**Cross-kinematics (#1354 compact, 2026-05-26):**
+**Cross-kinematics (Issue #1354 compact, 2026-05-26):**
 
 - 9/9 successful rows, `benchmark_success=true`, `amv_coverage_status=pass`,
   `snqi_contract_status=warn`
 
+**Synthetic actuation smoke (Issue #1569 with Issue #1572/Issue #1582 metadata contract):**
+
+- Verdict: `compact smoke run`, local and non-paper-facing.
+- Evidence bundle:
+  [evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json](evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json)
+  plus the Issue #1556 context note.
+- Campaign contract status: `campaign_execution_status=completed`, `evidence_status=valid`,
+  `successful_evidence_rows=3`, `accepted_unavailable_rows=0`, `unexpected_failed_rows=0`, and
+  `fallback_or_degraded_rows=0`.
+- Planner episode success remained `0.0000` for all three smoke rows (`goal`, `orca`,
+  `social_force`), so the smoke is executable diagnostics, not a performance result.
+- Command clipping was observed (`goal=0.0407`, `orca=0.1047`, `social_force=0.2346`), while
+  `yaw_rate_saturation_fraction` stayed `0.0000` for all rows.
+- Issue #1572/Issue #1582 closed the metadata-contract gap after the smoke by accepting slice-local
+  synthetic AMV overrides with explicit synthetic provenance and planner command-space/projection
+  metadata.
+  Unknown, unavailable, fallback, degraded, and failed rows remain caveats and must not count as
+  actuation-envelope success evidence.
+
+### AMV Actuation Claim Boundary
+
+| Evidence level | Current status | Claim use |
+| --- | --- | --- |
+| Synthetic diagnostics | Implemented by Issue #1556 using `amv-actuation-stress-v0` and `paper_facing: false`. | May describe a software stress diagnostic and artifact/provenance contract only. |
+| Compact smoke evidence | Issue #1569 produced a valid local 45-episode smoke; Issue #1572/Issue #1582 later repaired the metadata contract for future summaries. | May say the diagnostic slice runs and emits actuation metrics locally; must also state that task success was 0.0 and the evidence is non-paper-facing. |
+| Calibrated/paper-facing evidence | Blocked on Issue #1559 and its source/provenance follow-ups. | No paper-facing AMV actuation claim yet; no hardware, deployment, safety, or real-AMV envelope language from synthetic-only evidence. |
+
 ### Known Caveats
 
-1. **AMV coverage gap**: Both #1344 primary and #1353 broader nominal/stress campaigns report
+1. **AMV coverage gap**: Both Issue #1344 primary and Issue #1353 broader nominal/stress campaigns report
    `amv_coverage_status=warn`. Coverage summaries show `Observed = -` for all required AMV
    dimensions, meaning all required dimension values are missing from source scenario metadata. This
    is not partial coverage—it is zero observed coverage against required dimensions.
-2. **SNQI contract status**: #1353 stress reports `snqi_contract_status=fail`, preserving #1344's
-   caution. SNQI should not be promoted into paper-facing claims without an explicit claim-scope
-   decision.
+2. **SNQI contract status**: Issue #1353 stress reports `snqi_contract_status=fail`, preserving
+   Issue #1344's caution. SNQI should not be promoted into paper-facing claims without an explicit
+   claim-scope decision.
 3. **Low absolute success**: Even the best broader-baseline stress row (`ppo=0.2222`) shows modest
    success; many rows remain at or near zero.
-4. **SocNav unavailable**: `socnav_bench` is `not_available` in #1353 nominal/stress because
+4. **SocNav unavailable**: `socnav_bench` is `not_available` in Issue #1353 nominal/stress because
    SocNavBench control-pipeline assets are missing. This is caveated evidence, not a successful
    benchmark row.
-5. **Paper-facing status**: #1344 campaigns are `paper_facing=false`. #1353 campaigns use
+5. **Paper-facing status**: Issue #1344 campaigns are `paper_facing=false`. Issue #1353 campaigns use
    `paper_interpretation_profile=issue-1353-broader-amv-preflight`, explicitly non-paper-facing.
-6. **Runtime hotspot**: `prediction_planner` shows the longest runtime (`59.1s` nominal, `613.4s`
+6. **Synthetic actuation boundary**: Issue #1556/Issue #1569 add a useful synthetic diagnostic
+   slice, not a calibrated AMV actuation claim. Issue #1572/Issue #1582 resolved the compact
+   metadata contract, but that contract only makes future diagnostics clearer; it does not provide a
+   real hardware envelope, controller trace, or paper-facing calibration source.
+7. **Runtime hotspot**: `prediction_planner` shows the longest runtime (`59.1s` nominal, `613.4s`
    stress).
 
 ### Blocker / Next Action
@@ -125,11 +178,15 @@ tracks. See
    revise the SNQI contract before paper-facing promotion.
 3. Determine whether the low absolute success rates are acceptable for comparative claims or whether
    a tighter success gate is needed.
+4. Keep synthetic actuation diagnostics out of paper-facing claims until Issue #1559 identifies a
+   durable calibration source/profile and validates calibrated-vs-synthetic separation.
 
 ### Verdict
 
-`blocked` — AMV coverage gap and SNQI contract cautions block direct paper-facing promotion without
-a maintainer decision on acceptable evidence boundaries.
+`blocked` — AMV coverage gap, SNQI contract cautions, and missing calibrated actuation evidence
+block direct paper-facing promotion. The Issue #1569 smoke plus Issue #1572/Issue #1582 metadata
+repair make a future diagnostic or thesis-method subsection plausible, but only as explicitly
+synthetic diagnostics; a paper-facing AMV actuation subsection remains blocked on Issue #1559.
 
 ---
 

--- a/docs/context/issue_1556_amv_actuation_stress_slice.md
+++ b/docs/context/issue_1556_amv_actuation_stress_slice.md
@@ -95,12 +95,45 @@ Interpretation Boundary:
   mean any planner solved the slice.
 - This result is still **synthetic diagnostic only**. It does not promote the slice to a
   paper-facing claim, and it does not support hardware-calibration language.
-- The AMV claim map is **unchanged**. The smoke confirms that the issue-1556 slice is runnable and
-  emits the intended actuation diagnostics locally, but it does not strengthen any AMV performance
-  claim.
+- The AMV claim map remained **unchanged as a paper-facing claim**. The smoke confirms that the
+  issue-1556 slice is runnable and emits the intended actuation diagnostics locally, but it does not
+  strengthen any AMV performance claim.
 - `amv_coverage_status` remained `warn` because the resolved scenario rows in
   `configs/scenarios/classic_interactions_francis2023.yaml` still expose empty `amv` metadata
   blocks for this slice.
 - Adapter diagnostics remain part of the caveat surface: ORCA reported a high command projection
   rate (`0.8018`), and the smoke evidence records this without downgrading the row from accepted
-  adapter execution. Follow-up issue #1572 owns the remaining scenario and adapter metadata gaps.
+  adapter execution.
+
+## Issue #1572 / #1582 Metadata Contract Closure (2026-05-31)
+
+Issue #1572 and its decision split #1582 are now closed. Merged PR #1580 accepted the conservative
+metadata contract for future synthetic actuation diagnostics:
+
+1. The checked-in config may use slice-local synthetic AMV taxonomy overrides when those fields
+   remain tied to the versioned synthetic profile and diagnostic-only claim scope.
+2. Compact actuation summaries should expose scenario AMV rows plus planner command-space and
+   projection-policy metadata.
+3. Unknown, unavailable, fallback, degraded, skipped, and failed rows remain caveats and must not
+   count as actuation-envelope success evidence.
+
+This closure improves the interpretability of future `actuation_envelope_summary.*` artifacts. It
+does not change the Issue #1569 smoke's historical raw-campaign caveats, and it does not create
+calibrated or paper-facing actuation evidence.
+
+## Issue #1570 Claim-Map Verdict (2026-05-31)
+
+The claim-map boundary after the smoke verdict is:
+
+- **Synthetic diagnostics:** supported as a software stress diagnostic from Issue #1556. The profile
+  is `amv-actuation-stress-v0`, `paper_facing: false`, and `claim_scope: synthetic-only`.
+- **Compact smoke evidence:** supported only as non-paper-facing local evidence that the slice runs
+  and emits clip/yaw/braking diagnostics. The Issue #1569 smoke had valid executable rows but
+  `success_mean=0.0` for all planners, so it is not an AMV performance claim.
+- **Calibrated/paper-facing evidence:** still blocked. Issue
+  [#1559](https://github.com/ll7/robot_sf_ll7/issues/1559) remains the gate for a durable AMV
+  calibration source, calibrated-vs-synthetic profile separation, and validation that prevents
+  synthetic values from being reported as hardware evidence.
+
+Updated claim map:
+[`issue_1542_manuscript_claim_evidence_map.md`](issue_1542_manuscript_claim_evidence_map.md).


### PR DESCRIPTION
## Summary
- Tighten the AMV actuation claim boundary in the manuscript evidence map.
- Reclassify Issue #1569 actuation smoke evidence as synthetic, local, non-paper-facing diagnostics.
- Keep calibrated or paper-facing actuation claims blocked on Issue #1559.

## Validation
- `python -m json.tool docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`