### PR TITLE
feat: add cross-machine issue claim helper

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -65,23 +65,45 @@ unless the user explicitly chooses a stacked-PR route.
    - add `decision-required` (create if missing),
    - set status back to `Tracked`,
    - stop with blocker.
-5. Move the issue to `In progress` (optionally normalize priority).
-6. Create the issue branch in a linked worktree for non-trivial implementation. Prefer the
+5. Acquire the cross-machine issue claim before any implementation branch or worktree setup:
+
+   ```bash
+   uv run python scripts/dev/issue_claim.py acquire <issue-number>
+   ```
+
+   The command atomically creates the remote ref `agent-claims/issue-<issue-number>` through
+   GitHub's create-ref API, which fails when the ref already exists. If it exits non-zero, another
+   PC or agent probably claimed the issue first; run
+   `uv run python scripts/dev/issue_claim.py status <issue-number>`, record the collision, and skip
+   to the next candidate. Do not reimplement the issue unless the remote claim is confirmed stale
+   and deliberately released.
+6. After a successful claim, make the claim visible in GitHub issue/project state: move the issue to
+   `In progress`, add or preserve `state:running` when using state labels, assign the local actor
+   when practical, and add a short issue comment naming the claim ref, machine/thread, intended
+   implementation branch, and stale-claim cleanup condition.
+7. Create the issue branch in a linked worktree for non-trivial implementation. Prefer the
    `AGENTS.md` "Fresh Worktree Bootstrap" location, naming, machine-context symlink, and branch
    freshness rules; use an in-place branch only for tiny or explicitly requested main-checkout work.
-7. Implement inside accepted scope.
-8. Run validation gate and rerun on failures only when fixable.
-9. Commit with conventional message; if long-running benchmark evidence appears, classify artifacts.
-10. Sync with latest `origin/main`, rerun readiness, and check artifact durability.
-11. Re-check open PRs for the same linked issue, head scope, or title before opening a new PR.
-12. Open a ready PR using `gh-pr-opener`; use draft only when explicitly requested or when the
+8. Implement inside accepted scope.
+9. Run validation gate and rerun on failures only when fixable.
+10. Commit with conventional message; if long-running benchmark evidence appears, classify artifacts.
+11. Sync with latest `origin/main`, rerun readiness, and check artifact durability.
+12. Re-check open PRs for the same linked issue, head scope, or title before opening a new PR.
+13. Open a ready PR using `gh-pr-opener`; use draft only when explicitly requested or when the
     PR body names a concrete reason review should be blocked.
-13. For deferred important work, create follow-up issues and link them before final handoff.
+14. After the PR exists and the issue is visibly covered by the PR, release the transient claim with
+    `uv run python scripts/dev/issue_claim.py release <issue-number>`. Do not release the claim
+    earlier unless the run is abandoning the issue and records the handoff.
+15. For deferred important work, create follow-up issues and link them before final handoff.
 
 ## Branch and State Safety
 
 - One active issue branch by default.
 - Keep branch names stable and issue-linked.
+- Treat `agent-claims/issue-<number>` as the cross-machine mutex for implementation selection. A
+  successful claim means this run may proceed; a failed claim means skip the issue, inspect status,
+  and choose another candidate. Project status, labels, assignments, and comments are visibility
+  surfaces, not the atomic claim.
 - Before tearing down a worktree, follow `AGENTS.md` "Worktree Teardown And Preservation" so tracked,
   untracked, and ignored-but-important local changes are preserved or explicitly dismissed.
 - Do not force-push, rewrite branch history, or merge unrelated issues into this branch.

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -80,6 +80,9 @@ Record at start:
   saturated, or user stop.
 - Exclusions: blocked/decision-required issues, draft PRs, benchmark-heavy PRs that
   need manual review.
+- Coordination: implementation selection must use the `goal-issue-implementation` issue claim
+  protocol (`scripts/dev/issue_claim.py acquire <issue-number>`) before branching so concurrent
+  runs on different PCs do not implement the same issue.
 
 Do not ask for extra confirmation after this preflight.
 
