### PR TITLE
analysis: add pedestrian timing perturbation pilot

### DIFF
--- a/configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml
+++ b/configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml
@@ -1,0 +1,84 @@
+# Issue #1941 follow-up perturbation manifest for parent issue #1610.
+#
+# This manifest adds exactly one timing perturbation family for single-pedestrian Francis
+# scenarios. It is a validity-preflight and local-pilot input only; it does not make
+# benchmark-strength or paper-facing claims.
+
+schema_version: scenario_perturbation_manifest.v1
+manifest_id: issue_1610_ped_timing_phase_pilot_v1
+description: >-
+  Bounded #1610 follow-up manifest that holds the #1937 planner/seed/horizon pilot boundary
+  fixed while adding single-pedestrian start-delay offsets as the only new perturbation family.
+scenario_config: ../classic_interactions_francis2023.yaml
+seed_controls:
+  baseline_seeds: [112, 113, 115, 116, 240, 241, 242]
+  replay_seed_policy: explicit
+  source: docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/scenario_seed_sensitivity.csv
+validity:
+  require_scenario_certification: true
+  max_route_offset_m: 0.5
+  max_start_delay_offset_s: 1.0
+  invalid_variant_evidence_policy: exclude_from_success_evidence
+  notes: >-
+    The v1 timing preflight supports no-op baselines plus bounded start-delay offsets for
+    scenarios that expose single_pedestrians. Route-only pedestrian scenarios must fail closed
+    until a separate trajectory timing perturbation family is defined.
+variants:
+  - variant_id: francis2023_join_group_noop
+    scenario_id: francis2023_join_group
+    family: noop
+    seeds: [112, 113, 115, 116]
+    rationale: Baseline row for a Francis social-interaction scenario flagged by issue #1608.
+  - variant_id: francis2023_join_group_start_delay_h3_p050
+    scenario_id: francis2023_join_group
+    family: single_pedestrian_start_delay_offset
+    seeds: [112, 113, 115, 116]
+    rationale: >-
+      Delays the joining pedestrian to test whether local planners are sensitive to the phase of
+      the join-group interaction without changing the map or robot route.
+    parameters:
+      dt_s: 0.5
+      max_abs_dt_s: 1.0
+      pedestrian_id: h3
+
+  - variant_id: francis2023_intersection_wait_noop
+    scenario_id: francis2023_intersection_wait
+    family: noop
+    seeds: [240, 241, 242]
+    rationale: Baseline row for a single-pedestrian wait-then-cross Francis scenario.
+  - variant_id: francis2023_intersection_wait_start_delay_h1_p050
+    scenario_id: francis2023_intersection_wait
+    family: single_pedestrian_start_delay_offset
+    seeds: [240, 241, 242]
+    rationale: >-
+      Delays the crossing pedestrian start to probe phase sensitivity in an explicit intersection
+      wait scenario while leaving wait_at semantics unchanged.
+    parameters:
+      dt_s: 0.5
+      max_abs_dt_s: 1.0
+      pedestrian_id: h1
+
+  - variant_id: classic_head_on_corridor_low_noop
+    scenario_id: classic_head_on_corridor_low
+    family: noop
+    seeds: [111, 112, 116, 117]
+    rationale: Baseline row for the corridor route-based scenario used in #1939 trace analysis.
+  - variant_id: classic_head_on_corridor_low_start_delay_all_p050
+    scenario_id: classic_head_on_corridor_low
+    family: single_pedestrian_start_delay_offset
+    seeds: [111, 112, 116, 117]
+    rationale: >-
+      Fail-closed probe proving that route-only classic pedestrians are not silently treated as
+      single-pedestrian timing targets.
+    parameters:
+      dt_s: 0.5
+      max_abs_dt_s: 1.0
+      pedestrian_selector: all
+pilot_matrix_note:
+  parent_issue: "#1610"
+  next_step: >-
+    Run a tiny paired planner pilot over eligible no-op and single-pedestrian start-delay rows
+    using the same planner/config/seed controls except for variant_id.
+  evidence_boundary: >-
+    Preflight validity is necessary but not sufficient benchmark evidence; invalid, fallback,
+    degraded, missing, or stress-only rows are limitations rather than success evidence.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -226,6 +226,8 @@ knowledge, not every transient iteration detail.
   [issue_1937_ped_route_offset.md](issue_1937_ped_route_offset.md)
 * Issue #1939 Corridor Trace Response (2026-05-31):
   [issue_1939_corridor_trace_response.md](issue_1939_corridor_trace_response.md)
