### PR TITLE
docs: add learned-policy cards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -185,6 +185,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Issue #1073 Robot SF Empirical-Expansion Gate](./context/issue_1073_empirical_expansion_gate_2026_06_08.md)** - June 8 checkpoint rule for deciding whether Robot SF can move beyond dissertation-floor examples into bounded empirical expansion
 * **[Benchmark Static Dashboard](./benchmark_static_dashboard.md)** - Self-contained static HTML dashboard generation from camera-ready benchmark bundles
 * **[Trajectory Debug Visualization](./debug_visualization.md)** - Optional JSON/Rerun timeline export for inspecting one episode JSONL without treating debug artifacts as benchmark evidence
+* **[Learned-Policy Cards](./policy_cards/README.md)** - Human-readable learned-policy summaries that separate existence, smoke proof, benchmark comparison, and promotion boundaries
 * **[PR Promoted Planner Smoke](./benchmark_pr_promoted_planner_smoke.md)** - Pull-request micro-benchmark workflow, runtime target, and fail-closed summary contract
 * **[Issue #1065 Route-Clearance Warning Audit](./context/issue_1065_route_clearance_warning_audit.md)** - Paper and h500 route-clearance warning classification, planner-attribution boundary, and repair/certification follow-up
 * **[Issue #595 Seed-Variability Contract](./context/issue_595_seed_variability_contract.md)** - Frozen camera-ready artifact contract and pilot slice for paper-side seed variability analysis

--- a/docs/policy_cards/README.md
+++ b/docs/policy_cards/README.md
@@ -1,0 +1,91 @@
+# Learned-Policy Cards
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1865>
+
+Policy cards are human-readable summaries for learned local-navigation policies and learned-policy
+candidates. They sit above the canonical registries and reports: a card should make a policy's
+status, contracts, artifacts, evidence, and limitations easy to inspect without turning planning
+metadata into benchmark evidence.
+
+## Evidence Boundary
+
+These cards are documentation surfaces. They do not promote a checkpoint, create benchmark
+eligibility, or override the fail-closed fallback policy. Treat each factual field as sourced from
+the linked registry, config, artifact manifest, or report. If a field is absent from those sources,
+write `unknown`, `pending`, or `blocked`; do not infer it from the policy name.
+
+Canonical sources:
+
+- [Learned local-navigation policy registry](../context/policy_search/learned_policy_registry.md)
+- [Policy-search candidate registry](../context/policy_search/candidate_registry.yaml)
+- [Model registry](../../model/registry.yaml)
+- [Learned local-policy eligibility checklist](../context/policy_search/contracts/learned_local_policy_eligibility.md)
+- [External learned-policy intake contract](../context/policy_search/contracts/external_policy_intake.md)
+- [Artifact evidence vocabulary](../context/artifact_evidence_vocabulary.md)
+- [Benchmark fallback policy](../context/issue_691_benchmark_fallback_policy.md)
+
+## Initial Cards
+
+| Policy card | Current status | Evidence boundary |
+| --- | --- | --- |
+| [`ppo_issue791_best_v1`](ppo_issue791_best_v1.md) | Implemented learned baseline with comparison evidence | Best current learned-only baseline for success-oriented comparison; not a safety promotion or OOD claim. |
+
+## Template
+
+Use this template for new cards. Keep list values short and link every durable claim.
+
+```yaml
+policy_id: stable identifier from learned_policy_registry.md
+policy_family: learned_baseline | guarded_policy | residual_policy | auxiliary_risk |
+  predictive_model | lidar_policy | external_graph_policy | external_learned_policy |
+  external_visual_policy | external_world_model
+card_status: draft | current | blocked | superseded
+registry_status:
+  integration_status: implemented | staged | adapter_needed | monitor_only | rejected
+  reproducibility_status: smoke_proven | launch_packet | source_harness_required |
+    source_smoke_proven | comparison_available | proposal | prototype_only | monitor_only |
+    blocked | rejected
+  benchmark_status: smoke_only | comparison_available | not_benchmark_evidence |
+    blocked | rejected | rejected_for_current_adapter
+benchmark_track: named benchmark or promotion track, smoke-only track, not_benchmark_evidence,
+  blocked, or unknown
+evidence_boundary: one sentence describing what the current evidence supports
+not_for:
+  - claims this card must not support
+source_links:
+  learned_policy_registry: path
+  candidate_registry: path or not_applicable
+  model_registry: path or not_applicable
+  reports:
+    - path
+contracts:
+  observation_contract: exact observation mode/level/keys or unknown
+  action_contract: output family, frame, units, bounds, and projection policy
+  fallback_policy: fail-closed behavior or fallback/degraded caveat
+artifacts:
+  checkpoint_uri: durable URI or pending
+  checkpoint_checksum: checksum or unknown
+  normalizer_uri: durable URI, not_required, unknown, or pending
+  training_config: path or unknown
+  training_data_or_split: training/eval source, split contract, caveat, unknown, or pending
+  license_or_access: known license/access note or unknown
+evidence:
+  smoke: command/report/status or not_run
+  benchmark: report/status or not_benchmark_evidence
+known_failures:
+  - observed limitation or blocked prerequisite
+review_notes:
+  - maintenance note for future updates
+```
+
+## Maintenance Rules
+
+1. Add a card only when registry or model metadata is complete enough to avoid speculation.
+2. Prefer one card per stable `policy_id`.
+3. Separate existence, runnable smoke proof, benchmark comparison, and promotion.
+4. Mark local `output/` paths as cache or reproduced-output references unless they are backed by a
+   durable artifact entry.
+5. Keep fallback, degraded, guard-dominated, or missing-artifact execution as caveats unless the
+   issue explicitly measures that mode.
+6. Update the card when the learned-policy registry, candidate registry, model registry, or linked
+   report changes the policy's status.

--- a/docs/policy_cards/ppo_issue791_best_v1.md
+++ b/docs/policy_cards/ppo_issue791_best_v1.md
@@ -1,0 +1,101 @@
+# Policy Card: `ppo_issue791_best_v1`
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1865>
+
+## Summary
+
+```yaml
+policy_id: ppo_issue791_best_v1
+policy_family: learned_baseline
+card_status: current
+registry_status:
+  integration_status: implemented
+  reproducibility_status: comparison_available
+  benchmark_status: comparison_available
+benchmark_track: grid_socnav_v1 model-promotion track plus scoped policy-search/paper-matrix reports
+evidence_boundary: >
+  Best current learned-only baseline for success-oriented comparison; not a safety promotion
+  because the scoped paper-matrix collision rate is worse than ORCA.
+not_for:
+  - safety promotion
+  - out-of-distribution generalization claim
+  - unguarded replacement for collision-safer anchors
+```
+
+`ppo_issue791_best_v1` is the repository's current concrete learned-policy card example. It links a
+policy-search candidate, PPO baseline config, model-registry artifact, learned-policy registry row,
+adapter mapping, and recorded smoke/nominal/paper-matrix evidence.
+
+## Source Links
+
+| Source | Path |
+| --- | --- |
+| Learned-policy registry row | [`docs/context/policy_search/learned_policy_registry.md`](../context/policy_search/learned_policy_registry.md) |
+| Candidate registry row | [`docs/context/policy_search/candidate_registry.yaml`](../context/policy_search/candidate_registry.yaml) |
+| Candidate config | [`configs/policy_search/candidates/ppo_issue791_best_v1.yaml`](../../configs/policy_search/candidates/ppo_issue791_best_v1.yaml) |
+| Baseline config | [`configs/baselines/ppo_15m_grid_socnav.yaml`](../../configs/baselines/ppo_15m_grid_socnav.yaml) |
+| Adapter interface mapping | [`docs/context/issue_1618_learned_policy_adapter_interface.md`](../context/issue_1618_learned_policy_adapter_interface.md) |
+| Model registry | [`model/registry.yaml`](../../model/registry.yaml) |
+| Best-learning report | [`docs/context/policy_search/reports/2026-05-05_best_learning_policy.md`](../context/policy_search/reports/2026-05-05_best_learning_policy.md) |
+| Promotion verdict | [`docs/context/issue_791_best_policy_verdict_2026_04_21.md`](../context/issue_791_best_policy_verdict_2026_04_21.md) |
+| Narrow claim memory | [`memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md`](../../memory/decisions/2026-04-20_issue_791_narrow_benchmark_claim.md) |
+
+## Contracts
+
+| Field | Value |
+| --- | --- |
+| Observation contract | PPO dict observation with `tracked_agents_no_noise` promotion metadata and predictive-foresight features from `model/registry.yaml` and `configs/baselines/ppo_15m_grid_socnav.yaml`. |
+| Allowed observation keys | Listed in `model/registry.yaml` under the `benchmark_promotion.allowed_observation_keys` for `ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417`. |
+| Predictive dependency | `predictive_foresight_enabled: true`, `predictive_foresight_model_id: predictive_proxy_selected_v2_full`. |
+| Action contract | Deterministic unicycle velocity command through the PPO planner wrapper, with `v_max: 2.0` and `omega_max: 1.0`. |
+| Adapter implementation | `robot_sf/baselines/ppo.py`. |
+| Fallback policy | `fallback_to_goal: false`; missing or invalid model action should fail closed rather than silently switching to goal seeking. |
+
+## Artifacts
+
+| Field | Value |
+| --- | --- |
+| Model id | `ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417` |
+| W&B run | `ll7/robot_sf/ibo3aqus` |
+| W&B artifact | `ll7/robot_sf/ppo_expert_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity-best-success:v9` |
+| Public artifact source | GitHub release `artifact/models-2026-05-registry-v1` via `model/registry.yaml`. |
+| Checkpoint checksum | `2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d` |
+| Local checkpoint path | `output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/model.zip`; cache path only and may be absent in a fresh checkout. |
+| Training config | [`configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml`](../../configs/training/ppo/ablations/expert_ppo_issue_791_reward_curriculum_promotion_10m_env22_eval_aligned_large_capacity.yaml) |
+| Training data or split | In-repo PPO training through the training config above; model-registry and baseline notes identify the eval superset `ppo_full_maintained_eval_v1` caveat. No separate offline dataset artifact is declared for this policy card. |
+| Benchmark track | `grid_socnav_v1` in `model/registry.yaml`; policy-search evidence also includes the named smoke, nominal-sanity, and scoped paper-matrix reports in this card. |
+| Normalizer URI | `unknown`; no separate durable normalizer URI is declared in the current model registry row. |
+| License/access | Local repository policy plus W&B/GitHub release artifact access as recorded in `model/registry.yaml`; no separate third-party policy license is declared for this local PPO baseline. |
+
+## Evidence
+
+| Scope | Evidence |
+| --- | --- |
+| Training/eval promotion | Best eval summary in `model/registry.yaml`: 70 episodes on `ppo_full_maintained_eval_v1`, success `0.929`, collision `0.071`, SNQI `0.353`, step `9,961,472 / 10,000,000`. |
+| Policy-search smoke | `docs/context/policy_search/reports/2026-05-05_best_learning_policy.md`: smoke success `1.0000`, collision `0.0000`, near misses `0.0000`. |
+| Nominal sanity | Same report: 18 episodes, success `0.2778`, collision `0.0000`, near misses `0.2222`; decision `revise`. |
+| Scoped paper matrix | Same report: PPO success `0.2569`, collision `0.0903`, near misses `3.3403`, TTG norm `0.9305`; ORCA reference success `0.1806`, collision `0.0347`, near misses `4.9097`, TTG norm `0.9650`. |
+| Benchmark interpretation | Comparison evidence exists for the named config/checkpoint/stage only. PPO improves success in the scoped comparison but has worse collision rate than ORCA, so it is not a safety promotion. |
+
+## Known Failures And Caveats
+
+- Training used the eval superset identified in `configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml`; report those numbers as in-distribution benchmark-set performance, not OOD generalization.
+- The nominal-sanity pass still has many non-success episodes from low-progress timeouts and
+  intrusive near misses, according to the 2026-05-05 best-learning report.
+- The scoped paper-matrix collision rate is worse than ORCA, so collision-safer planners remain the
+  safety anchor.
+- The local checkpoint path is an ignored cache path; durable recovery depends on the registry's
+  W&B/GitHub release artifact metadata.
+- The card does not establish a reusable normalizer artifact because no separate normalizer URI is
+  declared in the current registry metadata.
+
+## Review Notes
+
+Update this card when any of these surfaces change:
+
+- `docs/context/policy_search/learned_policy_registry.md`
+- `docs/context/policy_search/candidate_registry.yaml`
+- `model/registry.yaml`
+- `configs/policy_search/candidates/ppo_issue791_best_v1.yaml`
+- `configs/baselines/ppo_15m_grid_socnav.yaml`
+- `docs/context/policy_search/reports/2026-05-05_best_learning_policy.md`


### PR DESCRIPTION
## Summary
Adds a learned-policy card entry point and the first evidence-bound card for `ppo_issue791_best_v1`.

## Linked Issues
- Closes `#1865`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: docs-only and based on current registry/model/report metadata on `origin/main`.

## What Changed
- Added `docs/policy_cards/README.md` with a reusable card template and maintenance rules.
- Added `docs/policy_cards/ppo_issue791_best_v1.md` with sourced contracts, artifacts, evidence, and caveats.
- Linked policy cards from `docs/README.md`.

## Why It Matters
- Added value: learned policies now have a human-readable surface that separates existence, smoke proof, comparison evidence, and promotion boundaries.
- Expected impact: reviewers can inspect the current learned PPO baseline without chasing registry, model, and report files separately.
- Why this is worth merging now: learned-policy intake and registry surfaces are mature enough for a conservative public docs layer.

## Validation / Proof
- Commands run:
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - explicit Python local Markdown link check across `docs/policy_cards/README.md`, `docs/policy_cards/ppo_issue791_best_v1.md`, and `docs/README.md`
  - `uv run python scripts/validation/validate_policy_search_registry.py`
  - explicit Python policy/model ID check against `learned_policy_registry.md`, `candidate_registry.yaml`, and `model/registry.yaml`
- Evidence that the change works here: docs proof passed for 3 changed files; 345 local links checked with no missing targets; registry validator passed.
- Benchmarks or smoke tests, if applicable: not run; docs-only change and no benchmark behavior changed.

## Risks / Rollout
- Compatibility risks: low; Markdown-only docs.
- Failure modes: card drift if registry/model/report metadata changes without updating the card.
- Rollback or fallback plan: remove the docs entry point and card if a better card schema replaces it.

## Docs / Provenance
- Updated docs: `docs/policy_cards/README.md`, `docs/policy_cards/ppo_issue791_best_v1.md`, `docs/README.md`.
- Relevant design or provenance notes: card links learned-policy registry, candidate registry, model registry, adapter interface note, best-learning report, promotion verdict, fallback policy, and narrow claim memory.
- Any assumptions that need to be preserved: missing metadata is marked `unknown` rather than inferred, including the normalizer URI.

## Downstream Propagation
- Parent issue updated: yes, closes #1865 through this PR.
- Claim map / benchmark report updated: NA.
- Registry or config index updated: NA; this reads existing registries only.
- Context index / memory note updated: NA; discoverability is via docs README.
- Follow-up issue opened for deferred propagation: NA.
- Not-applicable rationale: docs-only card surface; no benchmark, schema, or model artifact contract changed.

## Follow-Up Issues
- Deferred work: add more cards only when registry/model metadata is complete enough to avoid speculation.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that the card does not overclaim `ppo_issue791_best_v1`: it explicitly keeps the policy as a learned baseline, not a safety promotion or OOD claim.
- Known limitation: only one initial card is included because it is the clearest evidence-backed learned-policy candidate.