### PR TITLE
feat: add perturbation criticality summary schema

### DIFF
--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -183,10 +183,16 @@ validate_criticality_summary(payload)
 Or wrap an existing compact #1610 evidence payload (without raw output paths):
 
 ```python
+import json
+from pathlib import Path
+
 from robot_sf.scenario_certification import (
     build_criticality_summary_from_compact_evidence,
+    criticality_summary_to_dict,
+    validate_criticality_summary,
 )
 
+path = Path("docs/context/evidence/example/summary.json")
 evidence = json.loads(path.read_text())
 summary = build_criticality_summary_from_compact_evidence(evidence)
 payload = criticality_summary_to_dict(summary)

--- a/docs/scenario_perturbation_manifest.md
+++ b/docs/scenario_perturbation_manifest.md
@@ -120,6 +120,79 @@ The pilot writes raw episode JSONL under `output/` and, when requested, a compac
 under `docs/context/evidence/`. Fallback, degraded, invalid, missing, and failed rows are reported
 separately and excluded from completed-pair mean deltas.
 
+## Perturbation Family Registry
+
+The reusable family registry at
+[`robot_sf/scenario_certification/perturbation_family_registry.py`](../robot_sf/scenario_certification/perturbation_family_registry.py)
+defines each family's semantic boundary, target surface, validity constraints, fail-closed rules,
+and required/optional parameter keys. Downstream writers (preflight, criticality_summary.v1)
+should use the registry instead of hardcoding family knowledge.
+
+```python
+from robot_sf.scenario_certification import (
+    perturbation_families,
+    perturbation_family,
+    supported_perturbation_families,
+    validate_perturbation_family_parameters,
+)
+
+family = perturbation_family("robot_route_offset")
+assert family.target_surface == "robot_route_waypoints"
+reasons, family = validate_perturbation_family_parameters(
+    "robot_route_offset",
+    {"dx_m": 0.25, "dy_m": 0.0, "max_magnitude_m": 0.5},
+)
+```
+
+## Criticality Summary v1
+
+The criticality summary schema at
+[`robot_sf/benchmark/schemas/criticality_summary.v1.json`](../robot_sf/benchmark/schemas/criticality_summary.v1.json)
+and writer at
+[`robot_sf/scenario_certification/criticality_summary.py`](../robot_sf/scenario_certification/criticality_summary.py)
+provide a validated surface for #1610 perturbation-family summary payloads.
+Every summary must record explicit row status counts for `completed`, `invalid`, `fallback`,
+`degraded`, `missing`, and `failed` rows. Non-completed rows are tracked separately and never
+contribute to completed-pair effect means.
+
+Build a summary from pilot records:
+
+```python
+from robot_sf.scenario_certification import (
+    build_criticality_summary_from_pilot,
+    criticality_summary_to_dict,
+    validate_criticality_summary,
+)
+
+summary = build_criticality_summary_from_pilot(
+    records_by_planner=...,
+    scenario_metadata=...,
+    manifest="configs/scenarios/perturbations/example.yaml",
+    manifest_id="example_v1",
+    planners=["goal", "orca"],
+    horizon=80,
+    dt=0.1,
+    seed_limit=5,
+    materialization=...,
+    planner_runs=...,
+)
+payload = criticality_summary_to_dict(summary)
+validate_criticality_summary(payload)
+```
+
+Or wrap an existing compact #1610 evidence payload (without raw output paths):
+
+```python
+from robot_sf.scenario_certification import (
+    build_criticality_summary_from_compact_evidence,
+)
+
+evidence = json.loads(path.read_text())
+summary = build_criticality_summary_from_compact_evidence(evidence)
+payload = criticality_summary_to_dict(summary)
+validate_criticality_summary(payload)
+```
+
 ## Boundary
 
 This is not planner execution and not paper-facing evidence. It only proves that the selected

--- a/robot_sf/benchmark/schemas/criticality_summary.v1.json
+++ b/robot_sf/benchmark/schemas/criticality_summary.v1.json
@@ -247,7 +247,11 @@
           "minLength": 1
         },
         "noop_variant_id": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         },
         "perturbed_variant_id": {
           "type": "string",
@@ -258,7 +262,10 @@
           "minLength": 1
         },
         "seed": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 0
         },
         "pair_status": {
@@ -277,16 +284,28 @@
           "minLength": 1
         },
         "success_delta": {
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "collision_delta": {
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "timeout_delta": {
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "min_distance_delta": {
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "noop": {
           "type": "object"
@@ -311,6 +330,7 @@
         },
         "row_status_counts": {
           "type": "object",
+          "additionalProperties": false,
           "required": [
             "completed",
             "invalid",

--- a/robot_sf/benchmark/schemas/criticality_summary.v1.json
+++ b/robot_sf/benchmark/schemas/criticality_summary.v1.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/criticality_summary.v1.json",
+  "title": "RobotSF Criticality Summary (v1)",
+  "description": "Compact reviewed summary for #1610 perturbation-family criticality pilots. Requires explicit row status counts for completed, invalid, fallback, degraded, missing, and failed rows. Fallback/degraded/invalid/missing/failed rows are tracked separately from completed-pair effect means.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest",
+    "manifest_id",
+    "planners",
+    "horizon",
+    "dt",
+    "seed_limit",
+    "materialization",
+    "planner_runs",
+    "pair_summary",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "criticality_summary.v1"
+    },
+    "manifest": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository-relative path to the source perturbation manifest YAML."
+    },
+    "manifest_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$",
+      "description": "Manifest identifier."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional human-readable description for the criticality run."
+    },
+    "planners": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Planner labels used in this criticality pilot."
+    },
+    "horizon": {
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "dt": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "seed_limit": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "description": "Positive cap on seeds per variant."
+    },
+    "materialization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "manifest_id",
+        "included_variants",
+        "excluded_variants",
+        "variant_count",
+        "local_artifact_boundary"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string"
+        },
+        "manifest_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "included_variants": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excluded_variants": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "variant_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "local_artifact_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "planner_runs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "algo",
+          "source",
+          "episodes"
+        ],
+        "properties": {
+          "algo": {
+            "type": "string",
+            "minLength": 1
+          },
+          "algo_config_path": {
+            "type": ["string", "null"]
+          },
+          "source": {
+            "enum": [
+              "raw_algo",
+              "policy_search_candidate"
+            ]
+          },
+          "episodes": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "pair_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pairs",
+        "row_status_counts",
+        "mean_deltas_completed_pairs"
+      ],
+      "properties": {
+        "pairs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of pair rows."
+        },
+        "row_status_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "completed",
+            "invalid",
+            "fallback",
+            "degraded",
+            "missing",
+            "failed"
+          ],
+          "properties": {
+            "completed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "invalid": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "fallback": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "degraded": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "missing": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failed": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "description": "Per-perturbed-row status counts across all plans, scenarios, and seeds. Non-completed rows are tracked separately and excluded from mean_deltas_completed_pairs."
+        },
+        "mean_deltas_completed_pairs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Mean metric deltas over completed pair rows only. Non-completed rows (invalid, fallback, degraded, missing, failed) are excluded."
+        },
+        "by_planner": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/grouped_pair_summary"
+          }
+        },
+        "by_source_scenario": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/grouped_pair_summary"
+          }
+        },
+        "by_perturbation_family": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/grouped_pair_summary"
+          }
+        }
+      }
+    },
+    "pair_rows": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pair_row"
+      }
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Explicit evidence/claim boundary for the criticality summary."
+    }
+  },
+  "$defs": {
+    "pair_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planner",
+        "source_scenario_id",
+        "perturbed_variant_id",
+        "perturbed_family",
+        "seed",
+        "pair_status",
+        "noop_status",
+        "perturbed_status"
+      ],
+      "properties": {
+        "planner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_scenario_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "noop_variant_id": {
+          "type": "string"
+        },
+        "perturbed_variant_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "perturbed_family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "seed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pair_status": {
+          "enum": [
+            "completed",
+            "excluded",
+            "missing_noop"
+          ]
+        },
+        "noop_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "perturbed_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "success_delta": {
+          "type": "number"
+        },
+        "collision_delta": {
+          "type": "number"
+        },
+        "timeout_delta": {
+          "type": "number"
+        },
+        "min_distance_delta": {
+          "type": "number"
+        },
+        "noop": {
+          "type": "object"
+        },
+        "perturbed": {
+          "type": "object"
+        }
+      }
+    },
+    "grouped_pair_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pairs",
+        "row_status_counts",
+        "mean_deltas_completed_pairs"
+      ],
+      "properties": {
+        "pairs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "row_status_counts": {
+          "type": "object",
+          "required": [
+            "completed",
+            "invalid",
+            "fallback",
+            "degraded",
+            "missing",
+            "failed"
+          ],
+          "properties": {
+            "completed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "invalid": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "fallback": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "degraded": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "missing": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failed": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "mean_deltas_completed_pairs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/scenario_certification/__init__.py
+++ b/robot_sf/scenario_certification/__init__.py
@@ -1,5 +1,20 @@
 """Scenario certification public API."""
 
+from robot_sf.scenario_certification.criticality_summary import (
+    CRITICALITY_SUMMARY_SCHEMA_VERSION,
+    CriticalitySummaryV1,
+    build_criticality_summary_from_compact_evidence,
+    build_criticality_summary_from_pilot,
+    criticality_summary_to_dict,
+    validate_criticality_summary,
+)
+from robot_sf.scenario_certification.perturbation_family_registry import (
+    PerturbationFamily,
+    perturbation_families,
+    perturbation_family,
+    supported_perturbation_families,
+    validate_perturbation_family_parameters,
+)
 from robot_sf.scenario_certification.perturbation_preflight import (
     PERTURBATION_MANIFEST_SCHEMA_VERSION,
     PILOT_MATRIX_SCHEMA_VERSION,
@@ -23,19 +38,30 @@ from robot_sf.scenario_certification.v1 import (
 
 __all__ = [
     "CERT_SCHEMA_VERSION",
+    "CRITICALITY_SUMMARY_SCHEMA_VERSION",
     "PERTURBATION_MANIFEST_SCHEMA_VERSION",
     "PILOT_MATRIX_SCHEMA_VERSION",
     "PREFLIGHT_SCHEMA_VERSION",
     "CertificationSettings",
+    "CriticalitySummaryV1",
+    "PerturbationFamily",
     "PerturbationPilotMaterialization",
     "PerturbationPreflightReport",
     "PerturbationPreflightResult",
     "ScenarioCertificate",
+    "build_criticality_summary_from_compact_evidence",
+    "build_criticality_summary_from_pilot",
     "certificate_to_dict",
     "certify_map_definition",
     "certify_scenario",
     "certify_scenario_file",
+    "criticality_summary_to_dict",
     "materialize_perturbation_pilot_matrix",
+    "perturbation_families",
+    "perturbation_family",
     "preflight_perturbation_manifest",
     "preflight_to_dict",
+    "supported_perturbation_families",
+    "validate_criticality_summary",
+    "validate_perturbation_family_parameters",
 ]

--- a/robot_sf/scenario_certification/criticality_summary.py
+++ b/robot_sf/scenario_certification/criticality_summary.py
@@ -208,10 +208,10 @@ def _scenarios_by_source(
     """
     grouped: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
     for scenario_id, meta in scenario_metadata.items():
-        source = meta["source_scenario_id"]
-        family = meta["family"]
+        source = meta.get("source_scenario_id")
+        family = meta.get("family")
         if source and family:
-            grouped[source][family].append(scenario_id)
+            grouped[str(source)][str(family)].append(scenario_id)
     return grouped
 
 
@@ -360,8 +360,8 @@ def build_criticality_summary_from_compact_evidence(
         CriticalitySummaryV1: Enriched summary with explicit row status counts.
     """
     evidence = dict(compact_evidence)
-    raw_pair_summary = dict(evidence.get("pair_summary", {}))
-    pair_rows = list(evidence.get("pair_rows", []))
+    raw_pair_summary = dict(evidence.get("pair_summary") or {})
+    pair_rows = list(evidence.get("pair_rows") or [])
     status_counts = _extract_row_statuses(pair_rows)
     pair_summary = build_pair_summary_with_statuses(pair_rows, status_counts)
     for group_field in (
@@ -379,14 +379,14 @@ def build_criticality_summary_from_compact_evidence(
             pair_summary[group_field] = mapped
     return CriticalitySummaryV1(
         schema_version=CRITICALITY_SUMMARY_SCHEMA_VERSION,
-        manifest=str(evidence.get("manifest", "")),
-        manifest_id=str(evidence.get("materialization", {}).get("manifest_id", "")),
-        planners=list(evidence.get("planners", [])),
-        horizon=int(evidence.get("horizon", 0)),
-        dt=float(evidence.get("dt", 0.0)),
-        seed_limit=int(evidence.get("seed_limit", 0)),
-        materialization=dict(evidence.get("materialization", {})),
-        planner_runs=dict(evidence.get("planner_runs", {})),
+        manifest=str(evidence.get("manifest") or ""),
+        manifest_id=str((evidence.get("materialization") or {}).get("manifest_id") or ""),
+        planners=list(evidence.get("planners") or []),
+        horizon=int(evidence.get("horizon") or 0),
+        dt=float(evidence.get("dt") or 0.0),
+        seed_limit=int(evidence.get("seed_limit") or 0),
+        materialization=dict(evidence.get("materialization") or {}),
+        planner_runs=dict(evidence.get("planner_runs") or {}),
         pair_summary=pair_summary,
         pair_rows=pair_rows,
         description=str(evidence.get("description") or "") or None,
@@ -425,10 +425,10 @@ def _upgrade_to_row_status_counts(
             if key in combined:
                 combined[key] = int(count)
         return {
-            "pairs": int(group_payload.get("pairs", 0)),
+            "pairs": int(group_payload.get("pairs") or 0),
             "row_status_counts": combined,
             "mean_deltas_completed_pairs": dict(
-                group_payload.get("mean_deltas_completed_pairs", {})
+                group_payload.get("mean_deltas_completed_pairs") or {}
             ),
         }
     combined = dict(_zero_row_status_counts())
@@ -437,9 +437,9 @@ def _upgrade_to_row_status_counts(
             if key in combined:
                 combined[key] = int(count)
     return {
-        "pairs": int(group_payload.get("pairs", 0)),
+        "pairs": int(group_payload.get("pairs") or 0),
         "row_status_counts": combined,
-        "mean_deltas_completed_pairs": dict(group_payload.get("mean_deltas_completed_pairs", {})),
+        "mean_deltas_completed_pairs": dict(group_payload.get("mean_deltas_completed_pairs") or {}),
     }
 
 

--- a/robot_sf/scenario_certification/criticality_summary.py
+++ b/robot_sf/scenario_certification/criticality_summary.py
@@ -23,7 +23,7 @@ _CRITICALITY_SUMMARY_SCHEMA_PATH = (
 )
 
 
-def _sum(values: list[float]) -> float:
+def _mean(values: list[float]) -> float:
     """Return the arithmetic mean of a non-empty list."""
     return sum(values) / len(values)
 
@@ -174,7 +174,7 @@ def _aggregate_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
         "pairs": len(pair_rows),
         "row_status_counts": combined_status_counts,
         "mean_deltas_completed_pairs": {
-            field_name: _sum(values)
+            field_name: _mean(values)
             for field_name, values in sorted(delta_values.items())
             if values
         },
@@ -258,13 +258,14 @@ def build_criticality_summary_from_pilot(  # noqa: PLR0913
             )
             if not noop_ids:
                 for variant_id in perturbed_ids:
+                    perturbed_meta = scenario_metadata.get(variant_id, {})
                     pair_rows.append(
                         {
                             "planner": planner_name,
                             "source_scenario_id": source_scenario_id,
                             "noop_variant_id": None,
                             "perturbed_variant_id": variant_id,
-                            "perturbed_family": "unknown",
+                            "perturbed_family": str(perturbed_meta.get("family") or "unknown"),
                             "seed": None,
                             "pair_status": "missing_noop",
                             "noop_status": "missing",
@@ -479,7 +480,7 @@ def build_pair_summary_with_statuses(
         "pairs": len(pair_rows),
         "row_status_counts": combined,
         "mean_deltas_completed_pairs": {
-            field_name: _sum(values)
+            field_name: _mean(values)
             for field_name, values in sorted(delta_values.items())
             if values
         },

--- a/robot_sf/scenario_certification/criticality_summary.py
+++ b/robot_sf/scenario_certification/criticality_summary.py
@@ -1,0 +1,528 @@
+"""Criticality summary v1 writer/validator for #1610 perturbation-family pilots.
+
+This module produces and validates `criticality_summary.v1` payloads that record
+explicit row-status counts and exclude non-completed rows from effect means.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from jsonschema import Draft202012Validator
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+CRITICALITY_SUMMARY_SCHEMA_VERSION = "criticality_summary.v1"
+_CRITICALITY_SUMMARY_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1] / "benchmark" / "schemas" / "criticality_summary.v1.json"
+)
+
+
+def _sum(values: list[float]) -> float:
+    """Return the arithmetic mean of a non-empty list."""
+    return sum(values) / len(values)
+
+
+@dataclass(frozen=True)
+class CriticalitySummaryV1:
+    """Diagnostic criticality summary for one perturbation-family pilot.
+
+    This never carries benchmark-strength or paper-facing claims. It records
+    explicit row status counts and keeps fallback/degraded/invalid/missing/failed
+    rows separate from completed-pair effect means.
+    """
+
+    schema_version: str
+    manifest: str
+    manifest_id: str
+    planners: list[str]
+    horizon: int
+    dt: float
+    seed_limit: int
+    materialization: dict[str, Any]
+    planner_runs: dict[str, dict[str, Any]]
+    pair_summary: dict[str, Any]
+    pair_rows: list[dict[str, Any]] = field(default_factory=list)
+    description: str | None = None
+    claim_boundary: str = (
+        "diagnostic local pilot only; not benchmark-strength or paper-facing evidence"
+    )
+
+
+def _classify_episode_row_status(row: dict[str, Any] | None) -> str:
+    """Classify one episode row as completed, invalid, fallback, degraded, missing, or failed.
+
+    Returns:
+        str: One of completed, invalid, fallback, degraded, missing, or failed.
+    """
+    if row is None:
+        return "missing"
+    if isinstance(row.get("scenario_exclusion"), dict):
+        return "invalid"
+    algorithm_metadata = row.get("algorithm_metadata")
+    if isinstance(algorithm_metadata, dict):
+        metadata_strings = _nested_strings(algorithm_metadata)
+        if any("fallback" in item for item in metadata_strings):
+            return "fallback"
+        if any("degraded" in item for item in metadata_strings):
+            return "degraded"
+    reason = str(row.get("termination_reason") or "").strip().lower()
+    if reason == "error":
+        return "failed"
+    return "completed"
+
+
+def _nested_strings(value: Any) -> list[str]:
+    """Return lower-cased string leaves from a nested JSON-like value."""
+    strings: list[str] = []
+    if isinstance(value, str):
+        strings.append(value.strip().lower())
+    elif isinstance(value, dict):
+        for item in value.values():
+            strings.extend(_nested_strings(item))
+    elif isinstance(value, list | tuple):
+        for item in value:
+            strings.extend(_nested_strings(item))
+    return strings
+
+
+def _delta(after: int | float | None, before: int | float | None) -> float | None:
+    """Return numeric delta when both sides are available."""
+    if after is None or before is None:
+        return None
+    return float(after) - float(before)
+
+
+def _episode_value(row: dict[str, Any] | None, name: str) -> float | None:
+    """Read a numeric metric from an episode row.
+
+    Returns:
+        float | None: The metric value or None when the row or metric is absent.
+    """
+    if row is None:
+        return None
+    metrics = row.get("metrics")
+    if not isinstance(metrics, dict):
+        return None
+    value = metrics.get(name)
+    try:
+        return None if value is None else float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _episode_outcome(row: dict[str, Any] | None) -> dict[str, Any]:
+    """Return compact outcome values for one episode row."""
+    reason = str(row.get("termination_reason") or "") if row is not None else ""
+    return {
+        "success": 1 if reason.lower() == "success" else 0,
+        "collision": 1 if reason.lower() == "collision" else 0,
+        "timeout": 1 if reason.lower() in {"max_steps", "terminated", "truncated"} else 0,
+        "min_distance": _episode_value(row, "min_distance"),
+        "termination_reason": reason or None,
+    }
+
+
+_REQUIRED_ROW_STATUSES = frozenset(
+    {"completed", "invalid", "fallback", "degraded", "missing", "failed"}
+)
+
+
+def _zero_row_status_counts() -> dict[str, int]:
+    """Return a zeroed row-status-counts dict for all required statuses.
+
+    Returns:
+        dict[str, int]: Zeroed counts for completed, invalid, fallback,
+        degraded, missing, and failed.
+    """
+    return dict.fromkeys(sorted(_REQUIRED_ROW_STATUSES), 0)
+
+
+def _aggregate_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate one pair-table subset with row status counts and completed-pair means.
+
+    Returns:
+        dict[str, Any]: Aggregated subset with pairs count, row_status_counts,
+        and mean_deltas_completed_pairs.
+    """
+    status_counts: dict[str, int] = defaultdict(int)
+    delta_values: dict[str, list[float]] = defaultdict(list)
+    for row in pair_rows:
+        perturbed_status = str(row.get("perturbed_status") or "unknown")
+        status_counts[perturbed_status] += 1
+        if row.get("pair_status") != "completed":
+            continue
+        for field_name in (
+            "success_delta",
+            "collision_delta",
+            "timeout_delta",
+            "min_distance_delta",
+        ):
+            value = row.get(field_name)
+            if value is not None:
+                delta_values[field_name].append(float(value))
+    combined_status_counts = dict(_zero_row_status_counts())
+    for status, count in status_counts.items():
+        if status in combined_status_counts:
+            combined_status_counts[status] = count
+    return {
+        "pairs": len(pair_rows),
+        "row_status_counts": combined_status_counts,
+        "mean_deltas_completed_pairs": {
+            field_name: _sum(values)
+            for field_name, values in sorted(delta_values.items())
+            if values
+        },
+    }
+
+
+def _grouped_summaries(
+    pair_rows: list[dict[str, Any]],
+    *,
+    group_field: str,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate pair rows by one categorical group field.
+
+    Returns:
+        dict[str, dict[str, Any]]: Grouped aggregate summaries keyed by group value.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in pair_rows:
+        key = str(row.get(group_field) or "unknown")
+        grouped[key].append(row)
+    return {key: _aggregate_subset(rows) for key, rows in sorted(grouped.items())}
+
+
+def _scenarios_by_source(
+    scenario_metadata: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, list[str]]]:
+    """Group materialized scenario ids by source scenario and perturbation family.
+
+    Returns:
+        dict[str, dict[str, list[str]]]: Source-scenario → family → scenario-id list mapping.
+    """
+    grouped: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    for scenario_id, meta in scenario_metadata.items():
+        source = meta["source_scenario_id"]
+        family = meta["family"]
+        if source and family:
+            grouped[source][family].append(scenario_id)
+    return grouped
+
+
+def build_criticality_summary_from_pilot(  # noqa: PLR0913
+    records_by_planner: dict[str, list[dict[str, Any]]],
+    scenario_metadata: dict[str, dict[str, Any]],
+    *,
+    manifest: str,
+    manifest_id: str,
+    planners: list[str],
+    horizon: int,
+    dt: float,
+    seed_limit: int,
+    materialization: dict[str, Any],
+    planner_runs: dict[str, dict[str, Any]],
+    description: str | None = None,
+    claim_boundary: str = (
+        "diagnostic local pilot only; not benchmark-strength or paper-facing evidence"
+    ),
+) -> CriticalitySummaryV1:
+    """Build a criticality summary from raw pilot episode records.
+
+    Returns:
+        CriticalitySummaryV1: Summary with explicit row status counts and
+        completed-pair effect means split from non-completed rows.
+    """
+    rows_by_key: dict[tuple[str, str, int], dict[str, Any]] = {}
+    for planner_name, records in records_by_planner.items():
+        for row in records:
+            scenario_id = str(row.get("scenario_id") or row.get("scenario") or "")
+            seed = int(row.get("seed", 0))
+            rows_by_key[(planner_name, scenario_id, seed)] = row
+
+    grouped_scenarios = _scenarios_by_source(scenario_metadata)
+    pair_rows: list[dict[str, Any]] = []
+    for planner_name in sorted(records_by_planner):
+        for source_scenario_id, families in sorted(grouped_scenarios.items()):
+            noop_ids = sorted(families.get("noop", []))
+            perturbed_ids = sorted(
+                variant_id
+                for family, variant_ids in families.items()
+                if family != "noop"
+                for variant_id in variant_ids
+            )
+            if not noop_ids:
+                for variant_id in perturbed_ids:
+                    pair_rows.append(
+                        {
+                            "planner": planner_name,
+                            "source_scenario_id": source_scenario_id,
+                            "noop_variant_id": None,
+                            "perturbed_variant_id": variant_id,
+                            "perturbed_family": "unknown",
+                            "seed": None,
+                            "pair_status": "missing_noop",
+                            "noop_status": "missing",
+                            "perturbed_status": "missing",
+                        }
+                    )
+                continue
+            noop_id = noop_ids[0]
+            for variant_id in perturbed_ids:
+                seeds = sorted(
+                    {
+                        seed
+                        for (kp, sid, seed) in rows_by_key
+                        if kp == planner_name and sid in {noop_id, variant_id}
+                    }
+                )
+                for seed in seeds:
+                    noop_row = rows_by_key.get((planner_name, noop_id, seed))
+                    perturbed_row = rows_by_key.get((planner_name, variant_id, seed))
+                    noop_status = _classify_episode_row_status(noop_row)
+                    perturbed_status = _classify_episode_row_status(perturbed_row)
+                    pair_status = (
+                        "completed"
+                        if noop_status == "completed" and perturbed_status == "completed"
+                        else "excluded"
+                    )
+                    noop_outcome = _episode_outcome(noop_row)
+                    perturbed_outcome = _episode_outcome(perturbed_row)
+                    perturbed_meta = scenario_metadata.get(variant_id, {})
+                    pair_rows.append(
+                        {
+                            "planner": planner_name,
+                            "source_scenario_id": source_scenario_id,
+                            "noop_variant_id": noop_id,
+                            "perturbed_variant_id": variant_id,
+                            "perturbed_family": str(perturbed_meta.get("family") or "unknown"),
+                            "seed": seed,
+                            "pair_status": pair_status,
+                            "noop_status": noop_status,
+                            "perturbed_status": perturbed_status,
+                            "success_delta": _delta(
+                                perturbed_outcome["success"], noop_outcome["success"]
+                            ),
+                            "collision_delta": _delta(
+                                perturbed_outcome["collision"], noop_outcome["collision"]
+                            ),
+                            "timeout_delta": _delta(
+                                perturbed_outcome["timeout"], noop_outcome["timeout"]
+                            ),
+                            "min_distance_delta": _delta(
+                                perturbed_outcome["min_distance"], noop_outcome["min_distance"]
+                            ),
+                            "noop": noop_outcome,
+                            "perturbed": perturbed_outcome,
+                        }
+                    )
+    pair_summary = _aggregate_subset(pair_rows)
+    pair_summary["by_planner"] = _grouped_summaries(pair_rows, group_field="planner")
+    pair_summary["by_source_scenario"] = _grouped_summaries(
+        pair_rows, group_field="source_scenario_id"
+    )
+    pair_summary["by_perturbation_family"] = _grouped_summaries(
+        pair_rows, group_field="perturbed_family"
+    )
+    return CriticalitySummaryV1(
+        schema_version=CRITICALITY_SUMMARY_SCHEMA_VERSION,
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=planners,
+        horizon=horizon,
+        dt=dt,
+        seed_limit=seed_limit,
+        materialization=materialization,
+        planner_runs=planner_runs,
+        pair_summary=pair_summary,
+        pair_rows=pair_rows,
+        description=description,
+        claim_boundary=claim_boundary,
+    )
+
+
+def build_criticality_summary_from_compact_evidence(
+    compact_evidence: Mapping[str, Any],
+) -> CriticalitySummaryV1:
+    """Wrap an existing compact #1610 evidence payload as a CriticalitySummaryV1.
+
+    At least one existing compact summary must be representable without relying
+    on raw output paths. This constructor converts the existing format into the
+    v1 criticality summary, normalizing row status counts.
+
+    Returns:
+        CriticalitySummaryV1: Enriched summary with explicit row status counts.
+    """
+    evidence = dict(compact_evidence)
+    raw_pair_summary = dict(evidence.get("pair_summary", {}))
+    pair_rows = list(evidence.get("pair_rows", []))
+    status_counts = _extract_row_statuses(pair_rows)
+    pair_summary = build_pair_summary_with_statuses(pair_rows, status_counts)
+    for group_field in (
+        "by_planner",
+        "by_source_scenario",
+        "by_perturbation_family",
+    ):
+        if group_field in raw_pair_summary and isinstance(raw_pair_summary[group_field], dict):
+            mapped: dict[str, dict[str, Any]] = {}
+            for key, group_payload in raw_pair_summary[group_field].items():
+                if isinstance(group_payload, dict):
+                    mapped[key] = _upgrade_to_row_status_counts(group_payload)
+                else:
+                    mapped[key] = dict(group_payload) if group_payload else {}
+            pair_summary[group_field] = mapped
+    return CriticalitySummaryV1(
+        schema_version=CRITICALITY_SUMMARY_SCHEMA_VERSION,
+        manifest=str(evidence.get("manifest", "")),
+        manifest_id=str(evidence.get("materialization", {}).get("manifest_id", "")),
+        planners=list(evidence.get("planners", [])),
+        horizon=int(evidence.get("horizon", 0)),
+        dt=float(evidence.get("dt", 0.0)),
+        seed_limit=int(evidence.get("seed_limit", 0)),
+        materialization=dict(evidence.get("materialization", {})),
+        planner_runs=dict(evidence.get("planner_runs", {})),
+        pair_summary=pair_summary,
+        pair_rows=pair_rows,
+        description=str(evidence.get("description") or "") or None,
+        claim_boundary=str(
+            evidence.get("claim_boundary")
+            or "diagnostic local pilot only; not benchmark-strength or paper-facing evidence"
+        ),
+    )
+
+
+def _extract_row_statuses(pair_rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Extract explicit perturbed-row status counts from pair rows.
+
+    Returns:
+        dict[str, int]: Status key → count mapping.
+    """
+    status_counts: dict[str, int] = defaultdict(int)
+    for row in pair_rows:
+        status = str(row.get("perturbed_status") or "unknown")
+        status_counts[status] += 1
+    return dict(status_counts)
+
+
+def _upgrade_to_row_status_counts(
+    group_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Upgrade a grouped summary payload to explicit row_status_counts format.
+
+    Returns:
+        dict[str, Any]: Grouped summary with row_status_counts and mean_deltas_completed_pairs.
+    """
+    status_counts = group_payload.get("status_counts")
+    if isinstance(status_counts, dict) and "completed" in status_counts:
+        combined = dict(_zero_row_status_counts())
+        for key, count in status_counts.items():
+            if key in combined:
+                combined[key] = int(count)
+        return {
+            "pairs": int(group_payload.get("pairs", 0)),
+            "row_status_counts": combined,
+            "mean_deltas_completed_pairs": dict(
+                group_payload.get("mean_deltas_completed_pairs", {})
+            ),
+        }
+    combined = dict(_zero_row_status_counts())
+    if isinstance(status_counts, dict):
+        for key, count in status_counts.items():
+            if key in combined:
+                combined[key] = int(count)
+    return {
+        "pairs": int(group_payload.get("pairs", 0)),
+        "row_status_counts": combined,
+        "mean_deltas_completed_pairs": dict(group_payload.get("mean_deltas_completed_pairs", {})),
+    }
+
+
+def build_pair_summary_with_statuses(
+    pair_rows: list[dict[str, Any]],
+    row_status_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Build a pair summary payload with explicit row status counts.
+
+    Fallback/degraded/invalid/missing/failed rows are tracked separately
+    and excluded from completed-pair effect means.
+
+    Returns:
+        dict[str, Any]: Summary payload with pairs count, row_status_counts,
+        and mean_deltas_completed_pairs.
+    """
+    if row_status_counts is None:
+        row_status_counts = _extract_row_statuses(pair_rows)
+    combined = dict(_zero_row_status_counts())
+    for status, count in row_status_counts.items():
+        if status in combined:
+            combined[status] = count
+    delta_values: dict[str, list[float]] = defaultdict(list)
+    completed_count = 0
+    for row in pair_rows:
+        if row.get("pair_status") == "completed":
+            completed_count += 1
+            for field_name in (
+                "success_delta",
+                "collision_delta",
+                "timeout_delta",
+                "min_distance_delta",
+            ):
+                value = row.get(field_name)
+                if value is not None:
+                    delta_values[field_name].append(float(value))
+    return {
+        "pairs": len(pair_rows),
+        "row_status_counts": combined,
+        "mean_deltas_completed_pairs": {
+            field_name: _sum(values)
+            for field_name, values in sorted(delta_values.items())
+            if values
+        },
+    }
+
+
+def validate_criticality_summary(summary: dict[str, Any]) -> None:
+    """Validate a criticality summary payload against the public v1 schema.
+
+    Raises:
+        ValueError: When validation fails, describing the first violation.
+    """
+    schema = json.loads(_CRITICALITY_SUMMARY_SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(summary), key=lambda error: list(error.absolute_path))
+    if not errors:
+        return
+    error = errors[0]
+    location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+    raise ValueError(f"criticality_summary schema violation at {location}: {error.message}")
+
+
+def criticality_summary_to_dict(summary: CriticalitySummaryV1) -> dict[str, Any]:
+    """Serialize a CriticalitySummaryV1 to JSON-safe primitives.
+
+    Returns:
+        dict[str, Any]: JSON-safe payload suitable for schema validation and
+        compact evidence tracking.
+    """
+    payload: dict[str, Any] = {
+        "schema_version": summary.schema_version,
+        "manifest": summary.manifest,
+        "manifest_id": summary.manifest_id,
+        "planners": summary.planners,
+        "horizon": summary.horizon,
+        "dt": summary.dt,
+        "seed_limit": summary.seed_limit,
+        "materialization": summary.materialization,
+        "planner_runs": summary.planner_runs,
+        "pair_summary": summary.pair_summary,
+        "pair_rows": summary.pair_rows,
+        "claim_boundary": summary.claim_boundary,
+    }
+    if summary.description is not None:
+        payload["description"] = summary.description
+    return payload

--- a/robot_sf/scenario_certification/perturbation_family_registry.py
+++ b/robot_sf/scenario_certification/perturbation_family_registry.py
@@ -1,0 +1,227 @@
+"""Reusable perturbation-family registry for #1610 criticality workflows.
+
+Each family records its semantic boundary, target surface, validity constraints,
+fail-closed rules, and required parameter keys so downstream writers (preflight,
+criticality_summary) can stay consistent without hardcoding family knowledge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True)
+class PerturbationFamily:
+    """Reusable registry entry for one perturbation family."""
+
+    name: str
+    description: str
+    target_surface: str
+    semantic_boundary: str
+    validity_constraints: tuple[str, ...]
+    fail_closed_rules: tuple[str, ...]
+    required_parameters: tuple[str, ...]
+    optional_parameters: tuple[str, ...] = ()
+
+
+_PERTURBATION_FAMILIES: tuple[PerturbationFamily, ...] = (
+    PerturbationFamily(
+        name="noop",
+        description="Unperturbed baseline row for paired comparisons",
+        target_surface="none",
+        semantic_boundary="fixed identity; must be certified as identity variant",
+        validity_constraints=("require_scenario_certification",),
+        fail_closed_rules=(
+            "noop must carry identical scenario to source; any parameter override is invalid",
+        ),
+        required_parameters=(),
+    ),
+    PerturbationFamily(
+        name="robot_route_offset",
+        description="Bounded (dx_m, dy_m) shift applied to selected robot route waypoints",
+        target_surface="robot_route_waypoints",
+        semantic_boundary="euclidean distance from original waypoints ≤ min(variant_max_magnitude_m, manifest_max_route_offset_m)",
+        validity_constraints=(
+            "max_route_offset_m",
+            "waypoint_selector_all_only",
+        ),
+        fail_closed_rules=(
+            "magnitude_m > bound excludes variant",
+            "no robot routes in source map excludes variant",
+            "route offset outside map bounds excludes variant",
+        ),
+        required_parameters=("dx_m", "dy_m", "max_magnitude_m"),
+        optional_parameters=("spawn_id", "goal_id", "waypoint_selector"),
+    ),
+    PerturbationFamily(
+        name="pedestrian_route_offset",
+        description="Bounded (dx_m, dy_m) shift applied to selected pedestrian route waypoints",
+        target_surface="pedestrian_route_waypoints",
+        semantic_boundary="euclidean distance from original waypoints ≤ min(variant_max_magnitude_m, manifest_max_route_offset_m)",
+        validity_constraints=(
+            "max_route_offset_m",
+            "waypoint_selector_all_only",
+        ),
+        fail_closed_rules=(
+            "magnitude_m > bound excludes variant",
+            "no pedestrian routes in source map excludes variant",
+            "route offset outside map bounds excludes variant",
+        ),
+        required_parameters=("dx_m", "dy_m", "max_magnitude_m"),
+        optional_parameters=("spawn_id", "goal_id", "waypoint_selector"),
+    ),
+    PerturbationFamily(
+        name="single_pedestrian_start_delay_offset",
+        description="Bounded start-delay offset for explicit single_pedestrians",
+        target_surface="single_pedestrian_start_delay_s",
+        semantic_boundary="|dt_s| ≤ min(variant_max_abs_dt_s, manifest_max_start_delay_offset_s); updated delay ≥ 0 s",
+        validity_constraints=(
+            "max_start_delay_offset_s",
+            "pedestrian_selector_all_only",
+        ),
+        fail_closed_rules=(
+            "abs_dt_s > bound excludes variant",
+            "no single pedestrians in source scenario excludes variant",
+            "updated start_delay_s < 0 excludes variant",
+        ),
+        required_parameters=("dt_s", "max_abs_dt_s"),
+        optional_parameters=("pedestrian_id", "pedestrian_selector"),
+    ),
+    PerturbationFamily(
+        name="single_pedestrian_speed_offset",
+        description="Bounded speed offset for explicit single_pedestrians",
+        target_surface="single_pedestrian_speed_m_s",
+        semantic_boundary="|speed_delta_m_s| ≤ min(variant_max_abs_speed_delta_m_s, manifest_max_single_pedestrian_speed_delta_m_s); updated speed > 0 and ≤ min(optional caps)",
+        validity_constraints=(
+            "max_single_pedestrian_speed_delta_m_s",
+            "pedestrian_selector_all_only",
+        ),
+        fail_closed_rules=(
+            "abs_speed_delta_m_s > bound excludes variant",
+            "no single pedestrians in source scenario excludes variant",
+            "updated speed_m_s ≤ 0 excludes variant",
+            "updated speed_m_s > max_speed_m_s excludes variant",
+        ),
+        required_parameters=("speed_delta_m_s", "max_abs_speed_delta_m_s"),
+        optional_parameters=("pedestrian_id", "pedestrian_selector", "max_speed_m_s"),
+    ),
+    PerturbationFamily(
+        name="single_pedestrian_wait_duration_offset",
+        description="Bounded wait_at.wait_s offset for explicit single-pedestrian wait entries",
+        target_surface="single_pedestrian_wait_s",
+        semantic_boundary="|wait_delta_s| ≤ min(variant_max_abs_wait_delta_s, manifest_max_wait_duration_offset_s); updated wait_s ≥ 0 s",
+        validity_constraints=(
+            "max_wait_duration_offset_s",
+            "pedestrian_selector_all_only",
+        ),
+        fail_closed_rules=(
+            "abs_wait_delta_s > bound excludes variant",
+            "no single pedestrians in source scenario excludes variant",
+            "no wait_at entries for selected pedestrians excludes variant",
+            "updated wait_s < 0 excludes variant",
+        ),
+        required_parameters=("wait_delta_s", "max_abs_wait_delta_s"),
+        optional_parameters=("pedestrian_id", "pedestrian_selector"),
+    ),
+    PerturbationFamily(
+        name="single_pedestrian_trajectory_waypoint_offset",
+        description="Bounded (dx_m, dy_m) shift applied to trajectory waypoints for one explicit single_pedestrian",
+        target_surface="single_pedestrian_trajectory_waypoints",
+        semantic_boundary="euclidean distance from original waypoints ≤ min(variant_max_magnitude_m, manifest_max_trajectory_waypoint_offset_m); updated points inside map bounds",
+        validity_constraints=(
+            "max_single_pedestrian_trajectory_waypoint_offset_m",
+            "waypoint_selector_all_only",
+            "pedestrian_id_required",
+        ),
+        fail_closed_rules=(
+            "magnitude_m > bound excludes variant",
+            "no single pedestrians in source scenario excludes variant",
+            "selected pedestrian has no trajectory excludes variant",
+            "updated waypoints outside [0,width]×[0,height] excludes variant",
+        ),
+        required_parameters=(
+            "dx_m",
+            "dy_m",
+            "max_magnitude_m",
+            "pedestrian_id",
+            "waypoint_selector",
+        ),
+    ),
+    PerturbationFamily(
+        name="pedestrian_density_offset",
+        description="Bounded simulation_config.ped_density offset for scenarios with pedestrian routes",
+        target_surface="route_pedestrian_density",
+        semantic_boundary="|density_delta| ≤ min(variant_max_abs_density_delta, manifest_max_pedestrian_density_delta); updated density ≥ 0 and ≤ min(optional caps)",
+        validity_constraints=("max_pedestrian_density_delta",),
+        fail_closed_rules=(
+            "abs_density_delta > bound excludes variant",
+            "no pedestrian routes in source map excludes variant",
+            "updated ped_density < 0 excludes variant",
+            "updated ped_density > max_ped_density excludes variant",
+        ),
+        required_parameters=("density_delta", "max_abs_density_delta"),
+        optional_parameters=("max_ped_density",),
+    ),
+)
+
+_FAMILIES_BY_NAME: dict[str, PerturbationFamily] = {f.name: f for f in _PERTURBATION_FAMILIES}
+
+
+def perturbation_family(name: str) -> PerturbationFamily:
+    """Return a registered perturbation family by name.
+
+    Returns:
+        PerturbationFamily: Frozen family definition.
+
+    Raises:
+        ValueError: When the family is not registered.
+    """
+    entry = _FAMILIES_BY_NAME.get(name)
+    if entry is None:
+        raise ValueError(
+            f"unsupported perturbation family: {name!r}; "
+            f"registered: {sorted(_FAMILIES_BY_NAME.keys())}"
+        )
+    return entry
+
+
+def supported_perturbation_families() -> frozenset[str]:
+    """Return the set of registered perturbation family names."""
+    return frozenset(_FAMILIES_BY_NAME.keys())
+
+
+def perturbation_families() -> tuple[PerturbationFamily, ...]:
+    """Return the ordered tuple of registered perturbation families."""
+    return _PERTURBATION_FAMILIES
+
+
+def validate_perturbation_family_parameters(
+    family_name: str,
+    parameters: Mapping[str, Any],
+) -> tuple[list[str], PerturbationFamily]:
+    """Validate variant parameters against a registered family definition.
+
+    Returns:
+        tuple[list[str], PerturbationFamily]: Fail-closed reasons and the family entry.
+
+    Validation checks:
+        - family is registered
+        - required parameters are present
+        - extra parameters not in required+optional are rejected
+    """
+    family = perturbation_family(family_name)
+    reasons: list[str] = []
+    missing = [key for key in family.required_parameters if key not in parameters]
+    if missing:
+        reasons.append(f"{family_name} missing required parameters: {sorted(missing)}")
+    allowed = set(family.required_parameters).union(family.optional_parameters)
+    extra = [key for key in parameters if key not in allowed]
+    if extra:
+        reasons.append(
+            f"{family_name} unrecognized parameters: {sorted(extra)}; allowed: {sorted(allowed)}"
+        )
+    return reasons, family

--- a/tests/scenario_certification/test_criticality_summary.py
+++ b/tests/scenario_certification/test_criticality_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -260,7 +261,7 @@ def test_build_criticality_summary_records_missing_noop() -> None:
             "source_scenario_id": "demo",
             "noop_variant_id": None,
             "perturbed_variant_id": "demo_offset",
-            "perturbed_family": "unknown",
+            "perturbed_family": "robot_route_offset",
             "seed": None,
             "pair_status": "missing_noop",
             "noop_status": "missing",
@@ -331,7 +332,7 @@ def test_criticality_summary_is_immutable() -> None:
             "mean_deltas_completed_pairs": {},
         },
     )
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         summary.horizon = 100  # type: ignore[misc]
 
 
@@ -500,9 +501,7 @@ def test_build_from_compact_evidence_does_not_require_raw_output_paths(
     payload = criticality_summary_to_dict(summary)
     local_artifact_boundary = payload["materialization"].get("local_artifact_boundary")
     assert local_artifact_boundary is not None
-    assert "output/" not in str(payload.get("scenario_matrix_path", ""))
-    if "scenario_matrix_path" in payload.get("materialization", {}):
-        del payload["materialization"]["scenario_matrix_path"]
+    assert "output/" not in str(payload.get("materialization", {}).get("scenario_matrix_path", ""))
 
 
 def test_build_from_compact_evidence_sets_claim_boundary() -> None:

--- a/tests/scenario_certification/test_criticality_summary.py
+++ b/tests/scenario_certification/test_criticality_summary.py
@@ -1,0 +1,575 @@
+"""Tests for criticality_summary.v1 writer/validator contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.scenario_certification.criticality_summary import (
+    CRITICALITY_SUMMARY_SCHEMA_VERSION,
+    CriticalitySummaryV1,
+    _aggregate_subset,
+    _classify_episode_row_status,
+    _zero_row_status_counts,
+    build_criticality_summary_from_compact_evidence,
+    build_criticality_summary_from_pilot,
+    build_pair_summary_with_statuses,
+    criticality_summary_to_dict,
+    validate_criticality_summary,
+)
+
+
+def _sample_manifest_metadata() -> tuple[str, str]:
+    """Return a tiny (manifest, manifest_id) pair."""
+    return (
+        "configs/scenarios/perturbations/example_pilot_v1.yaml",
+        "example_pilot_v1",
+    )
+
+
+def _sample_materialization() -> dict[str, object]:
+    """Return a tiny materialization payload."""
+    return {
+        "schema_version": "scenario_perturbation_pilot_matrix.v1",
+        "manifest_id": "example_pilot_v1",
+        "included_variants": ["demo_noop", "demo_offset"],
+        "excluded_variants": [],
+        "variant_count": 2,
+        "local_artifact_boundary": (
+            "materialized scenario matrix, route overrides, and raw episode JSONL "
+            "remain ignored local outputs reproducible from the tracked manifest and command"
+        ),
+    }
+
+
+def _sample_planner_runs() -> dict[str, dict[str, object]]:
+    """Return a tiny planner-runs payload."""
+    return {
+        "goal": {
+            "algo": "goal",
+            "algo_config_path": None,
+            "source": "raw_algo",
+            "episodes": 3,
+        },
+    }
+
+
+def _sample_scenario_metadata() -> dict[str, dict[str, object]]:
+    """Return tiny scenario metadata with one noop and one offset."""
+    return {
+        "demo_noop": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_noop",
+            "family": "noop",
+        },
+        "demo_offset": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_offset",
+            "family": "robot_route_offset",
+        },
+    }
+
+
+def _sample_records() -> dict[str, list[dict[str, object]]]:
+    """Return minimal episode records for one planner and two variants."""
+    return {
+        "goal": [
+            {
+                "scenario_id": "demo_noop",
+                "seed": 111,
+                "termination_reason": "success",
+                "metrics": {"min_distance": 2.0},
+            },
+            {
+                "scenario_id": "demo_offset",
+                "seed": 111,
+                "termination_reason": "max_steps",
+                "metrics": {"min_distance": 1.5},
+            },
+            {
+                "scenario_id": "demo_noop",
+                "seed": 222,
+                "termination_reason": "collision",
+                "metrics": {"min_distance": 1.2},
+            },
+            {
+                "scenario_id": "demo_offset",
+                "seed": 222,
+                "termination_reason": "collision",
+                "metrics": {"min_distance": 1.1},
+            },
+        ],
+    }
+
+
+def test_schema_version_is_stable() -> None:
+    """The constant must match the schema file's version."""
+    assert CRITICALITY_SUMMARY_SCHEMA_VERSION == "criticality_summary.v1"
+
+
+def test_zero_row_status_counts_has_all_required_statuses() -> None:
+    """Zeroed row status counts must include all six required status keys."""
+    zeroed = _zero_row_status_counts()
+    assert set(zeroed.keys()) == {
+        "completed",
+        "invalid",
+        "fallback",
+        "degraded",
+        "missing",
+        "failed",
+    }
+    assert all(value == 0 for value in zeroed.values())
+
+
+def test_aggregate_subset_tracks_explicit_row_statuses() -> None:
+    """Aggregation must split status counts from completed-pair means."""
+    pair_rows = [
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": "demo_noop",
+            "perturbed_variant_id": "demo_offset",
+            "perturbed_family": "robot_route_offset",
+            "seed": 111,
+            "pair_status": "completed",
+            "noop_status": "completed",
+            "perturbed_status": "completed",
+            "success_delta": 1.0,
+            "collision_delta": 0.0,
+        },
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": "demo_noop",
+            "perturbed_variant_id": "demo_offset",
+            "perturbed_family": "robot_route_offset",
+            "seed": 222,
+            "pair_status": "excluded",
+            "noop_status": "completed",
+            "perturbed_status": "fallback",
+            "success_delta": None,
+            "collision_delta": None,
+        },
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": "demo_noop",
+            "perturbed_variant_id": "demo_other",
+            "perturbed_family": "robot_route_offset",
+            "seed": 333,
+            "pair_status": "excluded",
+            "noop_status": "completed",
+            "perturbed_status": "degraded",
+            "success_delta": None,
+            "collision_delta": None,
+        },
+    ]
+    result = _aggregate_subset(pair_rows)
+    assert result["pairs"] == 3
+    assert result["row_status_counts"]["completed"] == 1
+    assert result["row_status_counts"]["fallback"] == 1
+    assert result["row_status_counts"]["degraded"] == 1
+    assert result["row_status_counts"]["invalid"] == 0
+    assert result["row_status_counts"]["missing"] == 0
+    assert result["row_status_counts"]["failed"] == 0
+    assert result["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(1.0)
+    assert "success_delta" not in result.get("by_fallback", {})
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        (None, "missing"),
+        ({"scenario_exclusion": {"reason": "bound_exceeded"}}, "invalid"),
+        ({"algorithm_metadata": {"mode": "planner fallback"}}, "fallback"),
+        ({"algorithm_metadata": {"nested": ["degraded runtime"]}}, "degraded"),
+        ({"termination_reason": "error"}, "failed"),
+        ({"termination_reason": "success"}, "completed"),
+    ],
+)
+def test_classify_episode_row_statuses(row: dict[str, object] | None, expected: str) -> None:
+    """Episode row classification must preserve fail-closed diagnostic statuses."""
+    assert _classify_episode_row_status(row) == expected
+
+
+def test_build_criticality_summary_from_pilot_builds_valid_payload() -> None:
+    """Building from pilot records must produce a validatable v1 summary."""
+    manifest, manifest_id = _sample_manifest_metadata()
+    summary = build_criticality_summary_from_pilot(
+        records_by_planner=_sample_records(),
+        scenario_metadata=_sample_scenario_metadata(),
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization=_sample_materialization(),
+        planner_runs=_sample_planner_runs(),
+    )
+    assert summary.schema_version == "criticality_summary.v1"
+    assert summary.manifest == manifest
+    assert summary.manifest_id == manifest_id
+    assert summary.planners == ["goal"]
+    assert summary.horizon == 80
+    assert summary.dt == 0.1
+    assert summary.seed_limit == 1
+    row_status_counts = summary.pair_summary["row_status_counts"]
+    assert isinstance(row_status_counts, dict)
+    assert set(row_status_counts.keys()) == {
+        "completed",
+        "invalid",
+        "fallback",
+        "degraded",
+        "missing",
+        "failed",
+    }
+    assert summary.pair_summary["pairs"] == 2
+    assert len(summary.pair_rows) == 2
+
+
+def test_build_criticality_summary_records_missing_noop() -> None:
+    """A perturbed row without a noop baseline must remain excluded and counted missing."""
+    manifest, manifest_id = _sample_manifest_metadata()
+    summary = build_criticality_summary_from_pilot(
+        records_by_planner={"goal": []},
+        scenario_metadata={
+            "demo_offset": {
+                "source_scenario_id": "demo",
+                "variant_id": "demo_offset",
+                "family": "robot_route_offset",
+            },
+        },
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization=_sample_materialization(),
+        planner_runs=_sample_planner_runs(),
+        description="missing noop example",
+    )
+    payload = criticality_summary_to_dict(summary)
+    assert payload["description"] == "missing noop example"
+    assert summary.pair_rows == [
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": None,
+            "perturbed_variant_id": "demo_offset",
+            "perturbed_family": "unknown",
+            "seed": None,
+            "pair_status": "missing_noop",
+            "noop_status": "missing",
+            "perturbed_status": "missing",
+        }
+    ]
+    assert summary.pair_summary["row_status_counts"]["missing"] == 1
+
+
+def test_build_criticality_summary_includes_grouped_breakdowns() -> None:
+    """The v1 summary must include by-planner, by-scenario, and by-family groupings."""
+    manifest, manifest_id = _sample_manifest_metadata()
+    summary = build_criticality_summary_from_pilot(
+        records_by_planner=_sample_records(),
+        scenario_metadata=_sample_scenario_metadata(),
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization=_sample_materialization(),
+        planner_runs=_sample_planner_runs(),
+    )
+    assert "by_planner" in summary.pair_summary
+    assert "by_source_scenario" in summary.pair_summary
+    assert "by_perturbation_family" in summary.pair_summary
+    by_planner = summary.pair_summary["by_planner"]["goal"]
+    assert "row_status_counts" in by_planner
+    assert "mean_deltas_completed_pairs" in by_planner
+
+
+def test_criticality_summary_to_dict_is_json_safe() -> None:
+    """Serialization should produce JSON-safe primitives."""
+    manifest, manifest_id = _sample_manifest_metadata()
+    summary = build_criticality_summary_from_pilot(
+        records_by_planner=_sample_records(),
+        scenario_metadata=_sample_scenario_metadata(),
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization=_sample_materialization(),
+        planner_runs=_sample_planner_runs(),
+    )
+    payload = criticality_summary_to_dict(summary)
+    assert isinstance(payload, dict)
+    json.dumps(payload)
+
+
+def test_criticality_summary_is_immutable() -> None:
+    """CriticalitySummaryV1 must be frozen."""
+    summary = CriticalitySummaryV1(
+        schema_version=CRITICALITY_SUMMARY_SCHEMA_VERSION,
+        manifest="test.yaml",
+        manifest_id="test",
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization={},
+        planner_runs={},
+        pair_summary={
+            "pairs": 0,
+            "row_status_counts": _zero_row_status_counts(),
+            "mean_deltas_completed_pairs": {},
+        },
+    )
+    with pytest.raises(Exception):
+        summary.horizon = 100  # type: ignore[misc]
+
+
+def test_validate_criticality_summary_accepts_minimal_payload() -> None:
+    """Schema validation must accept a correctly structured minimal summary."""
+    payload = {
+        "schema_version": "criticality_summary.v1",
+        "manifest": "configs/scenarios/perturbations/test.yaml",
+        "manifest_id": "test",
+        "planners": ["goal"],
+        "horizon": 80,
+        "dt": 0.1,
+        "seed_limit": 1,
+        "materialization": {
+            "schema_version": "scenario_perturbation_pilot_matrix.v1",
+            "manifest_id": "test",
+            "included_variants": ["demo_noop"],
+            "excluded_variants": [],
+            "variant_count": 1,
+            "local_artifact_boundary": "test boundary",
+        },
+        "planner_runs": {
+            "goal": {
+                "algo": "goal",
+                "source": "raw_algo",
+                "episodes": 1,
+            },
+        },
+        "pair_summary": {
+            "pairs": 0,
+            "row_status_counts": {
+                "completed": 0,
+                "invalid": 0,
+                "fallback": 0,
+                "degraded": 0,
+                "missing": 0,
+                "failed": 0,
+            },
+            "mean_deltas_completed_pairs": {},
+        },
+        "claim_boundary": "diagnostic local pilot only; not benchmark-strength or paper-facing evidence",
+    }
+    validate_criticality_summary(payload)
+
+
+def test_validate_criticality_summary_rejects_missing_row_statuses() -> None:
+    """Schema must reject a payload missing required row_status_counts fields."""
+    payload = {
+        "schema_version": "criticality_summary.v1",
+        "manifest": "test.yaml",
+        "manifest_id": "test",
+        "planners": ["goal"],
+        "horizon": 80,
+        "dt": 0.1,
+        "seed_limit": 1,
+        "materialization": {
+            "schema_version": "scenario_perturbation_pilot_matrix.v1",
+            "manifest_id": "test",
+            "included_variants": [],
+            "excluded_variants": [],
+            "variant_count": 0,
+            "local_artifact_boundary": "test boundary",
+        },
+        "planner_runs": {
+            "goal": {"algo": "goal", "source": "raw_algo", "episodes": 0},
+        },
+        "pair_summary": {
+            "pairs": 0,
+            "row_status_counts": {
+                "completed": 0,
+            },
+            "mean_deltas_completed_pairs": {},
+        },
+        "claim_boundary": "diagnostic",
+    }
+    with pytest.raises(ValueError, match="row_status_counts"):
+        validate_criticality_summary(payload)
+
+
+def test_validate_criticality_summary_rejects_wrong_schema_version() -> None:
+    """Schema must reject wrong schema_version."""
+    payload = {
+        "schema_version": "criticality_summary.v2",
+        "manifest": "test.yaml",
+        "manifest_id": "test",
+        "planners": ["goal"],
+        "horizon": 80,
+        "dt": 0.1,
+        "seed_limit": 1,
+        "materialization": {
+            "schema_version": "x",
+            "manifest_id": "test",
+            "included_variants": [],
+            "excluded_variants": [],
+            "variant_count": 0,
+            "local_artifact_boundary": "test",
+        },
+        "planner_runs": {
+            "goal": {"algo": "goal", "source": "raw_algo", "episodes": 0},
+        },
+        "pair_summary": {
+            "pairs": 0,
+            "row_status_counts": _zero_row_status_counts(),
+            "mean_deltas_completed_pairs": {},
+        },
+        "claim_boundary": "diagnostic",
+    }
+    with pytest.raises(ValueError, match="schema_version"):
+        validate_criticality_summary(payload)
+
+
+def test_build_from_compact_evidence_represents_existing_summary(tmp_path: Path) -> None:
+    """An existing #1610 compact evidence summary must be representable."""
+    evidence_path = Path(
+        "docs/context/evidence/issue_1937_ped_route_offset_2026-05-31/summary.json"
+    )
+    if not evidence_path.exists():
+        pytest.skip("Existing compact evidence not available")
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    summary = build_criticality_summary_from_compact_evidence(evidence)
+    payload = criticality_summary_to_dict(summary)
+    validate_criticality_summary(payload)
+    assert payload["schema_version"] == "criticality_summary.v1"
+    row_status_counts = payload["pair_summary"]["row_status_counts"]
+    assert isinstance(row_status_counts, dict)
+    assert set(row_status_counts.keys()) == {
+        "completed",
+        "invalid",
+        "fallback",
+        "degraded",
+        "missing",
+        "failed",
+    }
+    assert "mean_deltas_completed_pairs" in payload["pair_summary"]
+
+
+def test_build_from_compact_evidence_includes_grouped_row_statuses(
+    tmp_path: Path,
+) -> None:
+    """Grouped summaries must carry explicit row_status_counts."""
+    evidence_path = Path(
+        "docs/context/evidence/issue_1937_ped_route_offset_2026-05-31/summary.json"
+    )
+    if not evidence_path.exists():
+        pytest.skip("Existing compact evidence not available")
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    summary = build_criticality_summary_from_compact_evidence(evidence)
+    payload = criticality_summary_to_dict(summary)
+    by_planner = payload["pair_summary"].get("by_planner", {})
+    for group in by_planner.values():
+        assert "row_status_counts" in group
+        assert "mean_deltas_completed_pairs" in group
+
+
+def test_build_from_compact_evidence_does_not_require_raw_output_paths(
+    tmp_path: Path,
+) -> None:
+    """Compact evidence must not require output/ paths to be representable."""
+    evidence_path = Path(
+        "docs/context/evidence/issue_1937_ped_route_offset_2026-05-31/summary.json"
+    )
+    if not evidence_path.exists():
+        pytest.skip("Existing compact evidence not available")
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    summary = build_criticality_summary_from_compact_evidence(evidence)
+    payload = criticality_summary_to_dict(summary)
+    local_artifact_boundary = payload["materialization"].get("local_artifact_boundary")
+    assert local_artifact_boundary is not None
+    assert "output/" not in str(payload.get("scenario_matrix_path", ""))
+    if "scenario_matrix_path" in payload.get("materialization", {}):
+        del payload["materialization"]["scenario_matrix_path"]
+
+
+def test_build_from_compact_evidence_sets_claim_boundary() -> None:
+    """Compact evidence must carry the diagnostic-vs-benchmark boundary."""
+    evidence_path = Path(
+        "docs/context/evidence/issue_1937_ped_route_offset_2026-05-31/summary.json"
+    )
+    if not evidence_path.exists():
+        pytest.skip("Existing compact evidence not available")
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    summary = build_criticality_summary_from_compact_evidence(evidence)
+    payload = criticality_summary_to_dict(summary)
+    assert "claim_boundary" in payload
+    assert "diagnostic" in payload["claim_boundary"].lower()
+    assert "not benchmark" in payload["claim_boundary"].lower()
+
+
+def test_pair_summary_excludes_fallback_from_means() -> None:
+    """Non-completed rows must not influence completed-pair means."""
+    pair_rows = [
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": "demo_noop",
+            "perturbed_variant_id": "demo_fallback",
+            "perturbed_family": "robot_route_offset",
+            "seed": 111,
+            "pair_status": "excluded",
+            "noop_status": "completed",
+            "perturbed_status": "fallback",
+            "success_delta": 0.5,
+        },
+        {
+            "planner": "goal",
+            "source_scenario_id": "demo",
+            "noop_variant_id": "demo_noop",
+            "perturbed_variant_id": "demo_offset",
+            "perturbed_family": "robot_route_offset",
+            "seed": 111,
+            "pair_status": "completed",
+            "noop_status": "completed",
+            "perturbed_status": "completed",
+            "success_delta": 1.0,
+        },
+    ]
+    result = _aggregate_subset(pair_rows)
+    assert result["row_status_counts"]["completed"] == 1
+    assert result["row_status_counts"]["fallback"] == 1
+    assert result["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(1.0)
+
+
+def test_build_pair_summary_derives_row_statuses_when_not_supplied() -> None:
+    """The public pair summary helper should derive row status counts when omitted."""
+    result = build_pair_summary_with_statuses(
+        [
+            {
+                "pair_status": "excluded",
+                "perturbed_status": "failed",
+                "success_delta": 1.0,
+            },
+            {
+                "pair_status": "completed",
+                "perturbed_status": "completed",
+                "success_delta": 0.25,
+            },
+        ]
+    )
+    assert result["row_status_counts"]["failed"] == 1
+    assert result["row_status_counts"]["completed"] == 1
+    assert result["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(0.25)

--- a/tests/scenario_certification/test_perturbation_family_registry.py
+++ b/tests/scenario_certification/test_perturbation_family_registry.py
@@ -1,0 +1,156 @@
+"""Tests for perturbation family registry contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.scenario_certification import (
+    perturbation_families,
+    perturbation_family,
+    supported_perturbation_families,
+    validate_perturbation_family_parameters,
+)
+from robot_sf.scenario_certification.perturbation_family_registry import (
+    PerturbationFamily,
+)
+
+
+def test_supported_families_covers_manifest_enum() -> None:
+    """Every family the manifest schema accepts must be registered."""
+    expected = {
+        "noop",
+        "robot_route_offset",
+        "pedestrian_route_offset",
+        "single_pedestrian_start_delay_offset",
+        "single_pedestrian_speed_offset",
+        "single_pedestrian_wait_duration_offset",
+        "single_pedestrian_trajectory_waypoint_offset",
+        "pedestrian_density_offset",
+    }
+    assert supported_perturbation_families() == expected
+
+
+def test_perturbation_families_iterable_is_ordered() -> None:
+    """The families tuple should return the same order each call."""
+    families = perturbation_families()
+    assert len(families) == 8
+    names = [f.name for f in families]
+    assert names[0] == "noop"
+    assert names[-1] == "pedestrian_density_offset"
+
+
+def test_perturbation_family_lookup() -> None:
+    """Lookup by name should return an immutable PerturbationFamily."""
+    family = perturbation_family("robot_route_offset")
+    assert isinstance(family, PerturbationFamily)
+    assert family.name == "robot_route_offset"
+    assert family.target_surface == "robot_route_waypoints"
+    assert "max_route_offset_m" in family.validity_constraints
+    assert len(family.required_parameters) == 3
+    assert "dx_m" in family.required_parameters
+    assert "dy_m" in family.required_parameters
+    assert "max_magnitude_m" in family.required_parameters
+
+
+def test_perturbation_family_noop_has_no_parameters() -> None:
+    """The noop family should accept no perturbation parameters."""
+    family = perturbation_family("noop")
+    assert family.required_parameters == ()
+    assert family.optional_parameters == ()
+
+
+def test_perturbation_family_unknown_raises() -> None:
+    """Unknown families should fail for any caller with a clear message."""
+    with pytest.raises(ValueError, match="unsupported perturbation family"):
+        perturbation_family("not_a_family")
+
+
+def test_perturbation_family_is_immutable() -> None:
+    """PerturbationFamily must be frozen for registry safety."""
+    family = perturbation_family("robot_route_offset")
+    with pytest.raises(Exception):
+        family.name = "altered"  # type: ignore[misc]
+
+
+def test_validate_parameters_rejects_missing_required() -> None:
+    """Validation must reject parameters missing required keys."""
+    reasons, _family = validate_perturbation_family_parameters(
+        "robot_route_offset",
+        {"max_magnitude_m": 0.5},
+    )
+    assert len(reasons) == 1
+    assert "missing required parameters" in reasons[0]
+
+
+def test_validate_parameters_rejects_extra_keys() -> None:
+    """Validation must reject parameters with keys not in required+optional."""
+    reasons, _family = validate_perturbation_family_parameters(
+        "robot_route_offset",
+        {
+            "dx_m": 0.25,
+            "dy_m": 0.0,
+            "max_magnitude_m": 0.5,
+            "dt_s": 0.5,
+        },
+    )
+    assert len(reasons) == 1
+    assert "unrecognized parameters" in reasons[0]
+
+
+def test_validate_parameters_accepts_valid() -> None:
+    """Validation should accept parameters with all required keys."""
+    reasons, family = validate_perturbation_family_parameters(
+        "robot_route_offset",
+        {"dx_m": 0.25, "dy_m": 0.0, "max_magnitude_m": 0.5},
+    )
+    assert reasons == []
+    assert family.name == "robot_route_offset"
+
+
+def test_validate_parameters_accepts_required_plus_optional() -> None:
+    """Validation should accept parameters that include optional keys."""
+    reasons, family = validate_perturbation_family_parameters(
+        "single_pedestrian_speed_offset",
+        {
+            "speed_delta_m_s": 0.25,
+            "max_abs_speed_delta_m_s": 0.5,
+            "pedestrian_id": "h3",
+        },
+    )
+    assert reasons == []
+    assert family.name == "single_pedestrian_speed_offset"
+
+
+def test_validate_parameters_for_noop_accepts_no_parameters() -> None:
+    """noop validation should accept an empty parameters mapping."""
+    reasons, family = validate_perturbation_family_parameters(
+        "noop",
+        {},
+    )
+    assert reasons == []
+    assert family.name == "noop"
+
+
+def test_all_families_have_descriptions_and_boundaries() -> None:
+    """Every registered family must carry concrete metadata for docs and preflight."""
+    for family in perturbation_families():
+        assert family.description, f"{family.name} missing description"
+        assert family.target_surface, f"{family.name} missing target_surface"
+        assert family.semantic_boundary, f"{family.name} missing semantic_boundary"
+        assert family.validity_constraints, f"{family.name} missing validity_constraints"
+        assert family.fail_closed_rules, f"{family.name} missing fail_closed_rules"
+
+
+def test_trajectory_family_requires_pedestrian_id() -> None:
+    """Trajectory waypoint offset must require pedestrian_id."""
+    family = perturbation_family("single_pedestrian_trajectory_waypoint_offset")
+    assert "pedestrian_id" in family.required_parameters
+    assert "waypoint_selector" in family.required_parameters
+
+
+def test_density_family_optional_max_ped_density() -> None:
+    """Density family must accept an optional max_ped_density cap."""
+    family = perturbation_family("pedestrian_density_offset")
+    assert "max_ped_density" in family.optional_parameters
+    assert "density_delta" in family.required_parameters
+    assert "max_abs_density_delta" in family.required_parameters

--- a/tests/scenario_certification/test_perturbation_family_registry.py
+++ b/tests/scenario_certification/test_perturbation_family_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from robot_sf.scenario_certification import (
@@ -68,7 +70,7 @@ def test_perturbation_family_unknown_raises() -> None:
 def test_perturbation_family_is_immutable() -> None:
     """PerturbationFamily must be frozen for registry safety."""
     family = perturbation_family("robot_route_offset")
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         family.name = "altered"  # type: ignore[misc]
 
 


### PR DESCRIPTION
## Summary
Adds a reusable perturbation-family registry and `criticality_summary.v1` schema/writer for #1610 perturbation criticality summaries.

## Linked Issues
- Closes `#1980`
- Relates to `#1965`
- Relates to `#1610`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Added `robot_sf.scenario_certification.perturbation_family_registry` with supported perturbation families, semantic boundaries, target surfaces, validity constraints, fail-closed rules, and parameter contracts.
- Added `criticality_summary.v1` JSON schema plus writer/validator helpers that keep completed row effect means separate from invalid, fallback, degraded, missing, and failed row counts.
- Exported the new public helpers and documented the registry/summary workflow in `docs/scenario_perturbation_manifest.md`.
- Added targeted tests proving registry coverage, summary schema validation, existing compact #1610 evidence representation, and non-completed-row exclusion from means.