+* Issue #1941 Pedestrian Timing Phase Perturbation (2026-05-31):
+  [issue_1941_ped_timing_phase.md](issue_1941_ped_timing_phase.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
 * Issue #1633 RobotEnv SNQI proxy extraction:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -102,3 +102,5 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_1939_corridor_trace_response_2026-05-31/`: compact diagnostic-only closest-approach trace
   slices for the `classic_head_on_corridor_low` pedestrian-route-offset response observed in the
   #1610/#1937 pilot.
+- `issue_1941_ped_timing_phase_2026-05-31/`: compact diagnostic-only paired
+  no-op-versus-start-delay summary for the #1610 single-pedestrian timing phase perturbation pilot.

--- a/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/README.md
+++ b/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/README.md
@@ -1,0 +1,17 @@
+# Issue #1941 Pedestrian Timing Phase Evidence
+
+Compact diagnostic-only evidence for
+[`docs/context/issue_1941_ped_timing_phase.md`](../../issue_1941_ped_timing_phase.md).
+
+## Files
+
+- `summary.json`: compact output from
+  `scripts/validation/run_scenario_perturbation_criticality_pilot.py` for
+  `configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml`.
+- `SHA256SUMS`: checksums for this evidence bundle.
+
+## Boundary
+
+The raw episode JSONL, materialized scenario matrix, generated scenario overrides, and coverage
+HTML remain ignored local outputs under `output/`. This bundle is diagnostic local evidence only
+and is not benchmark-strength or paper-facing evidence.

--- a/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/SHA256SUMS
+++ b/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/SHA256SUMS
@@ -1,0 +1,2 @@
+35e51eb1ba83b816de418e96624586090e6bc38382b11d454a7ad9ced0a27d51  docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/README.md
+2a84d52e64364915206dd5a22d345e34a052eac54e8d574cd8d59717ee9f3c20  docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/summary.json

--- a/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/summary.json
+++ b/docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/summary.json
@@ -1,0 +1,750 @@
+{
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 80,
+  "manifest": "configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [
+      "classic_head_on_corridor_low_start_delay_all_p050"
+    ],
+    "included_variants": [
+      "francis2023_join_group_noop",
+      "francis2023_join_group_start_delay_h3_p050",
+      "francis2023_intersection_wait_noop",
+      "francis2023_intersection_wait_start_delay_h1_p050",
+      "classic_head_on_corridor_low_noop"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1610_ped_timing_phase_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 5
+  },
+  "pair_rows": [
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 4.879051990361236,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.396640728620171,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.275692718981407,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "goal",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 4.846514018718986,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.50130537424527,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.347819392964256,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "goal",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 4.860000724686453,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.119166442080297,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 11.97916716676675,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "goal",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.006339899161680318,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.860499164278315,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.866839063439995,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "goal",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5542955250491202,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5542955250491202,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "goal",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.1354041290479486,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.1354041290479486,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "goal",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.720659113855012,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.409910230972628,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.13056934482764,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "orca",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.7859471680876844,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.373728612568657,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.159675780656341,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "orca",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.6371297433439285,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.16723292620106,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 11.804362669544988,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "orca",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.005570773629226311,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4492909863429455,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4548617599721718,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.002225321210047815,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.439309677641443,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.437084356431395,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "orca",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.015341777613543384,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4397620085044152,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4551037861179585,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "orca",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.009559112045163243,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4741467753802409,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.483705887425404,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "orca",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.9264949428062756,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.219161902426459,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.145656845232734,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.9986141637095507,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.180964865278593,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.179579028988144,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 3.7798077802946484,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.220298941258834,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 12.000106721553482,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_start_delay_h1_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4482470133949672,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4482470133949672,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4487350475219367,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4487350475219367,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4494315390472794,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4494315390472794,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4477641505470757,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4477641505470757,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_start_delay_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_start_delay_h3_p050",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    }
+  ],
+  "pair_summary": {
+    "by_perturbation_family": {
+      "single_pedestrian_start_delay_offset": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 1.7842288517668259,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 21,
+        "status_counts": {
+          "completed": 21
+        }
+      }
+    },
+    "by_planner": {
+      "goal": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 2.0845580904183367,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 7,
+        "status_counts": {
+          "completed": 7
+        }
+      },
+      "orca": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 1.595997481052073,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 7,
+        "status_counts": {
+          "completed": 7
+        }
+      },
+      "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 1.6721309838300678,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 7,
+        "status_counts": {
+          "completed": 7
+        }
+      }
+    },
+    "by_source_scenario": {
+      "francis2023_intersection_wait": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 4.159357738429309,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 9,
+        "status_counts": {
+          "completed": 9
+        }
+      },
+      "francis2023_join_group": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.002882186769963787,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 12,
+        "status_counts": {
+          "completed": 12
+        }
+      }
+    },
+    "mean_deltas_completed_pairs": {
+      "collision_delta": 0.0,
+      "min_distance_delta": 1.7842288517668259,
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    "pairs": 21,
+    "status_counts": {
+      "completed": 21
+    }
+  },
+  "planner_runs": {
+    "goal": {
+      "algo": "goal",
+      "algo_config_path": null,
+      "episodes": 18,
+      "source": "raw_algo"
+    },
+    "orca": {
+      "algo": "orca",
+      "algo_config_path": null,
+      "episodes": 18,
+      "source": "raw_algo"
+    },
+    "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+      "algo": "hybrid_rule_local_planner",
+      "algo_config_path": "configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml",
+      "episodes": 18,
+      "source": "policy_search_candidate"
+    }
+  },
+  "planners": [
+    "goal",
+    "orca",
+    "scenario_adaptive_hybrid_orca_v2_collision_guard"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 4
+}

