### PR TITLE
analysis: add single-ped speed perturbation pilot

### DIFF
--- a/configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml
+++ b/configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml
@@ -1,0 +1,106 @@
+# Issue #1943 follow-up perturbation manifest for parent issue #1610.
+#
+# This manifest adds exactly one speed perturbation family for single-pedestrian scenarios. It is
+# a validity-preflight and local-pilot input only; it does not make benchmark-strength or
+# paper-facing claims.
+
+schema_version: scenario_perturbation_manifest.v1
+manifest_id: issue_1610_ped_speed_pilot_v1
+description: >-
+  Bounded #1610 follow-up manifest that holds the #1941 planner/seed/horizon pilot boundary fixed
+  while adding single-pedestrian speed offsets as the only new perturbation family.
+scenario_config: ../classic_interactions_francis2023.yaml
+seed_controls:
+  baseline_seeds: [112, 113, 115, 116, 240, 241, 242, 258, 259, 260]
+  replay_seed_policy: explicit
+  source: docs/context/evidence/issue_1608_seed_sensitivity_2026-05-30/scenario_seed_sensitivity.csv
+validity:
+  require_scenario_certification: true
+  max_route_offset_m: 0.5
+  max_single_pedestrian_speed_delta_m_s: 0.5
+  max_single_pedestrian_speed_m_s: 2.0
+  invalid_variant_evidence_policy: exclude_from_success_evidence
+  notes: >-
+    The v1 speed preflight supports no-op baselines plus bounded speed offsets for scenarios that
+    expose single_pedestrians. Route-only pedestrian scenarios must fail closed because GlobalRoute
+    has no per-route speed field.
+variants:
+  - variant_id: francis2023_join_group_noop
+    scenario_id: francis2023_join_group
+    family: noop
+    seeds: [112, 113, 115, 116]
+    rationale: Baseline row for a Francis social-interaction scenario flagged by issue #1608.
+  - variant_id: francis2023_join_group_speed_h3_p025
+    scenario_id: francis2023_join_group
+    family: single_pedestrian_speed_offset
+    seeds: [112, 113, 115, 116]
+    rationale: >-
+      Speeds up the joining pedestrian to test whether local planners are sensitive to approach
+      velocity in the join-group interaction without changing the map or robot route.
+    parameters:
+      speed_delta_m_s: 0.25
+      max_abs_speed_delta_m_s: 0.5
+      max_speed_m_s: 2.0
+      pedestrian_id: h3
+
+  - variant_id: francis2023_intersection_wait_noop
+    scenario_id: francis2023_intersection_wait
+    family: noop
+    seeds: [240, 241, 242]
+    rationale: Baseline row for a single-pedestrian wait-then-cross Francis scenario.
+  - variant_id: francis2023_intersection_wait_speed_h1_p025
+    scenario_id: francis2023_intersection_wait
+    family: single_pedestrian_speed_offset
+    seeds: [240, 241, 242]
+    rationale: >-
+      Speeds up the crossing pedestrian to probe velocity sensitivity in the same scenario where
+      #1941 found a large timing-phase min-distance response.
+    parameters:
+      speed_delta_m_s: 0.25
+      max_abs_speed_delta_m_s: 0.5
+      max_speed_m_s: 2.0
+      pedestrian_id: h1
+
+  - variant_id: francis2023_leave_group_noop
+    scenario_id: francis2023_leave_group
+    family: noop
+    seeds: [258, 259, 260]
+    rationale: Baseline row for a multi-single-pedestrian group-leaving scenario.
+  - variant_id: francis2023_leave_group_speed_all_p025
+    scenario_id: francis2023_leave_group
+    family: single_pedestrian_speed_offset
+    seeds: [258, 259, 260]
+    rationale: >-
+      Speeds up all single pedestrians to exercise selector-all materialization on a
+      multi-single-pedestrian Francis scenario.
+    parameters:
+      speed_delta_m_s: 0.25
+      max_abs_speed_delta_m_s: 0.5
+      max_speed_m_s: 2.0
+      pedestrian_selector: all
+
+  - variant_id: classic_head_on_corridor_low_noop
+    scenario_id: classic_head_on_corridor_low
+    family: noop
+    seeds: [111, 112, 116, 117]
+    rationale: Baseline row for the corridor route-based scenario used in #1939 trace analysis.
+  - variant_id: classic_head_on_corridor_low_speed_all_p025
+    scenario_id: classic_head_on_corridor_low
+    family: single_pedestrian_speed_offset
+    seeds: [111, 112, 116, 117]
+    rationale: >-
+      Fail-closed probe proving that route-only classic pedestrians are not silently treated as
+      single-pedestrian speed targets.
+    parameters:
+      speed_delta_m_s: 0.25
+      max_abs_speed_delta_m_s: 0.5
+      max_speed_m_s: 2.0
+      pedestrian_selector: all
+pilot_matrix_note:
+  parent_issue: "#1610"
+  next_step: >-
+    Run a tiny paired planner pilot over eligible no-op and single-pedestrian speed rows using the
+    same planner/config/seed controls except for variant_id.
+  evidence_boundary: >-
+    Preflight validity is necessary but not sufficient benchmark evidence; invalid, fallback,
+    degraded, missing, or stress-only rows are limitations rather than success evidence.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -228,6 +228,8 @@ knowledge, not every transient iteration detail.
   [issue_1939_corridor_trace_response.md](issue_1939_corridor_trace_response.md)
 * Issue #1941 Pedestrian Timing Phase Perturbation (2026-05-31):
   [issue_1941_ped_timing_phase.md](issue_1941_ped_timing_phase.md)