## Why It Matters
- Added value: future perturbation-family pilots get a stable local contract instead of one-off summary formats.
- Expected impact: diagnostic summaries become easier to compare while preserving fail-closed row accounting.
- Why this is worth merging now: #1965 identified repeated family-summary drift; this gives the next #1610 lane a reusable schema before more pilots accumulate.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format robot_sf/scenario_certification/criticality_summary.py tests/scenario_certification/test_criticality_summary.py`
  - `uv run ruff check robot_sf/scenario_certification/criticality_summary.py tests/scenario_certification/test_criticality_summary.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/scenario_certification/criticality_summary.py robot_sf/scenario_certification/perturbation_family_registry.py robot_sf/scenario_certification/__init__.py tests/scenario_certification/test_criticality_summary.py tests/scenario_certification/test_perturbation_family_registry.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/scenario_certification/criticality_summary.py robot_sf/scenario_certification/perturbation_family_registry.py robot_sf/scenario_certification/__init__.py tests/scenario_certification/test_criticality_summary.py tests/scenario_certification/test_perturbation_family_registry.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/scenario_certification/test_criticality_summary.py tests/scenario_certification/test_perturbation_family_registry.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_preflight.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m json.tool robot_sf/benchmark/schemas/criticality_summary.v1.json`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_docs_proof_consistency.py --path docs/scenario_perturbation_manifest.md`
  - `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed on branch head `8a4350b108c916036498526e296985deb9c06928` with `4922 passed, 11 skipped`; changed-file coverage was 100.0% for `__init__.py`, 94.2% for `criticality_summary.py`, and 100.0% for `perturbation_family_registry.py`.
