### PR TITLE
feat: add pedestrian density perturbation pilot

### DIFF
--- a/configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml
+++ b/configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml
@@ -1,0 +1,70 @@
+# Issue #1959 exploratory density perturbation manifest for parent issue #1610.
+#
+# This manifest records a local pilot input for the pedestrian_density_offset family. It is not
+# benchmark-strength or paper-facing evidence.
+
+schema_version: scenario_perturbation_manifest.v1
+manifest_id: issue_1610_pedestrian_density_offset_pilot_v1
+description: >-
+  Exploratory #1610/#1959 local pilot input for bounded pedestrian-density offsets. The first
+  eligible candidate keeps the classic group-crossing map and seeds fixed while increasing
+  simulation_config.ped_density within the current high-density ceiling; the Francis wait scenario
+  is included only as a fail-closed probe for scenarios without pedestrian routes.
+scenario_config: ../classic_interactions_francis2023.yaml
+seed_controls:
+  baseline_seeds: [171, 172, 173, 240, 241, 242]
+  replay_seed_policy: explicit
+  source: >-
+    configs/scenarios/archetypes/classic_group_crossing.yaml and
+    configs/scenarios/single/francis2023_intersection_wait.yaml
+validity:
+  require_scenario_certification: true
+  max_route_offset_m: 0.5
+  max_pedestrian_density_delta: 0.03
+  max_pedestrian_density: 0.12
+  invalid_variant_evidence_policy: exclude_from_success_evidence
+  notes: >-
+    The density preflight supports no-op baselines plus bounded simulation_config.ped_density
+    offsets only for scenarios with route-spawn pedestrian routes. Scenarios without pedestrian
+    routes must fail closed and stay out of success evidence.
+variants:
+  - variant_id: classic_group_crossing_medium_noop
+    scenario_id: classic_group_crossing_medium
+    family: noop
+    seeds: [171, 172, 173]
+    rationale: >-
+      Baseline row for the verified medium-density classic group-crossing scenario
+      (ped_density=0.08).
+  - variant_id: classic_group_crossing_medium_density_p020
+    scenario_id: classic_group_crossing_medium
+    family: pedestrian_density_offset
+    seeds: [171, 172, 173]
+    rationale: >-
+      Raises the medium group-crossing density from 0.08 to 0.10 to probe whether local planners
+      respond to route-spawn crowd density without changing map, route, or seed controls.
+    parameters:
+      density_delta: 0.02
+      max_abs_density_delta: 0.03
+      max_ped_density: 0.12
+
+  - variant_id: francis2023_intersection_wait_density_p020
+    scenario_id: francis2023_intersection_wait
+    family: pedestrian_density_offset
+    seeds: [240, 241, 242]
+    rationale: >-
+      Fail-closed probe: this Francis scenario uses an explicit single pedestrian and has no
+      pedestrian routes, so it should be excluded rather than silently converted into a density
+      perturbation success row.
+    parameters:
+      density_delta: 0.02
+      max_abs_density_delta: 0.03
+      max_ped_density: 0.12
+pilot_matrix_note:
+  parent_issue: "#1610"
+  next_step: >-
+    Run a tiny paired planner pilot over the eligible no-op and density rows using the same
+    planner/config/seed controls except for variant_id.
+  evidence_boundary: >-
+    This tracked YAML is a local exploratory pilot input only. It is not planner execution,
+    benchmark evidence, or paper-facing evidence; invalid, unsupported, missing, fallback, or
+    degraded rows remain limitations rather than success evidence.

