### PR TITLE
feat: run scenario perturbation criticality pilot

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -212,6 +212,8 @@ knowledge, not every transient iteration detail.
   [issue_1503_adversarial_stress_synthesis.md](issue_1503_adversarial_stress_synthesis.md)
 * Issue #1861 Adversarial Replay Determinism Gate (2026-05-31):
   [issue_1861_adversarial_replay_determinism_gate.md](issue_1861_adversarial_replay_determinism_gate.md)
+* Issue #1904 Scenario Perturbation Criticality Pilot (2026-05-31):
+  [issue_1904_scenario_perturbation_criticality_pilot.md](issue_1904_scenario_perturbation_criticality_pilot.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
 * Issue #1633 RobotEnv SNQI proxy extraction:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -88,3 +88,6 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   reports from the May 4 run.
 - `issue_1692_topology_hypothesis_probe_2026-05-30/`: compact diagnostic-only evidence for the
   topology-hypothesis trace probe on `classic_realworld_double_bottleneck_high` seed 111.
+- `issue_1904_scenario_perturbation_pilot_2026-05-31/`: compact diagnostic-only paired
+  no-op-versus-route-offset pilot summary for the first #1610 scenario perturbation criticality
+  slice.

--- a/docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/README.md
+++ b/docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/README.md
@@ -1,0 +1,13 @@
+# Issue #1904 Scenario Perturbation Criticality Pilot Evidence
+
+This bundle contains compact diagnostic evidence for issue #1904. It preserves the paired
+no-op-versus-route-offset summary from a local pilot over the #1858 manifest after #1903
+materialization support landed.
+
+- `summary.json`: compact reviewable summary with materialized variant IDs, pair rows, pair status
+  counts, and mean deltas.
+
+Raw episode JSONL, generated scenario matrices, route override files, coverage output, and local
+runner summaries remain under ignored `output/` paths and are not mirrored here.
+
+Claim boundary: diagnostic local pilot only; not benchmark-strength or paper-facing evidence.

--- a/docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json
+++ b/docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json
@@ -1,0 +1,209 @@
+{
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 80,
+  "manifest": "configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [],
+    "included_variants": [
+      "classic_group_crossing_high_noop",
+      "classic_group_crossing_high_route_offset_x025",
+      "classic_head_on_corridor_low_noop",
+      "classic_head_on_corridor_low_route_offset_y025",
+      "francis2023_join_group_noop",
+      "francis2023_join_group_route_offset_x025"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1858_seed_sensitive_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 6
+  },
+  "pair_rows": [
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.005904823674986126,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.81814067199887,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.8122358483238838,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "goal",
+      "seed": 111,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.021713990718757792,
+      "noop": {
+        "collision": 0,
+        "min_distance": 5.061020535696914,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 5.082734526415671,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "goal",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0013309335961251278,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.488296144897157,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.004412621133507821,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5256092818038434,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5300219029373512,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "orca",
+      "seed": 111,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.003176856884758772,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.6702469202849204,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.6734237771696792,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "orca",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 7.814638987357903e-05,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4492909863429455,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.449369132732819,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    }
+  ],
+  "pair_summary": {
+    "mean_deltas_completed_pairs": {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.003690976309297785,
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    "pairs": 6,
+    "status_counts": {
+      "completed": 6
+    }
+  },
+  "planners": [
+    "goal",
+    "orca"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 1
+}

--- a/docs/context/issue_1904_scenario_perturbation_criticality_pilot.md
+++ b/docs/context/issue_1904_scenario_perturbation_criticality_pilot.md
@@ -1,0 +1,66 @@
+# Issue #1904 Scenario Perturbation Criticality Pilot
+
+Issue: [#1904](https://github.com/ll7/robot_sf_ll7/issues/1904)
+Parent: [#1610](https://github.com/ll7/robot_sf_ll7/issues/1610)
+Prerequisite: [PR #1903](https://github.com/ll7/robot_sf_ll7/pull/1903)
+
+## Goal
+
+Run the first tiny paired planner pilot over the #1858 scenario perturbation manifest after #1903
+made eligible no-op and route-offset variants materializable as local scenario-matrix rows.
+
+This is diagnostic local evidence only. It is not benchmark-strength or paper-facing evidence.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 \
+scripts/dev/run_worktree_shared_venv.sh -- python \
+  scripts/validation/run_scenario_perturbation_criticality_pilot.py \
+  configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1 \
+  --pilot-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1/results \
+  --seed-limit 1 \
+  --horizon 80 \
+  --workers 1 \
+  --planner goal \
+  --planner orca \
+  --evidence-summary docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json
+```
+
+## Result
+
+- Materialized variants: 6 included, 0 excluded.
+- Planners: `goal`, `orca`.
+- Pair rows: 6 completed pairs, 0 excluded pairs.
+- Mean deltas over completed pairs:
+  - success delta: `0.0000`
+  - collision delta: `0.0000`
+  - timeout delta: `0.0000`
+  - min-distance delta: `+0.0037 m`
+
+The first route-offset pilot is neutral at this scale. It proves the paired execution and compact
+aggregation path, but it does not show route perturbation criticality for success, collision, or
+timeout outcomes under the two cheap planners and one seed per source scenario.
+
+## Evidence Boundary
+
+Tracked compact evidence:
+
+- [summary.json](evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json)
+
+Ignored local outputs:
+
+- materialized matrix and route overrides under the local pilot output directory
+- raw planner episode JSONL
+- local `summary.json` / `summary.md` generated beside the raw outputs
+
+Fallback, degraded, invalid, missing, and failed rows are classified separately by the pilot
+script and excluded from completed-pair means. This first run had no such rows after correcting the
+pairing logic to compare only seeds observed for each no-op/perturbed source pair.
+
+## Routing
+
+Continue #1610 only with a larger, still bounded pilot if the next question needs sensitivity
+power. The next slice should add either more seeds or a stronger local planner candidate before
+spending effort on broader criticality statistics.

--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -59,6 +59,27 @@ rows are omitted from the matrix. When `--output-dir` points inside the reposito
 under the ignored `output/` tree so materialized pilot inputs do not become durable provenance by
 accident.
 
+## Criticality Pilot
+
+Run the first paired no-op versus route-offset pilot with:
+
+```bash
+uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py \
+  configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1 \
+  --pilot-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1/results \
+  --seed-limit 1 \
+  --horizon 80 \
+  --workers 1 \
+  --planner goal \
+  --planner orca \
+  --evidence-summary docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json
+```
+
+The pilot writes raw episode JSONL under `output/` and, when requested, a compact tracked summary
+under `docs/context/evidence/`. Fallback, degraded, invalid, missing, and failed rows are reported
+separately and excluded from completed-pair mean deltas.
+
 ## Boundary
 
 This is not planner execution and not paper-facing evidence. It only proves that the selected

--- a/scripts/validation/run_scenario_perturbation_criticality_pilot.py
+++ b/scripts/validation/run_scenario_perturbation_criticality_pilot.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Run a tiny paired planner pilot over materialized scenario perturbations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.scenario_certification import materialize_perturbation_pilot_matrix
+from robot_sf.training.scenario_loader import load_scenarios
+
+SCHEMA_VERSION = "scenario_perturbation_criticality_pilot.v1"
+_EPISODE_SCHEMA = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the pilot CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="Scenario perturbation manifest YAML.")
+    parser.add_argument(
+        "--materialized-output-dir",
+        type=Path,
+        required=True,
+        help="Ignored output/ directory for generated scenario matrix and route overrides.",
+    )
+    parser.add_argument(
+        "--pilot-output-dir",
+        type=Path,
+        required=True,
+        help="Ignored output/ directory for raw pilot JSONL and local summary.",
+    )
+    parser.add_argument(
+        "--planner",
+        action="append",
+        dest="planners",
+        help="Planner algorithm to run. Repeat for multiple planners. Defaults to goal and orca.",
+    )
+    parser.add_argument(
+        "--seed-limit",
+        type=int,
+        default=1,
+        help="Positive cap on seeds per materialized variant for this local pilot.",
+    )
+    parser.add_argument("--horizon", type=int, default=80)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument(
+        "--evidence-summary",
+        type=Path,
+        help="Optional compact tracked JSON summary path. Raw records are never copied here.",
+    )
+    return parser
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL rows from a benchmark episode file."""
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _scenario_metadata(scenarios: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return perturbation metadata keyed by materialized scenario id."""
+    metadata: dict[str, dict[str, Any]] = {}
+    for scenario in scenarios:
+        scenario_id = str(scenario.get("scenario_id") or scenario.get("name") or "")
+        raw = scenario.get("metadata")
+        perturbation = raw.get("scenario_perturbation") if isinstance(raw, dict) else None
+        if not isinstance(perturbation, dict):
+            continue
+        metadata[scenario_id] = {
+            "source_scenario_id": str(perturbation.get("source_scenario_id") or ""),
+            "variant_id": str(perturbation.get("variant_id") or scenario_id),
+            "family": str(perturbation.get("family") or ""),
+            "benchmark_evidence_status": str(perturbation.get("benchmark_evidence_status") or ""),
+            "evidence_boundary": str(perturbation.get("evidence_boundary") or ""),
+            "perturbation_summary": perturbation.get("perturbation_summary") or {},
+        }
+    return metadata
+
+
+def _nested_strings(value: Any) -> list[str]:
+    """Return lower-cased string leaves from a nested JSON-like value."""
+    strings: list[str] = []
+    if isinstance(value, str):
+        strings.append(value.strip().lower())
+    elif isinstance(value, dict):
+        for item in value.values():
+            strings.extend(_nested_strings(item))
+    elif isinstance(value, list | tuple):
+        for item in value:
+            strings.extend(_nested_strings(item))
+    return strings
+
+
+def classify_episode_status(row: dict[str, Any] | None) -> str:
+    """Classify whether an episode row can contribute to paired evidence."""
+    if row is None:
+        return "missing"
+    if isinstance(row.get("scenario_exclusion"), dict):
+        return "invalid"
+    metadata_strings = _nested_strings(row.get("algorithm_metadata"))
+    if any("fallback" in item for item in metadata_strings):
+        return "fallback"
+    if any("degraded" in item for item in metadata_strings):
+        return "degraded"
+    reason = str(row.get("termination_reason") or "").strip().lower()
+    if reason == "error":
+        return "failed"
+    return "completed"
+
+
+def _metric(row: dict[str, Any] | None, name: str) -> float | None:
+    """Read a numeric metric from an episode row."""
+    if row is None:
+        return None
+    metrics = row.get("metrics")
+    if not isinstance(metrics, dict):
+        return None
+    value = metrics.get(name)
+    try:
+        return None if value is None else float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _episode_values(row: dict[str, Any] | None) -> dict[str, Any]:
+    """Return compact outcome values for one episode row."""
+    reason = str(row.get("termination_reason") or "") if row is not None else ""
+    return {
+        "success": 1 if reason.lower() == "success" else 0,
+        "collision": 1 if reason.lower() == "collision" else 0,
+        "timeout": 1 if reason.lower() in {"max_steps", "terminated", "truncated"} else 0,
+        "min_distance": _metric(row, "min_distance"),
+        "termination_reason": reason or None,
+    }
+
+
+def _index_records_by_planner_seed(
+    records_by_planner: dict[str, list[dict[str, Any]]],
+) -> dict[tuple[str, str, int], dict[str, Any]]:
+    """Index episode records by planner, materialized scenario id, and seed."""
+    rows_by_key: dict[tuple[str, str, int], dict[str, Any]] = {}
+    for planner, records in records_by_planner.items():
+        for row in records:
+            scenario_id = str(row.get("scenario_id") or row.get("scenario") or "")
+            seed = int(row.get("seed", 0))
+            rows_by_key[(planner, scenario_id, seed)] = row
+    return rows_by_key
+
+
+def _scenarios_by_source(
+    scenario_metadata: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, list[str]]]:
+    """Group materialized scenario ids by source scenario and perturbation family."""
+    grouped: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    for scenario_id, metadata in scenario_metadata.items():
+        source = metadata["source_scenario_id"]
+        family = metadata["family"]
+        if source and family:
+            grouped[source][family].append(scenario_id)
+    return grouped
+
+
+def _seeds_for_pair(
+    rows_by_key: dict[tuple[str, str, int], dict[str, Any]],
+    *,
+    planner: str,
+    noop_id: str,
+    variant_id: str,
+) -> list[int]:
+    """Return seeds observed for either side of one no-op/perturbed pair."""
+    return sorted(
+        {
+            seed
+            for key_planner, scenario_id, seed in rows_by_key
+            if key_planner == planner and scenario_id in {noop_id, variant_id}
+        }
+    )
+
+
+def _delta(after: int | float | None, before: int | float | None) -> float | None:
+    """Return numeric delta when both sides are available."""
+    if after is None or before is None:
+        return None
+    return float(after) - float(before)
+
+
+def build_pair_table(
+    records_by_planner: dict[str, list[dict[str, Any]]],
+    scenario_metadata: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build paired no-op versus route-offset deltas for each planner and seed."""
+    rows_by_key = _index_records_by_planner_seed(records_by_planner)
+    grouped_scenarios = _scenarios_by_source(scenario_metadata)
+
+    pair_rows: list[dict[str, Any]] = []
+    for planner in sorted(records_by_planner):
+        for source_scenario_id, families in sorted(grouped_scenarios.items()):
+            noop_ids = sorted(families.get("noop", []))
+            perturbed_ids = sorted(
+                variant_id
+                for family, variant_ids in families.items()
+                if family != "noop"
+                for variant_id in variant_ids
+            )
+            if not noop_ids:
+                for variant_id in perturbed_ids:
+                    pair_rows.append(
+                        {
+                            "planner": planner,
+                            "source_scenario_id": source_scenario_id,
+                            "noop_variant_id": None,
+                            "perturbed_variant_id": variant_id,
+                            "seed": None,
+                            "pair_status": "missing_noop",
+                        }
+                    )
+                continue
+            noop_id = noop_ids[0]
+            for variant_id in perturbed_ids:
+                for seed in _seeds_for_pair(
+                    rows_by_key,
+                    planner=planner,
+                    noop_id=noop_id,
+                    variant_id=variant_id,
+                ):
+                    noop_row = rows_by_key.get((planner, noop_id, seed))
+                    perturbed_row = rows_by_key.get((planner, variant_id, seed))
+                    noop_status = classify_episode_status(noop_row)
+                    perturbed_status = classify_episode_status(perturbed_row)
+                    pair_status = (
+                        "completed"
+                        if noop_status == "completed" and perturbed_status == "completed"
+                        else "excluded"
+                    )
+                    noop_values = _episode_values(noop_row)
+                    perturbed_values = _episode_values(perturbed_row)
+                    pair_rows.append(
+                        {
+                            "planner": planner,
+                            "source_scenario_id": source_scenario_id,
+                            "noop_variant_id": noop_id,
+                            "perturbed_variant_id": variant_id,
+                            "seed": seed,
+                            "pair_status": pair_status,
+                            "noop_status": noop_status,
+                            "perturbed_status": perturbed_status,
+                            "success_delta": _delta(
+                                perturbed_values["success"], noop_values["success"]
+                            ),
+                            "collision_delta": _delta(
+                                perturbed_values["collision"], noop_values["collision"]
+                            ),
+                            "timeout_delta": _delta(
+                                perturbed_values["timeout"], noop_values["timeout"]
+                            ),
+                            "min_distance_delta": _delta(
+                                perturbed_values["min_distance"], noop_values["min_distance"]
+                            ),
+                            "noop": noop_values,
+                            "perturbed": perturbed_values,
+                        }
+                    )
+    return pair_rows
+
+
+def summarize_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate pair-table status counts and mean deltas."""
+    status_counts: dict[str, int] = defaultdict(int)
+    delta_values: dict[str, list[float]] = defaultdict(list)
+    for row in pair_rows:
+        status_counts[str(row.get("pair_status") or "unknown")] += 1
+        if row.get("pair_status") != "completed":
+            continue
+        for field in (
+            "success_delta",
+            "collision_delta",
+            "timeout_delta",
+            "min_distance_delta",
+        ):
+            value = row.get(field)
+            if value is not None:
+                delta_values[field].append(float(value))
+    return {
+        "pairs": len(pair_rows),
+        "status_counts": dict(sorted(status_counts.items())),
+        "mean_deltas_completed_pairs": {
+            field: sum(values) / len(values)
+            for field, values in sorted(delta_values.items())
+            if values
+        },
+    }
+
+
+def _write_markdown(summary: dict[str, Any], path: Path) -> None:
+    """Write a compact Markdown summary next to the local pilot artifacts."""
+    lines = [
+        "# Scenario Perturbation Criticality Pilot",
+        "",
+        "## Boundary",
+        "",
+        "Diagnostic local pilot only. Raw JSONL remains ignored local output; tracked evidence should use the compact summary.",
+        "",
+        "## Aggregate",
+        "",
+        f"- Planners: {', '.join(summary['planners'])}",
+        f"- Materialized variants: {summary['materialization']['variant_count']}",
+        f"- Pair rows: {summary['pair_summary']['pairs']}",
+        f"- Pair statuses: `{json.dumps(summary['pair_summary']['status_counts'], sort_keys=True)}`",
+        "",
+        "## Mean Deltas For Completed Pairs",
+        "",
+    ]
+    deltas = summary["pair_summary"]["mean_deltas_completed_pairs"]
+    if deltas:
+        for field, value in deltas.items():
+            lines.append(f"- `{field}`: `{value:.4f}`")
+    else:
+        lines.append("- none")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _compact_tracked_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return the small reviewable subset suitable for docs/context/evidence."""
+    materialization = dict(summary["materialization"])
+    materialization.pop("scenario_matrix_path", None)
+    materialization.pop("summary_path", None)
+    materialization["local_artifact_boundary"] = (
+        "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored "
+        "local outputs reproducible from the tracked manifest and command"
+    )
+    return {
+        "schema_version": summary["schema_version"],
+        "manifest": summary["manifest"],
+        "planners": summary["planners"],
+        "horizon": summary["horizon"],
+        "dt": summary["dt"],
+        "seed_limit": summary["seed_limit"],
+        "materialization": materialization,
+        "pair_summary": summary["pair_summary"],
+        "pair_rows": summary["pair_rows"],
+        "claim_boundary": summary["claim_boundary"],
+    }
+
+
+def main() -> int:
+    """Run the scenario perturbation pilot."""
+    args = _build_parser().parse_args()
+    planners = args.planners or ["goal", "orca"]
+    materialized = materialize_perturbation_pilot_matrix(
+        args.manifest,
+        output_dir=args.materialized_output_dir,
+        seed_limit=args.seed_limit,
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    scenarios = load_scenarios(matrix_path)
+    metadata = _scenario_metadata(scenarios)
+
+    args.pilot_output_dir.mkdir(parents=True, exist_ok=True)
+    records_by_planner: dict[str, list[dict[str, Any]]] = {}
+    planner_runs: dict[str, dict[str, Any]] = {}
+    for planner in planners:
+        jsonl_path = args.pilot_output_dir / f"{planner}.episodes.jsonl"
+        if jsonl_path.exists():
+            jsonl_path.unlink()
+        batch_summary = run_map_batch(
+            matrix_path,
+            jsonl_path,
+            schema_path=_EPISODE_SCHEMA,
+            algo=planner,
+            horizon=args.horizon,
+            dt=args.dt,
+            workers=args.workers,
+            resume=False,
+            benchmark_profile="experimental",
+        )
+        records = _load_jsonl(jsonl_path)
+        records_by_planner[planner] = records
+        planner_runs[planner] = {
+            "jsonl_path": jsonl_path.as_posix(),
+            "episodes": len(records),
+            "batch_summary": batch_summary,
+        }
+
+    pair_rows = build_pair_table(records_by_planner, metadata)
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "manifest": args.manifest.as_posix(),
+        "planners": planners,
+        "horizon": args.horizon,
+        "dt": args.dt,
+        "seed_limit": args.seed_limit,
+        "materialization": {
+            "schema_version": materialized.schema_version,
+            "manifest_id": materialized.manifest_id,
+            "scenario_matrix_path": materialized.scenario_matrix_path,
+            "summary_path": materialized.summary_path,
+            "included_variants": list(materialized.included_variants),
+            "excluded_variants": list(materialized.excluded_variants),
+            "variant_count": len(materialized.included_variants),
+        },
+        "planner_runs": planner_runs,
+        "pair_summary": summarize_pairs(pair_rows),
+        "pair_rows": pair_rows,
+        "claim_boundary": (
+            "diagnostic local pilot only; not benchmark-strength or paper-facing evidence"
+        ),
+    }
+    summary_path = args.pilot_output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(summary, args.pilot_output_dir / "summary.md")
+    if args.evidence_summary is not None:
+        args.evidence_summary.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence_summary.write_text(
+            json.dumps(_compact_tracked_summary(summary), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(
+        json.dumps(
+            {
+                "summary": summary_path.as_posix(),
+                "evidence_summary": (
+                    args.evidence_summary.as_posix() if args.evidence_summary is not None else None
+                ),
+                "pair_summary": summary["pair_summary"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
+++ b/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
@@ -1,0 +1,107 @@
+"""Tests for scenario perturbation criticality pilot aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.validation.run_scenario_perturbation_criticality_pilot import (
+    build_pair_table,
+    classify_episode_status,
+    summarize_pairs,
+)
+
+
+def test_classify_episode_status_separates_fallback_and_invalid_rows() -> None:
+    """Fallback/degraded/invalid records should not count as completed evidence."""
+    assert classify_episode_status(None) == "missing"
+    assert classify_episode_status({"scenario_exclusion": {"status": "invalid"}}) == "invalid"
+    assert (
+        classify_episode_status({"algorithm_metadata": {"planner": {"execution_mode": "fallback"}}})
+        == "fallback"
+    )
+    assert (
+        classify_episode_status({"algorithm_metadata": {"planner": {"execution_mode": "degraded"}}})
+        == "degraded"
+    )
+    assert classify_episode_status({"termination_reason": "error"}) == "failed"
+    assert classify_episode_status({"termination_reason": "success"}) == "completed"
+
+
+def test_build_pair_table_computes_completed_pair_deltas() -> None:
+    """No-op and route-offset rows should pair by source scenario, planner, and seed."""
+    metadata = {
+        "demo_noop": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_noop",
+            "family": "noop",
+        },
+        "demo_offset": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_offset",
+            "family": "robot_route_offset",
+        },
+    }
+    records = {
+        "goal": [
+            {
+                "scenario_id": "demo_noop",
+                "seed": 111,
+                "termination_reason": "success",
+                "metrics": {"min_distance": 2.0},
+            },
+            {
+                "scenario_id": "demo_offset",
+                "seed": 111,
+                "termination_reason": "max_steps",
+                "metrics": {"min_distance": 1.5},
+            },
+        ]
+    }
+
+    pairs = build_pair_table(records, metadata)
+
+    assert len(pairs) == 1
+    pair = pairs[0]
+    assert pair["pair_status"] == "completed"
+    assert pair["success_delta"] == pytest.approx(-1.0)
+    assert pair["timeout_delta"] == pytest.approx(1.0)
+    assert pair["collision_delta"] == pytest.approx(0.0)
+    assert pair["min_distance_delta"] == pytest.approx(-0.5)
+    assert summarize_pairs(pairs)["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(
+        -1.0
+    )
+
+
+def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None:
+    """Fallback perturbed rows should be visible but excluded from completed-pair means."""
+    metadata = {
+        "demo_noop": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_noop",
+            "family": "noop",
+        },
+        "demo_offset": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_offset",
+            "family": "robot_route_offset",
+        },
+    }
+    records = {
+        "orca": [
+            {"scenario_id": "demo_noop", "seed": 111, "termination_reason": "success"},
+            {
+                "scenario_id": "demo_offset",
+                "seed": 111,
+                "termination_reason": "success",
+                "algorithm_metadata": {"mode": "fallback"},
+            },
+        ]
+    }
+
+    pairs = build_pair_table(records, metadata)
+    summary = summarize_pairs(pairs)
+
+    assert pairs[0]["pair_status"] == "excluded"
+    assert pairs[0]["perturbed_status"] == "fallback"
+    assert summary["status_counts"] == {"excluded": 1}
+    assert summary["mean_deltas_completed_pairs"] == {}


### PR DESCRIPTION
## Summary
- add a scenario perturbation criticality pilot runner that materializes the #1858 seed-sensitive pilot matrix, runs bounded planner batches, and computes paired no-op vs route-offset deltas
- add unit coverage for paired-row classification, seed pairing, and tracked evidence boundary behavior
- record the 2026-05-31 diagnostic pilot result and compact tracked evidence under docs/context/evidence/

## Diagnostic Result
- command ran goal + orca with `--seed-limit 1 --horizon 80 --workers 1` on `configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml`
- result: 6 completed paired rows, 0 excluded rows
- mean deltas: success 0.0, collision 0.0, timeout 0.0, min_distance +0.0036909763 m
- interpretation: this proves the materialize -> run -> paired-aggregate path, but it is diagnostic only and not benchmark-strength or paper-facing evidence
- raw JSONL/output artifacts remain ignored under `output/`; tracked evidence strips local output paths and records that artifact boundary explicitly

## Validation
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/run_scenario_perturbation_criticality_pilot.py configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml --materialized-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1 --pilot-output-dir output/scenario_perturbation_pilot/issue_1904_seed_sensitive_pilot_v1/results --seed-limit 1 --horizon 80 --workers 1 --planner goal --planner orca --evidence-summary docs/context/evidence/issue_1904_scenario_perturbation_pilot_2026-05-31/summary.json`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_preflight.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh && git diff --check`
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4748 passed, 11 skipped, 8 warnings

Closes #1904
Refs #1610
