### PR TITLE
feat: validate policy-search registries

### DIFF
--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -123,7 +123,8 @@ Use it for three things only:
 - Retrieval index: `docs/context/policy_search/INDEX.md`
 - Candidate lifecycle summary: `docs/context/policy_search/candidate_registry_summary.md`
 - Candidate runner: `uv run python scripts/validation/run_policy_search_candidate.py`
-- Candidate registry validator: `uv run python scripts/validation/validate_policy_search_registry.py`
+- Candidate/learned-policy registry validator:
+  `uv run python scripts/validation/validate_policy_search_registry.py`
 - Candidate portfolio overview: `uv run python scripts/tools/summarize_policy_search_portfolio.py`
 - Candidate comparison: `uv run python scripts/tools/compare_policy_search_candidates.py`
 - Failure taxonomy: `uv run python scripts/tools/build_policy_search_failure_report.py`

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -110,6 +110,7 @@ candidates:
     family: scenario_adaptive_classical
     training_required: false
     promotion_gate: tier_b
+    benchmark_track: policy_search_full_matrix
     candidate_config_path: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
     hypothesis: >
       The retained fast-progress static-recenter hybrid candidate is strongest on most current
@@ -127,6 +128,7 @@ candidates:
     family: scenario_adaptive_classical
     training_required: false
     promotion_gate: tier_b
+    benchmark_track: policy_search_h500_leader_collision_slice
     candidate_config_path: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
     hypothesis: >
       The h500 leader misses the strict collision gate by one controllable merging collision plus
@@ -554,6 +556,7 @@ candidates:
     family: hybrid_model_based
     training_required: false
     promotion_gate: tier_b
+    benchmark_track: policy_search_full_matrix_if_promising
     candidate_config_path: configs/policy_search/candidates/hybrid_orca_sampler_v1.yaml
     hypothesis: >
       Keep ORCA-like safety behavior while allowing a short-horizon sampler to

--- a/docs/context/policy_search/learned_policy_registry.md
+++ b/docs/context/policy_search/learned_policy_registry.md
@@ -235,9 +235,9 @@ metadata before entering the runnable candidate registry.
 
 ## Validation
 
-This note is documentation and registry metadata only. Validate changes with:
+This note is documentation and registry metadata only. Validate candidate and learned-policy
+registry consistency with:
 
 ```bash
-git diff --check origin/main...HEAD
-BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+uv run python scripts/validation/validate_policy_search_registry.py
 ```

--- a/scripts/validation/validate_policy_search_registry.py
+++ b/scripts/validation/validate_policy_search_registry.py
@@ -17,6 +17,7 @@ from typing import Any
 import yaml
 
 DEFAULT_REGISTRY = Path("docs/context/policy_search/candidate_registry.yaml")