+* Issue #1943 Single-Pedestrian Speed Perturbation (2026-05-31):
+  [issue_1943_ped_speed_perturbation.md](issue_1943_ped_speed_perturbation.md)
 * Issue #1304 pedestrian config boundary:
   [issue_1304_pedestrian_config_boundary.md](issue_1304_pedestrian_config_boundary.md)
 * Issue #1633 RobotEnv SNQI proxy extraction:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -104,3 +104,5 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   #1610/#1937 pilot.
 - `issue_1941_ped_timing_phase_2026-05-31/`: compact diagnostic-only paired
   no-op-versus-start-delay summary for the #1610 single-pedestrian timing phase perturbation pilot.
+- `issue_1943_ped_speed_perturbation_2026-05-31/`: compact diagnostic-only paired
+  no-op-versus-speed summary for the #1610 single-pedestrian speed perturbation pilot.

--- a/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/README.md
+++ b/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/README.md
@@ -1,0 +1,17 @@
+# Issue #1943 Single-Pedestrian Speed Evidence
+
+Compact diagnostic-only evidence for
+[`docs/context/issue_1943_ped_speed_perturbation.md`](../../issue_1943_ped_speed_perturbation.md).
+
+## Files
+
+- `summary.json`: compact output from
+  `scripts/validation/run_scenario_perturbation_criticality_pilot.py` for
+  `configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml`.
+- `SHA256SUMS`: checksums for this evidence bundle.
+
+## Boundary
+
+The raw episode JSONL, materialized scenario matrix, generated scenario overrides, and coverage
+HTML remain ignored local outputs under `output/`. This bundle is diagnostic local evidence only
+and is not benchmark-strength or paper-facing evidence.

--- a/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/SHA256SUMS
+++ b/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/SHA256SUMS
@@ -1,0 +1,2 @@
+a96523f3519611969fab3d6dee0c8393059577054488f5b45fda467231b71735  docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/README.md
+4934aee408e3e2f3ee944248d1b5bb3276f314d29a1617a98d86c49fab9af1b0  docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/summary.json

