### PR TITLE
docs: add context pack manifests

### DIFF
--- a/docs/ai/context_packing.md
+++ b/docs/ai/context_packing.md
@@ -58,22 +58,20 @@ Weaknesses:
 
 ## Recommended Usage In This Repository
 
-Start with a documented Repomix workflow for focused bundles such as:
+Start with the curated manifests in [docs/context_packs](../context_packs/README.md) for recurring
+bundles such as:
 
-- benchmark core (`robot_sf/benchmark`, `configs/benchmarks`, key docs),
-- planner integration (`robot_sf/nav`, planner docs, planner quality audit docs),
-- training/eval context (`scripts/training`, `configs/training`, relevant runbooks).
+- learned-policy integration,
+- policy search,
+- benchmark evidence,
+- visualization workbench.
 
 Only add automation around this after a few manual bundle workflows prove useful.
 
-Use [docs/context/INDEX.md](../context/INDEX.md) as the maintained manifest source for recurring
-packs. It currently defines scoped starting points for:
-
-- `learned_policy_integration`,
-- `benchmark_campaign_evidence`,
-- `slurm_artifact_rescue`,
-- `root_layout_cleanup`,
-- `adversarial_search`.
+Use [docs/context/INDEX.md](../context/INDEX.md) as the retrieval index and
+[docs/context_packs](../context_packs/README.md) as the maintained manifest source for recurring
+pack scopes. Promote additional ad hoc scopes to manifests before treating them as repeatable
+workflows.
 
 Generated bundles should live under ignored paths such as `output/context_packs/`. Do not commit
 packed repository dumps, raw benchmark output, checkpoints, videos, or local machine context unless
@@ -84,7 +82,7 @@ Example command shape:
 ```bash
 repomix \
   --include "AGENTS.md,docs/context/INDEX.md,docs/context/issue_691_benchmark_fallback_policy.md,docs/benchmark*.md,robot_sf/benchmark/**,configs/benchmarks/**,scripts/validation/**" \
-  --output output/context_packs/benchmark_campaign_evidence.txt
+  --output output/context_packs/benchmark_evidence.txt
 ```
 
 ## Source Note

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -69,18 +69,21 @@ or the normal diff wrapper.
 ## Context-Pack Manifests
 
 Generated packs are temporary artifacts and should stay under ignored paths such as
-`output/context_packs/`.
+`output/context_packs/`. Source-controlled pack definitions live in
+[../context_packs/](../context_packs/README.md).
 
 Use [../ai/context_packing.md](../ai/context_packing.md) for the Repomix decision and command
-patterns. Start with these curated pack scopes:
+patterns. Start with these curated manifests:
 
-| Pack | Include globs | Exclude notes |
+| Pack | Entry point | Use for |
 |---|---|---|
-| `learned_policy_integration` | `AGENTS.md`, `docs/context/INDEX.md`, `docs/context/policy_search/**`, `docs/context/issue_1618_learned_policy_adapter_interface.md`, `robot_sf/nav/**`, `configs/training/**`, `scripts/training/**` | Exclude checkpoints and raw run output. |
-| `benchmark_campaign_evidence` | `AGENTS.md`, `docs/code_review.md`, `docs/context/INDEX.md`, `docs/context/issue_691_benchmark_fallback_policy.md`, `docs/context/artifact_evidence_vocabulary.md`, `docs/benchmark*.md`, `robot_sf/benchmark/**`, `configs/benchmarks/**`, `scripts/validation/**` | Exclude raw episode JSONL, videos, and coverage HTML. |
-| `slurm_artifact_rescue` | `AGENTS.md`, `local.machine.md` when local-only use is safe, `docs/dev/slurm*.md`, `docs/context/slurm_issue_batch_status_2026-05-21.md`, `docs/context/open_issues_training_split_audit_2026-05-30.md`, `model/registry.md` | Do not publish machine-local secrets or raw Slurm logs. |
-| `root_layout_cleanup` | `AGENTS.md`, `docs/context/issue_1690_root_layout_inventory.md`, `docs/context/issue_1583_high_risk_root_boundaries.md`, `docs/context/issue_1598_1599_root_compatibility_decisions.md`, `.github/**`, `scripts/dev/**` | Keep generated inventories under `output/` unless promoted as compact evidence. |
-| `adversarial_search` | `AGENTS.md`, `.agents/skills/adversarial-search-campaign/**`, `docs/context/issue_1457_adversarial_generation_protocol.md`, `docs/context/issue_1500_adversarial_manifest.md`, `docs/context/issue_1571_adversarial_smoke_packet_sharpening.md`, `configs/**`, `scripts/**` | Exclude large campaign bundles unless replaced by tracked summaries. |
+| [`learned_policy_integration`](../context_packs/learned_policy_integration.yaml) | `docs/context/policy_search/learned_policy_registry.md` | Learned-policy eligibility, adapter contracts, policy cards, and durable model metadata. |
+| [`policy_search`](../context_packs/policy_search.yaml) | `docs/context/policy_search/INDEX.md` | Candidate lifecycle routing, stage-gated execution, promotion gates, and policy-search tooling. |
+| [`benchmark_evidence`](../context_packs/benchmark_evidence.yaml) | `docs/context/issue_691_benchmark_fallback_policy.md` | Benchmark fallback policy, review/evidence vocabulary, release surfaces, and compact proof boundaries. |
+| [`visualization_workbench`](../context_packs/visualization_workbench.yaml) | `docs/debug_visualization.md` | Diagnostic trace export, analysis-workbench schemas, and benchmark visualization boundaries. |
+
+If an older ad hoc pack scope is still useful, add it under `docs/context_packs/` before relying on
+it as a repeatable workflow.
 
 ## Optional Tool Boundary
 

