### PR TITLE
docs: clarify worktree lifecycle guidance

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -17,6 +17,7 @@ generated routing index; read the specific `SKILL.md` before applying a skill.
 | Open a ready PR | `gh-pr-opener` | `artifact-provenance` |
 | Verify branch claims | `implementation-verification` | `pr-ready-check` |
 | Run the standard readiness gate | `pr-ready-check` | none |
+| Set up or clean up worktrees | `skill-picker` | `gh-issue-autopilot`, `clean-up`; see `AGENTS.md` |
 | Review benchmark output | `analyze-camera-ready-benchmark` | `benchmark-row-status`, `artifact-provenance` |
 | Classify benchmark rows | `benchmark-row-status` | `review-benchmark-change` |
 | Keep one training SLURM job active | `goal-slurm-experiment` | `goal-issue-implementation`, `slurm-campaign-submit` |

--- a/.agents/skills/clean-up/SKILL.md
+++ b/.agents/skills/clean-up/SKILL.md
@@ -39,18 +39,26 @@ parallel tests, and diff-based quality gates.
    - `BASE_REF=origin/main scripts/dev/check_docstring_todos_diff.sh`
 6. Report:
    - Summarize passed/failed commands and any residual risk blocks (flaky or deferred tests).
+7. Optional worktree hygiene:
+   - If asked to tidy stale worktrees, follow `AGENTS.md` "Worktree Teardown And Preservation"
+     before removing or pruning anything.
+   - Inspect `output/` and other ignored local artifacts before cleanup; classify them as
+     disposable, ignored-cache, tracked-manifest, durable-required, or handoff-needed.
 
 ## Guardrails
 
 - Fix failures with intent; do not silence value-heavy tests without explicit direction.
 - If touched tests were added, verify those new tests locally.
 - For rendering or benchmark-affecting work, keep GUI/benchmarks in follow-up if required and noted.
+- Do not remove dirty or unpushed worktrees as part of cleanup unless preservation is explicitly
+  recorded.
 
 ## Output
 
 - Commands executed and pass/fail status.
 - List of remaining failures and the decision (fix, defer, investigate).
 - Remaining follow-up tasks before merge-ready handoff.
+- Any worktree or artifact cleanup inspected, preserved, skipped, or deferred.
 ## When to use
 
 Use this skill for the scope named in its frontmatter description and registry metadata.

--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -66,7 +66,9 @@ unless the user explicitly chooses a stacked-PR route.
    - set status back to `Tracked`,
    - stop with blocker.
 5. Move the issue to `In progress` (optionally normalize priority).
-6. Create issue branch (`gh issue develop` preferred; fallback to git branch).
+6. Create the issue branch in a linked worktree for non-trivial implementation. Prefer the
+   `AGENTS.md` "Fresh Worktree Bootstrap" location, naming, machine-context symlink, and branch
+   freshness rules; use an in-place branch only for tiny or explicitly requested main-checkout work.
 7. Implement inside accepted scope.
 8. Run validation gate and rerun on failures only when fixable.
 9. Commit with conventional message; if long-running benchmark evidence appears, classify artifacts.
@@ -80,6 +82,8 @@ unless the user explicitly chooses a stacked-PR route.
 
 - One active issue branch by default.
 - Keep branch names stable and issue-linked.
+- Before tearing down a worktree, follow `AGENTS.md` "Worktree Teardown And Preservation" so tracked,
+  untracked, and ignored-but-important local changes are preserved or explicitly dismissed.
 - Do not force-push, rewrite branch history, or merge unrelated issues into this branch.
 - If status/branch drift is detected mid-flow, pause and re-check before continuing.
 

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -290,7 +290,9 @@ Route remaining issues by their blocker:
 1. Select one issue (`gh-issue-sequencer` output or explicit user target).
 2. Re-check issue body/comments and open PRs for source-PR dependencies, active coverage, and
    duplicate branch/PR risk before branching.
-3. Create/checkout isolated implementation branch.
+3. Create/checkout the isolated implementation branch. For non-trivial local changes, prefer a
+   linked worktree and follow `AGENTS.md` "Fresh Worktree Bootstrap" for location, naming,
+   machine-context symlink, environment setup, and early `origin/main` freshness.
 4. Implement only in-scope behavior and required tests/docs.
 5. Validate using the narrowest meaningful level first, then expand.
 6. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
@@ -384,6 +386,9 @@ When a delegated worker produces a reusable workflow lesson, include an
 ## Race-Condition / Multi-Agent Safety
 
 - Operate one implementation branch at a time by default.