--- a/docs/context/issue_1941_ped_timing_phase.md
+++ b/docs/context/issue_1941_ped_timing_phase.md
@@ -1,0 +1,94 @@
+# Issue #1941 Pedestrian Timing Phase Perturbation
+
+Issue: [#1941](https://github.com/ll7/robot_sf_ll7/issues/1941)
+Parent: [#1610](https://github.com/ll7/robot_sf_ll7/issues/1610)
+Predecessors: [#1937](https://github.com/ll7/robot_sf_ll7/issues/1937),
+[#1939](https://github.com/ll7/robot_sf_ll7/issues/1939)
+
+## Goal
+
+Add a narrowly bounded timing perturbation family to the #1610 scenario-perturbation pilot so
+local planners can be probed for phase sensitivity in Francis single-pedestrian interactions.
+This note is diagnostic local evidence only; it is not benchmark-strength or paper-facing evidence.
+
+## Implementation
+
+`single_pedestrian_start_delay_offset` changes `start_delay_s` on selected
+`single_pedestrians` before certification and materialization. The family deliberately does not
+target route-based pedestrian trajectories or `wait_at` waypoints; unsupported scenarios fail
+closed and are excluded from success evidence.
+
+The public manifest schema now distinguishes family-specific parameter requirements:
+
+- route-offset families require `dx_m`, `dy_m`, and `max_magnitude_m`;
+- start-delay offsets require `dt_s` and `max_abs_dt_s`;
+- no-op variants must remain parameter-free.
+
+The tracked pilot manifest is
+`configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml`.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 \
+uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py \
+  configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbations/issue1941_ped_timing_phase/materialized \
+  --pilot-output-dir output/scenario_perturbations/issue1941_ped_timing_phase/pilot \
+  --seed-limit 4 \
+  --horizon 80 \
+  --workers 1 \
+  --planner goal \
+  --planner orca \
+  --planner scenario_adaptive_hybrid_orca_v2_collision_guard \
+  --evidence-summary docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/summary.json
+```
+
+## Result
+
+The diagnostic pilot completed 21/21 paired no-op-versus-start-delay rows with no invalid,
+fallback, degraded, missing, or failed pair statuses. The route-only
+`classic_head_on_corridor_low_start_delay_all_p050` probe failed closed during preflight and was
+excluded from paired success evidence, as intended.
+
+Mean completed-pair deltas over `goal`, `orca`, and
+`scenario_adaptive_hybrid_orca_v2_collision_guard`:
+
+| Slice | Pairs | Min-Distance Delta | Success Delta | Collision Delta | Timeout Delta |
+|---|---:|---:|---:|---:|---:|
+| all start-delay pairs | 21 | `+1.784229 m` | `0.0` | `0.0` | `0.0` |
+| `francis2023_intersection_wait` | 9 | `+4.159358 m` | `0.0` | `0.0` | `0.0` |
+| `francis2023_join_group` | 12 | `+0.002882 m` | `0.0` | `0.0` | `0.0` |
+| `goal` | 7 | `+2.084558 m` | `0.0` | `0.0` | `0.0` |
+| `orca` | 7 | `+1.595997 m` | `0.0` | `0.0` | `0.0` |
+| `scenario_adaptive_hybrid_orca_v2_collision_guard` | 7 | `+1.672131 m` | `0.0` | `0.0` | `0.0` |
+
+Interpretation: delaying the crossing pedestrian in `francis2023_intersection_wait` changes the
+closest-approach geometry substantially in this short horizon, but it does not change success,
+collision, or timeout outcomes. Delaying the joining pedestrian in `francis2023_join_group` barely
+moves the min-distance metric. This is useful as a phase-sensitivity diagnostic and not evidence
+that timing delays improve planner robustness.
+
+## Evidence Boundary
+
+Tracked compact evidence will live under
+`docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/`:
+
+- [summary.json](evidence/issue_1941_ped_timing_phase_2026-05-31/summary.json)
+- [README.md](evidence/issue_1941_ped_timing_phase_2026-05-31/README.md)
+- [SHA256SUMS](evidence/issue_1941_ped_timing_phase_2026-05-31/SHA256SUMS)
+
+Ignored local outputs:
+
+- materialized matrix and scenario overrides under
+  `output/scenario_perturbations/issue1941_ped_timing_phase/`
+- coverage output from targeted tests
+
+The run emitted the known `uni_campus_big.svg` invalid obstacle warning during combined scenario
+materialization but completed all eligible paired rows.
+
+## Routing
+
+This timing family is intentionally conservative. A later trajectory timing family can explore
+pedestrian routes or `wait_at` phase perturbations, but that should be a separate issue because it
+needs a different validity contract.

--- a/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/robot-sf/scenario_perturbation_manifest.v1.json",
   "title": "RobotSF Scenario Perturbation Manifest (v1)",
-  "description": "Minimal manifest for no-op baselines and bounded route perturbation preflight. Validity preflight is not benchmark execution evidence.",
+  "description": "Minimal manifest for no-op baselines plus bounded route and pedestrian timing perturbation preflight. Validity preflight is not benchmark execution evidence.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -71,6 +71,10 @@
           "type": "number",
           "exclusiveMinimum": 0
         },
+        "max_start_delay_offset_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
         "invalid_variant_evidence_policy": {
           "const": "exclude_from_success_evidence"
         },
@@ -102,6 +106,39 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "variants": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "const": "single_pedestrian_start_delay_offset"
+                }
+              },
+              "required": [
+                "family"
+              ]
+            }
+          }
+        },
+        "required": [
+          "variants"
+        ]
+      },
+      "then": {
+        "properties": {
+          "validity": {
+            "required": [
+              "max_start_delay_offset_s"
+            ]
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "variant": {
       "type": "object",
@@ -126,7 +163,8 @@
           "enum": [
             "noop",
             "robot_route_offset",
-            "pedestrian_route_offset"
+            "pedestrian_route_offset",
+            "single_pedestrian_start_delay_offset"
           ]
         },
         "seeds": {
@@ -143,11 +181,6 @@
         "parameters": {
           "type": "object",
           "additionalProperties": false,
-          "required": [
-            "dx_m",
-            "dy_m",
-            "max_magnitude_m"
-          ],
           "properties": {
             "dx_m": {
               "type": "number"
@@ -168,6 +201,20 @@
               "minimum": 0
             },
             "waypoint_selector": {
+              "const": "all"
+            },
+            "dt_s": {
+              "type": "number"
+            },
+            "max_abs_dt_s": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "pedestrian_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "pedestrian_selector": {
               "const": "all"
             }
           }
@@ -191,7 +238,84 @@
           "then": {
             "required": [
               "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "dx_m",
+                  "dy_m",
+                  "max_magnitude_m"
+                ],
+                "properties": {
+                  "dx_m": {
+                    "type": "number"
+                  },
+                  "dy_m": {
+                    "type": "number"
+                  },
+                  "max_magnitude_m": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "spawn_id": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "goal_id": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "waypoint_selector": {
+                    "const": "all"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "family": {
+                "const": "single_pedestrian_start_delay_offset"
+              }
+            },
+            "required": [
+              "family"
             ]
+          },
+          "then": {
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "dt_s",
+                  "max_abs_dt_s"
+                ],
+                "properties": {
+                  "dt_s": {
+                    "type": "number"
+                  },
+                  "max_abs_dt_s": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "pedestrian_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "pedestrian_selector": {
+                    "const": "all"
+                  }
+                }
+              }
+            }
           }
         },
         {

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -406,7 +406,12 @@ def _normalize_variant(variant: Any) -> Mapping[str, Any]:
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"variant.{field_name} must be a non-empty string")
     family = str(variant["family"])
-    if family not in {"noop", "robot_route_offset", "pedestrian_route_offset"}:
+    if family not in {
+        "noop",
+        "robot_route_offset",
+        "pedestrian_route_offset",
+        "single_pedestrian_start_delay_offset",
+    }:
         raise ValueError(f"unsupported perturbation family: {family}")
     return variant
 
@@ -441,6 +446,9 @@ def _validate_perturbation_bounds(
     parameters = variant.get("parameters")
     if not isinstance(parameters, Mapping):
         raise ValueError(f"{family} variants require a parameters mapping")
+    if family == "single_pedestrian_start_delay_offset":
+        return _validate_start_delay_offset_bounds(variant, manifest=manifest)
+
     dx = _finite_float(parameters.get("dx_m", 0.0), field_name="parameters.dx_m")
     dy = _finite_float(parameters.get("dy_m", 0.0), field_name="parameters.dy_m")
     magnitude = math.hypot(dx, dy)
@@ -472,6 +480,49 @@ def _validate_perturbation_bounds(
     return [], summary
 
 
+def _validate_start_delay_offset_bounds(
+    variant: Mapping[str, Any],
+    *,
+    manifest: Mapping[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    """Validate bounded pedestrian start-delay perturbations.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Fail-closed reasons and perturbation summary.
+    """
+    family = str(variant["family"])
+    parameters = variant.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError(f"{family} variants require a parameters mapping")
+    dt_s = _finite_float(parameters.get("dt_s"), field_name="parameters.dt_s")
+    variant_max = _positive_float(
+        parameters.get("max_abs_dt_s"),
+        field_name="parameters.max_abs_dt_s",
+    )
+    manifest_max_raw = manifest["validity"].get("max_start_delay_offset_s")
+    manifest_max = _positive_float(
+        manifest_max_raw,
+        field_name="validity.max_start_delay_offset_s",
+    )
+    bound = min(variant_max, manifest_max)
+    abs_dt_s = abs(dt_s)
+    summary = {
+        "family": family,
+        "dt_s": dt_s,
+        "abs_dt_s": abs_dt_s,
+        "max_abs_dt_s": bound,
+        "target": {
+            "pedestrian_id": parameters.get("pedestrian_id"),
+            "selector": parameters.get("pedestrian_selector", "all"),
+        },
+    }
+    if abs_dt_s > bound:
+        return [
+            f"{family} abs_dt_s {abs_dt_s:.6f} s exceeds variant max_abs_dt_s {bound:.6f} s"
+        ], summary
+    return [], summary
+
+
 def _certify_variant(
     variant: Mapping[str, Any],
     *,
@@ -493,13 +544,20 @@ def _certify_variant(
         raise ValueError("scenario map pool is empty")
     _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
     perturbed_map = deepcopy(map_def)
-    _apply_route_offset(
-        _routes_for_family(perturbed_map, str(variant["family"])),
-        dx=float(perturbation_summary["dx_m"]),
-        dy=float(perturbation_summary["dy_m"]),
-        parameters=variant.get("parameters", {}),
-        family=str(variant["family"]),
-    )
+    if variant["family"] == "single_pedestrian_start_delay_offset":
+        _apply_start_delay_offset(
+            perturbed_map.single_pedestrians,
+            dt_s=float(perturbation_summary["dt_s"]),
+            parameters=variant.get("parameters", {}),
+        )
+    else:
+        _apply_route_offset(
+            _routes_for_family(perturbed_map, str(variant["family"])),
+            dx=float(perturbation_summary["dx_m"]),
+            dy=float(perturbation_summary["dy_m"]),
+            parameters=variant.get("parameters", {}),
+            family=str(variant["family"]),
+        )
     perturbed_map.__post_init__()
     scenario["metadata"] = _variant_metadata(
         scenario.get("metadata"), variant, perturbation_summary
@@ -559,6 +617,13 @@ def _materialize_variant_scenario(
             route_path=route_path,
         )
         scenario["route_overrides_file"] = route_path.relative_to(matrix_path.parent).as_posix()
+    elif variant["family"] == "single_pedestrian_start_delay_offset":
+        scenario["single_pedestrians"] = _single_pedestrian_overrides_for_start_delay(
+            variant,
+            scenario=scenario,
+            scenario_config=scenario_config,
+            perturbation_summary=result.perturbation_summary,
+        )
     return scenario
 
 
@@ -648,6 +713,80 @@ def _routes_for_family(map_def: Any, family: str) -> list[GlobalRoute]:
     if family == "pedestrian_route_offset":
         return map_def.ped_routes
     raise ValueError(f"unsupported route-offset family: {family}")
+
+
+def _select_single_pedestrians(pedestrians: list[Any], parameters: Any) -> list[Any]:
+    """Return the single-pedestrian definitions targeted by a timing perturbation."""
+    if not isinstance(parameters, Mapping):
+        raise ValueError("parameters must be a mapping")
+    selector = str(parameters.get("pedestrian_selector", "all"))
+    if selector != "all":
+        raise ValueError("single_pedestrian_start_delay_offset supports selector='all' only")
+    pedestrian_id = parameters.get("pedestrian_id")
+    selected = [
+        ped for ped in pedestrians if pedestrian_id is None or str(ped.id) == str(pedestrian_id)
+    ]
+    if not selected:
+        raise ValueError("single_pedestrian_start_delay_offset selected no single pedestrians")
+    return selected
+
+
+def _apply_start_delay_offset(
+    pedestrians: list[Any],
+    *,
+    dt_s: float,
+    parameters: Any,
+) -> None:
+    """Offset selected single-pedestrian start delays in place."""
+    selected = _select_single_pedestrians(pedestrians, parameters)
+    for ped in selected:
+        updated = float(ped.start_delay_s) + float(dt_s)
+        if updated < 0.0:
+            raise ValueError(
+                "single_pedestrian_start_delay_offset would make "
+                f"pedestrian {ped.id!r} start_delay_s negative"
+            )
+        ped.start_delay_s = updated
+
+
+def _single_pedestrian_overrides_for_start_delay(
+    variant: Mapping[str, Any],
+    *,
+    scenario: Mapping[str, Any],
+    scenario_config: Path,
+    perturbation_summary: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return scenario overrides with adjusted single-pedestrian start delays."""
+    config = build_robot_config_from_scenario(dict(scenario), scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    selected = _select_single_pedestrians(
+        list(map_def.single_pedestrians),
+        variant.get("parameters", {}),
+    )
+    selected_ids = {str(ped.id) for ped in selected}
+    delays = {}
+    for ped in selected:
+        updated = float(ped.start_delay_s) + float(perturbation_summary["dt_s"])
+        if updated < 0.0:
+            raise ValueError(
+                "single_pedestrian_start_delay_offset would make "
+                f"pedestrian {ped.id!r} start_delay_s negative"
+            )
+        delays[str(ped.id)] = updated
+
+    raw_overrides = scenario.get("single_pedestrians")
+    overrides = [dict(item) for item in raw_overrides] if isinstance(raw_overrides, list) else []
+    seen_ids: set[str] = set()
+    for entry in overrides:
+        ped_id = str(entry.get("id") or "")
+        seen_ids.add(ped_id)
+        if ped_id in selected_ids:
+            entry["start_delay_s"] = delays[ped_id]
+    for ped_id in sorted(selected_ids - seen_ids):
+        overrides.append({"id": ped_id, "start_delay_s": delays[ped_id]})
+    return overrides
 
 
 def _route_to_payload(route: GlobalRoute) -> dict[str, Any]:

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -101,6 +101,52 @@ def _write_pedestrian_route_manifest(path: Path, *, scenario_id: str) -> Path:
     return path
 
 
+def _write_start_delay_manifest(
+    path: Path,
+    *,
+    scenario_id: str,
+    dt_s: float = 0.5,
+    max_abs_dt_s: float = 1.0,
+) -> Path:
+    """Write a perturbation manifest that offsets single-pedestrian start delay."""
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_start_delay_perturbation_manifest",
+        "scenario_config": "configs/scenarios/classic_interactions_francis2023.yaml",
+        "seed_controls": {
+            "baseline_seeds": [112],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": {
+            "require_scenario_certification": True,
+            "max_route_offset_m": 0.5,
+            "max_start_delay_offset_s": 1.0,
+            "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+        },
+        "variants": [
+            {
+                "variant_id": f"{scenario_id}_noop",
+                "scenario_id": scenario_id,
+                "family": "noop",
+                "seeds": [112],
+            },
+            {
+                "variant_id": f"{scenario_id}_start_delay_offset",
+                "scenario_id": scenario_id,
+                "family": "single_pedestrian_start_delay_offset",
+                "seeds": [112],
+                "parameters": {
+                    "dt_s": dt_s,
+                    "max_abs_dt_s": max_abs_dt_s,
+                    "pedestrian_id": "h3",
+                },
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_manifest_schema_accepts_noop_and_bounded_route_offset(tmp_path: Path) -> None:
     """The public schema should document the first supported perturbation surface."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
@@ -128,6 +174,68 @@ def test_manifest_schema_accepts_bounded_pedestrian_route_offset(tmp_path: Path)
     )
 
     jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_accepts_bounded_single_pedestrian_start_delay_offset(
+    tmp_path: Path,
+) -> None:
+    """The public schema should expose the start-delay timing family."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_requires_manifest_timing_cap_for_start_delay_offset(
+    tmp_path: Path,
+) -> None:
+    """Timing manifests should carry both variant-local and policy-level bounds."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    del manifest["validity"]["max_start_delay_offset_s"]
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with pytest.raises(jsonschema.ValidationError, match="max_start_delay_offset_s"):
+        jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None:
+    """Family-specific parameter schemas should catch typo-shaped irrelevant fields."""
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    route_manifest_path = _write_manifest(tmp_path / "route_perturbations.yaml")
+    route_manifest = yaml.safe_load(route_manifest_path.read_text(encoding="utf-8"))
+    route_manifest["variants"][1]["parameters"]["dt_s"] = 0.5
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(route_manifest, schema)
+
+    timing_manifest_path = _write_start_delay_manifest(
+        tmp_path / "timing_perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    timing_manifest = yaml.safe_load(timing_manifest_path.read_text(encoding="utf-8"))
+    timing_manifest["variants"][1]["parameters"]["dx_m"] = 0.0
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(timing_manifest, schema)
 
 
 def test_preflight_rejects_manifest_that_violates_public_schema(tmp_path: Path) -> None:
@@ -194,6 +302,90 @@ def test_preflight_excludes_pedestrian_route_offset_without_ped_routes(tmp_path:
     assert excluded.certificate is None
     assert excluded.reasons == [
         "preflight_error: pedestrian_route_offset selected no pedestrian routes"
+    ]
+
+
+def test_preflight_certifies_bounded_single_pedestrian_start_delay_offset(
+    tmp_path: Path,
+) -> None:
+    """Single-pedestrian start-delay offsets should certify when the target exists."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    assert [result.variant_id for result in report.results] == [
+        "francis2023_join_group_noop",
+        "francis2023_join_group_start_delay_offset",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    assert report.results[1].family == "single_pedestrian_start_delay_offset"
+    assert report.results[1].perturbation_summary["dt_s"] == pytest.approx(0.5)
+    assert report.results[1].perturbation_summary["target"]["pedestrian_id"] == "h3"
+
+
+def test_preflight_excludes_start_delay_offset_without_single_pedestrians(
+    tmp_path: Path,
+) -> None:
+    """A timing perturbation must fail closed when no single pedestrians exist."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_high",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.family == "single_pedestrian_start_delay_offset"
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_start_delay_offset selected no single pedestrians"
+    ]
+
+
+def test_preflight_excludes_unbounded_start_delay_offset_before_certification(
+    tmp_path: Path,
+) -> None:
+    """Out-of-bounds timing perturbations should fail closed without certification."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+        dt_s=1.25,
+        max_abs_dt_s=1.0,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "single_pedestrian_start_delay_offset abs_dt_s 1.250000 s exceeds variant max_abs_dt_s 1.000000 s"
+    ]
+
+
+def test_preflight_excludes_negative_start_delay_result(tmp_path: Path) -> None:
+    """Negative timing offsets cannot make the selected start delay negative."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+        dt_s=-0.5,
+        max_abs_dt_s=1.0,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_start_delay_offset would make pedestrian 'h3' start_delay_s negative"
     ]
 
 
@@ -306,6 +498,75 @@ def test_materialize_pilot_matrix_writes_pedestrian_route_overrides(tmp_path: Pa
     offset_point = offset_map.ped_routes[0].waypoints[0]
     assert offset_point[0] == pytest.approx(original_point[0])
     assert offset_point[1] == pytest.approx(original_point[1] + 0.25)
+
+
+def test_materialize_pilot_matrix_writes_start_delay_overrides(tmp_path: Path) -> None:
+    """Start-delay variants should preserve single-ped entries while updating delay."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    output_dir = tmp_path / "pilot"
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=output_dir,
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "francis2023_join_group_noop",
+        "francis2023_join_group_start_delay_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    overrides = {entry["id"]: entry for entry in offset_scenario["single_pedestrians"]}
+    assert overrides["h3"]["role"] == "join"
+    assert overrides["h3"]["role_target_id"] == "h1"
+    assert overrides["h3"]["start_delay_s"] == pytest.approx(0.5)
+
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    delays = {ped.id: ped.start_delay_s for ped in offset_map.single_pedestrians}
+    assert delays["h3"] == pytest.approx(0.5)
+
+
+def test_materialize_pilot_matrix_start_delay_selector_all(tmp_path: Path) -> None:
+    """The timing family can intentionally phase-shift every single pedestrian."""
+    manifest_path = _write_start_delay_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_leave_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    parameters = manifest["variants"][1]["parameters"]
+    del parameters["pedestrian_id"]
+    parameters["pedestrian_selector"] = "all"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "francis2023_leave_group_noop",
+        "francis2023_leave_group_start_delay_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    delays = {ped.id: ped.start_delay_s for ped in offset_map.single_pedestrians}
+    assert delays == {"h1": pytest.approx(0.5), "h2": pytest.approx(0.5), "h3": pytest.approx(0.5)}
 
 
 def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1941.

Adds a bounded `single_pedestrian_start_delay_offset` perturbation family for #1610-style scenario perturbation pilots. The schema now requires a manifest-level `validity.max_start_delay_offset_s` whenever timing variants are present, and family-specific parameter schemas reject cross-family fields so route/timing typos do not silently pass through.

Adds the tracked diagnostic manifest `configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml`, compact evidence under `docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/`, and a context note at `docs/context/issue_1941_ped_timing_phase.md`.

## Diagnostic result

- Pilot command completed 21/21 paired no-op-versus-start-delay rows.
- The route-only `classic_head_on_corridor_low_start_delay_all_p050` probe failed closed during preflight and was excluded from paired success evidence.
- Mean completed-pair min-distance delta: `+1.784229 m` overall.
- By source scenario: `francis2023_intersection_wait` `+4.159358 m`; `francis2023_join_group` `+0.002882 m`.
- Success, collision, and timeout deltas were all `0.0`; this is diagnostic phase-sensitivity evidence, not a robustness or benchmark-strength claim.

## Validation

- `uv run ruff check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `uv run ruff format --check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py` -> 21 passed
- `sha256sum --check docs/context/evidence/issue_1941_ped_timing_phase_2026-05-31/SHA256SUMS`
- Schema validation for `issue_1610_ped_route_offset_pilot_v1.yaml` and `issue_1610_ped_timing_phase_pilot_v1.yaml`
- Timing pilot command from `docs/context/issue_1941_ped_timing_phase.md`; emitted the known `uni_campus_big.svg` invalid obstacle warning and completed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4809 passed, 11 skipped, 8 warnings; changed-file coverage warning only for `robot_sf/scenario_certification/perturbation_preflight.py` at 89.6%

## Artifact boundary

Raw episode JSONL, materialized scenario matrices/overrides, coverage HTML, and readiness stamps remain ignored under `output/`. The tracked compact evidence is `summary.json`, `README.md`, and `SHA256SUMS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pedestrian start-delay timing perturbation scenarios with bounded parameters to scenario perturbation manifest support.

* **Documentation**
  * Added pedestrian timing phase perturbation documentation and evidence bundle for pilot results.

* **Tests**
  * Expanded test coverage for timing perturbation validation, boundary constraints, and scenario materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->