### PR TITLE
analysis: expand perturbation seed coverage

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -218,6 +218,8 @@ knowledge, not every transient iteration detail.
   [issue_1861_adversarial_replay_determinism_gate.md](issue_1861_adversarial_replay_determinism_gate.md)
 * Issue #1904 Scenario Perturbation Criticality Pilot (2026-05-31):
   [issue_1904_scenario_perturbation_criticality_pilot.md](issue_1904_scenario_perturbation_criticality_pilot.md)
+* Issue #1933 Perturbation Seed Coverage (2026-05-31):
+  [issue_1933_perturbation_seed_coverage.md](issue_1933_perturbation_seed_coverage.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
 * Issue #1633 RobotEnv SNQI proxy extraction:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -91,3 +91,5 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_1904_scenario_perturbation_pilot_2026-05-31/`: compact diagnostic-only paired
   no-op-versus-route-offset pilot summary for the first #1610 scenario perturbation criticality
   slice.
+- `issue_1933_perturbation_seed_coverage_2026-05-31/`: compact diagnostic-only seed-limit-4
+  paired no-op-versus-route-offset summary for the #1610 scenario perturbation criticality pilot.

--- a/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/README.md
+++ b/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/README.md
@@ -1,0 +1,13 @@
+# Issue #1933 Perturbation Seed-Coverage Evidence
+
+This bundle contains compact diagnostic evidence for issue #1933, the expanded-seed follow-up to
+the first #1610 scenario perturbation criticality pilot.
+
+- `summary.json`: reviewable seed-limit-4 paired no-op-versus-route-offset summary, with aggregate
+  deltas grouped by planner, source scenario, and perturbation family.
+- `SHA256SUMS`: checksum for the tracked summary.
+
+Raw episode JSONL, generated scenario matrices, route override files, and local runner summaries
+remain under ignored `output/` paths and are not mirrored here.
+
+Claim boundary: diagnostic local pilot only; not benchmark-strength or paper-facing evidence.

--- a/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/SHA256SUMS
+++ b/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/SHA256SUMS
@@ -1,0 +1,1 @@
+4d86e3de81c70f63aae584bb5e9b921834f7ac9a11bb27ae1c1c1f29eb48e393  docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json

--- a/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json
+++ b/docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json
@@ -1,0 +1,815 @@
+{
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 80,
+  "manifest": "configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [],
+    "included_variants": [
+      "classic_group_crossing_high_noop",
+      "classic_group_crossing_high_route_offset_x025",
+      "classic_head_on_corridor_low_noop",
+      "classic_head_on_corridor_low_route_offset_y025",
+      "francis2023_join_group_noop",
+      "francis2023_join_group_route_offset_x025"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1858_seed_sensitive_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 6
+  },
+  "pair_rows": [
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.005904823674986126,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.81814067199887,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.8122358483238838,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "goal",
+      "seed": 111,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0005392180203078745,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.1577979198433974,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.1583371378637053,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.016263523668517355,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.1655053423048587,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.181768865973376,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "goal",
+      "seed": 117,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0033433728518068584,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.3737888643178642,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 1.377132237169671,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "goal",
+      "seed": 119,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.021713990718757792,
+      "noop": {
+        "collision": 0,
+        "min_distance": 5.061020535696914,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 5.082734526415671,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "goal",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.000557703564545875,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.717274301619378,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 7.717832005183924,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -7.196379763918515e-05,
+      "noop": {
+        "collision": 1,
+        "min_distance": 7.653239894206032,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 7.653167930408393,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "goal",
+      "seed": 116,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.07110674939792894,
+      "noop": {
+        "collision": 0,
+        "min_distance": 4.093522415831196,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 4.164629165229125,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "goal",
+      "seed": 117,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0013309335961251278,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.488296144897157,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.007726294013136403,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.860499164278315,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.8527728702651785,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "goal",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.010253463936579443,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5542955250491202,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5645489889856996,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "goal",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.014492410844535453,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.1354041290479486,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.149896539892484,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "goal",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.004412621133507821,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5256092818038434,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5300219029373512,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "orca",
+      "seed": 111,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.015595208918059322,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5082689511439706,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.52386416006203,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.005007133364269611,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.751918317314495,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.7569254506787646,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "orca",
+      "seed": 117,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.14942324998977163,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5686344810856916,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_high_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.41921123109592,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_high_route_offset_x025",
+      "planner": "orca",
+      "seed": 119,
+      "source_scenario_id": "classic_group_crossing_high",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.003176856884758772,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.6702469202849204,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.6734237771696792,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "orca",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.00031026205209894187,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.438003009020353,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 7.4383132710724515,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 1,
+        "min_distance": 7.644056905954665,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 7.644056905954665,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "orca",
+      "seed": 116,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0019146783323962246,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.596850415524658,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.594935737192262,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_head_on_corridor_low_route_offset_y025",
+      "planner": "orca",
+      "seed": 117,
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 7.814638987357903e-05,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4492909863429455,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.449369132732819,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.00038332177099031917,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.439309677641443,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4389263558704526,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "orca",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0018904396798549161,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4397620085044152,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4378715688245602,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "orca",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.017795915649092997,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4741467753802409,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4919426910293339,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "robot_route_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_route_offset_x025",
+      "planner": "orca",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    }
+  ],
+  "pair_summary": {
+    "by_perturbation_family": {
+      "robot_route_offset": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.0006667030224891957,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 24,
+        "status_counts": {
+          "completed": 24
+        }
+      }
+    },
+    "by_planner": {
+      "goal": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.010269701493424396,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 12,
+        "status_counts": {
+          "completed": 12
+        }
+      },
+      "orca": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -0.008936295448446005,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 12,
+        "status_counts": {
+          "completed": 12
+        }
+      }
+    },
+    "by_source_scenario": {
+      "classic_group_crossing_high": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -0.013770874463536115,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 8,
+        "status_counts": {
+          "completed": 8
+        }
+      },
+      "classic_head_on_corridor_low": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.011859865061006863,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 8,
+        "status_counts": {
+          "completed": 8
+        }
+      },
+      "francis2023_join_group": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.003911118469996838,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 8,
+        "status_counts": {
+          "completed": 8
+        }
+      }
+    },
+    "mean_deltas_completed_pairs": {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0006667030224891957,
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    "pairs": 24,
+    "status_counts": {
+      "completed": 24
+    }
+  },
+  "planners": [
+    "goal",
+    "orca"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 4
+}