+- Before cleaning stale worktrees at loop end or after a PR handoff, follow `AGENTS.md` "Worktree
+  Teardown And Preservation" and record how relevant tracked, untracked, and ignored local changes
+  were preserved.
 - Before pushing, verify branch state is expected and avoid rewriting branch history.
 - If remote branch changed unexpectedly:
   - stop,

--- a/.agents/skills/skill-picker/SKILL.md
+++ b/.agents/skills/skill-picker/SKILL.md
@@ -46,6 +46,7 @@ Select the smallest useful repo-local skill stack when the user request is ambig
 | Open PR | `gh-pr-opener` | `artifact-provenance` |
 | Verify implementation | `implementation-verification` | `pr-ready-check` |
 | Branch cleanup | `clean-up` | `pr-ready-check` |
+| Worktree setup or cleanup | `skill-picker` | `gh-issue-autopilot`, `clean-up`; see `AGENTS.md` |
 | Benchmark-sensitive review | `review-benchmark-change` | `benchmark-row-status` |
 | Camera-ready benchmark audit | `analyze-camera-ready-benchmark` | `artifact-provenance` |
 | Submit training or benchmark job | `slurm-campaign-submit` | `artifact-provenance` |
@@ -68,7 +69,9 @@ Select the smallest useful repo-local skill stack when the user request is ambig
 - Do not treat skill-picker as mandatory pre-step for explicit single-skill requests.
 - Avoid proposing overly broad bundles that overlap the same phase.
 - Use exact repository-specific terminology from AGENTS/skills docs.
-- Match mutating skills to the user's permission and the current worktree safety constraints.
+- Match mutating skills to the user's permission and the current worktree safety constraints. For
+  worktree creation or cleanup, route to the existing issue/cleanup skill and the `AGENTS.md`
+  worktree lifecycle sections instead of inventing a new skill.
 
 ## Output
 

--- a/.agents/skills/tests/routing_cases.yaml
+++ b/.agents/skills/tests/routing_cases.yaml
@@ -39,6 +39,11 @@ cases:
   - pr-ready-check
   negative:
   - autoresearch
+- intent: Set up or clean up worktrees
+  primary: skill-picker
+  secondary:
+  - gh-issue-autopilot
+  - clean-up
 - intent: Edit non-claim docs
   primary: update-docs-on-code-change
   secondary: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,21 @@ When working in a linked Git worktree, detect bootstrap state before running exp
 - Do not create divergent per-worktree machine context files unless the worktree really needs
   machine-specific behavior that should not be inherited from the main checkout.
 
+## Worktree Teardown And Preservation
+
+Before removing or pruning worktrees, enumerate them with `git worktree list --porcelain` from the
+main checkout. For each candidate, inspect `git -C <path> status --short --branch`; when generated
+outputs may matter, also inspect ignored output paths such as
+`git -C <path> status --ignored --short -uall output`.
+
+- Preserve every relevant tracked, untracked, and ignored-but-important local change before removal
+  by committing it, stashing it, saving a patch, promoting a durable artifact, or recording an
+  explicit handoff.
+- Do not remove a dirty worktree or a worktree with unpushed commits unless the preservation record
+  says exactly what was kept or why nothing needed preservation.
+- Prefer `git worktree remove <path>` for clean worktrees and `git worktree prune` only after
+  verifying stale administrative entries no longer point at useful local state.
+
 ## Knowledge Capture & Context Notes
 
 Treat `docs/context/` as the repository's Markdown knowledge base for issue execution history and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ When working in a linked Git worktree, detect bootstrap state before running exp
 Before removing or pruning worktrees, enumerate them with `git worktree list --porcelain` from the
 main checkout. For each candidate, inspect `git -C <path> status --short --branch`; when generated
 outputs may matter, also inspect ignored output paths such as
-`git -C <path> status --ignored --short -uall output`.
+`[ -d "<path>/output" ] && git -C <path> status --ignored --short -uall output`.
 
 - Preserve every relevant tracked, untracked, and ignored-but-important local change before removal
   by committing it, stashing it, saving a patch, promoting a durable artifact, or recording an
@@ -275,9 +275,9 @@ resolving lint or test failures locally before requesting review.
   Merge the latest `origin/main` into the current branch at the start of active work, and repeat
   that sync before PR creation so validation covers the newest shared baseline.
 - Before creating a PR, inspect newly created `output/*` files, including ignored paths via
-  `git status --ignored --short -uall output`. Decide whether each output is disposable, should remain
-  ignored, should be represented by a tracked manifest or registry entry, or must be uploaded to a
-  durable artifact store before the branch is handed off.
+  `[ -d output ] && git status --ignored --short -uall output`. Decide whether each output is
+  disposable, should remain ignored, should be represented by a tracked manifest or registry entry,
+  or must be uploaded to a durable artifact store before the branch is handed off.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -105,7 +105,7 @@ git merge origin/main
 Before deleting old worktrees, run `git worktree list --porcelain` from the main checkout and inspect
 each candidate with `git -C <path> status --short --branch`. If the worktree may contain generated
 evidence or local experiment outputs, also inspect relevant ignored paths, for example
