### PR TITLE
feat: add local smoke benchmark demo

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -12,6 +12,29 @@ The RobotSF benchmark system uses a consolidated schema management approach to e
 
 **See also**: [SNQI Weight Tools](./snqi-weight-tools/README.md) for weight recomputation and optimization, and [Distribution Plots](./distribution_plots.md) for visualization guidance.
 
+## Local Smoke Benchmark Demo
+
+For a quick local sanity check that the benchmark runner can execute a small map scenario with two
+low-cost planners, run:
+
+```bash
+uv run python scripts/demo/run_robot_sf_smoke.py
+```
+
+The command runs `configs/scenarios/single/planner_sanity_simple.yaml` with `simple_policy` and
+`social_force`, then writes disposable local artifacts under
+`output/demo/smoke_benchmark/`:
+
+- `summary.json`: machine-readable planner status and aggregate metrics.
+- `report.md`: short human-readable result table and artifact pointers.
+- `episodes/*.jsonl`: per-planner episode records used to build the summary.
+
+Pass `--verbose` when debugging simulator or map-runner logs.
+
+These outputs are a local demo only. They are not durable benchmark evidence and should not be used
+for paper-facing or promotion claims unless promoted separately with the repository's normal
+artifact provenance and validation process.
+
 Benchmark outcomes are separate from dense training rewards. Benchmark claims must rely on
 schema-checked episode records, deterministic metrics, termination/outcome fields, and explicit
 runtime/readiness metadata; training reward totals are not benchmark-success evidence. See

--- a/scripts/demo/__init__.py
+++ b/scripts/demo/__init__.py
@@ -1,0 +1,2 @@
+"""Local demo entry points."""
+

--- a/scripts/demo/__init__.py
+++ b/scripts/demo/__init__.py
@@ -1,2 +1,1 @@
 """Local demo entry points."""
-