@@ -122,6 +125,9 @@ Do not reorder phases or skip a phase that has eligible work.
 Each delegate skill may fail. Handle failures per phase:
 
 - `implement` failure:
+  - If issue-claim acquisition fails: classify the issue as already claimed/running, record
+    `scripts/dev/issue_claim.py status <issue-number>` output, skip the issue, and continue to the
+    next candidate. Do not branch or make local edits for that issue.
   - If the issue is ambiguous: route to `issue-contract-maintainer`, mark skipped.
   - If validation fails twice: mark issue `blocked`, record the failing command
     and last error, and continue to the next eligible issue.

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -290,14 +290,31 @@ Route remaining issues by their blocker:
 1. Select one issue (`gh-issue-sequencer` output or explicit user target).
 2. Re-check issue body/comments and open PRs for source-PR dependencies, active coverage, and
    duplicate branch/PR risk before branching.
-3. Create/checkout the isolated implementation branch. For non-trivial local changes, prefer a
+3. Acquire the cross-machine issue claim before branching:
+
+   ```bash
+   uv run python scripts/dev/issue_claim.py acquire <issue-number>
+   ```
+
+   The helper creates `agent-claims/issue-<issue-number>` through GitHub's create-ref API, which
+   fails when the ref already exists. If the command fails, treat the issue as already claimed by
+   another PC or agent, run `uv run python scripts/dev/issue_claim.py status <issue-number>` for the
+   handoff, and skip to the next candidate unless the claim is explicitly confirmed stale and
+   released.
+4. Make the successful claim visible in the issue/project surfaces: move the issue to `In progress`
+   or `state:running`, assign the actor when practical, and add a concise issue comment with the
+   claim ref, machine/thread, planned branch, and stale-claim cleanup condition.
+5. Create/checkout the isolated implementation branch. For non-trivial local changes, prefer a
    linked worktree and follow `AGENTS.md` "Fresh Worktree Bootstrap" for location, naming,
    machine-context symlink, environment setup, and early `origin/main` freshness.
-4. Implement only in-scope behavior and required tests/docs.
-5. Validate using the narrowest meaningful level first, then expand.
-6. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
-7. Prepare proof and branch handoff via `gh-pr-opener`.
-8. Open PR, then report and move to next queue item.
+6. Implement only in-scope behavior and required tests/docs.
+7. Validate using the narrowest meaningful level first, then expand.
+8. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
+9. Prepare proof and branch handoff via `gh-pr-opener`.
+10. Open PR, release the transient claim with
+    `uv run python scripts/dev/issue_claim.py release <issue-number>` once the PR visibly covers the
+    issue, then report and move to next queue item. If the run abandons the issue before PR opening,
+    release the claim only after recording the blocker or handoff.
 
 Never run unrelated refactors or paper-facing claims in this loop.
 
@@ -386,6 +403,13 @@ When a delegated worker produces a reusable workflow lesson, include an
 ## Race-Condition / Multi-Agent Safety
 
 - Operate one implementation branch at a time by default.
+- Use `scripts/dev/issue_claim.py acquire <issue-number>` as the first write after candidate
+  selection and duplicate-PR checks. The remote `agent-claims/issue-<number>` ref is the atomic
+  cross-machine claim; labels, assignments, Project #5 status, and comments are secondary visibility
+  signals.
+- If acquiring the claim fails, do not branch or implement. Record the existing claim status and
+  select another issue. Release only stale or abandoned claims after checking for an open PR or a
+  recent issue comment from the claimant.
 - Before cleaning stale worktrees at loop end or after a PR handoff, follow `AGENTS.md` "Worktree
   Teardown And Preservation" and record how relevant tracked, untracked, and ignored local changes
   were preserved.