-`git -C <path> status --ignored --short -uall output`.
+`[ -d "<path>/output" ] && git -C <path> status --ignored --short -uall output`.
 
 Only remove a worktree after preserving relevant tracked, untracked, and ignored-but-important
 changes through a commit, stash, patch, durable artifact promotion, or explicit handoff note. Do not

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -100,6 +100,19 @@ git fetch origin main
 git merge origin/main
 ```
 
+### Worktree teardown and preservation
+
+Before deleting old worktrees, run `git worktree list --porcelain` from the main checkout and inspect
+each candidate with `git -C <path> status --short --branch`. If the worktree may contain generated
+evidence or local experiment outputs, also inspect relevant ignored paths, for example
+`git -C <path> status --ignored --short -uall output`.
+
+Only remove a worktree after preserving relevant tracked, untracked, and ignored-but-important
+changes through a commit, stash, patch, durable artifact promotion, or explicit handoff note. Do not
+delete dirty or unpushed worktrees unless the cleanup record states what was preserved or why nothing
+needed preservation. Use `git worktree remove <path>` for clean worktrees; reserve
+`git worktree prune` for stale administrative entries after local state is checked.
+
 ### Targeted shared-venv worktree validation
 
 For quick, targeted checks in a sibling worktree, you can reuse the main checkout virtualenv while

--- a/scripts/dev/generate_skills_readme.py
+++ b/scripts/dev/generate_skills_readme.py
@@ -71,6 +71,7 @@ def render_readme(registry: dict[str, Any]) -> str:
         "| Open a ready PR | `gh-pr-opener` | `artifact-provenance` |",
         "| Verify branch claims | `implementation-verification` | `pr-ready-check` |",
         "| Run the standard readiness gate | `pr-ready-check` | none |",
+        "| Set up or clean up worktrees | `skill-picker` | `gh-issue-autopilot`, `clean-up`; see `AGENTS.md` |",
         "| Review benchmark output | `analyze-camera-ready-benchmark` | `benchmark-row-status`, `artifact-provenance` |",
         "| Classify benchmark rows | `benchmark-row-status` | `review-benchmark-change` |",
         "| Keep one training SLURM job active | `goal-slurm-experiment` | `goal-issue-implementation`, `slurm-campaign-submit` |",


### PR DESCRIPTION
## Summary
Clarifies Robot SF worktree setup, teardown, and local-change preservation guidance in the central agent docs and the repo-local skill routing surfaces.

## Linked Issues
- Closes #1997

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Added `AGENTS.md` and `docs/dev_guide.md` guidance for inspecting worktrees before removal and preserving tracked, untracked, and ignored-but-important local changes.
- Updated issue implementation, issue autopilot, cleanup, and skill-picker guidance to route worktree setup/cleanup through existing skills and central docs instead of adding a new skill.
- Regenerated the skills README and added a routing golden for worktree setup/cleanup.

## Why It Matters
- Added value: reduces risk that agents delete local worktree changes or mix issue work into the main checkout.
- Expected impact: agents can find worktree lifecycle rules from the skills they already use.
- Why this is worth merging now: the policy existed centrally, but skill-level entry points did not make it discoverable.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/generate_skills_readme.py`
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `git diff --check`
- Evidence that the change works here: skill registry, generated README, routing tests, and AI-config symlink checks all passed.
- Benchmarks or smoke tests, if applicable: not applicable; this is a Tier 0 docs/skill guidance change.

## Risks / Rollout
- Compatibility risks: low; no skill names, schemas, runtime code, benchmark contracts, or planner behavior changed.
- Failure modes: agents may over-apply worktree creation for tiny edits; wording keeps linked worktrees preferred for non-trivial implementation and allows explicit main-checkout work.
- Rollback or fallback plan: revert the docs/skill wording if it proves too prescriptive.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/dev_guide.md`, `.agents/skills/*`, `.agents/skills/README.md`
- Relevant design or provenance notes: issue #1997
- Any assumptions that need to be preserved: no new `worktree-*` skill was added; central docs remain the source of truth.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): yes, generated skill README and routing golden updated
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not-applicable rationale: no benchmark, paper-facing, schema, or runtime contract changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: wording stays concise and points to central policy rather than duplicating a separate worktree skill.
- Any known limitations: full `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` was intentionally skipped for this docs/skill-only change.