--- a/scripts/demo/run_robot_sf_smoke.py
+++ b/scripts/demo/run_robot_sf_smoke.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Run a local one-command Robot SF smoke benchmark demo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+from loguru import logger
+
+# Keep import-time Robot SF registry logs out of the default one-command demo.
+logger.remove()
+logger.add(sys.stderr, level="ERROR")
+
+from robot_sf.benchmark.aggregate import compute_aggregates, read_jsonl  # noqa: E402
+from robot_sf.benchmark.runner import run_batch  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MATRIX = ROOT / "configs/scenarios/single/planner_sanity_simple.yaml"
+DEFAULT_SCHEMA = ROOT / "robot_sf/benchmark/schemas/episode.schema.v1.json"
+DEFAULT_OUTPUT_ROOT = ROOT / "output/demo/smoke_benchmark"
+DEFAULT_PLANNERS = ("simple_policy", "social_force")
+DEFAULT_HORIZON = 300
+DEFAULT_DT = 0.1
+CLAIM_BOUNDARY = "Local demo output is not durable benchmark evidence unless promoted separately."
+
+
+@dataclass(frozen=True)
+class PlannerDemoResult:
+    """Summary for one planner row in the smoke demo."""
+
+    planner: str
+    status: str
+    episodes_path: Path
+    record_count: int
+    duration_seconds: float
+    run_summary: dict[str, Any]
+    error: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable planner summary."""
+        payload: dict[str, Any] = {
+            "planner": self.planner,
+            "status": self.status,
+            "episodes_path": str(self.episodes_path),
+            "record_count": self.record_count,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "run_summary": self.run_summary,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write stable JSON with a trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _configure_demo_logging(*, verbose: bool) -> None:
+    """Keep the one-command demo readable unless detailed logs are requested."""
+    logger.remove()
+    if verbose:
+        logger.add(sys.stderr, level="DEBUG")
+    else:
+        logger.add(sys.stderr, level="ERROR")
+
+
+def _metric_mean(aggregate_summary: dict[str, Any], planner: str, metric: str) -> str:
+    """Return a compact aggregate mean string for a planner metric."""
+    value = aggregate_summary.get(planner, {}).get(metric, {}).get("mean")
+    if isinstance(value, int | float):
+        return f"{float(value):.3f}"
+    return "n/a"
+
+
+def _planner_status(
+    *,
+    error: str | None,
+    record_count: int,
+    run_summary: dict[str, Any],
+) -> str:
+    """Classify a planner demo row."""
+    if error:
+        return "failed"
+    failures = run_summary.get("failures") or []
+    if failures:
+        return "failed"
+    if record_count <= 0:
+        return "failed"
+    return "passed"
+
+
+def _run_planner(
+    *,
+    planner: str,
+    matrix: Path,
+    output_root: Path,
+    horizon: int,
+    dt: float,
+    workers: int,
+) -> PlannerDemoResult:
+    """Run one planner through the benchmark runner."""
+    episodes_path = output_root / "episodes" / f"{planner}.jsonl"
+    if episodes_path.exists():
+        episodes_path.unlink()
+    started = time.perf_counter()
+    error: str | None = None
+    run_summary: dict[str, Any] = {}
+    try:
+        run_summary = run_batch(
+            matrix,
+            out_path=episodes_path,
+            schema_path=DEFAULT_SCHEMA,
+            horizon=horizon,
+            dt=dt,
+            record_forces=False,
+            algo=planner,
+            workers=workers,
+            resume=False,
+            benchmark_profile="baseline-safe",
+        )
+    except Exception as exc:  # pragma: no cover - exercised through tests with monkeypatch
+        error = str(exc)
+    duration_seconds = time.perf_counter() - started
+    records = read_jsonl(episodes_path, strict=False) if episodes_path.exists() else []
+    status = _planner_status(
+        error=error,
+        record_count=len(records),
+        run_summary=run_summary,
+    )
+    return PlannerDemoResult(
+        planner=planner,
+        status=status,
+        episodes_path=episodes_path,
+        record_count=len(records),
+        duration_seconds=duration_seconds,
+        run_summary=run_summary,
+        error=error,
+    )
+
+
+def _write_report(path: Path, summary: dict[str, Any]) -> None:
+    """Write a concise Markdown report for humans."""
+    rows = [
+        "| Planner | Status | Records | Success mean | Collisions mean | Notes |",
+        "| --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    aggregate_summary = summary.get("aggregate_summary", {})
+    for planner in summary["planners"]:
+        note = planner.get("error") or ""
+        rows.append(
+            "| {planner} | {status} | {records} | {success} | {collisions} | {note} |".format(
+                planner=planner["planner"],
+                status=planner["status"],
+                records=planner["record_count"],
+                success=_metric_mean(aggregate_summary, planner["planner"], "success"),
+                collisions=_metric_mean(aggregate_summary, planner["planner"], "collisions"),
+                note=note.replace("|", "\\|"),
+            )
+        )
+
+    body = "\n".join(
+        [
+            "# Robot SF Smoke Benchmark Demo",
+            "",
+            f"- Status: {'passed' if summary['passed'] else 'failed'}",
+            f"- Scenario matrix: `{summary['matrix']}`",
+            f"- Output root: `{summary['output_root']}`",
+            f"- Claim boundary: {summary['claim_boundary']}",
+            "",
+            "## Planner Results",
+            "",
+            *rows,
+            "",
+            "## Artifacts",
+            "",
+            f"- Summary JSON: `{summary['artifacts']['summary_json']}`",
+            f"- Report Markdown: `{summary['artifacts']['report_md']}`",
+            f"- Episode JSONL directory: `{summary['artifacts']['episodes_dir']}`",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def run_demo(
+    *,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    matrix: Path = DEFAULT_MATRIX,
+    planners: tuple[str, ...] = DEFAULT_PLANNERS,
+    horizon: int = DEFAULT_HORIZON,
+    dt: float = DEFAULT_DT,
+    workers: int = 1,
+) -> dict[str, Any]:
+    """Run the local smoke benchmark demo and write summary artifacts."""
+    output_root = Path(output_root)
+    matrix = Path(matrix)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    planner_results = [
+        _run_planner(
+            planner=planner,
+            matrix=matrix,
+            output_root=output_root,
+            horizon=horizon,
+            dt=dt,
+            workers=workers,
+        )
+        for planner in planners
+    ]
+    episode_paths = [
+        result.episodes_path for result in planner_results if result.episodes_path.exists()
+    ]
+    records = read_jsonl(episode_paths, strict=False) if episode_paths else []
+    aggregate_summary = compute_aggregates(records) if records else {}
+
+    summary_path = output_root / "summary.json"
+    report_path = output_root / "report.md"
+    payload: dict[str, Any] = {
+        "schema_version": "robot_sf_smoke_demo.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "matrix": str(matrix),
+        "output_root": str(output_root),
+        "planners": [result.to_json_dict() for result in planner_results],
+        "passed": all(result.status == "passed" for result in planner_results),
+        "claim_boundary": CLAIM_BOUNDARY,
+        "aggregate_summary": aggregate_summary,
+        "parameters": {
+            "horizon": int(horizon),
+            "dt": float(dt),
+            "workers": int(workers),
+        },
+        "artifacts": {
+            "summary_json": str(summary_path),
+            "report_md": str(report_path),
+            "episodes_dir": str(output_root / "episodes"),
+        },
+    }
+    _write_json(summary_path, payload)
+    _write_report(report_path, payload)
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the smoke demo command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--matrix", type=Path, default=DEFAULT_MATRIX)
+    parser.add_argument("--planners", nargs="+", default=list(DEFAULT_PLANNERS))
+    parser.add_argument("--horizon", type=int, default=DEFAULT_HORIZON)
+    parser.add_argument("--dt", type=float, default=DEFAULT_DT)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed simulator and map-runner logs.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the smoke demo CLI."""
+    args = build_parser().parse_args(argv)
+    _configure_demo_logging(verbose=args.verbose)
+    summary = run_demo(
+        output_root=args.output_root,
+        matrix=args.matrix,
+        planners=tuple(args.planners),
+        horizon=args.horizon,
+        dt=args.dt,
+        workers=args.workers,
+    )
+    status = "passed" if summary["passed"] else "failed"
+    print(f"Robot SF smoke benchmark demo {status}.")
+    print(f"Output: {summary['output_root']}")
+    print(
+        "Planners: "
+        + ", ".join(
+            f"{planner['planner']}={planner['status']} ({planner['record_count']} records)"
+            for planner in summary["planners"]
+        )
+    )
+    print(CLAIM_BOUNDARY)
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/demo/test_run_robot_sf_smoke.py
+++ b/tests/demo/test_run_robot_sf_smoke.py
@@ -1,0 +1,103 @@
+"""Tests for the local Robot SF smoke benchmark demo."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from scripts.demo import run_robot_sf_smoke as smoke
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _episode(algorithm: str, *, success: float = 1.0, collisions: float = 0.0) -> dict[str, Any]:
+    """Build a minimal aggregate-compatible episode record."""
+    return {
+        "episode_id": f"demo::{algorithm}::1",
+        "scenario_id": "planner_sanity_simple",
+        "seed": 0,
+        "algo": algorithm,
+        "scenario_params": {"algo": algorithm},
+        "metrics": {
+            "success": success,
+            "collisions": collisions,
+            "near_misses": 0.0,
+            "time_to_goal_norm": 0.5,
+            "path_efficiency": 1.0,
+        },
+    }
+
+
+def test_run_demo_writes_summary_and_report(monkeypatch, tmp_path: Path) -> None:
+    """The demo writes machine and Markdown summaries for two local planners."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_batch(
+        scenarios_or_path: Path,
+        out_path: Path,
+        schema_path: Path,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del scenarios_or_path, schema_path
+        algorithm = str(kwargs["algo"])
+        calls.append(
+            {"algorithm": algorithm, "horizon": kwargs["horizon"], "workers": kwargs["workers"]}
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(_episode(algorithm)) + "\n", encoding="utf-8")
+        return {"wrote": 1, "failures": [], "total_jobs": 1}
+
+    monkeypatch.setattr(smoke, "run_batch", fake_run_batch)
+
+    output_root = tmp_path / "smoke_benchmark"
+    result = smoke.run_demo(output_root=output_root, planners=("simple_policy", "social_force"))
+
+    assert result["passed"] is True
+    assert result["output_root"] == str(output_root)
+    assert result["claim_boundary"] == smoke.CLAIM_BOUNDARY
+    assert [row["planner"] for row in result["planners"]] == ["simple_policy", "social_force"]
+    assert calls == [
+        {"algorithm": "simple_policy", "horizon": smoke.DEFAULT_HORIZON, "workers": 1},
+        {"algorithm": "social_force", "horizon": smoke.DEFAULT_HORIZON, "workers": 1},
+    ]
+
+    payload = json.loads((output_root / "summary.json").read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "robot_sf_smoke_demo.v1"
+    assert payload["passed"] is True
+    assert payload["aggregate_summary"]["simple_policy"]["success"]["mean"] == 1.0
+
+    report = (output_root / "report.md").read_text(encoding="utf-8")
+    assert "Robot SF Smoke Benchmark Demo" in report
+    assert "not durable benchmark evidence" in report
+    assert "simple_policy" in report
+    assert "social_force" in report
+
+
+def test_run_demo_records_failed_planner_without_crashing(monkeypatch, tmp_path: Path) -> None:
+    """A failed planner row is preserved in the summary and report."""
+
+    def fake_run_batch(
+        scenarios_or_path: Path,
+        out_path: Path,
+        schema_path: Path,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del scenarios_or_path, out_path, schema_path
+        if kwargs["algo"] == "social_force":
+            raise RuntimeError("planner unavailable")
+        return {"wrote": 0, "failures": [], "total_jobs": 1}
+
+    monkeypatch.setattr(smoke, "run_batch", fake_run_batch)
+
+    output_root = tmp_path / "smoke_benchmark"
+    result = smoke.run_demo(output_root=output_root, planners=("simple_policy", "social_force"))
+
+    assert result["passed"] is False
+    assert result["planners"][0]["status"] == "failed"
+    assert result["planners"][1]["status"] == "failed"
+    assert "planner unavailable" in result["planners"][1]["error"]
+
+    report = (output_root / "report.md").read_text(encoding="utf-8")
+    assert "failed" in report
+    assert "planner unavailable" in report


### PR DESCRIPTION
## Summary
- adds `uv run python scripts/demo/run_robot_sf_smoke.py` as a one-command local benchmark smoke demo
- runs `planner_sanity_simple` with `simple_policy` and `social_force`, writing `summary.json`, `report.md`, and per-planner `episodes/*.jsonl` under `output/demo/smoke_benchmark/`
- keeps the default output concise, with `--verbose` for simulator/map-runner logs
- documents that demo artifacts are local and not durable benchmark evidence unless promoted separately

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/demo/run_robot_sf_smoke.py tests/demo/test_run_robot_sf_smoke.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/demo/run_robot_sf_smoke.py tests/demo/test_run_robot_sf_smoke.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/demo/test_run_robot_sf_smoke.py -q` (`2 passed`)
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/demo/run_robot_sf_smoke.py --output-root output/demo/smoke_benchmark_issue1868_post_merge`

Actual demo result: `simple_policy=passed (3 records)`, `social_force=passed (3 records)`. Generated `output/demo/...` and `output/coverage/...` artifacts are ignored/disposable local outputs, not tracked evidence.

Closes #1868