### PR TITLE
feat: add draft scenario authoring tools

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -38,6 +38,31 @@ metadata:
       force_q95: null
 ```
 
+## Draft authoring workflow
+
+For a small reviewable starting point, generate a draft YAML from the v1 authoring template and
+validate it before handing the file to training or benchmark commands:
+
+```bash
+uv run python scripts/tools/create_scenario.py \
+  --template bottleneck \
+  --name draft_bottleneck_review \
+  --output configs/scenarios/single/draft_bottleneck_review.yaml
+
+uv run python scripts/tools/validate_scenario.py \
+  configs/scenarios/single/draft_bottleneck_review.yaml
+```
+
+The generator currently supports the conservative `bottleneck` template. It writes deterministic
+YAML with a `map_id`, `simulation_config`, empty `robot_config`, `metadata.authoring`, and explicit
+`seeds`. The validator is intentionally stricter than the general scenario loader for authored
+drafts: it requires a scenario name, exactly one map reference, required config/metadata sections,
+non-empty integer seeds, and then reuses the repository scenario loader plus map/config builder to
+catch map and config errors.
+
+Passing this authoring validator only means the draft is structurally reviewable and loadable. It is
+not scenario certification, benchmark promotion, or benchmark evidence.
+
 ## Scenario Contracts
 
 Versioned scenario-intent contracts live under `contracts/`. `scenario_contract.v1` captures

--- a/docs/scenario_zoo/index.md
+++ b/docs/scenario_zoo/index.md
@@ -15,6 +15,25 @@ For the evidence boundary, keep these surfaces separate:
 - Fallback and degraded execution policy:
   [Issue #691 Benchmark Fallback Policy](../context/issue_691_benchmark_fallback_policy.md).
 
+## Draft Authoring
+
+Use the v1 authoring tools when a contributor needs a small, deterministic YAML skeleton instead of
+copying a large existing scenario by hand:
+
+```bash
+uv run python scripts/tools/create_scenario.py \
+  --template bottleneck \
+  --name draft_bottleneck_review \
+  --output configs/scenarios/single/draft_bottleneck_review.yaml
+
+uv run python scripts/tools/validate_scenario.py \
+  configs/scenarios/single/draft_bottleneck_review.yaml
+```
+
+The authoring validator checks required draft fields, map references, and seed metadata, then reuses
+the maintained scenario loader and map/config builder. A passing draft is reviewable and loadable,
+but it is not certified and is not benchmark evidence.
+
 ## Families
 
 | Family | Scenario ids / examples | Maps and configs | Agents / actors | Difficulty | Known failure modes | Recommended seed / source | Example command or links |

--- a/scripts/tools/create_scenario.py
+++ b/scripts/tools/create_scenario.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Create deterministic draft scenario YAML from safe authoring templates."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.tools.scenario_authoring import (
+    add_common_seed_argument,
+    available_templates,
+    build_scenario_payload,
+    configure_authoring_tool_logging,
+    parse_seed_args,
+    validate_scenario_file,
+    write_scenario_yaml,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the scenario creation CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--template",
+        choices=available_templates(),
+        default="bottleneck",
+        help="Draft scenario template to materialize.",
+    )
+    parser.add_argument("--name", required=True, help="Stable scenario name to write.")
+    parser.add_argument("--output", type=Path, required=True, help="YAML file to create.")
+    parser.add_argument(
+        "--source-issue",
+        default="#1891",
+        help="Issue or provenance label to store in metadata.authoring.source_issue.",
+    )
+    add_common_seed_argument(parser)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace the output path if it already exists.",
+    )
+    parser.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="Write the draft without running the local authoring validator.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show loader and map-parser logs during validation.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the draft scenario generator."""
+
+    args = _build_parser().parse_args(argv)
+    configure_authoring_tool_logging(verbose=args.verbose)
+    payload = build_scenario_payload(
+        template=args.template,
+        name=args.name,
+        seeds=parse_seed_args(args.seeds),
+        source_issue=args.source_issue,
+    )
+    write_scenario_yaml(args.output, payload, overwrite=args.overwrite)
+    if args.skip_validation:
+        print(f"Wrote draft scenario: {args.output}")
+        return 0
+
+    report = validate_scenario_file(args.output)
+    if report.ok:
+        print(f"Wrote and validated {report.scenario_count} draft scenario(s): {args.output}")
+        return 0
+
+    print(f"Wrote draft scenario but validation found {len(report.issues)} issue(s): {args.output}")
+    for issue in report.issues:
+        print(f"- {issue.format()}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/scenario_authoring.py
+++ b/scripts/tools/scenario_authoring.py
@@ -1,0 +1,542 @@
+"""Small v1 helpers for draft scenario authoring and validation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from loguru import logger
+
+if TYPE_CHECKING:
+    import argparse
+    from pathlib import Path
+
+AUTHORING_SCHEMA_VERSION = "robot_sf.scenario_authoring.v1"
+SCENARIO_MATRIX_SCHEMA_VERSION = "robot_sf.scenario_matrix.v1"
+DEFAULT_SOURCE_ISSUE = "#1891"
+DEFAULT_SEEDS = (101, 102, 103)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationIssue:
+    """Actionable validation issue for an authored scenario YAML file."""
+
+    path: str
+    message: str
+    hint: str
+
+    def format(self) -> str:
+        """Return a stable, human-readable validation message."""
+
+        return f"{self.path}: {self.message} Hint: {self.hint}"
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationReport:
+    """Validation result for a scenario authoring YAML file."""
+
+    scenario_path: Path
+    scenario_count: int
+    issues: tuple[ValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Whether the authored scenario file passed v1 checks."""
+
+        return not self.issues
+
+
+def available_templates() -> tuple[str, ...]:
+    """Return supported deterministic draft template names."""
+
+    return ("bottleneck",)
+
+
+def configure_authoring_tool_logging(*, verbose: bool = False) -> None:
+    """Keep authoring CLI output focused unless loader details are requested."""
+
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if verbose else "ERROR")
+
+
+def build_scenario_payload(
+    *,
+    template: str,
+    name: str,
+    seeds: tuple[int, ...] = DEFAULT_SEEDS,
+    source_issue: str = DEFAULT_SOURCE_ISSUE,
+) -> dict[str, Any]:
+    """Build a deterministic, reviewable scenario YAML payload.
+
+    The generated payload is intentionally marked as draft and not benchmark
+    evidence. It is a starting point for review and later certification.
+    """
+
+    normalized_template = template.strip().lower()
+    if normalized_template != "bottleneck":
+        raise ValueError(
+            f"Unknown scenario template '{template}'. "
+            f"Available templates: {', '.join(available_templates())}."
+        )
+    scenario_name = _validate_output_name(name)
+    seed_values = _validate_seed_tuple(seeds)
+    return {
+        "schema_version": SCENARIO_MATRIX_SCHEMA_VERSION,
+        "authoring_schema_version": AUTHORING_SCHEMA_VERSION,
+        "scenarios": [
+            {
+                "name": scenario_name,
+                "map_id": "classic_bottleneck",
+                "simulation_config": {
+                    "max_episode_steps": 300,
+                    "ped_density": 0.0,
+                },
+                "robot_config": {},
+                "metadata": {
+                    "archetype": "bottleneck",
+                    "density": "draft_low",
+                    "flow": "bi",
+                    "purpose": "Draft bottleneck scenario for review and local smoke validation.",
+                    "authoring": {
+                        "status": "draft",
+                        "template": "bottleneck",
+                        "template_version": AUTHORING_SCHEMA_VERSION,
+                        "source_issue": source_issue,
+                        "generated_by": "scripts/tools/create_scenario.py",
+                        "benchmark_evidence": False,
+                        "promotion_note": (
+                            "Not benchmark evidence until separately reviewed, certified, "
+                            "and executed through the benchmark workflow."
+                        ),
+                    },
+                },
+                "seeds": list(seed_values),
+            },
+        ],
+    }
+
+
+def dump_scenario_yaml(payload: dict[str, Any]) -> str:
+    """Serialize a scenario payload with stable key order and block lists."""
+
+    return yaml.dump(
+        payload,
+        sort_keys=False,
+        width=100,
+        allow_unicode=False,
+        Dumper=_IndentedSafeDumper,
+    )
+
+
+def write_scenario_yaml(path: Path, payload: dict[str, Any], *, overwrite: bool = False) -> None:
+    """Write a scenario payload, refusing accidental overwrites by default."""
+
+    if path.exists() and not overwrite:
+        raise FileExistsError(
+            f"{path} already exists; pass --overwrite to replace it intentionally."
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_scenario_yaml(payload), encoding="utf-8")
+
+
+def validate_scenario_file(
+    path: Path, *, require_authoring_metadata: bool = True
+) -> ValidationReport:
+    """Validate a draft scenario YAML file for authoring-time mistakes."""
+
+    from robot_sf.training.scenario_loader import (
+        build_robot_config_from_scenario,
+        load_scenarios,
+    )
+
+    issues: list[ValidationIssue] = []
+    raw = _load_raw_yaml(path, issues)
+    raw_scenarios = _extract_raw_scenarios(raw, path=path, issues=issues)
+    for index, scenario in enumerate(raw_scenarios):
+        _validate_raw_scenario(
+            scenario,
+            index=index,
+            issues=issues,
+            require_authoring_metadata=require_authoring_metadata,
+        )
+
+    normalized_scenarios: list[dict[str, Any]] = []
+    if not issues:
+        try:
+            normalized_scenarios = [dict(item) for item in load_scenarios(path)]
+        except Exception as exc:
+            issues.append(
+                ValidationIssue(
+                    path="$",
+                    message=f"scenario loader rejected the file: {exc}",
+                    hint="Fix the YAML shape, includes, map_id, map_file, or map_search_paths.",
+                )
+            )
+
+    for index, scenario in enumerate(normalized_scenarios):
+        scenario_name = str(scenario.get("name") or scenario.get("scenario_id") or index)
+        try:
+            config = build_robot_config_from_scenario(scenario, scenario_path=path)
+        except Exception as exc:
+            issues.append(
+                ValidationIssue(
+                    path=f"/scenarios/{index}",
+                    message=f"scenario '{scenario_name}' could not build a robot config: {exc}",
+                    hint="Check map references, route overrides, robot_config, and simulation_config.",
+                )
+            )
+            continue
+        if not getattr(config, "map_pool", None) or not config.map_pool.map_defs:
+            issues.append(
+                ValidationIssue(
+                    path=f"/scenarios/{index}/map_file",
+                    message=f"scenario '{scenario_name}' resolved no map definitions",
+                    hint="Use a valid map_id from maps/registry.yaml or an existing map_file path.",
+                )
+            )
+
+    return ValidationReport(
+        scenario_path=path,
+        scenario_count=len(raw_scenarios),
+        issues=tuple(issues),
+    )
+
+
+def parse_seed_args(raw_seeds: list[str] | None) -> tuple[int, ...]:
+    """Parse repeated or comma-separated seed CLI values."""
+
+    if not raw_seeds:
+        return DEFAULT_SEEDS
+    parsed: list[int] = []
+    for raw in raw_seeds:
+        for item in raw.split(","):
+            value = item.strip()
+            if not value:
+                continue
+            parsed.append(_parse_seed(value))
+    return _validate_seed_tuple(tuple(parsed))
+
+
+def add_common_seed_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the shared seed argument used by authoring CLIs."""
+
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        help="Draft seed list, either space-separated or comma-separated. Defaults to 101 102 103.",
+    )
+
+
+class _IndentedSafeDumper(yaml.SafeDumper):
+    """PyYAML dumper that keeps nested sequences easy to review."""
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+        """Indent nested lists under their mapping key."""
+
+        return super().increase_indent(flow, False)
+
+
+def _validate_output_name(name: str) -> str:
+    """Validate a scenario name supplied to the generator."""
+
+    normalized = name.strip()
+    if not normalized:
+        raise ValueError("Scenario name must be non-empty.")
+    return normalized
+
+
+def _parse_seed(raw: str) -> int:
+    """Parse one CLI seed, rejecting booleans and floats."""
+
+    try:
+        return int(raw, 10)
+    except ValueError as exc:
+        raise ValueError(f"Seed '{raw}' must be an integer.") from exc
+
+
+def _validate_seed_tuple(seeds: tuple[int, ...]) -> tuple[int, ...]:
+    """Validate deterministic seed metadata for generated scenarios."""
+
+    if not seeds:
+        raise ValueError("At least one seed is required.")
+    for seed in seeds:
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError("Seeds must contain integers.")
+        if seed < 0:
+            raise ValueError("Seeds must be non-negative integers.")
+    return seeds
+
+
+def _load_raw_yaml(path: Path, issues: list[ValidationIssue]) -> Any:
+    """Load YAML while converting parser errors into validation issues."""
+
+    if not path.exists():
+        issues.append(
+            ValidationIssue(
+                path="$",
+                message=f"scenario file does not exist: {path}",
+                hint="Pass a path to a generated or hand-authored scenario YAML file.",
+            )
+        )
+        return None
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        issues.append(
+            ValidationIssue(
+                path="$",
+                message=f"invalid YAML: {exc}",
+                hint="Fix the YAML syntax before running scenario validation again.",
+            )
+        )
+        return None
+
+
+def _extract_raw_scenarios(
+    raw: Any,
+    *,
+    path: Path,
+    issues: list[ValidationIssue],
+) -> list[Any]:
+    """Extract raw scenario entries for strict authoring validation."""
+
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        scenarios = raw.get("scenarios")
+        if isinstance(scenarios, list):
+            if not scenarios:
+                issues.append(
+                    ValidationIssue(
+                        path="/scenarios",
+                        message=f"{path} must contain a non-empty scenarios list",
+                        hint="Generate a skeleton with scripts/tools/create_scenario.py.",
+                    )
+                )
+            return scenarios
+        issues.append(
+            ValidationIssue(
+                path="/scenarios",
+                message=f"{path} must contain a non-empty scenarios list",
+                hint="Generate a skeleton with scripts/tools/create_scenario.py or add scenarios: [...].",
+            )
+        )
+        return []
+    issues.append(
+        ValidationIssue(
+            path="$",
+            message=f"{path} must contain a mapping with scenarios or a scenario list",
+            hint="Use the robot_sf.scenario_matrix.v1 YAML shape.",
+        )
+    )
+    return []
+
+
+def _validate_raw_scenario(
+    scenario: Any,
+    *,
+    index: int,
+    issues: list[ValidationIssue],
+    require_authoring_metadata: bool,
+) -> None:
+    """Validate one raw scenario before invoking heavier repository loaders."""
+
+    prefix = f"/scenarios/{index}"
+    if not isinstance(scenario, dict):
+        issues.append(
+            ValidationIssue(
+                path=prefix,
+                message="scenario entry must be a mapping",
+                hint="Use key/value YAML fields such as name, map_id, simulation_config, metadata, seeds.",
+            )
+        )
+        return
+
+    _require_non_empty_string(scenario, "name", path=prefix, issues=issues)
+    _validate_map_reference(scenario, path=prefix, issues=issues)
+    _require_mapping(scenario, "simulation_config", path=prefix, issues=issues)
+    _require_mapping(scenario, "robot_config", path=prefix, issues=issues)
+    _validate_metadata(
+        scenario.get("metadata"),
+        path=f"{prefix}/metadata",
+        issues=issues,
+        require_authoring_metadata=require_authoring_metadata,
+    )
+    _validate_seeds(scenario.get("seeds"), path=f"{prefix}/seeds", issues=issues)
+
+
+def _require_non_empty_string(
+    mapping: dict[str, Any],
+    key: str,
+    *,
+    path: str,
+    issues: list[ValidationIssue],
+) -> None:
+    """Require a non-empty string field."""
+
+    value = mapping.get(key)
+    if isinstance(value, str) and value.strip():
+        return
+    issues.append(
+        ValidationIssue(
+            path=f"{path}/{key}",
+            message=f"{key} is required and must be a non-empty string",
+            hint=f"Add {key}: <stable_identifier>.",
+        )
+    )
+
+
+def _require_mapping(
+    mapping: dict[str, Any],
+    key: str,
+    *,
+    path: str,
+    issues: list[ValidationIssue],
+) -> None:
+    """Require a mapping field, accepting an intentionally empty mapping."""
+
+    if isinstance(mapping.get(key), dict):
+        return
+    issues.append(
+        ValidationIssue(
+            path=f"{path}/{key}",
+            message=f"{key} is required and must be a mapping",
+            hint=f"Add {key}: {{}} or the specific override fields for this scenario.",
+        )
+    )
+
+
+def _validate_map_reference(
+    scenario: dict[str, Any],
+    *,
+    path: str,
+    issues: list[ValidationIssue],
+) -> None:
+    """Require exactly one non-empty map reference field."""
+
+    map_id = scenario.get("map_id")
+    map_file = scenario.get("map_file")
+    has_map_id = isinstance(map_id, str) and bool(map_id.strip())
+    has_map_file = isinstance(map_file, str) and bool(map_file.strip())
+    if has_map_id ^ has_map_file:
+        return
+    if has_map_id and has_map_file:
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message="scenario must set only one of map_id or map_file",
+                hint="Prefer map_id for portable authored scenarios; remove the duplicate map reference.",
+            )
+        )
+        return
+    issues.append(
+        ValidationIssue(
+            path=path,
+            message="scenario must set map_id or map_file",
+            hint="Use map_id from maps/registry.yaml, for example classic_bottleneck.",
+        )
+    )
+
+
+def _validate_metadata(
+    metadata: Any,
+    *,
+    path: str,
+    issues: list[ValidationIssue],
+    require_authoring_metadata: bool,
+) -> None:
+    """Validate required draft metadata and benchmark-evidence caveats."""
+
+    if not isinstance(metadata, dict):
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message="metadata is required and must be a mapping",
+                hint="Include purpose plus metadata.authoring with draft status and benchmark_evidence: false.",
+            )
+        )
+        return
+    _metadata_string(metadata, "purpose", path=path, issues=issues)
+    if not require_authoring_metadata:
+        return
+    authoring = metadata.get("authoring")
+    if not isinstance(authoring, dict):
+        issues.append(
+            ValidationIssue(
+                path=f"{path}/authoring",
+                message="metadata.authoring is required for draft authoring validation",
+                hint="Generate a skeleton or add status, template, source_issue, and benchmark_evidence.",
+            )
+        )
+        return
+    _metadata_string(authoring, "status", path=f"{path}/authoring", issues=issues)
+    _metadata_string(authoring, "template", path=f"{path}/authoring", issues=issues)
+    _metadata_string(authoring, "source_issue", path=f"{path}/authoring", issues=issues)
+    if authoring.get("benchmark_evidence") is not False:
+        issues.append(
+            ValidationIssue(
+                path=f"{path}/authoring/benchmark_evidence",
+                message="benchmark_evidence must be false for generated draft scenarios",
+                hint="Do not mark authored drafts as benchmark evidence; use certification and benchmark runs.",
+            )
+        )
+
+
+def _metadata_string(
+    metadata: dict[str, Any],
+    key: str,
+    *,
+    path: str,
+    issues: list[ValidationIssue],
+) -> None:
+    """Require a non-empty metadata string."""
+
+    value = metadata.get(key)
+    if isinstance(value, str) and value.strip():
+        return
+    issues.append(
+        ValidationIssue(
+            path=f"{path}/{key}",
+            message=f"{key} is required and must be a non-empty string",
+            hint=f"Add {key}: <reviewable text>.",
+        )
+    )
+
+
+def _validate_seeds(raw_seeds: Any, *, path: str, issues: list[ValidationIssue]) -> None:
+    """Require deterministic non-empty integer seed metadata."""
+
+    if not isinstance(raw_seeds, list) or not raw_seeds:
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message="seeds is required and must be a non-empty list",
+                hint="Add deterministic seeds such as seeds: [101, 102, 103].",
+            )
+        )
+        return
+    invalid = [seed for seed in raw_seeds if isinstance(seed, bool) or not isinstance(seed, int)]
+    if invalid:
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message=f"seeds must contain integers; invalid entries: {invalid}",
+                hint="Use integer YAML values, not strings, floats, or booleans.",
+            )
+        )
+        return
+    negative = [seed for seed in raw_seeds if seed < 0]
+    if negative:
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message=f"seeds must be non-negative integers; invalid entries: {negative}",
+                hint="Use stable non-negative seed values.",
+            )
+        )

--- a/scripts/tools/validate_scenario.py
+++ b/scripts/tools/validate_scenario.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate draft scenario YAML before training or benchmark workflows consume it."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.tools.scenario_authoring import (
+    configure_authoring_tool_logging,
+    validate_scenario_file,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the scenario validation CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario_config", type=Path, help="Scenario YAML file to validate.")
+    parser.add_argument(
+        "--allow-legacy-metadata",
+        action="store_true",
+        help="Do not require metadata.authoring; useful for checking older maintained configs.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show loader and map-parser logs during validation.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scenario authoring validation and print actionable errors."""
+
+    args = _build_parser().parse_args(argv)
+    configure_authoring_tool_logging(verbose=args.verbose)
+    report = validate_scenario_file(
+        args.scenario_config,
+        require_authoring_metadata=not args.allow_legacy_metadata,
+    )
+    if report.ok:
+        print(f"OK: validated {report.scenario_count} scenario(s) in {args.scenario_config}")
+        print("Status: draft validation only; not benchmark evidence.")
+        return 0
+
+    print(f"FAILED: found {len(report.issues)} issue(s) in {args.scenario_config}")
+    for issue in report.issues:
+        print(f"- {issue.format()}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_scenario_authoring.py
+++ b/tests/tools/test_scenario_authoring.py
@@ -1,0 +1,133 @@
+"""Tests for the v1 scenario authoring generator and validator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools import create_scenario, validate_scenario
+from scripts.tools.scenario_authoring import (
+    build_scenario_payload,
+    dump_scenario_yaml,
+    validate_scenario_file,
+    write_scenario_yaml,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_bottleneck_template_generation_is_deterministic_and_draft_only() -> None:
+    """The v1 generator should produce stable YAML without benchmark-evidence claims."""
+
+    payload = build_scenario_payload(
+        template="bottleneck",
+        name="draft_bottleneck_review",
+        seeds=(7, 8),
+        source_issue="#1891",
+    )
+
+    first = dump_scenario_yaml(payload)
+    second = dump_scenario_yaml(payload)
+    parsed = yaml.safe_load(first)
+
+    assert first == second
+    assert parsed["schema_version"] == "robot_sf.scenario_matrix.v1"
+    scenario = parsed["scenarios"][0]
+    assert scenario["name"] == "draft_bottleneck_review"
+    assert scenario["map_id"] == "classic_bottleneck"
+    assert scenario["seeds"] == [7, 8]
+    assert scenario["metadata"]["authoring"]["status"] == "draft"
+    assert scenario["metadata"]["authoring"]["benchmark_evidence"] is False
+
+
+def test_generated_bottleneck_template_validates_with_existing_loader(tmp_path: Path) -> None:
+    """Generated YAML should pass authoring checks and the repository scenario loader."""
+
+    scenario_path = tmp_path / "draft_bottleneck.yaml"
+    write_scenario_yaml(
+        scenario_path,
+        build_scenario_payload(template="bottleneck", name="draft_bottleneck_review"),
+    )
+
+    report = validate_scenario_file(scenario_path)
+
+    assert report.ok is True
+    assert report.scenario_count == 1
+    assert report.issues == ()
+
+
+def test_validator_reports_missing_required_fields_with_actionable_paths(tmp_path: Path) -> None:
+    """Authoring validation should catch malformed drafts before benchmark tools run."""
+
+    scenario_path = tmp_path / "broken.yaml"
+    scenario_path.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "broken_missing_seed_metadata",
+                        "map_id": "classic_bottleneck",
+                        "simulation_config": {"max_episode_steps": 100},
+                        "robot_config": {},
+                        "metadata": {"purpose": "Broken draft for validation test."},
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = validate_scenario_file(scenario_path)
+    messages = [issue.format() for issue in report.issues]
+
+    assert report.ok is False
+    assert any(
+        "/scenarios/0/seeds" in message and "deterministic seeds" in message for message in messages
+    )
+    assert any(
+        "/scenarios/0/metadata/authoring" in message and "metadata.authoring" in message
+        for message in messages
+    )
+
+
+def test_validator_reports_unknown_map_id_from_loader(tmp_path: Path) -> None:
+    """Map-id mistakes should surface as loader-backed, actionable validation errors."""
+
+    scenario_path = tmp_path / "missing_map.yaml"
+    payload = build_scenario_payload(template="bottleneck", name="missing_map_review")
+    payload["scenarios"][0]["map_id"] = "not_a_registered_map"
+    write_scenario_yaml(scenario_path, payload)
+
+    report = validate_scenario_file(scenario_path)
+
+    assert report.ok is False
+    assert len(report.issues) == 1
+    assert report.issues[0].path == "$"
+    assert "Unknown map_id 'not_a_registered_map'" in report.issues[0].message
+
+
+def test_create_and_validate_clis_return_success_for_generated_template(tmp_path: Path) -> None:
+    """The documented v1 CLI path should create and validate a draft YAML file."""
+
+    scenario_path = tmp_path / "cli_draft.yaml"
+
+    create_result = create_scenario.main(
+        [
+            "--template",
+            "bottleneck",
+            "--name",
+            "cli_draft_bottleneck",
+            "--seeds",
+            "11,12",
+            "--output",
+            str(scenario_path),
+        ]
+    )
+    validate_result = validate_scenario.main([str(scenario_path)])
+
+    assert create_result == 0
+    assert validate_result == 0
+    assert scenario_path.exists()


### PR DESCRIPTION
Closes #1891.

## Summary
- add a v1 deterministic draft scenario authoring path with a conservative `bottleneck` template
- add `create_scenario.py` and `validate_scenario.py` CLIs plus shared validation logic that checks draft fields, map references, seed metadata, and loader/config compatibility
- document the draft authoring workflow from `configs/scenarios/README.md` and the scenario zoo

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/tools/test_scenario_authoring.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/tools/scenario_authoring.py scripts/tools/create_scenario.py scripts/tools/validate_scenario.py tests/tools/test_scenario_authoring.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/tools/scenario_authoring.py scripts/tools/create_scenario.py scripts/tools/validate_scenario.py tests/tools/test_scenario_authoring.py`
- documented CLI smoke:
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/create_scenario.py --template bottleneck --name draft_bottleneck_review --output output/scenario_authoring/manual_review/draft_bottleneck_review.yaml`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/validate_scenario.py output/scenario_authoring/manual_review/draft_bottleneck_review.yaml`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Notes
- This v1 supports one safe `bottleneck` template; it is not a general scenario synthesis system.
- Passing validation means the draft is reviewable/loadable, not certified and not benchmark evidence.
- Ignored proof artifacts were generated under `.venv/`, `output/coverage/`, and `output/scenario_authoring/`.