+DEFAULT_LEARNED_REGISTRY = Path("docs/context/policy_search/learned_policy_registry.md")
 IMPLEMENTED_STATUSES = {"implemented", "experimental_spike", "prototype"}
 SLURM_STATUSES = {"slurm_handoff_required"}
 LEARNED_FAMILIES = {
@@ -24,6 +25,16 @@ LEARNED_FAMILIES = {
     "learned_policy_network",
     "learned_style_value_scorer",
 }
+LOCAL_ONLY_ARTIFACT_PREFIXES = (
+    "output/",
+    "results/",
+    ".git/",
+    ".venv/",
+    "/tmp/",
+    "/var/tmp/",
+    "/home/",
+)
+BENCHMARK_STAGES = {"full_matrix", "leader_collision_slice_h500"}
 
 
 @dataclass(frozen=True)
@@ -94,6 +105,36 @@ def _validate_path_field(
         return
     if not path.exists():
         issues.append(RegistryIssue(f"{prefix}.{field}", f"path does not exist: {row[field]}"))
+
+
+def _is_worktree_local_artifact_path(value: str) -> bool:
+    """Return whether a string names a disposable/local-only artifact path."""
+    stripped = value.strip()
+    return stripped.startswith(LOCAL_ONLY_ARTIFACT_PREFIXES) or ".worktrees/" in stripped
+
+
+def _walk_local_artifact_paths(value: Any, *, prefix: str) -> list[RegistryIssue]:
+    """Find local-only artifact paths in nested registry/config metadata."""
+    issues: list[RegistryIssue] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key)
+            child_prefix = f"{prefix}.{key_text}" if prefix else key_text
+            issues.extend(_walk_local_artifact_paths(child, prefix=child_prefix))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            issues.extend(_walk_local_artifact_paths(child, prefix=f"{prefix}[{index}]"))
+    elif isinstance(value, str) and _is_worktree_local_artifact_path(value):
+        issues.append(
+            RegistryIssue(
+                prefix,
+                (
+                    f"worktree-local artifact path is not durable: {value}; use a durable "
+                    "artifact URI or tracked manifest pointer"
+                ),
+            )
+        )
+    return issues
 
 
 def _parse_registry_date(value: Any) -> date | None:
@@ -243,6 +284,47 @@ def _validate_required_stages(
             )
 
 
+def _benchmark_stages(stages: Any) -> list[str]:
+    """Return benchmark-track stages from a candidate's required stages."""
+    if not isinstance(stages, list):
+        return []
+    benchmark_stages: list[str] = []
+    for stage in stages:
+        if not isinstance(stage, str):
+            continue
+        base_stage = stage.removesuffix("_if_promising")
+        if base_stage in BENCHMARK_STAGES or base_stage.endswith("_h500"):
+            benchmark_stages.append(stage)
+    return benchmark_stages
+
+
+def _validate_benchmark_boundary(
+    issues: list[RegistryIssue],
+    row: dict[str, Any],
+    *,
+    prefix: str,
+) -> None:
+    """Require benchmark-track metadata for benchmark-routed candidates."""
+    stages = _benchmark_stages(row.get("required_stages"))
+    if not stages:
+        return
+    if not _is_missing(row.get("benchmark_track")):
+        return
+    if not _is_missing(row.get("non_benchmark_boundary")):
+        return
+    if row.get("claim_scope") == "diagnostic_only":
+        return
+    issues.append(
+        RegistryIssue(
+            f"{prefix}.benchmark_track",
+            (
+                "is required for benchmark stages "
+                f"{', '.join(stages)} unless non_benchmark_boundary is set"
+            ),
+        )
+    )
+
+
 def _validate_learned_link(
     issues: list[RegistryIssue],
     row: dict[str, Any],
@@ -353,11 +435,24 @@ def _validate_candidate(
             field="candidate_config_path",
             repo_root=repo_root,
         )
+        candidate_config_path = _resolve_repo_path(repo_root, row.get("candidate_config_path"))
+        if candidate_config_path is not None and candidate_config_path.exists():
+            candidate_config = _load_yaml(candidate_config_path)
+            issues.extend(
+                _walk_local_artifact_paths(
+                    candidate_config,
+                    prefix=f"{prefix}.candidate_config_path",
+                )
+            )
         _validate_required_stages(issues, row, prefix=prefix, known_stages=known_stages)
     elif status in SLURM_STATUSES:
         _validate_slurm_row(issues, row, prefix=prefix, repo_root=repo_root)
     else:
         issues.append(RegistryIssue(f"{prefix}.status", f"unknown status: {status}"))
+
+    if status in IMPLEMENTED_STATUSES:
+        issues.extend(_walk_local_artifact_paths(row, prefix=prefix))
+        _validate_benchmark_boundary(issues, row, prefix=prefix)
 
     gate = row.get("promotion_gate")
     if isinstance(gate, str) and known_gates and gate not in known_gates:
@@ -406,6 +501,66 @@ def validate_registry(
     return issues
 
 
+def _split_markdown_table_row(line: str) -> list[str]:
+    """Split a simple Markdown table row into cells."""
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return []
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+def _clean_markdown_cell(value: str) -> str:
+    """Normalize a Markdown table cell for validation."""
+    return value.strip().strip("`").strip()
+
+
+def _is_markdown_separator(cells: list[str]) -> bool:
+    """Return whether table cells are the Markdown separator row."""
+    return bool(cells) and all(set(cell.replace(":", "").strip()) <= {"-"} for cell in cells)
+
+
+def _iter_learned_policy_rows(path: Path) -> list[dict[str, str]]:
+    """Parse learned-policy entries from the first table with a policy_id header."""
+    rows: list[dict[str, str]] = []
+    headers: list[str] | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        cells = _split_markdown_table_row(line)
+        if not cells:
+            if headers is not None and rows:
+                break
+            continue
+        cleaned = [_clean_markdown_cell(cell) for cell in cells]
+        if headers is None:
+            if cleaned and cleaned[0] == "policy_id":
+                headers = cleaned
+            continue
+        if _is_markdown_separator(cleaned):
+            continue
+        if len(cleaned) < len(headers):
+            continue
+        rows.append(dict(zip(headers, cleaned, strict=False)))
+    return rows
+
+
+def validate_learned_policy_registry(
+    registry_path: Path = DEFAULT_LEARNED_REGISTRY,
+) -> list[RegistryIssue]:
+    """Validate learned-policy registry table consistency."""
+    rows = _iter_learned_policy_rows(Path(registry_path))
+    issues: list[RegistryIssue] = []
+    seen_policy_ids: set[str] = set()
+    for index, row in enumerate(rows):
+        policy_id = row.get("policy_id", "").strip()
+        path = f"learned_policy_registry.entries[{index}].policy_id"
+        if not policy_id:
+            issues.append(RegistryIssue(path, "is required"))
+            continue
+        if policy_id in seen_policy_ids:
+            issues.append(RegistryIssue(path, f"duplicate policy_id: {policy_id}"))
+        seen_policy_ids.add(policy_id)
+    return issues
+
+
 def _parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -415,6 +570,12 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         default=DEFAULT_REGISTRY,
         help="Policy-search candidate registry YAML.",
+    )
+    parser.add_argument(
+        "--learned-policy-registry",
+        type=Path,
+        default=DEFAULT_LEARNED_REGISTRY,
+        help="Learned-policy registry Markdown table.",
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON issues.")
     parser.add_argument(
@@ -440,11 +601,15 @@ def main() -> int:
         as_of=args.as_of,
         max_age_days=args.max_age_days,
     )
+    issues.extend(validate_learned_policy_registry(args.learned_policy_registry))
     if args.json:
         print(json.dumps([issue.__dict__ for issue in issues], indent=2, sort_keys=True))
     else:
         if not issues:
-            print(f"OK: {args.registry} satisfies the policy-search registry contract.")
+            print(
+                f"OK: {args.registry} and {args.learned_policy_registry} satisfy "
+                "the policy-search registry contract."
+            )
         for issue in issues:
             print(f"ERROR: {issue.path}: {issue.message}")
     return 1 if issues else 0

--- a/scripts/validation/validate_policy_search_registry.py
+++ b/scripts/validation/validate_policy_search_registry.py
@@ -519,7 +519,7 @@ def _is_markdown_separator(cells: list[str]) -> bool:
     return bool(cells) and all(set(cell.replace(":", "").strip()) <= {"-"} for cell in cells)
 
 
-def _iter_learned_policy_rows(path: Path) -> list[dict[str, str]]:
+def _iter_learned_policy_rows(path: Path) -> tuple[list[dict[str, str]], bool]:
     """Parse learned-policy entries from the first table with a policy_id header."""
     rows: list[dict[str, str]] = []
     headers: list[str] | None = None
@@ -539,15 +539,26 @@ def _iter_learned_policy_rows(path: Path) -> list[dict[str, str]]:
         if len(cleaned) < len(headers):
             continue
         rows.append(dict(zip(headers, cleaned, strict=False)))
-    return rows
+    return rows, headers is not None
 
 
 def validate_learned_policy_registry(
     registry_path: Path = DEFAULT_LEARNED_REGISTRY,
 ) -> list[RegistryIssue]:
     """Validate learned-policy registry table consistency."""
-    rows = _iter_learned_policy_rows(Path(registry_path))
+    rows, has_policy_table = _iter_learned_policy_rows(Path(registry_path))
     issues: list[RegistryIssue] = []
+    if not has_policy_table:
+        issues.append(
+            RegistryIssue(
+                "learned_policy_registry",
+                "must contain a Markdown table with policy_id as the first column",
+            )
+        )
+        return issues
+    if not rows:
+        issues.append(RegistryIssue("learned_policy_registry.entries", "must not be empty"))
+        return issues
     seen_policy_ids: set[str] = set()
     for index, row in enumerate(rows):
         policy_id = row.get("policy_id", "").strip()

--- a/tests/validation/test_validate_policy_search_registry.py
+++ b/tests/validation/test_validate_policy_search_registry.py
@@ -6,7 +6,11 @@ from datetime import date
 from pathlib import Path
 from textwrap import dedent
 
-from scripts.validation.validate_policy_search_registry import _load_known_names, validate_registry
+from scripts.validation.validate_policy_search_registry import (
+    _load_known_names,
+    validate_learned_policy_registry,
+    validate_registry,
+)
 
 
 def _write(path: Path, text: str) -> None:
@@ -33,6 +37,14 @@ def _write_support_files(root: Path) -> None:
         """,
     )
     _write(root / "configs/policy_search/candidates/demo.yaml", "name: demo\n")
+    _write(
+        root / "configs/policy_search/candidates/local_artifact.yaml",
+        """
+        name: local_artifact
+        algo: ppo
+        model_artifact: output/model_cache/local.pt
+        """,
+    )
     _write(root / "docs/context/policy_search/SLURM/demo.md", "# Handoff\n")
     _write(
         root / "configs/training/demo_launch.yaml",
@@ -91,6 +103,17 @@ def test_checked_in_policy_search_registry_validates() -> None:
     issues = validate_registry(
         repo_root / "docs/context/policy_search/candidate_registry.yaml",
         as_of=date(2026, 5, 31),
+    )
+
+    assert issues == []
+
+
+def test_checked_in_learned_policy_registry_validates() -> None:
+    """The tracked learned-policy registry should keep policy IDs unique."""
+    repo_root = Path(__file__).parents[2]
+
+    issues = validate_learned_policy_registry(
+        repo_root / "docs/context/policy_search/learned_policy_registry.md"
     )
 
     assert issues == []
@@ -181,5 +204,73 @@ def test_learned_candidate_requires_registry_or_adapter_link(tmp_path: Path) -> 
     assert any(
         issue.path == "candidates.learned_candidate"
         and "learned_policy_registry_id" in issue.message
+        for issue in issues
+    )
+
+
+def test_learned_policy_registry_duplicate_ids_are_reported(tmp_path: Path) -> None:
+    """Duplicate learned-policy table IDs should fail before docs consume the registry."""
+    registry = tmp_path / "learned_policy_registry.md"
+    _write(
+        registry,
+        """
+        # Learned Registry
+
+        | `policy_id` | `policy_family` | `integration_status` |
+        | --- | --- | --- |
+        | `arena_rosnav_stack` | `external_learned_policy` | `monitor_only` |
+        | `arena_rosnav_stack` | `external_learned_policy` | `monitor_only` |
+        """,
+    )
+
+    issues = validate_learned_policy_registry(registry)
+
+    assert [(issue.path, issue.message) for issue in issues] == [
+        (
+            "learned_policy_registry.entries[1].policy_id",
+            "duplicate policy_id: arena_rosnav_stack",
+        )
+    ]
+
+
+def test_runnable_candidate_rejects_worktree_local_artifact_paths(tmp_path: Path) -> None:
+    """Runnable candidates should not depend only on output/ artifacts."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(
+        registry,
+        _valid_registry_text().replace(
+            "candidate_config_path: configs/policy_search/candidates/demo.yaml",
+            "candidate_config_path: configs/policy_search/candidates/local_artifact.yaml",
+            1,
+        ),
+    )
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31))
+
+    assert any(
+        issue.path == "candidates.demo_candidate.candidate_config_path.model_artifact"
+        and "worktree-local artifact path" in issue.message
+        for issue in issues
+    )
+
+
+def test_full_matrix_stage_requires_benchmark_track_or_boundary(tmp_path: Path) -> None:
+    """Benchmark-routed candidates need a track or explicit non-benchmark boundary."""
+    _write_support_files(tmp_path)
+    registry = tmp_path / "candidate_registry.yaml"
+    _write(
+        registry,
+        _valid_registry_text().replace(
+            "required_stages: [smoke]",
+            "required_stages: [smoke, full_matrix]",
+            1,
+        ),
+    )
+
+    issues = validate_registry(registry, as_of=date(2026, 5, 31))
+
+    assert any(
+        issue.path == "candidates.demo_candidate.benchmark_track" and "full_matrix" in issue.message
         for issue in issues
     )