--- a/docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json
+++ b/docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "scenario_perturbation_preflight_summary.v1",
+  "issue": "#1959",
+  "parent_issue": "#1610",
+  "manifest": "configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml",
+  "generated_from": {
+    "command": "scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml --output output/scenario_perturbation_preflight/issue_1610_pedestrian_density_offset_pilot_v1.json --fail-on-excluded",
+    "exit_code": 2,
+    "exit_code_interpretation": "--fail-on-excluded returned non-zero because the Francis fail-closed probe was excluded as intended.",
+    "raw_output_path": "output/scenario_perturbation_preflight/issue_1610_pedestrian_density_offset_pilot_v1.json",
+    "raw_output_tracked": false
+  },
+  "evidence_boundary": "Local validity preflight only; not planner execution, benchmark evidence, or paper-facing evidence.",
+  "variant_results": [
+    {
+      "variant_id": "classic_group_crossing_medium_noop",
+      "scenario_id": "classic_group_crossing_medium",
+      "family": "noop",
+      "seeds": [171, 172, 173],
+      "validity_status": "valid",
+      "benchmark_evidence_status": "eligible_success_evidence_candidate",
+      "summary": {
+        "family": "noop",
+        "magnitude_m": 0.0
+      }
+    },
+    {
+      "variant_id": "classic_group_crossing_medium_density_p020",
+      "scenario_id": "classic_group_crossing_medium",
+      "family": "pedestrian_density_offset",
+      "seeds": [171, 172, 173],
+      "validity_status": "valid",
+      "benchmark_evidence_status": "eligible_success_evidence_candidate",
+      "summary": {
+        "baseline_ped_density": 0.08,
+        "density_delta": 0.02,
+        "updated_ped_density": 0.1,
+        "max_abs_density_delta": 0.03,
+        "max_ped_density": 0.12,
+        "pedestrian_route_count": 1
+      }
+    },
+    {
+      "variant_id": "francis2023_intersection_wait_density_p020",
+      "scenario_id": "francis2023_intersection_wait",
+      "family": "pedestrian_density_offset",
+      "seeds": [240, 241, 242],
+      "validity_status": "invalid",
+      "benchmark_evidence_status": "excluded_from_success_evidence",
+      "reason": "preflight_error: pedestrian_density_offset selected no pedestrian routes"
+    }
+  ],
+  "status_counts": {
+    "eligible_success_evidence_candidate": 2,
+    "excluded_from_success_evidence": 1
+  }
+}

