### PR TITLE
feat: add single-pedestrian trajectory perturbation

### DIFF
--- a/configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml
+++ b/configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml
@@ -1,0 +1,51 @@
+schema_version: scenario_perturbation_manifest.v1
+manifest_id: issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1
+description: >-
+  Compact diagnostic #1610 pilot for bounded explicit single-pedestrian trajectory waypoint
+  offsets. The eligible row shifts francis2023_intersection_wait pedestrian h1's coordinate
+  trajectory by 0.25 m on x. The join-group row is an intentional fail-closed probe because h3 is
+  role-based and has no coordinate trajectory.
+scenario_config: ../classic_interactions_francis2023.yaml
+seed_controls:
+  baseline_seeds: [240, 241, 242]
+  replay_seed_policy: explicit
+validity:
+  require_scenario_certification: true
+  max_route_offset_m: 0.5
+  max_single_pedestrian_trajectory_waypoint_offset_m: 0.5
+  invalid_variant_evidence_policy: exclude_from_success_evidence
+variants:
+  - variant_id: francis2023_intersection_wait_noop
+    scenario_id: francis2023_intersection_wait
+    family: noop
+    seeds: [240, 241, 242]
+  - variant_id: francis2023_intersection_wait_traj_h1_x025
+    scenario_id: francis2023_intersection_wait
+    family: single_pedestrian_trajectory_waypoint_offset
+    seeds: [240, 241, 242]
+    rationale: >-
+      Shift the explicit h1 crossing trajectory laterally by a small bounded amount while keeping
+      wait_at indices and replay seeds fixed.
+    parameters:
+      dx_m: 0.25
+      dy_m: 0.0
+      max_magnitude_m: 0.5
+      pedestrian_id: h1
+      waypoint_selector: all
+  - variant_id: francis2023_join_group_traj_h3_x025
+    scenario_id: francis2023_join_group
+    family: single_pedestrian_trajectory_waypoint_offset
+    seeds: [255, 256, 257]
+    rationale: >-
+      Fail-closed probe proving role-only single pedestrians are not silently coerced into
+      trajectory perturbations.
+    parameters:
+      dx_m: 0.25
+      dy_m: 0.0
+      max_magnitude_m: 0.5
+      pedestrian_id: h3
+      waypoint_selector: all
+pilot_matrix_note:
+  parent_issue: "#1610"
+  next_step: "Run a tiny local paired planner pilot before treating this as diagnostic evidence."
+  evidence_boundary: "local preflight/materialization input only; not benchmark evidence"

