### PR TITLE
docs: add autopilot delegation checkpoints

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -102,10 +102,10 @@ Before each phase, run a delegation checkpoint:
   `critical-path-blocker`, `route-unavailable`, `sensitive-context`, `pure-synthesis`, or
   `local-publication-step`.
 
-Publication and final judgment remain local: delegates must not push, open or merge PRs, change
-labels/project state, resolve review threads, or make final benchmark/paper/safety claims unless
-the user explicitly grants that permission. Their output is route evidence that must be reviewed and
-validated before phase completion.
+Publication and final judgment remain local: delegates must not push, open, or merge PRs; change
+labels or project state; resolve review threads; or make final benchmark, paper, or safety claims
+unless the user explicitly grants that permission. Their output is route evidence that must be
+reviewed and validated before phase completion.
 
 Transitions:
 - After `implement`, proceed to `review`.

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -92,6 +92,21 @@ Each cycle iteration follows a fixed phase order:
 3. `merge` — delegate to `gh-pr-merger` for all `merge-ready` PRs.
 4. `discover` — delegate to `goal-issue-discovery` for bounded discovery.
 
+Before each phase, run a delegation checkpoint:
+
+- Choose the routed helper role for the phase when `ai-delegation-routing` is active:
+  queue scout, PR blocker reviewer, bounded editor, validation verifier, or discovery scout.
+- Start at least one eligible routed worker or Spark sidecar for any phase likely to exceed about
+  10 minutes, unless the next action is a local-only publication step or all routes are unavailable.
+- If no helper is used, record `delegation_skipped: <reason>` with one of: `tiny`,
+  `critical-path-blocker`, `route-unavailable`, `sensitive-context`, `pure-synthesis`, or
+  `local-publication-step`.
+
+Publication and final judgment remain local: delegates must not push, open or merge PRs, change
+labels/project state, resolve review threads, or make final benchmark/paper/safety claims unless
+the user explicitly grants that permission. Their output is route evidence that must be reviewed and
+validated before phase completion.
+
 Transitions:
 - After `implement`, proceed to `review`.
 - After `review`, proceed to `merge`.


### PR DESCRIPTION
## Summary
Adds an explicit delegation checkpoint to `goal-autopilot` so each phase records whether it routed helper work or why it stayed local.

## What Changed
- Requires an `ai-delegation-routing` checkpoint before each autopilot phase.
- Names expected helper roles: queue scout, PR blocker reviewer, bounded editor, validation verifier, or discovery scout.
- Requires `delegation_skipped: <reason>` when no helper is used.
- Preserves local ownership for publication, remote state changes, final validation, and benchmark/paper/safety judgment.

## Validation
- `git diff --check`
- `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`

## Notes
The companion personal-skill update was committed and pushed separately to `codex-personal-skills` as `4a0f508 docs: require delegation checkpoints`.
