### PR TITLE
docs: add static docs site navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .github/cache/
 __pycache__/
 build
+docs/_build/
 file.log
 images
 logs

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,19 @@ Welcome to the Robot SF documentation! This directory contains comprehensive gui
 [`configs/benchmarks/route_clearance_certifications_v1.yaml`](../configs/benchmarks/route_clearance_certifications_v1.yaml);
 see [issue_1105_route_clearance_certification.md](./context/issue_1105_route_clearance_certification.md).
 
+## Static Docs Site
+
+This repository includes a lightweight Sphinx site over the existing Markdown docs. Build it from
+the repository root with:
+
+```bash
+uv run --group docs sphinx-build -b html docs docs/_build/html
+```
+
+Open `docs/_build/html/index.html` for the browsable navigation layer. The site is intentionally
+thin: existing Markdown files remain the source of truth, and generated HTML under
+`docs/_build/` is disposable local output.
+
 ## 🚀 Social Navigation Benchmark Platform (Complete)
 
 **The Social Navigation Benchmark Platform is now fully operational!**

--- a/docs/benchmark_suites.md
+++ b/docs/benchmark_suites.md
@@ -1,0 +1,40 @@
+# Benchmark Suites Map
+
+Robot SF has benchmark-suite documentation on this branch, but no separate generated suite catalog.
+This page is the docs-site navigation layer over the existing suite, campaign, leaderboard, and
+evidence surfaces.
+
+## Suite And Campaign Entry Points
+
+- [Benchmark Spec](benchmark_spec.md) defines the canonical classic-interactions and Francis 2023
+  scenario split, seed policy, baseline categories, and reproducible commands.
+- [Benchmark Runner And Metrics](benchmark.md) documents the benchmark runner, schema handling,
+  metrics, SNQI boundaries, and the local smoke benchmark demo.
+- [Camera-Ready Benchmark Workflow](benchmark_camera_ready.md) lists camera-ready, paper-matrix,
+  h500, cross-kinematics, SocNavBench, and sanity benchmark configs.
+- [Benchmark Release Protocol](benchmark_release_protocol.md) defines release-versioning and
+  publication expectations for paper-facing benchmark artifacts.
+- [Static Leaderboards](leaderboards/README.md) documents the Markdown leaderboard row contract and
+  current smoke, nominal-sanity, AMV, and LiDAR result surfaces.
+
+## Benchmark Boundaries
+
+- [Benchmark Fallback Policy](context/issue_691_benchmark_fallback_policy.md) is the fail-closed
+  rule for fallback, degraded, and unavailable rows.
+- [Planner Family Coverage](benchmark_planner_family_coverage.md) tracks planner-family coverage
+  boundaries.
+- [Experimental Planner Guardrails](benchmark_experimental_planners.md) explains when exploratory
+  planners are diagnostics rather than benchmark evidence.
+- [Evidence Bundles](context/evidence/README.md) describes what belongs in tracked evidence and
+  what must remain in disposable `output/` or an external artifact store.
+
+## Config Roots
+
+The source configs remain outside the Sphinx source tree and are linked from the docs above:
+
+- `configs/scenarios/classic_interactions_francis2023.yaml`
+- `configs/scenarios/classic_interactions.yaml`
+- `configs/scenarios/francis2023.yaml`
+- `configs/benchmarks/camera_ready_all_planners.yaml`
+- `configs/benchmarks/paper_experiment_matrix_v1.yaml`
+- `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,58 @@
+"""Sphinx configuration for the lightweight Robot SF documentation site."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+project = "Robot SF"
+author = "Robot SF contributors"
+copyright = "2026, Robot SF contributors"
+
+extensions = [
+    "myst_parser",
+]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+master_doc = "index"
+
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+]
+suppress_warnings = [
+    # The first site pass intentionally exposes a curated nav over a much larger Markdown corpus.
+    "toc.not_included",
+    # Existing repo-relative links often point outside docs/ or to GitHub-flavored anchors.
+    "myst.xref_missing",
+    # Some historical notes start below H1 or end on Markdown transitions.
+    "myst.header",
+    "docutils",
+    # Historical docs include mermaid/jsonc fences and illustrative JSON with ellipses.
+    "misc.highlighting_failure",
+]
+
+html_theme = "sphinx_rtd_theme"
+html_title = "Robot SF Documentation"
+html_short_title = "Robot SF"
+html_show_sourcelink = True
+
+myst_heading_anchors = 3
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "substitution",
+]
+myst_substitutions = {
+    "repo_root": str(ROOT),
+}
+
+linkcheck_anchors = False
+linkcheck_ignore = [
+    r"https://github\.com/.*",
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,88 @@
+Robot SF Documentation
+======================
+
+This is a lightweight Sphinx navigation layer over the existing Robot SF Markdown docs. It keeps the
+repository docs as the source of truth and provides a local browsable site for quick orientation,
+planner and scenario discovery, benchmark surfaces, evidence policy, agent workflow, and developer
+references.
+
+.. toctree::
+   :caption: Overview
+   :maxdepth: 1
+
+   Docs Index <README>
+   Repository Overview <ai/repo_overview>
+   Maintainer Values <maintainer_values>
+
+.. toctree::
+   :caption: Quickstart
+   :maxdepth: 1
+
+   Quickstart Map <quickstart>
+   Development Guide <dev_guide>
+   Runtime Requirements <dev_runtime_requirements>
+
+.. toctree::
+   :caption: Scenario Zoo
+   :maxdepth: 1
+
+   Scenario Zoo Index <scenario_zoo/index>
+   Scenario Contracts <scenario_contracts>
+   Scenario Certification <scenario_certification>
+   Scenario Perturbation Manifest <scenario_perturbation_manifest>
+
+.. toctree::
+   :caption: Planner Zoo
+   :maxdepth: 1
+
+   Planner Zoo Index <planner_zoo/index>
+   Planner Contribution Guide <contributing_planner>
+   Policy Search Portfolio <context/policy_search/portfolio_overview_2026-05-05>
+   Candidate Registry Summary <context/policy_search/candidate_registry_summary>
+
+.. toctree::
+   :caption: Benchmark Suites
+   :maxdepth: 1
+
+   Benchmark Suites Map <benchmark_suites>
+   Benchmark Runner And Metrics <benchmark>
+   Benchmark Spec <benchmark_spec>
+   Camera-Ready Benchmark Workflow <benchmark_camera_ready>
+   Static Leaderboards <leaderboards/README>
+
+.. toctree::
+   :caption: Learned Policy Integration
+   :maxdepth: 1
+
+   Learned Policy Registry <context/policy_search/learned_policy_registry>
+   Learned Policy Eligibility <context/policy_search/contracts/learned_local_policy_eligibility>
+   External Policy Intake <context/policy_search/contracts/external_policy_intake>
+   Policy Cards <policy_cards/README>
+
+.. toctree::
+   :caption: Evidence And Artifacts
+   :maxdepth: 1
+
+   Evidence Bundles <context/evidence/README>
+   Artifact Publication <benchmark_artifact_publication>
+   Model Registry Publication <model_registry_publication>
+   Benchmark Release Protocol <benchmark_release_protocol>
+
+.. toctree::
+   :caption: Agent Workflow
+   :maxdepth: 1
+
+   AI Coding Workflow <ai/ai-workflow>
+   Agent Index <AGENT_INDEX>
+   Context Notes Workflow <context/README>
+   Context Retrieval Index <context/INDEX>
+
+.. toctree::
+   :caption: Developer/API Reference
+   :maxdepth: 1
+
+   Developer Guide <dev_guide>
+   Environment API <ENVIRONMENT>
+   Observation Contract <dev/observation_contract>
+   Helper Catalog <dev/helper_catalog>
+   Code Review Guide <code_review>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart Map
+
+Use this page as the docs-site entry point for first-run and local development paths. The canonical
+guides remain in their existing Markdown locations.
+
+## First Local Checks
+
+- [Development Guide](dev_guide.md) covers setup, test commands, quality gates, and local workflow.
+- [Runtime Requirements](dev_runtime_requirements.md) lists non-`uv` host tools and optional Docker
+  support.
+- [Benchmark Runner And Metrics](benchmark.md) includes the local smoke benchmark demo:
+  `uv run python scripts/demo/run_robot_sf_smoke.py`.
+- The social-navigation benchmark quickstart lives outside the Sphinx source tree at
+  `specs/120-social-navigation-benchmark-plan/quickstart.md`.
+
+## Discovery Paths
+
+- [Scenario Zoo](scenario_zoo/index.md) summarizes maintained and emerging scenario families.
+- [Planner Zoo](planner_zoo/index.md) summarizes runnable, diagnostic, learned-policy, and blocked
+  planner rows.
+- [Benchmark Suites Map](benchmark_suites.md) points to the benchmark suite and campaign surfaces.
+- [Evidence Bundles](context/evidence/README.md) explains which generated artifacts are durable
+  enough to preserve in git.
+
+## Agent And Contributor Orientation
+
+- [AI Coding Workflow](ai/ai-workflow.md) describes the issue-to-PR workflow used by agents.
+- [Agent Index](AGENT_INDEX.md) collects agent-facing training, benchmarking, observation, and
+  artifact entry points.
+- [Maintainer Values](maintainer_values.md) is the compact source of truth for validation depth and
+  research-progress priorities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ gpu = [
     "torch[cuda]>=2.5.1",
 ]
 docs = [
+    "myst-parser>=4.0.0",
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",
 ]
@@ -481,6 +482,7 @@ dev = [
     "pytest-xdist>=3.6.1",
 ]
 docs = [
+    "myst-parser>=4.0.0",
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=2.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2444,14 +2444,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -2611,6 +2611,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -2940,6 +2952,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
 ]
 
 [[package]]
@@ -4876,6 +4906,7 @@ dev = [
     { name = "mypy" },
 ]
 docs = [
+    { name = "myst-parser" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
     { name = "sphinx-rtd-theme" },
@@ -4910,6 +4941,7 @@ dev = [
     { name = "pytest-xdist" },
 ]
 docs = [
+    { name = "myst-parser" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-robot-sf-rllib' and extra == 'group-8-robot-sf-imitation')" },
     { name = "sphinx-rtd-theme" },
@@ -4933,6 +4965,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.9.2" },
     { name = "moviepy", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.0" },
     { name = "networkx", specifier = ">=2.8,<3.0" },
     { name = "numba", specifier = ">=0.60.0" },
     { name = "numpy", specifier = ">=1.26.4" },
@@ -4987,6 +5020,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.6.1" },
 ]
 docs = [
+    { name = "myst-parser", specifier = ">=4.0.0" },
     { name = "sphinx", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
Closes #1892.

## Summary
- add a thin Sphinx/MyST docs-site layer over the existing Markdown docs
- add top-level navigation for overview, quickstart, scenario zoo, planner zoo, benchmark suites, learned-policy integration, evidence/artifacts, agent workflow, and developer/API references
- document the local build command and ignore disposable `docs/_build/` output

## Validation
- `uv lock`
- `uv run --group docs sphinx-build -q -b html docs docs/_build/html`
- focused rendered-page proof for `docs/_build/html/index.html`, `quickstart.html`, and `benchmark_suites.html`
- `uv run ruff check docs/conf.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Notes
- This is a navigation layer over existing docs, not a full historical docs warning cleanup.
- The build suppresses known warning classes from the existing Markdown corpus; the focused proof covers the new top-level navigation surface.
- Ignored local outputs from validation: `.venv/` and `docs/_build/html/`.
