### PR TITLE
analysis: inspect corridor perturbation trace response

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -224,6 +224,8 @@ knowledge, not every transient iteration detail.
   [issue_1935_stronger_perturbation_planner.md](issue_1935_stronger_perturbation_planner.md)
 * Issue #1937 Pedestrian Route Offset Pilot (2026-05-31):
   [issue_1937_ped_route_offset.md](issue_1937_ped_route_offset.md)
+* Issue #1939 Corridor Trace Response (2026-05-31):
+  [issue_1939_corridor_trace_response.md](issue_1939_corridor_trace_response.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
 * Issue #1633 RobotEnv SNQI proxy extraction:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -99,3 +99,6 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_1937_ped_route_offset_2026-05-31/`: compact diagnostic-only seed-limit-4 paired
   no-op-versus-route-offset summary with the pedestrian-route-offset perturbation family added to
   the #1610 scenario perturbation criticality pilot.
+- `issue_1939_corridor_trace_response_2026-05-31/`: compact diagnostic-only closest-approach trace
+  slices for the `classic_head_on_corridor_low` pedestrian-route-offset response observed in the
+  #1610/#1937 pilot.

--- a/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/README.md
+++ b/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/README.md
@@ -1,0 +1,16 @@
+# Issue #1939 Corridor Trace-Response Evidence
+
+This bundle contains compact diagnostic evidence for issue #1939, the trace-level follow-up to the
+#1937 pedestrian-route-offset pilot under parent issue #1610.
+
+- `closest_approach_trace_slices.json`: closest-approach slices for
+  `classic_head_on_corridor_low` no-op versus `pedestrian_route_offset` pairs across `goal`,
+  `orca`, and `scenario_adaptive_hybrid_orca_v2_collision_guard`.
+- `report.md`: compact generated Markdown summary with aggregate and per-planner deltas.
+- `SHA256SUMS`: checksums for the tracked evidence files.
+
+Raw rerun outputs, generated scenario matrices, and route override files remain under ignored
+`output/` paths and are not mirrored here.
+
+Claim boundary: diagnostic local trace inspection only; not benchmark-strength or paper-facing
+evidence.

--- a/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/SHA256SUMS
+++ b/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/SHA256SUMS
@@ -1,0 +1,2 @@
+964f2a6f45bea05fb5147b637af0ed92bd62383a441a316ef8836020d4ae2774  closest_approach_trace_slices.json
+c8bf0a89e451442b74d3a8374f74af2eecdf3139bed1465e155ef0c7754aec3a  report.md

--- a/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/closest_approach_trace_slices.json
+++ b/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/closest_approach_trace_slices.json
@@ -1,0 +1,2569 @@
+{
+  "claim_boundary": "diagnostic local trace inspection only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 80,
+  "manifest": "configs/scenarios/perturbations/issue_1610_ped_route_offset_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [
+      "francis2023_join_group_ped_route_offset_x025"
+    ],
+    "included_variants": [
+      "classic_group_crossing_high_noop",
+      "classic_group_crossing_high_route_offset_x025",
+      "classic_group_crossing_high_ped_route_offset_x025",
+      "classic_head_on_corridor_low_noop",
+      "classic_head_on_corridor_low_route_offset_y025",
+      "classic_head_on_corridor_low_ped_route_offset_y025",
+      "francis2023_join_group_noop",
+      "francis2023_join_group_route_offset_x025"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix and route overrides remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1610_ped_route_offset_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 8
+  },
+  "pair_summary": {
+    "by_planner": {
+      "goal": {
+        "mean_closest_approach_deltas_completed_pairs": {
+          "center_distance_m": 0.159909,
+          "clearance_m": 0.159909,
+          "goal_distance_m": 0.024577,
+          "progress_m": -0.024578,
+          "time_s": 0.025
+        },
+        "pairs": 4,
+        "status_counts": {
+          "completed": 4
+        }
+      },
+      "orca": {
+        "mean_closest_approach_deltas_completed_pairs": {
+          "center_distance_m": 0.157236,
+          "clearance_m": 0.157236,
+          "goal_distance_m": 0.049732,
+          "progress_m": -0.049732,
+          "time_s": 0.025
+        },
+        "pairs": 4,
+        "status_counts": {
+          "completed": 4
+        }
+      },
+      "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+        "mean_closest_approach_deltas_completed_pairs": {
+          "center_distance_m": 0.143321,
+          "clearance_m": 0.143321,
+          "goal_distance_m": -1.593735,
+          "progress_m": 1.593735,
+          "time_s": -0.8
+        },
+        "pairs": 4,
+        "status_counts": {
+          "completed": 4
+        }
+      }
+    },
+    "mean_closest_approach_deltas_completed_pairs": {
+      "center_distance_m": 0.153489,
+      "clearance_m": 0.153489,
+      "goal_distance_m": -0.506475,
+      "progress_m": 0.506475,
+      "time_s": -0.25
+    },
+    "pairs": 12,
+    "status_counts": {
+      "completed": 12
+    }
+  },
+  "perturbed_family": "pedestrian_route_offset",
+  "planner_runs": {
+    "goal": {
+      "algo": "goal",
+      "algo_config_path": null,
+      "output_stem": "goal",
+      "source": "raw_algo"
+    },
+    "orca": {
+      "algo": "orca",
+      "algo_config_path": null,
+      "output_stem": "orca",
+      "source": "raw_algo"
+    },
+    "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+      "algo": "hybrid_rule_local_planner",
+      "algo_config_path": "configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml",
+      "output_stem": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "source": "policy_search_candidate"
+    }
+  },
+  "planners": [
+    "goal",
+    "orca",
+    "scenario_adaptive_hybrid_orca_v2_collision_guard"
+  ],
+  "schema_version": "scenario_perturbation_trace_response.v1",
+  "seed_limit": 4,
+  "slice_window": 2,
+  "source_scenario_id": "classic_head_on_corridor_low",
+  "trace_pairs": [
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.228334,
+        "clearance_m": 0.228334,
+        "goal_distance_m": 0.0,
+        "progress_m": 0.0,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 5.061021,
+            "clearance_m": 3.661021,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              17.232273,
+              16.360453
+            ]
+          },
+          "goal_distance_m": 3.585466,
+          "progress_m": 0.712829,
+          "robot_position": [
+            15.129238,
+            11.757065
+          ],
+          "step": 79,
+          "time_s": 8.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.353909,
+              "clearance_m": 3.953909,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.193179,
+                16.484435
+              ]
+            },
+            "goal_distance_m": 3.385731,
+            "progress_m": 0.912564,
+            "robot_position": [
+              15.089751,
+              11.561029
+            ],
+            "step": 77,
+            "time_s": 7.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.207074,
+              "clearance_m": 3.807074,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.212737,
+                16.422447
+              ]
+            },
+            "goal_distance_m": 3.485594,
+            "progress_m": 0.812701,
+            "robot_position": [
+              15.109492,
+              11.659047
+            ],
+            "step": 78,
+            "time_s": 7.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.061021,
+              "clearance_m": 3.661021,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.232273,
+                16.360453
+              ]
+            },
+            "goal_distance_m": 3.585466,
+            "progress_m": 0.712829,
+            "robot_position": [
+              15.129238,
+              11.757065
+            ],
+            "step": 79,
+            "time_s": 8.0
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 5.289355,
+            "clearance_m": 3.889355,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              17.232217,
+              16.61039
+            ]
+          },
+          "goal_distance_m": 3.585466,
+          "progress_m": 0.712829,
+          "robot_position": [
+            15.129238,
+            11.757065
+          ],
+          "step": 79,
+          "time_s": 8.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.58459,
+              "clearance_m": 4.18459,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.193121,
+                16.734372
+              ]
+            },
+            "goal_distance_m": 3.385731,
+            "progress_m": 0.912564,
+            "robot_position": [
+              15.089751,
+              11.561029
+            ],
+            "step": 77,
+            "time_s": 7.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.436631,
+              "clearance_m": 4.036631,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.21268,
+                16.672384
+              ]
+            },
+            "goal_distance_m": 3.485594,
+            "progress_m": 0.812701,
+            "robot_position": [
+              15.109492,
+              11.659047
+            ],
+            "step": 78,
+            "time_s": 7.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 5.289355,
+              "clearance_m": 3.889355,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.232217,
+                16.61039
+              ]
+            },
+            "goal_distance_m": 3.585466,
+            "progress_m": 0.712829,
+            "robot_position": [
+              15.129238,
+              11.757065
+            ],
+            "step": 79,
+            "time_s": 8.0
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "goal",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.183227,
+        "clearance_m": 0.183227,
+        "goal_distance_m": 0.0,
+        "progress_m": 0.0,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.717274,
+            "clearance_m": 6.317274,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.195237,
+              9.644436
+            ]
+          },
+          "goal_distance_m": 4.253992,
+          "progress_m": 0.336771,
+          "robot_position": [
+            13.888123,
+            4.041682
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.94826,
+              "clearance_m": 6.54826,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173443,
+                9.756513
+              ]
+            },
+            "goal_distance_m": 4.446868,
+            "progress_m": 0.143895,
+            "robot_position": [
+              13.853567,
+              3.851112
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.832416,
+              "clearance_m": 6.432416,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184224,
+                9.701132
+              ]
+            },
+            "goal_distance_m": 4.3506,
+            "progress_m": 0.240163,
+            "robot_position": [
+              13.871294,
+              3.946177
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.717274,
+              "clearance_m": 6.317274,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.195237,
+                9.644436
+              ]
+            },
+            "goal_distance_m": 4.253992,
+            "progress_m": 0.336771,
+            "robot_position": [
+              13.888123,
+              4.041682
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.528349,
+              "clearance_m": 29.128349,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989655,
+                34.646626
+              ]
+            },
+            "goal_distance_m": 4.157075,
+            "progress_m": 0.433688,
+            "robot_position": [
+              13.904123,
+              4.137583
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.368431,
+              "clearance_m": 28.968431,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.002676,
+                34.582944
+              ]
+            },
+            "goal_distance_m": 4.05988,
+            "progress_m": 0.530883,
+            "robot_position": [
+              13.919358,
+              4.233842
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.900501,
+            "clearance_m": 6.500501,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.19525,
+              9.89423
+            ]
+          },
+          "goal_distance_m": 4.253992,
+          "progress_m": 0.336771,
+          "robot_position": [
+            13.888123,
+            4.041682
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 8.135676,
+              "clearance_m": 6.735676,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173447,
+                10.006443
+              ]
+            },
+            "goal_distance_m": 4.446868,
+            "progress_m": 0.143895,
+            "robot_position": [
+              13.853567,
+              3.851112
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 8.017807,
+              "clearance_m": 6.617807,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184232,
+                9.951002
+              ]
+            },
+            "goal_distance_m": 4.3506,
+            "progress_m": 0.240163,
+            "robot_position": [
+              13.871294,
+              3.946177
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.900501,
+              "clearance_m": 6.500501,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.19525,
+                9.89423
+              ]
+            },
+            "goal_distance_m": 4.253992,
+            "progress_m": 0.336771,
+            "robot_position": [
+              13.888123,
+              4.041682
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.528277,
+              "clearance_m": 29.128277,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989305,
+                34.646567
+              ]
+            },
+            "goal_distance_m": 4.157075,
+            "progress_m": 0.433688,
+            "robot_position": [
+              13.904123,
+              4.137583
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.368163,
+              "clearance_m": 28.968163,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.001486,
+                34.582718
+              ]
+            },
+            "goal_distance_m": 4.05988,
+            "progress_m": 0.530883,
+            "robot_position": [
+              13.919358,
+              4.233842
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.234365,
+        "clearance_m": 0.234365,
+        "goal_distance_m": 0.0,
+        "progress_m": 0.0,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.65324,
+            "clearance_m": 6.25324,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535804,
+              10.031229
+            ]
+          },
+          "goal_distance_m": 5.439548,
+          "progress_m": 0.043001,
+          "robot_position": [
+            14.833109,
+            2.871094
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.65324,
+              "clearance_m": 6.25324,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535804,
+                10.031229
+              ]
+            },
+            "goal_distance_m": 5.439548,
+            "progress_m": 0.043001,
+            "robot_position": [
+              14.833109,
+              2.871094
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "collision",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.887605,
+            "clearance_m": 6.487605,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535805,
+              10.281206
+            ]
+          },
+          "goal_distance_m": 5.439548,
+          "progress_m": 0.043001,
+          "robot_position": [
+            14.833109,
+            2.871094
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.887605,
+              "clearance_m": 6.487605,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535805,
+                10.281206
+              ]
+            },
+            "goal_distance_m": 5.439548,
+            "progress_m": 0.043001,
+            "robot_position": [
+              14.833109,
+              2.871094
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "collision",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "goal",
+      "seed": 116,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": -0.006291,
+        "clearance_m": -0.006291,
+        "goal_distance_m": 0.09831,
+        "progress_m": -0.098311,
+        "time_s": 0.1
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 4.093522,
+            "clearance_m": 2.693522,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              19.076324,
+              10.033972
+            ]
+          },
+          "goal_distance_m": 2.028875,
+          "progress_m": 2.69563,
+          "robot_position": [
+            14.985154,
+            10.172743
+          ],
+          "step": 68,
+          "time_s": 6.9
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.104609,
+              "clearance_m": 2.704609,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.048693,
+                10.157773
+              ]
+            },
+            "goal_distance_m": 1.832832,
+            "progress_m": 2.891672,
+            "robot_position": [
+              14.948087,
+              9.976539
+            ],
+            "step": 66,
+            "time_s": 6.7
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.095966,
+              "clearance_m": 2.695966,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.062505,
+                10.095858
+              ]
+            },
+            "goal_distance_m": 1.930747,
+            "progress_m": 2.793757,
+            "robot_position": [
+              14.966594,
+              10.074637
+            ],
+            "step": 67,
+            "time_s": 6.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.093522,
+              "clearance_m": 2.693522,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.076324,
+                10.033972
+              ]
+            },
+            "goal_distance_m": 2.028875,
+            "progress_m": 2.69563,
+            "robot_position": [
+              14.985154,
+              10.172743
+            ],
+            "step": 68,
+            "time_s": 6.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.097292,
+              "clearance_m": 2.697292,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.090149,
+                9.972116
+              ]
+            },
+            "goal_distance_m": 2.127185,
+            "progress_m": 2.597319,
+            "robot_position": [
+              15.003762,
+              10.270856
+            ],
+            "step": 69,
+            "time_s": 7.0
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.10726,
+              "clearance_m": 2.70726,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.10398,
+                9.910291
+              ]
+            },
+            "goal_distance_m": 2.225655,
+            "progress_m": 2.498849,
+            "robot_position": [
+              15.022413,
+              10.368975
+            ],
+            "step": 70,
+            "time_s": 7.1
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 4.087231,
+            "clearance_m": 2.687231,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              19.090656,
+              10.218303
+            ]
+          },
+          "goal_distance_m": 2.127185,
+          "progress_m": 2.597319,
+          "robot_position": [
+            15.003762,
+            10.270856
+          ],
+          "step": 69,
+          "time_s": 7.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.105112,
+              "clearance_m": 2.705112,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.062974,
+                10.342244
+              ]
+            },
+            "goal_distance_m": 1.930747,
+            "progress_m": 2.793757,
+            "robot_position": [
+              14.966594,
+              10.074637
+            ],
+            "step": 67,
+            "time_s": 6.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.09307,
+              "clearance_m": 2.69307,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.076811,
+                10.28026
+              ]
+            },
+            "goal_distance_m": 2.028875,
+            "progress_m": 2.69563,
+            "robot_position": [
+              14.985154,
+              10.172743
+            ],
+            "step": 68,
+            "time_s": 6.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.087231,
+              "clearance_m": 2.687231,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.090656,
+                10.218303
+              ]
+            },
+            "goal_distance_m": 2.127185,
+            "progress_m": 2.597319,
+            "robot_position": [
+              15.003762,
+              10.270856
+            ],
+            "step": 69,
+            "time_s": 7.0
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.087627,
+              "clearance_m": 2.687627,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.104508,
+                10.156374
+              ]
+            },
+            "goal_distance_m": 2.225655,
+            "progress_m": 2.498849,
+            "robot_position": [
+              15.022413,
+              10.368975
+            ],
+            "step": 70,
+            "time_s": 7.1
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 4.094257,
+              "clearance_m": 2.694257,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                19.118368,
+                10.094475
+              ]
+            },
+            "goal_distance_m": 2.324263,
+            "progress_m": 2.400241,
+            "robot_position": [
+              15.041103,
+              10.467099
+            ],
+            "step": 71,
+            "time_s": 7.2
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "goal",
+      "seed": 117,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": -0.002252,
+        "clearance_m": -0.002252,
+        "goal_distance_m": 0.197818,
+        "progress_m": -0.197817,
+        "time_s": 0.1
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 1.670247,
+            "clearance_m": 0.270247,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              16.880447,
+              18.560892
+            ]
+          },
+          "goal_distance_m": 9.978592,
+          "progress_m": -5.680297,
+          "robot_position": [
+            15.247708,
+            18.208913
+          ],
+          "step": 71,
+          "time_s": 7.2
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.742232,
+              "clearance_m": 0.342232,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.761543,
+                18.611248
+              ]
+            },
+            "goal_distance_m": 9.578671,
+            "progress_m": -5.280376,
+            "robot_position": [
+              15.214316,
+              17.810335
+            ],
+            "step": 69,
+            "time_s": 7.0
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.691613,
+              "clearance_m": 0.291613,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.81982,
+                18.584331
+              ]
+            },
+            "goal_distance_m": 9.778594,
+            "progress_m": -5.480299,
+            "robot_position": [
+              15.228757,
+              18.009813
+            ],
+            "step": 70,
+            "time_s": 7.1
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.670247,
+              "clearance_m": 0.270247,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.880447,
+                18.560892
+              ]
+            },
+            "goal_distance_m": 9.978592,
+            "progress_m": -5.680297,
+            "robot_position": [
+              15.247708,
+              18.208913
+            ],
+            "step": 71,
+            "time_s": 7.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.674618,
+              "clearance_m": 0.274618,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.941488,
+                18.538553
+              ]
+            },
+            "goal_distance_m": 10.178544,
+            "progress_m": -5.880249,
+            "robot_position": [
+              15.272011,
+              18.407431
+            ],
+            "step": 72,
+            "time_s": 7.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.702977,
+              "clearance_m": 0.302977,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.002024,
+                18.514881
+              ]
+            },
+            "goal_distance_m": 10.378321,
+            "progress_m": -6.080026,
+            "robot_position": [
+              15.301446,
+              18.605253
+            ],
+            "step": 73,
+            "time_s": 7.4
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 1.667995,
+            "clearance_m": 0.267995,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              16.896497,
+              18.752346
+            ]
+          },
+          "goal_distance_m": 10.17641,
+          "progress_m": -5.878114,
+          "robot_position": [
+            15.264856,
+            18.406002
+          ],
+          "step": 72,
+          "time_s": 7.3
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.736443,
+              "clearance_m": 0.336443,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.776889,
+                18.802035
+              ]
+            },
+            "goal_distance_m": 9.776517,
+            "progress_m": -5.478221,
+            "robot_position": [
+              15.232988,
+              18.0073
+            ],
+            "step": 70,
+            "time_s": 7.1
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.687771,
+              "clearance_m": 0.287771,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.835733,
+                18.775429
+              ]
+            },
+            "goal_distance_m": 9.976416,
+            "progress_m": -5.678121,
+            "robot_position": [
+              15.246623,
+              18.206835
+            ],
+            "step": 71,
+            "time_s": 7.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.667995,
+              "clearance_m": 0.267995,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.896497,
+                18.752346
+              ]
+            },
+            "goal_distance_m": 10.17641,
+            "progress_m": -5.878114,
+            "robot_position": [
+              15.264856,
+              18.406002
+            ],
+            "step": 72,
+            "time_s": 7.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.673744,
+              "clearance_m": 0.273744,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.95762,
+                18.730233
+              ]
+            },
+            "goal_distance_m": 10.376372,
+            "progress_m": -6.078077,
+            "robot_position": [
+              15.288598,
+              18.604588
+            ],
+            "step": 73,
+            "time_s": 7.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.703242,
+              "clearance_m": 0.303242,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.018198,
+                18.706669
+              ]
+            },
+            "goal_distance_m": 10.576164,
+            "progress_m": -6.277869,
+            "robot_position": [
+              15.317652,
+              18.802467
+            ],
+            "step": 74,
+            "time_s": 7.5
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "orca",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.179201,
+        "clearance_m": 0.179201,
+        "goal_distance_m": -7e-05,
+        "progress_m": 7e-05,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.438003,
+            "clearance_m": 6.038003,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.195237,
+              9.644436
+            ]
+          },
+          "goal_distance_m": 3.891628,
+          "progress_m": 0.699135,
+          "robot_position": [
+            13.917994,
+            4.402815
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.821535,
+              "clearance_m": 6.421535,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173443,
+                9.756513
+              ]
+            },
+            "goal_distance_m": 4.291488,
+            "progress_m": 0.299275,
+            "robot_position": [
+              13.872364,
+              4.005428
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.627936,
+              "clearance_m": 6.227936,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184224,
+                9.701132
+              ]
+            },
+            "goal_distance_m": 4.091571,
+            "progress_m": 0.499192,
+            "robot_position": [
+              13.895793,
+              4.204051
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.438003,
+              "clearance_m": 6.038003,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.195237,
+                9.644436
+              ]
+            },
+            "goal_distance_m": 3.891628,
+            "progress_m": 0.699135,
+            "robot_position": [
+              13.917994,
+              4.402815
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.063311,
+              "clearance_m": 28.663311,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989655,
+                34.646626
+              ]
+            },
+            "goal_distance_m": 3.691673,
+            "progress_m": 0.89909,
+            "robot_position": [
+              13.939408,
+              4.601666
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 29.800598,
+              "clearance_m": 28.400598,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.002676,
+                34.582944
+              ]
+            },
+            "goal_distance_m": 3.491708,
+            "progress_m": 1.099055,
+            "robot_position": [
+              13.96015,
+              4.800587
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.617204,
+            "clearance_m": 6.217204,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.19525,
+              9.89423
+            ]
+          },
+          "goal_distance_m": 3.891558,
+          "progress_m": 0.699205,
+          "robot_position": [
+            13.916171,
+            4.403045
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 8.007437,
+              "clearance_m": 6.607437,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173447,
+                10.006443
+              ]
+            },
+            "goal_distance_m": 4.291451,
+            "progress_m": 0.299312,
+            "robot_position": [
+              13.871751,
+              4.00552
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.810664,
+              "clearance_m": 6.410664,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184232,
+                9.951002
+              ]
+            },
+            "goal_distance_m": 4.091515,
+            "progress_m": 0.499248,
+            "robot_position": [
+              13.894529,
+              4.204219
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.617204,
+              "clearance_m": 6.217204,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.19525,
+                9.89423
+              ]
+            },
+            "goal_distance_m": 3.891558,
+            "progress_m": 0.699205,
+            "robot_position": [
+              13.916171,
+              4.403045
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.063041,
+              "clearance_m": 28.663041,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989305,
+                34.646567
+              ]
+            },
+            "goal_distance_m": 3.691591,
+            "progress_m": 0.899172,
+            "robot_position": [
+              13.937126,
+              4.601944
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 29.800107,
+              "clearance_m": 28.400107,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.001486,
+                34.582718
+              ]
+            },
+            "goal_distance_m": 3.491618,
+            "progress_m": 1.099145,
+            "robot_position": [
+              13.957499,
+              4.800903
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.235284,
+        "clearance_m": 0.235284,
+        "goal_distance_m": 0.000919,
+        "progress_m": -0.00092,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.644057,
+            "clearance_m": 6.244057,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535804,
+              10.031229
+            ]
+          },
+          "goal_distance_m": 5.430252,
+          "progress_m": 0.052298,
+          "robot_position": [
+            14.834072,
+            2.880547
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.644057,
+              "clearance_m": 6.244057,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535804,
+                10.031229
+              ]
+            },
+            "goal_distance_m": 5.430252,
+            "progress_m": 0.052298,
+            "robot_position": [
+              14.834072,
+              2.880547
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "collision",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.879341,
+            "clearance_m": 6.479341,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535805,
+              10.281206
+            ]
+          },
+          "goal_distance_m": 5.431171,
+          "progress_m": 0.051378,
+          "robot_position": [
+            14.833899,
+            2.879604
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.879341,
+              "clearance_m": 6.479341,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535805,
+                10.281206
+              ]
+            },
+            "goal_distance_m": 5.431171,
+            "progress_m": 0.051378,
+            "robot_position": [
+              14.833899,
+              2.879604
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "collision",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "orca",
+      "seed": 116,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.216711,
+        "clearance_m": 0.216711,
+        "goal_distance_m": 0.000262,
+        "progress_m": -0.000263,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 2.59685,
+            "clearance_m": 1.19685,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              16.264083,
+              21.686817
+            ]
+          },
+          "goal_distance_m": 11.236545,
+          "progress_m": -6.51204,
+          "robot_position": [
+            16.961821,
+            19.185458
+          ],
+          "step": 79,
+          "time_s": 8.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.056767,
+              "clearance_m": 1.656767,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.236808,
+                21.798896
+              ]
+            },
+            "goal_distance_m": 10.83717,
+            "progress_m": -6.112666,
+            "robot_position": [
+              16.844322,
+              18.803107
+            ],
+            "step": 77,
+            "time_s": 7.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 2.823044,
+              "clearance_m": 1.423044,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.25085,
+                21.741264
+              ]
+            },
+            "goal_distance_m": 11.036885,
+            "progress_m": -6.312381,
+            "robot_position": [
+              16.902495,
+              18.994459
+            ],
+            "step": 78,
+            "time_s": 7.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 2.59685,
+              "clearance_m": 1.19685,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.264083,
+                21.686817
+              ]
+            },
+            "goal_distance_m": 11.236545,
+            "progress_m": -6.51204,
+            "robot_position": [
+              16.961821,
+              19.185458
+            ],
+            "step": 79,
+            "time_s": 8.0
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 2.813561,
+            "clearance_m": 1.413561,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              16.265611,
+              21.927627
+            ]
+          },
+          "goal_distance_m": 11.236807,
+          "progress_m": -6.512303,
+          "robot_position": [
+            16.929882,
+            19.193607
+          ],
+          "step": 79,
+          "time_s": 8.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.286891,
+              "clearance_m": 1.886891,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.236993,
+                22.045692
+              ]
+            },
+            "goal_distance_m": 10.837298,
+            "progress_m": -6.112794,
+            "robot_position": [
+              16.815917,
+              18.810187
+            ],
+            "step": 77,
+            "time_s": 7.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.047058,
+              "clearance_m": 1.647058,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.25161,
+                21.985217
+              ]
+            },
+            "goal_distance_m": 11.037076,
+            "progress_m": -6.312572,
+            "robot_position": [
+              16.872356,
+              19.002058
+            ],
+            "step": 78,
+            "time_s": 7.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 2.813561,
+              "clearance_m": 1.413561,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.265611,
+                21.927627
+              ]
+            },
+            "goal_distance_m": 11.236807,
+            "progress_m": -6.512303,
+            "robot_position": [
+              16.929882,
+              19.193607
+            ],
+            "step": 79,
+            "time_s": 8.0
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "orca",
+      "seed": 117,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": -0.013537,
+        "clearance_m": -0.013537,
+        "goal_distance_m": 0.206569,
+        "progress_m": -0.206569,
+        "time_s": 0.1
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 1.653526,
+            "clearance_m": 0.253526,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              17.100746,
+              17.302873
+            ]
+          },
+          "goal_distance_m": 8.0435,
+          "progress_m": -3.745205,
+          "robot_position": [
+            17.41031,
+            15.678582
+          ],
+          "step": 70,
+          "time_s": 7.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.665451,
+              "clearance_m": 0.265451,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.053867,
+                17.29462
+              ]
+            },
+            "goal_distance_m": 7.969321,
+            "progress_m": -3.671026,
+            "robot_position": [
+              17.294646,
+              15.646666
+            ],
+            "step": 68,
+            "time_s": 6.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.655516,
+              "clearance_m": 0.255516,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.077622,
+                17.296072
+              ]
+            },
+            "goal_distance_m": 8.006979,
+            "progress_m": -3.708684,
+            "robot_position": [
+              17.352239,
+              15.663492
+            ],
+            "step": 69,
+            "time_s": 7.0
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.653526,
+              "clearance_m": 0.253526,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.100746,
+                17.302873
+              ]
+            },
+            "goal_distance_m": 8.0435,
+            "progress_m": -3.745205,
+            "robot_position": [
+              17.41031,
+              15.678582
+            ],
+            "step": 70,
+            "time_s": 7.1
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.657153,
+              "clearance_m": 0.257153,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.123064,
+                17.313988
+              ]
+            },
+            "goal_distance_m": 8.079946,
+            "progress_m": -3.78165,
+            "robot_position": [
+              17.468493,
+              15.693237
+            ],
+            "step": 71,
+            "time_s": 7.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.664577,
+              "clearance_m": 0.264577,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.144412,
+                17.328444
+              ]
+            },
+            "goal_distance_m": 8.117025,
+            "progress_m": -3.81873,
+            "robot_position": [
+              17.526564,
+              15.708328
+            ],
+            "step": 72,
+            "time_s": 7.3
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 1.639989,
+            "clearance_m": 0.239989,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              17.117513,
+              17.498727
+            ]
+          },
+          "goal_distance_m": 8.250069,
+          "progress_m": -3.951774,
+          "robot_position": [
+            17.439238,
+            15.890605
+          ],
+          "step": 71,
+          "time_s": 7.2
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.65158,
+              "clearance_m": 0.25158,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.071745,
+                17.487349
+              ]
+            },
+            "goal_distance_m": 8.173707,
+            "progress_m": -3.875412,
+            "robot_position": [
+              17.324583,
+              15.855237
+            ],
+            "step": 69,
+            "time_s": 7.0
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.641715,
+              "clearance_m": 0.241715,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.094975,
+                17.490274
+              ]
+            },
+            "goal_distance_m": 8.212452,
+            "progress_m": -3.914157,
+            "robot_position": [
+              17.381645,
+              15.873781
+            ],
+            "step": 70,
+            "time_s": 7.1
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.639989,
+              "clearance_m": 0.239989,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.117513,
+                17.498727
+              ]
+            },
+            "goal_distance_m": 8.250069,
+            "progress_m": -3.951774,
+            "robot_position": [
+              17.439238,
+              15.890605
+            ],
+            "step": 71,
+            "time_s": 7.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.644043,
+              "clearance_m": 0.244043,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.139182,
+                17.511638
+              ]
+            },
+            "goal_distance_m": 8.287601,
+            "progress_m": -3.989306,
+            "robot_position": [
+              17.496956,
+              15.906997
+            ],
+            "step": 72,
+            "time_s": 7.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 1.652023,
+              "clearance_m": 0.252023,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                17.159822,
+                17.527993
+              ]
+            },
+            "goal_distance_m": 8.325744,
+            "progress_m": -4.027448,
+            "robot_position": [
+              17.554549,
+              15.923821
+            ],
+            "step": 73,
+            "time_s": 7.4
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 111,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.179201,
+        "clearance_m": 0.179201,
+        "goal_distance_m": 0.0,
+        "progress_m": 0.0,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.428543,
+            "clearance_m": 6.028543,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.195237,
+              9.644436
+            ]
+          },
+          "goal_distance_m": 3.915005,
+          "progress_m": 0.675758,
+          "robot_position": [
+            13.958079,
+            4.376095
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.831393,
+              "clearance_m": 6.431393,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173443,
+                9.756513
+              ]
+            },
+            "goal_distance_m": 4.312555,
+            "progress_m": 0.278208,
+            "robot_position": [
+              13.881702,
+              3.983456
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.628584,
+              "clearance_m": 6.228584,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184224,
+                9.701132
+              ]
+            },
+            "goal_distance_m": 4.113765,
+            "progress_m": 0.476998,
+            "robot_position": [
+              13.920284,
+              4.179699
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.428543,
+              "clearance_m": 6.028543,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.195237,
+                9.644436
+              ]
+            },
+            "goal_distance_m": 3.915005,
+            "progress_m": 0.675758,
+            "robot_position": [
+              13.958079,
+              4.376095
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.090549,
+              "clearance_m": 28.690549,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989655,
+                34.646626
+              ]
+            },
+            "goal_distance_m": 3.716378,
+            "progress_m": 0.874385,
+            "robot_position": [
+              13.995874,
+              4.572492
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 29.829799,
+              "clearance_m": 28.429799,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.002676,
+                34.582944
+              ]
+            },
+            "goal_distance_m": 3.517907,
+            "progress_m": 1.072857,
+            "robot_position": [
+              14.033668,
+              4.768888
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.607744,
+            "clearance_m": 6.207744,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              19.19525,
+              9.89423
+            ]
+          },
+          "goal_distance_m": 3.915005,
+          "progress_m": 0.675758,
+          "robot_position": [
+            13.958079,
+            4.376095
+          ],
+          "step": 3,
+          "time_s": 0.4
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 8.017415,
+              "clearance_m": 6.617415,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.173447,
+                10.006443
+              ]
+            },
+            "goal_distance_m": 4.312555,
+            "progress_m": 0.278208,
+            "robot_position": [
+              13.881702,
+              3.983456
+            ],
+            "step": 1,
+            "time_s": 0.2
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.811343,
+              "clearance_m": 6.411343,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.184232,
+                9.951002
+              ]
+            },
+            "goal_distance_m": 4.113765,
+            "progress_m": 0.476998,
+            "robot_position": [
+              13.920284,
+              4.179699
+            ],
+            "step": 2,
+            "time_s": 0.3
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.607744,
+              "clearance_m": 6.207744,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                19.19525,
+                9.89423
+              ]
+            },
+            "goal_distance_m": 3.915005,
+            "progress_m": 0.675758,
+            "robot_position": [
+              13.958079,
+              4.376095
+            ],
+            "step": 3,
+            "time_s": 0.4
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 30.090478,
+              "clearance_m": 28.690478,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                14.989305,
+                34.646567
+              ]
+            },
+            "goal_distance_m": 3.716378,
+            "progress_m": 0.874385,
+            "robot_position": [
+              13.995874,
+              4.572492
+            ],
+            "step": 4,
+            "time_s": 0.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 29.829535,
+              "clearance_m": 28.429535,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                15.001486,
+                34.582718
+              ]
+            },
+            "goal_distance_m": 3.517907,
+            "progress_m": 1.072857,
+            "robot_position": [
+              14.033668,
+              4.768888
+            ],
+            "step": 5,
+            "time_s": 0.6
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 112,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.234286,
+        "clearance_m": 0.234286,
+        "goal_distance_m": 0.0,
+        "progress_m": 0.0,
+        "time_s": 0.0
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.608895,
+            "clearance_m": 6.208895,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535804,
+              10.031229
+            ]
+          },
+          "goal_distance_m": 5.396707,
+          "progress_m": 0.085842,
+          "robot_position": [
+            14.841989,
+            2.915145
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.608895,
+              "clearance_m": 6.208895,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535804,
+                10.031229
+              ]
+            },
+            "goal_distance_m": 5.396707,
+            "progress_m": 0.085842,
+            "robot_position": [
+              14.841989,
+              2.915145
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "collision",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 7.843181,
+            "clearance_m": 6.443181,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              17.535805,
+              10.281206
+            ]
+          },
+          "goal_distance_m": 5.396707,
+          "progress_m": 0.085842,
+          "robot_position": [
+            14.841989,
+            2.915145
+          ],
+          "step": 0,
+          "time_s": 0.1
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 7.843181,
+              "clearance_m": 6.443181,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                17.535805,
+                10.281206
+              ]
+            },
+            "goal_distance_m": 5.396707,
+            "progress_m": 0.085842,
+            "robot_position": [
+              14.841989,
+              2.915145
+            ],
+            "step": 0,
+            "time_s": 0.1
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "collision",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 116,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    },
+    {
+      "closest_approach_delta": {
+        "center_distance_m": 0.173336,
+        "clearance_m": 0.173336,
+        "goal_distance_m": -6.581509,
+        "progress_m": 6.581509,
+        "time_s": -3.3
+      },
+      "noop_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 3.173034,
+            "clearance_m": 1.773034,
+            "pedestrian_index": 0,
+            "pedestrian_position": [
+              16.2675,
+              21.669732
+            ]
+          },
+          "goal_distance_m": 10.524621,
+          "progress_m": -5.800117,
+          "robot_position": [
+            16.673524,
+            18.522783
+          ],
+          "step": 79,
+          "time_s": 8.0
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.684323,
+              "clearance_m": 2.284323,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.237281,
+                21.796171
+              ]
+            },
+            "goal_distance_m": 10.125055,
+            "progress_m": -5.400551,
+            "robot_position": [
+              16.599484,
+              18.129695
+            ],
+            "step": 77,
+            "time_s": 7.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.428299,
+              "clearance_m": 2.028299,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.252391,
+                21.732951
+              ]
+            },
+            "goal_distance_m": 10.324834,
+            "progress_m": -5.60033,
+            "robot_position": [
+              16.636504,
+              18.326239
+            ],
+            "step": 78,
+            "time_s": 7.9
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.173034,
+              "clearance_m": 1.773034,
+              "pedestrian_index": 0,
+              "pedestrian_position": [
+                16.2675,
+                21.669732
+              ]
+            },
+            "goal_distance_m": 10.524621,
+            "progress_m": -5.800117,
+            "robot_position": [
+              16.673524,
+              18.522783
+            ],
+            "step": 79,
+            "time_s": 8.0
+          }
+        ],
+        "status": "ok"
+      },
+      "noop_termination_reason": "max_steps",
+      "noop_variant_id": "classic_head_on_corridor_low_noop",
+      "pair_status": "completed",
+      "perturbed_closest_approach": {
+        "closest": {
+          "closest_pedestrian": {
+            "center_distance_m": 3.34637,
+            "clearance_m": 1.94637,
+            "pedestrian_index": 1,
+            "pedestrian_position": [
+              18.776166,
+              11.649235
+            ]
+          },
+          "goal_distance_m": 3.943112,
+          "progress_m": 0.781392,
+          "robot_position": [
+            15.452309,
+            12.036749
+          ],
+          "step": 46,
+          "time_s": 4.7
+        },
+        "frames": [
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.370015,
+              "clearance_m": 1.970015,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                18.746001,
+                11.774277
+              ]
+            },
+            "goal_distance_m": 3.546474,
+            "progress_m": 1.17803,
+            "robot_position": [
+              15.378521,
+              11.643614
+            ],
+            "step": 44,
+            "time_s": 4.5
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.346812,
+              "clearance_m": 1.946812,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                18.75975,
+                11.711799
+              ]
+            },
+            "goal_distance_m": 3.744702,
+            "progress_m": 0.979802,
+            "robot_position": [
+              15.415401,
+              11.840184
+            ],
+            "step": 45,
+            "time_s": 4.6
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.34637,
+              "clearance_m": 1.94637,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                18.776166,
+                11.649235
+              ]
+            },
+            "goal_distance_m": 3.943112,
+            "progress_m": 0.781392,
+            "robot_position": [
+              15.452309,
+              12.036749
+            ],
+            "step": 46,
+            "time_s": 4.7
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.367924,
+              "clearance_m": 1.967924,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                18.794545,
+                11.586888
+              ]
+            },
+            "goal_distance_m": 4.141678,
+            "progress_m": 0.582826,
+            "robot_position": [
+              15.489238,
+              12.23331
+            ],
+            "step": 47,
+            "time_s": 4.8
+          },
+          {
+            "closest_pedestrian": {
+              "center_distance_m": 3.408225,
+              "clearance_m": 2.008225,
+              "pedestrian_index": 1,
+              "pedestrian_position": [
+                18.811968,
+                11.524531
+              ]
+            },
+            "goal_distance_m": 4.340378,
+            "progress_m": 0.384126,
+            "robot_position": [
+              15.526185,
+              12.429868
+            ],
+            "step": 48,
+            "time_s": 4.9
+          }
+        ],
+        "status": "ok"
+      },
+      "perturbed_family": "pedestrian_route_offset",
+      "perturbed_termination_reason": "max_steps",
+      "perturbed_variant_id": "classic_head_on_corridor_low_ped_route_offset_y025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 117,
+      "source_scenario_id": "classic_head_on_corridor_low"
+    }
+  ],
+  "variant_metadata": {
+    "classic_head_on_corridor_low_noop": {
+      "benchmark_evidence_status": "eligible_success_evidence_candidate",
+      "evidence_boundary": "local_pilot_input_not_benchmark_evidence",
+      "family": "noop",
+      "perturbation_summary": {
+        "family": "noop",
+        "magnitude_m": 0.0
+      },
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "variant_id": "classic_head_on_corridor_low_noop"
+    },
+    "classic_head_on_corridor_low_ped_route_offset_y025": {
+      "benchmark_evidence_status": "eligible_success_evidence_candidate",
+      "evidence_boundary": "local_pilot_input_not_benchmark_evidence",
+      "family": "pedestrian_route_offset",
+      "perturbation_summary": {
+        "dx_m": 0.0,
+        "dy_m": 0.25,
+        "family": "pedestrian_route_offset",
+        "magnitude_m": 0.25,
+        "max_magnitude_m": 0.5,
+        "target": {
+          "goal_id": null,
+          "spawn_id": null,
+          "waypoint_selector": "all"
+        }
+      },
+      "source_scenario_id": "classic_head_on_corridor_low",
+      "variant_id": "classic_head_on_corridor_low_ped_route_offset_y025"
+    }
+  }
+}

