### PR TITLE
feat: add trace annotation fixture contract

### DIFF
--- a/docs/context/issue_1689_simulation_trace_export_schema.md
+++ b/docs/context/issue_1689_simulation_trace_export_schema.md
@@ -19,6 +19,11 @@ consumers. It does not add a frontend, renderer, benchmark metric, or paper-faci
 - Loader: `robot_sf/analysis_workbench/simulation_trace_export.py`
 - Fixture: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json`
 - Test: `tests/analysis_workbench/test_simulation_trace_export.py`
+- Annotation schema: `robot_sf/analysis_workbench/schemas/trace_annotation_set.v1.json`
+- Annotation loader: `robot_sf/analysis_workbench/trace_annotation.py`
+- Annotation fixture:
+  `tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json`
+- Annotation test: `tests/analysis_workbench/test_trace_annotation.py`
 
 The trace contains source metadata, a strict `analysis_workbench_only` evidence boundary, frame
 units, robot state, pedestrian state, and a small planner action/event block. The typed loader also
@@ -32,10 +37,15 @@ benchmark evidence, not a success claim, and not a replacement for schema-checke
 records or durable campaign summaries. If a payload changes `evidence_boundary` to
 `benchmark_evidence`, validation fails closed.
 
+`trace_annotation_set.v1` follows the same boundary. It records qualitative frame-range annotations
+against a tracked trace fixture and rejects missing timeline fixtures, generated `output/` timeline
+references, unknown event IDs, unsupported categories, and benchmark-evidence provenance.
+
 ## Validation
 
 ```bash
 uv run pytest -q tests/analysis_workbench/test_simulation_trace_export.py
+uv run pytest -q tests/analysis_workbench/test_trace_annotation.py
 ```
 
-Expected result: `3 passed`.
+Expected result: both targeted suites pass.

--- a/docs/debug_visualization.md
+++ b/docs/debug_visualization.md
@@ -30,6 +30,15 @@ uv run python scripts/tools/render_trace_report.py \
   --output output/debug/trace_report/report.md
 ```
 
