### PR TITLE
feat: select perturbation trace variant

### DIFF
--- a/scripts/validation/run_scenario_perturbation_trace_response.py
+++ b/scripts/validation/run_scenario_perturbation_trace_response.py
@@ -91,6 +91,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Perturbation family to pair against the no-op variant.",
     )
     parser.add_argument(
+        "--perturbed-variant-id",
+        help=(
+            "Optional exact perturbed variant_id to pair against the no-op. "
+            "When omitted, the first variant matching --perturbed-family is used."
+        ),
+    )
+    parser.add_argument(
         "--planner",
         action="append",
         dest="planners",
@@ -462,6 +469,7 @@ def _select_variant_pair(
     *,
     source_scenario_id: str,
     perturbed_family: str,
+    perturbed_variant_id: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Return the no-op and perturbed scenario entries for one source scenario."""
     noop: dict[str, Any] | None = None
@@ -474,13 +482,23 @@ def _select_variant_pair(
         if str(payload.get("source_scenario_id") or "") != source_scenario_id:
             continue
         family = str(payload.get("family") or "")
+        variant_id = str(payload.get("variant_id") or "")
         if family == "noop" and noop is None:
             noop = scenario
-        elif family == perturbed_family and perturbed is None:
+        elif (
+            family == perturbed_family
+            and perturbed is None
+            and (perturbed_variant_id is None or variant_id == perturbed_variant_id)
+        ):
             perturbed = scenario
     if noop is None:
         raise ValueError(f"No no-op variant found for source scenario {source_scenario_id!r}")
     if perturbed is None:
+        if perturbed_variant_id is not None:
+            raise ValueError(
+                f"No {perturbed_family!r} variant with variant_id {perturbed_variant_id!r} "
+                f"found for source scenario {source_scenario_id!r}"
+            )
         raise ValueError(
             f"No {perturbed_family!r} variant found for source scenario {source_scenario_id!r}"
         )
@@ -509,6 +527,7 @@ def _write_markdown(report: dict[str, Any], path: Path) -> None:
         "",
         f"- Source scenario: `{report['source_scenario_id']}`",
         f"- Perturbed family: `{report['perturbed_family']}`",
+        f"- Perturbed variant: `{report['perturbed_variant_id']}`",
         f"- Planners: {', '.join(f'`{planner}`' for planner in report['planners'])}",
         f"- Pair rows: `{summary['pairs']}`",
         f"- Pair statuses: `{json.dumps(summary['status_counts'], sort_keys=True)}`",
@@ -571,6 +590,22 @@ def main() -> int:
         scenarios,
         source_scenario_id=args.source_scenario_id,
         perturbed_family=args.perturbed_family,
+        perturbed_variant_id=args.perturbed_variant_id,
+    )
+    perturbed_metadata = (
+        perturbed_scenario.get("metadata")
+        if isinstance(perturbed_scenario.get("metadata"), dict)
+        else {}
+    )
+    perturbed_payload = (
+        perturbed_metadata.get("scenario_perturbation")
+        if isinstance(perturbed_metadata, dict)
+        else {}
+    )
+    selected_perturbed_variant_id = (
+        str(perturbed_payload.get("variant_id") or perturbed_scenario.get("scenario_id") or "")
+        if isinstance(perturbed_payload, dict)
+        else str(perturbed_scenario.get("scenario_id") or "")
     )
     seeds = sorted(set(_scenario_seeds(noop_scenario)) & set(_scenario_seeds(perturbed_scenario)))
     pair_rows: list[dict[str, Any]] = []
@@ -607,6 +642,8 @@ def main() -> int:
         "manifest": args.manifest.as_posix(),
         "source_scenario_id": args.source_scenario_id,
         "perturbed_family": args.perturbed_family,
+        "perturbed_variant_id": selected_perturbed_variant_id,
+        "requested_perturbed_variant_id": args.perturbed_variant_id,
         "planners": [spec.label for spec in planner_specs],
         "horizon": args.horizon,
         "dt": args.dt,

--- a/tests/scenario_certification/test_scenario_perturbation_trace_response.py
+++ b/tests/scenario_certification/test_scenario_perturbation_trace_response.py
@@ -6,6 +6,7 @@ import pytest
 
 from scripts.validation.run_scenario_perturbation_trace_response import (
     TraceRun,
+    _select_variant_pair,
     build_trace_pair_summary,
     closest_approach_slice,
     summarize_trace_pairs,
@@ -24,6 +25,20 @@ def _frame(step: int, *, distance: float, clearance: float, goal_distance: float
             "pedestrian_position": [float(step), 0.0],
             "center_distance_m": distance,
             "clearance_m": clearance,
+        },
+    }
+
+
+def _scenario(source: str, family: str, variant: str) -> dict:
+    """Return a compact materialized perturbation scenario payload."""
+    return {
+        "scenario_id": variant,
+        "metadata": {
+            "scenario_perturbation": {
+                "source_scenario_id": source,
+                "family": family,
+                "variant_id": variant,
+            }
         },
     }
 
@@ -111,3 +126,65 @@ def test_summarize_trace_pairs_groups_by_planner_without_recursive_summary() -> 
     )
     assert summary["by_planner"]["goal"]["pairs"] == 1
     assert "by_planner" not in summary["by_planner"]["goal"]
+
+
+def test_select_variant_pair_defaults_to_first_family_match() -> None:
+    """Trace selection should preserve the legacy first-family-match behavior."""
+    scenarios = [
+        _scenario("intersection", "noop", "intersection_noop"),
+        _scenario("intersection", "single_pedestrian_speed_offset", "intersection_speed_m025"),
+        _scenario("intersection", "single_pedestrian_speed_offset", "intersection_speed_p050"),
+    ]
+
+    noop, perturbed = _select_variant_pair(
+        scenarios,
+        source_scenario_id="intersection",
+        perturbed_family="single_pedestrian_speed_offset",
+    )
+
+    assert noop["scenario_id"] == "intersection_noop"
+    assert perturbed["scenario_id"] == "intersection_speed_m025"
+
+
+def test_select_variant_pair_can_target_specific_perturbed_variant() -> None:
+    """An explicit variant id should select that row within the requested source and family."""
+    scenarios = [
+        _scenario("intersection", "noop", "intersection_noop"),
+        _scenario("intersection", "single_pedestrian_speed_offset", "intersection_speed_m025"),
+        _scenario("intersection", "single_pedestrian_speed_offset", "intersection_speed_p050"),
+        _scenario(
+            "intersection", "single_pedestrian_start_delay_offset", "intersection_delay_p050"
+        ),
+        _scenario("corridor", "single_pedestrian_speed_offset", "corridor_speed_p050"),
+    ]
+
+    noop, perturbed = _select_variant_pair(
+        scenarios,
+        source_scenario_id="intersection",
+        perturbed_family="single_pedestrian_speed_offset",
+        perturbed_variant_id="intersection_speed_p050",
+    )
+
+    assert noop["scenario_id"] == "intersection_noop"
+    assert perturbed["scenario_id"] == "intersection_speed_p050"
+
+
+def test_select_variant_pair_reports_missing_specific_variant_context() -> None:
+    """Missing targeted variants should identify the requested source, family, and variant id."""
+    scenarios = [
+        _scenario("intersection", "noop", "intersection_noop"),
+        _scenario("intersection", "single_pedestrian_speed_offset", "intersection_speed_m025"),
+    ]
+
+    with pytest.raises(ValueError) as excinfo:
+        _select_variant_pair(
+            scenarios,
+            source_scenario_id="intersection",
+            perturbed_family="single_pedestrian_speed_offset",
+            perturbed_variant_id="intersection_speed_p050",
+        )
+
+    message = str(excinfo.value)
+    assert "intersection" in message
+    assert "single_pedestrian_speed_offset" in message
+    assert "intersection_speed_p050" in message


### PR DESCRIPTION
## Summary
Adds `--perturbed-variant-id` to the perturbation trace-response runner so diagnostics can target a specific materialized perturbed variant while preserving the old first-family-match default.

## Linked Issues
- Closes `#1955`
- Relates to `#1610`
- Follows `#1953`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added an optional exact perturbed variant selector to `scripts/validation/run_scenario_perturbation_trace_response.py`.
- Included the selected and requested perturbed variant ids in JSON report metadata, and the selected variant in Markdown scope output.
- Added focused unit coverage for legacy default selection, exact variant selection, and missing variant error context.

## Why It Matters
- Added value: removes the filtered-manifest workaround used by `#1953` when inspecting a non-first speed-grid row.
- Expected impact: future local trace diagnostics can select a specific row from multi-variant perturbation manifests directly.
- Why this is worth merging now: it is a narrow tooling fix with full tests and a real manifest smoke proof.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format scripts/validation/run_scenario_perturbation_trace_response.py tests/scenario_certification/test_scenario_perturbation_trace_response.py`
  - `uv run ruff check scripts/validation/run_scenario_perturbation_trace_response.py tests/scenario_certification/test_scenario_perturbation_trace_response.py`
  - `uv run pytest tests/scenario_certification/test_scenario_perturbation_trace_response.py`
  - `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/validation/run_scenario_perturbation_trace_response.py configs/scenarios/perturbations/issue_1610_intersection_wait_phase_grid_v1.yaml --materialized-output-dir output/scenario_perturbations/issue1955_trace_variant_selector/materialized --output output/scenario_perturbations/issue1955_trace_variant_selector/trace.json --source-scenario-id francis2023_intersection_wait --perturbed-family single_pedestrian_speed_offset --perturbed-variant-id francis2023_intersection_wait_speed_h1_p050 --seed-limit 1 --horizon 20 --dt 0.1 --slice-window 1 --planner goal`
  - `jq '{perturbed_variant_id, requested_perturbed_variant_id, pair_variant_ids: [.trace_pairs[].perturbed_variant_id], pairs: .pair_summary.pairs, status_counts: .pair_summary.status_counts}' output/scenario_perturbations/issue1955_trace_variant_selector/trace.json`
  - `git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted trace tests: `6 passed in 16.89s`.
  - Real manifest smoke selected `francis2023_intersection_wait_speed_h1_p050` as both selected/requested report metadata and as the only trace-pair `perturbed_variant_id`; 1/1 goal pair completed.
  - Final readiness: `4828 passed, 11 skipped, 9 warnings in 313.27s`; clean-tree stamp at `output/validation/pr_ready/issue-1955-trace-variant-selector.json`.
- Benchmarks or smoke tests, if applicable: local diagnostic trace smoke only; not benchmark-strength evidence.

## Risks / Rollout
- Compatibility risks: low; omitting `--perturbed-variant-id` keeps the existing first-family-match behavior and is covered by a regression test.
- Failure modes: a typoed variant id now fails with source scenario, family, and variant context.
- Rollback or fallback plan: remove the CLI argument and helper branch; old family-only selection remains simple.

## Docs / Provenance
- Updated docs: none; CLI help and report metadata carry the contract.
- Relevant design or provenance notes: `#1953` observed the filtered-manifest workaround that this removes.
- Any assumptions that need to be preserved: diagnostic local trace inspection remains non-paper-facing evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, PR links `#1610`
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: this is a local tooling selector, not a new benchmark result, metric, registry entry, or planner claim.

## Follow-Up Issues
- Deferred work: continue `#1610` perturbation family exploration, especially explicit single-pedestrian trajectory waypoint offsets.
- Issues opened for follow-up: none in this PR.

## Reviewer Notes
- Verify that default selection remains first matching family and exact selection does not cross source scenario or family boundaries.
- Known limitation: selection only targets the perturbed variant; no-op selection remains the first no-op for the source scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional command-line argument to select a specific perturbed scenario variant when running perturbation trace responses
  * Enhanced report outputs to include perturbed variant information, displaying both requested and effective variant selections

* **Tests**
  * Added comprehensive test coverage for variant pair selection logic, including default behavior and explicit variant targeting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->