--- a/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/summary.json
+++ b/docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/summary.json
@@ -1,0 +1,1025 @@
+{
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 80,
+  "manifest": "configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [
+      "classic_head_on_corridor_low_speed_all_p025"
+    ],
+    "included_variants": [
+      "francis2023_join_group_noop",
+      "francis2023_join_group_speed_h3_p025",
+      "francis2023_intersection_wait_noop",
+      "francis2023_intersection_wait_speed_h1_p025",
+      "francis2023_leave_group_noop",
+      "francis2023_leave_group_speed_all_p025",
+      "classic_head_on_corridor_low_noop"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1610_ped_speed_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 7
+  },
+  "pair_rows": [
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -2.3114866049253884,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.396640728620171,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 5.085154123694783,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "goal",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -2.290897456841522,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.50130537424527,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 5.210407917403748,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "goal",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -2.2936836547177526,
+      "noop": {
+        "collision": 0,
+        "min_distance": 7.119166442080297,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 4.825482787362544,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "goal",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.489627078493282,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "goal",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.006339899161680318,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.860499164278315,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.866839063439995,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "goal",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5542955250491202,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5542955250491202,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "goal",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 2.1354041290479486,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 2.1354041290479486,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "goal",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.002027434418448326,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.3890071223697769,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 1.3869796879513285,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "goal",
+      "seed": 258,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.016635608023517268,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.3717746434984393,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 1.3884102515219565,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "goal",
+      "seed": 259,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.08293764987391494,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.399946555342972,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 1.317008905469057,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "goal",
+      "seed": 260,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.8154889770045628,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.409910230972628,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.594421253968065,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "orca",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.8349887094198376,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.373728612568657,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.538739903148819,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "orca",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.810025913954152,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.16723292620106,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.357207012246907,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "orca",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0033332886246757454,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4492909863429455,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4459576977182698,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "orca",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.0014981811475689444,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.439309677641443,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.437811496493874,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "orca",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -9.538736683412097e-05,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4397620085044152,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.439666621137581,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "orca",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.02747195671415792,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4741467753802409,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.446674818666083,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "orca",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": -1.0,
+      "min_distance_delta": 0.01324802303149486,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.3989791295768006,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4122271526082955,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "orca",
+      "seed": 258,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 1.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -0.010946433094039865,
+      "noop": {
+        "collision": 1,
+        "min_distance": 1.397375601640609,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 1,
+        "min_distance": 1.386429168546569,
+        "success": 0,
+        "termination_reason": "collision",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "orca",
+      "seed": 259,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.10121123120699349,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4235830142893957,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5247942454963892,
+        "success": 1,
+        "termination_reason": "success",
+        "timeout": 0
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "orca",
+      "seed": 260,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.881998172916271,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.219161902426459,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.337163729510188,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.9031966889107856,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.180964865278593,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.2777681763678075,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": -1.8844834423771823,
+      "noop": {
+        "collision": 0,
+        "min_distance": 8.220298941258834,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 6.335815498881652,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_speed_h1_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 242,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4482470133949672,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4482470133949672,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 112,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4487350475219367,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4487350475219367,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 113,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4494315390472794,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4494315390472794,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 115,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4477641505470757,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_join_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.4477641505470757,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_join_group_speed_h3_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 116,
+      "source_scenario_id": "francis2023_join_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.08267971781593797,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.5126069816360954,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5952866994520334,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 258,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.14604244448258252,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4476440318966894,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.593686476379272,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 259,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.1379792775921853,
+      "noop": {
+        "collision": 0,
+        "min_distance": 1.4471693418500375,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_leave_group_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 1.5851486194422229,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_speed_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_leave_group_speed_all_p025",
+      "planner": "scenario_adaptive_hybrid_orca_v2_collision_guard",
+      "seed": 260,
+      "source_scenario_id": "francis2023_leave_group",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    }
+  ],
+  "pair_summary": {
+    "by_perturbation_family": {
+      "single_pedestrian_speed_offset": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": -0.03333333333333333,
+          "min_distance_delta": -0.5883474583664233,
+          "success_delta": 0.03333333333333333,
+          "timeout_delta": 0.0
+        },
+        "pairs": 30,
+        "status_counts": {
+          "completed": 30
+        }
+      }
+    },
+    "by_planner": {
+      "goal": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -0.6958057293591828,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 10,
+        "status_counts": {
+          "completed": 10
+        }
+      },
+      "orca": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": -0.1,
+          "min_distance_delta": -0.538938959308734,
+          "success_delta": 0.1,
+          "timeout_delta": 0.0
+        },
+        "pairs": 10,
+        "status_counts": {
+          "completed": 10
+        }
+      },
+      "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -0.5302976864313533,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 10,
+        "status_counts": {
+          "completed": 10
+        }
+      }
+    },
+    "by_source_scenario": {
+      "francis2023_intersection_wait": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -2.0029166245630505,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 9,
+        "status_counts": {
+          "completed": 9
+        }
+      },
+      "francis2023_join_group": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": -0.0021715762242963677,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 12,
+        "status_counts": {
+          "completed": 12
+        }
+      },
+      "francis2023_leave_group": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": -0.1111111111111111,
+          "min_distance_delta": 0.04465386497403426,
+          "success_delta": 0.1111111111111111,
+          "timeout_delta": 0.0
+        },
+        "pairs": 9,
+        "status_counts": {
+          "completed": 9
+        }
+      }
+    },
+    "mean_deltas_completed_pairs": {
+      "collision_delta": -0.03333333333333333,
+      "min_distance_delta": -0.5883474583664233,
+      "success_delta": 0.03333333333333333,
+      "timeout_delta": 0.0
+    },
+    "pairs": 30,
+    "status_counts": {
+      "completed": 30
+    }
+  },
+  "planner_runs": {
+    "goal": {
+      "algo": "goal",
+      "algo_config_path": null,
+      "episodes": 24,
+      "source": "raw_algo"
+    },
+    "orca": {
+      "algo": "orca",
+      "algo_config_path": null,
+      "episodes": 24,
+      "source": "raw_algo"
+    },
+    "scenario_adaptive_hybrid_orca_v2_collision_guard": {
+      "algo": "hybrid_rule_local_planner",
+      "algo_config_path": "configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml",
+      "episodes": 24,
+      "source": "policy_search_candidate"
+    }
+  },
+  "planners": [
+    "goal",
+    "orca",
+    "scenario_adaptive_hybrid_orca_v2_collision_guard"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 4
+}