+Qualitative frame-range annotations for trace fixtures use `trace_annotation_set.v1`. They anchor
+review comments to inclusive trace steps, optional planner event IDs, and robot or pedestrian
+entities while preserving a strict `analysis_workbench_qualitative_only` evidence boundary. The
+fixture added for issue #1962 is:
+
+```text
+tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json
+```
+
 An optional Rerun output path is available when `rerun-sdk` is installed in the active environment:
 
 ```bash

--- a/robot_sf/analysis_workbench/__init__.py
+++ b/robot_sf/analysis_workbench/__init__.py
@@ -1,1 +1,29 @@
 """Analysis-workbench contracts and helpers."""
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SIMULATION_TRACE_EXPORT_SCHEMA_VERSION,
+    SimulationTraceExport,
+    SimulationTraceExportValidationError,
+    load_simulation_trace_export,
+    simulation_trace_export_from_dict,
+)
+from robot_sf.analysis_workbench.trace_annotation import (
+    TRACE_ANNOTATION_SET_SCHEMA_VERSION,
+    TraceAnnotationSet,
+    TraceAnnotationSetValidationError,
+    load_trace_annotation_set,
+    trace_annotation_set_from_dict,
+)
+
+__all__ = [
+    "SIMULATION_TRACE_EXPORT_SCHEMA_VERSION",
+    "TRACE_ANNOTATION_SET_SCHEMA_VERSION",
+    "SimulationTraceExport",
+    "SimulationTraceExportValidationError",
+    "TraceAnnotationSet",
+    "TraceAnnotationSetValidationError",
+    "load_simulation_trace_export",
+    "load_trace_annotation_set",
+    "simulation_trace_export_from_dict",
+    "trace_annotation_set_from_dict",
+]

--- a/robot_sf/analysis_workbench/schemas/trace_annotation_set.v1.json
+++ b/robot_sf/analysis_workbench/schemas/trace_annotation_set.v1.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/trace_annotation_set.v1.json",
+  "title": "Robot SF Trace Annotation Set v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "annotation_set_id",
+    "timeline",
+    "provenance",
+    "annotations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "trace_annotation_set.v1"
+    },
+    "annotation_set_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timeline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "schema_version", "trace_id"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_version": {
+          "const": "simulation_trace_export.v1"
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "source_issue",
+        "author",
+        "created_at",
+        "evidence_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "enum": ["tracked_fixture"]
+        },
+        "source_issue": {
+          "type": "string",
+          "pattern": "^#[0-9]+$"
+        },
+        "author": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date"
+        },
+        "evidence_boundary": {
+          "const": "analysis_workbench_qualitative_only"
+        }
+      }
+    },
+    "annotations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "annotation_id",
+          "category",
+          "evidence_type",
+          "anchor",
+          "summary"
+        ],
+        "properties": {
+          "annotation_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "enum": ["planner_action", "interaction", "safety_margin", "data_quality"]
+          },
+          "evidence_type": {
+            "enum": ["observed", "hypothesis", "commentary"]
+          },
+          "anchor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["frame_start", "frame_end"],
+            "properties": {
+              "frame_start": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "frame_end": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "event_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              },
+              "entities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["type", "id"],
+                  "properties": {
+                    "type": {
+                      "enum": ["robot", "pedestrian"]
+                    },
+                    "id": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "details": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/analysis_workbench/trace_annotation.py
+++ b/robot_sf/analysis_workbench/trace_annotation.py
@@ -1,0 +1,460 @@
+"""Typed loader for ``trace_annotation_set.v1`` analysis-workbench annotations."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SIMULATION_TRACE_EXPORT_SCHEMA_VERSION,
+    SimulationTraceExport,
+    SimulationTraceExportValidationError,
+    load_simulation_trace_export,
+)
+
+TRACE_ANNOTATION_SET_SCHEMA_VERSION = "trace_annotation_set.v1"
+TRACE_ANNOTATION_SET_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "trace_annotation_set.v1.json"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotationTimelineRef:
+    """Reference to the trace export annotated by an annotation set."""
+
+    path: str
+    schema_version: str
+    trace_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotationProvenance:
+    """Review provenance and evidence boundary for annotation payloads."""
+
+    kind: str
+    source_issue: str
+    author: str
+    created_at: str
+    evidence_boundary: str
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotationEntityRef:
+    """Entity named by a frame-range annotation."""
+
+    type: str
+    id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotationAnchor:
+    """Frame-range anchor for a qualitative annotation."""
+
+    frame_start: int
+    frame_end: int
+    event_ids: list[str]
+    entities: list[TraceAnnotationEntityRef]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotation:
+    """One qualitative annotation on a simulation trace export."""
+
+    annotation_id: str
+    category: str
+    evidence_type: str
+    anchor: TraceAnnotationAnchor
+    summary: str
+    details: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TraceAnnotationSet:
+    """Typed ``trace_annotation_set.v1`` payload."""
+
+    schema_version: str
+    annotation_set_id: str
+    timeline: TraceAnnotationTimelineRef
+    provenance: TraceAnnotationProvenance
+    annotations: list[TraceAnnotation]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the annotation set to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation suitable for JSON Schema validation.
+        """
+
+        payload = asdict(self)
+        for annotation in payload["annotations"]:
+            if annotation.get("details") is None:
+                annotation.pop("details", None)
+        return payload
+
+
+class TraceAnnotationSetValidationError(ValueError):
+    """Raised when a trace annotation set fails validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_trace_annotation_set_schema() -> dict[str, Any]:
+    """Load the public ``trace_annotation_set.v1`` JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(TRACE_ANNOTATION_SET_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_trace_annotation_set(path: Path) -> TraceAnnotationSet:
+    """Load one trace annotation set from JSON.
+
+    Returns:
+        Typed trace annotation set.
+    """
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise TraceAnnotationSetValidationError(["expected a mapping payload"], source=path)
+    return trace_annotation_set_from_dict(raw, source=path)
+
+
+def trace_annotation_set_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> TraceAnnotationSet:
+    """Validate and convert a mapping into a typed trace annotation set.
+
+    Returns:
+        Typed trace annotation set.
+    """
+
+    source_path = Path(source) if source is not None else None
+    errors = _schema_validation_errors(payload)
+    trace = _load_referenced_trace(payload, source_path=source_path, errors=errors)
+    if trace is not None:
+        errors.extend(_semantic_validation_errors(payload, trace))
+    if errors:
+        raise TraceAnnotationSetValidationError(errors, source=source)
+    return _annotation_set_from_payload(payload)
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors."""
+
+    validator = Draft202012Validator(load_trace_annotation_set_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(
+            validator.iter_errors(payload),
+            key=lambda err: list(err.absolute_path),
+        )
+    ]
+
+
+def _load_referenced_trace(
+    payload: Mapping[str, Any],
+    *,
+    source_path: Path | None,
+    errors: list[str],
+) -> SimulationTraceExport | None:
+    """Load the referenced timeline when enough payload fields are schema-shaped.
+
+    Returns:
+        Referenced trace export, or ``None`` when the reference is invalid.
+    """
+
+    timeline = payload.get("timeline")
+    if not isinstance(timeline, Mapping):
+        return None
+    raw_path = timeline.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    timeline_path = Path(raw_path)
+    if timeline_path.is_absolute():
+        errors.append("/timeline/path: expected repository-relative or fixture-relative path")
+        return None
+    if any(part in {"output", "results"} for part in timeline_path.parts):
+        errors.append("/timeline/path: expected tracked fixture path, not generated output")
+        return None
+    base_dir = source_path.parent if source_path is not None and source_path.parent else Path.cwd()
+    resolved_path = (base_dir / timeline_path).resolve()
+    if not resolved_path.exists():
+        errors.append(f"/timeline/path: referenced trace fixture does not exist: {raw_path}")
+        return None
+    try:
+        return load_simulation_trace_export(resolved_path)
+    except (
+        OSError,
+        json.JSONDecodeError,
+        SimulationTraceExportValidationError,
+    ) as exc:  # pragma: no cover - exercised by trace-export tests.
+        errors.append(f"/timeline/path: referenced trace fixture is invalid: {exc}")
+        return None
+
+
+def _semantic_validation_errors(
+    payload: Mapping[str, Any],
+    trace: SimulationTraceExport,
+) -> list[str]:
+    """Return cross-file validation errors for a trace annotation payload."""
+
+    errors: list[str] = []
+    errors.extend(_timeline_validation_errors(payload, trace))
+
+    annotations = payload.get("annotations")
+    if not isinstance(annotations, list):
+        return errors
+
+    frame_steps = {frame.step for frame in trace.frames}
+    event_ids = {
+        event_id
+        for frame in trace.frames
+        if isinstance(event_id := frame.planner.get("event_id"), str)
+    }
+    pedestrian_ids = {
+        str(pedestrian["id"])
+        for frame in trace.frames
+        for pedestrian in frame.pedestrians
+        if "id" in pedestrian
+    }
+
+    for index, annotation in enumerate(annotations):
+        if not isinstance(annotation, Mapping):
+            continue
+        anchor = annotation.get("anchor")
+        if isinstance(anchor, Mapping):
+            errors.extend(
+                _anchor_validation_errors(
+                    anchor,
+                    index=index,
+                    frame_steps=frame_steps,
+                    event_ids=event_ids,
+                    pedestrian_ids=pedestrian_ids,
+                )
+            )
+    return errors
+
+
+def _timeline_validation_errors(
+    payload: Mapping[str, Any],
+    trace: SimulationTraceExport,
+) -> list[str]:
+    """Return errors for the annotation-to-trace reference."""
+
+    errors: list[str] = []
+    timeline = payload.get("timeline")
+    if isinstance(timeline, Mapping):
+        if timeline.get("schema_version") != SIMULATION_TRACE_EXPORT_SCHEMA_VERSION:
+            errors.append("/timeline/schema_version: unsupported trace schema version")
+        if timeline.get("trace_id") != trace.trace_id:
+            errors.append(f"/timeline/trace_id: expected referenced trace_id {trace.trace_id!r}")
+    return errors
+
+
+def _anchor_validation_errors(
+    anchor: Mapping[str, Any],
+    *,
+    index: int,
+    frame_steps: set[int],
+    event_ids: set[str],
+    pedestrian_ids: set[str],
+) -> list[str]:
+    """Return errors for one annotation anchor against a loaded trace."""
+
+    errors = _frame_range_validation_errors(
+        anchor,
+        index=index,
+        frame_steps=frame_steps,
+    )
+    errors.extend(_event_id_validation_errors(anchor, index=index, event_ids=event_ids))
+    errors.extend(
+        _entity_anchor_validation_errors(
+            anchor,
+            index=index,
+            pedestrian_ids=pedestrian_ids,
+        )
+    )
+    return errors
+
+
+def _frame_range_validation_errors(
+    anchor: Mapping[str, Any],
+    *,
+    index: int,
+    frame_steps: set[int],
+) -> list[str]:
+    """Return errors for one annotation frame range."""
+
+    errors: list[str] = []
+    min_step = min(frame_steps)
+    max_step = max(frame_steps)
+    frame_start = anchor.get("frame_start")
+    frame_end = anchor.get("frame_end")
+    if isinstance(frame_start, int) and isinstance(frame_end, int):
+        if frame_start > frame_end:
+            errors.append(f"/annotations/{index}/anchor/frame_start: expected <= frame_end")
+        if frame_start < min_step or frame_end > max_step:
+            errors.append(
+                f"/annotations/{index}/anchor: frame range {frame_start}-{frame_end} "
+                f"outside referenced trace steps {min_step}-{max_step}"
+            )
+        if frame_start not in frame_steps:
+            errors.append(
+                f"/annotations/{index}/anchor/frame_start: "
+                f"unknown referenced trace step {frame_start}"
+            )
+        if frame_end not in frame_steps:
+            errors.append(
+                f"/annotations/{index}/anchor/frame_end: unknown referenced trace step {frame_end}"
+            )
+    return errors
+
+
+def _event_id_validation_errors(
+    anchor: Mapping[str, Any],
+    *,
+    index: int,
+    event_ids: set[str],
+) -> list[str]:
+    """Return errors for event IDs referenced by one annotation anchor."""
+
+    errors: list[str] = []
+    event_id_values = anchor.get("event_ids", [])
+    if isinstance(event_id_values, list):
+        for event_index, event_id in enumerate(event_id_values):
+            if not isinstance(event_id, str) or event_id in event_ids:
+                continue
+            errors.append(
+                f"/annotations/{index}/anchor/event_ids/{event_index}: "
+                f"unknown referenced trace event_id {event_id!r}"
+            )
+    return errors
+
+
+def _entity_anchor_validation_errors(
+    anchor: Mapping[str, Any],
+    *,
+    index: int,
+    pedestrian_ids: set[str],
+) -> list[str]:
+    """Return errors for entities referenced by one annotation anchor."""
+
+    errors: list[str] = []
+    entity_values = anchor.get("entities", [])
+    if isinstance(entity_values, list):
+        for entity_index, entity in enumerate(entity_values):
+            if isinstance(entity, Mapping):
+                errors.extend(
+                    _entity_validation_errors(
+                        entity,
+                        index=index,
+                        entity_index=entity_index,
+                        pedestrian_ids=pedestrian_ids,
+                    )
+                )
+    return errors
+
+
+def _entity_validation_errors(
+    entity: Mapping[str, Any],
+    *,
+    index: int,
+    entity_index: int,
+    pedestrian_ids: set[str],
+) -> list[str]:
+    """Return errors for one entity reference."""
+
+    entity_type = entity.get("type")
+    entity_id = entity.get("id")
+    if entity_type == "robot" and entity_id != "robot":
+        return [
+            f"/annotations/{index}/anchor/entities/{entity_index}/id: "
+            "robot entity id must be 'robot'"
+        ]
+    if entity_type == "pedestrian":
+        if not isinstance(entity_id, str) or entity_id in pedestrian_ids:
+            return []
+        return [
+            f"/annotations/{index}/anchor/entities/{entity_index}/id: "
+            f"unknown pedestrian id {entity_id!r}"
+        ]
+    return []
+
+
+def _annotation_set_from_payload(payload: Mapping[str, Any]) -> TraceAnnotationSet:
+    """Build a typed annotation set from a schema-valid payload.
+
+    Returns:
+        Typed trace annotation set.
+    """
+
+    timeline = payload["timeline"]
+    provenance = payload["provenance"]
+    return TraceAnnotationSet(
+        schema_version=str(payload["schema_version"]),
+        annotation_set_id=str(payload["annotation_set_id"]),
+        timeline=TraceAnnotationTimelineRef(
+            path=str(timeline["path"]),
+            schema_version=str(timeline["schema_version"]),
+            trace_id=str(timeline["trace_id"]),
+        ),
+        provenance=TraceAnnotationProvenance(
+            kind=str(provenance["kind"]),
+            source_issue=str(provenance["source_issue"]),
+            author=str(provenance["author"]),
+            created_at=str(provenance["created_at"]),
+            evidence_boundary=str(provenance["evidence_boundary"]),
+        ),
+        annotations=[
+            TraceAnnotation(
+                annotation_id=str(annotation["annotation_id"]),
+                category=str(annotation["category"]),
+                evidence_type=str(annotation["evidence_type"]),
+                anchor=TraceAnnotationAnchor(
+                    frame_start=int(annotation["anchor"]["frame_start"]),
+                    frame_end=int(annotation["anchor"]["frame_end"]),
+                    event_ids=[
+                        str(event_id) for event_id in annotation["anchor"].get("event_ids", [])
+                    ],
+                    entities=[
+                        TraceAnnotationEntityRef(
+                            type=str(entity["type"]),
+                            id=str(entity["id"]),
+                        )
+                        for entity in annotation["anchor"].get("entities", [])
+                    ],
+                ),
+                summary=str(annotation["summary"]),
+                details=(str(annotation["details"]) if "details" in annotation else None),
+            )
+            for annotation in payload["annotations"]
+        ],
+    )
+
+
+def _json_pointer(path: Any) -> str:
+    """Render a JSON Schema error path as an RFC6901-style pointer.
+
+    Returns:
+        JSON pointer string for the provided path.
+    """
+
+    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
+    return "/" + "/".join(parts) if parts else "/"

--- a/tests/analysis_workbench/test_trace_annotation.py
+++ b/tests/analysis_workbench/test_trace_annotation.py
@@ -1,0 +1,125 @@
+"""Contract tests for analysis-workbench trace annotation sets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.analysis_workbench.trace_annotation import (
+    TRACE_ANNOTATION_SET_SCHEMA_VERSION,
+    TraceAnnotationSetValidationError,
+    load_trace_annotation_set,
+    trace_annotation_set_from_dict,
+)
+
+ANNOTATION_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "trace_annotation_set_v1"
+    / "issue_1962_planner_sanity_open_annotations.json"
+)
+
+
+def test_load_trace_annotation_fixture() -> None:
+    """The annotation fixture should validate against its referenced trace."""
+
+    annotation_set = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH)
+
+    assert annotation_set.schema_version == TRACE_ANNOTATION_SET_SCHEMA_VERSION
+    assert annotation_set.annotation_set_id == "issue_1962_planner_sanity_open_annotations"
+    assert annotation_set.timeline.schema_version == "simulation_trace_export.v1"
+    assert annotation_set.provenance.evidence_boundary == ("analysis_workbench_qualitative_only")
+    assert [annotation.evidence_type for annotation in annotation_set.annotations] == [
+        "observed",
+        "hypothesis",
+        "commentary",
+    ]
+    assert annotation_set.annotations[0].anchor.frame_start == 1
+    assert annotation_set.annotations[0].anchor.frame_end == 2
+    assert annotation_set.annotations[0].anchor.entities[0].id == "robot"
+
+
+def test_trace_annotation_rejects_missing_trace_fixture() -> None:
+    """Annotation sets should fail closed when their source timeline is missing."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["timeline"]["path"] = "../simulation_trace_export_v1/missing.json"
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="does not exist"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_invalid_frame_range_order() -> None:
+    """Frame ranges should be ordered inclusively by trace step."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["annotations"][0]["anchor"]["frame_start"] = 3
+    payload["annotations"][0]["anchor"]["frame_end"] = 2
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="expected <= frame_end"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_frame_range_outside_trace() -> None:
+    """Frame anchors should point at steps present in the referenced trace."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["annotations"][0]["anchor"]["frame_start"] = 0
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="outside referenced trace"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_output_timeline_dependency() -> None:
+    """Annotation fixtures should not depend on worktree-local generated output."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["timeline"]["path"] = "output/debug/generated_trace.json"
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="not generated output"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_unknown_event_id() -> None:
+    """Event references should resolve against the referenced timeline."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["annotations"][0]["anchor"]["event_ids"] = ["missing-event"]
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="unknown referenced trace"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_unsupported_category() -> None:
+    """Categories are intentionally finite so downstream views can remain stable."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["annotations"][0]["category"] = "storytelling"
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="/annotations/0/category"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_unsupported_provenance() -> None:
+    """Generated-output provenance should not masquerade as a tracked fixture."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["provenance"]["kind"] = "output_run"
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="/provenance/kind"):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)
+
+
+def test_trace_annotation_rejects_benchmark_evidence_boundary() -> None:
+    """Qualitative annotations should never be validated as benchmark evidence."""
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["provenance"]["evidence_boundary"] = "benchmark_evidence"
+
+    with pytest.raises(
+        TraceAnnotationSetValidationError,
+        match="/provenance/evidence_boundary",
+    ):
+        trace_annotation_set_from_dict(payload, source=ANNOTATION_FIXTURE_PATH)

--- a/tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json
+++ b/tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "trace_annotation_set.v1",
+  "annotation_set_id": "issue_1962_planner_sanity_open_annotations",
+  "timeline": {
+    "path": "../simulation_trace_export_v1/planner_sanity_open_episode_0000.json",
+    "schema_version": "simulation_trace_export.v1",
+    "trace_id": "planner_sanity_open-ep0-seed7-source-aae87cf6"
+  },
+  "provenance": {
+    "kind": "tracked_fixture",
+    "source_issue": "#1962",
+    "author": "codex",
+    "created_at": "2026-06-01",
+    "evidence_boundary": "analysis_workbench_qualitative_only"
+  },
+  "annotations": [
+    {
+      "annotation_id": "issue_1962_step_1_to_2_goal_action_observed",
+      "category": "planner_action",
+      "evidence_type": "observed",
+      "anchor": {
+        "frame_start": 1,
+        "frame_end": 2,
+        "event_ids": [
+          "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000",
+          "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0001"
+        ],
+        "entities": [
+          {
+            "type": "robot",
+            "id": "robot"
+          }
+        ]
+      },
+      "summary": "The robot stays nearly stationary on the first frame and then selects a small forward command.",
+      "details": "This is a qualitative fixture annotation for report and viewer plumbing only."
+    },
+    {
+      "annotation_id": "issue_1962_step_3_heading_hypothesis",
+      "category": "interaction",
+      "evidence_type": "hypothesis",
+      "anchor": {
+        "frame_start": 3,
+        "frame_end": 3,
+        "event_ids": [
+          "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002"
+        ],
+        "entities": [
+          {
+            "type": "robot",
+            "id": "robot"
+          }
+        ]
+      },
+      "summary": "The final small angular command can be discussed as a candidate heading correction, not as benchmark evidence."
+    },
+    {
+      "annotation_id": "issue_1962_fixture_scope_commentary",
+      "category": "data_quality",
+      "evidence_type": "commentary",
+      "anchor": {
+        "frame_start": 1,
+        "frame_end": 3,
+        "entities": [
+          {
+            "type": "robot",
+            "id": "robot"
+          }
+        ]
+      },
+      "summary": "The fixture is intentionally tiny and renderer-neutral, so it is suitable for contract tests but not for performance conclusions."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a compact `trace_annotation_set.v1` analysis-workbench contract with a typed loader, schema, and tracked fixture for frame-range annotations on the #1859 timeline fixture.

Closes #1962.
Relates to #1646.

## Stack / Dependency
- Base dependency: none; built on current `main` after #1964 merged.
- Required prior PRs: none.
- Safe to review independently: yes.

## What Changed
- Added `robot_sf/analysis_workbench/trace_annotation.py` and `trace_annotation_set.v1` JSON Schema.
- Added a tiny tracked annotation fixture for `planner_sanity_open_episode_0000.json` with observed, hypothesis, and commentary annotations.
- Added tests for missing timeline fixtures, invalid frame ranges, generated `output/` dependencies, unknown event IDs, unsupported categories/provenance, and benchmark-evidence boundary rejection.
- Updated analysis-workbench exports and docs/context notes for future report/viewer consumers.

## Why It Matters
- Gives the analysis workbench a renderer-neutral way to anchor human/agent notes to trace frame ranges and planner event IDs.
- Keeps qualitative annotation clearly separate from benchmark evidence.
- Provides the next small building block for #1646 without adding a viewer or raw output dependency.

## Validation / Proof
- `uv run ruff format robot_sf/analysis_workbench/trace_annotation.py tests/analysis_workbench/test_trace_annotation.py robot_sf/analysis_workbench/__init__.py`
- `uv run ruff check robot_sf/analysis_workbench/trace_annotation.py tests/analysis_workbench/test_trace_annotation.py robot_sf/analysis_workbench/__init__.py`
- `python -m json.tool robot_sf/analysis_workbench/schemas/trace_annotation_set.v1.json`
- `python -m json.tool tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json`
- `PYTHONPATH=$PWD uv run pytest tests/analysis_workbench/test_trace_annotation.py -q` -> 9 passed
- `PYTHONPATH=$PWD uv run pytest tests/analysis_workbench/test_trace_annotation.py tests/analysis_workbench/test_simulation_trace_export.py tests/analysis_workbench/test_trace_report_renderer.py -q` -> 23 passed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4851 passed, 11 skipped, 9 warnings in 313.88s; changed-file coverage warning only for `robot_sf/analysis_workbench/trace_annotation.py` at 92.3%; readiness stamp passed for `0c32c95c3d23d13cdb966758fb592e802dcaec59` with clean tree.

## Risks / Rollout
- Compatibility risk is low: this adds a new schema/loader/fixture and does not change benchmark, rendering, or planner behavior.
- Failure mode is fail-closed validation for malformed annotations or missing referenced trace fixtures.
- Rollback is deleting the new annotation contract and fixture.

## Docs / Provenance
- Updated `docs/debug_visualization.md` and `docs/context/issue_1689_simulation_trace_export_schema.md`.
- The fixture references the tracked #1859 timeline fixture; no local `output/` artifact is required.
- Qualitative annotations remain `analysis_workbench_qualitative_only`, not benchmark evidence.

## Downstream Propagation
- Parent issue updated: yes, https://github.com/ll7/robot_sf_ll7/issues/1646#issuecomment-4589495543
- Claim map / benchmark report updated: NA; no benchmark claim.
- Registry or config index updated: NA.
- Context index / memory note updated: existing #1689 context note updated.
- Follow-up issue opened for deferred propagation: NA; next #1646 child candidate is recorded on the parent issue.

## Follow-Up Issues
- Deferred work: browser/viewer integration and AI discussion workflow remain out of scope for #1962.

## Reviewer Notes
- Please verify the annotation evidence boundary stays qualitative and the fixture remains compact/tracked rather than pointing at generated output.