- Benchmarks or smoke tests, if applicable: no benchmark run; this is workflow/schema support and does not claim new planner performance evidence.

## Risks / Rollout
- Compatibility risks: new public exports are additive; existing perturbation preflight and pilot scripts are unchanged.
- Failure modes: future summaries that omit explicit row status counts fail schema validation instead of silently mixing excluded rows into means.
- Rollback or fallback plan: remove the additive registry/summary module and schema; existing compact #1610 evidence files remain unchanged.

## Docs / Provenance
- Updated docs: `docs/scenario_perturbation_manifest.md`.
- Relevant design or provenance notes: issue `#1965` synthesis and parent issue `#1610` perturbation-criticality lane.
- Any assumptions that need to be preserved: `criticality_summary.v1` is diagnostic/workflow evidence only, not benchmark-strength or paper-facing evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): no
- Registry or config index updated (yes/no/NA): yes, the perturbation-family registry and summary schema are added in this PR.
- Context index / memory note updated (yes/no/NA): no
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not-applicable rationale: this PR creates the reusable schema/writer surface; it does not reinterpret existing planner results or update paper-facing claim maps.

## Follow-Up Issues
- Deferred work: optional refactor of `scripts/validation/run_scenario_perturbation_criticality_pilot.py` to call the new writer directly.
- Issues opened for follow-up: none

## Reviewer Notes
- Please verify the row status separation contract: `completed` rows are the only rows included in effect means, while `invalid`, `fallback`, `degraded`, `missing`, and `failed` remain explicit counts.
- Known limitation: the pilot script is not refactored in this PR, by design, to keep the issue scope bounded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added criticality summary format with validation and construction capabilities to build summaries from pilot records or existing evidence
  * Added perturbation family registry for defining and managing perturbation configurations

* **Documentation**
  * Added comprehensive guide on using the perturbation family registry and constructing criticality summaries with practical examples

* **Tests**
  * Added test coverage for criticality summary and perturbation family registry functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->