--- a/docs/context/issue_1943_ped_speed_perturbation.md
+++ b/docs/context/issue_1943_ped_speed_perturbation.md
@@ -1,0 +1,94 @@
+# Issue #1943 Single-Pedestrian Speed Perturbation
+
+Issue: [#1943](https://github.com/ll7/robot_sf_ll7/issues/1943)
+Parent: [#1610](https://github.com/ll7/robot_sf_ll7/issues/1610)
+Predecessors: [#1937](https://github.com/ll7/robot_sf_ll7/issues/1937),
+[#1939](https://github.com/ll7/robot_sf_ll7/issues/1939),
+[#1941](https://github.com/ll7/robot_sf_ll7/issues/1941)
+
+## Goal
+
+Add a narrowly bounded single-pedestrian speed perturbation family to the #1610
+scenario-perturbation pilot lane. This note is diagnostic local evidence only; it is not
+benchmark-strength or paper-facing evidence.
+
+## Implementation
+
+`single_pedestrian_speed_offset` changes selected `single_pedestrians` by adding
+`speed_delta_m_s` to their baseline `speed_m_s` before certification and materialization. When a
+source pedestrian omits `speed_m_s`, the perturbation uses the current runtime default single-ped
+initial speed of `0.5 m/s` as the diagnostic baseline and writes an explicit `speed_m_s` override
+into the materialized scenario.
+
+The family deliberately does not target route-based pedestrians. `GlobalRoute` has no per-route
+speed field, so route-only scenarios fail closed and are excluded from success evidence rather than
+falling back to global `peds_speed_mult`.
+
+The tracked pilot manifest is
+`configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml`.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 \
+uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py \
+  configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml \
+  --materialized-output-dir output/scenario_perturbations/issue1943_ped_speed/materialized \
+  --pilot-output-dir output/scenario_perturbations/issue1943_ped_speed/pilot \
+  --seed-limit 4 \
+  --horizon 80 \
+  --workers 1 \
+  --planner goal \
+  --planner orca \
+  --planner scenario_adaptive_hybrid_orca_v2_collision_guard \
+  --evidence-summary docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/summary.json
+```
+
+## Result
+
+The diagnostic pilot completed 30/30 eligible no-op-versus-speed rows with no invalid, fallback,
+degraded, missing, or failed pair statuses. The route-only
+`classic_head_on_corridor_low_speed_all_p025` probe failed closed during preflight and was
+excluded from paired success evidence, as intended.
+
+Mean completed-pair deltas over `goal`, `orca`, and
+`scenario_adaptive_hybrid_orca_v2_collision_guard`:
+
+| Slice | Pairs | Min-Distance Delta | Success Delta | Collision Delta | Timeout Delta |
+|---|---:|---:|---:|---:|---:|
+| all speed pairs | 30 | `-0.588347 m` | `+0.033333` | `-0.033333` | `0.0` |
+| `francis2023_intersection_wait` | 9 | `-2.002917 m` | `0.0` | `0.0` | `0.0` |
+| `francis2023_join_group` | 12 | `-0.002172 m` | `0.0` | `0.0` | `0.0` |
+| `francis2023_leave_group` | 9 | `+0.044654 m` | `+0.111111` | `-0.111111` | `0.0` |
+| `goal` | 10 | `-0.695806 m` | `0.0` | `0.0` | `0.0` |
+| `orca` | 10 | `-0.538939 m` | `+0.1` | `-0.1` | `0.0` |
+| `scenario_adaptive_hybrid_orca_v2_collision_guard` | 10 | `-0.530298 m` | `0.0` | `0.0` | `0.0` |
+
+Interpretation: increasing selected single-pedestrian speed generally decreases closest approach
+distance in this short-horizon diagnostic, especially in `francis2023_intersection_wait`. The one
+outcome change is ORCA on `francis2023_leave_group` seed 258, where the perturbed row changes from
+collision to success while min distance changes only `+0.013248 m`. Treat that as a seed-local
+mechanism clue, not a planner robustness claim.
+
+## Evidence Boundary
+
+Tracked compact evidence:
+
+- [summary.json](evidence/issue_1943_ped_speed_perturbation_2026-05-31/summary.json)
+- [README.md](evidence/issue_1943_ped_speed_perturbation_2026-05-31/README.md)
+- [SHA256SUMS](evidence/issue_1943_ped_speed_perturbation_2026-05-31/SHA256SUMS)
+
+Ignored local outputs:
+
+- materialized matrix and scenario overrides under
+  `output/scenario_perturbations/issue1943_ped_speed/`
+- coverage output from targeted tests
+
+The run emitted the known `uni_campus_big.svg` invalid obstacle warning during combined scenario
+materialization but completed all eligible paired rows.
+
+## Routing
+
+This family is intentionally single-pedestrian-first. A later route-pedestrian speed perturbation
+should define an explicit route-speed adapter or global-speed-multiplier contract before it is
+allowed into the paired evidence lane.

--- a/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/robot-sf/scenario_perturbation_manifest.v1.json",
   "title": "RobotSF Scenario Perturbation Manifest (v1)",
-  "description": "Minimal manifest for no-op baselines plus bounded route and pedestrian timing perturbation preflight. Validity preflight is not benchmark execution evidence.",
+  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, and single-pedestrian speed perturbation preflight. Validity preflight is not benchmark execution evidence.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -75,6 +75,14 @@
           "type": "number",
           "exclusiveMinimum": 0
         },
+        "max_single_pedestrian_speed_delta_m_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_single_pedestrian_speed_m_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
         "invalid_variant_evidence_policy": {
           "const": "exclude_from_success_evidence"
         },
@@ -137,6 +145,37 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "variants": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "const": "single_pedestrian_speed_offset"
+                }
+              },
+              "required": [
+                "family"
+              ]
+            }
+          }
+        },
+        "required": [
+          "variants"
+        ]
+      },
+      "then": {
+        "properties": {
+          "validity": {
+            "required": [
+              "max_single_pedestrian_speed_delta_m_s"
+            ]
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -164,7 +203,8 @@
             "noop",
             "robot_route_offset",
             "pedestrian_route_offset",
-            "single_pedestrian_start_delay_offset"
+            "single_pedestrian_start_delay_offset",
+            "single_pedestrian_speed_offset"
           ]
         },
         "seeds": {
@@ -216,6 +256,17 @@
             },
             "pedestrian_selector": {
               "const": "all"
+            },
+            "speed_delta_m_s": {
+              "type": "number"
+            },
+            "max_abs_speed_delta_m_s": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "max_speed_m_s": {
+              "type": "number",
+              "exclusiveMinimum": 0
             }
           }
         }
@@ -268,6 +319,53 @@
                     "minimum": 0
                   },
                   "waypoint_selector": {
+                    "const": "all"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "family": {
+                "const": "single_pedestrian_speed_offset"
+              }
+            },
+            "required": [
+              "family"
+            ]
+          },
+          "then": {
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "speed_delta_m_s",
+                  "max_abs_speed_delta_m_s"
+                ],
+                "properties": {
+                  "speed_delta_m_s": {
+                    "type": "number"
+                  },
+                  "max_abs_speed_delta_m_s": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "max_speed_m_s": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "pedestrian_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "pedestrian_selector": {
                     "const": "all"
                   }
                 }

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -47,6 +47,7 @@ _LOCAL_OUTPUT_ROOT = _REPOSITORY_ROOT / "output"
 _SUCCESS_EVIDENCE_CANDIDATE = "eligible_success_evidence_candidate"
 _EXCLUDED_FROM_SUCCESS_EVIDENCE = "excluded_from_success_evidence"
 _STRESS_ONLY_NOT_SUCCESS_EVIDENCE = "stress_only_not_success_evidence"
+_DEFAULT_SINGLE_PEDESTRIAN_SPEED_M_S = 0.5
 
 
 @dataclass(frozen=True)
@@ -411,6 +412,7 @@ def _normalize_variant(variant: Any) -> Mapping[str, Any]:
         "robot_route_offset",
         "pedestrian_route_offset",
         "single_pedestrian_start_delay_offset",
+        "single_pedestrian_speed_offset",
     }:
         raise ValueError(f"unsupported perturbation family: {family}")
     return variant
@@ -448,6 +450,8 @@ def _validate_perturbation_bounds(
         raise ValueError(f"{family} variants require a parameters mapping")
     if family == "single_pedestrian_start_delay_offset":
         return _validate_start_delay_offset_bounds(variant, manifest=manifest)
+    if family == "single_pedestrian_speed_offset":
+        return _validate_single_pedestrian_speed_offset_bounds(variant, manifest=manifest)
 
     dx = _finite_float(parameters.get("dx_m", 0.0), field_name="parameters.dx_m")
     dy = _finite_float(parameters.get("dy_m", 0.0), field_name="parameters.dy_m")
@@ -478,6 +482,13 @@ def _validate_perturbation_bounds(
             f"{family} magnitude {magnitude:.6f} m exceeds variant max_magnitude_m {bound:.6f} m"
         ], summary
     return [], summary
+
+
+def _optional_positive_float(raw: Any, *, field_name: str) -> float | None:
+    """Return a positive float when present."""
+    if raw is None:
+        return None
+    return _positive_float(raw, field_name=field_name)
 
 
 def _validate_start_delay_offset_bounds(
@@ -523,6 +534,64 @@ def _validate_start_delay_offset_bounds(
     return [], summary
 
 
+def _validate_single_pedestrian_speed_offset_bounds(
+    variant: Mapping[str, Any],
+    *,
+    manifest: Mapping[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    """Validate bounded single-pedestrian speed perturbations.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Fail-closed reasons and perturbation summary.
+    """
+    family = str(variant["family"])
+    parameters = variant.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError(f"{family} variants require a parameters mapping")
+    speed_delta_m_s = _finite_float(
+        parameters.get("speed_delta_m_s"),
+        field_name="parameters.speed_delta_m_s",
+    )
+    variant_max = _positive_float(
+        parameters.get("max_abs_speed_delta_m_s"),
+        field_name="parameters.max_abs_speed_delta_m_s",
+    )
+    manifest_max = _positive_float(
+        manifest["validity"].get("max_single_pedestrian_speed_delta_m_s"),
+        field_name="validity.max_single_pedestrian_speed_delta_m_s",
+    )
+    bound = min(variant_max, manifest_max)
+    manifest_speed_cap = _optional_positive_float(
+        manifest["validity"].get("max_single_pedestrian_speed_m_s"),
+        field_name="validity.max_single_pedestrian_speed_m_s",
+    )
+    variant_speed_cap = _optional_positive_float(
+        parameters.get("max_speed_m_s"),
+        field_name="parameters.max_speed_m_s",
+    )
+    speed_caps = [value for value in (manifest_speed_cap, variant_speed_cap) if value is not None]
+    max_speed_m_s = min(speed_caps) if speed_caps else None
+    abs_speed_delta_m_s = abs(speed_delta_m_s)
+    summary = {
+        "family": family,
+        "speed_delta_m_s": speed_delta_m_s,
+        "abs_speed_delta_m_s": abs_speed_delta_m_s,
+        "max_abs_speed_delta_m_s": bound,
+        "max_speed_m_s": max_speed_m_s,
+        "default_baseline_speed_m_s": _DEFAULT_SINGLE_PEDESTRIAN_SPEED_M_S,
+        "target": {
+            "pedestrian_id": parameters.get("pedestrian_id"),
+            "selector": parameters.get("pedestrian_selector", "all"),
+        },
+    }
+    if abs_speed_delta_m_s > bound:
+        return [
+            f"{family} abs_speed_delta_m_s {abs_speed_delta_m_s:.6f} m/s exceeds "
+            f"variant max_abs_speed_delta_m_s {bound:.6f} m/s"
+        ], summary
+    return [], summary
+
+
 def _certify_variant(
     variant: Mapping[str, Any],
     *,
@@ -548,6 +617,13 @@ def _certify_variant(
         _apply_start_delay_offset(
             perturbed_map.single_pedestrians,
             dt_s=float(perturbation_summary["dt_s"]),
+            parameters=variant.get("parameters", {}),
+        )
+    elif variant["family"] == "single_pedestrian_speed_offset":
+        _apply_single_pedestrian_speed_offset(
+            perturbed_map.single_pedestrians,
+            speed_delta_m_s=float(perturbation_summary["speed_delta_m_s"]),
+            max_speed_m_s=perturbation_summary.get("max_speed_m_s"),
             parameters=variant.get("parameters", {}),
         )
     else:
@@ -619,6 +695,13 @@ def _materialize_variant_scenario(
         scenario["route_overrides_file"] = route_path.relative_to(matrix_path.parent).as_posix()
     elif variant["family"] == "single_pedestrian_start_delay_offset":
         scenario["single_pedestrians"] = _single_pedestrian_overrides_for_start_delay(
+            variant,
+            scenario=scenario,
+            scenario_config=scenario_config,
+            perturbation_summary=result.perturbation_summary,
+        )
+    elif variant["family"] == "single_pedestrian_speed_offset":
+        scenario["single_pedestrians"] = _single_pedestrian_overrides_for_speed(
             variant,
             scenario=scenario,
             scenario_config=scenario_config,
@@ -715,19 +798,24 @@ def _routes_for_family(map_def: Any, family: str) -> list[GlobalRoute]:
     raise ValueError(f"unsupported route-offset family: {family}")
 
 
-def _select_single_pedestrians(pedestrians: list[Any], parameters: Any) -> list[Any]:
+def _select_single_pedestrians(
+    pedestrians: list[Any],
+    parameters: Any,
+    *,
+    family: str = "single_pedestrian_start_delay_offset",
+) -> list[Any]:
     """Return the single-pedestrian definitions targeted by a timing perturbation."""
     if not isinstance(parameters, Mapping):
         raise ValueError("parameters must be a mapping")
     selector = str(parameters.get("pedestrian_selector", "all"))
     if selector != "all":
-        raise ValueError("single_pedestrian_start_delay_offset supports selector='all' only")
+        raise ValueError(f"{family} supports selector='all' only")
     pedestrian_id = parameters.get("pedestrian_id")
     selected = [
         ped for ped in pedestrians if pedestrian_id is None or str(ped.id) == str(pedestrian_id)
     ]
     if not selected:
-        raise ValueError("single_pedestrian_start_delay_offset selected no single pedestrians")
+        raise ValueError(f"{family} selected no single pedestrians")
     return selected
 
 
@@ -747,6 +835,57 @@ def _apply_start_delay_offset(
                 f"pedestrian {ped.id!r} start_delay_s negative"
             )
         ped.start_delay_s = updated
+
+
+def _baseline_single_pedestrian_speed(ped: Any) -> float:
+    """Return the speed used by runtime when a single pedestrian has no explicit override."""
+    return (
+        float(ped.speed_m_s)
+        if getattr(ped, "speed_m_s", None) is not None
+        else _DEFAULT_SINGLE_PEDESTRIAN_SPEED_M_S
+    )
+
+
+def _updated_single_pedestrian_speed(
+    ped: Any,
+    *,
+    speed_delta_m_s: float,
+    max_speed_m_s: Any,
+) -> float:
+    """Return a bounded updated single-pedestrian speed."""
+    updated = _baseline_single_pedestrian_speed(ped) + float(speed_delta_m_s)
+    if updated <= 0.0:
+        raise ValueError(
+            "single_pedestrian_speed_offset would make "
+            f"pedestrian {ped.id!r} speed_m_s non-positive"
+        )
+    if max_speed_m_s is not None and updated > float(max_speed_m_s):
+        raise ValueError(
+            "single_pedestrian_speed_offset would make "
+            f"pedestrian {ped.id!r} speed_m_s exceed max_speed_m_s"
+        )
+    return updated
+
+
+def _apply_single_pedestrian_speed_offset(
+    pedestrians: list[Any],
+    *,
+    speed_delta_m_s: float,
+    max_speed_m_s: Any,
+    parameters: Any,
+) -> None:
+    """Offset selected single-pedestrian speed overrides in place."""
+    selected = _select_single_pedestrians(
+        pedestrians,
+        parameters,
+        family="single_pedestrian_speed_offset",
+    )
+    for ped in selected:
+        ped.speed_m_s = _updated_single_pedestrian_speed(
+            ped,
+            speed_delta_m_s=speed_delta_m_s,
+            max_speed_m_s=max_speed_m_s,
+        )
 
 
 def _single_pedestrian_overrides_for_start_delay(
@@ -786,6 +925,45 @@ def _single_pedestrian_overrides_for_start_delay(
             entry["start_delay_s"] = delays[ped_id]
     for ped_id in sorted(selected_ids - seen_ids):
         overrides.append({"id": ped_id, "start_delay_s": delays[ped_id]})
+    return overrides
+
+
+def _single_pedestrian_overrides_for_speed(
+    variant: Mapping[str, Any],
+    *,
+    scenario: Mapping[str, Any],
+    scenario_config: Path,
+    perturbation_summary: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return scenario overrides with adjusted single-pedestrian speeds."""
+    config = build_robot_config_from_scenario(dict(scenario), scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    selected = _select_single_pedestrians(
+        list(map_def.single_pedestrians),
+        variant.get("parameters", {}),
+        family="single_pedestrian_speed_offset",
+    )
+    selected_ids = {str(ped.id) for ped in selected}
+    speeds = {}
+    for ped in selected:
+        speeds[str(ped.id)] = _updated_single_pedestrian_speed(
+            ped,
+            speed_delta_m_s=float(perturbation_summary["speed_delta_m_s"]),
+            max_speed_m_s=perturbation_summary.get("max_speed_m_s"),
+        )
+
+    raw_overrides = scenario.get("single_pedestrians")
+    overrides = [dict(item) for item in raw_overrides] if isinstance(raw_overrides, list) else []
+    seen_ids: set[str] = set()
+    for entry in overrides:
+        ped_id = str(entry.get("id") or "")
+        seen_ids.add(ped_id)
+        if ped_id in selected_ids:
+            entry["speed_m_s"] = speeds[ped_id]
+    for ped_id in sorted(selected_ids - seen_ids):
+        overrides.append({"id": ped_id, "speed_m_s": speeds[ped_id]})
     return overrides
 
 

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -147,6 +147,53 @@ def _write_start_delay_manifest(
     return path
 
 
+def _write_speed_manifest(
+    path: Path,
+    *,
+    scenario_id: str,
+    speed_delta_m_s: float = 0.25,
+    max_abs_speed_delta_m_s: float = 0.5,
+) -> Path:
+    """Write a perturbation manifest that offsets single-pedestrian speed."""
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_speed_perturbation_manifest",
+        "scenario_config": "configs/scenarios/classic_interactions_francis2023.yaml",
+        "seed_controls": {
+            "baseline_seeds": [112],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": {
+            "require_scenario_certification": True,
+            "max_route_offset_m": 0.5,
+            "max_single_pedestrian_speed_delta_m_s": 0.5,
+            "max_single_pedestrian_speed_m_s": 2.0,
+            "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+        },
+        "variants": [
+            {
+                "variant_id": f"{scenario_id}_noop",
+                "scenario_id": scenario_id,
+                "family": "noop",
+                "seeds": [112],
+            },
+            {
+                "variant_id": f"{scenario_id}_speed_offset",
+                "scenario_id": scenario_id,
+                "family": "single_pedestrian_speed_offset",
+                "seeds": [112],
+                "parameters": {
+                    "speed_delta_m_s": speed_delta_m_s,
+                    "max_abs_speed_delta_m_s": max_abs_speed_delta_m_s,
+                    "pedestrian_id": "h3",
+                },
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_manifest_schema_accepts_noop_and_bounded_route_offset(tmp_path: Path) -> None:
     """The public schema should document the first supported perturbation surface."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
@@ -214,6 +261,44 @@ def test_manifest_schema_requires_manifest_timing_cap_for_start_delay_offset(
         jsonschema.validate(manifest, schema)
 
 
+def test_manifest_schema_accepts_bounded_single_pedestrian_speed_offset(
+    tmp_path: Path,
+) -> None:
+    """The public schema should expose the single-pedestrian speed family."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_requires_manifest_speed_cap_for_speed_offset(
+    tmp_path: Path,
+) -> None:
+    """Speed manifests should carry both variant-local and policy-level bounds."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    del manifest["validity"]["max_single_pedestrian_speed_delta_m_s"]
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with pytest.raises(jsonschema.ValidationError, match="max_single_pedestrian_speed_delta_m_s"):
+        jsonschema.validate(manifest, schema)
+
+
 def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None:
     """Family-specific parameter schemas should catch typo-shaped irrelevant fields."""
     schema = json.loads(
@@ -236,6 +321,15 @@ def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None
     timing_manifest["variants"][1]["parameters"]["dx_m"] = 0.0
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(timing_manifest, schema)
+
+    speed_manifest_path = _write_speed_manifest(
+        tmp_path / "speed_perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    speed_manifest = yaml.safe_load(speed_manifest_path.read_text(encoding="utf-8"))
+    speed_manifest["variants"][1]["parameters"]["dt_s"] = 0.5
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(speed_manifest, schema)
 
 
 def test_preflight_rejects_manifest_that_violates_public_schema(tmp_path: Path) -> None:
@@ -386,6 +480,92 @@ def test_preflight_excludes_negative_start_delay_result(tmp_path: Path) -> None:
     assert excluded.certificate is None
     assert excluded.reasons == [
         "preflight_error: single_pedestrian_start_delay_offset would make pedestrian 'h3' start_delay_s negative"
+    ]
+
+
+def test_preflight_certifies_bounded_single_pedestrian_speed_offset(
+    tmp_path: Path,
+) -> None:
+    """Single-pedestrian speed offsets should certify when the target exists."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    assert [result.variant_id for result in report.results] == [
+        "francis2023_join_group_noop",
+        "francis2023_join_group_speed_offset",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    assert report.results[1].family == "single_pedestrian_speed_offset"
+    assert report.results[1].perturbation_summary["speed_delta_m_s"] == pytest.approx(0.25)
+    assert report.results[1].perturbation_summary["default_baseline_speed_m_s"] == pytest.approx(
+        0.5
+    )
+    assert report.results[1].perturbation_summary["target"]["pedestrian_id"] == "h3"
+
+
+def test_preflight_excludes_speed_offset_without_single_pedestrians(tmp_path: Path) -> None:
+    """A speed perturbation must fail closed when no single pedestrians exist."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_high",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.family == "single_pedestrian_speed_offset"
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_speed_offset selected no single pedestrians"
+    ]
+
+
+def test_preflight_excludes_unbounded_speed_offset_before_certification(
+    tmp_path: Path,
+) -> None:
+    """Out-of-bounds speed perturbations should fail closed without certification."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+        speed_delta_m_s=0.75,
+        max_abs_speed_delta_m_s=0.5,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "single_pedestrian_speed_offset abs_speed_delta_m_s 0.750000 m/s exceeds "
+        "variant max_abs_speed_delta_m_s 0.500000 m/s"
+    ]
+
+
+def test_preflight_excludes_non_positive_speed_result(tmp_path: Path) -> None:
+    """Negative speed deltas cannot make the selected speed non-positive."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+        speed_delta_m_s=-0.5,
+        max_abs_speed_delta_m_s=0.5,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_speed_offset would make pedestrian 'h3' speed_m_s non-positive"
     ]
 
 
@@ -567,6 +747,79 @@ def test_materialize_pilot_matrix_start_delay_selector_all(tmp_path: Path) -> No
     _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
     delays = {ped.id: ped.start_delay_s for ped in offset_map.single_pedestrians}
     assert delays == {"h1": pytest.approx(0.5), "h2": pytest.approx(0.5), "h3": pytest.approx(0.5)}
+
+
+def test_materialize_pilot_matrix_writes_speed_overrides(tmp_path: Path) -> None:
+    """Speed variants should preserve single-ped entries while updating speed."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+    )
+    output_dir = tmp_path / "pilot"
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=output_dir,
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "francis2023_join_group_noop",
+        "francis2023_join_group_speed_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    overrides = {entry["id"]: entry for entry in offset_scenario["single_pedestrians"]}
+    assert overrides["h3"]["role"] == "join"
+    assert overrides["h3"]["role_target_id"] == "h1"
+    assert overrides["h3"]["speed_m_s"] == pytest.approx(0.75)
+
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    speeds = {ped.id: ped.speed_m_s for ped in offset_map.single_pedestrians}
+    assert speeds["h3"] == pytest.approx(0.75)
+
+
+def test_materialize_pilot_matrix_speed_selector_all(tmp_path: Path) -> None:
+    """The speed family can intentionally shift every single pedestrian speed."""
+    manifest_path = _write_speed_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_leave_group",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    parameters = manifest["variants"][1]["parameters"]
+    del parameters["pedestrian_id"]
+    parameters["pedestrian_selector"] = "all"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "francis2023_leave_group_noop",
+        "francis2023_leave_group_speed_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    speeds = {ped.id: ped.speed_m_s for ped in offset_map.single_pedestrians}
+    assert speeds == {
+        "h1": pytest.approx(0.75),
+        "h2": pytest.approx(0.75),
+        "h3": pytest.approx(0.75),
+    }
 
 
 def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1943.

Adds a bounded `single_pedestrian_speed_offset` perturbation family for #1610-style local scenario perturbation pilots. The schema now requires a manifest-level `validity.max_single_pedestrian_speed_delta_m_s` whenever speed variants are present, rejects cross-family parameter leakage, and supports optional speed caps.

Adds the tracked diagnostic manifest `configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml`, compact evidence under `docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/`, and a context note at `docs/context/issue_1943_ped_speed_perturbation.md`.

## Diagnostic result

- Pilot completed 30/30 eligible no-op-versus-speed pairs.
- The route-only `classic_head_on_corridor_low_speed_all_p025` probe failed closed during preflight and was excluded from paired success evidence.
- Mean completed-pair min-distance delta: `-0.588347 m` overall.
- By source scenario: `francis2023_intersection_wait` `-2.002917 m`; `francis2023_join_group` `-0.002172 m`; `francis2023_leave_group` `+0.044654 m`.
- Outcome deltas were seed-local: ORCA on `francis2023_leave_group` seed 258 changed from collision to success; this is diagnostic mechanism evidence, not a planner robustness claim.

## Validation

- `uv run ruff check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `uv run ruff format --check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py` -> 29 passed
- `sha256sum --check docs/context/evidence/issue_1943_ped_speed_perturbation_2026-05-31/SHA256SUMS`
- Schema validation for route, timing, and speed perturbation manifests
- Speed pilot command from `docs/context/issue_1943_ped_speed_perturbation.md`; emitted the known `uni_campus_big.svg` invalid obstacle warning and completed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4817 passed, 11 skipped, 8 warnings; changed-file coverage warning only for `robot_sf/scenario_certification/perturbation_preflight.py` at 90.2%

## Artifact boundary

Raw episode JSONL, materialized scenario matrices/overrides, coverage HTML, and readiness stamps remain ignored under `output/`. The tracked compact evidence is `summary.json`, `README.md`, and `SHA256SUMS`.