### PR TITLE
docs: add static leaderboards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -184,6 +184,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
 * **[Issue #1073 Robot SF Empirical-Expansion Gate](./context/issue_1073_empirical_expansion_gate_2026_06_08.md)** - June 8 checkpoint rule for deciding whether Robot SF can move beyond dissertation-floor examples into bounded empirical expansion
 * **[Benchmark Static Dashboard](./benchmark_static_dashboard.md)** - Self-contained static HTML dashboard generation from camera-ready benchmark bundles
+* **[Static Leaderboards](./leaderboards/README.md)** - Markdown leaderboard row contract and first evidence-bound smoke, nominal-sanity, AMV, and LiDAR result surfaces
 * **[Trajectory Debug Visualization](./debug_visualization.md)** - Optional JSON/Rerun timeline export for inspecting one episode JSONL without treating debug artifacts as benchmark evidence
 * **[Learned-Policy Cards](./policy_cards/README.md)** - Human-readable learned-policy summaries that separate existence, smoke proof, benchmark comparison, and promotion boundaries
 * **[PR Promoted Planner Smoke](./benchmark_pr_promoted_planner_smoke.md)** - Pull-request micro-benchmark workflow, runtime target, and fail-closed summary contract

--- a/docs/leaderboards/README.md
+++ b/docs/leaderboards/README.md
@@ -1,0 +1,55 @@
+# Static Leaderboards
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1866>
+
+Static leaderboards are Markdown result surfaces for benchmark and smoke evidence that is already
+tracked in this repository. They are intentionally small: each row must name its evidence URI,
+status, benchmark track, and claim boundary so a scan-friendly table does not become an accidental
+promotion claim.
+
+## Pages
+
+| Page | Scope | Population status |
+| --- | --- | --- |
+| [Smoke](smoke.md) | Policy-search and benchmark smoke rows with durable report or compact-summary evidence. | initial rows |
+| [Nominal Sanity](nominal_sanity.md) | Nominal-sanity policy-search rows. | initial row |
+| [AMV Actuation](amv_actuation.md) | Synthetic AMV actuation smoke and diagnostic rows. | initial rows |
+| [LiDAR 2D](lidar_2d.md) | LiDAR learned-policy smoke rows. | initial row |
+
+## Row Contract
+
+Every populated row should include these visible fields:
+
+| Field | Meaning |
+| --- | --- |
+| `planner` | Planner, policy, or candidate identifier. |
+| `suite` | Scenario suite, policy-search stage, or benchmark surface. |
+| `success` | Mean success metric, or `not_recorded` when the durable evidence does not expose it. |
+| `collision` | Collision metric from the evidence source, or `not_recorded`. |
+| `near_miss` | Near-miss metric from the evidence source, or `not_recorded`. |
+| `low_progress` | Low-progress count/rate when reported, or `not_recorded`. |
+| `min_distance` | Minimum-distance metric when reported, or `not_recorded`. |
+| `runtime` | Runtime or wall-clock metric when reported, or `not_recorded`. |
+| `benchmark_track` | Named benchmark, policy-search stage, observation track, or `not_benchmark_evidence`. |
+| `evidence_uri` | Repository-relative tracked evidence path. Do not point at worktree-local `output/`. |
+| `status` | Evidence status such as `pass`, `revise`, `successful_evidence`, `not_available`, `excluded`, or `not_yet_populated`. |
+| `claim_boundary` | One-line statement of what the row can and cannot support. |
+
+## Evidence Rules
+
+- Use tracked reports, tracked compact summaries, release manifests, or other durable repository
+  evidence as `evidence_uri`.
+- Do not populate rows directly from worktree-local `output/` paths. If a report mentions an
+  `output/` summary but no compact tracked evidence exists, link the tracked report and mark any
+  missing metrics as `not_recorded`.
+- Keep fallback, degraded, unavailable, excluded, and failed rows visible as caveats. They are not
+  successful benchmark evidence unless the issue explicitly measures that mode.
+- Keep smoke, diagnostic, training-smoke, and synthetic AMV rows separate from paper-facing
+  benchmark claims.
+- Prefer `not_yet_populated` over inventing a metric or copying an untracked artifact.
+
+## Maintenance
+
+Update these pages when a tracked evidence bundle, policy-search report, benchmark release, or
+claim-map decision changes the row status. For bulk population or automation, preserve the row
+contract above so generated tables retain the same evidence boundary.

--- a/docs/leaderboards/amv_actuation.md
+++ b/docs/leaderboards/amv_actuation.md
@@ -1,0 +1,16 @@
+# AMV Actuation Leaderboard
+
+This page covers synthetic AMV actuation surfaces. These rows are diagnostic unless a linked
+claim-map decision explicitly promotes them. The first populated rows come from compact tracked
+evidence for Issue #1569, whose own summary says the smoke does not strengthen AMV performance
+claims.
+
+| planner | suite | success | collision | near_miss | low_progress | min_distance | runtime | benchmark_track | evidence_uri | status | claim_boundary |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |
+| `goal` | `amv_actuation_smoke` | `0.0000` | `0.2000` | `1.0000` | `not_recorded` | `not_recorded` | `13.4813s` | `synthetic_amv_actuation_smoke` | [`docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json`](../context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json) | `successful_evidence` | Executable synthetic diagnostic row; no paper-facing AMV performance claim. |
+| `orca` | `amv_actuation_smoke` | `0.0000` | `0.1333` | `3.4667` | `not_recorded` | `not_recorded` | `7.9955s` | `synthetic_amv_actuation_smoke` | [`docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json`](../context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json) | `successful_evidence` | Executable synthetic diagnostic row; ORCA projection diagnostics remain caveated. |
+| `social_force` | `amv_actuation_smoke` | `0.0000` | `0.2667` | `1.0000` | `not_recorded` | `not_recorded` | `6.4261s` | `synthetic_amv_actuation_smoke` | [`docs/context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json`](../context/evidence/issue_1569_amv_actuation_smoke_2026-05-27/summary.json) | `successful_evidence` | Executable synthetic diagnostic row; command-space and projection-policy metadata remain caveated. |
+| `actuation_aware_hybrid_rule_v0` | `amv_actuation_smoke` | `0.0000` | `1.0000 raw; adjusted not_available` | `0.0000` | `not_recorded` | `1.0513 raw; adjusted not_available` | `not_recorded` | `synthetic_amv_actuation_smoke` | [`docs/context/policy_search/reports/2026-05-31_actuation_aware_hybrid_rule_v0_amv_actuation_smoke.md`](../context/policy_search/reports/2026-05-31_actuation_aware_hybrid_rule_v0_amv_actuation_smoke.md) | `excluded` | The only episode was excluded for initial overlap; raw metrics are diagnostic context, not benchmark-strength evidence. |
+
+The Issue #1569 bundle reports AMV coverage `warn`, not a clean AMV-coverage pass. Keep that caveat
+with any downstream reuse of these rows.

--- a/docs/leaderboards/lidar_2d.md
+++ b/docs/leaderboards/lidar_2d.md
@@ -1,0 +1,11 @@
+# LiDAR 2D Leaderboard
+
+This page tracks LiDAR learned-policy smoke evidence. The first row is a training-smoke plumbing
+result, not a benchmark row or model promotion.
+
+| planner | suite | success | collision | near_miss | low_progress | min_distance | runtime | benchmark_track | evidence_uri | status | claim_boundary |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |
+| `ppo_lidar_mlp_gate_v1` | `lidar_2d_training_smoke` | `0.0000` | `0.0000` | `not_recorded` | `not_recorded` | `not_recorded` | `59.7432s` | `lidar_2d_training_smoke` | [`docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json`](../context/evidence/issue_1662_lidar_ppo_smoke_summary.json) | `completed_smoke_not_benchmark_evidence` | Proves fixed LiDAR PPO MLP training/eval plumbing only; no durable checkpoint or benchmark readiness. |
+
+Longer LiDAR training, deployment-adapter, or benchmark rows should not be added here until a
+durable checkpoint or tracked benchmark evidence bundle exists.

--- a/docs/leaderboards/nominal_sanity.md
+++ b/docs/leaderboards/nominal_sanity.md
@@ -1,0 +1,12 @@
+# Nominal-Sanity Leaderboard
+
+This page starts with rows whose nominal-sanity evidence is already represented by tracked
+policy-search reports. Nominal-sanity rows are useful triage evidence; they do not by themselves
+promote a planner to a paper-facing benchmark result.
+
+| planner | suite | success | collision | near_miss | low_progress | min_distance | runtime | benchmark_track | evidence_uri | status | claim_boundary |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |
+| `ppo_issue791_best_v1` | `policy_search:nominal_sanity` | `0.2778` | `0.0000` | `0.2222` | `10/18` | `3.7136` | `not_recorded` | `policy_search_nominal_sanity` | [`docs/context/policy_search/reports/2026-05-05_ppo_issue791_best_v1_nominal_sanity.md`](../context/policy_search/reports/2026-05-05_ppo_issue791_best_v1_nominal_sanity.md) | `revise` | Strongest learned-only nominal-sanity row in that pass, but still limited by low-progress timeouts and intrusive near misses. |
+
+Additional nominal-sanity candidates should be added only after their tracked reports or compact
+summaries are checked against this row contract.

--- a/docs/leaderboards/smoke.md
+++ b/docs/leaderboards/smoke.md
@@ -1,0 +1,13 @@
+# Smoke Leaderboard
+
+This page lists smoke rows with durable tracked evidence. Smoke success proves that a narrow
+execution path ran; it is not benchmark-strength planner ranking evidence.
+
+| planner | suite | success | collision | near_miss | low_progress | min_distance | runtime | benchmark_track | evidence_uri | status | claim_boundary |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- |
+| `orca_residual_guarded_ppo_v0` | `policy_search:smoke` | `1.0000` | `0.0000` | `0.0000` | `0` | `not_recorded` | `16.2991s` | `policy_search_smoke` | [`docs/context/evidence/issue_1428_orca_residual_lineage_2026-05-24/orca_residual_guarded_ppo_v0_smoke_summary.json`](../context/evidence/issue_1428_orca_residual_lineage_2026-05-24/orca_residual_guarded_ppo_v0_smoke_summary.json) | `pass` | Runtime smoke only; not learned-residual training evidence. |
+| `ppo_issue791_best_v1` | `policy_search:smoke` | `1.0000` | `0.0000` | `0.0000` | `not_recorded` | `not_recorded` | `not_recorded` | `policy_search_smoke` | [`docs/context/policy_search/reports/2026-05-05_best_learning_policy.md`](../context/policy_search/reports/2026-05-05_best_learning_policy.md) | `pass` | Smoke proves artifact hydration and runnable learned-policy inference only. |
+| `hybrid_orca_sampler_v1` | `policy_search:smoke` | `1.0000` | `0.0000` | `0.0000` | `0` | `not_recorded` | `not_recorded` | `policy_search_smoke` | [`docs/context/policy_search/reports/2026-05-31_hybrid_orca_sampler_v1_smoke.md`](../context/policy_search/reports/2026-05-31_hybrid_orca_sampler_v1_smoke.md) | `pass` | Smoke evidence for the 120-step horizon probe only; not candidate promotion. |
+
+Rows omitted from this first page are not negative results. They are simply not yet audited into
+this static row contract.


### PR DESCRIPTION
## Summary
Adds a Markdown static leaderboard entry point plus first evidence-bound pages for smoke, nominal-sanity, AMV actuation, and LiDAR 2D surfaces.

## Linked Issues
- Closes `#1866`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: docs-only and based on tracked evidence already present on `origin/main`.

## What Changed
- Added `docs/leaderboards/README.md` with the static leaderboard row contract and evidence rules.
- Added first pages for `smoke`, `nominal_sanity`, `amv_actuation`, and `lidar_2d`.
- Linked the leaderboard entry point from `docs/README.md`.

## Why It Matters
- Added value: users can scan result surfaces without reading many context notes one by one.
- Expected impact: makes benchmark/status boundaries visible through required `status`, `benchmark_track`, `evidence_uri`, and `claim_boundary` fields.
- Why this is worth merging now: it gives future automation a conservative static row shape before result tables expand.

## Validation / Proof
- Commands run:
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - explicit Python local Markdown link check across `docs/leaderboards/*.md` and `docs/README.md`
  - explicit Python header check that each leaderboard page includes required visible row fields
- Evidence that the change works here: docs proof passed for 6 changed files; 341 local Markdown links checked; all leaderboard pages include the required row fields.
- Benchmarks or smoke tests, if applicable: not run; docs-only change that summarizes existing tracked evidence.

## Risks / Rollout
- Compatibility risks: low; Markdown-only docs.
- Failure modes: leaderboard rows can drift if tracked evidence bundles are updated without updating the pages.
- Rollback or fallback plan: remove the static pages or mark rows `not_yet_populated` if a future automated leaderboard replaces the manual surface.

## Docs / Provenance
- Updated docs: `docs/leaderboards/README.md`, `docs/leaderboards/smoke.md`, `docs/leaderboards/nominal_sanity.md`, `docs/leaderboards/amv_actuation.md`, `docs/leaderboards/lidar_2d.md`, `docs/README.md`.
- Relevant design or provenance notes: rows cite tracked evidence under `docs/context/evidence/` or tracked policy-search reports, never worktree-local `output/` paths.
- Any assumptions that need to be preserved: smoke, diagnostic, synthetic AMV, and training-smoke rows are not benchmark-strength promotion evidence.

## Downstream Propagation
- Parent issue updated: yes, closes #1866 through this PR.
- Claim map / benchmark report updated: NA; this is a read-only index over existing evidence.
- Registry or config index updated: NA.
- Context index / memory note updated: NA; discoverability is via docs README.
- Follow-up issue opened for deferred propagation: none.
- Not-applicable rationale: no benchmark, schema, model, or claim-map semantics changed.

## Follow-Up Issues
- Deferred work: populate more rows only after durable evidence is audited into the row contract.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify row boundaries: fallback/degraded/excluded/diagnostic rows are visible as caveats, not successes.
- Known limitation: this is a manually curated first surface, not an automated leaderboard generator.