### PR TITLE
feat: materialize scenario perturbation pilot inputs

### DIFF
--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -42,6 +42,21 @@ The preflight uses `scenario_cert.v1` after applying each supported perturbation
 Rows marked `excluded_from_success_evidence` or `stress_only_not_success_evidence` must be reported
 as limitations and must not count as successful benchmark evidence.
 
+## Pilot Materialization
+
+After preflight passes, materialize only eligible variants into a local scenario matrix:
+
+```bash
+uv run python scripts/tools/materialize_scenario_perturbation_pilot.py \
+  configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml \
+  --output-dir output/scenario_perturbation_pilot/issue_1610_seed_sensitive_pilot_v1 \
+  --seed-limit 1
+```
+
+The generated `scenario_matrix.yaml` and route override files are local execution inputs for the
+next paired planner pilot. They are not benchmark evidence by themselves, and excluded preflight
+rows are omitted from the matrix.
+
 ## Boundary
 
 This is not planner execution and not paper-facing evidence. It only proves that the selected

--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -55,7 +55,9 @@ uv run python scripts/tools/materialize_scenario_perturbation_pilot.py \
 
 The generated `scenario_matrix.yaml` and route override files are local execution inputs for the
 next paired planner pilot. They are not benchmark evidence by themselves, and excluded preflight
-rows are omitted from the matrix.
+rows are omitted from the matrix. When `--output-dir` points inside the repository, it must be
+under the ignored `output/` tree so materialized pilot inputs do not become durable provenance by
+accident.
 
 ## Boundary
 

--- a/robot_sf/scenario_certification/__init__.py
+++ b/robot_sf/scenario_certification/__init__.py
@@ -2,9 +2,12 @@
 
 from robot_sf.scenario_certification.perturbation_preflight import (
     PERTURBATION_MANIFEST_SCHEMA_VERSION,
+    PILOT_MATRIX_SCHEMA_VERSION,
     PREFLIGHT_SCHEMA_VERSION,
+    PerturbationPilotMaterialization,
     PerturbationPreflightReport,
     PerturbationPreflightResult,
+    materialize_perturbation_pilot_matrix,
     preflight_perturbation_manifest,
     preflight_to_dict,
 )