--- a/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/report.md
+++ b/docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/report.md
@@ -1,0 +1,31 @@
+# Scenario Perturbation Trace Response
+
+## Boundary
+
+diagnostic local trace inspection only; not benchmark-strength or paper-facing evidence
+
+## Scope
+
+- Source scenario: `classic_head_on_corridor_low`
+- Perturbed family: `pedestrian_route_offset`
+- Planners: `goal`, `orca`, `scenario_adaptive_hybrid_orca_v2_collision_guard`
+- Pair rows: `12`
+- Pair statuses: `{"completed": 12}`
+
+## Mean Closest-Approach Deltas
+
+- `center_distance_m`: `0.153489`
+- `clearance_m`: `0.153489`
+- `goal_distance_m`: `-0.506475`
+- `progress_m`: `0.506475`
+- `time_s`: `-0.25`
+
+Positive clearance/center-distance deltas mean the perturbed run was farther from the closest pedestrian at its closest approach.
+
+## By Planner
+
+| Planner | Pairs | Center Distance Delta | Progress Delta | Time Delta |
+|---|---:|---:|---:|---:|
+| `goal` | 4 | `0.159909` | `-0.024578` | `0.025` |
+| `orca` | 4 | `0.157236` | `-0.049732` | `0.025` |
+| `scenario_adaptive_hybrid_orca_v2_collision_guard` | 4 | `0.143321` | `1.593735` | `-0.8` |

