### PR TITLE
Record issue 1474 interim eval milestone

### DIFF
--- a/docs/context/slurm_issue_batch_status_2026-05-21.md
+++ b/docs/context/slurm_issue_batch_status_2026-05-21.md
@@ -173,9 +173,11 @@ slurm_issue_status:
   notes_non_evidence: >
     Failed warm-start probe 12673 showed the durable BR06 v3 checkpoint observation space no longer
     matches the current training env. Active retrain job 12674 intentionally starts from the current
-    env with exactly the collision penalty repair delta. Health check at 2026-06-01T07:03+02:00
-    showed RUNNING on a30, W&B run d8w8uykh, CUDA selected, num_envs=10, and 450560/5000000
-    timesteps reached; this is live training state only, not benchmark or guarded-policy evidence.
+    env with exactly the collision penalty repair delta. Health check at 2026-06-01T07:33+02:00
+    showed RUNNING on a30, W&B run d8w8uykh, CUDA selected, num_envs=10, and 819200/5000000
+    timesteps reached. The first 500k evaluation gate emitted success_rate=0.36,
+    collision_rate=0.61, snqi=-1.58, path_efficiency=0.782, and eval_episode_return=-0.437;
+    this is an interim training milestone only, not benchmark or guarded-policy evidence.
     Guard-saturated gains must not be reported as raw PPO improvement.
 ```
 


### PR DESCRIPTION
## Summary
- update the SLURM issue ledger with the latest #1474 job 12674 monitor state
- preserve the first 500k evaluation-gate metrics as interim, non-final training evidence
- keep the guardrail that this is not benchmark or guarded-policy evidence until the full run plus smoke/nominal gates complete

## Validation
- `git diff --check`
- live SLURM/log inspection: `squeue -j 12674`, `sacct -j 12674`, and `output/slurm/12674-issue1474-shielded-ppo-repair.out`

Related: #1474