### PR TITLE
feat: render annotation-aware trace reports

### DIFF
--- a/scripts/tools/render_trace_report.py
+++ b/scripts/tools/render_trace_report.py
@@ -434,11 +434,8 @@ def _format_value(value: Any) -> str:
 def _validate_tracked_fixture_path(path: Path, *, label: str) -> None:
     """Reject output-only paths before report rendering."""
 
-    if path.is_absolute():
-        candidate = path
-    else:
-        candidate = Path.cwd() / path
-    if any(part in {"output", "results"} for part in candidate.parts):
+    relative_path = _repo_relative_path(path)
+    if any(part in {"output", "results"} for part in relative_path.parts):
         raise ValueError(f"{label} path must be a tracked fixture, not generated output: {path}")
 
 
@@ -474,10 +471,17 @@ def _validate_annotation_matches_trace(
 def _display_path(path: Path) -> str:
     """Return a stable repo-friendly display path when possible."""
 
+    return str(_repo_relative_path(path))
+
+
+def _repo_relative_path(path: Path) -> Path:
+    """Return a path relative to the repository root when possible."""
+
+    repo_root = Path(__file__).resolve().parents[2]
     try:
-        return str(path.resolve().relative_to(Path.cwd().resolve()))
+        return path.resolve().relative_to(repo_root)
     except ValueError:
-        return str(path)
+        return path
 
 
 def _markdown_table(headers: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> list[str]:

--- a/scripts/tools/render_trace_report.py
+++ b/scripts/tools/render_trace_report.py
@@ -20,6 +20,12 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
     SimulationTraceFrame,
     load_simulation_trace_export,
 )
+from robot_sf.analysis_workbench.trace_annotation import (
+    TraceAnnotation,
+    TraceAnnotationSet,
+    TraceAnnotationSetValidationError,
+    load_trace_annotation_set,
+)
 
 ANNOTATION_KEYS = {
     "annotation",
@@ -37,7 +43,13 @@ ANNOTATION_KEYS = {
 }
 
 
-def render_trace_report(trace: SimulationTraceExport) -> str:
+def render_trace_report(
+    trace: SimulationTraceExport,
+    *,
+    trace_path: Path | None = None,
+    annotation_set: TraceAnnotationSet | None = None,
+    annotation_path: Path | None = None,
+) -> str:
     """Render a loaded trace export as Markdown.
 
     Returns:
@@ -56,23 +68,48 @@ def render_trace_report(trace: SimulationTraceExport) -> str:
     ]
     lines.extend(_trace_metadata(trace))
     lines.extend(_summary(trace))
+    if trace_path is not None or annotation_set is not None:
+        lines.extend(_source_fixture_summary(trace_path, annotation_set, annotation_path))
     lines.extend(_event_summary(trace.frames))
     lines.extend(_planner_key_summary(trace.frames))
     lines.extend(_annotation_summary(trace.frames))
+    if annotation_set is not None:
+        lines.extend(_annotation_set_summary(annotation_set))
     lines.extend(_frame_table(trace.frames))
     return "\n".join(lines).rstrip() + "\n"
 
 
-def write_trace_report(*, trace_path: Path, output: Path) -> Path:
+def write_trace_report(
+    *,
+    trace_path: Path,
+    output: Path,
+    annotation_path: Path | None = None,
+) -> Path:
     """Load a trace export and write a Markdown report.
 
     Raises:
         SimulationTraceExportValidationError: if ``trace_path`` is not a valid trace export.
+        TraceAnnotationSetValidationError: if ``annotation_path`` is invalid or mismatched.
         OSError: if input or output files cannot be read or written.
     """
 
+    _validate_tracked_fixture_path(trace_path, label="trace")
     trace = load_simulation_trace_export(trace_path)
-    markdown = render_trace_report(trace)
+    annotation_set = None
+    if annotation_path is not None:
+        _validate_tracked_fixture_path(annotation_path, label="annotation")
+        annotation_set = load_trace_annotation_set(annotation_path)
+        _validate_annotation_matches_trace(
+            trace=trace,
+            trace_path=trace_path,
+            annotation_set=annotation_set,
+        )
+    markdown = render_trace_report(
+        trace,
+        trace_path=trace_path,
+        annotation_set=annotation_set,
+        annotation_path=annotation_path,
+    )
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(markdown, encoding="utf-8")
     return output
@@ -130,6 +167,35 @@ def _summary(trace: SimulationTraceExport) -> list[str]:
     ]
 
 
+def _source_fixture_summary(
+    trace_path: Path | None,
+    annotation_set: TraceAnnotationSet | None,
+    annotation_path: Path | None,
+) -> list[str]:
+    """Render source fixture paths and annotation metadata."""
+
+    rows: list[tuple[str, Any]] = []
+    if trace_path is not None:
+        rows.append(("trace_path", _display_path(trace_path)))
+    if annotation_path is not None:
+        rows.append(("annotation_path", _display_path(annotation_path)))
+    if annotation_set is not None:
+        rows.extend(
+            [
+                ("annotation_set_id", annotation_set.annotation_set_id),
+                ("annotation_source_issue", annotation_set.provenance.source_issue),
+                ("annotation_evidence_boundary", annotation_set.provenance.evidence_boundary),
+                ("annotation_count", len(annotation_set.annotations)),
+            ]
+        )
+    return [
+        "## Source Fixtures",
+        "",
+        *_markdown_table(("field", "value"), rows),
+        "",
+    ]
+
+
 def _event_summary(frames: Iterable[SimulationTraceFrame]) -> list[str]:
     """Render event and selected-action counts."""
 
@@ -179,6 +245,55 @@ def _annotation_summary(frames: Iterable[SimulationTraceFrame]) -> list[str]:
         *_markdown_table(("step", "annotation", "value"), rows),
         "",
     ]
+
+
+def _annotation_set_summary(annotation_set: TraceAnnotationSet) -> list[str]:
+    """Render external qualitative annotation anchors and evidence boundaries."""
+
+    rows = [_annotation_row(annotation) for annotation in annotation_set.annotations]
+    return [
+        "## Annotation Review",
+        "",
+        (
+            "Annotation review rows preserve their evidence type. `observed` rows cite trace "
+            "contents, `hypothesis` rows are candidate interpretations, and `commentary` rows "
+            "are reviewer notes. These qualitative rows are diagnostic-only and not benchmark "
+            "evidence."
+        ),
+        "",
+        *_markdown_table(
+            (
+                "annotation_id",
+                "evidence_type",
+                "category",
+                "frame_range",
+                "event_ids",
+                "entities",
+                "summary",
+                "details",
+            ),
+            rows,
+        ),
+        "",
+    ]
+
+
+def _annotation_row(annotation: TraceAnnotation) -> tuple[str, str, str, str, str, str, str, str]:
+    """Format one external annotation as a Markdown-table row."""
+
+    anchor = annotation.anchor
+    return (
+        annotation.annotation_id,
+        annotation.evidence_type,
+        annotation.category,
+        f"{anchor.frame_start}-{anchor.frame_end}",
+        ", ".join(anchor.event_ids) if anchor.event_ids else "none",
+        ", ".join(f"{entity.type}:{entity.id}" for entity in anchor.entities)
+        if anchor.entities
+        else "none",
+        annotation.summary,
+        annotation.details or "",
+    )
 
 
 def _frame_table(frames: Iterable[SimulationTraceFrame]) -> list[str]:
@@ -316,6 +431,55 @@ def _format_value(value: Any) -> str:
     return json.dumps(value, sort_keys=True)
 
 
+def _validate_tracked_fixture_path(path: Path, *, label: str) -> None:
+    """Reject output-only paths before report rendering."""
+
+    if path.is_absolute():
+        candidate = path
+    else:
+        candidate = Path.cwd() / path
+    if any(part in {"output", "results"} for part in candidate.parts):
+        raise ValueError(f"{label} path must be a tracked fixture, not generated output: {path}")
+
+
+def _validate_annotation_matches_trace(
+    *,
+    trace: SimulationTraceExport,
+    trace_path: Path,
+    annotation_set: TraceAnnotationSet,
+) -> None:
+    """Fail closed when the external annotation set points at another trace."""
+
+    if annotation_set.timeline.trace_id != trace.trace_id:
+        raise TraceAnnotationSetValidationError(
+            [
+                "/timeline/trace_id: "
+                f"expected supplied trace_id {trace.trace_id!r}, "
+                f"got {annotation_set.timeline.trace_id!r}"
+            ],
+            source=annotation_set.annotation_set_id,
+        )
+    expected_name = Path(annotation_set.timeline.path).name
+    if expected_name != trace_path.name:
+        raise TraceAnnotationSetValidationError(
+            [
+                "/timeline/path: "
+                f"annotation references {annotation_set.timeline.path!r}, "
+                f"but supplied trace path is {str(trace_path)!r}"
+            ],
+            source=annotation_set.annotation_set_id,
+        )
+
+
+def _display_path(path: Path) -> str:
+    """Return a stable repo-friendly display path when possible."""
+
+    try:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(path)
+
+
 def _markdown_table(headers: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> list[str]:
     """Render a simple GitHub-flavored Markdown table."""
 
@@ -344,6 +508,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--trace", type=Path, required=True, help="simulation_trace_export.v1 JSON."
     )
     parser.add_argument(
+        "--annotations",
+        type=Path,
+        help="Optional trace_annotation_set.v1 JSON to cite in the report.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         default=Path("report.md"),
@@ -359,8 +528,17 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        output = write_trace_report(trace_path=args.trace, output=args.output)
-    except (OSError, ValueError, SimulationTraceExportValidationError) as exc:
+        output = write_trace_report(
+            trace_path=args.trace,
+            annotation_path=args.annotations,
+            output=args.output,
+        )
+    except (
+        OSError,
+        ValueError,
+        SimulationTraceExportValidationError,
+        TraceAnnotationSetValidationError,
+    ) as exc:
         print(f"{exc}", file=sys.stderr)
         return 1
 

--- a/tests/analysis_workbench/test_trace_report_renderer.py
+++ b/tests/analysis_workbench/test_trace_report_renderer.py
@@ -201,3 +201,33 @@ def test_trace_report_renderer_rejects_output_only_annotation_sources(
             annotation_path=ANNOTATION_FIXTURE_PATH,
             output=tmp_path / "report.md",
         )
+
+
+def test_trace_report_renderer_uses_repo_relative_paths_from_subdirectory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fixture validation and display paths should not depend on the current directory."""
+
+    from scripts.tools.render_trace_report import write_trace_report
+
+    nested_cwd = tmp_path / "nested"
+    nested_cwd.mkdir()
+    output = tmp_path / "subdir_report.md"
+    monkeypatch.chdir(nested_cwd)
+
+    write_trace_report(
+        trace_path=ANNOTATED_TRACE_FIXTURE_PATH,
+        annotation_path=ANNOTATION_FIXTURE_PATH,
+        output=output,
+    )
+
+    markdown = output.read_text(encoding="utf-8")
+    assert (
+        "| trace_path | tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+        "planner_sanity_open_episode_0000.json |"
+    ) in markdown
+    assert (
+        "| annotation_path | tests/fixtures/analysis_workbench/trace_annotation_set_v1/"
+        "issue_1962_planner_sanity_open_annotations.json |"
+    ) in markdown

--- a/tests/analysis_workbench/test_trace_report_renderer.py
+++ b/tests/analysis_workbench/test_trace_report_renderer.py
@@ -11,6 +11,10 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
     SimulationTraceExportValidationError,
     load_simulation_trace_export,
 )
+from robot_sf.analysis_workbench.trace_annotation import (
+    TraceAnnotationSetValidationError,
+    load_trace_annotation_set,
+)
 
 FIXTURE_PATH = (
     Path(__file__).resolve().parents[1]
@@ -18,6 +22,20 @@ FIXTURE_PATH = (
     / "analysis_workbench"
     / "simulation_trace_export_v1"
     / "minimal_trace.json"
+)
+ANNOTATED_TRACE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "planner_sanity_open_episode_0000.json"
+)
+ANNOTATION_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "trace_annotation_set_v1"
+    / "issue_1962_planner_sanity_open_annotations.json"
 )
 
 