--- a/docs/context/issue_713_batch_first_issue_workflow.md
+++ b/docs/context/issue_713_batch_first_issue_workflow.md
@@ -115,6 +115,43 @@ For larger automation, prefer a GitHub App or brokered local queue over several 
 sharing one rate-limit bucket. The broker should cache reads, throttle writes, prioritize project
 mutations, and degrade to local/REST-only mode when GraphQL quota is low.
 
+### Cross-Machine Issue Claims
+
+When two `goal-autopilot` or `goal-issue-implementation` runs may execute on different PCs, use a
+stable remote Git ref as the implementation mutex before creating a worktree or branch:
+
+```bash
+uv run python scripts/dev/issue_claim.py acquire <issue-number>
+```
+
+The helper creates `refs/heads/agent-claims/issue-<issue-number>` through GitHub's create-ref API,
+which fails when the ref already exists. That makes acquisition atomic enough for this workflow: the
+first PC succeeds, and later PCs fail instead of doing the same implementation work. A failed
+acquisition means "skip this issue now", not "retry until it wins". Inspect the current claim with:
+
+```bash
+uv run python scripts/dev/issue_claim.py status <issue-number>
+```
+
+After acquiring a claim, make it visible to humans and other agents by moving the issue to
+`In progress`/`state:running`, assigning the actor when practical, and adding a short comment with:
+
+- claim ref: `agent-claims/issue-<issue-number>`;
+- machine/thread identity;
+- intended implementation branch or worktree;
+- stale-claim cleanup condition.
+
+After a PR is open and duplicate-PR checks can see that the issue is covered, release the transient
+claim:
+
+```bash
+uv run python scripts/dev/issue_claim.py release <issue-number>
+```
+
+Only release another run's claim after checking that there is no open PR, no recent claimant comment,
+and the claim is clearly stale or abandoned. Do not use Project #5 status or labels as the mutex;
+they are useful visibility and routing metadata, but they are not atomic across two PCs.
+
 ## Diagnostic Boundary
 
 - This workflow is about GitHub issue/project hygiene.

