### PR TITLE
fix: align ORCA residual BC observations

### DIFF
--- a/configs/policy_search/candidates/orca_residual_guarded_ppo_v0.yaml
+++ b/configs/policy_search/candidates/orca_residual_guarded_ppo_v0.yaml
@@ -3,6 +3,17 @@ algo: guarded_ppo
 base_config_path: configs/algos/guarded_ppo_relaxed_v2.yaml
 params:
   prior_residual_mode: true
+  observation_mode: socnav_state
+  env_overrides:
+    predictive_foresight_enabled: true
+    predictive_foresight_model_id: predictive_proxy_selected_v2_full
+    predictive_foresight_device: cpu
+    predictive_foresight_max_agents: 16
+    predictive_foresight_horizon_steps: 8
+    predictive_foresight_rollout_dt: 0.2
+    predictive_foresight_near_distance: 0.7
+    predictive_foresight_front_corridor_length: 3.0
+    predictive_foresight_front_corridor_half_width: 1.0
   prior_residual_max_linear_delta: 0.25
   prior_residual_max_angular_delta: 0.35
   prior_policy: orca

--- a/docs/context/evidence/issue_1967_orca_residual_bc_smoke_adapter_summary.json
+++ b/docs/context/evidence/issue_1967_orca_residual_bc_smoke_adapter_summary.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "robot-sf-evidence-summary.v1",
+  "issue": 1967,
+  "parent_issue": 1475,
+  "generated_at_utc": "2026-06-01T04:37:08Z",
+  "commit_under_test": "worktree-uncommitted-after-2469d1d0f5adf0d9a4afc95c40b483c6f2855c1f",
+  "claim_boundary": "Adapter/observation-contract repair only. This is not evidence that the ORCA-residual BC policy is useful.",
+  "change_summary": [
+    "Guarded PPO/BC candidate smoke now forwards candidate observation_mode=socnav_state to the benchmark runner.",
+    "Policy-search candidate env_overrides now restore the predictive-foresight observation fields used by the BC dataset and checkpoint.",
+    "PPOPlanner validates flat-Box checkpoint compatibility during env binding and flattens runtime Dict observations through the bound observation_space."
+  ],
+  "pre_fix_fail_closed_runs": [
+    {
+      "run_dir": "output/slurm/issue1475-orca-residual-bc-local-1967-20260601T042948Z",
+      "summary_path": "output/slurm/issue1475-orca-residual-bc-local-1967-20260601T042948Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke/summary.json",
+      "decision": "revise",
+      "episodes": 0,
+      "availability_reason": "Runtime Dict observation space does not flatten to checkpoint Box: runtime flatdim=831, checkpoint shape=(77095,)."
+    },
+    {
+      "run_dir": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun-20260601T043407Z",
+      "summary_path": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun-20260601T043407Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke/summary.json",
+      "decision": "revise",
+      "episodes": 0,
+      "availability_reason": "Runtime Dict observation space does not flatten to checkpoint Box: runtime flatdim=77088, checkpoint shape=(77095,)."
+    }
+  ],
+  "successful_adapter_smoke": {
+    "run_dir": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z",
+    "materialized_manifest_path": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/issue1475_materialized_candidate/materialized_candidate_manifest.json",
+    "summary_path": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke/summary.json",
+    "jsonl_path": "output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke/smoke__orca_residual_guarded_ppo_v0.jsonl",
+    "candidate_runner_decision": "pass",
+    "episodes": 1,
+    "success_rate": 0.0,
+    "collision_rate": 0.0,
+    "near_miss_rate": 0.0,
+    "termination_reason_counts": {
+      "max_steps": 1
+    },
+    "row_summary": {
+      "scenario_id": "planner_sanity_simple",
+      "seed": 111,
+      "status": "failure",
+      "termination_reason": "max_steps",
+      "steps": 80,
+      "observation_mode": "socnav_state",
+      "observation_level": "tracked_agents_no_noise",
+      "success": false,
+      "collisions": 0,
+      "near_misses": 0
+    },
+    "issue_1475_wrapper_gate": {
+      "status": "revise",
+      "reason": "The strict #1475 wrapper gate requires success_rate=1.0 and collision_rate=0.0 before nominal escalation; this smoke produced a usable row but success_rate=0.0.",
+      "nominal_submitted": false
+    }
+  },
+  "checksums": {
+    "summary_sha256": "b74f88762ad8dd1e79e01171eb98442be44a0d9a14306c85763dcd26734a2606",
+    "jsonl_sha256": "61da7f9d8aceb13bd0482d59fb01c94e6b879d1e4ce45dacbbaeb4dc59deb2be",
+    "materialized_manifest_sha256": "35d3a7a36694cadbdfd836168bc00d4a89015c68ef314b9e1a70d1f99e0eddc2",
+    "policy_checkpoint_sha256": "bc121479723da9c47909d4e2fa0555d7002b6f4d4a0ec143d84b72f1c7c86708"
+  },
+  "validation_commands": [
+    "uv run ruff check robot_sf/benchmark/algorithm_metadata.py scripts/validation/run_policy_search_candidate.py tests/benchmark/test_algorithm_metadata_contract.py tests/validation/test_run_policy_search_candidate.py robot_sf/baselines/ppo.py robot_sf/benchmark/map_runner.py tests/baselines/test_ppo_planner.py tests/test_map_runner_ppo.py",
+    "PYTHONPATH=$PWD uv run pytest tests/baselines/test_ppo_planner.py tests/test_map_runner_ppo.py tests/benchmark/test_algorithm_metadata_contract.py tests/validation/test_run_policy_search_candidate.py tests/tools/test_materialize_orca_residual_candidate.py -q",
+    "uv run python scripts/tools/materialize_orca_residual_candidate.py --policy-model-id issue_1428_orca_residual_bc_policy_smoke --policy-model-path output/slurm/issue1475-orca-residual-bc-local-1967-20260601T042948Z/benchmarks/expert_policies/issue_1428_orca_residual_bc_policy_smoke.zip --candidate orca_residual_guarded_ppo_v0 --output-dir output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/issue1475_materialized_candidate --json",
+    "uv run python scripts/validation/run_policy_search_candidate.py --candidate orca_residual_guarded_ppo_v0 --candidate-registry output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/issue1475_materialized_candidate/candidate_registry.yaml --stage smoke --workers 1 --output-dir output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke"
+  ]
+}

