### PR TITLE
docs: add benchmark suite catalog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,7 @@ see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_cle
 * **[Scenario Perturbation Manifest](./scenario_perturbation_manifest.md)** - `scenario_perturbation_manifest.v1` schema, no-op and bounded route-offset preflight, and evidence boundary for perturbation pilots
 * **[Issue #1272 Safety-Oriented Validation And Falsification Strategy](./context/issue_1272_validation_falsification_strategy.md)** - Current roadmap note for positioning Robot SF as validation/falsification infrastructure without certification or proof-of-safety claims
 * **[Benchmark: Camera-ready / Scenario Reports](./benchmark_camera_ready.md)** - Camera-ready campaign workflow, planner report partitions, and publication-grade artifact contract
+* **[Benchmark Suite Catalog](./benchmark_suites/README.md)** - Named suite IDs, canonical commands, runtimes, eligible planners, and claim boundaries for smoke, nominal, stress, AMV, LiDAR, and adversarial surfaces
 * **[Issue #1073 Robot SF Empirical-Expansion Gate](./context/issue_1073_empirical_expansion_gate_2026_06_08.md)** - June 8 checkpoint rule for deciding whether Robot SF can move beyond dissertation-floor examples into bounded empirical expansion
 * **[Benchmark Static Dashboard](./benchmark_static_dashboard.md)** - Self-contained static HTML dashboard generation from camera-ready benchmark bundles
 * **[Static Leaderboards](./leaderboards/README.md)** - Markdown leaderboard row contract and first evidence-bound smoke, nominal-sanity, AMV, and LiDAR result surfaces

--- a/docs/benchmark_suites/README.md
+++ b/docs/benchmark_suites/README.md
@@ -1,0 +1,52 @@
+# Benchmark Suite Catalog
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1863>
+
+This catalog names the smallest useful Robot SF benchmark and diagnostic suites. It is a
+navigation layer over existing configs, runners, evidence notes, and policies; it does not promote
+any suite to paper-grade evidence.
+
+## Evidence Boundary
+
+Use these policies with every suite in this catalog:
+
+- [Benchmark fallback policy](../context/issue_691_benchmark_fallback_policy.md): fallback,
+  degraded, failed, skipped, or unavailable rows are caveats or exclusions, not successful
+  benchmark outcomes.
+- [Artifact evidence vocabulary](../context/artifact_evidence_vocabulary.md): durable claims need
+  tracked compact evidence, release artifacts, or explicit external artifact pointers.
+- [Benchmark camera-ready workflow](../benchmark_camera_ready.md): publication-grade campaign
+  claims require the camera-ready artifact contract, not only a local smoke run.
+- [Static leaderboards](../leaderboards/README.md): leaderboard rows must keep `status`,
+  `benchmark_track`, `evidence_uri`, and `claim_boundary` visible.
+
+## Suites
+
+| Suite | Purpose | Status |
+| --- | --- | --- |
+| [Smoke](smoke.md) | Cheapest policy-search candidate sanity run. | runnable local diagnostic |
+| [Nominal Sanity](nominal_sanity.md) | First multi-scenario policy-search gate. | runnable local diagnostic |
+| [Stress Slice](stress_slice.md) | Harder local stress stage for policy-search candidates. | runnable local diagnostic |
+| [AMV Actuation Diagnostic](amv_actuation_diagnostic.md) | Synthetic AMV actuation stress diagnostic. | runnable local diagnostic, not paper-facing |
+| [LiDAR 2D Track](lidar_2d_track.md) | LiDAR observation-track smoke and compatibility surface. | contract/training-smoke surface |
+| [Adversarial Smoke](adversarial_smoke.md) | Bounded adversarial route/search smoke. | development stress evidence |
+
+## Suite Field Contract
+
+Each suite page records:
+
+- `suite_id`
+- purpose
+- scenario IDs or scenario config
+- seed set
+- eligible planners
+- `benchmark_track`
+- metrics
+- expected runtime
+- canonical command
+- claim boundary
+- fallback/degraded caveats
+
+Keep future additions config-first and repository-relative. If a command writes raw output under
+`output/`, treat that output as local and non-durable until a compact tracked evidence bundle or
+explicit artifact pointer is created.

--- a/docs/benchmark_suites/adversarial_smoke.md
+++ b/docs/benchmark_suites/adversarial_smoke.md
@@ -1,0 +1,79 @@
+# Adversarial Smoke Suite
+
+```yaml
+suite_id: adversarial_smoke
+benchmark_track: development_stress_test
+status: runnable_with_surface_specific_limits
+```
+
+## Purpose
+
+Run bounded adversarial route/search probes that produce explicit candidate status, failure, and
+invalid-candidate accounting. This suite is for development stress and falsification-oriented
+triage, not nominal benchmark aggregation.
+
+## Scenarios And Seeds
+
+Two current anchors exist:
+
+- Route/start-state generation prototype:
+  - Config: `configs/adversarial_routes/default.yaml`
+  - Source scenario file: `configs/scenarios/classic_interactions.yaml`
+  - Scenario ID: `classic_head_on_corridor_low`
+  - Seed: `123`
+  - Trial count: `20`
+- Crossing/TTC smoke evidence:
+  - Search space: `configs/adversarial/crossing_ttc_space.yaml`
+  - Launcher: `SLURM/Auxme/adversarial_smoke_1501.sl`
+  - Seed: `42`
+  - Budget: `32` candidates per sampler
+  - Samplers: `random`, `optuna`
+
+## Eligible Planners
+
+The route-generation prototype uses `ClassicGlobalPlanner` / `theta_star_v2` for route feasibility.
+The crossing/TTC smoke mapped the frozen `classic_global_theta_star` row to the current `goal`
+benchmark policy and ran `orca` directly; guided route search was recorded as `not_available`.
+
+## Metrics
+
+Valid trials, failed trials, invalid candidates, simulation errors, not-available rows, objective
+score, objective components, valid non-failure count, valid failure count, archived failure count,
+cluster count, sampler comparison, and row-status summary.
+
+## Canonical Commands
+
+Route/start-state generation prototype:
+
+```bash
+uv run python scripts/tools/generate_adversarial_routes.py \
+  --config configs/adversarial_routes/default.yaml
+```
+
+Crossing/TTC SLURM smoke launcher:
+
+```bash
+ADVERSARIAL_SMOKE_LABEL=manual-crossing-ttc \
+ADVERSARIAL_SMOKE_BUDGET=32 \
+ADVERSARIAL_SMOKE_SEED=42 \
+scripts/dev/sbatch_use_max_time.sh --time 04:00:00 --partition a30 --qos a30-gpu \
+  SLURM/Auxme/adversarial_smoke_1501.sl
+```
+
+## Expected Runtime
+
+The route/start-state prototype is a local smoke. The crossing/TTC smoke is a SLURM/Auxme run; the
+recorded Issue #1501 job completed in about two minutes after scheduling, but queue time and
+partition availability vary.
+
+## Claim Boundary
+
+Adversarial smoke is development stress evidence. It does not certify a scenario, prove planner
+robustness, or create paper-facing benchmark rows. Generated cases need explicit promotion review
+before entering durable scenario configs or aggregate benchmarks.
+
+## Caveats
+
+Invalid candidates, simulation errors, not-available rows, fallback rows, and degraded rows do not
+count as success evidence. High invalid-candidate counts are generator-quality signals, not
+successful stress evidence.

--- a/docs/benchmark_suites/amv_actuation_diagnostic.md
+++ b/docs/benchmark_suites/amv_actuation_diagnostic.md
@@ -1,0 +1,83 @@
+# AMV Actuation Diagnostic Suite
+
+```yaml
+suite_id: amv_actuation_diagnostic
+benchmark_track: synthetic_amv_actuation_diagnostic
+status: runnable_local_diagnostic
+```
+
+## Purpose
+
+Run synthetic actuation-envelope diagnostics for AMV-style command stress. This suite is designed
+to reveal command clipping, yaw saturation, braking peaks, projection rates, and row-status
+caveats; it is not calibrated hardware evidence.
+
+## Scenarios And Seeds
+
+Two related local surfaces exist:
+
+- Policy-search smoke stage:
+  - Stage config: `configs/policy_search/funnel.yaml`
+  - Scenario matrix: `configs/scenarios/sets/classic_cross_trap_subset.yaml`
+  - Scenario filter: `classic_cross_trap_high`
+  - Seed: `111`
+  - Horizon: `80`
+- Camera-ready-style diagnostic config:
+  - Config: `configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml`
+  - Scenario candidates: `classic_overtaking_medium`, `classic_bottleneck_high`,
+    `classic_cross_trap_high`, `francis2023_blind_corner`,
+    `francis2023_intersection_wait`
+  - Seed policy: eval seed set from `configs/benchmarks/seed_sets_v1.yaml`
+  - Horizon: `100`
+
+## Eligible Planners
+
+For the compact Issue #1569 smoke evidence: `goal`, `orca`, and `social_force`. For policy-search
+experiments: only candidates whose config intentionally declares an AMV actuation diagnostic
+hypothesis and can preserve fail-closed row status.
+
+## Metrics
+
+Success, collision, near misses, command clip fraction, yaw-rate saturation fraction, signed braking
+peak, projection rate, infeasible rate, runtime, AMV coverage status, row-status summary, and SNQI
+when produced by the camera-ready analyzer.
+
+## Canonical Commands
+
+Policy-search candidate diagnostic:
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate <candidate_id> \
+  --stage amv_actuation_smoke \
+  --output-dir output/policy_search/<candidate_id>/amv_actuation_smoke/manual \
+  --workers 1
+```
+
+Camera-ready-style diagnostic:
+
+```bash
+uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/issue_1556_amv_actuation_stress_slice_v0.yaml \
+  --label manual-amv-diagnostic \
+  --output-root output/benchmarks/manual_amv_actuation \
+  --log-level WARNING
+```
+
+## Expected Runtime
+
+The policy-search smoke is expected to be quick. The camera-ready-style diagnostic is broader and
+should be treated as a local benchmark run whose runtime depends on planner availability and
+analysis settings.
+
+## Claim Boundary
+
+Synthetic AMV actuation diagnostics are non-paper-facing unless a separate claim-map decision
+promotes a specific evidence bundle. The tracked Issue #1569 evidence explicitly says it does not
+strengthen AMV performance claims.
+
+## Caveats
+
+AMV coverage warnings, command-space gaps, projection-heavy rows, excluded rows, fallback rows, and
+unavailable rows remain visible limitations. Do not reinterpret diagnostic rows as calibrated
+hardware evidence.

--- a/docs/benchmark_suites/lidar_2d_track.md
+++ b/docs/benchmark_suites/lidar_2d_track.md
@@ -1,0 +1,69 @@
+# LiDAR 2D Track
+
+```yaml
+suite_id: lidar_2d_track
+benchmark_track: lidar_2d_v1
+status: contract_and_training_smoke_surface
+```
+
+## Purpose
+
+Document the current LiDAR observation-track smoke and compatibility surface. The first useful
+checks prove observation metadata, adapter compatibility, and small learned-policy training
+plumbing; they do not prove benchmark performance.
+
+## Scenarios And Seeds
+
+- Observation-track smoke config: `configs/benchmarks/lidar/observation_track_smoke_issue_1613.yaml`
+- Scenario matrix: `configs/scenarios/sanity_v1.yaml`
+- Seed policy: fixed seed `1613`
+- Observation level: `lidar_2d`
+- Runtime inputs: robot state, goal, and LiDAR rays
+- Compatibility audit: `configs/benchmarks/lidar/planner_compatibility_issue_1614.yaml`
+- Training smoke config: `configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml`
+
+## Eligible Planners
+
+The compatibility audit classifies planners. Current first-track learned-policy work centers on
+`ppo_lidar_mlp_gate_v1`; other planners must not enter benchmark rows until their LiDAR adapter
+contracts and observation metadata pass.
+
+## Metrics
+
+Observation-level metadata, observation mode, runtime input keys, fallback policy, training smoke
+completion, wall-clock time, training environment steps/sec, evaluation success/collision/SNQI, and
+checkpoint artifact status.
+
+## Canonical Commands
+
+Contract tests:
+
+```bash
+uv run pytest -q tests/benchmark/test_lidar_observation_track.py \
+  tests/benchmark/test_lidar_planner_compatibility.py
+```
+
+Training smoke:
+
+```bash
+DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
+  uv run python scripts/training/train_ppo.py \
+  --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml \
+  --log-level INFO \
+  --log-file output/training/lidar_learned_policy/issue_1662/ppo_lidar_mlp_gate_v1_smoke.log
+```
+
+## Expected Runtime
+
+Contract tests should be quick. The Issue #1662 training smoke recorded about one minute of wall
+clock time on its local run, but runtime depends on hardware and worker setup.
+
+## Claim Boundary
+
+This track currently supports contract and training-smoke evidence only. A benchmark row needs a
+durable checkpoint or adapter evidence bundle plus fail-closed result handling.
+
+## Caveats
+
+Do not treat a LiDAR training smoke as benchmark readiness. Output checkpoints under `output/` are
+ignored local artifacts unless promoted to a durable store and represented by a tracked manifest.

--- a/docs/benchmark_suites/nominal_sanity.md
+++ b/docs/benchmark_suites/nominal_sanity.md
@@ -1,0 +1,64 @@
+# Nominal-Sanity Suite
+
+```yaml
+suite_id: policy_search_nominal_sanity
+benchmark_track: policy_search_nominal_sanity
+status: runnable_local_diagnostic
+```
+
+## Purpose
+
+Run a candidate over a small nominal policy-search matrix before any broader stress or full-matrix
+campaign. This stage is the first useful signal for common route-following, crossing, doorway, and
+following-human behavior.
+
+## Scenarios And Seeds
+
+- Scenario matrix: `configs/policy_search/nominal_sanity_matrix.yaml`
+- Seed manifest: `configs/policy_search/nominal_sanity_seeds.yaml`
+- Scenario IDs:
+  - `planner_sanity_simple`
+  - `classic_head_on_corridor_low`
+  - `classic_crossing_low`
+  - `classic_doorway_low`
+  - `classic_overtaking_low`
+  - `francis2023_following_human`
+- Seeds: `111`, `112`, `113` for each scenario
+- Horizon: `120`
+- Workers: `2`
+
+## Eligible Planners
+
+Policy-search candidates with successful smoke evidence and a valid candidate registry entry.
+Candidates with missing artifacts or adapter prerequisites should fail closed before this stage.
+
+## Metrics
+
+Success rate, collision rate, near-miss rate, low-progress timeouts via termination/failure
+taxonomy, scenario exclusions, scenario-family split, mean minimum distance, and mean speed.
+
+## Canonical Command
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate <candidate_id> \
+  --stage nominal_sanity \
+  --output-dir output/policy_search/<candidate_id>/nominal_sanity/manual \
+  --workers 2
+```
+
+## Expected Runtime
+
+Typically minutes for lightweight candidates. Treat runtime as candidate-dependent; learned-model
+hydration, simulator startup, and planner-specific rollouts can dominate.
+
+## Claim Boundary
+
+Nominal sanity is triage and promotion-gate evidence for policy search. It is not a paper-grade
+benchmark and does not by itself prove generalization or safety.
+
+## Caveats
+
+The configured gate in `configs/policy_search/funnel.yaml` is useful for local screening, but any
+planner promotion or paper-facing claim needs durable evidence and the appropriate benchmark
+contract. Fallback/degraded rows remain caveats.

--- a/docs/benchmark_suites/smoke.md
+++ b/docs/benchmark_suites/smoke.md
@@ -1,0 +1,57 @@
+# Smoke Suite
+
+```yaml
+suite_id: policy_search_smoke
+benchmark_track: policy_search_smoke
+status: runnable_local_diagnostic
+```
+
+## Purpose
+
+Run one policy-search candidate on the smallest planner sanity scenario. This is the first check
+that a candidate config loads, produces commands, and writes policy-search diagnostics.
+
+## Scenarios And Seeds
+
+- Scenario config: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Scenario ID: `planner_sanity_simple`
+- Seed set: fixed seed `111` from `configs/policy_search/funnel.yaml`
+- Horizon: `80`
+- Workers: `1`
+
+## Eligible Planners
+
+Any candidate in `docs/context/policy_search/candidate_registry.yaml` with a concrete
+`candidate_config_path` and no missing local prerequisites. Learned or external candidates must
+still satisfy their adapter/checkpoint availability contracts.
+
+## Metrics
+
+Success rate, collision rate, near-miss rate, termination reason counts, scenario exclusions,
+scenario-family metrics, mean minimum distance when recorded, and mean speed.
+
+## Canonical Command
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate <candidate_id> \
+  --stage smoke \
+  --output-dir output/policy_search/<candidate_id>/smoke/manual \
+  --workers 1
+```
+
+## Expected Runtime
+
+Usually under a few minutes on a warmed local checkout for lightweight classical candidates.
+Learned checkpoints may take longer if artifact hydration is required.
+
+## Claim Boundary
+
+Smoke success is runnable-wiring evidence only. It is not benchmark-strength ranking evidence,
+planner promotion, safety evidence, or paper-facing evidence.
+
+## Caveats
+
+Fallback, degraded, missing-checkpoint, unavailable, or failed rows must be reported as caveats or
+exclusions. Do not count fallback-only execution as a successful smoke unless the suite is explicitly
+measuring fallback behavior.

--- a/docs/benchmark_suites/stress_slice.md
+++ b/docs/benchmark_suites/stress_slice.md
@@ -1,0 +1,65 @@
+# Stress-Slice Suite
+
+```yaml
+suite_id: policy_search_stress_slice
+benchmark_track: policy_search_stress_slice
+status: runnable_local_diagnostic
+```
+
+## Purpose
+
+Exercise a candidate on harder bottleneck, doorway, group-crossing, intersection, and Francis-style
+stress cases after smoke and nominal-sanity checks.
+
+## Scenarios And Seeds
+
+- Scenario matrix: `configs/policy_search/stress_slice_matrix.yaml`
+- Seed manifest: `configs/policy_search/stress_slice_seeds.yaml`
+- Scenario IDs:
+  - `classic_bottleneck_medium`
+  - `classic_doorway_medium`
+  - `classic_group_crossing_medium`
+  - `classic_t_intersection_medium`
+  - `francis2023_blind_corner`
+  - `francis2023_intersection_wait`
+  - `francis2023_parallel_traffic`
+  - `francis2023_crowd_navigation`
+- Seeds: `111`, `112`, `113` for each scenario
+- Horizon: `120`
+- Workers: `2`
+
+## Eligible Planners
+
+Policy-search candidates that have at least smoke evidence and a clear reason to test hard cases.
+Expensive or artifact-bound planners should document the artifact availability path before running.
+
+## Metrics
+
+Success rate, collision rate, near-miss rate, low-progress timeouts, scenario-family split,
+scenario exclusions, mean minimum distance, mean speed, and failure taxonomy.
+
+## Canonical Command
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate <candidate_id> \
+  --stage stress_slice \
+  --output-dir output/policy_search/<candidate_id>/stress_slice/manual \
+  --workers 2
+```
+
+## Expected Runtime
+
+Usually longer than nominal sanity and highly candidate-dependent. Use local workers conservatively;
+route-heavy planners and learned checkpoints may require more time.
+
+## Claim Boundary
+
+Stress-slice results are development evidence for hard-case behavior. They do not certify scenario
+coverage and should not be merged into nominal benchmark aggregates without an explicit benchmark
+contract.
+
+## Caveats
+
+Treat fallback/degraded rows as limitations. A stress failure can be valuable diagnostic evidence,
+but it is not a benchmark promotion signal without durable artifacts and clear row status.


### PR DESCRIPTION
## Summary
Adds a benchmark suite catalog with named pages for smoke, nominal sanity, stress slice, AMV actuation diagnostic, LiDAR 2D, and adversarial smoke surfaces.

## Linked Issues
- Closes `#1863`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: docs-only catalog over existing scripts/configs/evidence policies.

## What Changed
- Added `docs/benchmark_suites/README.md` with suite catalog boundaries and field contract.
- Added suite pages for `smoke`, `nominal_sanity`, `stress_slice`, `amv_actuation_diagnostic`, `lidar_2d_track`, and `adversarial_smoke`.
- Linked the catalog from `docs/README.md`.

## Why It Matters
- Added value: users can find the right first benchmark or diagnostic command without context-note archaeology.
- Expected impact: suites now have stable IDs, canonical commands, runtime expectations, eligible-planner boundaries, and claim boundaries.
- Why this is worth merging now: it gives the external-usability docs spine a compact benchmark entry point without changing benchmark semantics.

## Validation / Proof
- Commands run:
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - explicit Python local Markdown link check across `docs/benchmark_suites/*.md` and `docs/README.md`
  - explicit Python existence check for all referenced configs, scripts, tests, and launcher paths
  - `uv run python scripts/validation/run_policy_search_candidate.py --help`
  - `uv run python scripts/tools/run_camera_ready_benchmark.py --help`
  - `uv run python scripts/tools/generate_adversarial_routes.py --help`
  - `bash -n SLURM/Auxme/adversarial_smoke_1501.sl`
- Evidence that the change works here: docs proof passed for 8 changed files; 339 local Markdown links checked; all referenced command/config paths exist; runner help and launcher syntax checks passed.
- Benchmarks or smoke tests, if applicable: not run; this is docs-only and intentionally avoids launching benchmark campaigns.

## Risks / Rollout
- Compatibility risks: low; Markdown-only docs.
- Failure modes: command docs can drift if suite configs or runners move.
- Rollback or fallback plan: remove or mark a suite page deferred if a future automated catalog replaces it.

## Docs / Provenance
- Updated docs: `docs/benchmark_suites/*.md`, `docs/README.md`.
- Relevant design or provenance notes: suite pages link fallback/artifact/static leaderboard policies and use repository-relative command paths.
- Any assumptions that need to be preserved: smoke, stress, AMV, LiDAR, and adversarial rows are diagnostic/development surfaces unless a separate durable benchmark claim promotes them.

## Downstream Propagation
- Parent issue updated: yes, closes #1863 through this PR.
- Claim map / benchmark report updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA; discoverability is via docs README.
- Follow-up issue opened for deferred propagation: none.
- Not-applicable rationale: no benchmark result, schema, config, or claim-map semantics changed.

## Follow-Up Issues
- Deferred work: automate catalog generation only after suite metadata stabilizes further.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that canonical commands remain conservative and that no suite page implies paper-grade evidence.
- Known limitation: expected runtimes are qualitative except where existing evidence already records a runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive benchmark suite catalog with six new documentation pages covering Smoke, Nominal Sanity, Stress Slice, Adversarial Smoke, AMV Actuation Diagnostic, and LiDAR 2D Track test suites. Each includes metadata, execution commands, eligible planner criteria, tracked metrics, runtime expectations, and evidence claim boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->