--- a/scripts/dev/issue_claim.py
+++ b/scripts/dev/issue_claim.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Claim GitHub issues for cross-machine agent work with an atomic remote ref.
+
+The claim is a stable remote branch named ``agent-claims/issue-<number>``. Creating that
+ref through GitHub's create-ref API is atomic: if another machine already created it, the
+API call fails and this agent should skip the issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_REMOTE = "origin"
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_SOURCE_REF = "origin/main"
+CLAIM_PREFIX = "agent-claims"
+ISSUE_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Captured subprocess result with the command that produced it."""
+
+    command: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def validate_issue_number(value: str) -> int:
+    """Return a valid positive GitHub issue number."""
+    if not ISSUE_RE.match(value):
+        raise argparse.ArgumentTypeError("issue number must be a positive integer")
+    return int(value)
+
+
+def claim_ref(issue_number: int, *, prefix: str = CLAIM_PREFIX) -> str:
+    """Return the full Git ref used as the cross-machine issue claim."""
+    return f"refs/heads/{prefix}/issue-{issue_number}"
+
+
+def short_claim_ref(issue_number: int, *, prefix: str = CLAIM_PREFIX) -> str:
+    """Return the branch-style claim ref without ``refs/heads/``."""
+    return f"{prefix}/issue-{issue_number}"
+
+
+def _run(command: list[str]) -> CommandResult:
+    """Run a command without invoking a shell."""
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    return CommandResult(
+        command=tuple(command),
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def build_status_command(issue_number: int, *, remote: str) -> list[str]:
+    """Build the command that checks whether a claim ref exists."""
+    return ["git", "ls-remote", "--heads", remote, claim_ref(issue_number)]
+
+
+def build_resolve_source_command(*, source_ref: str) -> list[str]:
+    """Build the command that resolves the source commit for a new claim."""
+    return ["git", "rev-parse", "--verify", f"{source_ref}^{{commit}}"]
+
+
+def build_acquire_command(issue_number: int, *, repo: str, sha: str) -> list[str]:
+    """Build the atomic GitHub ref creation command."""
+    return [
+        "gh",
+        "api",
+        "-X",
+        "POST",
+        f"repos/{repo}/git/refs",
+        "-f",
+        f"ref={claim_ref(issue_number)}",
+        "-f",
+        f"sha={sha}",
+    ]
+
+
+def build_release_command(issue_number: int, *, remote: str) -> list[str]:
+    """Build the command that deletes a remote claim ref."""
+    return ["git", "push", remote, f":{claim_ref(issue_number)}"]
+
+
+def _status_from_ls_remote(
+    result: CommandResult, *, issue_number: int, remote: str
+) -> dict[str, Any]:
+    """Convert ``git ls-remote`` output into the command payload."""
+    if result.returncode != 0:
+        return {
+            "schema": "issue_claim.v1",
+            "action": "status",
+            "ok": False,
+            "claimed": None,
+            "issue": issue_number,
+            "remote": remote,
+            "claim_ref": short_claim_ref(issue_number),
+            "error": (result.stderr or result.stdout).strip(),
+            "command": list(result.command),
+        }
+
+    line = (result.stdout or "").strip()
+    if not line:
+        return {
+            "schema": "issue_claim.v1",
+            "action": "status",
+            "ok": True,
+            "claimed": False,
+            "issue": issue_number,
+            "remote": remote,
+            "claim_ref": short_claim_ref(issue_number),
+            "sha": None,
+            "command": list(result.command),
+        }
+
+    sha = line.split()[0]
+    return {
+        "schema": "issue_claim.v1",
+        "action": "status",
+        "ok": True,
+        "claimed": True,
+        "issue": issue_number,
+        "remote": remote,
+        "claim_ref": short_claim_ref(issue_number),
+        "sha": sha,
+        "command": list(result.command),
+    }
+
+
+def status_issue(issue_number: int, *, remote: str) -> dict[str, Any]:
+    """Return whether a remote claim currently exists."""
+    return _status_from_ls_remote(
+        _run(build_status_command(issue_number, remote=remote)),
+        issue_number=issue_number,
+        remote=remote,
+    )
+
+
+def acquire_issue(issue_number: int, *, repo: str, remote: str, source_ref: str) -> dict[str, Any]:
+    """Try to create the claim ref and return a machine-readable result."""
+    source_result = _run(build_resolve_source_command(source_ref=source_ref))
+    if source_result.returncode != 0:
+        return {
+            "schema": "issue_claim.v1",
+            "action": "acquire",
+            "ok": False,
+            "claimed": False,
+            "issue": issue_number,
+            "repo": repo,
+            "remote": remote,
+            "source_ref": source_ref,
+            "claim_ref": short_claim_ref(issue_number),
+            "command": list(source_result.command),
+            "stdout": source_result.stdout.strip(),
+            "stderr": source_result.stderr.strip(),
+            "error": "source_ref_resolution_failed",
+        }
+
+    sha = source_result.stdout.strip()
+    result = _run(build_acquire_command(issue_number, repo=repo, sha=sha))
+    ok = result.returncode == 0
+    return {
+        "schema": "issue_claim.v1",
+        "action": "acquire",
+        "ok": ok,
+        "claimed": ok,
+        "issue": issue_number,
+        "repo": repo,
+        "remote": remote,
+        "source_ref": source_ref,
+        "sha": sha,
+        "claim_ref": short_claim_ref(issue_number),
+        "command": list(result.command),
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+        "error": None
+        if ok
+        else (
+            "claim_ref_already_exists_or_create_ref_failed; run status to inspect the current owner "
+            "signal and skip this issue unless the claim is confirmed stale"
+        ),
+    }
+
+
+def release_issue(issue_number: int, *, remote: str) -> dict[str, Any]:
+    """Delete the remote claim ref."""
+    result = _run(build_release_command(issue_number, remote=remote))
+    ok = result.returncode == 0
+    return {
+        "schema": "issue_claim.v1",
+        "action": "release",
+        "ok": ok,
+        "claimed": False if ok else None,
+        "issue": issue_number,
+        "remote": remote,
+        "claim_ref": short_claim_ref(issue_number),
+        "command": list(result.command),
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+        "error": None
+        if ok
+        else "claim_ref_release_failed; inspect remote branch state before retrying",
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("acquire", "status", "release"))
+    parser.add_argument("issue", type=validate_issue_number)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository as OWNER/REPO.")
+    parser.add_argument("--remote", default=DEFAULT_REMOTE, help="Git remote to use for the claim.")
+    parser.add_argument(
+        "--source-ref",
+        default=DEFAULT_SOURCE_REF,
+        help="Local ref to push when acquiring the claim. Defaults to origin/main.",
+    )
+    return parser
+
+
+def _dump_json(payload: dict[str, Any]) -> None:
+    """Print stable JSON to stdout."""
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    if args.action == "status":
+        payload = status_issue(args.issue, remote=args.remote)
+    elif args.action == "acquire":
+        payload = acquire_issue(
+            args.issue,
+            repo=args.repo,
+            remote=args.remote,
+            source_ref=args.source_ref,
+        )
+    else:
+        payload = release_issue(args.issue, remote=args.remote)
+
+    _dump_json(payload)
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dev/issue_claim.py
+++ b/scripts/dev/issue_claim.py
@@ -108,8 +108,15 @@ def _status_from_ls_remote(
             "command": list(result.command),
         }
 
-    line = (result.stdout or "").strip()
-    if not line:
+    target_ref = claim_ref(issue_number)
+    sha = None
+    for line in (result.stdout or "").strip().splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == target_ref:
+            sha = parts[0]
+            break
+
+    if sha is None:
         return {
             "schema": "issue_claim.v1",
             "action": "status",
@@ -122,7 +129,6 @@ def _status_from_ls_remote(
             "command": list(result.command),
         }
 
-    sha = line.split()[0]
     return {
         "schema": "issue_claim.v1",
         "action": "status",
@@ -193,6 +199,22 @@ def acquire_issue(issue_number: int, *, repo: str, remote: str, source_ref: str)
 
 def release_issue(issue_number: int, *, remote: str) -> dict[str, Any]:
     """Delete the remote claim ref."""
+    status = status_issue(issue_number, remote=remote)
+    if status["ok"] and not status["claimed"]:
+        return {
+            "schema": "issue_claim.v1",
+            "action": "release",
+            "ok": True,
+            "claimed": False,
+            "issue": issue_number,
+            "remote": remote,
+            "claim_ref": short_claim_ref(issue_number),
+            "command": status["command"],
+            "stdout": "Ref does not exist, nothing to release.",
+            "stderr": "",
+            "error": None,
+        }
+
     result = _run(build_release_command(issue_number, remote=remote))
     ok = result.returncode == 0
     return {

--- a/tests/dev/test_issue_claim.py
+++ b/tests/dev/test_issue_claim.py
@@ -82,6 +82,100 @@ def test_status_payload_for_claimed_issue() -> None:
     assert payload["sha"] == "abc123"
 
 
+def test_status_payload_ignores_non_exact_ls_remote_matches() -> None:
+    """ls-remote may return suffix matches, so status should require the exact claim ref."""
+    result = issue_claim.CommandResult(
+        command=("git", "ls-remote"),
+        returncode=0,
+        stdout=(
+            "abc123\trefs/heads/archive/agent-claims/issue-123\n"
+            "def456\trefs/heads/agent-claims/issue-123-extra\n"
+        ),
+        stderr="",
+    )
+
+    payload = issue_claim._status_from_ls_remote(result, issue_number=123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["sha"] is None
+
+
+def test_status_payload_uses_exact_match_from_multiline_ls_remote() -> None:
+    """When multiple refs are returned, the exact claim ref should determine the status."""
+    result = issue_claim.CommandResult(
+        command=("git", "ls-remote"),
+        returncode=0,
+        stdout=(
+            "abc123\trefs/heads/archive/agent-claims/issue-123\n"
+            "def456\trefs/heads/agent-claims/issue-123\n"
+        ),
+        stderr="",
+    )
+
+    payload = issue_claim._status_from_ls_remote(result, issue_number=123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is True
+    assert payload["sha"] == "def456"
+
+
+def test_release_issue_succeeds_when_claim_ref_is_already_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release should be safe to retry after another process already deleted the ref."""
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> issue_claim.CommandResult:
+        calls.append(command)
+        return issue_claim.CommandResult(
+            command=tuple(command),
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(issue_claim, "_run", fake_run)
+
+    payload = issue_claim.release_issue(123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["stdout"] == "Ref does not exist, nothing to release."
+    assert len(calls) == 1
+    assert calls[0][0:2] == ["git", "ls-remote"]
+
+
+def test_release_issue_deletes_existing_claim_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Release should still delete the remote ref when status finds an existing claim."""
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> issue_claim.CommandResult:
+        calls.append(command)
+        if command[0:2] == ["git", "ls-remote"]:
+            return issue_claim.CommandResult(
+                command=tuple(command),
+                returncode=0,
+                stdout="abc123\trefs/heads/agent-claims/issue-123\n",
+                stderr="",
+            )
+        return issue_claim.CommandResult(
+            command=tuple(command),
+            returncode=0,
+            stdout="deleted\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(issue_claim, "_run", fake_run)
+
+    payload = issue_claim.release_issue(123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["stdout"] == "deleted"
+    assert calls[-1] == ["git", "push", "origin", ":refs/heads/agent-claims/issue-123"]
+
+
 def test_main_returns_failure_when_acquire_push_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """A rejected GitHub create-ref call should make the acquire command fail closed."""
     calls: list[list[str]] = []

--- a/tests/dev/test_issue_claim.py
+++ b/tests/dev/test_issue_claim.py
@@ -1,0 +1,108 @@
+"""Tests for the cross-machine issue claim helper."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from scripts.dev import issue_claim
+
+
+def test_claim_ref_is_stable_per_issue() -> None:
+    """Claim refs should be predictable so every PC contends for the same ref."""
+    assert issue_claim.claim_ref(123) == "refs/heads/agent-claims/issue-123"
+    assert issue_claim.short_claim_ref(123) == "agent-claims/issue-123"
+
+
+def test_validate_issue_number_rejects_non_positive_values() -> None:
+    """The CLI should reject invalid issue identifiers before building git refs."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        issue_claim.validate_issue_number("0")
+    with pytest.raises(argparse.ArgumentTypeError):
+        issue_claim.validate_issue_number("-1")
+    with pytest.raises(argparse.ArgumentTypeError):
+        issue_claim.validate_issue_number("abc")
+
+
+def test_build_resolve_source_command_uses_requested_ref() -> None:
+    """Acquire should resolve the requested source ref before creating a GitHub ref."""
+    command = issue_claim.build_resolve_source_command(source_ref="origin/main")
+
+    assert command == ["git", "rev-parse", "--verify", "origin/main^{commit}"]
+
+
+def test_build_acquire_command_uses_github_create_ref_api() -> None:
+    """Acquire should use GitHub create-ref so existing claims fail instead of fast-forwarding."""
+    command = issue_claim.build_acquire_command(123, repo="ll7/robot_sf_ll7", sha="abc123")
+
+    assert command == [
+        "gh",
+        "api",
+        "-X",
+        "POST",
+        "repos/ll7/robot_sf_ll7/git/refs",
+        "-f",
+        "ref=refs/heads/agent-claims/issue-123",
+        "-f",
+        "sha=abc123",
+    ]
+
+
+def test_status_payload_for_unclaimed_issue() -> None:
+    """Empty ls-remote output means no current issue claim."""
+    result = issue_claim.CommandResult(
+        command=("git", "ls-remote"),
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+
+    payload = issue_claim._status_from_ls_remote(result, issue_number=123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["claim_ref"] == "agent-claims/issue-123"
+    assert payload["sha"] is None
+
+
+def test_status_payload_for_claimed_issue() -> None:
+    """A matching remote ref should produce a claimed status with its SHA."""
+    result = issue_claim.CommandResult(
+        command=("git", "ls-remote"),
+        returncode=0,
+        stdout="abc123\trefs/heads/agent-claims/issue-123\n",
+        stderr="",
+    )
+
+    payload = issue_claim._status_from_ls_remote(result, issue_number=123, remote="origin")
+
+    assert payload["ok"] is True
+    assert payload["claimed"] is True
+    assert payload["sha"] == "abc123"
+
+
+def test_main_returns_failure_when_acquire_push_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rejected GitHub create-ref call should make the acquire command fail closed."""
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> issue_claim.CommandResult:
+        calls.append(command)
+        if command[0:2] == ["git", "rev-parse"]:
+            return issue_claim.CommandResult(
+                command=tuple(command),
+                returncode=0,
+                stdout="abc123\n",
+                stderr="",
+            )
+        return issue_claim.CommandResult(
+            command=tuple(command),
+            returncode=1,
+            stdout="",
+            stderr="remote ref already exists",
+        )
+
+    monkeypatch.setattr(issue_claim, "_run", fake_run)
+
+    assert issue_claim.main(["acquire", "123"]) == 1
+    assert calls[-1][0:4] == ["gh", "api", "-X", "POST"]


### PR DESCRIPTION
## Summary
Adds a cross-machine issue claim helper so two `goal-autopilot` runs do not implement the same issue in parallel. Updates the issue-implementation/autopilot skill docs and the Project #5 workflow note to acquire the claim before branching.

## Linked Issues
- Relates to multi-PC `goal-autopilot` coordination.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Added `scripts/dev/issue_claim.py` to acquire/status/release `agent-claims/issue-<number>` refs using GitHub create-ref for acquisition.
- Added focused unit tests for claim ref construction, status parsing, and fail-closed acquisition behavior.
- Updated `goal-autopilot`, `goal-issue-implementation`, `gh-issue-autopilot`, and `docs/context/issue_713_batch_first_issue_workflow.md` to treat the remote claim ref as the mutex and Project/labels/comments as visibility surfaces.

## Why It Matters
- Added value: prevents duplicate work when autonomous issue loops run on two PCs.
- Expected impact: the second runner skips an already claimed issue before creating a worktree or branch.
- Why this is worth merging now: it removes a practical race in the current multi-machine workflow without adding a new service.

## Validation / Proof
- Commands run: none in this PR-opening turn, per user instruction to open the PR without local tests.
- Evidence that the change works here: not locally re-run for this PR handoff.
- Benchmarks or smoke tests, if applicable: N/A.

Note: the commit hook automatically ran Ruff and Ruff format during `git commit`; no pytest or PR-readiness gate was run in this turn.

## Risks / Rollout
- Compatibility risks: requires `gh` auth with permission to create Git refs in `ll7/robot_sf_ll7`.
- Failure modes: stale claim refs can block an issue until inspected and released; the docs require checking for open PRs/recent claimant comments before releasing another run's claim.
- Rollback or fallback plan: revert the helper/docs and return to Project status/duplicate-PR checks only.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-autopilot/SKILL.md`, `.agents/skills/goal-issue-implementation/SKILL.md`, `.agents/skills/gh-issue-autopilot/SKILL.md`, `docs/context/issue_713_batch_first_issue_workflow.md`.
- Relevant design or provenance notes: issue claims are transient remote refs; Project status, labels, assignments, and comments are secondary visibility signals.
- Any assumptions that need to be preserved: claim acquisition happens after candidate/duplicate-PR checks and before branch/worktree creation.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not-applicable rationale: workflow helper/docs change only; no benchmark, registry, or paper-facing surface changed.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify whether the chosen transient ref namespace `agent-claims/issue-<number>` is acceptable for this repository.
- Verify the stale-claim release policy is conservative enough for two-PC autopilot use.