--- a/docs/context/policy_search/reports/2026-06-01_orca_residual_guarded_ppo_v0_smoke.md
+++ b/docs/context/policy_search/reports/2026-06-01_orca_residual_guarded_ppo_v0_smoke.md
@@ -1,0 +1,47 @@
+# Candidate Report: orca_residual_guarded_ppo_v0 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+Unsafe PPO proposals can be reinterpreted as a bounded residual over the nominal ORCA command before falling through to the existing prior/fallback shield. This v0 entry wires the benchmark surface, clipping bounds, and diagnostics needed before launching the #1358 training campaign.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `guarded_ppo`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/slurm/issue1475-orca-residual-bc-local-1967-rerun2-20260601T043657Z/policy_search/orca_residual_guarded_ppo_v0/smoke/issue1475_smoke/summary.json`
+- Git commit: `2469d1d0f5adf0d9a4afc95c40b483c6f2855c1f`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 0.0000 | 0.0000 | 0.0000 | n/a | 0.8041 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 0.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- `timeout_low_progress`: `1`
+
+## Issue #1475 Gate Note
+
+This candidate-runner smoke decision is `pass` because the adapter fix produced a usable episode row. The stricter #1475 wrapper gate is still `revise`: success_rate is `0.0000`, collision_rate is `0.0000`, and nominal_sanity was not submitted.
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | -0.0142 | -0.2411 | n/a |
+| orca | -0.1844 | -0.0355 | n/a |
+| ppo | -0.2482 | -0.0993 | n/a |

