### PR TITLE
test: add trace export source fixture

### DIFF
--- a/tests/analysis_workbench/test_simulation_trace_export.py
+++ b/tests/analysis_workbench/test_simulation_trace_export.py
@@ -28,6 +28,14 @@ MATERIALIZED_FIXTURE_PATH = (
     / "simulation_trace_export_v1"
     / "planner_sanity_open_episode_0000.json"
 )
+SOURCE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "sources"
+    / "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl"
+)
 
 
 def test_load_minimal_simulation_trace_export_fixture() -> None:
@@ -108,14 +116,14 @@ def test_materialized_trace_fixture_has_source_provenance_and_event_ids() -> Non
 
     trace = load_simulation_trace_export(MATERIALIZED_FIXTURE_PATH)
 
-    assert trace.trace_id == "planner_sanity_open-ep0-seed7-source-f6b33f7c"
+    assert trace.trace_id == "planner_sanity_open-ep0-seed7-source-aae87cf6"
     assert trace.source.scenario_id == "planner_sanity_open"
     assert trace.source.planner_id == "trace_fixture_gen"
     assert trace.source.seed == 7
     assert (
         "scripts.tools.build_simulation_trace_export from "
         "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl "
-        "source_sha256:f6b33f7c4a67" in trace.source.generated_by
+        "source_sha256:aae87cf69fbf" in trace.source.generated_by
     )
     assert [frame.step for frame in trace.frames] == [1, 2, 3]
     assert [frame.planner["event"] for frame in trace.frames] == ["step", "step", "step"]
@@ -124,6 +132,17 @@ def test_materialized_trace_fixture_has_source_provenance_and_event_ids() -> Non
         "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0001",
         "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002",
     ]
+
+
+def test_materialized_trace_fixture_regenerates_from_tracked_source() -> None:
+    """The durable timeline fixture should be reproducible from a tracked source slice."""
+
+    assert SOURCE_FIXTURE_PATH.exists()
+
+    payload = build_simulation_trace_export(SOURCE_FIXTURE_PATH)
+    materialized = load_simulation_trace_export(MATERIALIZED_FIXTURE_PATH).to_dict()
+
+    assert payload == materialized
 
 
 def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json
@@ -78,12 +78,12 @@
   "schema_version": "simulation_trace_export.v1",
   "source": {
     "episode_id": "0",
-    "generated_by": "scripts.tools.build_simulation_trace_export from issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl source_sha256:f6b33f7c4a67",
+    "generated_by": "scripts.tools.build_simulation_trace_export from issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl source_sha256:aae87cf69fbf",
     "planner_id": "trace_fixture_gen",
     "scenario_id": "planner_sanity_open",
     "seed": 7
   },
-  "trace_id": "planner_sanity_open-ep0-seed7-source-f6b33f7c",
+  "trace_id": "planner_sanity_open-ep0-seed7-source-aae87cf6",
   "units": {
     "heading": "rad",
     "position": "m",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl
@@ -1,0 +1,3 @@
+{"event":"step","episode_id":0,"state":{"pedestrian_positions":[],"robot_pose":[[3.156921863555908,5.2030253410339355],0.04605550691485405],"timestep":1.0},"step_idx":1}
+{"event":"step","episode_id":0,"state":{"pedestrian_positions":[],"robot_pose":[[3.340054750442505,5.2176361083984375],0.1131734549999237],"timestep":2.0},"step_idx":2}
+{"event":"step","episode_id":0,"state":{"pedestrian_positions":[],"robot_pose":[[3.5387051105499268,5.240832328796387],0.11931054294109344],"timestep":3.0},"step_idx":3}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.meta.json
@@ -1,0 +1,10 @@
+{
+  "algorithm": "trace_fixture_gen",
+  "boundary": "analysis_workbench_only",
+  "episode_id": 0,
+  "issue": 1859,
+  "notes": "Compact three-frame source slice for regenerating the renderer-neutral timeline fixture. This is not a raw campaign dump or benchmark result.",
+  "scenario": "planner_sanity_open",
+  "seed": 7,
+  "source_kind": "tracked_compact_trace_fixture"
+}


### PR DESCRIPTION
## Summary
Adds a tiny tracked source slice for the analysis-workbench simulation trace fixture and proves the materialized renderer-neutral timeline regenerates exactly from that source.

## Linked Issues
- Closes `#1859`
- Relates to `#1646`
- Relates to `#1689`

## Stack / Dependency
- Base dependency: `origin/main` as of `7b998523`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Adds a compact three-frame `planner_sanity_open` JSONL source fixture plus metadata under `tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/`.
- Refreshes the materialized `simulation_trace_export.v1` fixture provenance to reference the tracked source SHA prefix.
- Adds a test that rebuilds the materialized timeline from the source slice and asserts exact payload equality.

## Why It Matters
- Added value: Gives analysis-workbench follow-ups a durable, reviewable timeline artifact with source provenance.
- Expected impact: Later annotation/report/viewer work can depend on a tiny renderer-neutral fixture instead of worktree-local `output/` files or raw dumps.
- Why this is worth merging now: It satisfies the first executable child slice for #1646 without broad UI work.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest -q tests/analysis_workbench`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/analysis_workbench/test_simulation_trace_export.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
- Evidence that the change works here: analysis-workbench tests report `14 passed`; the regeneration test asserts exact equality between the tracked source-derived payload and the materialized fixture.
- Benchmarks or smoke tests, if applicable: NA; this is analysis-workbench fixture evidence, not benchmark evidence.

## Risks / Rollout
- Compatibility risks: Low; the existing materialized fixture shape is preserved while provenance changes.
- Failure modes: If future schema changes alter derived fields, this exact-regeneration test will need a deliberate fixture update.
- Rollback or fallback plan: Revert the fixture-source files and regeneration assertion.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: source metadata explicitly marks `boundary: analysis_workbench_only`.
- Any assumptions that need to be preserved: This is not a raw campaign dump, video, output artifact, or benchmark result.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not-applicable rationale: This PR creates the durable fixture needed by later #1646 children; it makes no benchmark or paper-facing claim.

## Follow-Up Issues
- Deferred work: analysis-workbench UI/viewer/annotation children remain out of scope for #1859.
- Issues opened for follow-up: none

## Reviewer Notes
- Please verify the fixture stays compact and provenance-bound; it should not become a precedent for committing raw episode dumps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated simulation trace export test suite with improved fixture data and added automated verification to ensure reproducible trace generation from source inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->