--- a/docs/context/issue_1904_scenario_perturbation_criticality_pilot.md
+++ b/docs/context/issue_1904_scenario_perturbation_criticality_pilot.md
@@ -64,3 +64,6 @@ pairing logic to compare only seeds observed for each no-op/perturbed source pai
 Continue #1610 only with a larger, still bounded pilot if the next question needs sensitivity
 power. The next slice should add either more seeds or a stronger local planner candidate before
 spending effort on broader criticality statistics.
+
+Successor: [issue_1933_perturbation_seed_coverage.md](issue_1933_perturbation_seed_coverage.md)
+expanded the same manifest and planner set to four seeds per variant.

--- a/docs/context/issue_1933_perturbation_seed_coverage.md
+++ b/docs/context/issue_1933_perturbation_seed_coverage.md
@@ -1,0 +1,74 @@
+# Issue #1933 Perturbation Seed Coverage
+
+Issue: [#1933](https://github.com/ll7/robot_sf_ll7/issues/1933)
+Parent: [#1610](https://github.com/ll7/robot_sf_ll7/issues/1610)
+Predecessor: [#1904](https://github.com/ll7/robot_sf_ll7/issues/1904)
+
+## Goal
+
+Expand the first #1610 paired perturbation pilot from one seed per variant to the full four-seed
+manifest slice while keeping the manifest, perturbation family, and cheap planner set fixed.
+
+This is diagnostic local evidence only. It is not benchmark-strength or paper-facing evidence.
+
+## Command
+
+```bash
+uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py \
+  configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbations/issue1933_seed4/materialized \
+  --pilot-output-dir output/scenario_perturbations/issue1933_seed4/pilot \
+  --seed-limit 4 \
+  --horizon 80 \
+  --workers 1 \
+  --evidence-summary docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json
+```
+
+## Result
+
+- Materialized variants: 6 included, 0 excluded.
+- Planners: `goal`, `orca`.
+- Pair rows: 24 completed pairs, 0 excluded pairs.
+- Mean deltas over completed pairs:
+  - success delta: `0.0000`
+  - collision delta: `0.0000`
+  - timeout delta: `0.0000`
+  - min-distance delta: `+0.0007 m`
+
+Grouped min-distance deltas:
+
+| Group | Pairs | Mean Min-Distance Delta |
+|---|---:|---:|
+| `goal` | 12 | `+0.0103 m` |
+| `orca` | 12 | `-0.0089 m` |
+| `classic_group_crossing_high` | 8 | `-0.0138 m` |
+| `classic_head_on_corridor_low` | 8 | `+0.0119 m` |
+| `francis2023_join_group` | 8 | `+0.0039 m` |
+| `robot_route_offset` | 24 | `+0.0007 m` |
+
+Interpretation: the route-offset perturbation family remains neutral for success, collision, and
+timeout across the four-seed local pilot for `goal` and `orca`. Clearance shifts are tiny and
+mixed by planner/scenario, so this evidence supports treating the current route-offset family as a
+low-criticality diagnostic slice, not as a discovered robustness failure.
+
+## Evidence Boundary
+
+Tracked compact evidence:
+
+- [summary.json](evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json)
+- [SHA256SUMS](evidence/issue_1933_perturbation_seed_coverage_2026-05-31/SHA256SUMS)
+
+Ignored local outputs:
+
+- materialized matrix and route overrides under `output/scenario_perturbations/issue1933_seed4/`
+- raw planner episode JSONL
+- local `summary.json` / `summary.md` generated beside the raw outputs
+
+Fallback, degraded, invalid, missing, and failed rows are classified separately by the pilot script
+and excluded from completed-pair means. This run had no such rows.
+
+## Routing
+
+The next #1610 child should change exactly one dimension: either add a stronger local planner
+candidate to this same route-offset slice, or add a second perturbation family while keeping the
+planner/seed budget fixed. Do not broaden both at once.

--- a/scripts/validation/run_scenario_perturbation_criticality_pilot.py
+++ b/scripts/validation/run_scenario_perturbation_criticality_pilot.py
@@ -244,12 +244,14 @@ def build_pair_table(
                     )
                     noop_values = _episode_values(noop_row)
                     perturbed_values = _episode_values(perturbed_row)
+                    perturbed_metadata = scenario_metadata.get(variant_id, {})
                     pair_rows.append(
                         {
                             "planner": planner,
                             "source_scenario_id": source_scenario_id,
                             "noop_variant_id": noop_id,
                             "perturbed_variant_id": variant_id,
+                            "perturbed_family": str(perturbed_metadata.get("family") or "unknown"),
                             "seed": seed,
                             "pair_status": pair_status,
                             "noop_status": noop_status,
@@ -273,8 +275,8 @@ def build_pair_table(
     return pair_rows
 
 
-def summarize_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate pair-table status counts and mean deltas."""
+def _summarize_pair_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate one pair-table subset."""
     status_counts: dict[str, int] = defaultdict(int)
     delta_values: dict[str, list[float]] = defaultdict(list)
     for row in pair_rows:
@@ -299,6 +301,34 @@ def summarize_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
             if values
         },
     }
+
+
+def _grouped_pair_summaries(
+    pair_rows: list[dict[str, Any]],
+    *,
+    field: str,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate pair rows by one categorical field."""
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in pair_rows:
+        key = str(row.get(field) or "unknown")
+        grouped[key].append(row)
+    return {key: _summarize_pair_subset(rows) for key, rows in sorted(grouped.items())}
+
+
+def summarize_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate pair-table status counts and mean deltas."""
+    summary = _summarize_pair_subset(pair_rows)
+    summary["by_planner"] = _grouped_pair_summaries(pair_rows, field="planner")
+    summary["by_source_scenario"] = _grouped_pair_summaries(
+        pair_rows,
+        field="source_scenario_id",
+    )
+    summary["by_perturbation_family"] = _grouped_pair_summaries(
+        pair_rows,
+        field="perturbed_family",
+    )
+    return summary
 
 
 def _write_markdown(summary: dict[str, Any], path: Path) -> None:

--- a/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
+++ b/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
@@ -63,6 +63,7 @@ def test_build_pair_table_computes_completed_pair_deltas() -> None:
     assert len(pairs) == 1
     pair = pairs[0]
     assert pair["pair_status"] == "completed"
+    assert pair["perturbed_family"] == "robot_route_offset"
     assert pair["success_delta"] == pytest.approx(-1.0)
     assert pair["timeout_delta"] == pytest.approx(1.0)
     assert pair["collision_delta"] == pytest.approx(0.0)
@@ -70,6 +71,14 @@ def test_build_pair_table_computes_completed_pair_deltas() -> None:
     assert summarize_pairs(pairs)["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(
         -1.0
     )
+    summary = summarize_pairs(pairs)
+    assert summary["by_planner"]["goal"]["mean_deltas_completed_pairs"][
+        "success_delta"
+    ] == pytest.approx(-1.0)
+    assert summary["by_source_scenario"]["demo"]["pairs"] == 1
+    assert summary["by_perturbation_family"]["robot_route_offset"]["status_counts"] == {
+        "completed": 1
+    }
 
 
 def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None:


### PR DESCRIPTION
## Summary
- Closes #1933.
- Adds grouped criticality summaries by planner, source scenario, and perturbation family to the #1610 perturbation pilot output.
- Runs the existing #1858 no-op vs route-offset pilot at `--seed-limit 4` for `goal` and `orca`, preserving only compact diagnostic evidence.
- Documents the result and links it from the context/evidence indexes.

## Result
- 6 materialized variants included, 0 excluded.
- 24 paired rows completed, 0 invalid/fallback/degraded/missing/failed rows.
- Mean completed-pair deltas: success `0.0`, collision `0.0`, timeout `0.0`, min-distance `+0.0006667030 m`.
- Interpretation: the current route-offset family remains neutral for success/collision/timeout across this four-seed local pilot; clearance shifts are tiny and mixed by planner/scenario, so this is diagnostic-only low-criticality evidence, not benchmark-strength or paper-facing evidence.

## Validation
- `uv run pytest -q tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py --no-cov` — 3 passed.
- `uv run pytest -q tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_preflight.py --no-cov` — 11 passed.
- `uv run ruff check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py` — passed.
- `uv run ruff format --check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py` — passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed.
- Pilot command: `uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml --materialized-output-dir output/scenario_perturbations/issue1933_seed4/materialized --pilot-output-dir output/scenario_perturbations/issue1933_seed4/pilot --seed-limit 4 --horizon 80 --workers 1 --evidence-summary docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/summary.json`.
- Final PR gate after merging latest `origin/main`: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 4791 passed, 11 skipped, 8 warnings; clean stamp at `f1a3174aa1f3591cdfee4358f8e702f7bde75d80`.

## Artifact Boundary
- Tracked: compact evidence bundle under `docs/context/evidence/issue_1933_perturbation_seed_coverage_2026-05-31/`.
- Ignored local outputs inspected: generated perturbation matrices/route overrides/raw JSONL under `output/scenario_perturbations/issue1933_seed4/` plus coverage outputs from readiness; none are committed.