--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -32,6 +32,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from gymnasium import spaces as gym_spaces
+from gymnasium.spaces.utils import flatdim, flatten
 from loguru import logger
 
 try:  # Lazy import; not required for type-check only
@@ -114,6 +116,7 @@ class PPOPlanner:
         self._status = "ok"
         self._fallback_reason: str | None = None
         self._predictive_foresight: PredictiveForesightEncoder | None = None
+        self._runtime_observation_space: gym_spaces.Space | None = None
         self._load_model()
         self._init_predictive_foresight()
 
@@ -215,6 +218,14 @@ class PPOPlanner:
         """
         if seed is not None:
             self._seed = seed
+
+    def bind_env(self, env: Any) -> None:
+        """Bind runtime observation space for dict-to-Box checkpoint adapters."""
+
+        obs_space = getattr(env, "observation_space", None)
+        if isinstance(obs_space, gym_spaces.Space):
+            self._runtime_observation_space = obs_space
+            self._validate_runtime_observation_space()
 
     def close(self) -> None:
         """Release the loaded PPO model."""
@@ -328,11 +339,11 @@ class PPOPlanner:
             logger.debug("PPO model prediction failed: %s", exc, exc_info=True)
             return None
 
-    def _build_model_obs_dict(self, obs: dict[str, Any]) -> dict[str, np.ndarray]:
-        """Build model-ready dict observation and align dtypes/shapes to model space.
+    def _build_model_obs_dict(self, obs: dict[str, Any]) -> dict[str, np.ndarray] | np.ndarray:
+        """Build model-ready observation payload and align it to the model space.
 
         Returns:
-            Dict payload shaped and typed to match the loaded model's observation space.
+            Payload shaped and typed to match the loaded model's observation space.
         """
         if self._model is None:
             return {str(k): np.asarray(v) for k, v in obs.items()}
@@ -340,7 +351,19 @@ class PPOPlanner:
         space = getattr(self._model, "observation_space", None)
         spaces = getattr(space, "spaces", None)
         if not isinstance(spaces, dict):
+            if isinstance(space, gym_spaces.Box):
+                return self._build_model_obs_flat_box(obs, space)
             return {str(k): np.asarray(v) for k, v in obs.items()}
