### PR TITLE
docs: define external policy intake

### DIFF
--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -26,6 +26,9 @@ Use it for three things only:
   variants, DRL-VO, and source-side-only candidates. Check this before proposing a new follow-up.
 - `experiment_ledger.md`: compact execution log for implemented candidates.
 - `contracts/`: project contract, gates, taxonomy, and runbook.
+  - `external_policy_intake.md`: staged source-to-benchmark intake contract for external learned
+    local-navigation policies; keeps source-side and adapter-only evidence out of benchmark claims
+    until the registry and benchmark suite support them.
   - `oracle_imitation_dataset_split.md`: train/validation/evaluation seed-split policy, hard-slice assignment rules, relabeling boundaries, and manifest schema for oracle-imitation datasets (issue #1443).
 - `reasoning/`: bounded planning and design notes.
 - `reports/`: per-run markdown reports emitted by the policy-search runner.
@@ -138,10 +141,12 @@ Use it for three things only:
 ## Learned-Policy Intake
 
 Before adding a learned local-navigation method to `candidate_registry.yaml`, apply
-`contracts/learned_local_policy_eligibility.md`. The registry is reserved for implemented or
-concrete runnable Robot SF candidates with config pointers; source-only, monitor-only, or
-privileged-evaluation methods should stay in context notes until they have a runnable adapter
-contract.
+`contracts/learned_local_policy_eligibility.md`. For external learned-policy families, first apply
+`contracts/external_policy_intake.md` so source screen, license, checkpoint, observation/action,
+source-side smoke, adapter, Robot SF smoke, and benchmark-suite evidence are not collapsed into one
+ambiguous status. The registry is reserved for implemented or concrete runnable Robot SF candidates
+with config pointers; source-only, monitor-only, adapter-only, or privileged-evaluation methods
+should stay in context notes until they have a runnable adapter contract and smoke proof.
 
 For repeatable checklist-input validation, record the candidate's learned-policy metadata as YAML or
 JSON and run:
@@ -152,6 +157,10 @@ uv run python scripts/validation/check_learned_policy_eligibility.py <candidate-
 
 This helper checks completeness and consistency of the eligibility inputs only. It does not turn a
 candidate into a benchmark-ready planner or replace adapter, smoke, or benchmark validation.
+
+`learned_policy_registry.md` remains the durable current-state registry for learned-policy
+families. The external intake contract supplies the stage checklist and status mapping; it must not
+be maintained as a parallel source of truth.
 
 ## Scope Boundary
 

--- a/docs/context/policy_search/contracts/external_policy_intake.md
+++ b/docs/context/policy_search/contracts/external_policy_intake.md
@@ -1,0 +1,107 @@
+# External Learned-Policy Intake Contract
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1870>
+
+## Purpose
+
+Use this contract when an external learned local-navigation family is screened for possible Robot
+SF adapter work. It is an intake and routing contract only: it does not download checkpoints,
+implement policies, reproduce upstream training, or reclassify the full learned-policy registry.
+
+`docs/context/policy_search/learned_policy_registry.md` remains the source of truth for the durable
+current-state row. This note defines the stage evidence that a row or family-specific assessment
+must cite before the registry status can move.
+
+## Stage Status Enum
+
+Use this small per-stage status vocabulary in source-assessment notes, issue comments, or intake
+checklists:
+
+| Status | Meaning |
+| --- | --- |
+| `not_started` | No review evidence has been recorded for the stage. |
+| `needs_evidence` | The candidate may be viable, but the required proof is missing or incomplete. |
+| `passed` | The named stage has direct evidence and a link to the command, artifact, or source note. |
+| `blocked` | A known missing dependency, asset, license answer, contract, or runtime prevents progress. |
+| `rejected` | The candidate is incompatible with the current Robot SF local-planner contract. |
+| `not_applicable` | The stage is irrelevant for this candidate and the reason is stated. |
+
+These values are not a second registry. Durable roll-up status belongs in
+`learned_policy_registry.md` using `integration_status`, `reproducibility_status`, and
+`benchmark_status`.
+
+## Intake Stages
+
+Move through the stages in order. Do not skip a stage unless the assessment records why it is
+`not_applicable`.
+
+| Stage | Required evidence | Registry effect |
+| --- | --- | --- |
+| Source screen | Upstream paper/repository or local source note, intended task, sensor assumptions, action output, and dependency class. | May justify a `monitor_only` row, but not adapter work by itself. |
+| License check | License text, asset/checkpoint license when different, and compatibility note for source reuse versus clean-room reimplementation. | Missing or incompatible license keeps `integration_status: monitor_only` or `rejected`. |
+| Checkpoint check | Durable checkpoint URI, checksum or source manifest, normalizer/statistics availability, and access constraints. | Missing checkpoint keeps benchmark status `blocked` unless the candidate is explicitly a design/reference family. |
+| Observation/action contract | Mapping to Robot SF observations, forbidden/training-only fields, action frame/units/bounds, and projection or guard behavior. | Required before `adapter_needed` can become `staged` or `implemented`. |
+| Source-side smoke | Upstream or source-harness inference command that runs the named policy/checkpoint in its native environment. | Source-side success is `not_benchmark_evidence`; it can only support source confidence or adapter planning. |
+| Robot SF adapter | Adapter path, config pointer, metadata fields, fail-closed behavior, and raw/adapted/post-guard action logging plan. | Adapter-only status is `not_benchmark_evidence` until the Robot SF smoke runs through that adapter. |
+| Robot SF smoke | Minimal Robot SF command that loads the adapter and checkpoint and records expected diagnostics without fallback-only success. | Supports `smoke_only`, not benchmark ranking or paper-facing claims. |
+| Benchmark suite | Declared benchmark config/stage, candidate-registry row, promotion gate, artifact provenance, and fail-closed result handling. | Only this stage can support `comparison_available` benchmark evidence. |
+
+## Registry Mapping
+
+Use this roll-up mapping when updating `learned_policy_registry.md`. Keep detailed stage evidence in
+the family note or issue; keep only the current state and anchors in the registry row.
+
+| Intake roll-up | Minimum completed stage | `integration_status` | `reproducibility_status` | `benchmark_status` |
+| --- | --- | --- | --- | --- |
+| `source_screened` | Source screen | `monitor_only` | `monitor_only` or `source_harness_required` | `blocked` or `not_benchmark_evidence` |
+| `license_or_checkpoint_blocked` | Source screen, with license or checkpoint blocker | `monitor_only` or `rejected` | `blocked` or `source_harness_required` | `blocked` or `rejected_for_current_adapter` |
+| `contract_blocked` | Observation/action contract attempted | `monitor_only` or `adapter_needed` | `source_harness_required` or `monitor_only` | `blocked` or `rejected_for_current_adapter` |
+| `source_smoke_only` | Source-side smoke | `monitor_only` or `adapter_needed` | `source_smoke_proven` | `not_benchmark_evidence` |
+| `adapter_only` | Robot SF adapter | `staged` or `adapter_needed` | `launch_packet` or `source_smoke_proven` | `not_benchmark_evidence` |
+| `robot_sf_smoke_only` | Robot SF smoke | `staged` or `implemented` | `smoke_proven` | `smoke_only` |
+| `benchmark_suite_complete` | Benchmark suite | `implemented` | `comparison_available` | `comparison_available` |
+
+When the table above conflicts with a stricter existing row, keep the stricter row. For example, a
+candidate with a successful source-side smoke but a missing Robot SF observation/action contract
+still remains blocked for Robot SF benchmark use.
+
+## Example: Arena-Rosnav Stack
+
+`arena_rosnav_stack` is already tracked in
+`docs/context/policy_search/learned_policy_registry.md` and assessed in
+`docs/context/policy_search/issue_1758_arena_rosnav_source_assessment.md`.
+
+Current intake interpretation:
+
+- Source screen: `passed`; the source family is identified as a ROS Noetic/Gazebo/Flatland stack.
+- License, checkpoint, and source-side smoke: `needs_evidence` or `blocked` until a named Rosnav
+  agent, durable source assets, and source command are proven.
+- Observation/action contract and Robot SF adapter: `not_started`; no single Robot SF-compatible
+  policy checkpoint or adapter contract is claimed.
+- Robot SF smoke and benchmark suite: `blocked`.
+
+Registry roll-up stays `integration_status: monitor_only`,
+`reproducibility_status: source_harness_required`, and `benchmark_status: blocked`. This prevents
+the source-side assessment from becoming benchmark evidence.
+
+## Benchmark Evidence Boundary
+
+Source-side success is not Robot SF evidence. Adapter import success is not benchmark evidence.
+Fallback-only, degraded, guard-dominated, or missing-checkpoint execution must be reported as a
+caveat or blocker unless the issue explicitly exists to measure that mode.
+
+A policy may support benchmark claims only after the benchmark-suite stage names the runnable
+Robot SF candidate, config, checkpoint/artifact provenance, observation/action contract, smoke
+proof, benchmark stage, promotion gate, and fail-closed status.
+
+## Validation
+
+For docs-only changes to this contract or linked registry rows, use the cheap validation path:
+
+```bash
+BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
+git diff --check
+uv run python scripts/validation/validate_policy_search_registry.py
+test -e docs/context/policy_search/learned_policy_registry.md
+test -e docs/context/policy_search/issue_1758_arena_rosnav_source_assessment.md
+```

--- a/docs/context/policy_search/learned_policy_registry.md
+++ b/docs/context/policy_search/learned_policy_registry.md
@@ -7,6 +7,8 @@ Related issues:
   <https://github.com/ll7/robot_sf_ll7/issues/1618>
 - Issue #1363 learned-policy eligibility checklist:
   <https://github.com/ll7/robot_sf_ll7/issues/1363>
+- Issue #1870 external learned-policy intake:
+  <https://github.com/ll7/robot_sf_ll7/issues/1870>
 
 ## Purpose
 
@@ -49,7 +51,8 @@ checkpoint_availability: local_registry | wandb_artifact | pending | source_clai
 expected_dependencies: local_repo | slurm | external_legacy_env | source_harness |
   unknown
 reproducibility_status: smoke_proven | launch_packet | source_harness_required |
-  comparison_available | proposal | prototype_only | monitor_only | blocked | rejected
+  source_smoke_proven | comparison_available | proposal | prototype_only | monitor_only |
+  blocked | rejected
 integration_status: implemented | staged | adapter_needed | monitor_only | rejected
 benchmark_status: smoke_only | comparison_available | not_benchmark_evidence |
   blocked | rejected | rejected_for_current_adapter
@@ -61,6 +64,12 @@ local_anchors: local docs, configs, tests, issues, or model registry paths
 Passing this registry screen does not make a policy benchmark-ready. Any learned policy still needs
 the checklist in `docs/context/policy_search/contracts/learned_local_policy_eligibility.md`, adapter
 metadata from Issue #1618, smoke proof, and fail-closed handling before benchmark claims.
+
+External learned-policy families must also follow
+`docs/context/policy_search/contracts/external_policy_intake.md`. That contract defines the
+source-screen, license, checkpoint, observation/action, source-side-smoke, Robot SF adapter,
+Robot SF smoke, and benchmark-suite stages. This registry owns only the durable roll-up status; do
+not maintain a second current-state table in the intake contract or family notes.
 
 ## Status Crosswalk
 
@@ -77,6 +86,22 @@ stricter benchmark-readiness interpretation wins.
 | `monitor_only` with `monitor_only` | `monitor only` or `defer` | Track for future review; do not open implementation work without materially new source or contract evidence. |
 | `blocked` benchmark status | `defer`, `source-side reproduction first`, or `prototype only` | Treat as blocked for benchmark use; the row may still guide a narrow prerequisite issue. |
 | `rejected` or `rejected_for_current_adapter` | `reject for now` | Not compatible with the current local-planner adapter contract; reopen only with new public assets or a narrower reduction proof. |
+
+## External Intake Crosswalk
+
+Use this crosswalk with `contracts/external_policy_intake.md` when an external family moves through
+source-side and Robot SF adapter intake. The mapping is fail-closed: source-side proof and
+adapter-only proof are useful planning evidence, but they are not benchmark evidence.
+
+| External intake roll-up | Registry fields | Benchmark-readiness interpretation |
+| --- | --- | --- |
+| `source_screened` | `integration_status: monitor_only`; `reproducibility_status: monitor_only` or `source_harness_required`; `benchmark_status: blocked` or `not_benchmark_evidence` | Interesting enough to track, not enough to implement or benchmark. |
+| `license_or_checkpoint_blocked` | `integration_status: monitor_only` or `rejected`; `reproducibility_status: blocked` or `source_harness_required`; `benchmark_status: blocked` or `rejected_for_current_adapter` | Do not start adapter work until license and durable artifact blockers are cleared. |
+| `contract_blocked` | `integration_status: monitor_only` or `adapter_needed`; `reproducibility_status: source_harness_required` or `monitor_only`; `benchmark_status: blocked` or `rejected_for_current_adapter` | Observation/action mismatch blocks Robot SF benchmark use even if the source looks promising. |
+| `source_smoke_only` | `integration_status: monitor_only` or `adapter_needed`; `reproducibility_status: source_smoke_proven`; `benchmark_status: not_benchmark_evidence` | Native upstream/source-harness inference worked, but no Robot SF benchmark claim is allowed. |
+| `adapter_only` | `integration_status: staged` or `adapter_needed`; `reproducibility_status: launch_packet` or `source_smoke_proven`; `benchmark_status: not_benchmark_evidence` | Adapter import or metadata exists, but the Robot SF runtime path has not produced smoke evidence. |
+| `robot_sf_smoke_only` | `integration_status: staged` or `implemented`; `reproducibility_status: smoke_proven`; `benchmark_status: smoke_only` | Local smoke supports adapter viability only, not ranking or paper-facing comparison. |
+| `benchmark_suite_complete` | `integration_status: implemented`; `reproducibility_status: comparison_available`; `benchmark_status: comparison_available` | Benchmark evidence is available only for the named config, checkpoint, stage, and promotion gate. |
 
 ## Entries
 


### PR DESCRIPTION
## Summary
- adds `docs/context/policy_search/contracts/external_policy_intake.md` for staged external learned-policy intake
- defines source-screen, license, checkpoint, observation/action, source-smoke, adapter, Robot SF smoke, and benchmark-suite stages
- maps external intake roll-ups back to `learned_policy_registry.md` without creating a parallel source of truth
- links the contract from the policy-search README and keeps source-side or adapter-only evidence out of benchmark claims

## Validation
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_policy_search_registry.py`
- referenced path checks for learned-policy registry, Arena-Rosnav assessment, learned-policy eligibility contract, and fallback policy

Full `scripts/dev/pr_ready_check.sh` not run because this is docs/registry vocabulary only; no policy implementation, checkpoint download, source reproduction, or benchmark run is included.

Closes #1870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated policy search workflow documentation to clarify intake contracts and registry status management.
  * Introduced new external policy intake guidance with defined stages, required evidence, and validation procedures.
  * Enhanced registry schema with additional status options and intake-to-registry mapping documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->