--- a/docs/context_packs/README.md
+++ b/docs/context_packs/README.md
@@ -1,0 +1,30 @@
+# Context-Pack Manifests
+
+Issue: [#1871](https://github.com/ll7/robot_sf_ll7/issues/1871)
+
+This directory contains small, source-controlled manifests for recurring agent context packs. They
+describe what to include when building a focused Repomix or equivalent bundle; they are not generated
+bundles themselves.
+
+Generated pack outputs must stay under ignored paths such as `output/context_packs/`. Do not commit
+packed repository dumps, raw benchmark output, videos, checkpoints, or local machine context.
+
+## Manifests
+
+| Pack | Entry point | Use for |
+|---|---|---|
+| [learned_policy_integration.yaml](learned_policy_integration.yaml) | `docs/context/policy_search/learned_policy_registry.md` | Learned-policy eligibility, adapter contracts, policy-card boundaries, and durable model metadata. |
+| [policy_search.yaml](policy_search.yaml) | `docs/context/policy_search/INDEX.md` | Candidate lifecycle routing, stage-gated execution, promotion gates, and policy-search tooling. |
+| [benchmark_evidence.yaml](benchmark_evidence.yaml) | `docs/context/issue_691_benchmark_fallback_policy.md` | Benchmark fallback policy, review/evidence vocabulary, release surfaces, and compact proof boundaries. |
+| [visualization_workbench.yaml](visualization_workbench.yaml) | `docs/debug_visualization.md` | Diagnostic trace export, analysis-workbench schemas, and benchmark visualization boundaries. |
+
+Each manifest uses the same required fields:
+
+- `name`: stable pack slug.
+- `purpose`: short human-readable scope.
+- `entrypoint`: first file to read before expanding the pack.
+- `include`: files or globs that form the pack.
+- `exclude`: files or globs that must stay out of generated packs.
+- `do_not_read_by_default`: high-volume, generated, historical, or optional surfaces that require a
+  specific reason before reading.
+

--- a/docs/context_packs/benchmark_evidence.yaml
+++ b/docs/context_packs/benchmark_evidence.yaml
@@ -1,0 +1,43 @@
+name: benchmark_evidence
+purpose: >
+  Focused context for benchmark evidence policy, fallback/degraded classification, release surfaces,
+  and compact proof artifacts without raw episode logs or generated media.
+entrypoint: docs/context/issue_691_benchmark_fallback_policy.md
+include:
+  - AGENTS.md
+  - docs/context/INDEX.md
+  - docs/code_review.md
+  - docs/context/issue_691_benchmark_fallback_policy.md
+  - docs/context/artifact_evidence_vocabulary.md
+  - docs/context/issue_1436_reproducibility_flaky_acceptance.md
+  - docs/benchmark.md
+  - docs/benchmark_spec.md
+  - docs/benchmark_camera_ready.md
+  - docs/benchmark_release_protocol.md
+  - docs/benchmark_release_reproducibility.md
+  - docs/benchmark_artifact_publication.md
+  - docs/benchmark_suites/**
+  - docs/leaderboards/README.md
+  - robot_sf/benchmark/**
+  - configs/benchmarks/**
+  - scripts/tools/run_camera_ready_benchmark.py
+  - scripts/tools/run_benchmark_release.py
+  - scripts/tools/benchmark_publication_bundle.py
+  - scripts/repro/benchmark_bundle_smoke.sh
+  - scripts/validation/check_docs_proof_consistency.py
+exclude:
+  - output/**
+  - results/**
+  - docs/context/evidence/**/episodes*.jsonl
+  - docs/context/evidence/**/*.mp4
+  - docs/context/evidence/**/coverage_html/**
+  - docs/context/policy_search/reports/**
+  - wandb/**
+  - .venv/**
+do_not_read_by_default:
+  - docs/context/evidence/**
+  - docs/context/policy_search/reports/**
+  - tests/benchmark/**
+  - specs/**
+  - output/benchmarks/**
+

--- a/docs/context_packs/learned_policy_integration.yaml
+++ b/docs/context_packs/learned_policy_integration.yaml
@@ -1,0 +1,42 @@
+name: learned_policy_integration
+purpose: >
+  Focused context for learned local-policy eligibility, adapter integration, policy-card status,
+  and durable checkpoint metadata without pulling raw model artifacts or full training history.
+entrypoint: docs/context/policy_search/learned_policy_registry.md
+include:
+  - AGENTS.md
+  - docs/context/INDEX.md
+  - docs/context/policy_search/INDEX.md
+  - docs/context/policy_search/learned_policy_registry.md
+  - docs/context/policy_search/contracts/learned_local_policy_eligibility.md
+  - docs/context/policy_search/contracts/external_policy_intake.md
+  - docs/context/issue_1618_learned_policy_adapter_interface.md
+  - docs/context/issue_1685_dummy_learned_policy_adapter.md
+  - docs/context/issue_1720_learned_policy_roadmap.md
+  - docs/policy_cards/README.md
+  - docs/training/environment_contract.md
+  - docs/training/ppo_training_workflow.md
+  - model/registry.md
+  - model/registry.yaml
+  - robot_sf/models/**
+  - robot_sf/planner/learned_policy_adapter.py
+  - robot_sf/benchmark/learned_policy_transfer_metadata.py
+  - robot_sf/benchmark/schemas/learned-policy-transfer-metadata.schema.v1.json
+  - scripts/validation/check_learned_policy_eligibility.py
+exclude:
+  - output/**
+  - results/**
+  - model/**/*.zip
+  - model/**/*.pt
+  - model/**/*.pth
+  - model/**/*.ckpt
+  - model/**/*.onnx
+  - wandb/**
+  - .venv/**
+do_not_read_by_default:
+  - docs/context/policy_search/reports/**
+  - docs/context/policy_search/validation/**
+  - docs/context/policy_search/SLURM/**
+  - docs/training/**
+  - tests/**
+

--- a/docs/context_packs/policy_search.yaml
+++ b/docs/context_packs/policy_search.yaml
@@ -1,0 +1,44 @@
+name: policy_search
+purpose: >
+  Focused context for policy-search candidate routing, staged evaluation commands, promotion gates,
+  and candidate registry maintenance without loading every historical candidate report.
+entrypoint: docs/context/policy_search/INDEX.md
+include:
+  - AGENTS.md
+  - docs/context/INDEX.md
+  - docs/context/policy_search/INDEX.md
+  - docs/context/policy_search/README.md
+  - docs/context/policy_search/candidate_registry.yaml
+  - docs/context/policy_search/candidate_registry_summary.md
+  - docs/context/policy_search/contracts/agent_runbook.md
+  - docs/context/policy_search/contracts/failure_taxonomy.md
+  - docs/context/policy_search/contracts/promotion_gates.md
+  - docs/context/policy_search/portfolio_overview_2026-05-05.md
+  - docs/benchmark_suites/README.md
+  - docs/benchmark_suites/smoke.md
+  - docs/benchmark_suites/nominal_sanity.md
+  - docs/benchmark_suites/stress_slice.md
+  - configs/policy_search/**
+  - scripts/validation/run_policy_search_candidate.py
+  - scripts/validation/policy_search_common.py
+  - scripts/validation/validate_policy_search_registry.py
+  - scripts/dev/sbatch_policy_search_sweep.sh
+  - scripts/tools/summarize_policy_search_portfolio.py
+  - scripts/tools/promote_policy_search_candidate.py
+  - scripts/tools/compare_policy_search_candidates.py
+  - scripts/tools/build_policy_search_failure_report.py
+exclude:
+  - output/**
+  - results/**
+  - docs/context/policy_search/reports/**
+  - docs/context/policy_search/validation/**
+  - docs/context/policy_search/SLURM/**
+  - wandb/**
+  - .venv/**
+do_not_read_by_default:
+  - docs/context/policy_search/reports/**
+  - docs/context/policy_search/validation/**
+  - docs/context/policy_search/reasoning/**
+  - tests/benchmark/**
+  - output/policy_search/**
+

--- a/docs/context_packs/visualization_workbench.yaml
+++ b/docs/context_packs/visualization_workbench.yaml
@@ -1,0 +1,41 @@
+name: visualization_workbench
+purpose: >
+  Focused context for diagnostic trace export, analysis-workbench report rendering, benchmark
+  visualization manifests, and the boundary between debug visuals and benchmark evidence.
+entrypoint: docs/debug_visualization.md
+include:
+  - AGENTS.md
+  - docs/context/INDEX.md
+  - docs/debug_visualization.md
+  - docs/benchmark_visuals.md
+  - docs/benchmark_static_dashboard.md
+  - docs/context/issue_1151_manual_control_mvp_foundation.md
+  - docs/context/issue_1689_simulation_trace_export_schema.md
+  - robot_sf/analysis_workbench/**
+  - robot_sf/benchmark/full_classic/plots.py
+  - robot_sf/benchmark/full_classic/videos.py
+  - robot_sf/benchmark/full_classic/visuals.py
+  - robot_sf/benchmark/full_classic/validation.py
+  - robot_sf/benchmark/visualization.py
+  - scripts/tools/build_simulation_trace_export.py
+  - scripts/tools/render_trace_report.py
+  - scripts/tools/rerun_debug_export.py
+  - scripts/tools/generate_benchmark_dashboard.py
+  - tests/analysis_workbench/**
+  - tests/fixtures/analysis_workbench/**
+exclude:
+  - output/**
+  - results/**
+  - "**/*.mp4"
+  - "**/*.rrd"
+  - "**/*.pdf"
+  - "**/coverage_html/**"
+  - wandb/**
+  - .venv/**
+do_not_read_by_default:
+  - tests/visuals/**
+  - specs/127-enhance-benchmark-visual/**
+  - output/debug/**
+  - output/benchmarks/**
+  - docs/context/evidence/**
+


### PR DESCRIPTION
## Summary
Adds source-controlled context-pack manifests for recurring agent workflows and links them from the context-packing docs and context index.

## Linked Issues
- Closes `#1871`

## Stack / Dependency
- Base dependency: `origin/main` as of `7b998523`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Adds `docs/context_packs/` with four YAML manifests: learned-policy integration, policy search, benchmark evidence, and visualization workbench.
- Each manifest defines `name`, `purpose`, `entrypoint`, `include`, `exclude`, and `do_not_read_by_default`.
- Updates `docs/ai/context_packing.md` and `docs/context/INDEX.md` to point recurring pack users to these manifests.
- Keeps generated bundles explicitly under ignored `output/context_packs/`.

## Why It Matters
- Added value: Agents can start from bounded, reusable context scopes instead of broad context-note reads.
- Expected impact: Less duplicate context assembly and lower risk of dragging generated/raw artifacts into prompts or commits.
- Why this is worth merging now: It operationalizes the existing context-packing docs with a small docs-only surface.

## Validation / Proof
- Commands run:
  - YAML/manifest check confirming required keys and resolving entrypoints/include globs.
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/INDEX.md --path docs/ai/context_packing.md --path docs/context_packs/README.md`
  - `git diff --check`
- Evidence that the change works here: all four manifests validated; docs proof check passed; no generated `output/context_packs/` bundle was created.
- Benchmarks or smoke tests, if applicable: NA; docs-only manifest curation.

## Risks / Rollout
- Compatibility risks: Low; manifests are advisory source docs and do not change tooling behavior.
- Failure modes: Manifest drift if referenced files move without updating `docs/context_packs/`.
- Rollback or fallback plan: Revert the manifest directory and doc links; existing context index remains the fallback.

## Docs / Provenance
- Updated docs: `docs/context_packs/README.md`, `docs/ai/context_packing.md`, `docs/context/INDEX.md`.
- Relevant design or provenance notes: generated context packs remain ignored under `output/context_packs/`.
- Any assumptions that need to be preserved: `do_not_read_by_default` entries are intentionally not pack defaults.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): docs context index updated.
- Context index / memory note updated (yes/no/NA): yes.
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not-applicable rationale: No benchmark/schema/model claim changes.

## Follow-Up Issues
- Deferred work: Possible future manifests for SLURM rescue, root cleanup, and adversarial search.
- Issues opened for follow-up: none

## Reviewer Notes
- Please verify the manifests stay short and advisory rather than becoming another broad context dump.
