### PR TITLE
feat: add model artifact promotion planner

### DIFF
--- a/scripts/tools/plan_model_artifact_promotion.py
+++ b/scripts/tools/plan_model_artifact_promotion.py
@@ -19,9 +19,11 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.local_model_artifacts import (
+    BlocklistMetadata,
     display_path,
     iter_local_model_references,
     iter_yaml_files,
+    load_blocklist,
     load_promoted_surfaces,
     path_lookup_candidates,
 )
@@ -29,6 +31,7 @@ from robot_sf.benchmark.local_model_artifacts import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")
 DEFAULT_PROMOTED_SURFACES_PATH = Path("configs/benchmarks/promoted_config_surfaces.yaml")
+DEFAULT_BLOCKLIST_PATH = Path("configs/baselines/local_model_artifact_blocklist.yaml")
 SCHEMA_VERSION = "robot-sf-model-artifact-promotion-plan.v1"
 
 INITIAL_TARGET_CONFIGS = [
@@ -44,10 +47,15 @@ INITIAL_TARGET_CONFIGS = [
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:
     """Load one YAML mapping from disk."""
-    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    payload = _load_yaml_payload(path)
     if not isinstance(payload, dict):
         raise ValueError(f"{path}: expected top-level mapping")
     return payload
+
+
+def _load_yaml_payload(path: Path) -> Any:
+    """Load one YAML payload from disk."""
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
 def _load_registry(path: Path) -> dict[str, dict[str, Any]]:
@@ -71,14 +79,24 @@ def _load_registry(path: Path) -> dict[str, dict[str, Any]]:
 def _is_durable_registry_entry(entry: dict[str, Any]) -> bool:
     """Return whether a registry entry has a durable artifact pointer."""
     github_release = entry.get("github_release")
-    if isinstance(github_release, dict) and github_release.get("url"):
+    if _github_release_is_public_pointer(github_release):
         return True
     return bool(
-        entry.get("public_artifact_source")
-        or entry.get("wandb_artifact_path")
+        entry.get("wandb_artifact_path")
         or entry.get("wandb_run_path")
-        or entry.get("wandb_run_id")
+        or (entry.get("wandb_entity") and entry.get("wandb_project") and entry.get("wandb_run_id"))
     )
+
+
+def _github_release_is_public_pointer(release: Any) -> bool:
+    """Return whether GitHub release metadata is enough to retrieve and verify an asset."""
+    if not isinstance(release, dict):
+        return False
+    has_location = bool(
+        release.get("url")
+        or (release.get("repo") and release.get("tag") and release.get("asset_name"))
+    )
+    return bool(has_location and release.get("sha256"))
 
 
 def _sha256(path: Path) -> str:
@@ -190,6 +208,7 @@ def _row_for_local_reference(
     payload: dict[str, Any],
     repo_root: Path,
     promoted_reason: str,
+    blocker_reason: str,
 ) -> dict[str, Any]:
     """Classify one local output artifact reference."""
     artifact = _artifact_metadata(value, repo_root=repo_root)
@@ -210,6 +229,7 @@ def _row_for_local_reference(
             "value": value,
             "artifact": artifact,
             "promotion_plan": promotion_plan,
+            "blocker_reason": blocker_reason or None,
             "claim_boundary": "not benchmark evidence until durable artifact exists",
             "action": (
                 f"{promoted_reason} This local-only path must not be treated as benchmark "
@@ -239,6 +259,8 @@ def _row_for_local_reference(
             "Missing checkpoint: recover the checkpoint from a durable source or retire this "
             "config; do not use it as benchmark evidence."
         )
+    if blocker_reason:
+        action = f"{blocker_reason} {action}"
 
     return {
         "config_path": config_path,
@@ -249,6 +271,7 @@ def _row_for_local_reference(
         "value": value,
         "artifact": artifact,
         "promotion_plan": promotion_plan,
+        "blocker_reason": blocker_reason or None,
         "claim_boundary": "not benchmark evidence until durable artifact exists",
         "action": action,
     }
@@ -301,10 +324,24 @@ def _row_for_config(
     repo_root: Path,
     registry: dict[str, dict[str, Any]],
     promoted_surfaces: dict[str, str],
+    blocklist: BlocklistMetadata,
 ) -> dict[str, Any]:
     """Build one planner row for a YAML config."""
-    payload = _load_yaml_mapping(config_path)
     rel_path = display_path(config_path, repo_root=repo_root)
+    payload = _load_yaml_payload(config_path)
+    if not isinstance(payload, dict):
+        return {
+            "config_path": rel_path,
+            "classification": "manual_decision_required",
+            "decision": "unsupported_yaml_shape",
+            "surface": "non_mapping_yaml",
+            "yaml_top_level_type": type(payload).__name__,
+            "claim_boundary": "not benchmark evidence until artifact provenance is explicit",
+            "action": (
+                "Top-level YAML is not a mapping, so model artifact fields were not interpreted; "
+                "inspect this file manually or exclude it from the model promotion scan."
+            ),
+        }
     local_references = iter_local_model_references(payload)
     promoted_reason = _promoted_reason_for(
         config_path,
@@ -313,6 +350,7 @@ def _row_for_config(
     )
     if local_references:
         field, value = local_references[0]
+        blocker_reason = blocklist.reasons.get((rel_path, field, value), "")
         row = _row_for_local_reference(
             config_path=rel_path,
             field=field,
@@ -320,6 +358,7 @@ def _row_for_config(
             payload=payload,
             repo_root=repo_root,
             promoted_reason=promoted_reason,
+            blocker_reason=blocker_reason,
         )
         row["local_references"] = [
             {"field": reference_field, "value": reference_value}
@@ -347,6 +386,7 @@ def build_promotion_report(
     repo_root: Path = REPO_ROOT,
     registry_path: Path = DEFAULT_REGISTRY_PATH,
     promoted_surfaces_path: Path = DEFAULT_PROMOTED_SURFACES_PATH,
+    blocklist_path: Path = DEFAULT_BLOCKLIST_PATH,
 ) -> dict[str, Any]:
     """Build a metadata-only promotion/retirement report for config paths."""
     registry_resolved = registry_path if registry_path.is_absolute() else repo_root / registry_path
@@ -355,15 +395,29 @@ def build_promotion_report(
         if promoted_surfaces_path.is_absolute()
         else repo_root / promoted_surfaces_path
     )
+    blocklist_resolved = (
+        blocklist_path if blocklist_path.is_absolute() else repo_root / blocklist_path
+    )
     registry = _load_registry(registry_resolved)
     promoted_surfaces = load_promoted_surfaces(promoted_resolved, strict=True)
-    config_paths = _expand_config_paths(paths or INITIAL_TARGET_CONFIGS, repo_root=repo_root)
+    blocklist = load_blocklist(blocklist_resolved, strict=True)
+    ignored_manifest_paths = {
+        registry_resolved.resolve(),
+        promoted_resolved.resolve(),
+        blocklist_resolved.resolve(),
+    }
+    config_paths = [
+        path
+        for path in _expand_config_paths(paths or INITIAL_TARGET_CONFIGS, repo_root=repo_root)
+        if path.resolve() not in ignored_manifest_paths
+    ]
     rows = [
         _row_for_config(
             path,
             repo_root=repo_root,
             registry=registry,
             promoted_surfaces=promoted_surfaces,
+            blocklist=blocklist,
         )
         for path in config_paths
     ]
@@ -411,6 +465,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--registry-path", type=Path, default=DEFAULT_REGISTRY_PATH)
     parser.add_argument("--promoted-surfaces", type=Path, default=DEFAULT_PROMOTED_SURFACES_PATH)
+    parser.add_argument("--blocklist-path", type=Path, default=DEFAULT_BLOCKLIST_PATH)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -447,6 +502,7 @@ def main(argv: list[str] | None = None) -> int:
         repo_root=args.repo_root,
         registry_path=args.registry_path,
         promoted_surfaces_path=args.promoted_surfaces,
+        blocklist_path=args.blocklist_path,
     )
 
     if args.command == "write-report":

--- a/scripts/tools/plan_model_artifact_promotion.py
+++ b/scripts/tools/plan_model_artifact_promotion.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Plan local model-artifact promotion or retirement decisions.
+
+This tool is metadata-only. It computes small, reviewable plans for local
+``output/...`` checkpoint references and durable ``model_id`` references; it
+does not upload, copy, or commit checkpoint artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.local_model_artifacts import (
+    display_path,
+    iter_local_model_references,
+    iter_yaml_files,
+    load_promoted_surfaces,
+    path_lookup_candidates,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")
+DEFAULT_PROMOTED_SURFACES_PATH = Path("configs/benchmarks/promoted_config_surfaces.yaml")
+SCHEMA_VERSION = "robot-sf-model-artifact-promotion-plan.v1"
+
+INITIAL_TARGET_CONFIGS = [
+    Path("configs/baselines/ppo_issue_791_horizon100_12178.yaml"),
+    Path("configs/baselines/ppo_issue_856_all_scenarios_12223.yaml"),
+    Path("configs/baselines/sac_gate_socnav_struct.yaml"),
+    Path("configs/baselines/sac_gate_socnav_struct_ego.yaml"),
+    Path("configs/baselines/sac_gate_socnav_struct_ego_multi.yaml"),
+    Path("configs/baselines/sac_gate_socnav_struct_ego_safe.yaml"),
+    Path("configs/baselines/drl_vo_default.yaml"),
+]
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Load one YAML mapping from disk."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected top-level mapping")
+    return payload
+
+
+def _load_registry(path: Path) -> dict[str, dict[str, Any]]:
+    """Load model registry entries keyed by model id."""
+    if not path.exists():
+        return {}
+    payload = _load_yaml_mapping(path)
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise ValueError(f"{path}: models must be a list")
+    registry: dict[str, dict[str, Any]] = {}
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        model_id = str(entry.get("model_id") or "").strip()
+        if model_id:
+            registry[model_id] = entry
+    return registry
+
+
+def _is_durable_registry_entry(entry: dict[str, Any]) -> bool:
+    """Return whether a registry entry has a durable artifact pointer."""
+    github_release = entry.get("github_release")
+    if isinstance(github_release, dict) and github_release.get("url"):
+        return True
+    return bool(
+        entry.get("public_artifact_source")
+        or entry.get("wandb_artifact_path")
+        or entry.get("wandb_run_path")
+        or entry.get("wandb_run_id")
+    )
+
+
+def _sha256(path: Path) -> str:
+    """Compute a SHA256 checksum for a local artifact."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_model_id(config_path: str) -> str:
+    """Build a conservative candidate registry id from a config path."""
+    stem = Path(config_path).stem
+    cleaned = re.sub(r"[^A-Za-z0-9_]+", "_", stem).strip("_").lower()
+    if not cleaned:
+        cleaned = "local_model"
+    return f"{cleaned}_local_artifact_candidate"
+
+
+def _resolve_repo_path(path_value: str, *, repo_root: Path) -> Path:
+    """Resolve an artifact path relative to the repository root."""
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def _artifact_metadata(path_value: str, *, repo_root: Path) -> dict[str, Any]:
+    """Return metadata for a local artifact path without copying or uploading it."""
+    resolved = _resolve_repo_path(path_value, repo_root=repo_root)
+    metadata: dict[str, Any] = {
+        "source_path": path_value,
+        "exists": resolved.exists(),
+        "size_bytes": None,
+        "sha256": None,
+    }
+    if resolved.is_file():
+        metadata["size_bytes"] = resolved.stat().st_size
+        metadata["sha256"] = _sha256(resolved)
+    return metadata
+
+
+def _expand_config_paths(paths: list[Path], *, repo_root: Path) -> list[Path]:
+    """Expand file and directory arguments into ordered YAML config files."""
+    expanded: list[Path] = []
+    for path in paths:
+        resolved = path if path.is_absolute() else repo_root / path
+        if resolved.is_dir():
+            expanded.extend(iter_yaml_files([resolved]))
+        elif resolved.suffix.lower() in {".yaml", ".yml"}:
+            expanded.append(resolved)
+        else:
+            raise FileNotFoundError(f"Expected YAML file or directory: {path}")
+    return expanded
+
+
+def _promoted_reason_for(
+    config_path: Path,
+    *,
+    repo_root: Path,
+    promoted_surfaces: dict[str, str],
+) -> str:
+    """Return the promoted-surface reason for a config, if any."""
+    candidates = path_lookup_candidates(config_path, repo_root=repo_root, cwd=Path.cwd())
+    return next(
+        (
+            promoted_surfaces[candidate]
+            for candidate in candidates
+            if candidate in promoted_surfaces
+        ),
+        "",
+    )
+
+
+def _promotion_plan(
+    *,
+    config_path: str,
+    field: str,
+    value: str,
+    artifact: dict[str, Any],
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the metadata-only promotion plan for a local artifact reference."""
+    return {
+        "target_registry_id": _safe_model_id(config_path),
+        "source_config": config_path,
+        "source_field": field,
+        "source_path": value,
+        "sha256": artifact["sha256"],
+        "size_bytes": artifact["size_bytes"],
+        "license_access_note": (
+            "Maintainer must confirm checkpoint license, access rights, source run, and durable "
+            "publication target before promotion."
+        ),
+        "claim_boundary": "not benchmark evidence until durable artifact exists",
+        "source_commit": payload.get("commit"),
+        "training_config": (payload.get("provenance") or {}).get("training_config")
+        if isinstance(payload.get("provenance"), dict)
+        else None,
+    }
+
+
+def _row_for_local_reference(
+    *,
+    config_path: str,
+    field: str,
+    value: str,
+    payload: dict[str, Any],
+    repo_root: Path,
+    promoted_reason: str,
+) -> dict[str, Any]:
+    """Classify one local output artifact reference."""
+    artifact = _artifact_metadata(value, repo_root=repo_root)
+    promotion_plan = _promotion_plan(
+        config_path=config_path,
+        field=field,
+        value=value,
+        artifact=artifact,
+        payload=payload,
+    )
+    if promoted_reason:
+        return {
+            "config_path": config_path,
+            "classification": "manual_decision_required",
+            "decision": "replace_local_artifact_before_benchmark_use",
+            "surface": "benchmark_promoted",
+            "field": field,
+            "value": value,
+            "artifact": artifact,
+            "promotion_plan": promotion_plan,
+            "claim_boundary": "not benchmark evidence until durable artifact exists",
+            "action": (
+                f"{promoted_reason} This local-only path must not be treated as benchmark "
+                "evidence; replace it with a durable model_id/artifact pointer or remove the "
+                "config from promoted surfaces."
+            ),
+        }
+
+    if artifact["exists"]:
+        classification = "promotable"
+        decision = "prepare_promotion_metadata"
+        action = (
+            "Review provenance, license/access, source commit, and target registry id before any "
+            "explicit promotion/upload step."
+        )
+    elif str(payload.get("profile") or "").strip().lower() == "experimental":
+        classification = "retire_candidate"
+        decision = "recover_or_retire"
+        action = (
+            "Missing experimental checkpoint: recover the checkpoint and prove provenance if it "
+            "is worth promoting; otherwise retire or rewrite this config."
+        )
+    else:
+        classification = "missing"
+        decision = "recover_before_promotion"
+        action = (
+            "Missing checkpoint: recover the checkpoint from a durable source or retire this "
+            "config; do not use it as benchmark evidence."
+        )
+
+    return {
+        "config_path": config_path,
+        "classification": classification,
+        "decision": decision,
+        "surface": "local_experimental",
+        "field": field,
+        "value": value,
+        "artifact": artifact,
+        "promotion_plan": promotion_plan,
+        "claim_boundary": "not benchmark evidence until durable artifact exists",
+        "action": action,
+    }
+
+
+def _row_for_model_id(
+    *,
+    config_path: str,
+    model_id: str,
+    registry: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Classify a config that references a model registry id."""
+    entry = registry.get(model_id)
+    if entry is not None and _is_durable_registry_entry(entry):
+        return {
+            "config_path": config_path,
+            "classification": "already_registered",
+            "decision": "no_local_promotion_needed",
+            "surface": "durable_registry",
+            "model_id": model_id,
+            "registry_entry": {
+                "model_id": model_id,
+                "public_artifact_source": entry.get("public_artifact_source"),
+                "github_release": entry.get("github_release"),
+                "wandb_artifact_path": entry.get("wandb_artifact_path"),
+                "wandb_run_path": entry.get("wandb_run_path"),
+            },
+            "claim_boundary": (
+                "durable artifact pointer exists; benchmark claims still require benchmark proof"
+            ),
+            "action": "No local artifact promotion needed for this config.",
+        }
+    return {
+        "config_path": config_path,
+        "classification": "manual_decision_required",
+        "decision": "resolve_model_id_alias",
+        "surface": "registry_alias",
+        "model_id": model_id,
+        "claim_boundary": "not benchmark evidence until durable artifact exists",
+        "action": (
+            "model_id is not backed by a durable registry entry; add registry provenance, "
+            "replace the alias, or retire the config."
+        ),
+    }
+
+
+def _row_for_config(
+    config_path: Path,
+    *,
+    repo_root: Path,
+    registry: dict[str, dict[str, Any]],
+    promoted_surfaces: dict[str, str],
+) -> dict[str, Any]:
+    """Build one planner row for a YAML config."""
+    payload = _load_yaml_mapping(config_path)
+    rel_path = display_path(config_path, repo_root=repo_root)
+    local_references = iter_local_model_references(payload)
+    promoted_reason = _promoted_reason_for(
+        config_path,
+        repo_root=repo_root,
+        promoted_surfaces=promoted_surfaces,
+    )
+    if local_references:
+        field, value = local_references[0]
+        row = _row_for_local_reference(
+            config_path=rel_path,
+            field=field,
+            value=value,
+            payload=payload,
+            repo_root=repo_root,
+            promoted_reason=promoted_reason,
+        )
+        row["local_references"] = [
+            {"field": reference_field, "value": reference_value}
+            for reference_field, reference_value in local_references
+        ]
+        return row
+
+    model_id = payload.get("model_id")
+    if isinstance(model_id, str) and model_id.strip():
+        return _row_for_model_id(config_path=rel_path, model_id=model_id.strip(), registry=registry)
+
+    return {
+        "config_path": rel_path,
+        "classification": "manual_decision_required",
+        "decision": "no_model_reference_found",
+        "surface": "unknown",
+        "claim_boundary": "not benchmark evidence until artifact provenance is explicit",
+        "action": "No local model_path or model_id was found; inspect this config manually.",
+    }
+
+
+def build_promotion_report(
+    paths: list[Path],
+    *,
+    repo_root: Path = REPO_ROOT,
+    registry_path: Path = DEFAULT_REGISTRY_PATH,
+    promoted_surfaces_path: Path = DEFAULT_PROMOTED_SURFACES_PATH,
+) -> dict[str, Any]:
+    """Build a metadata-only promotion/retirement report for config paths."""
+    registry_resolved = registry_path if registry_path.is_absolute() else repo_root / registry_path
+    promoted_resolved = (
+        promoted_surfaces_path
+        if promoted_surfaces_path.is_absolute()
+        else repo_root / promoted_surfaces_path
+    )
+    registry = _load_registry(registry_resolved)
+    promoted_surfaces = load_promoted_surfaces(promoted_resolved, strict=True)
+    config_paths = _expand_config_paths(paths or INITIAL_TARGET_CONFIGS, repo_root=repo_root)
+    rows = [
+        _row_for_config(
+            path,
+            repo_root=repo_root,
+            registry=registry,
+            promoted_surfaces=promoted_surfaces,
+        )
+        for path in config_paths
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": datetime.now(UTC).isoformat(timespec="seconds"),
+        "claim_boundary": (
+            "Planner output is metadata/provenance guidance only; it is not benchmark evidence "
+            "and does not publish artifacts."
+        ),
+        "rows": rows,
+    }
+
+
+def render_issue_table(report: dict[str, Any]) -> str:
+    """Render a concise GitHub-issue-ready decision table."""
+    lines = [
+        "| Config | Classification | Decision | Action |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in report["rows"]:
+        action = str(row["action"]).replace("\n", " ")
+        if len(action) > 180:
+            action = action[:177].rstrip() + "..."
+        lines.append(
+            "| {config_path} | {classification} | {decision} | {action} |".format(
+                config_path=row["config_path"],
+                classification=row["classification"],
+                decision=row["decision"],
+                action=action,
+            )
+        )
+    return "\n".join(lines)
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    """Write report JSON to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add shared path arguments to a subcommand parser."""
+    parser.add_argument("paths", nargs="*", type=Path, help="YAML config files or directories.")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--registry-path", type=Path, default=DEFAULT_REGISTRY_PATH)
+    parser.add_argument("--promoted-surfaces", type=Path, default=DEFAULT_PROMOTED_SURFACES_PATH)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scan = subparsers.add_parser("scan", help="Scan configs and print a promotion table.")
+    _add_common_args(scan)
+    scan.add_argument("--json", action="store_true", help="Print report JSON instead of Markdown.")
+
+    plan = subparsers.add_parser("plan", help="Plan one or more configs.")
+    _add_common_args(plan)
+    plan.add_argument("--config", action="append", type=Path, default=[], help="Config path.")
+    plan.add_argument("--json", action="store_true", help="Print report JSON instead of Markdown.")
+
+    write_report = subparsers.add_parser(
+        "write-report",
+        help="Write JSON report and print a GitHub issue decision table.",
+    )
+    _add_common_args(write_report)
+    write_report.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the artifact-promotion planner CLI."""
+    args = _build_parser().parse_args(argv)
+    paths = list(args.paths)
+    if args.command == "plan":
+        paths = [*args.config, *paths]
+    report = build_promotion_report(
+        paths,
+        repo_root=args.repo_root,
+        registry_path=args.registry_path,
+        promoted_surfaces_path=args.promoted_surfaces,
+    )
+
+    if args.command == "write-report":
+        _write_report(args.output, report)
+        print(render_issue_table(report))
+        return 0
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_issue_table(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_plan_model_artifact_promotion.py
+++ b/tests/tools/test_plan_model_artifact_promotion.py
@@ -46,8 +46,35 @@ profile: experimental
     )
     registered_config = tmp_path / "configs" / "baselines" / "registered.yaml"
     _write(registered_config, "model_id: durable_model\n")
+    source_only_config = tmp_path / "configs" / "baselines" / "source_only.yaml"
+    _write(source_only_config, "model_id: source_only_model\n")
+    run_id_only_config = tmp_path / "configs" / "baselines" / "run_id_only.yaml"
+    _write(run_id_only_config, "model_id: run_id_only_model\n")
     promoted_config = tmp_path / "configs" / "benchmarks" / "promoted.yaml"
     _write(promoted_config, "model_path: output/model_cache/promoted/model.zip\n")
+    matrix_config = tmp_path / "configs" / "baselines" / "example_matrix.yaml"
+    _write(
+        matrix_config,
+        """
+- id: demo
+  repeats: 1
+""".strip()
+        + "\n",
+    )
+    blocklist = tmp_path / "configs" / "baselines" / "local_model_artifact_blocklist.yaml"
+    _write(
+        blocklist,
+        """
+version: 1
+follow_up_issue: https://github.com/ll7/robot_sf_ll7/issues/1764
+blocked_references:
+  - path: configs/baselines/missing.yaml
+    field: model_path
+    value: output/models/missing/model.zip
+    reason: Synthetic missing checkpoint is local-only.
+""".strip()
+        + "\n",
+    )
     registry = tmp_path / "model" / "registry.yaml"
     _write(
         registry,
@@ -61,6 +88,10 @@ models:
       url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models/durable.zip
       sha256: abc123
       size_bytes: 123
+  - model_id: source_only_model
+    public_artifact_source: github_release
+  - model_id: run_id_only_model
+    wandb_run_id: abc123
 """.strip()
         + "\n",
     )
@@ -80,8 +111,12 @@ promoted_configs:
         "present_config": present_config,
         "missing_config": missing_config,
         "registered_config": registered_config,
+        "source_only_config": source_only_config,
+        "run_id_only_config": run_id_only_config,
         "promoted_config": promoted_config,
+        "matrix_config": matrix_config,
         "registry": registry,
+        "blocklist": blocklist,
         "promoted_surfaces": promoted_surfaces,
     }
 
@@ -97,6 +132,8 @@ def test_plan_classifies_present_missing_registered_and_promoted_local_configs(
             paths["present_config"],
             paths["missing_config"],
             paths["registered_config"],
+            paths["source_only_config"],
+            paths["run_id_only_config"],
             paths["promoted_config"],
         ],
         repo_root=tmp_path,
@@ -116,12 +153,21 @@ def test_plan_classifies_present_missing_registered_and_promoted_local_configs(
     missing = rows["configs/baselines/missing.yaml"]
     assert missing["classification"] == "retire_candidate"
     assert missing["artifact"]["exists"] is False
+    assert missing["blocker_reason"] == "Synthetic missing checkpoint is local-only."
     assert "recover the checkpoint" in missing["action"]
 
     registered = rows["configs/baselines/registered.yaml"]
     assert registered["classification"] == "already_registered"
     assert registered["model_id"] == "durable_model"
     assert registered["registry_entry"]["public_artifact_source"] == "github_release"
+
+    source_only = rows["configs/baselines/source_only.yaml"]
+    assert source_only["classification"] == "manual_decision_required"
+    assert source_only["decision"] == "resolve_model_id_alias"
+
+    run_id_only = rows["configs/baselines/run_id_only.yaml"]
+    assert run_id_only["classification"] == "manual_decision_required"
+    assert run_id_only["decision"] == "resolve_model_id_alias"
 
     promoted = rows["configs/benchmarks/promoted.yaml"]
     assert promoted["classification"] == "manual_decision_required"
@@ -162,6 +208,22 @@ def test_write_report_emits_json_and_issue_table(tmp_path: Path, capsys) -> None
     stdout = capsys.readouterr().out
     assert "| Config | Classification | Decision | Action |" in stdout
     assert "configs/baselines/present.yaml" in stdout
+
+
+def test_directory_scan_handles_non_mapping_yaml_and_skips_manifests(tmp_path: Path) -> None:
+    """Directory scans should report unsupported YAML shapes without scanning manifests as configs."""
+    paths = _repo_fixture(tmp_path)
+
+    report = plan_model_artifact_promotion.build_promotion_report(
+        [tmp_path / "configs" / "baselines"],
+        repo_root=tmp_path,
+        registry_path=paths["registry"],
+        promoted_surfaces_path=paths["promoted_surfaces"],
+    )
+
+    rows = {row["config_path"]: row for row in report["rows"]}
+    assert "configs/baselines/local_model_artifact_blocklist.yaml" not in rows
+    assert rows["configs/baselines/example_matrix.yaml"]["decision"] == "unsupported_yaml_shape"
 
 
 def test_initial_issue_config_list_gets_one_row_per_config() -> None:

--- a/tests/tools/test_plan_model_artifact_promotion.py
+++ b/tests/tools/test_plan_model_artifact_promotion.py
@@ -1,0 +1,176 @@
+"""Tests for the local model-artifact promotion planner."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.tools import plan_model_artifact_promotion
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, payload: bytes | str) -> None:
+    """Write a small fixture file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+
+
+def _repo_fixture(tmp_path: Path) -> dict[str, Path]:
+    """Create a tiny repo-like tree with local and durable model configs."""
+    present_model = tmp_path / "output" / "model_cache" / "present" / "model.zip"
+    _write(present_model, b"checkpoint")
+    present_config = tmp_path / "configs" / "baselines" / "present.yaml"
+    _write(
+        present_config,
+        """
+model_path: output/model_cache/present/model.zip
+profile: experimental
+provenance:
+  training_config: configs/training/present.yaml
+""".strip()
+        + "\n",
+    )
+    missing_config = tmp_path / "configs" / "baselines" / "missing.yaml"
+    _write(
+        missing_config,
+        """
+model_path: output/models/missing/model.zip
+profile: experimental
+""".strip()
+        + "\n",
+    )
+    registered_config = tmp_path / "configs" / "baselines" / "registered.yaml"
+    _write(registered_config, "model_id: durable_model\n")
+    promoted_config = tmp_path / "configs" / "benchmarks" / "promoted.yaml"
+    _write(promoted_config, "model_path: output/model_cache/promoted/model.zip\n")
+    registry = tmp_path / "model" / "registry.yaml"
+    _write(
+        registry,
+        """
+version: 1
+models:
+  - model_id: durable_model
+    local_path: output/model_cache/durable_model/model.zip
+    public_artifact_source: github_release
+    github_release:
+      url: https://github.com/ll7/robot_sf_ll7/releases/download/artifact/models/durable.zip
+      sha256: abc123
+      size_bytes: 123
+""".strip()
+        + "\n",
+    )
+    promoted_surfaces = tmp_path / "configs" / "benchmarks" / "promoted_config_surfaces.yaml"
+    _write(
+        promoted_surfaces,
+        f"""
+version: 1
+promoted_configs:
+  - path: {promoted_config.relative_to(tmp_path).as_posix()}
+    reason: Synthetic promoted benchmark config.
+""".strip()
+        + "\n",
+    )
+    return {
+        "present_model": present_model,
+        "present_config": present_config,
+        "missing_config": missing_config,
+        "registered_config": registered_config,
+        "promoted_config": promoted_config,
+        "registry": registry,
+        "promoted_surfaces": promoted_surfaces,
+    }
+
+
+def test_plan_classifies_present_missing_registered_and_promoted_local_configs(
+    tmp_path: Path,
+) -> None:
+    """Planner rows should distinguish local artifacts from durable registry ids."""
+    paths = _repo_fixture(tmp_path)
+
+    report = plan_model_artifact_promotion.build_promotion_report(
+        [
+            paths["present_config"],
+            paths["missing_config"],
+            paths["registered_config"],
+            paths["promoted_config"],
+        ],
+        repo_root=tmp_path,
+        registry_path=paths["registry"],
+        promoted_surfaces_path=paths["promoted_surfaces"],
+    )
+
+    rows = {row["config_path"]: row for row in report["rows"]}
+    present = rows["configs/baselines/present.yaml"]
+    assert present["classification"] == "promotable"
+    assert present["artifact"]["source_path"] == "output/model_cache/present/model.zip"
+    assert present["artifact"]["size_bytes"] == len(b"checkpoint")
+    assert present["artifact"]["sha256"]
+    assert present["promotion_plan"]["target_registry_id"] == "present_local_artifact_candidate"
+    assert present["claim_boundary"] == "not benchmark evidence until durable artifact exists"
+
+    missing = rows["configs/baselines/missing.yaml"]
+    assert missing["classification"] == "retire_candidate"
+    assert missing["artifact"]["exists"] is False
+    assert "recover the checkpoint" in missing["action"]
+
+    registered = rows["configs/baselines/registered.yaml"]
+    assert registered["classification"] == "already_registered"
+    assert registered["model_id"] == "durable_model"
+    assert registered["registry_entry"]["public_artifact_source"] == "github_release"
+
+    promoted = rows["configs/benchmarks/promoted.yaml"]
+    assert promoted["classification"] == "manual_decision_required"
+    assert promoted["surface"] == "benchmark_promoted"
+    assert "must not be treated as benchmark evidence" in promoted["action"]
+
+
+def test_write_report_emits_json_and_issue_table(tmp_path: Path, capsys) -> None:
+    """The CLI should write a reviewable JSON plan plus issue-ready Markdown."""
+    paths = _repo_fixture(tmp_path)
+    output = tmp_path / "docs" / "context" / "evidence" / "plan.json"
+
+    exit_code = plan_model_artifact_promotion.main(
+        [
+            "write-report",
+            "--repo-root",
+            str(tmp_path),
+            "--registry-path",
+            str(paths["registry"]),
+            "--promoted-surfaces",
+            str(paths["promoted_surfaces"]),
+            "--output",
+            str(output),
+            str(paths["present_config"]),
+            str(paths["missing_config"]),
+            str(paths["registered_config"]),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "robot-sf-model-artifact-promotion-plan.v1"
+    assert [row["classification"] for row in payload["rows"]] == [
+        "promotable",
+        "retire_candidate",
+        "already_registered",
+    ]
+    stdout = capsys.readouterr().out
+    assert "| Config | Classification | Decision | Action |" in stdout
+    assert "configs/baselines/present.yaml" in stdout
+
+
+def test_initial_issue_config_list_gets_one_row_per_config() -> None:
+    """The issue #1764 target list should remain the default planning surface."""
+    report = plan_model_artifact_promotion.build_promotion_report(
+        plan_model_artifact_promotion.INITIAL_TARGET_CONFIGS
+    )
+
+    assert [row["config_path"] for row in report["rows"]] == [
+        path.as_posix() for path in plan_model_artifact_promotion.INITIAL_TARGET_CONFIGS
+    ]
+    assert all(row["claim_boundary"] for row in report["rows"])


### PR DESCRIPTION
## Summary
- Add a metadata-only model artifact promotion planner for local checkpoint references and durable `model_id` references.
- Classify initial issue-target configs as promotable, missing/retire candidates, already registered, or manual decisions.
- Harden directory scans so non-config YAML and support manifests do not crash or pollute promotion decisions.
- Require durable registry pointers to include enough retrieval/checksum provenance before treating a `model_id` as registered.

## Validation
- `uv run pytest -q tests/tools/test_plan_model_artifact_promotion.py`
- `uv run ruff check scripts/tools/plan_model_artifact_promotion.py tests/tools/test_plan_model_artifact_promotion.py`
- `uv run ruff format --check scripts/tools/plan_model_artifact_promotion.py tests/tools/test_plan_model_artifact_promotion.py`
- `git diff --check`