@@ -21,8 +24,10 @@ from robot_sf.scenario_certification.v1 import (
 __all__ = [
     "CERT_SCHEMA_VERSION",
     "PERTURBATION_MANIFEST_SCHEMA_VERSION",
+    "PILOT_MATRIX_SCHEMA_VERSION",
     "PREFLIGHT_SCHEMA_VERSION",
     "CertificationSettings",
+    "PerturbationPilotMaterialization",
     "PerturbationPreflightReport",
     "PerturbationPreflightResult",
     "ScenarioCertificate",
@@ -30,6 +35,7 @@ __all__ = [
     "certify_map_definition",
     "certify_scenario",
     "certify_scenario_file",
+    "materialize_perturbation_pilot_matrix",
     "preflight_perturbation_manifest",
     "preflight_to_dict",
 ]

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
 PERTURBATION_MANIFEST_SCHEMA_VERSION = "scenario_perturbation_manifest.v1"
 PREFLIGHT_SCHEMA_VERSION = "scenario_perturbation_preflight.v1"
+PILOT_MATRIX_SCHEMA_VERSION = "scenario_perturbation_pilot_matrix.v1"
 _PERTURBATION_MANIFEST_SCHEMA_PATH = (
     Path(__file__).resolve().parents[1]
     / "benchmark"
@@ -70,6 +71,19 @@ class PerturbationPreflightReport:
     manifest_path: str
     scenario_config: str
     results: list[PerturbationPreflightResult] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PerturbationPilotMaterialization:
+    """Local scenario matrix emitted from preflight-eligible perturbation variants."""
+
+    schema_version: str
+    manifest_id: str
+    manifest_path: str
+    scenario_matrix_path: str
+    summary_path: str
+    included_variants: tuple[str, ...]
+    excluded_variants: tuple[str, ...]
 
 
 def preflight_perturbation_manifest(manifest_path: Path | str) -> PerturbationPreflightReport:
@@ -132,6 +146,92 @@ def preflight_to_dict(report: PerturbationPreflightReport) -> dict[str, Any]:
             for result in report.results
         ],
     }
+
+
+def materialize_perturbation_pilot_matrix(
+    manifest_path: Path | str,
+    *,
+    output_dir: Path | str,
+    seed_limit: int | None = None,
+) -> PerturbationPilotMaterialization:
+    """Write a local scenario matrix for preflight-eligible perturbation variants.
+
+    The generated files are execution inputs for a later small planner pilot. They are not
+    benchmark evidence on their own, and variants excluded by the preflight are omitted.
+
+    Returns:
+        PerturbationPilotMaterialization: Paths and included/excluded variant IDs.
+    """
+    path = Path(manifest_path)
+    out_dir = Path(output_dir)
+    manifest = _load_manifest(path)
+    report = preflight_perturbation_manifest(path)
+    preflight_by_variant = {result.variant_id: result for result in report.results}
+    scenario_config = _resolve_path(
+        manifest["scenario_config"],
+        base_dir=path.parent,
+        field_name="scenario_config",
+    )
+    scenarios = load_scenarios(scenario_config)
+    matrix_path = out_dir / "scenario_matrix.yaml"
+    routes_dir = out_dir / "route_overrides"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    routes_dir.mkdir(parents=True, exist_ok=True)
+
+    materialized_scenarios: list[dict[str, Any]] = []
+    included: list[str] = []
+    excluded: list[str] = []
+    for variant in manifest["variants"]:
+        normalized = _normalize_variant(variant)
+        result = preflight_by_variant[normalized["variant_id"]]
+        if result.benchmark_evidence_status != _SUCCESS_EVIDENCE_CANDIDATE:
+            excluded.append(result.variant_id)
+            continue
+        scenario = _materialize_variant_scenario(
+            normalized,
+            result=result,
+            manifest=manifest,
+            scenario_config=scenario_config,
+            scenarios=scenarios,
+            routes_dir=routes_dir,
+            matrix_path=matrix_path,
+            seed_limit=seed_limit,
+        )
+        materialized_scenarios.append(scenario)
+        included.append(result.variant_id)
+
+    matrix_payload = {
+        "schema_version": PILOT_MATRIX_SCHEMA_VERSION,
+        "source_manifest": path.as_posix(),
+        "source_manifest_id": manifest["manifest_id"],
+        "evidence_boundary": (
+            "local pilot execution input only; not benchmark or paper-facing evidence"
+        ),
+        "scenarios": materialized_scenarios,
+    }
+    matrix_path.write_text(yaml.safe_dump(matrix_payload, sort_keys=False), encoding="utf-8")
+    summary_path = out_dir / "materialization_summary.json"
+    summary_payload = {
+        "schema_version": PILOT_MATRIX_SCHEMA_VERSION,
+        "manifest_id": manifest["manifest_id"],
+        "manifest_path": path.as_posix(),
+        "scenario_matrix_path": matrix_path.as_posix(),
+        "preflight_schema_version": report.schema_version,
+        "included_variants": included,
+        "excluded_variants": excluded,
+        "seed_limit": seed_limit,
+        "variant_count": len(materialized_scenarios),
+    }
+    summary_path.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n")
+    return PerturbationPilotMaterialization(
+        schema_version=PILOT_MATRIX_SCHEMA_VERSION,
+        manifest_id=str(manifest["manifest_id"]),
+        manifest_path=path.as_posix(),
+        scenario_matrix_path=matrix_path.as_posix(),
+        summary_path=summary_path.as_posix(),
+        included_variants=tuple(included),
+        excluded_variants=tuple(excluded),
+    )
 
 
 def _load_manifest(path: Path) -> Mapping[str, Any]:
@@ -371,6 +471,138 @@ def _certify_variant(
         robot_config=config.robot_config,
         sim_config=config.sim_config,
     )
+
+
+def _materialize_variant_scenario(
+    variant: Mapping[str, Any],
+    *,
+    result: PerturbationPreflightResult,
+    manifest: Mapping[str, Any],
+    scenario_config: Path,
+    scenarios: list[Mapping[str, Any]],
+    routes_dir: Path,
+    matrix_path: Path,
+    seed_limit: int | None,
+) -> dict[str, Any]:
+    """Build one scenario entry suitable for a local paired planner pilot.
+
+    Returns:
+        dict[str, Any]: Scenario entry with variant identity, seeds, and optional route override.
+    """
+    scenario = deepcopy(dict(select_scenario(scenarios, str(variant["scenario_id"]))))
+    scenario = _resolve_materialized_scenario_paths(scenario, scenario_config=scenario_config)
+    scenario["name"] = str(variant["variant_id"])
+    scenario["scenario_id"] = str(variant["variant_id"])
+    scenario["seeds"] = _limit_seeds(result.seeds, seed_limit)
+    metadata = (
+        dict(scenario.get("metadata")) if isinstance(scenario.get("metadata"), Mapping) else {}
+    )
+    metadata["scenario_perturbation"] = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "source_manifest_id": manifest["manifest_id"],
+        "source_scenario_id": variant["scenario_id"],
+        "variant_id": variant["variant_id"],
+        "family": variant["family"],
+        "validity_status": result.validity_status,
+        "benchmark_evidence_status": result.benchmark_evidence_status,
+        "perturbation_summary": dict(result.perturbation_summary),
+        "evidence_boundary": "local_pilot_input_not_benchmark_evidence",
+    }
+    scenario["metadata"] = metadata
+    if variant["family"] == "robot_route_offset":
+        route_path = routes_dir / f"{variant['variant_id']}.route_overrides.yaml"
+        _write_route_offset_override(
+            variant,
+            scenario_config=scenario_config,
+            scenarios=scenarios,
+            perturbation_summary=result.perturbation_summary,
+            route_path=route_path,
+        )
+        scenario["route_overrides_file"] = route_path.relative_to(matrix_path.parent).as_posix()
+    return scenario
+
+
+def _resolve_materialized_scenario_paths(
+    scenario: dict[str, Any],
+    *,
+    scenario_config: Path,
+) -> dict[str, Any]:
+    """Resolve source scenario asset paths before writing an out-of-tree matrix.
+
+    Returns:
+        dict[str, Any]: Scenario entry with loadable path fields.
+    """
+    updated = dict(scenario)
+    for field_name in ("map_file", "route_overrides_file"):
+        value = updated.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        candidate = Path(value)
+        if candidate.is_absolute():
+            continue
+        resolved = (scenario_config.parent / candidate).resolve()
+        if resolved.exists():
+            updated[field_name] = resolved.as_posix()
+    return updated
+
+
+def _limit_seeds(seeds: tuple[int, ...], seed_limit: int | None) -> list[int]:
+    """Apply an optional positive seed limit to a variant seed tuple.
+
+    Returns:
+        list[int]: Variant seeds, optionally truncated for a small local pilot.
+    """
+    if seed_limit is None:
+        return list(seeds)
+    if seed_limit <= 0:
+        raise ValueError("seed_limit must be positive when provided")
+    return list(seeds[:seed_limit])
+
+
+def _write_route_offset_override(
+    variant: Mapping[str, Any],
+    *,
+    scenario_config: Path,
+    scenarios: list[Mapping[str, Any]],
+    perturbation_summary: Mapping[str, Any],
+    route_path: Path,
+) -> None:
+    """Write a route override artifact for one robot-route offset variant."""
+    scenario = dict(select_scenario(scenarios, str(variant["scenario_id"])))
+    config = build_robot_config_from_scenario(scenario, scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    perturbed_map = deepcopy(map_def)
+    _apply_robot_route_offset(
+        perturbed_map.robot_routes,
+        dx=float(perturbation_summary["dx_m"]),
+        dy=float(perturbation_summary["dy_m"]),
+        parameters=variant.get("parameters", {}),
+    )
+    route_payload = {
+        "schema_version": "scenario_route_overrides.v1",
+        "source": f"{scenario_config.as_posix()}#{variant['scenario_id']}",
+        "variant_id": variant["variant_id"],
+        "route_payload": {
+            "robot_routes": [_route_to_payload(route) for route in perturbed_map.robot_routes],
+            "ped_routes": [],
+        },
+    }
+    route_path.write_text(yaml.safe_dump(route_payload, sort_keys=False), encoding="utf-8")
+
+
+def _route_to_payload(route: GlobalRoute) -> dict[str, Any]:
+    """Serialize a global route into the route-override YAML surface.
+
+    Returns:
+        dict[str, Any]: Route override entry with spawn, goal, and waypoints.
+    """
+    return {
+        "spawn_id": int(route.spawn_id),
+        "goal_id": int(route.goal_id),
+        "waypoints": [[float(x), float(y)] for x, y in route.waypoints],
+    }
 
 
 def _apply_robot_route_offset(

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -41,6 +41,8 @@ _PERTURBATION_MANIFEST_SCHEMA_PATH = (
     / "schemas"
     / "scenario_perturbation_manifest.v1.json"
 )
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+_LOCAL_OUTPUT_ROOT = _REPOSITORY_ROOT / "output"
 
 _SUCCESS_EVIDENCE_CANDIDATE = "eligible_success_evidence_candidate"
 _EXCLUDED_FROM_SUCCESS_EVIDENCE = "excluded_from_success_evidence"
@@ -164,6 +166,7 @@ def materialize_perturbation_pilot_matrix(
     """
     path = Path(manifest_path)
     out_dir = Path(output_dir)
+    _ensure_local_output_boundary(out_dir)
     manifest = _load_manifest(path)
     report = preflight_perturbation_manifest(path)
     preflight_by_variant = {result.variant_id: result for result in report.results}
@@ -174,9 +177,15 @@ def materialize_perturbation_pilot_matrix(
     )
     scenarios = load_scenarios(scenario_config)
     matrix_path = out_dir / "scenario_matrix.yaml"
+    summary_path = out_dir / "materialization_summary.json"
     routes_dir = out_dir / "route_overrides"
     out_dir.mkdir(parents=True, exist_ok=True)
     routes_dir.mkdir(parents=True, exist_ok=True)
+    _clear_previous_materialization(
+        matrix_path=matrix_path,
+        summary_path=summary_path,
+        routes_dir=routes_dir,
+    )
 
     materialized_scenarios: list[dict[str, Any]] = []
     included: list[str] = []
@@ -210,7 +219,6 @@ def materialize_perturbation_pilot_matrix(
         "scenarios": materialized_scenarios,
     }
     matrix_path.write_text(yaml.safe_dump(matrix_payload, sort_keys=False), encoding="utf-8")
-    summary_path = out_dir / "materialization_summary.json"
     summary_payload = {
         "schema_version": PILOT_MATRIX_SCHEMA_VERSION,
         "manifest_id": manifest["manifest_id"],
@@ -232,6 +240,38 @@ def materialize_perturbation_pilot_matrix(
         included_variants=tuple(included),
         excluded_variants=tuple(excluded),
     )
+
+
+def _ensure_local_output_boundary(output_dir: Path) -> None:
+    """Keep repository-local generated pilot inputs under the ignored output tree."""
+    resolved = output_dir.resolve()
+    try:
+        resolved.relative_to(_REPOSITORY_ROOT)
+    except ValueError:
+        return
+    try:
+        resolved.relative_to(_LOCAL_OUTPUT_ROOT)
+    except ValueError as exc:
+        raise ValueError(
+            "output_dir inside the repository must be under output/ so generated "
+            "pilot inputs remain local, ignored artifacts"
+        ) from exc
+
+
+def _clear_previous_materialization(
+    *,
+    matrix_path: Path,
+    summary_path: Path,
+    routes_dir: Path,
+) -> None:
+    """Remove stale materializer-owned files before writing a fresh pilot matrix."""
+    for generated_path in (matrix_path, summary_path):
+        if generated_path.exists():
+            generated_path.unlink()
+    if not routes_dir.is_dir():
+        raise ValueError(f"route_overrides path exists and is not a directory: {routes_dir}")
+    for route_path in routes_dir.glob("*.route_overrides.yaml"):
+        route_path.unlink()
 
 
 def _load_manifest(path: Path) -> Mapping[str, Any]:

--- a/scripts/tools/materialize_scenario_perturbation_pilot.py
+++ b/scripts/tools/materialize_scenario_perturbation_pilot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Materialize preflight-eligible scenario perturbations into a local pilot matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.scenario_certification import materialize_perturbation_pilot_matrix
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the perturbation pilot materialization parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="Scenario perturbation manifest YAML.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for the generated scenario matrix and route overrides.",
+    )
+    parser.add_argument(
+        "--seed-limit",
+        type=int,
+        help="Optional positive cap on seeds per materialized variant for local smoke pilots.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run perturbation pilot materialization."""
+    args = _build_parser().parse_args()
+    result = materialize_perturbation_pilot_matrix(
+        args.manifest,
+        output_dir=args.output_dir,
+        seed_limit=args.seed_limit,
+    )
+    print(
+        json.dumps(
+            {
+                "schema_version": result.schema_version,
+                "manifest_id": result.manifest_id,
+                "scenario_matrix_path": result.scenario_matrix_path,
+                "summary_path": result.summary_path,
+                "included_variants": list(result.included_variants),
+                "excluded_variants": list(result.excluded_variants),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/materialize_scenario_perturbation_pilot.py
+++ b/scripts/tools/materialize_scenario_perturbation_pilot.py
@@ -18,7 +18,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         type=Path,
         required=True,
-        help="Directory for the generated scenario matrix and route overrides.",
+        help=(
+            "Directory for the generated scenario matrix and route overrides. "
+            "Repository-local outputs must be under output/."
+        ),
     )
     parser.add_argument(
         "--seed-limit",

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -177,3 +177,32 @@ def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Pa
     assert [scenario["name"] for scenario in generated_scenarios] == ["planner_sanity_simple_noop"]
     route_files = list((tmp_path / "pilot" / "route_overrides").glob("*"))
     assert route_files == []
+
+
+def test_materialize_pilot_matrix_clears_stale_generated_routes(tmp_path: Path) -> None:
+    """A rerun should not leave old route files for newly excluded variants."""
+    manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
+    output_dir = tmp_path / "pilot"
+
+    materialize_perturbation_pilot_matrix(manifest_path, output_dir=output_dir)
+    assert len(list((output_dir / "route_overrides").glob("*.route_overrides.yaml"))) == 1
+
+    _write_manifest(manifest_path, max_route_offset_m=0.2)
+    materialized = materialize_perturbation_pilot_matrix(manifest_path, output_dir=output_dir)
+
+    assert materialized.included_variants == ("planner_sanity_simple_noop",)
+    assert materialized.excluded_variants == ("planner_sanity_simple_route_offset",)
+    assert list((output_dir / "route_overrides").glob("*.route_overrides.yaml")) == []
+    generated_scenarios = load_scenarios(Path(materialized.scenario_matrix_path))
+    assert [scenario["name"] for scenario in generated_scenarios] == ["planner_sanity_simple_noop"]
+
+
+def test_materialize_pilot_matrix_rejects_tracked_repo_output_location(tmp_path: Path) -> None:
+    """Repository-local materialized pilot inputs should stay under ignored output/."""
+    manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
+
+    with pytest.raises(ValueError, match="must be under output/"):
+        materialize_perturbation_pilot_matrix(
+            manifest_path,
+            output_dir=Path("docs") / "scenario_perturbation_pilot_test",
+        )

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -11,9 +11,11 @@ import yaml
 
 from robot_sf.scenario_certification.perturbation_preflight import (
     PERTURBATION_MANIFEST_SCHEMA_VERSION,
+    materialize_perturbation_pilot_matrix,
     preflight_perturbation_manifest,
     preflight_to_dict,
 )
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
 
 def _write_manifest(path: Path, *, max_route_offset_m: float = 0.5) -> Path:
@@ -23,7 +25,7 @@ def _write_manifest(path: Path, *, max_route_offset_m: float = 0.5) -> Path:
         "manifest_id": "test_perturbation_manifest",
         "scenario_config": "configs/scenarios/single/planner_sanity_simple.yaml",
         "seed_controls": {
-            "baseline_seeds": [101],
+            "baseline_seeds": [101, 102],
             "replay_seed_policy": "explicit",
         },
         "validity": {
@@ -36,13 +38,13 @@ def _write_manifest(path: Path, *, max_route_offset_m: float = 0.5) -> Path:
                 "variant_id": "planner_sanity_simple_noop",
                 "scenario_id": "planner_sanity_simple",
                 "family": "noop",
-                "seeds": [101],
+                "seeds": [101, 102],
             },
             {
                 "variant_id": "planner_sanity_simple_route_offset",
                 "scenario_id": "planner_sanity_simple",
                 "family": "robot_route_offset",
-                "seeds": [101],
+                "seeds": [101, 102],
                 "parameters": {
                     "dx_m": 0.25,
                     "dy_m": 0.0,
@@ -113,3 +115,65 @@ def test_preflight_excludes_unbounded_route_offset_before_certification(tmp_path
     ]
     payload = preflight_to_dict(report)
     assert payload["results"][1]["certificate"] is None
+
+
+def test_materialize_pilot_matrix_writes_runnable_variant_scenarios(tmp_path: Path) -> None:
+    """Preflight-eligible variants should become local scenario-matrix rows."""
+    manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
+    output_dir = tmp_path / "pilot"
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=output_dir,
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "planner_sanity_simple_noop",
+        "planner_sanity_simple_route_offset",
+    )
+    assert materialized.excluded_variants == ()
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    assert [scenario["name"] for scenario in generated_scenarios] == [
+        "planner_sanity_simple_noop",
+        "planner_sanity_simple_route_offset",
+    ]
+    assert {tuple(scenario["seeds"]) for scenario in generated_scenarios} == {(101,)}
+    offset_scenario = generated_scenarios[1]
+    metadata = offset_scenario["metadata"]["scenario_perturbation"]
+    assert metadata["source_scenario_id"] == "planner_sanity_simple"
+    assert metadata["evidence_boundary"] == "local_pilot_input_not_benchmark_evidence"
+
+    original = load_scenarios("configs/scenarios/single/planner_sanity_simple.yaml")[0]
+    original_config = build_robot_config_from_scenario(
+        original,
+        scenario_path=Path("configs/scenarios/single/planner_sanity_simple.yaml"),
+    )
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, original_map = next(iter(original_config.map_pool.map_defs.items()))
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    original_point = original_map.robot_routes[0].waypoints[0]
+    offset_point = offset_map.robot_routes[0].waypoints[0]
+    assert offset_point[0] == pytest.approx(original_point[0] + 0.25)
+    assert offset_point[1] == pytest.approx(original_point[1])
+
+
+def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Path) -> None:
+    """Invalid variants should stay out of executable pilot inputs."""
+    manifest_path = _write_manifest(tmp_path / "perturbations.yaml", max_route_offset_m=0.2)
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+    )
+
+    assert materialized.included_variants == ("planner_sanity_simple_noop",)
+    assert materialized.excluded_variants == ("planner_sanity_simple_route_offset",)
+    generated_scenarios = load_scenarios(Path(materialized.scenario_matrix_path))
+    assert [scenario["name"] for scenario in generated_scenarios] == ["planner_sanity_simple_noop"]
+    route_files = list((tmp_path / "pilot" / "route_overrides").glob("*"))
+    assert route_files == []


### PR DESCRIPTION
## Summary
- adds a materializer for #1858 preflight-eligible perturbation variants so #1610 can move from schema/preflight into a runnable paired-planner pilot input
- emits an ignored local scenario matrix plus route override files for eligible variants only
- records local-pilot-input evidence boundaries in matrix metadata and docs; this is still not benchmark or paper-facing evidence

## What This Does Not Do
- does not run planner comparisons
- does not compute the final criticality statistic
- does not promote generated `output/` files as durable evidence

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/scenario_certification/test_scenario_perturbation_preflight.py -q` -> 6 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/scenario_certification/perturbation_preflight.py robot_sf/scenario_certification/__init__.py scripts/tools/materialize_scenario_perturbation_pilot.py tests/scenario_certification/test_scenario_perturbation_preflight.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check ...` -> passed
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed
- `git diff --check` -> passed
- actual materialization: `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/materialize_scenario_perturbation_pilot.py configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml --output-dir output/scenario_perturbation_pilot/issue_1610_seed_sensitive_pilot_v1 --seed-limit 1` -> 6 included variants, 0 excluded
- generated matrix load/build smoke: loaded all 6 generated scenarios and built robot configs for each
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4713 passed, 11 skipped, 9 warnings; clean stamp; changed-file coverage warning for `robot_sf/scenario_certification/perturbation_preflight.py`

Relates #1610.