--- a/docs/context/issue_1939_corridor_trace_response.md
+++ b/docs/context/issue_1939_corridor_trace_response.md
@@ -1,0 +1,96 @@
+# Issue #1939 Corridor Trace Response
+
+Issue: [#1939](https://github.com/ll7/robot_sf_ll7/issues/1939)
+Parent: [#1610](https://github.com/ll7/robot_sf_ll7/issues/1610)
+Predecessor: [#1937](https://github.com/ll7/robot_sf_ll7/issues/1937)
+
+## Goal
+
+Inspect the trace-level mechanism behind the larger `classic_head_on_corridor_low`
+`pedestrian_route_offset` min-distance response observed in the #1937 pilot. This note is
+diagnostic local evidence only; it is not benchmark-strength or paper-facing evidence.
+
+## Implementation
+
+`scripts/validation/run_scenario_perturbation_trace_response.py` materializes the tracked #1937
+manifest, selects one no-op and one perturbed variant for a source scenario, reruns each selected
+planner/seed pair, and records compact closest-approach slices instead of raw episode videos or
+full traces.
+
+The script resolves policy-search candidate keys through the same registry helper used by the
+criticality pilot, so `scenario_adaptive_hybrid_orca_v2_collision_guard` remains a planner label
+while executing its configured `hybrid_rule_local_planner` candidate config.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 \
+uv run python scripts/validation/run_scenario_perturbation_trace_response.py \
+  configs/scenarios/perturbations/issue_1610_ped_route_offset_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbations/issue1939_corridor_trace_response/materialized \
+  --output docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/closest_approach_trace_slices.json \
+  --markdown-output docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/report.md \
+  --source-scenario-id classic_head_on_corridor_low \
+  --perturbed-family pedestrian_route_offset \
+  --seed-limit 4 \
+  --horizon 80 \
+  --dt 0.1 \
+  --slice-window 2 \
+  --planner goal \
+  --planner orca \
+  --planner scenario_adaptive_hybrid_orca_v2_collision_guard
+```
+
+The run emitted the known `uni_campus_big.svg` invalid obstacle warning during materialization but
+completed all selected trace pairs.
+
+## Result
+
+- Source scenario: `classic_head_on_corridor_low`.
+- Perturbed family: `pedestrian_route_offset`.
+- Planners: `goal`, `orca`, `scenario_adaptive_hybrid_orca_v2_collision_guard`.
+- Pair rows: 12 completed pairs, 0 excluded pairs.
+- Mean closest-approach deltas over completed pairs:
+  - center distance: `+0.153489 m`
+  - clearance: `+0.153489 m`
+  - progress: `+0.506475 m`
+  - closest-approach time: `-0.25 s`
+
+By planner:
+
+| Planner | Pairs | Center-Distance Delta | Progress Delta | Time Delta |
+|---|---:|---:|---:|---:|
+| `goal` | 4 | `+0.159909 m` | `-0.024578 m` | `+0.025 s` |
+| `orca` | 4 | `+0.157236 m` | `-0.049732 m` | `+0.025 s` |
+| `scenario_adaptive_hybrid_orca_v2_collision_guard` | 4 | `+0.143321 m` | `+1.593735 m` | `-0.8 s` |
+
+Interpretation: the pedestrian-route offset generally moves the closest pedestrian farther from
+the robot at closest approach in this corridor slice. The large hybrid-candidate progress delta is
+driven by seed 117, where the perturbed trace reaches closest approach `3.3 s` earlier and roughly
+`6.58 m` farther along the route than the no-op trace. Other hybrid seeds show clearance changes
+without that route-progress jump, so the mechanism should be treated as seed-local diagnostic
+evidence rather than a broad planner claim.
+
+Seed 116 remains collision-terminated in both no-op and perturbed traces for all three planners.
+The trace slices therefore explain clearance geometry around closest approach, not a solved
+collision outcome.
+
+## Evidence Boundary
+
+Tracked compact evidence:
+
+- [closest_approach_trace_slices.json](evidence/issue_1939_corridor_trace_response_2026-05-31/closest_approach_trace_slices.json)
+- [report.md](evidence/issue_1939_corridor_trace_response_2026-05-31/report.md)
+- [SHA256SUMS](evidence/issue_1939_corridor_trace_response_2026-05-31/SHA256SUMS)
+
+Ignored local outputs:
+
+- materialized matrix and route overrides under
+  `output/scenario_perturbations/issue1939_corridor_trace_response/`
+- coverage output from targeted tests
+
+## Routing
+
+Useful next #1610 children could test a timing or speed perturbation family, but the trace evidence
+argues against presenting corridor pedestrian-route offsets as a success/robustness benchmark on
+their own. They are currently a local diagnostic lens for clearance and route-progress mechanisms.

--- a/scripts/validation/run_scenario_perturbation_trace_response.py
+++ b/scripts/validation/run_scenario_perturbation_trace_response.py
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+"""Extract closest-approach trace slices for paired scenario perturbations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.algorithm_metadata import resolve_observation_mode
+from robot_sf.benchmark.map_runner import (
+    _apply_active_observation_mode_to_env_config,
+    _apply_planner_selector_v2_context,
+    _build_env_config,
+    _build_policy,
+    _parse_algo_config,
+    _policy_command_to_env_action,
+    _resolve_policy_search_candidate_runtime,
+    _robot_kinematics_label,
+    _scenario_with_episode_seed_defaults,
+    _validate_planner_contract,
+    _validate_sensor_fusion_adapter_config,
+)
+from robot_sf.benchmark.termination_reason import (
+    collision_event,
+    resolve_termination_reason,
+    route_complete_success,
+)
+from robot_sf.gym_env.environment_factory import make_robot_env
+from robot_sf.scenario_certification import materialize_perturbation_pilot_matrix
+from robot_sf.training.scenario_loader import load_scenarios
+from scripts.validation.run_scenario_perturbation_criticality_pilot import (
+    PlannerRunSpec,
+    _planner_output_stem,
+    _scenario_metadata,
+    resolve_planner_run_spec,
+)
+
+SCHEMA_VERSION = "scenario_perturbation_trace_response.v1"
+
+
+@dataclass(frozen=True)
+class TraceRun:
+    """One diagnostic rollout trace."""
+
+    planner: str
+    scenario_id: str
+    source_scenario_id: str
+    variant_id: str
+    family: str
+    seed: int
+    termination_reason: str
+    frames: list[dict[str, Any]]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the trace-response CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="Scenario perturbation manifest YAML.")
+    parser.add_argument(
+        "--materialized-output-dir",
+        type=Path,
+        required=True,
+        help="Ignored output/ directory for generated scenario matrix and route overrides.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Tracked compact JSON report path.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional tracked Markdown report path.",
+    )
+    parser.add_argument(
+        "--source-scenario-id",
+        default="classic_head_on_corridor_low",
+        help="Source scenario to inspect.",
+    )
+    parser.add_argument(
+        "--perturbed-family",
+        default="pedestrian_route_offset",
+        help="Perturbation family to pair against the no-op variant.",
+    )
+    parser.add_argument(
+        "--planner",
+        action="append",
+        dest="planners",
+        help="Planner algorithm or policy-search candidate key. Defaults to goal, orca, and the promoted collision guard.",
+    )
+    parser.add_argument(
+        "--planner-candidate-registry",
+        type=Path,
+        default=Path("docs/context/policy_search/candidate_registry.yaml"),
+        help="Policy-search candidate registry used to resolve planner keys.",
+    )
+    parser.add_argument("--seed-limit", type=int, default=4)
+    parser.add_argument("--horizon", type=int, default=80)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument(
+        "--slice-window",
+        type=int,
+        default=2,
+        help="Frames to include before and after each closest approach.",
+    )
+    return parser
+
+
+def _round_float(value: float | None, *, digits: int = 6) -> float | None:
+    """Round finite floats for compact JSON output."""
+    if value is None or not math.isfinite(float(value)):
+        return None
+    return round(float(value), digits)
+
+
+def _xy(value: Any) -> list[float]:
+    """Return a compact ``[x, y]`` pair."""
+    arr = np.asarray(value, dtype=float).reshape(-1)
+    if arr.size < 2:
+        return [0.0, 0.0]
+    return [_round_float(float(arr[0])) or 0.0, _round_float(float(arr[1])) or 0.0]
+
+
+def _closest_pedestrian_payload(
+    *,
+    robot_position: np.ndarray,
+    pedestrian_positions: np.ndarray,
+    robot_radius: float,
+    ped_radius: float,
+) -> dict[str, Any] | None:
+    """Return the closest pedestrian payload for one frame."""
+    if pedestrian_positions.size == 0:
+        return None
+    if pedestrian_positions.ndim != 2 or pedestrian_positions.shape[1] < 2:
+        return None
+    distances = np.linalg.norm(pedestrian_positions[:, :2] - robot_position[:2], axis=1)
+    if distances.size == 0 or not np.isfinite(distances).any():
+        return None
+    ped_index = int(np.nanargmin(distances))
+    center_distance = float(distances[ped_index])
+    clearance = center_distance - float(robot_radius + ped_radius)
+    return {
+        "pedestrian_index": ped_index,
+        "pedestrian_position": _xy(pedestrian_positions[ped_index]),
+        "center_distance_m": _round_float(center_distance),
+        "clearance_m": _round_float(clearance),
+    }
+
+
+def closest_approach_slice(
+    frames: list[dict[str, Any]],
+    *,
+    window: int = 2,
+) -> dict[str, Any]:
+    """Return the closest-approach frame and a compact local slice."""
+    candidates = [
+        (index, frame)
+        for index, frame in enumerate(frames)
+        if isinstance(frame.get("closest_pedestrian"), dict)
+        and frame["closest_pedestrian"].get("center_distance_m") is not None
+    ]
+    if not candidates:
+        return {"status": "no_pedestrians", "closest": None, "frames": []}
+    closest_index, closest = min(
+        candidates,
+        key=lambda item: float(item[1]["closest_pedestrian"]["center_distance_m"]),
+    )
+    start = max(0, closest_index - max(0, int(window)))
+    stop = min(len(frames), closest_index + max(0, int(window)) + 1)
+    return {
+        "status": "ok",
+        "closest": closest,
+        "frames": frames[start:stop],
+    }
+
+
+def _delta(after: float | int | None, before: float | int | None) -> float | None:
+    """Return a rounded numeric delta when both sides are present."""
+    if after is None or before is None:
+        return None
+    return _round_float(float(after) - float(before))
+
+
+def build_trace_pair_summary(
+    *,
+    planner: str,
+    seed: int,
+    noop: TraceRun,
+    perturbed: TraceRun,
+    window: int,
+) -> dict[str, Any]:
+    """Build one paired closest-approach summary."""
+    noop_slice = closest_approach_slice(noop.frames, window=window)
+    perturbed_slice = closest_approach_slice(perturbed.frames, window=window)
+    noop_closest = noop_slice.get("closest") if isinstance(noop_slice.get("closest"), dict) else {}
+    perturbed_closest = (
+        perturbed_slice.get("closest") if isinstance(perturbed_slice.get("closest"), dict) else {}
+    )
+    noop_ped = (
+        noop_closest.get("closest_pedestrian") if isinstance(noop_closest, dict) else None
+    ) or {}
+    perturbed_ped = (
+        perturbed_closest.get("closest_pedestrian") if isinstance(perturbed_closest, dict) else None
+    ) or {}
+    return {
+        "planner": planner,
+        "seed": int(seed),
+        "source_scenario_id": noop.source_scenario_id,
+        "noop_variant_id": noop.variant_id,
+        "perturbed_variant_id": perturbed.variant_id,
+        "perturbed_family": perturbed.family,
+        "pair_status": (
+            "completed"
+            if noop_slice["status"] == "ok" and perturbed_slice["status"] == "ok"
+            else "excluded"
+        ),
+        "noop_termination_reason": noop.termination_reason,
+        "perturbed_termination_reason": perturbed.termination_reason,
+        "closest_approach_delta": {
+            "time_s": _delta(perturbed_closest.get("time_s"), noop_closest.get("time_s")),
+            "center_distance_m": _delta(
+                perturbed_ped.get("center_distance_m"),
+                noop_ped.get("center_distance_m"),
+            ),
+            "clearance_m": _delta(perturbed_ped.get("clearance_m"), noop_ped.get("clearance_m")),
+            "goal_distance_m": _delta(
+                perturbed_closest.get("goal_distance_m"),
+                noop_closest.get("goal_distance_m"),
+            ),
+            "progress_m": _delta(
+                perturbed_closest.get("progress_m"),
+                noop_closest.get("progress_m"),
+            ),
+        },
+        "noop_closest_approach": noop_slice,
+        "perturbed_closest_approach": perturbed_slice,
+    }
+
+
+def _summarize_trace_pair_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate one subset of trace-pair deltas."""
+    status_counts: dict[str, int] = defaultdict(int)
+    delta_values: dict[str, list[float]] = defaultdict(list)
+    for row in pair_rows:
+        status_counts[str(row.get("pair_status") or "unknown")] += 1
+        if row.get("pair_status") != "completed":
+            continue
+        deltas = row.get("closest_approach_delta")
+        if not isinstance(deltas, dict):
+            continue
+        for field, value in deltas.items():
+            if isinstance(value, int | float):
+                delta_values[field].append(float(value))
+    return {
+        "pairs": len(pair_rows),
+        "status_counts": dict(sorted(status_counts.items())),
+        "mean_closest_approach_deltas_completed_pairs": {
+            field: _round_float(sum(values) / len(values))
+            for field, values in sorted(delta_values.items())
+            if values
+        },
+    }
+
+
+def summarize_trace_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate trace-pair deltas overall and by planner."""
+    by_planner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in pair_rows:
+        by_planner[str(row.get("planner") or "unknown")].append(row)
+    return {
+        **_summarize_trace_pair_subset(pair_rows),
+        "by_planner": {
+            planner: _summarize_trace_pair_subset(rows)
+            for planner, rows in sorted(by_planner.items())
+        },
+    }
+
+
+def _frame_payload(
+    *,
+    step: int,
+    dt: float,
+    robot_position: np.ndarray,
+    pedestrian_positions: np.ndarray,
+    goal_position: np.ndarray,
+    start_goal_distance: float,
+    robot_radius: float,
+    ped_radius: float,
+) -> dict[str, Any]:
+    """Build one compact diagnostic frame."""
+    goal_distance = float(np.linalg.norm(goal_position[:2] - robot_position[:2]))
+    return {
+        "step": int(step),
+        "time_s": _round_float((int(step) + 1) * float(dt)),
+        "robot_position": _xy(robot_position),
+        "goal_distance_m": _round_float(goal_distance),
+        "progress_m": _round_float(start_goal_distance - goal_distance),
+        "closest_pedestrian": _closest_pedestrian_payload(
+            robot_position=robot_position,
+            pedestrian_positions=pedestrian_positions,
+            robot_radius=robot_radius,
+            ped_radius=ped_radius,
+        ),
+    }
+
+
+def _run_trace_episode(
+    scenario: dict[str, Any],
+    *,
+    seed: int,
+    planner_spec: PlannerRunSpec,
+    horizon: int,
+    dt: float,
+    scenario_path: Path,
+) -> TraceRun:
+    """Run one local diagnostic episode and capture compact per-step geometry."""
+    scenario = _scenario_with_episode_seed_defaults(scenario, seed=seed)
+    metadata = scenario.get("metadata") if isinstance(scenario.get("metadata"), dict) else {}
+    perturbation = metadata.get("scenario_perturbation") if isinstance(metadata, dict) else {}
+    config = _build_env_config(scenario, scenario_path=scenario_path)
+    config.sim_config.time_per_step_in_secs = float(dt)
+    raw_policy_cfg = (
+        _parse_algo_config(planner_spec.algo_config_path.as_posix())
+        if planner_spec.algo_config_path is not None
+        else {}
+    )
+    algo, policy_cfg = _resolve_policy_search_candidate_runtime(
+        default_algo=planner_spec.algo,
+        algo_config_path=(
+            planner_spec.algo_config_path.as_posix()
+            if planner_spec.algo_config_path is not None
+            else None
+        ),
+        algo_config=raw_policy_cfg,
+        scenario=scenario,
+    )
+    policy_cfg = _apply_planner_selector_v2_context(
+        algo,
+        policy_cfg,
+        scenario=scenario,
+        seed=int(seed),
+    )
+    observation_mode = resolve_observation_mode(algo, None, observation_level=None)
+    _apply_active_observation_mode_to_env_config(
+        config,
+        active_observation_mode=observation_mode,
+    )
+    _validate_sensor_fusion_adapter_config(
+        algo=algo,
+        active_observation_mode=observation_mode,
+        algo_config=policy_cfg,
+    )
+    robot_kinematics = _robot_kinematics_label(config)
+    robot_command_mode = str(getattr(config.robot_config, "command_mode", "vx_vy")).strip().lower()
+    _validate_planner_contract(
+        algo=algo,
+        robot_kinematics=robot_kinematics,
+        algo_config=policy_cfg,
+        observation_mode=observation_mode,
+        observation_level=None,
+    )
+    policy_fn, _algo_meta = _build_policy(
+        algo,
+        policy_cfg,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+        adapter_impact_eval=False,
+    )
+    planner_close = getattr(policy_fn, "_planner_close", None)
+    planner_reset = getattr(policy_fn, "_planner_reset", None)
+    planner_bind_env = getattr(policy_fn, "_planner_bind_env", None)
+    planner_native_action = getattr(policy_fn, "_planner_native_env_action", False)
+
+    env = make_robot_env(config=config, seed=int(seed), debug=False)
+    frames: list[dict[str, Any]] = []
+    termination_reason = "max_steps"
+    try:
+        obs, _ = env.reset(seed=int(seed))
+        if callable(planner_bind_env):
+            planner_bind_env(env)
+        if callable(planner_reset):
+            planner_reset(seed=int(seed))
+        goal_position = np.asarray(env.simulator.goal_pos[0], dtype=float)
+        robot_start = np.asarray(env.simulator.robot_pos[0], dtype=float)
+        start_goal_distance = float(np.linalg.norm(goal_position[:2] - robot_start[:2]))
+        robot_radius = float(getattr(config.robot_config, "radius", 1.0))
+        ped_radius = float(getattr(config.sim_config, "ped_radius", 0.4))
+
+        for step_idx in range(int(horizon)):
+            policy_command = policy_fn(obs)
+            step_is_native = getattr(policy_fn, "_last_step_native", planner_native_action)
+            if step_is_native:
+                action = np.asarray(policy_command, dtype=np.float32)
+            else:
+                action = _policy_command_to_env_action(
+                    env=env,
+                    config=config,
+                    command=policy_command,
+                )
+            obs, _reward, terminated, truncated, info = env.step(action)
+            robot_position = np.asarray(env.simulator.robot_pos[0], dtype=float)
+            pedestrian_positions = np.asarray(env.simulator.ped_pos, dtype=float)
+            frames.append(
+                _frame_payload(
+                    step=step_idx,
+                    dt=dt,
+                    robot_position=robot_position,
+                    pedestrian_positions=pedestrian_positions,
+                    goal_position=goal_position,
+                    start_goal_distance=start_goal_distance,
+                    robot_radius=robot_radius,
+                    ped_radius=ped_radius,
+                )
+            )
+
+            step_collision = collision_event(info)
+            step_success = route_complete_success(info) and not step_collision
+            if step_success:
+                termination_reason = resolve_termination_reason(
+                    terminated=True,
+                    truncated=False,
+                    success=True,
+                    collision=step_collision,
+                )
+                break
+            if terminated or truncated:
+                termination_reason = resolve_termination_reason(
+                    terminated=bool(terminated),
+                    truncated=bool(truncated),
+                    success=step_success,
+                    collision=step_collision,
+                )
+                break
+    finally:
+        if callable(planner_close):
+            planner_close()
+        env.close()
+
+    scenario_id = str(scenario.get("scenario_id") or scenario.get("name") or "")
+    return TraceRun(
+        planner=planner_spec.label,
+        scenario_id=scenario_id,
+        source_scenario_id=str(perturbation.get("source_scenario_id") or scenario_id),
+        variant_id=str(perturbation.get("variant_id") or scenario_id),
+        family=str(perturbation.get("family") or ""),
+        seed=int(seed),
+        termination_reason=termination_reason,
+        frames=frames,
+    )
+
+
+def _select_variant_pair(
+    scenarios: list[dict[str, Any]],
+    *,
+    source_scenario_id: str,
+    perturbed_family: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return the no-op and perturbed scenario entries for one source scenario."""
+    noop: dict[str, Any] | None = None
+    perturbed: dict[str, Any] | None = None
+    for scenario in scenarios:
+        metadata = scenario.get("metadata") if isinstance(scenario.get("metadata"), dict) else {}
+        payload = metadata.get("scenario_perturbation") if isinstance(metadata, dict) else None
+        if not isinstance(payload, dict):
+            continue
+        if str(payload.get("source_scenario_id") or "") != source_scenario_id:
+            continue
+        family = str(payload.get("family") or "")
+        if family == "noop" and noop is None:
+            noop = scenario
+        elif family == perturbed_family and perturbed is None:
+            perturbed = scenario
+    if noop is None:
+        raise ValueError(f"No no-op variant found for source scenario {source_scenario_id!r}")
+    if perturbed is None:
+        raise ValueError(
+            f"No {perturbed_family!r} variant found for source scenario {source_scenario_id!r}"
+        )
+    return noop, perturbed
+
+
+def _scenario_seeds(scenario: dict[str, Any]) -> list[int]:
+    """Return explicit scenario seeds."""
+    raw = scenario.get("seeds")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"Scenario {scenario.get('scenario_id')} has no explicit seeds")
+    return [int(seed) for seed in raw]
+
+
+def _write_markdown(report: dict[str, Any], path: Path) -> None:
+    """Write a compact Markdown trace-response report."""
+    summary = report["pair_summary"]
+    lines = [
+        "# Scenario Perturbation Trace Response",
+        "",
+        "## Boundary",
+        "",
+        report["claim_boundary"],
+        "",
+        "## Scope",
+        "",
+        f"- Source scenario: `{report['source_scenario_id']}`",
+        f"- Perturbed family: `{report['perturbed_family']}`",
+        f"- Planners: {', '.join(f'`{planner}`' for planner in report['planners'])}",
+        f"- Pair rows: `{summary['pairs']}`",
+        f"- Pair statuses: `{json.dumps(summary['status_counts'], sort_keys=True)}`",
+        "",
+        "## Mean Closest-Approach Deltas",
+        "",
+    ]
+    deltas = summary["mean_closest_approach_deltas_completed_pairs"]
+    if deltas:
+        for field, value in deltas.items():
+            lines.append(f"- `{field}`: `{value}`")
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "Positive clearance/center-distance deltas mean the perturbed run was farther from the closest pedestrian at its closest approach.",
+            "",
+            "## By Planner",
+            "",
+            "| Planner | Pairs | Center Distance Delta | Progress Delta | Time Delta |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    for planner, planner_summary in sorted(summary.get("by_planner", {}).items()):
+        planner_deltas = planner_summary.get("mean_closest_approach_deltas_completed_pairs", {})
+        lines.append(
+            "| "
+            f"`{planner}` | "
+            f"{planner_summary.get('pairs', 0)} | "
+            f"`{planner_deltas.get('center_distance_m')}` | "
+            f"`{planner_deltas.get('progress_m')}` | "
+            f"`{planner_deltas.get('time_s')}` |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    """Run the trace-response diagnostic."""
+    args = _build_parser().parse_args()
+    planners = args.planners or [
+        "goal",
+        "orca",
+        "scenario_adaptive_hybrid_orca_v2_collision_guard",
+    ]
+    planner_specs = [
+        resolve_planner_run_spec(planner, candidate_registry_path=args.planner_candidate_registry)
+        for planner in planners
+    ]
+    materialized = materialize_perturbation_pilot_matrix(
+        args.manifest,
+        output_dir=args.materialized_output_dir,
+        seed_limit=args.seed_limit,
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    scenarios = load_scenarios(matrix_path)
+    metadata = _scenario_metadata(scenarios)
+    noop_scenario, perturbed_scenario = _select_variant_pair(
+        scenarios,
+        source_scenario_id=args.source_scenario_id,
+        perturbed_family=args.perturbed_family,
+    )
+    seeds = sorted(set(_scenario_seeds(noop_scenario)) & set(_scenario_seeds(perturbed_scenario)))
+    pair_rows: list[dict[str, Any]] = []
+    for planner_spec in planner_specs:
+        for seed in seeds:
+            noop_trace = _run_trace_episode(
+                noop_scenario,
+                seed=seed,
+                planner_spec=planner_spec,
+                horizon=args.horizon,
+                dt=args.dt,
+                scenario_path=matrix_path,
+            )
+            perturbed_trace = _run_trace_episode(
+                perturbed_scenario,
+                seed=seed,
+                planner_spec=planner_spec,
+                horizon=args.horizon,
+                dt=args.dt,
+                scenario_path=matrix_path,
+            )
+            pair_rows.append(
+                build_trace_pair_summary(
+                    planner=planner_spec.label,
+                    seed=seed,
+                    noop=noop_trace,
+                    perturbed=perturbed_trace,
+                    window=args.slice_window,
+                )
+            )
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "manifest": args.manifest.as_posix(),
+        "source_scenario_id": args.source_scenario_id,
+        "perturbed_family": args.perturbed_family,
+        "planners": [spec.label for spec in planner_specs],
+        "horizon": args.horizon,
+        "dt": args.dt,
+        "seed_limit": args.seed_limit,
+        "slice_window": args.slice_window,
+        "materialization": {
+            "schema_version": materialized.schema_version,
+            "manifest_id": materialized.manifest_id,
+            "included_variants": list(materialized.included_variants),
+            "excluded_variants": list(materialized.excluded_variants),
+            "variant_count": len(materialized.included_variants),
+            "local_artifact_boundary": (
+                "materialized scenario matrix and route overrides remain ignored local outputs "
+                "reproducible from the tracked manifest and command"
+            ),
+        },
+        "variant_metadata": {
+            key: value
+            for key, value in sorted(metadata.items())
+            if value.get("source_scenario_id") == args.source_scenario_id
+            and value.get("family") in {"noop", args.perturbed_family}
+        },
+        "planner_runs": {
+            spec.label: {
+                "algo": spec.algo,
+                "algo_config_path": (
+                    spec.algo_config_path.as_posix() if spec.algo_config_path is not None else None
+                ),
+                "source": spec.source,
+                "output_stem": _planner_output_stem(spec.label),
+            }
+            for spec in planner_specs
+        },
+        "pair_summary": summarize_trace_pairs(pair_rows),
+        "trace_pairs": pair_rows,
+        "claim_boundary": (
+            "diagnostic local trace inspection only; not benchmark-strength or paper-facing evidence"
+        ),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.markdown_output is not None:
+        _write_markdown(report, args.markdown_output)
+    print(
+        json.dumps(
+            {
+                "output": args.output.as_posix(),
+                "markdown_output": (
+                    args.markdown_output.as_posix() if args.markdown_output is not None else None
+                ),
+                "pair_summary": report["pair_summary"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scenario_certification/test_scenario_perturbation_trace_response.py
+++ b/tests/scenario_certification/test_scenario_perturbation_trace_response.py
@@ -1,0 +1,113 @@
+"""Tests for scenario perturbation trace-response aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.validation.run_scenario_perturbation_trace_response import (
+    TraceRun,
+    build_trace_pair_summary,
+    closest_approach_slice,
+    summarize_trace_pairs,
+)
+
+
+def _frame(step: int, *, distance: float, clearance: float, goal_distance: float) -> dict:
+    """Return a compact trace frame for aggregation tests."""
+    return {
+        "step": step,
+        "time_s": step * 0.1,
+        "goal_distance_m": goal_distance,
+        "progress_m": 10.0 - goal_distance,
+        "closest_pedestrian": {
+            "pedestrian_index": 0,
+            "pedestrian_position": [float(step), 0.0],
+            "center_distance_m": distance,
+            "clearance_m": clearance,
+        },
+    }
+
+
+def test_closest_approach_slice_returns_window_around_minimum() -> None:
+    """Trace slices should center on the minimum robot-pedestrian distance frame."""
+    frames = [
+        _frame(0, distance=2.0, clearance=0.6, goal_distance=9.0),
+        _frame(1, distance=1.0, clearance=-0.4, goal_distance=8.5),
+        _frame(2, distance=1.5, clearance=0.1, goal_distance=8.0),
+    ]
+
+    result = closest_approach_slice(frames, window=1)
+
+    assert result["status"] == "ok"
+    assert result["closest"]["step"] == 1
+    assert [frame["step"] for frame in result["frames"]] == [0, 1, 2]
+
+
+def test_build_trace_pair_summary_reports_closest_approach_deltas() -> None:
+    """No-op and perturbed traces should compare closest-approach timing and clearance."""
+    noop = TraceRun(
+        planner="goal",
+        scenario_id="demo_noop",
+        source_scenario_id="demo",
+        variant_id="demo_noop",
+        family="noop",
+        seed=111,
+        termination_reason="max_steps",
+        frames=[
+            _frame(0, distance=2.0, clearance=0.6, goal_distance=9.0),
+            _frame(1, distance=1.0, clearance=-0.4, goal_distance=8.5),
+        ],
+    )
+    perturbed = TraceRun(
+        planner="goal",
+        scenario_id="demo_ped_offset",
+        source_scenario_id="demo",
+        variant_id="demo_ped_offset",
+        family="pedestrian_route_offset",
+        seed=111,
+        termination_reason="max_steps",
+        frames=[
+            _frame(0, distance=2.5, clearance=1.1, goal_distance=9.2),
+            _frame(1, distance=1.4, clearance=0.0, goal_distance=8.8),
+        ],
+    )
+
+    row = build_trace_pair_summary(
+        planner="goal",
+        seed=111,
+        noop=noop,
+        perturbed=perturbed,
+        window=0,
+    )
+
+    assert row["pair_status"] == "completed"
+    assert row["closest_approach_delta"]["center_distance_m"] == pytest.approx(0.4)
+    assert row["closest_approach_delta"]["clearance_m"] == pytest.approx(0.4)
+    assert row["closest_approach_delta"]["goal_distance_m"] == pytest.approx(0.3)
+    assert row["closest_approach_delta"]["progress_m"] == pytest.approx(-0.3)
+
+
+def test_summarize_trace_pairs_groups_by_planner_without_recursive_summary() -> None:
+    """Planner grouping should not recursively nest planner summaries."""
+    rows = [
+        {
+            "planner": "goal",
+            "pair_status": "completed",
+            "closest_approach_delta": {"clearance_m": 0.4},
+        },
+        {
+            "planner": "orca",
+            "pair_status": "excluded",
+            "closest_approach_delta": {"clearance_m": 0.1},
+        },
+    ]
+
+    summary = summarize_trace_pairs(rows)
+
+    assert summary["pairs"] == 2
+    assert summary["status_counts"] == {"completed": 1, "excluded": 1}
+    assert summary["mean_closest_approach_deltas_completed_pairs"]["clearance_m"] == pytest.approx(
+        0.4
+    )
+    assert summary["by_planner"]["goal"]["pairs"] == 1
+    assert "by_planner" not in summary["by_planner"]["goal"]


### PR DESCRIPTION
## Summary

- closes #1939
- adds `run_scenario_perturbation_trace_response.py` to rerun selected #1610 perturbation pairs and extract compact closest-approach trace slices
- records diagnostic evidence for `classic_head_on_corridor_low` no-op vs `pedestrian_route_offset` across `goal`, `orca`, and `scenario_adaptive_hybrid_orca_v2_collision_guard`
- documents the seed-local mechanism boundary in `docs/context/issue_1939_corridor_trace_response.md`

## Findings

- 12/12 trace pairs completed.
- Mean closest-approach clearance delta was `+0.153489 m` for the pedestrian-route-offset traces.
- The hybrid collision-guard candidate showed `+1.593735 m` mean progress delta at closest approach, but that average is driven mainly by seed 117, so the result is diagnostic only.
- Seed 116 remains collision-terminated on both no-op and perturbed traces for all three planners.

## Validation

- `uv run ruff check scripts/validation/run_scenario_perturbation_trace_response.py tests/scenario_certification/test_scenario_perturbation_trace_response.py`
- `uv run ruff format --check scripts/validation/run_scenario_perturbation_trace_response.py tests/scenario_certification/test_scenario_perturbation_trace_response.py`
- `uv run pytest tests/scenario_certification/test_scenario_perturbation_trace_response.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py`
- `python -m json.tool closest_approach_trace_slices.json >/dev/null && sha256sum -c SHA256SUMS` from `docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/`
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/validation/run_scenario_perturbation_trace_response.py configs/scenarios/perturbations/issue_1610_ped_route_offset_pilot_v1.yaml --materialized-output-dir output/scenario_perturbations/issue1939_corridor_trace_response/materialized --output docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/closest_approach_trace_slices.json --markdown-output docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/report.md --source-scenario-id classic_head_on_corridor_low --perturbed-family pedestrian_route_offset --seed-limit 4 --horizon 80 --dt 0.1 --slice-window 2 --planner goal --planner orca --planner scenario_adaptive_hybrid_orca_v2_collision_guard`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4800 passed, 11 skipped, 9 warnings`)

## Artifact Boundary

Ignored outputs inspected before PR: coverage output, `output/scenario_perturbations/issue1939_corridor_trace_response/` materialized matrix/route overrides, and `output/validation/pr_ready/issue-1939-corridor-trace-response.json`. Durable evidence is the tracked compact JSON/Markdown/checksum bundle under `docs/context/evidence/issue_1939_corridor_trace_response_2026-05-31/`.

## Claim Boundary

Diagnostic local trace inspection only; not benchmark-strength or paper-facing evidence.