--- a/docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json
+++ b/docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json
@@ -1,57 +1,146 @@
 {
-  "schema_version": "scenario_perturbation_preflight_summary.v1",
-  "issue": "#1959",
-  "parent_issue": "#1610",
+  "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+  "dt": 0.1,
+  "horizon": 40,
   "manifest": "configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml",
-  "generated_from": {
-    "command": "scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml --output output/scenario_perturbation_preflight/issue_1610_pedestrian_density_offset_pilot_v1.json --fail-on-excluded",
-    "exit_code": 2,
-    "exit_code_interpretation": "--fail-on-excluded returned non-zero because the Francis fail-closed probe was excluded as intended.",
-    "raw_output_path": "output/scenario_perturbation_preflight/issue_1610_pedestrian_density_offset_pilot_v1.json",
-    "raw_output_tracked": false
+  "materialization": {
+    "excluded_variants": [
+      "francis2023_intersection_wait_density_p020"
+    ],
+    "included_variants": [
+      "classic_group_crossing_medium_noop",
+      "classic_group_crossing_medium_density_p020"
+    ],
+    "local_artifact_boundary": "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored local outputs reproducible from the tracked manifest and command",
+    "manifest_id": "issue_1610_pedestrian_density_offset_pilot_v1",
+    "schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "variant_count": 2
   },
-  "evidence_boundary": "Local validity preflight only; not planner execution, benchmark evidence, or paper-facing evidence.",
-  "variant_results": [
+  "pair_rows": [
     {
-      "variant_id": "classic_group_crossing_medium_noop",
-      "scenario_id": "classic_group_crossing_medium",
-      "family": "noop",
-      "seeds": [171, 172, 173],
-      "validity_status": "valid",
-      "benchmark_evidence_status": "eligible_success_evidence_candidate",
-      "summary": {
-        "family": "noop",
-        "magnitude_m": 0.0
-      }
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 5.888901685943133,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_medium_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 5.888901685943133,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "pedestrian_density_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_medium_density_p020",
+      "planner": "goal",
+      "seed": 171,
+      "source_scenario_id": "classic_group_crossing_medium",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
     },
     {
-      "variant_id": "classic_group_crossing_medium_density_p020",
-      "scenario_id": "classic_group_crossing_medium",
-      "family": "pedestrian_density_offset",
-      "seeds": [171, 172, 173],
-      "validity_status": "valid",
-      "benchmark_evidence_status": "eligible_success_evidence_candidate",
-      "summary": {
-        "baseline_ped_density": 0.08,
-        "density_delta": 0.02,
-        "updated_ped_density": 0.1,
-        "max_abs_density_delta": 0.03,
-        "max_ped_density": 0.12,
-        "pedestrian_route_count": 1
-      }
-    },
-    {
-      "variant_id": "francis2023_intersection_wait_density_p020",
-      "scenario_id": "francis2023_intersection_wait",
-      "family": "pedestrian_density_offset",
-      "seeds": [240, 241, 242],
-      "validity_status": "invalid",
-      "benchmark_evidence_status": "excluded_from_success_evidence",
-      "reason": "preflight_error: pedestrian_density_offset selected no pedestrian routes"
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "noop": {
+        "collision": 0,
+        "min_distance": 3.5610923405200428,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "noop_status": "completed",
+      "noop_variant_id": "classic_group_crossing_medium_noop",
+      "pair_status": "completed",
+      "perturbed": {
+        "collision": 0,
+        "min_distance": 3.5610923405200428,
+        "success": 0,
+        "termination_reason": "max_steps",
+        "timeout": 1
+      },
+      "perturbed_family": "pedestrian_density_offset",
+      "perturbed_status": "completed",
+      "perturbed_variant_id": "classic_group_crossing_medium_density_p020",
+      "planner": "goal",
+      "seed": 172,
+      "source_scenario_id": "classic_group_crossing_medium",
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
     }
   ],
-  "status_counts": {
-    "eligible_success_evidence_candidate": 2,
-    "excluded_from_success_evidence": 1
-  }
+  "pair_summary": {
+    "by_perturbation_family": {
+      "pedestrian_density_offset": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.0,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "by_planner": {
+      "goal": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.0,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "by_source_scenario": {
+      "classic_group_crossing_medium": {
+        "mean_deltas_completed_pairs": {
+          "collision_delta": 0.0,
+          "min_distance_delta": 0.0,
+          "success_delta": 0.0,
+          "timeout_delta": 0.0
+        },
+        "pairs": 2,
+        "status_counts": {
+          "completed": 2
+        }
+      }
+    },
+    "mean_deltas_completed_pairs": {
+      "collision_delta": 0.0,
+      "min_distance_delta": 0.0,
+      "success_delta": 0.0,
+      "timeout_delta": 0.0
+    },
+    "pairs": 2,
+    "status_counts": {
+      "completed": 2
+    }
+  },
+  "planner_runs": {
+    "goal": {
+      "algo": "goal",
+      "algo_config_path": null,
+      "episodes": 4,
+      "source": "raw_algo"
+    }
+  },
+  "planners": [
+    "goal"
+  ],
+  "schema_version": "scenario_perturbation_criticality_pilot.v1",
+  "seed_limit": 2
 }

--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -4,27 +4,50 @@
 
 `scenario_perturbation_manifest.v1` is a small preflight surface for issue #1858 and parent
 criticality issue #1610. It records the scenario, seeds, perturbation family, magnitude bounds, and
-validity policy before any perturbed row is allowed into a planner pilot.
+validity policy before any perturbed row is allowed into a planner pilot. Tracked manifests are
+local pilot inputs unless a later command records planner execution evidence.
 
 The schema lives at
 [`robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json`](../robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json).
-The first tracked example is
-[`configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml).
+Tracked examples include
+[`configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1858_seed_sensitive_pilot_v1.yaml)
+and the exploratory density input
+[`configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml).
 
 ## Contract
 
-The v1 manifest intentionally supports only:
+The executable v1 schema/preflight path currently supports:
 
 - `noop`: the unperturbed baseline row for paired comparisons;
-- `robot_route_offset`: a bounded `(dx_m, dy_m)` shift applied to selected robot route waypoints.
+- `robot_route_offset`: a bounded `(dx_m, dy_m)` shift applied to selected robot route waypoints;
+- `pedestrian_route_offset`: the same bounded waypoint shift applied to selected pedestrian routes;
+- `single_pedestrian_start_delay_offset`: a bounded start-delay offset for explicit
+  `single_pedestrians`;
+- `single_pedestrian_speed_offset`: a bounded speed offset for explicit `single_pedestrians`;
+- `single_pedestrian_wait_duration_offset`: a bounded `wait_at.wait_s` offset for explicit
+  single-pedestrian wait entries;
+- `pedestrian_density_offset`: a bounded `simulation_config.ped_density` offset for scenarios
+  with pedestrian routes.
+
+Issue #1959 adds a tracked exploratory pilot input for `pedestrian_density_offset`:
+[`configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml`](../configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml).
+That manifest records a bounded `simulation_config.ped_density` delta for
+`classic_group_crossing_medium` and a fail-closed Francis wait probe that should be excluded
+because it has no pedestrian routes. Treat the manifest and preflight result as local pilot input,
+not planner execution or benchmark evidence.
 
 Every manifest must include:
 
 - `scenario_config`: the source scenario manifest;
 - `seed_controls.baseline_seeds`: explicit replay seeds;
-- `validity.max_route_offset_m`: manifest-level offset bound;
+- `validity.max_route_offset_m`: manifest-level route-offset bound used by the executable v1
+  preflight path;
 - `validity.invalid_variant_evidence_policy: exclude_from_success_evidence`;
 - one or more `variants`, each with `variant_id`, `scenario_id`, `family`, and `seeds`.
+
+Density inputs additionally record `validity.max_pedestrian_density_delta`,
+`validity.max_pedestrian_density`, and per-variant `density_delta`, `max_abs_density_delta`, and
+`max_ped_density` parameters.
 
 ## Preflight
 

--- a/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/robot-sf/scenario_perturbation_manifest.v1.json",
   "title": "RobotSF Scenario Perturbation Manifest (v1)",
-  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, and single-pedestrian speed/wait perturbation preflight. Validity preflight is not benchmark execution evidence.",
+  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, single-pedestrian speed/wait, and pedestrian-density perturbation preflight. Validity preflight is not benchmark execution evidence.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -84,6 +84,14 @@
           "exclusiveMinimum": 0
         },
         "max_single_pedestrian_speed_m_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_pedestrian_density_delta": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_pedestrian_density": {
           "type": "number",
           "exclusiveMinimum": 0
         },
@@ -211,6 +219,37 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "variants": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "const": "pedestrian_density_offset"
+                }
+              },
+              "required": [
+                "family"
+              ]
+            }
+          }
+        },
+        "required": [
+          "variants"
+        ]
+      },
+      "then": {
+        "properties": {
+          "validity": {
+            "required": [
+              "max_pedestrian_density_delta"
+            ]
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -240,7 +279,8 @@
             "pedestrian_route_offset",
             "single_pedestrian_start_delay_offset",
             "single_pedestrian_speed_offset",
-            "single_pedestrian_wait_duration_offset"
+            "single_pedestrian_wait_duration_offset",
+            "pedestrian_density_offset"
           ]
         },
         "seeds": {
@@ -308,6 +348,17 @@
               "type": "number"
             },
             "max_abs_wait_delta_s": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "density_delta": {
+              "type": "number"
+            },
+            "max_abs_density_delta": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "max_ped_density": {
               "type": "number",
               "exclusiveMinimum": 0
             }
@@ -496,6 +547,46 @@
                   },
                   "pedestrian_selector": {
                     "const": "all"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "family": {
+                "const": "pedestrian_density_offset"
+              }
+            },
+            "required": [
+              "family"
+            ]
+          },
+          "then": {
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "density_delta",
+                  "max_abs_density_delta"
+                ],
+                "properties": {
+                  "density_delta": {
+                    "type": "number"
+                  },
+                  "max_abs_density_delta": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "max_ped_density": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
                   }
                 }
               }

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -361,6 +361,12 @@ def _preflight_variant(
                 reasons=bound_reasons,
                 perturbation_summary=perturbation_summary,
             )
+        perturbation_summary = _resolve_scenario_dependent_perturbation_summary(
+            normalized,
+            perturbation_summary=perturbation_summary,
+            scenario_config=scenario_config,
+            scenarios=scenarios,
+        )
         certificate = _certify_variant(
             normalized,
             scenario_config=scenario_config,
@@ -414,6 +420,7 @@ def _normalize_variant(variant: Any) -> Mapping[str, Any]:
         "single_pedestrian_start_delay_offset",
         "single_pedestrian_speed_offset",
         "single_pedestrian_wait_duration_offset",
+        "pedestrian_density_offset",
     }:
         raise ValueError(f"unsupported perturbation family: {family}")
     return variant
@@ -455,6 +462,8 @@ def _validate_perturbation_bounds(
         return _validate_single_pedestrian_speed_offset_bounds(variant, manifest=manifest)
     if family == "single_pedestrian_wait_duration_offset":
         return _validate_wait_duration_offset_bounds(variant, manifest=manifest)
+    if family == "pedestrian_density_offset":
+        return _validate_pedestrian_density_offset_bounds(variant, manifest=manifest)
 
     dx = _finite_float(parameters.get("dx_m", 0.0), field_name="parameters.dx_m")
     dy = _finite_float(parameters.get("dy_m", 0.0), field_name="parameters.dy_m")
@@ -492,6 +501,113 @@ def _optional_positive_float(raw: Any, *, field_name: str) -> float | None:
     if raw is None:
         return None
     return _positive_float(raw, field_name=field_name)
+
+
+def _validate_pedestrian_density_offset_bounds(
+    variant: Mapping[str, Any],
+    *,
+    manifest: Mapping[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    """Validate bounded scenario-level pedestrian-density perturbations.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Fail-closed reasons and perturbation summary.
+    """
+    family = str(variant["family"])
+    parameters = variant.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError(f"{family} variants require a parameters mapping")
+    density_delta = _finite_float(
+        parameters.get("density_delta"),
+        field_name="parameters.density_delta",
+    )
+    variant_max = _positive_float(
+        parameters.get("max_abs_density_delta"),
+        field_name="parameters.max_abs_density_delta",
+    )
+    manifest_max = _positive_float(
+        manifest["validity"].get("max_pedestrian_density_delta"),
+        field_name="validity.max_pedestrian_density_delta",
+    )
+    bound = min(variant_max, manifest_max)
+    manifest_density_cap = _optional_positive_float(
+        manifest["validity"].get("max_pedestrian_density"),
+        field_name="validity.max_pedestrian_density",
+    )
+    variant_density_cap = _optional_positive_float(
+        parameters.get("max_ped_density"),
+        field_name="parameters.max_ped_density",
+    )
+    density_caps = [
+        value for value in (manifest_density_cap, variant_density_cap) if value is not None
+    ]
+    max_ped_density = min(density_caps) if density_caps else None
+    abs_density_delta = abs(density_delta)
+    summary = {
+        "family": family,
+        "density_delta": density_delta,
+        "abs_density_delta": abs_density_delta,
+        "max_abs_density_delta": bound,
+        "max_ped_density": max_ped_density,
+    }
+    if abs_density_delta > bound:
+        return [
+            f"{family} abs_density_delta {abs_density_delta:.6f} exceeds "
+            f"variant max_abs_density_delta {bound:.6f}"
+        ], summary
+    return [], summary
+
+
+def _resolve_scenario_dependent_perturbation_summary(
+    variant: Mapping[str, Any],
+    *,
+    perturbation_summary: Mapping[str, Any],
+    scenario_config: Path,
+    scenarios: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Enrich perturbation summaries that need scenario-specific facts.
+
+    Returns:
+        dict[str, Any]: Scenario-independent or enriched perturbation summary.
+    """
+    if variant["family"] != "pedestrian_density_offset":
+        return dict(perturbation_summary)
+    return _pedestrian_density_summary_for_scenario(
+        variant,
+        perturbation_summary=perturbation_summary,
+        scenario_config=scenario_config,
+        scenarios=scenarios,
+    )
+
+
+def _pedestrian_density_summary_for_scenario(
+    variant: Mapping[str, Any],
+    *,
+    perturbation_summary: Mapping[str, Any],
+    scenario_config: Path,
+    scenarios: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return density perturbation facts that depend on the selected source scenario."""
+    scenario = dict(select_scenario(scenarios, str(variant["scenario_id"])))
+    config = build_robot_config_from_scenario(scenario, scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    if not map_def.ped_routes:
+        raise ValueError("pedestrian_density_offset selected no pedestrian routes")
+    baseline_ped_density = float(config.sim_config.peds_per_area_m2)
+    density_delta = float(perturbation_summary["density_delta"])
+    updated_ped_density = baseline_ped_density + density_delta
+    if updated_ped_density < 0.0:
+        raise ValueError("pedestrian_density_offset would make ped_density negative")
+    max_ped_density = perturbation_summary.get("max_ped_density")
+    if max_ped_density is not None and updated_ped_density > float(max_ped_density):
+        raise ValueError("pedestrian_density_offset would make ped_density exceed max_ped_density")
+    summary = dict(perturbation_summary)
+    summary["baseline_ped_density"] = baseline_ped_density
+    summary["updated_ped_density"] = updated_ped_density
+    summary["pedestrian_route_count"] = len(map_def.ped_routes)
+    return summary
 
 
 def _validate_start_delay_offset_bounds(
@@ -656,6 +772,15 @@ def _certify_variant(
     scenario = dict(select_scenario(scenarios, str(variant["scenario_id"])))
     if variant["family"] == "noop":
         return certify_scenario(scenario, scenario_path=scenario_config)
+    if variant["family"] == "pedestrian_density_offset":
+        scenario = _scenario_with_pedestrian_density_offset(
+            scenario,
+            perturbation_summary=perturbation_summary,
+        )
+        scenario["metadata"] = _variant_metadata(
+            scenario.get("metadata"), variant, perturbation_summary
+        )
+        return certify_scenario(scenario, scenario_path=scenario_config)
 
     config = build_robot_config_from_scenario(scenario, scenario_path=scenario_config)
     if not config.map_pool.map_defs:
@@ -769,7 +894,29 @@ def _materialize_variant_scenario(
             scenario_config=scenario_config,
             perturbation_summary=result.perturbation_summary,
         )
+    elif variant["family"] == "pedestrian_density_offset":
+        scenario = _scenario_with_pedestrian_density_offset(
+            scenario,
+            perturbation_summary=result.perturbation_summary,
+        )
     return scenario
+
+
+def _scenario_with_pedestrian_density_offset(
+    scenario: Mapping[str, Any],
+    *,
+    perturbation_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a scenario payload with an updated route-pedestrian density."""
+    updated = deepcopy(dict(scenario))
+    simulation_config = (
+        dict(updated.get("simulation_config"))
+        if isinstance(updated.get("simulation_config"), Mapping)
+        else {}
+    )
+    simulation_config["ped_density"] = float(perturbation_summary["updated_ped_density"])
+    updated["simulation_config"] = simulation_config
+    return updated
 
 
 def _resolve_materialized_scenario_paths(

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -241,6 +241,59 @@ def _write_wait_duration_manifest(
     return path
 
 
+def _write_pedestrian_density_manifest(
+    path: Path,
+    *,
+    scenario_id: str,
+    density_delta: float = 0.02,
+    max_abs_density_delta: float = 0.03,
+    manifest_delta_cap: float = 0.03,
+    max_ped_density: float | None = 0.12,
+) -> Path:
+    """Write a perturbation manifest that offsets route-pedestrian density."""
+    validity = {
+        "require_scenario_certification": True,
+        "max_route_offset_m": 0.5,
+        "max_pedestrian_density_delta": manifest_delta_cap,
+        "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+    }
+    if max_ped_density is not None:
+        validity["max_pedestrian_density"] = max_ped_density
+    parameters = {
+        "density_delta": density_delta,
+        "max_abs_density_delta": max_abs_density_delta,
+    }
+    if max_ped_density is not None:
+        parameters["max_ped_density"] = max_ped_density
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_pedestrian_density_perturbation_manifest",
+        "scenario_config": "configs/scenarios/classic_interactions_francis2023.yaml",
+        "seed_controls": {
+            "baseline_seeds": [171],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": validity,
+        "variants": [
+            {
+                "variant_id": f"{scenario_id}_noop",
+                "scenario_id": scenario_id,
+                "family": "noop",
+                "seeds": [171],
+            },
+            {
+                "variant_id": f"{scenario_id}_density_offset",
+                "scenario_id": scenario_id,
+                "family": "pedestrian_density_offset",
+                "seeds": [171],
+                "parameters": parameters,
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_manifest_schema_accepts_noop_and_bounded_route_offset(tmp_path: Path) -> None:
     """The public schema should document the first supported perturbation surface."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml")
@@ -384,6 +437,44 @@ def test_manifest_schema_requires_manifest_wait_duration_cap_for_wait_duration_o
         jsonschema.validate(manifest, schema)
 
 
+def test_manifest_schema_accepts_bounded_pedestrian_density_offset(
+    tmp_path: Path,
+) -> None:
+    """The public schema should expose the route-pedestrian density family."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_requires_manifest_density_cap_for_density_offset(
+    tmp_path: Path,
+) -> None:
+    """Density manifests should carry both variant-local and policy-level bounds."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+    )
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    del manifest["validity"]["max_pedestrian_density_delta"]
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with pytest.raises(jsonschema.ValidationError, match="max_pedestrian_density_delta"):
+        jsonschema.validate(manifest, schema)
+
+
 def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None:
     """Family-specific parameter schemas should catch typo-shaped irrelevant fields."""
     schema = json.loads(
@@ -424,6 +515,15 @@ def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None
     wait_manifest["variants"][1]["parameters"]["speed_delta_m_s"] = 0.25
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(wait_manifest, schema)
+
+    density_manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "density_perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+    )
+    density_manifest = yaml.safe_load(density_manifest_path.read_text(encoding="utf-8"))
+    density_manifest["variants"][1]["parameters"]["dx_m"] = 0.0
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(density_manifest, schema)
 
 
 def test_preflight_rejects_manifest_that_violates_public_schema(tmp_path: Path) -> None:
@@ -778,6 +878,95 @@ def test_preflight_excludes_negative_wait_duration_result(tmp_path: Path) -> Non
     ]
 
 
+def test_preflight_certifies_bounded_pedestrian_density_offset(
+    tmp_path: Path,
+) -> None:
+    """Pedestrian density offsets should certify when route pedestrians can spawn."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    assert [result.variant_id for result in report.results] == [
+        "classic_group_crossing_medium_noop",
+        "classic_group_crossing_medium_density_offset",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    density_result = report.results[1]
+    assert density_result.family == "pedestrian_density_offset"
+    assert density_result.perturbation_summary["baseline_ped_density"] == pytest.approx(0.08)
+    assert density_result.perturbation_summary["updated_ped_density"] == pytest.approx(0.10)
+    assert density_result.perturbation_summary["pedestrian_route_count"] > 0
+
+
+def test_preflight_excludes_density_offset_without_pedestrian_routes(
+    tmp_path: Path,
+) -> None:
+    """Density offsets must fail closed when the source scenario has no route pedestrians."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="francis2023_intersection_wait",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.family == "pedestrian_density_offset"
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: pedestrian_density_offset selected no pedestrian routes"
+    ]
+
+
+def test_preflight_excludes_unbounded_density_offset_before_certification(
+    tmp_path: Path,
+) -> None:
+    """Out-of-bounds density perturbations should fail closed without certification."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+        density_delta=0.04,
+        max_abs_density_delta=0.03,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "pedestrian_density_offset abs_density_delta 0.040000 exceeds "
+        "variant max_abs_density_delta 0.030000"
+    ]
+
+
+def test_preflight_excludes_negative_density_result(tmp_path: Path) -> None:
+    """Negative density offsets cannot make route-pedestrian density negative."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+        density_delta=-0.10,
+        max_abs_density_delta=0.12,
+        manifest_delta_cap=0.12,
+        max_ped_density=None,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: pedestrian_density_offset would make ped_density negative"
+    ]
+
+
 def test_preflight_excludes_unbounded_route_offset_before_certification(tmp_path: Path) -> None:
     """Out-of-bounds perturbations should fail closed without becoming benchmark evidence."""
     manifest_path = _write_manifest(tmp_path / "perturbations.yaml", max_route_offset_m=0.2)
@@ -1070,6 +1259,40 @@ def test_materialize_pilot_matrix_writes_wait_duration_overrides(tmp_path: Path)
         ped.id: [rule.wait_s for rule in ped.wait_at or []] for ped in offset_map.single_pedestrians
     }
     assert waits["h1"] == [pytest.approx(2.5)]
+
+
+def test_materialize_pilot_matrix_writes_pedestrian_density_override(
+    tmp_path: Path,
+) -> None:
+    """Density variants should write an executable scenario-level density override."""
+    manifest_path = _write_pedestrian_density_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_id="classic_group_crossing_medium",
+    )
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "classic_group_crossing_medium_noop",
+        "classic_group_crossing_medium_density_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    assert offset_scenario["simulation_config"]["ped_density"] == pytest.approx(0.10)
+    metadata = offset_scenario["metadata"]["scenario_perturbation"]
+    assert metadata["family"] == "pedestrian_density_offset"
+    assert metadata["perturbation_summary"]["updated_ped_density"] == pytest.approx(0.10)
+
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    assert offset_config.sim_config.peds_per_area_m2 == pytest.approx(0.10)
 
 
 def test_materialize_pilot_matrix_skips_preflight_excluded_variants(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds `pedestrian_density_offset` as a bounded scenario perturbation family for route-pedestrian scenarios.
- Adds the #1959/#1610 exploratory density pilot manifest and tracked compact pilot evidence.
- Merges the current trajectory-waypoint perturbation family from `origin/main` and keeps both families covered in schema, preflight, materialization, docs, and tests.

Closes #1959.

## Evidence Boundary
This is diagnostic local pilot evidence only, not benchmark-strength or paper-facing evidence. The Francis wait density row is intentionally excluded because it has no pedestrian routes. The tiny goal-planner pilot completed 2/2 pairs and observed zero mean deltas for success, timeout, collision, and min-distance under `seed_limit=2`, `horizon=40`.

## Validation
- `uv run ruff format robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `uv run ruff check robot_sf/scenario_certification/perturbation_preflight.py tests/scenario_certification/test_scenario_perturbation_preflight.py`
- `python -m json.tool robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json`
- `python -m json.tool docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json`
- `PYTHONPATH=$PWD uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py -k "pedestrian_density or trajectory_waypoint or cross_family_parameters"` -> 11 passed
- `PYTHONPATH=$PWD uv run pytest tests/scenario_certification/test_scenario_perturbation_preflight.py` -> 51 passed
- `PYTHONPATH=$PWD uv run python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml --output output/scenario_perturbation_preflight/issue_1959_ped_density.json`
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 PYTHONPATH=$PWD uv run python scripts/tools/materialize_scenario_perturbation_pilot.py configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml --output-dir output/scenario_perturbation_pilot/issue_1959_ped_density --seed-limit 2`
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 PYTHONPATH=$PWD uv run python scripts/validation/run_scenario_perturbation_criticality_pilot.py configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml --materialized-output-dir output/scenario_perturbations/issue1959_ped_density/materialized --pilot-output-dir output/scenario_perturbations/issue1959_ped_density/results --seed-limit 2 --horizon 40 --planner goal --evidence-summary docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json`
- OpenCode Go routed review: `opencode-go/deepseek-v4-flash`, no findings, no edits
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4842 passed, 11 skipped, 8 warnings in 301.05s; changed-file coverage warning only for `robot_sf/scenario_certification/perturbation_preflight.py` at 90.9%; readiness stamp passed with clean tree on head `753f42fea7742f24d8554372cef2fc1b65d9d0e7`

## Output Artifacts
Ignored `output/` artifacts from coverage, preflight, materialization, and raw pilot runs are disposable local outputs. The durable tracked evidence is `docs/context/evidence/issue_1959_pedestrian_density_pilot_summary.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pedestrian density offset as a new scenario perturbation type with configurable density modification parameters.
  * Implemented validation constraints and fail-closed behavior for pedestrian density adjustments.

* **Documentation**
  * Updated scenario perturbation manifest documentation to include pedestrian density offset support and associated validation requirements.

* **Tests**
  * Added comprehensive test coverage for pedestrian density offset perturbation validation and scenario certification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->