@@ -87,3 +105,99 @@ def test_trace_report_renderer_uses_existing_trace_validation_path(
         write_trace_report(trace_path=trace_path, output=output)
 
     assert not output.exists()
+
+
+def test_trace_report_renderer_writes_annotation_review_report(tmp_path: Path) -> None:
+    """Trace and annotation fixtures should render a cited qualitative review report."""
+
+    from scripts.tools.render_trace_report import write_trace_report
+
+    output = tmp_path / "annotation_report.md"
+
+    write_trace_report(
+        trace_path=ANNOTATED_TRACE_FIXTURE_PATH,
+        annotation_path=ANNOTATION_FIXTURE_PATH,
+        output=output,
+    )
+
+    markdown = output.read_text(encoding="utf-8")
+    assert "## Source Fixtures" in markdown
+    assert "| annotation_set_id | issue_1962_planner_sanity_open_annotations |" in markdown
+    assert "| annotation_source_issue | #1962 |" in markdown
+    assert "## Annotation Review" in markdown
+    assert "diagnostic-only and not benchmark evidence" in markdown
+    assert (
+        "| issue_1962_step_1_to_2_goal_action_observed | observed | planner_action | 1-2 |"
+        in markdown
+    )
+    assert "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000" in markdown
+    assert "| issue_1962_step_3_heading_hypothesis | hypothesis | interaction | 3-3 |" in markdown
+    assert "| issue_1962_fixture_scope_commentary | commentary | data_quality | 1-3 |" in markdown
+    assert "robot:robot" in markdown
+
+
+def test_trace_report_renderer_rejects_mismatched_annotation_trace(
+    tmp_path: Path,
+) -> None:
+    """The supplied trace must match the trace referenced by the annotation fixture."""
+
+    from scripts.tools.render_trace_report import write_trace_report
+
+    output = tmp_path / "report.md"
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="/timeline/trace_id"):
+        write_trace_report(
+            trace_path=FIXTURE_PATH,
+            annotation_path=ANNOTATION_FIXTURE_PATH,
+            output=output,
+        )
+
+    assert not output.exists()
+
+
+def test_trace_report_renderer_rejects_invalid_annotation_references(
+    tmp_path: Path,
+) -> None:
+    """Invalid annotation-to-trace references should fail closed before output writes."""
+
+    from scripts.tools.render_trace_report import write_trace_report
+
+    payload = load_trace_annotation_set(ANNOTATION_FIXTURE_PATH).to_dict()
+    payload["annotations"][0]["anchor"]["event_ids"] = ["missing-event"]
+    trace_dir = tmp_path / "simulation_trace_export_v1"
+    annotation_dir = tmp_path / "trace_annotation_set_v1"
+    trace_dir.mkdir()
+    annotation_dir.mkdir()
+    trace_copy = trace_dir / ANNOTATED_TRACE_FIXTURE_PATH.name
+    trace_copy.write_text(ANNOTATED_TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    annotation_path = annotation_dir / "bad_annotations.json"
+    output = tmp_path / "report.md"
+    annotation_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(TraceAnnotationSetValidationError, match="unknown referenced trace"):
+        write_trace_report(
+            trace_path=trace_copy,
+            annotation_path=annotation_path,
+            output=output,
+        )
+
+    assert not output.exists()
+
+
+def test_trace_report_renderer_rejects_output_only_annotation_sources(
+    tmp_path: Path,
+) -> None:
+    """Annotation reports should not depend on generated output-only trace sources."""
+
+    from scripts.tools.render_trace_report import write_trace_report
+
+    output_trace = tmp_path / "output" / "trace.json"
+    output_trace.parent.mkdir()
+    output_trace.write_text(ANNOTATED_TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    with pytest.raises(ValueError, match="not generated output"):
+        write_trace_report(
+            trace_path=output_trace,
+            annotation_path=ANNOTATION_FIXTURE_PATH,
+            output=tmp_path / "report.md",
+        )


### PR DESCRIPTION
## Summary
Adds annotation-aware Markdown rendering to the existing static simulation trace report tool for #1996.

## Linked Issues
- Closes #1996
- Relates to #1646
- Relates to #1859
- Relates to #1962

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Extended `scripts/tools/render_trace_report.py` with optional `--annotations` support for `trace_annotation_set.v1` fixtures.
- Added source-fixture and annotation-review sections that cite trace path, annotation path, annotation set id, frame ranges, event ids, entity refs, categories, and evidence types.
- Reused the existing annotation loader so missing trace fixtures, invalid frame ranges, unknown event ids, and generated `output/` timeline dependencies fail closed.
- Added renderer tests for report generation, mismatched trace/annotation pairs, invalid annotation references, and generated-output source rejection.

## Why It Matters
- Added value: gives the analysis workbench a compact, reviewable qualitative report before heavier viewer or AI discussion workflows.
- Expected impact: reviewers can inspect annotation anchors and evidence boundaries from tracked fixtures without running a browser UI.
- Why this is worth merging now: #1962 added the annotation fixture contract; this is the next smallest consumer proving the path is useful.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/tools/render_trace_report.py tests/analysis_workbench/test_trace_report_renderer.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/tools/render_trace_report.py tests/analysis_workbench/test_trace_report_renderer.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/analysis_workbench/test_trace_report_renderer.py tests/analysis_workbench/test_trace_annotation.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/render_trace_report.py --trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json --annotations tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json --output output/analysis_workbench/issue_1996_annotation_report.md`
  - `git diff --check`
- Evidence that the change works here: targeted tests passed with `16 passed`; the generated Markdown report includes `Source Fixtures`, `Annotation Review`, annotation set id `issue_1962_planner_sanity_open_annotations`, frame ranges `1-2`, `3-3`, `1-3`, event ids, `robot:robot`, and diagnostic-only wording.
- Benchmarks or smoke tests, if applicable: no benchmark run; this is analysis-workbench reporting only.

## Risks / Rollout
- Compatibility risks: existing `--trace` only usage remains supported; `--annotations` is optional.
- Failure modes: mismatched trace/annotation inputs now fail closed instead of producing a misleading report.
- Rollback or fallback plan: remove the optional annotation path and keep the trace-only renderer.

## Docs / Provenance
- Updated docs: none; the command help and PR body document the new option.
- Relevant design or provenance notes: parent #1646, trace fixture child #1859, annotation fixture child #1962.
- Any assumptions that need to be preserved: annotation reports are qualitative diagnostic artifacts, not benchmark or paper-facing evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): pending comment after PR creation
- Claim map / benchmark report updated (yes/no/NA): N/A
- Registry or config index updated (yes/no/NA): N/A
- Context index / memory note updated (yes/no/NA): N/A
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not-applicable rationale: this PR adds a bounded report generator and keeps browser/Three.js/AI discussion work deferred.

## Follow-Up Issues
- Deferred work: browser/Three.js viewer and AI discussion workflow remain out of scope per #1996.
- Issues opened for follow-up: none

## Reviewer Notes
- Please check that `observed`, `hypothesis`, and `commentary` are kept separate in the report table and that generated `output/` sources cannot be used as trace/annotation inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trace reports now support including external annotation data to enrich simulation summaries
  * Added `--annotations` CLI option to supply annotation sets during report generation

* **Bug Fixes**
  * Improved validation to detect mismatched or invalid annotation references before report output

* **Tests**
  * Expanded test coverage for annotation rendering and validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->