--- a/docs/context/evidence/issue_1957_trajectory_waypoint_pilot_summary.json
+++ b/docs/context/evidence/issue_1957_trajectory_waypoint_pilot_summary.json
@@ -1,0 +1,146 @@
+{
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 40,
+  "manifest": "configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml",
+  "materialization": {
+    "excluded_variants": [
+      "francis2023_join_group_traj_h3_x025"
+    ],
+    "included_variants": [
+      "francis2023_intersection_wait_noop",
+      "francis2023_intersection_wait_traj_h1_x025"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 2
+  },
+  "pair_rows": [
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.033832585236350354,
+      "noop": {
+        "collision": 0,
+        "min_distance": 11.399756917343742,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 11.433589502580093,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_trajectory_waypoint_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_traj_h1_x025",
+      "planner": "goal",
+      "seed": 240,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.03432788489824112,
+      "noop": {
+        "collision": 0,
+        "min_distance": 11.55981333382666,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "francis2023_intersection_wait_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 11.594141218724902,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "single_pedestrian_trajectory_waypoint_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "francis2023_intersection_wait_traj_h1_x025",
+      "planner": "goal",
+      "seed": 241,
+      "source_scenario_id": "francis2023_intersection_wait",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    }
+  ],
+  "pair_summary": {
+    "by_perturbation_family": {
+      "single_pedestrian_trajectory_waypoint_offset": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.03408023506729574,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "by_planner": {
+      "goal": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.03408023506729574,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "by_source_scenario": {
+      "francis2023_intersection_wait": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.03408023506729574,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "mean_deltas_completed_pairs": {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.03408023506729574,
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    "pairs": 2,
+    "status_counts": {
+      "completed": 2
+    }
+  },
+  "planner_runs": {
+    "goal": {
+      "algo": "goal",
+      "algo_config_path": null,
+      "episodes": 4,
+      "source": "raw_algo"
+    }
+  },
+  "planners": [
+    "goal"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 2
+}

--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -10,13 +10,24 @@ The schema lives at
 [`robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json`](../robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json).
 The first tracked example is
 [`configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml).
+The current #1610 single-pedestrian trajectory example is
+[`configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml).
 
 ## Contract
 
-The v1 manifest intentionally supports only:
+The v1 manifest intentionally supports:
 
 - `noop`: the unperturbed baseline row for paired comparisons;
-- `robot_route_offset`: a bounded `(dx_m, dy_m)` shift applied to selected robot route waypoints.
+- `robot_route_offset`: a bounded `(dx_m, dy_m)` shift applied to selected robot route waypoints;
+- `pedestrian_route_offset`: the same bounded shift applied to selected pedestrian route waypoints;
+- `single_pedestrian_start_delay_offset`: a bounded start-delay phase shift for explicit
+  `single_pedestrians`;
+- `single_pedestrian_speed_offset`: a bounded per-pedestrian speed change for explicit
+  `single_pedestrians`;
+- `single_pedestrian_wait_duration_offset`: a bounded `wait_at` duration change for explicit
+  trajectory pedestrians with wait rules;
+- `single_pedestrian_trajectory_waypoint_offset`: a bounded `(dx_m, dy_m)` shift applied to all
+  coordinate trajectory waypoints for one explicit `single_pedestrians` entry.
 
 Every manifest must include:
 
@@ -25,6 +36,19 @@ Every manifest must include:
 - `validity.max_route_offset_m`: manifest-level offset bound;
 - `validity.invalid_variant_evidence_policy: exclude_from_success_evidence`;
 - one or more `variants`, each with `variant_id`, `scenario_id`, `family`, and `seeds`.
+
+Family-specific validity caps are required when a manifest uses the matching family:
+
+- `validity.max_start_delay_offset_s` for `single_pedestrian_start_delay_offset`;
+- `validity.max_wait_duration_offset_s` for `single_pedestrian_wait_duration_offset`;
+- `validity.max_single_pedestrian_speed_delta_m_s` for `single_pedestrian_speed_offset`;
+- `validity.max_single_pedestrian_trajectory_waypoint_offset_m` for
+  `single_pedestrian_trajectory_waypoint_offset`.
+
+`single_pedestrian_trajectory_waypoint_offset` is intentionally narrow: it requires
+`parameters.pedestrian_id`, `parameters.waypoint_selector: all`, and an existing non-empty
+coordinate `trajectory`. Route pedestrians, role-only pedestrians, goal-only pedestrians, POI-only
+trajectory materialization, and individual waypoint indexes fail closed until separately scoped.
 
 ## Preflight
 

--- a/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/robot-sf/scenario_perturbation_manifest.v1.json",
   "title": "RobotSF Scenario Perturbation Manifest (v1)",
-  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, and single-pedestrian speed/wait perturbation preflight. Validity preflight is not benchmark execution evidence.",
+  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, and single-pedestrian speed/wait/trajectory perturbation preflight. Validity preflight is not benchmark execution evidence.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -84,6 +84,10 @@
           "exclusiveMinimum": 0
         },
         "max_single_pedestrian_speed_m_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_single_pedestrian_trajectory_waypoint_offset_m": {
           "type": "number",
           "exclusiveMinimum": 0
         },
@@ -211,6 +215,37 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "variants": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "const": "single_pedestrian_trajectory_waypoint_offset"
+                }
+              },
+              "required": [
+                "family"
+              ]
+            }
+          }
+        },
+        "required": [
+          "variants"
+        ]
+      },
+      "then": {
+        "properties": {
+          "validity": {
+            "required": [
+              "max_single_pedestrian_trajectory_waypoint_offset_m"
+            ]
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -240,7 +275,8 @@
             "pedestrian_route_offset",
             "single_pedestrian_start_delay_offset",
             "single_pedestrian_speed_offset",
-            "single_pedestrian_wait_duration_offset"
+            "single_pedestrian_wait_duration_offset",
+            "single_pedestrian_trajectory_waypoint_offset"
           ]
         },
         "seeds": {
@@ -360,6 +396,55 @@
                   "goal_id": {
                     "type": "integer",
                     "minimum": 0
+                  },
+                  "waypoint_selector": {
+                    "const": "all"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "family": {
+                "const": "single_pedestrian_trajectory_waypoint_offset"
+              }
+            },
+            "required": [
+              "family"
+            ]
+          },
+          "then": {
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "dx_m",
+                  "dy_m",
+                  "max_magnitude_m",
+                  "pedestrian_id",
+                  "waypoint_selector"
+                ],
+                "properties": {
+                  "dx_m": {
+                    "type": "number"
+                  },
+                  "dy_m": {
+                    "type": "number"
+                  },
+                  "max_magnitude_m": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "pedestrian_id": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "waypoint_selector": {
                     "const": "all"

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -414,6 +414,7 @@ def _normalize_variant(variant: Any) -> Mapping[str, Any]:
         "single_pedestrian_start_delay_offset",
         "single_pedestrian_speed_offset",
         "single_pedestrian_wait_duration_offset",
+        "single_pedestrian_trajectory_waypoint_offset",
     }:
         raise ValueError(f"unsupported perturbation family: {family}")
     return variant
@@ -455,6 +456,8 @@ def _validate_perturbation_bounds(
         return _validate_single_pedestrian_speed_offset_bounds(variant, manifest=manifest)
     if family == "single_pedestrian_wait_duration_offset":
         return _validate_wait_duration_offset_bounds(variant, manifest=manifest)
+    if family == "single_pedestrian_trajectory_waypoint_offset":
+        return _validate_trajectory_waypoint_offset_bounds(variant, manifest=manifest)
 
     dx = _finite_float(parameters.get("dx_m", 0.0), field_name="parameters.dx_m")
     dy = _finite_float(parameters.get("dy_m", 0.0), field_name="parameters.dy_m")
@@ -477,6 +480,50 @@ def _validate_perturbation_bounds(
         "target": {
             "spawn_id": parameters.get("spawn_id"),
             "goal_id": parameters.get("goal_id"),
+            "waypoint_selector": parameters.get("waypoint_selector", "all"),
+        },
+    }
+    if magnitude > bound:
+        return [
+            f"{family} magnitude {magnitude:.6f} m exceeds variant max_magnitude_m {bound:.6f} m"
+        ], summary
+    return [], summary
+
+
+def _validate_trajectory_waypoint_offset_bounds(
+    variant: Mapping[str, Any],
+    *,
+    manifest: Mapping[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    """Validate bounded single-pedestrian trajectory waypoint perturbations.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Fail-closed reasons and perturbation summary.
+    """
+    family = str(variant["family"])
+    parameters = variant.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError(f"{family} variants require a parameters mapping")
+    dx = _finite_float(parameters.get("dx_m"), field_name="parameters.dx_m")
+    dy = _finite_float(parameters.get("dy_m"), field_name="parameters.dy_m")
+    magnitude = math.hypot(dx, dy)
+    variant_max = _positive_float(
+        parameters.get("max_magnitude_m"),
+        field_name="parameters.max_magnitude_m",
+    )
+    manifest_max = _positive_float(
+        manifest["validity"].get("max_single_pedestrian_trajectory_waypoint_offset_m"),
+        field_name="validity.max_single_pedestrian_trajectory_waypoint_offset_m",
+    )
+    bound = min(variant_max, manifest_max)
+    summary = {
+        "family": family,
+        "dx_m": dx,
+        "dy_m": dy,
+        "magnitude_m": magnitude,
+        "max_magnitude_m": bound,
+        "target": {
+            "pedestrian_id": parameters.get("pedestrian_id"),
             "waypoint_selector": parameters.get("waypoint_selector", "all"),
         },
     }
@@ -681,6 +728,13 @@ def _certify_variant(
             wait_delta_s=float(perturbation_summary["wait_delta_s"]),
             parameters=variant.get("parameters", {}),
         )
+    elif variant["family"] == "single_pedestrian_trajectory_waypoint_offset":
+        _apply_trajectory_waypoint_offset(
+            perturbed_map,
+            dx=float(perturbation_summary["dx_m"]),
+            dy=float(perturbation_summary["dy_m"]),
+            parameters=variant.get("parameters", {}),
+        )
     else:
         _apply_route_offset(
             _routes_for_family(perturbed_map, str(variant["family"])),
@@ -764,6 +818,13 @@ def _materialize_variant_scenario(
         )
     elif variant["family"] == "single_pedestrian_wait_duration_offset":
         scenario["single_pedestrians"] = _single_pedestrian_overrides_for_wait_duration(
+            variant,
+            scenario=scenario,
+            scenario_config=scenario_config,
+            perturbation_summary=result.perturbation_summary,
+        )
+    elif variant["family"] == "single_pedestrian_trajectory_waypoint_offset":
+        scenario["single_pedestrians"] = _single_pedestrian_overrides_for_trajectory_waypoint(
             variant,
             scenario=scenario,
             scenario_config=scenario_config,
@@ -1013,6 +1074,94 @@ def _apply_wait_duration_offset(
             rule.wait_s = float(payload["wait_s"])
 
 
+def _select_trajectory_waypoint_pedestrians(pedestrians: list[Any], parameters: Any) -> list[Any]:
+    """Return the explicit trajectory pedestrian targeted by a waypoint-offset perturbation."""
+    family = "single_pedestrian_trajectory_waypoint_offset"
+    if not isinstance(parameters, Mapping):
+        raise ValueError("parameters must be a mapping")
+    selector = str(parameters.get("waypoint_selector", "all"))
+    if selector != "all":
+        raise ValueError(f"{family} supports waypoint_selector='all' only")
+    pedestrian_id = parameters.get("pedestrian_id")
+    if not isinstance(pedestrian_id, str) or not pedestrian_id.strip():
+        raise ValueError(f"{family} requires parameters.pedestrian_id")
+    selected = [ped for ped in pedestrians if str(ped.id) == pedestrian_id]
+    if not selected:
+        raise ValueError(f"{family} selected no single pedestrians")
+    for ped in selected:
+        if not getattr(ped, "trajectory", None):
+            raise ValueError(f"{family} selected pedestrian {ped.id!r} has no trajectory")
+    return selected
+
+
+def _offset_trajectory_points(
+    ped: Any,
+    *,
+    dx: float,
+    dy: float,
+    map_width: float,
+    map_height: float,
+) -> list[tuple[float, float]]:
+    """Return trajectory points after a bounded offset, failing closed outside map bounds."""
+    updated: list[tuple[float, float]] = []
+    for idx, (x, y) in enumerate(ped.trajectory or []):
+        point = (float(x) + float(dx), float(y) + float(dy))
+        if not (0.0 <= point[0] <= map_width and 0.0 <= point[1] <= map_height):
+            raise ValueError(
+                "single_pedestrian_trajectory_waypoint_offset would move "
+                f"pedestrian {ped.id!r} trajectory waypoint {idx} outside map bounds"
+            )
+        updated.append(point)
+    return updated
+
+
+def _trajectory_payloads_for_selected_pedestrians(
+    pedestrians: list[Any],
+    *,
+    dx: float,
+    dy: float,
+    parameters: Any,
+    map_width: float,
+    map_height: float,
+) -> dict[str, list[tuple[float, float]]]:
+    """Return updated trajectory payloads for selected pedestrians."""
+    selected = _select_trajectory_waypoint_pedestrians(pedestrians, parameters)
+    return {
+        str(ped.id): _offset_trajectory_points(
+            ped,
+            dx=dx,
+            dy=dy,
+            map_width=map_width,
+            map_height=map_height,
+        )
+        for ped in selected
+    }
+
+
+def _apply_trajectory_waypoint_offset(
+    map_def: Any,
+    *,
+    dx: float,
+    dy: float,
+    parameters: Any,
+) -> None:
+    """Offset selected single-pedestrian trajectory waypoints in place."""
+    trajectories = _trajectory_payloads_for_selected_pedestrians(
+        list(map_def.single_pedestrians),
+        dx=dx,
+        dy=dy,
+        parameters=parameters,
+        map_width=float(map_def.width),
+        map_height=float(map_def.height),
+    )
+    for ped in map_def.single_pedestrians:
+        updated = trajectories.get(str(ped.id))
+        if updated is None:
+            continue
+        ped.goal = None
+        ped.trajectory = updated
+
+
 def _single_pedestrian_overrides_for_start_delay(
     variant: Mapping[str, Any],
     *,
@@ -1121,6 +1270,50 @@ def _single_pedestrian_overrides_for_wait_duration(
             entry["wait_at"] = waits_by_pedestrian[ped_id]
     for ped_id in sorted(selected_ids - seen_ids):
         overrides.append({"id": ped_id, "wait_at": waits_by_pedestrian[ped_id]})
+    return overrides
+
+
+def _single_pedestrian_overrides_for_trajectory_waypoint(
+    variant: Mapping[str, Any],
+    *,
+    scenario: Mapping[str, Any],
+    scenario_config: Path,
+    perturbation_summary: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return scenario overrides with adjusted single-pedestrian trajectory points."""
+    config = build_robot_config_from_scenario(dict(scenario), scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    trajectories = _trajectory_payloads_for_selected_pedestrians(
+        list(map_def.single_pedestrians),
+        dx=float(perturbation_summary["dx_m"]),
+        dy=float(perturbation_summary["dy_m"]),
+        parameters=variant.get("parameters", {}),
+        map_width=float(map_def.width),
+        map_height=float(map_def.height),
+    )
+    selected_ids = set(trajectories)
+
+    raw_overrides = scenario.get("single_pedestrians")
+    overrides = [dict(item) for item in raw_overrides] if isinstance(raw_overrides, list) else []
+    seen_ids: set[str] = set()
+    for entry in overrides:
+        ped_id = str(entry.get("id") or "")
+        seen_ids.add(ped_id)
+        if ped_id in selected_ids:
+            entry["trajectory"] = [[float(x), float(y)] for x, y in trajectories[ped_id]]
+            entry["goal"] = None
+            entry.pop("goal_poi", None)
+            entry.pop("trajectory_poi", None)
+    for ped_id in sorted(selected_ids - seen_ids):
+        overrides.append(
+            {
+                "id": ped_id,
+                "goal": None,
+                "trajectory": [[float(x), float(y)] for x, y in trajectories[ped_id]],
+            }
+        )
     return overrides
 
 

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -241,6 +241,57 @@ def _write_wait_duration_manifest(
     return path
 
 
+def _write_trajectory_waypoint_manifest(
+    path: Path,
+    *,
+    scenario_id: str,
+    pedestrian_id: str = "h1",
+    dx_m: float = 0.25,
+    dy_m: float = 0.0,
+    max_magnitude_m: float = 0.5,
+    manifest_cap_m: float = 0.5,
+) -> Path:
+    """Write a perturbation manifest that offsets single-pedestrian trajectories."""
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_trajectory_waypoint_perturbation_manifest",
+        "scenario_config": "configs/scenarios/classic_interactions_francis2023.yaml",
+        "seed_controls": {
+            "baseline_seeds": [240],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": {
+            "require_scenario_certification": True,
+            "max_route_offset_m": 0.5,
+            "max_single_pedestrian_trajectory_waypoint_offset_m": manifest_cap_m,
+            "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+        },
+        "variants": [
+            {
+                "variant_id": f"{scenario_id}_noop",
+                "scenario_id": scenario_id,
+                "family": "noop",
+                "seeds": [240],
+            },
+            {
+                "variant_id": f"{scenario_id}_trajectory_waypoint_offset",
+                "scenario_id": scenario_id,
+                "family": "single_pedestrian_trajectory_waypoint_offset",
+                "seeds": [240],
+                "parameters": {
+                    "dx_m": dx_m,
+                    "dy_m": dy_m,
+                    "max_magnitude_m": max_magnitude_m,
+                    "pedestrian_id": pedestrian_id,
+                    "waypoint_selector": "all",
+                },
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_manifest_schema_accepts_noop_and_bounded_route_offset(tmp_path: Path) -> None:
     """The public schema should document the first supported perturbation surface."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
@@ -384,6 +435,47 @@ def test_manifest_schema_requires_manifest_wait_duration_cap_for_wait_duration_o
         jsonschema.validate(manifest, schema)
 
 
+def test_manifest_schema_accepts_bounded_single_pedestrian_trajectory_waypoint_offset(
+    tmp_path: Path,
+) -> None:
+    """The public schema should expose the single-pedestrian trajectory family."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_requires_manifest_trajectory_waypoint_cap(
+    tmp_path: Path,
+) -> None:
+    """Trajectory waypoint manifests should carry variant-local and policy-level bounds."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    del manifest["validity"]["max_single_pedestrian_trajectory_waypoint_offset_m"]
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with pytest.raises(
+        jsonschema.ValidationError,
+        match="max_single_pedestrian_trajectory_waypoint_offset_m",
+    ):
+        jsonschema.validate(manifest, schema)
+
+
 def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None:
     """Family-specific parameter schemas should catch typo-shaped irrelevant fields."""
     schema = json.loads(
@@ -424,6 +516,15 @@ def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None
     wait_manifest["variants"][1]["parameters"]["speed_delta_m_s"] = 0.25
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(wait_manifest, schema)
+
+    trajectory_manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "trajectory_perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+    trajectory_manifest = yaml.safe_load(trajectory_manifest_path.read_text(encoding="utf-8"))
+    trajectory_manifest["variants"][1]["parameters"]["wait_delta_s"] = 0.25
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(trajectory_manifest, schema)
 
 
 def test_preflight_rejects_manifest_that_violates_public_schema(tmp_path: Path) -> None:
@@ -778,6 +879,97 @@ def test_preflight_excludes_negative_wait_duration_result(tmp_path: Path) -> Non
     ]
 
 
+def test_preflight_certifies_bounded_single_pedestrian_trajectory_waypoint_offset(
+    tmp_path: Path,
+) -> None:
+    """Single-pedestrian trajectory waypoint offsets should certify when target exists."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    assert [result.variant_id for result in report.results] == [
+        "francis2023_intersection_wait_noop",
+        "francis2023_intersection_wait_trajectory_waypoint_offset",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    assert report.results[1].family == "single_pedestrian_trajectory_waypoint_offset"
+    assert report.results[1].perturbation_summary["dx_m"] == pytest.approx(0.25)
+    assert report.results[1].perturbation_summary["target"]["pedestrian_id"] == "h1"
+
+
+def test_preflight_excludes_trajectory_waypoint_offset_without_trajectory(
+    tmp_path: Path,
+) -> None:
+    """A trajectory perturbation must fail closed for role-only single pedestrians."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_join_group",
+        pedestrian_id="h3",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.family == "single_pedestrian_trajectory_waypoint_offset"
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_trajectory_waypoint_offset selected pedestrian "
+        "'h3' has no trajectory"
+    ]
+
+
+def test_preflight_excludes_unbounded_trajectory_waypoint_offset_before_certification(
+    tmp_path: Path,
+) -> None:
+    """Out-of-bounds trajectory magnitudes should fail closed without certification."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+        dx_m=0.75,
+        max_magnitude_m=0.5,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "single_pedestrian_trajectory_waypoint_offset magnitude 0.750000 m exceeds "
+        "variant max_magnitude_m 0.500000 m"
+    ]
+
+
+def test_preflight_excludes_trajectory_waypoint_offset_outside_map_bounds(
+    tmp_path: Path,
+) -> None:
+    """Trajectory waypoint offsets must fail closed when updated points leave the map."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+        dx_m=1000.0,
+        max_magnitude_m=2000.0,
+        manifest_cap_m=2000.0,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: single_pedestrian_trajectory_waypoint_offset would move "
+        "pedestrian 'h1' trajectory waypoint 0 outside map bounds"
+    ]
+
+
 def test_preflight_excludes_unbounded_route_offset_before_certification(tmp_path: Path) -> None:
     """Out-of-bounds perturbations should fail closed without becoming benchmark evidence."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml", max_route_offset_m=0.2)
@@ -1070,6 +1262,50 @@ def test_materialize_pilot_matrix_writes_wait_duration_overrides(tmp_path: Path)
         ped.id: [rule.wait_s for rule in ped.wait_at or []] for ped in offset_map.single_pedestrians
     }
     assert waits["h1"] == [pytest.approx(2.5)]
+
+
+def test_materialize_pilot_matrix_writes_trajectory_waypoint_overrides(tmp_path: Path) -> None:
+    """Trajectory variants should preserve single-ped entries while updating trajectory points."""
+    manifest_path = _write_trajectory_waypoint_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "francis2023_intersection_wait_noop",
+        "francis2023_intersection_wait_trajectory_waypoint_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    overrides = {entry["id"]: entry for entry in offset_scenario["single_pedestrians"]}
+    assert overrides["h1"]["note"] == "intersection wait"
+    assert overrides["h1"]["goal"] is None
+    assert "goal_poi" not in overrides["h1"]
+    assert "trajectory_poi" not in overrides["h1"]
+    assert overrides["h1"]["trajectory"] == [
+        [pytest.approx(14.25), pytest.approx(17.5)],
+        [pytest.approx(14.25), pytest.approx(15.0)],
+        [pytest.approx(14.25), pytest.approx(4.0)],
+    ]
+
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    trajectories = {ped.id: ped.trajectory for ped in offset_map.single_pedestrians}
+    assert trajectories["h1"] == [
+        (pytest.approx(14.25), pytest.approx(17.5)),
+        (pytest.approx(14.25), pytest.approx(15.0)),
+        (pytest.approx(14.25), pytest.approx(4.0)),
+    ]
 
 
 def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds the bounded `single_pedestrian_trajectory_waypoint_offset` scenario perturbation family for explicit coordinate trajectories, plus a small #1610 pilot manifest and durable diagnostic evidence summary.

## Linked Issues
- Closes `#1957`
- Relates to `#1610`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added schema support for `single_pedestrian_trajectory_waypoint_offset` with a required manifest cap and family-specific parameters.
- Implemented preflight/materialization support for one explicit `single_pedestrians` trajectory target with `waypoint_selector: all`.
- Fail closed for unsupported selectors, missing pedestrian ids, route/role/goal-only targets with no trajectory, out-of-bounds magnitudes, and updated points outside map bounds.
- Added `configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml` with one eligible `francis2023_intersection_wait` h1 row and one intentional role-only fail-closed probe.
- Refreshed `docs/scenario_perturbation_manifest.md` and tracked compact evidence at `docs/context/evidence/issue_1957_trajectory_waypoint_pilot_summary.json`.

## Why It Matters
- Added value: #1610 now has a spatial trajectory-shape perturbation axis, complementing timing, speed, wait-duration, and route-offset probes.
- Expected impact: local planner/search-policy diagnostics can test sensitivity to small pedestrian path geometry changes while keeping replay seeds and scenario structure fixed.
- Why this is worth merging now: the implementation is bounded, fail-closed, and has both unit proof and a tiny execution proof.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
  - `uv run ruff check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
  - `python -m json.tool robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json >/dev/null`
  - `uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py -k "trajectory_waypoint_offset or cross_family_parameters"`
  - `uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py`
  - `uv run python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml --output output/scenario_perturbation_preflight/issue_1957_trajectory_waypoint_preflight.json`
  - `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/materialize_scenario_perturbation_pilot.py configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml --output-dir output/scenario_perturbation_pilot/issue_1957_trajectory_waypoint --seed-limit 2`
  - `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py configs/scenarios/perturbations/issue_1610_single_ped_trajectory_waypoint_offset_pilot_v1.yaml --materialized-output-dir output/scenario_perturbations/issue1957_trajectory_waypoint/materialized --pilot-output-dir output/scenario_perturbations/issue1957_trajectory_waypoint/results --seed-limit 2 --horizon 40 --planner goal --evidence-summary docs/context/evidence/issue_1957_trajectory_waypoint_pilot_summary.json`
  - `git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused trajectory tests: `6 passed, 38 deselected in 18.40s`.
  - Full perturbation preflight tests: `44 passed in 17.88s`.
  - Tracked manifest preflight: no-op and h1 trajectory-offset rows eligible; join-group h3 probe excluded with `selected pedestrian 'h3' has no trajectory`.
  - Materialization included exactly `francis2023_intersection_wait_noop` and `francis2023_intersection_wait_traj_h1_x025`; excluded `francis2023_join_group_traj_h3_x025`.
  - Tiny goal pilot: 2/2 completed pairs, mean `min_distance_delta = +0.03408023506729574`, no success/collision/timeout deltas.
  - Final readiness: `4832 passed, 11 skipped, 8 warnings in 311.27s`; changed-file coverage warning only for `perturbation_preflight.py` at 90.5%.
- Benchmarks or smoke tests, if applicable: diagnostic local pilot only; not benchmark-strength or paper-facing evidence.

## Risks / Rollout
- Compatibility risks: low for existing manifests; new family is opt-in and schema-gated.
- Failure modes: unsupported selector or non-trajectory targets are excluded from success evidence rather than silently coerced.
- Rollback or fallback plan: remove the family enum/schema branch and preflight/materialization dispatch; existing perturbation families remain unchanged.

## Docs / Provenance
- Updated docs: `docs/scenario_perturbation_manifest.md`.
- Relevant design or provenance notes: parent `#1610`; compact pilot evidence in `docs/context/evidence/issue_1957_trajectory_waypoint_pilot_summary.json`.
- Any assumptions that need to be preserved: this family currently supports all-waypoint offsets only for explicit coordinate trajectories.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, PR links `#1610`
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: this is diagnostic perturbation tooling plus a small pilot, not a benchmark claim or paper-facing result.

## Follow-Up Issues
- Deferred work: broader trajectory selectors, POI trajectories, route-density/spacing perturbations, and multi-planner/local-planner sweeps can be split separately.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check the fail-closed boundaries closely: `waypoint_selector` is intentionally only `all`, and role-only/goal-only pedestrians should not be accepted.
- Known limitation: the tiny pilot only exercises the `goal` planner over two seeds; the result is diagnostic smoke evidence, not planner robustness evidence.