--- a/tests/validation/test_validate_policy_search_registry.py
+++ b/tests/validation/test_validate_policy_search_registry.py
@@ -233,6 +233,42 @@ def test_learned_policy_registry_duplicate_ids_are_reported(tmp_path: Path) -> N
     ]
 
 
+def test_learned_policy_registry_missing_table_is_reported(tmp_path: Path) -> None:
+    """A learned-policy registry without the policy_id table should fail closed."""
+    registry = tmp_path / "learned_policy_registry.md"
+    _write(registry, "# Learned Registry\n\nNo table yet.")
+
+    issues = validate_learned_policy_registry(registry)
+
+    assert [(issue.path, issue.message) for issue in issues] == [
+        (
+            "learned_policy_registry",
+            "must contain a Markdown table with policy_id as the first column",
+        )
+    ]
+
+
+def test_learned_policy_registry_blank_ids_are_reported(tmp_path: Path) -> None:
+    """Blank learned-policy IDs should not silently pass uniqueness checks."""
+    registry = tmp_path / "learned_policy_registry.md"
+    _write(
+        registry,
+        """
+        # Learned Registry
+
+        | `policy_id` | `policy_family` | `integration_status` |
+        | --- | --- | --- |
+        |  | `external_learned_policy` | `monitor_only` |
+        """,
+    )
+
+    issues = validate_learned_policy_registry(registry)
+
+    assert [(issue.path, issue.message) for issue in issues] == [
+        ("learned_policy_registry.entries[0].policy_id", "is required")
+    ]
+
+
 def test_runnable_candidate_rejects_worktree_local_artifact_paths(tmp_path: Path) -> None:
     """Runnable candidates should not depend only on output/ artifacts."""
     _write_support_files(tmp_path)


### PR DESCRIPTION
## Summary
- Harden the policy-search candidate registry validator with freshness, stage/gate, local-artifact, and benchmark-boundary checks.
- Add learned-policy registry consistency checks for duplicate policy IDs.
- Update policy-search docs and registry metadata to satisfy the stricter contract.

## Validation
- `uv run pytest -q tests/validation/test_validate_policy_search_registry.py`
- `uv run ruff check scripts/validation/validate_policy_search_registry.py tests/validation/test_validate_policy_search_registry.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`