+
+        source_obs = self._source_obs_with_predictive_backfill(obs, spaces)
+        return self._align_model_obs_dict(source_obs, spaces)
+
+    def _source_obs_with_predictive_backfill(
+        self,
+        obs: dict[str, Any],
+        spaces: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return dict observations plus any missing predictive feature payload."""
 
         source_obs = dict(obs)
         if self._predictive_foresight is not None:
@@ -352,6 +375,18 @@ class PPOPlanner:
                 source_obs.update(
                     {key: value for key, value in payload.items() if key in missing_predictive}
                 )
+        return source_obs
+
+    def _align_model_obs_dict(
+        self,
+        source_obs: dict[str, Any],
+        spaces: dict[str, Any],
+    ) -> dict[str, np.ndarray]:
+        """Align source observation fields to a model-declared Dict space.
+
+        Returns:
+            Dict payload shaped and typed to match the model-declared subspaces.
+        """
 
         converted: dict[str, np.ndarray] = {}
         missing: list[str] = []
@@ -375,6 +410,73 @@ class PPOPlanner:
             missing_preview = ", ".join(missing[:6])
             raise ValueError(f"Missing required dict observation keys: {missing_preview}")
         return converted
+
+    def _validate_runtime_observation_space(self) -> None:
+        """Fail closed when a flat checkpoint cannot match runtime observations."""
+
+        if self._model is None:
+            return
+        model_space = getattr(self._model, "observation_space", None)
+        if not isinstance(model_space, gym_spaces.Box) or not self._uses_dict_observation():
+            return
+
+        runtime_space = self._runtime_observation_space
+        model_size = int(np.prod(model_space.shape))
+        if isinstance(runtime_space, gym_spaces.Dict):
+            runtime_size = int(flatdim(runtime_space))
+            if runtime_size != model_size:
+                raise ValueError(
+                    "Runtime Dict observation space does not flatten to the checkpoint "
+                    f"Box shape: runtime flatdim={runtime_size}, "
+                    f"checkpoint shape={tuple(model_space.shape)}."
+                )
+            return
+        if isinstance(runtime_space, gym_spaces.Box):
+            runtime_size = int(np.prod(runtime_space.shape))
+            if runtime_size != model_size:
+                raise ValueError(
+                    "Runtime Box observation space does not match checkpoint Box shape: "
+                    f"runtime shape={tuple(runtime_space.shape)}, "
+                    f"checkpoint shape={tuple(model_space.shape)}."
+                )
+            return
+        raise ValueError(
+            "PPO checkpoint expects a flat Box observation but runtime observation_space "
+            f"is {type(runtime_space).__name__}; cannot prove adapter compatibility."
+        )
+
+    def _build_model_obs_flat_box(
+        self,
+        obs: dict[str, Any],
+        model_space: gym_spaces.Box,
+    ) -> np.ndarray:
+        """Flatten a runtime Dict observation for a flat-Box SB3 checkpoint.
+
+        Returns:
+            Model-ready flat observation matching the checkpoint shape.
+        """
+
+        runtime_space = self._runtime_observation_space
+        if isinstance(runtime_space, gym_spaces.Dict):
+            try:
+                flat_obs = np.asarray(flatten(runtime_space, obs), dtype=model_space.dtype)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Failed to flatten runtime Dict observation for PPO checkpoint."
+                ) from exc
+        else:
+            flat_obs = np.asarray(obs, dtype=model_space.dtype)
+
+        target_shape = tuple(model_space.shape)
+        if tuple(flat_obs.shape) != target_shape:
+            target_size = int(np.prod(target_shape))
+            if int(flat_obs.size) != target_size:
+                raise ValueError(
+                    "Flattened PPO observation size mismatch: "
+                    f"got shape {tuple(flat_obs.shape)}, expected {target_shape}."
+                )
+            flat_obs = flat_obs.reshape(target_shape)
+        return flat_obs
 
     def _predictive_feature_payload(self, obs: dict[str, Any]) -> dict[str, np.ndarray]:
         """Map nested predictive foresight outputs to flat PPO observation keys.

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -203,15 +203,28 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
     },
     "ppo": {
         "default_mode": "sensor_fusion_state",
-        "supported_modes": ("sensor_fusion_state",),
+        "supported_modes": ("sensor_fusion_state", "socnav_state"),
         "inputs": ("robot_state", "goal", "lidar_rays", "history"),
-        "notes": "PPO checkpoint inference uses the configured sensor-fusion observation stack.",
+        "notes": (
+            "PPO checkpoint inference uses sensor-fusion by default; BC/materialized "
+            "checkpoints may opt into the SocNav structured observation stack they were "
+            "trained with."
+        ),
     },
     "guarded_ppo": {
         "default_mode": "sensor_fusion_state",
-        "supported_modes": ("sensor_fusion_state",),
-        "inputs": ("robot_state", "goal", "lidar_rays", "history", "safety_guard"),
-        "notes": "Guarded PPO uses sensor-fusion policy inputs plus a local safety guard.",
+        "supported_modes": ("sensor_fusion_state", "socnav_state"),
+        "inputs": (
+            "robot_state",
+            "goal",
+            "lidar_rays",
+            "history",
+            "safety_guard",
+        ),
+        "notes": (
+            "Guarded PPO uses sensor-fusion policy inputs plus a local safety guard by "
+            "default; materialized BC checkpoints may request SocNav structured inputs."
+        ),
     },
     "crowdnav_height": {
         "default_mode": "lidar_human_state",

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 import time
+from collections.abc import Mapping
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from copy import deepcopy
 from dataclasses import fields
@@ -1921,6 +1922,9 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             return linear, angular
 
         _policy._planner_close = ppo_planner.close
+        ppo_bind_env = getattr(ppo_planner, "bind_env", None)
+        if callable(ppo_bind_env):
+            _policy._planner_bind_env = ppo_bind_env
         if "status" not in meta:
             meta["status"] = "ok"
         meta.setdefault("algorithm", "ppo")
@@ -2195,9 +2199,17 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 guard_close()
 
         _policy._planner_close = _close_guarded_ppo
+        ppo_bind_env = getattr(ppo_planner, "bind_env", None)
         guard_bind_env = getattr(guard_adapter, "bind_env", None)
-        if callable(guard_bind_env):
-            _policy._planner_bind_env = guard_bind_env
+        bind_hooks = [hook for hook in (ppo_bind_env, guard_bind_env) if callable(hook)]
+        if bind_hooks:
+
+            def _bind_guarded_ppo_env(env: Any) -> None:
+                """Bind PPO runtime observation space and guard map context."""
+                for hook in bind_hooks:
+                    hook(env)
+
+            _policy._planner_bind_env = _bind_guarded_ppo_env
         meta.setdefault("algorithm", "guarded_ppo")
         meta.setdefault("status", "ok")
         meta.setdefault("config", algo_config)
@@ -2852,6 +2864,36 @@ def _apply_active_observation_mode_to_env_config(
     config.grid_config = None
 
 
+_POLICY_ENV_OBSERVATION_OVERRIDE_KEYS = frozenset(
+    {
+        "predictive_foresight_enabled",
+        "predictive_foresight_model_id",
+        "predictive_foresight_checkpoint_path",
+        "predictive_foresight_device",
+        "predictive_foresight_max_agents",
+        "predictive_foresight_horizon_steps",
+        "predictive_foresight_rollout_dt",
+        "predictive_foresight_ego_conditioning",
+        "predictive_foresight_near_distance",
+        "predictive_foresight_front_corridor_length",
+        "predictive_foresight_front_corridor_half_width",
+    }
+)
+
+
+def _apply_policy_env_observation_overrides(
+    config: RobotSimulationConfig,
+    policy_cfg: Mapping[str, Any],
+) -> None:
+    """Apply candidate observation-contract env overrides before env construction."""
+
+    raw_overrides = policy_cfg.get("env_overrides")
+    overrides = raw_overrides if isinstance(raw_overrides, Mapping) else {}
+    for key in _POLICY_ENV_OBSERVATION_OVERRIDE_KEYS:
+        if key in overrides:
+            setattr(config, key, overrides[key])
+
+
 def _validate_sensor_fusion_adapter_config(
     *,
     algo: str,
@@ -3245,6 +3287,7 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         config,
         active_observation_mode=active_observation_mode,
     )
+    _apply_policy_env_observation_overrides(config, policy_cfg)
     _validate_sensor_fusion_adapter_config(
         algo=algo,
         active_observation_mode=active_observation_mode,

--- a/scripts/validation/run_policy_search_candidate.py
+++ b/scripts/validation/run_policy_search_candidate.py
@@ -394,6 +394,16 @@ def _stage_synthetic_actuation_profile(
     return synthetic_actuation_profile
 
 
+def _candidate_observation_override(algo_cfg: Mapping[str, Any], key: str) -> str | None:
+    """Return a non-empty candidate observation override, if configured."""
+
+    raw = algo_cfg.get(key)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
 def _load_records(path: Path) -> list[dict[str, Any]]:
     """Load policy-search episode records from JSONL.
 
@@ -579,6 +589,8 @@ def _run_stage_eval(  # noqa: PLR0913
         workers=int(workers),
         resume=False,
         benchmark_profile=str(benchmark_profile),
+        observation_mode=_candidate_observation_override(algo_cfg, "observation_mode"),
+        observation_level=_candidate_observation_override(algo_cfg, "observation_level"),
         synthetic_actuation_profile=synthetic_actuation_profile,
     )
     missing_jsonl = not jsonl_path.exists()

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import yaml
+from gymnasium import spaces
 
 from robot_sf.baselines.ppo import PPOPlanner, PPOPlannerConfig
 from robot_sf.baselines.social_force import Observation
@@ -83,6 +84,81 @@ def test_build_model_obs_dict_reshapes_to_model_space():
     converted = planner._build_model_obs_dict({"occupancy_grid": [0, 1, 2, 3]})
     assert converted["occupancy_grid"].shape == (2, 2)
     assert converted["occupancy_grid"].dtype == np.float32
+
+
+def test_step_dict_mode_flattens_runtime_dict_for_box_checkpoint() -> None:
+    """BC checkpoints trained with FlattenObservation should receive flat Box inputs."""
+    planner = PPOPlanner(_planner_config(obs_mode="dict", action_space="unicycle"))
+    captured: dict[str, np.ndarray | bool] = {}
+
+    class _Model:
+        """Flat-Box model stub that records prediction observations."""
+
+        observation_space = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+
+        def predict(self, obs, deterministic: bool = True):
+            """Record the flattened observation and return a unicycle action."""
+            captured["obs"] = np.asarray(obs)
+            captured["deterministic"] = deterministic
+            return np.array([0.4, -0.1], dtype=np.float32), None
+
+    planner._model = _Model()
+    planner._status = "ok"
+    planner.bind_env(
+        SimpleNamespace(
+            observation_space=spaces.Dict(
+                {
+                    "robot_position": spaces.Box(
+                        low=-10.0,
+                        high=10.0,
+                        shape=(2,),
+                        dtype=np.float32,
+                    ),
+                    "sim_timestep": spaces.Box(
+                        low=0.0,
+                        high=1.0,
+                        shape=(1,),
+                        dtype=np.float32,
+                    ),
+                }
+            )
+        )
+    )
+
+    action = planner.step(
+        {
+            "robot_position": np.array([1.0, 2.0], dtype=np.float32),
+            "sim_timestep": np.array([0.2], dtype=np.float32),
+        }
+    )
+
+    assert action == {"v": pytest.approx(0.4), "omega": pytest.approx(-0.1)}
+    assert np.asarray(captured["obs"]).shape == (3,)
+    assert np.asarray(captured["obs"]).dtype == np.float32
+
+
+def test_bind_env_rejects_flat_box_checkpoint_shape_mismatch() -> None:
+    """Runtime binding should fail before benchmark execution on adapter mismatch."""
+    planner = PPOPlanner(_planner_config(obs_mode="dict"))
+    planner._model = SimpleNamespace(
+        observation_space=spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32),
+    )
+
+    with pytest.raises(ValueError, match="does not flatten to the checkpoint Box shape"):
+        planner.bind_env(
+            SimpleNamespace(
+                observation_space=spaces.Dict(
+                    {
+                        "robot_position": spaces.Box(
+                            low=-1.0,
+                            high=1.0,
+                            shape=(2,),
+                            dtype=np.float32,
+                        )
+                    }
+                )
+            )
+        )
 
 
 def test_build_model_obs_dict_raises_on_missing_key():

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -31,6 +31,7 @@ def test_observation_spec_declares_supported_modes_and_rejects_invalid_override(
     meta = enrich_algorithm_metadata(algo="goal", observation_mode="socnav_state")
     assert meta["observation_spec"]["active_mode"] == "socnav_state"
     assert meta["observation_spec"]["override_applied"] is True
+    assert resolve_observation_mode("guarded_ppo", "socnav_state") == "socnav_state"
 
     with pytest.raises(ValueError) as excinfo:
         resolve_observation_mode("orca", "goal_state")

--- a/tests/test_map_runner_ppo.py
+++ b/tests/test_map_runner_ppo.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from robot_sf.benchmark import map_runner
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
 
 
 class _DummyPPOPlanner:
@@ -18,6 +19,7 @@ class _DummyPPOPlanner:
         self.seed = seed
         self.closed = False
         self.last_obs = None
+        self.bound_envs = []
 
     def step(self, _obs):
         """Return the configured action and retain the received observation."""
@@ -27,6 +29,10 @@ class _DummyPPOPlanner:
     def close(self):
         """Mark the dummy planner as closed."""
         self.closed = True
+
+    def bind_env(self, env):
+        """Record runtime env binding."""
+        self.bound_envs.append(env)
 
     def get_metadata(self):
         """Return map-runner metadata for the dummy planner.
@@ -279,6 +285,54 @@ def test_build_policy_guarded_ppo_arbitrates_and_tracks_guard_stats(monkeypatch)
     assert guard.bound_envs == [env]
     assert guard.reset_seeds == [5]
     assert guard.closed
+
+
+def test_build_policy_guarded_ppo_binds_ppo_and_guard_env(monkeypatch):
+    """Guarded PPO should bind both PPO obs adapter and guard map context."""
+    _DummyGuardedPPOAdapter.instances = []
+    ppo_instances: list[_DummyPPOPlanner] = []
+
+    def _make_ppo(*args, **kwargs):
+        planner = _DummyPPOPlanner(*args, **kwargs)
+        ppo_instances.append(planner)
+        return planner
+
+    monkeypatch.setattr(map_runner, "PPOPlanner", _make_ppo)
+    monkeypatch.setattr(map_runner, "GuardedPPOAdapter", _DummyGuardedPPOAdapter)
+    monkeypatch.setattr(map_runner, "build_guarded_ppo_fallback", lambda cfg: object())
+
+    policy, _ = map_runner._build_policy(
+        "guarded_ppo",
+        {"obs_mode": "dict", "test_action": {"v": 0.7, "omega": 0.3}},
+    )
+
+    env = object()
+    policy._planner_bind_env(env)
+
+    assert ppo_instances[-1].bound_envs == [env]
+    assert _DummyGuardedPPOAdapter.instances[-1].bound_envs == [env]
+
+
+def test_policy_env_observation_overrides_apply_predictive_contract() -> None:
+    """Policy-search candidate env_overrides should restore BC observation features."""
+    config = RobotSimulationConfig()
+
+    map_runner._apply_policy_env_observation_overrides(
+        config,
+        {
+            "env_overrides": {
+                "predictive_foresight_enabled": True,
+                "predictive_foresight_device": "cpu",
+                "predictive_foresight_max_agents": 16,
+                "predictive_foresight_horizon_steps": 8,
+            }
+        },
+    )
+
+    assert config.predictive_foresight_enabled is True
+    assert config.predictive_foresight_device == "cpu"
+    assert config.predictive_foresight_max_agents == 16
+    assert config.predictive_foresight_horizon_steps == 8
 
 
 def test_obs_to_ppo_format_uses_ped_count_and_sim_timestep():

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -111,6 +111,26 @@ def test_checked_in_actuation_aware_candidate_uses_synthetic_amv_smoke_stage() -
     assert stage["paper_facing"] is False
 
 
+def test_orca_residual_guarded_candidate_requests_training_observation_contract() -> None:
+    """Materialized ORCA-residual BC smoke should use the SocNav contract it trains with."""
+    repo_root = Path(__file__).parents[2]
+
+    _entry, payload, config, config_path = load_candidate_definition(
+        repo_root / "docs/context/policy_search/candidate_registry.yaml",
+        "orca_residual_guarded_ppo_v0",
+    )
+
+    assert payload["algo"] == "guarded_ppo"
+    assert config["obs_mode"] == "dict"
+    assert config["observation_mode"] == "socnav_state"
+    assert (
+        config_path
+        == (
+            repo_root / "configs/policy_search/candidates/orca_residual_guarded_ppo_v0.yaml"
+        ).resolve()
+    )
+
+
 def test_risk_surface_candidate_uses_smoke_progress_recovery_speed() -> None:
     """Risk-surface smoke candidate should opt into the 2 m/s local command envelope."""
     repo_root = Path(__file__).resolve().parents[2]
@@ -532,6 +552,39 @@ def test_run_stage_eval_records_missing_jsonl_as_fail_closed(
     assert summary["preflight"]["compatibility_status"] == "incompatible"
     assert summary["benchmark_availability"]["status"] == "not_available"
     assert decide_stage_status("smoke", {}, summary) == "revise"
+
+
+def test_run_stage_eval_passes_candidate_observation_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Candidate-level observation_mode should reach the benchmark runner."""
+
+    def fake_run_map_batch(*args: object, **kwargs: object) -> dict[str, object]:
+        jsonl_path = Path(args[1])
+        jsonl_path.write_text(
+            '{"scenario_id":"planner_sanity_simple","seed":111,"metrics":{"success":1.0}}\n',
+            encoding="utf-8",
+        )
+        assert kwargs["observation_mode"] == "socnav_state"
+        assert kwargs["observation_level"] is None
+        return {"written": 1, "successful_jobs": 1, "failed_jobs": 0}
+
+    monkeypatch.setattr(candidate_runner, "run_map_batch", fake_run_map_batch)
+
+    result = candidate_runner._run_stage_eval(
+        scenarios_or_path=[{"name": "planner_sanity_simple", "map_file": "unused.svg"}],
+        algo="guarded_ppo",
+        algo_cfg={"model_path": "/tmp/model.zip", "observation_mode": "socnav_state"},
+        out_dir=tmp_path,
+        tag="smoke__cand",
+        horizon=1,
+        dt=0.1,
+        workers=1,
+        benchmark_profile="experimental",
+    )
+
+    assert result["summary"]["episodes"] == 1
 
 
 def test_annotate_initial_overlap_exclusions_requires_first_step_evidence() -> None:


### PR DESCRIPTION
## Summary

Fixes #1967 by aligning the materialized ORCA-residual BC runtime observation contract with the checkpoint it was trained against.

- binds PPO planners to the runtime env before benchmark execution and fail-closes when a flat-Box checkpoint cannot match the env observation space
- flattens runtime Dict observations through the bound Gymnasium observation space for flat-Box SB3 checkpoints
- forwards candidate-level `observation_mode` / `observation_level` into policy-search smoke runs
- pins `orca_residual_guarded_ppo_v0` to `socnav_state` plus the predictive-foresight env fields present in the BC dataset contract
- records bounded #1475 smoke evidence and the remaining policy-quality limitation

## Evidence

Local validation on head `69057e461635eda59c5c256d4bdd9846185de133`:

- `uv run ruff check robot_sf/benchmark/algorithm_metadata.py scripts/validation/run_policy_search_candidate.py tests/benchmark/test_algorithm_metadata_contract.py tests/validation/test_run_policy_search_candidate.py robot_sf/baselines/ppo.py robot_sf/benchmark/map_runner.py tests/baselines/test_ppo_planner.py tests/test_map_runner_ppo.py`
- `PYTHONPATH=$PWD uv run pytest tests/baselines/test_ppo_planner.py tests/test_map_runner_ppo.py tests/benchmark/test_algorithm_metadata_contract.py tests/validation/test_run_policy_search_candidate.py tests/tools/test_materialize_orca_residual_candidate.py -q` -> 88 passed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 4849 passed, 10 skipped, 8 warnings

Bounded #1475 smoke evidence:

- First pre-fix local chain reproduced fail-closed adapter mismatch: runtime flatdim `831` vs checkpoint `77095`.
- SocNav-only rerun narrowed the mismatch to missing predictive features: runtime flatdim `77088` vs checkpoint `77095`.
- Final rerun with candidate observation/env contract produced one usable JSONL row: `decision=pass`, `episodes=1`, `collision_rate=0.0`, `success_rate=0.0`, `termination_reason=max_steps`.
- #1475 wrapper gate remains `revise`: no nominal_sanity escalation was submitted because success is still 0.0.

Tracked evidence: `docs/context/evidence/issue_1967_orca_residual_bc_smoke_adapter_summary.json`.
Generated report: `docs/context/policy_search/reports/2026-06-01_orca_residual_guarded_ppo_v0_smoke.md`.

## Claim Boundary

This PR repairs the runtime adapter / observation contract. It does not claim the ORCA-residual learned policy is useful. The next #1475 decision is still `revise` unless a later smoke improves success while preserving zero collisions.
