### PR TITLE
fix: repair shielded PPO smoke handoff

### DIFF
--- a/configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml
+++ b/configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml
@@ -3,6 +3,7 @@ algo: guarded_ppo
 base_config_path: configs/algos/guarded_ppo_relaxed_v2.yaml
 params:
   model_id: ppo_expert_issue_1474_shielded_repair_collision20_5m
+  observation_mode: socnav_state
   guard_rollout_steps: 5
   guard_hard_ped_clearance: 0.44
   guard_first_step_ped_clearance: 0.56

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -287,6 +287,8 @@ knowledge, not every transient iteration detail.
   [issue_1396_shielded_ppo_launch_packet.md](issue_1396_shielded_ppo_launch_packet.md)
 * Issue #1474 Shielded PPO Repair Closeout (2026-06-01):
   [issue_1474_shielded_ppo_repair_closeout.md](issue_1474_shielded_ppo_repair_closeout.md)
+* Issue #2006 Guarded-PPO Zero-Motion Repair (2026-06-01):
+  [issue_2006_guarded_ppo_zero_motion_repair.md](issue_2006_guarded_ppo_zero_motion_repair.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
 * Issue #1686 Learned-Policy Artifact Manifest Fields (2026-05-30):

--- a/docs/context/evidence/issue_2006_shielded_ppo_smoke_after_summary.json
+++ b/docs/context/evidence/issue_2006_shielded_ppo_smoke_after_summary.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "artifact_provenance_summary.v1",
+  "issue": 2006,
+  "candidate": "shielded_ppo_issue1474_collision20_v1",
+  "stage": "smoke",
+  "classification": "tracked-compact-evidence",
+  "generated_at_date": "2026-06-01",
+  "git_commit_before_fix": "3cc4a21e6e151e9830e89d07dff95bdbc5337536",
+  "command": "scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/run_policy_search_candidate.py --candidate shielded_ppo_issue1474_collision20_v1 --stage smoke --horizon 80 --workers 1 --output-dir output/issue_2006_policy_smoke_h80_after",
+  "local_artifacts": {
+    "summary_json": "output/issue_2006_policy_smoke_h80_after/summary.json",
+    "jsonl": "output/issue_2006_policy_smoke_h80_after/smoke__shielded_ppo_issue1474_collision20_v1.jsonl"
+  },
+  "config_change_under_test": {
+    "path": "configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml",
+    "field": "params.observation_mode",
+    "value": "socnav_state"
+  },
+  "before_repair": {
+    "source": "docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md before issue-2006 repair",
+    "success_rate": 0.0,
+    "collision_rate": 0.0,
+    "mean_avg_speed": 0.0,
+    "failure_mode": "overconservative_stop",
+    "shield_decision_count": 80,
+    "shield_intervention_count": 0,
+    "shield_override_count": 0,
+    "guard_decision_counts": {
+      "goal_reached": 80
+    }
+  },
+  "after_repair": {
+    "episodes": 1,
+    "success_rate": 1.0,
+    "collision_rate": 0.0,
+    "near_miss_rate": 0.0,
+    "mean_avg_speed": 1.8865534541613158,
+    "termination_reason_counts": {
+      "success": 1
+    },
+    "failure_mode_counts": {},
+    "shield_decision_count": 75,
+    "shield_intervention_count": 10,
+    "shield_override_count": 10,
+    "guard_decision_counts": {
+      "ppo_clear": 65,
+      "fallback_safe": 10
+    },
+    "observation_mode": "socnav_state",
+    "observation_level": "tracked_agents_no_noise"
+  },
+  "claim_boundary": "Single-episode local smoke evidence that the issue-2006 zero-motion launch-packet blocker is repaired; not nominal, stress, full-matrix, or benchmark-strength evidence."
+}

--- a/docs/context/issue_2006_guarded_ppo_zero_motion_repair.md
+++ b/docs/context/issue_2006_guarded_ppo_zero_motion_repair.md
@@ -1,0 +1,61 @@
+# Issue #2006 Guarded-PPO Zero-Motion Repair 2026-06-01
+
+## Scope
+
+Issue #2006 repairs the first post-training smoke failure for
+`shielded_ppo_issue1474_collision20_v1`. The failure was not a new training failure: the runtime
+handoff evaluated the #1474 checkpoint through the default guarded-PPO observation path instead of
+the SocNav structured observation contract used during training.
+
+## Root Cause
+
+Two local guard assumptions made the failure look like an overconservative stop:
+
+- `configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml` did not request
+  `observation_mode: socnav_state`, so the PPO and guard received the wrong benchmark observation
+  surface.
+- `GuardedPPOAdapter` selected `goal.next` whenever it was nonzero and did not honor array-shaped
+  pedestrian counts. With padded/default observations this could produce repeated
+  `goal_reached` decisions or treat padded zero pedestrian rows as real near-field blockers.
+
+## Local Repair Evidence
+
+Local validation from branch `issue-2006-guarded-ppo-zero-motion`:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run pytest \
+  tests/planner/test_guarded_ppo.py \
+  tests/validation/test_run_policy_search_candidate.py::test_shielded_ppo_issue1474_candidate_requests_training_observation_contract -q
+scripts/dev/run_worktree_shared_venv.sh -- uv run python \
+  scripts/validation/validate_policy_search_registry.py \
+  docs/context/policy_search/candidate_registry.yaml --max-age-days 30
+scripts/dev/run_worktree_shared_venv.sh -- uv run python \
+  scripts/validation/validate_shielded_ppo_launch_packet.py \
+  --config configs/training/shielded_ppo_issue_1396_launch_packet.yaml --json
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 \
+  scripts/dev/run_worktree_shared_venv.sh -- uv run python \
+  scripts/validation/run_policy_search_candidate.py \
+  --candidate shielded_ppo_issue1474_collision20_v1 \
+  --stage smoke --workers 1 --output-dir output/policy_search_issue2006_local
+```
+
+The repaired local smoke passed the launch-packet smoke gate:
+
+| Metric | Value |
+| --- | ---: |
+| `success_rate` | `1.0` |
+| `collision_rate` | `0.0` |
+| `near_miss_rate` | `0.0` |
+| `mean_avg_speed` | `1.9996905469041861` |
+| `shield_decision_count` | `71` |
+| `shield_intervention_rate` | `0.0` |
+| `shield_override_rate` | `0.0` |
+
+The guard diagnostics were `decision_counts.ppo_clear=71`, replacing the previous
+`decision_counts.goal_reached=80` zero-motion timeout.
+
+## Boundary
+
+This is local smoke evidence, not benchmark promotion evidence. The local machine context forbids
+SLURM submission from this host, so SLURM smoke replay remains a follow-up gate before any
+nominal-sanity, stress, or full-matrix escalation.

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -715,8 +715,9 @@ candidates:
       checkpoint should reduce unsafe PPO proposals while preserving enough
       learned progress to pass the shielded-PPO smoke and nominal-sanity stop
       gates. The first post-training smoke failed the launch-packet success
-      gate with an overconservative zero-motion timeout, so this candidate
-      should not be included in routine sweeps until repaired.
+      gate with an overconservative zero-motion timeout; issue #2006 repaired
+      the local smoke handoff, but the row stays prototype-gated until SLURM
+      smoke replay and nominal-sanity escalation are explicitly approved.
     required_stages:
       - smoke
       - nominal_sanity

--- a/docs/context/policy_search/learned_policy_registry.md
+++ b/docs/context/policy_search/learned_policy_registry.md
@@ -177,11 +177,11 @@ adapter-only proof are useful planning evidence, but they are not benchmark evid
 - `checkpoint_availability`: W&B artifact
   `ll7/robot_sf/ppo_expert_issue_1474_shielded_repair_collision20_5m-best-success:v5`.
 - `expected_dependencies`: local repo plus W&B artifact hydration.
-- `reproducibility_status`: training complete; first guarded smoke failed the launch-packet success
-  gate with an overconservative zero-motion timeout.
-- `integration_status`: staged candidate config, blocked from routine sweeps until repaired.
-- `benchmark_status`: blocked until the launch-packet smoke and nominal-sanity stop gates pass with
-  guard diagnostics present.
+- `reproducibility_status`: training complete; issue #2006 local guarded smoke passes the
+  launch-packet smoke gate after restoring the SocNav observation handoff.
+- `integration_status`: staged candidate config, prototype-gated until SLURM smoke replay or an
+  explicit maintainer escalation decision.
+- `benchmark_status`: blocked until nominal-sanity stop gates pass with guard diagnostics present.
 - `local_anchors`:
   - `configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml`
   - `configs/training/shielded_ppo_issue_1396_launch_packet.yaml`

--- a/docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md
+++ b/docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md
@@ -4,18 +4,14 @@
 
 pass
 
-## Launch Packet Gate
-
-fail
-
-The generic policy-search smoke decision is `pass` because the single episode had no collision or
-near miss. The issue #1396/#1474 launch packet is stricter: smoke requires success `1.0`, collision
-`0.0`, and guard fallback rate at most `0.60`. This run had success `0.0`, so nominal-sanity
-escalation is blocked.
-
 ## Hypothesis
 
 Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_ppo_v1 runtime guard with the issue #1474 collision-20 repair checkpoint should reduce unsafe PPO proposals while preserving enough learned progress to pass the shielded-PPO smoke and nominal-sanity stop gates.
+
+Issue #2006 root cause: the candidate previously inherited the guarded-PPO default
+`sensor_fusion_state` observation mode, but the runtime guard consumes SocNav goal fields. The guard
+therefore parsed missing goal fields as zeros, classified every step as `goal_reached`, and selected
+zero motion. The repaired candidate sets `params.observation_mode: socnav_state`.
 
 
 ## Evaluation Scope
@@ -24,35 +20,39 @@ Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_
 - Algorithm: `guarded_ppo`
 - Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
 - Seed manifest: `suite default`
-- Summary JSON: `output/policy_search/shielded_ppo_issue1474_collision20_v1/smoke/issue1474_collision20_post_training_smoke/summary.json`
-- Git commit: `dac66644c040ca3d25e334bce9815b926ff4be5f`
+- Summary JSON: `output/issue_2006_policy_smoke_h80_after/summary.json`
+- Compact evidence: `docs/context/evidence/issue_2006_shielded_ppo_smoke_after_summary.json`
+- Git commit: `3cc4a21e6e151e9830e89d07dff95bdbc5337536`
 
 ## Aggregate Results
 
 | Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
 |---:|---:|---:|---:|---:|---:|
-| 1 | 0.0000 | 0.0000 | 0.0000 | n/a | 0.0000 |
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.8866 |
 
 ## Scenario-Family Split
 
 | Family | Episodes | Success | Collision | Near Miss |
 |---|---:|---:|---:|---:|
-| nominal | 1 | 0.0000 | 0.0000 | 0.0000 |
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
 
 ## Failure Taxonomy
 
-- `overconservative_stop`: `1`
+- No failures recorded.
 
 ## Guard Diagnostics
 
-The smoke JSONL reports `shield_decision_count=80`, `shield_intervention_count=0`,
-`shield_override_count=0`, and `decision_counts.goal_reached=80`. The guarded wrapper selected zero
-motion throughout the episode, producing a timeout rather than a useful smoke success.
+Before the issue #2006 repair, the smoke JSONL reported `shield_decision_count=80`,
+`shield_intervention_count=0`, `shield_override_count=0`, and
+`decision_counts.goal_reached=80`. After the observation-contract repair, the local smoke reported
+`shield_decision_count=75`, `shield_intervention_count=10`, `shield_override_count=10`,
+`decision_counts.ppo_clear=65`, and `decision_counts.fallback_safe=10`. Treat this as
+single-episode launch-packet smoke evidence, not nominal, stress, or full-matrix evidence.
 
 ## Baseline Deltas
 
 | Baseline | Success Delta | Collision Delta | Near-Miss Delta |
 |---|---:|---:|---:|
-| goal | -0.0142 | -0.2411 | n/a |
-| orca | -0.1844 | -0.0355 | n/a |
-| ppo | -0.2482 | -0.0993 | n/a |
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |

--- a/docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md
+++ b/docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md
@@ -6,16 +6,23 @@ pass
 
 ## Launch Packet Gate
 
-fail
+pass
 
-The generic policy-search smoke decision is `pass` because the single episode had no collision or
-near miss. The issue #1396/#1474 launch packet is stricter: smoke requires success `1.0`, collision
-`0.0`, and guard fallback rate at most `0.60`. This run had success `0.0`, so nominal-sanity
-escalation is blocked.
+The issue #1396/#1474 launch packet requires smoke success `1.0`, collision `0.0`, and
+guard fallback rate at most `0.60`. The issue #2006 local repair smoke observed success `1.0`,
+collision `0.0`, near miss `0.0`, shield intervention rate `0.0`, and shield override rate `0.0`.
+All `71` shield decisions were `ppo_clear`.
+
+## Repair Note
+
+Issue #2006 fixed the handoff by running this guarded-PPO candidate with the SocNav observation
+contract used by the #1474 training checkpoint. The guard also now tracks `goal.current` before
+switching to `goal.next` and honors array-shaped pedestrian counts so padded observation rows do
+not become synthetic near-field blockers.
 
 ## Hypothesis
 
-Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_ppo_v1 runtime guard with the issue #1474 collision-20 repair checkpoint should reduce unsafe PPO proposals while preserving enough learned progress to pass the shielded-PPO smoke and nominal-sanity stop gates.
+Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_ppo_v1 runtime guard with the issue #1474 collision-20 repair checkpoint should reduce unsafe PPO proposals while preserving enough learned progress to pass the shielded-PPO smoke and nominal-sanity stop gates. The first post-training smoke failed the launch-packet success gate with an overconservative zero-motion timeout; issue #2006 repaired the local smoke handoff, but the row stays prototype-gated until SLURM smoke replay and nominal-sanity escalation are explicitly approved.
 
 
 ## Evaluation Scope
@@ -24,35 +31,29 @@ Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_
 - Algorithm: `guarded_ppo`
 - Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
 - Seed manifest: `suite default`
-- Summary JSON: `output/policy_search/shielded_ppo_issue1474_collision20_v1/smoke/issue1474_collision20_post_training_smoke/summary.json`
-- Git commit: `dac66644c040ca3d25e334bce9815b926ff4be5f`
+- Summary JSON: `output/policy_search_issue2006_local/summary.json`
+- Git commit: `b6f17e45de2d12303a692353d615bf98397caa07`
 
 ## Aggregate Results
 
 | Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
 |---:|---:|---:|---:|---:|---:|
-| 1 | 0.0000 | 0.0000 | 0.0000 | n/a | 0.0000 |
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.9997 |
 
 ## Scenario-Family Split
 
 | Family | Episodes | Success | Collision | Near Miss |
 |---|---:|---:|---:|---:|
-| nominal | 1 | 0.0000 | 0.0000 | 0.0000 |
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
 
 ## Failure Taxonomy
 
-- `overconservative_stop`: `1`
-
-## Guard Diagnostics
-
-The smoke JSONL reports `shield_decision_count=80`, `shield_intervention_count=0`,
-`shield_override_count=0`, and `decision_counts.goal_reached=80`. The guarded wrapper selected zero
-motion throughout the episode, producing a timeout rather than a useful smoke success.
+- No failures recorded.
 
 ## Baseline Deltas
 
 | Baseline | Success Delta | Collision Delta | Near-Miss Delta |
 |---|---:|---:|---:|
-| goal | -0.0142 | -0.2411 | n/a |
-| orca | -0.1844 | -0.0355 | n/a |
-| ppo | -0.2482 | -0.0993 | n/a |
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |

--- a/robot_sf/planner/guarded_ppo.py
+++ b/robot_sf/planner/guarded_ppo.py
@@ -206,14 +206,21 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
         heading = float(self._as_1d_float(robot_state.get("heading", [0.0]), pad=1)[0])
         goal_next = self._as_1d_float(goal_state.get("next", [0.0, 0.0]), pad=2)[:2]
         goal_current = self._as_1d_float(goal_state.get("current", [0.0, 0.0]), pad=2)[:2]
-        goal = goal_next if np.linalg.norm(goal_next - robot_pos) > 1e-6 else goal_current
+        current_dist = float(np.linalg.norm(goal_current - robot_pos))
+        next_dist = float(np.linalg.norm(goal_next - robot_pos))
+        if current_dist > float(self.config.goal_tolerance):
+            goal = goal_current
+        elif next_dist > 1e-6:
+            goal = goal_next
+        else:
+            goal = goal_current
 
         ped_positions_raw = ped_state.get("positions")
         ped_velocities_raw = ped_state.get("velocities")
         ped_pos = np.asarray([] if ped_positions_raw is None else ped_positions_raw, dtype=float)
         ped_vel = np.asarray([] if ped_velocities_raw is None else ped_velocities_raw, dtype=float)
-        ped_count_raw = ped_state.get("count")
-        ped_count = int(ped_count_raw) if isinstance(ped_count_raw, int | np.integer) else None
+        ped_count_arr = self._as_1d_float(ped_state.get("count", []), pad=0)
+        ped_count = int(max(ped_count_arr[0], 0.0)) if ped_count_arr.size > 0 else None
         if (
             ped_pos.ndim == 1
             and ped_count is not None
@@ -230,8 +237,12 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
             ped_vel = ped_vel.reshape(-1, 2)[:ped_count]
         if ped_pos.ndim != 2 or ped_pos.shape[-1] != 2:
             ped_pos = np.zeros((0, 2), dtype=float)
+        elif ped_count is not None:
+            ped_pos = ped_pos[: min(ped_count, ped_pos.shape[0])]
         if ped_vel.ndim != 2 or ped_vel.shape[-1] != 2 or ped_vel.shape[0] != ped_pos.shape[0]:
             ped_vel = np.zeros_like(ped_pos)
+        elif ped_count is not None:
+            ped_vel = ped_vel[: min(ped_count, ped_vel.shape[0])]
         return robot_pos, heading, goal, ped_pos, ped_vel
 
     def _min_obstacle_clearance(self, point: np.ndarray, observation: dict[str, Any]) -> float:

--- a/tests/planner/test_guarded_ppo.py
+++ b/tests/planner/test_guarded_ppo.py
@@ -17,12 +17,16 @@ def _obs(
     robot=(0.0, 0.0),
     heading=0.0,
     goal=(2.0, 0.0),
+    next_goal=None,
     ped_positions=None,
     ped_velocities=None,
+    ped_count=None,
 ) -> dict[str, object]:
     """Build the minimal observation payload consumed by the guard tests."""
     ped_positions = [] if ped_positions is None else ped_positions
     ped_velocities = [] if ped_velocities is None else ped_velocities
+    next_goal = goal if next_goal is None else next_goal
+    ped_count = len(ped_positions) if ped_count is None else ped_count
     return {
         "robot": {
             "position": np.asarray(robot, dtype=float),
@@ -31,11 +35,12 @@ def _obs(
         },
         "goal": {
             "current": np.asarray(goal, dtype=float),
-            "next": np.asarray(goal, dtype=float),
+            "next": np.asarray(next_goal, dtype=float),
         },
         "pedestrians": {
             "positions": np.asarray(ped_positions, dtype=float),
             "velocities": np.asarray(ped_velocities, dtype=float),
+            "count": np.asarray([ped_count], dtype=float),
         },
     }
 
@@ -514,6 +519,42 @@ def test_guarded_ppo_goal_and_clear_branches() -> None:
     assert decision == "goal_reached"
 
     command, decision = guard.choose_command(_obs(ped_positions=[(2.0, 2.0)]), (0.3, 0.1))
+    assert command == (0.3, 0.1)
+    assert decision == "ppo_clear"
+
+
+def test_guarded_ppo_tracks_current_goal_before_next_waypoint() -> None:
+    """Near next waypoint should not short-circuit while the current goal remains far away."""
+    guard = GuardedPPOAdapter(
+        config=build_guarded_ppo_config({"goal_tolerance": 0.3, "guard_near_field_distance": 0.5}),
+        fallback_adapter=_FallbackAdapter((0.1, 0.2)),
+    )
+
+    command, decision = guard.choose_command(
+        _obs(robot=(1.0, 1.0), goal=(5.0, 1.0), next_goal=(1.1, 1.0)),
+        (0.3, 0.1),
+    )
+
+    assert command == (0.3, 0.1)
+    assert decision == "ppo_clear"
+
+
+def test_guarded_ppo_honors_array_pedestrian_count_for_padded_rows() -> None:
+    """Padded zero pedestrian rows from SocNav observations should not become real blockers."""
+    guard = GuardedPPOAdapter(
+        config=build_guarded_ppo_config({"guard_near_field_distance": 0.5}),
+        fallback_adapter=_FallbackAdapter((0.1, 0.2)),
+    )
+
+    command, decision = guard.choose_command(
+        _obs(
+            ped_positions=[(0.0, 0.0), (0.0, 0.0)],
+            ped_velocities=[(0.0, 0.0), (0.0, 0.0)],
+            ped_count=0,
+        ),
+        (0.3, 0.1),
+    )
+
     assert command == (0.3, 0.1)
     assert decision == "ppo_clear"
 

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -133,7 +133,7 @@ def test_orca_residual_guarded_candidate_requests_training_observation_contract(
 
 def test_issue1474_shielded_ppo_candidate_requests_guard_observation_contract() -> None:
     """Issue #2006 candidate should expose goal fields consumed by the runtime guard."""
-    repo_root = Path(__file__).parents[2]
+    repo_root = Path(__file__).resolve().parents[2]
 
     _entry, payload, config, config_path = load_candidate_definition(
         repo_root / "docs/context/policy_search/candidate_registry.yaml",

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -131,6 +131,27 @@ def test_orca_residual_guarded_candidate_requests_training_observation_contract(
     )
 
 
+def test_issue1474_shielded_ppo_candidate_requests_guard_observation_contract() -> None:
+    """Issue #2006 candidate should expose goal fields consumed by the runtime guard."""
+    repo_root = Path(__file__).parents[2]
+
+    _entry, payload, config, config_path = load_candidate_definition(
+        repo_root / "docs/context/policy_search/candidate_registry.yaml",
+        "shielded_ppo_issue1474_collision20_v1",
+    )
+
+    assert payload["algo"] == "guarded_ppo"
+    assert config["obs_mode"] == "dict"
+    assert config["observation_mode"] == "socnav_state"
+    assert (
+        config_path
+        == (
+            repo_root
+            / "configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml"
+        ).resolve()
+    )
+
+
 def test_risk_surface_candidate_uses_smoke_progress_recovery_speed() -> None:
     """Risk-surface smoke candidate should opt into the 2 m/s local command envelope."""
     repo_root = Path(__file__).resolve().parents[2]

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -131,6 +131,28 @@ def test_orca_residual_guarded_candidate_requests_training_observation_contract(
     )
 
 
+def test_shielded_ppo_issue1474_candidate_requests_training_observation_contract() -> None:
+    """Issue #1474 shielded-PPO repair should use the SocNav contract it trained with."""
+    repo_root = Path(__file__).parents[2]
+
+    _entry, payload, config, config_path = load_candidate_definition(
+        repo_root / "docs/context/policy_search/candidate_registry.yaml",
+        "shielded_ppo_issue1474_collision20_v1",
+    )
+
+    assert payload["algo"] == "guarded_ppo"
+    assert config["obs_mode"] == "dict"
+    assert config["observation_mode"] == "socnav_state"
+    assert config["model_id"] == "ppo_expert_issue_1474_shielded_repair_collision20_5m"
+    assert (
+        config_path
+        == (
+            repo_root
+            / "configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml"
+        ).resolve()
+    )
+
+
 def test_risk_surface_candidate_uses_smoke_progress_recovery_speed() -> None:
     """Risk-surface smoke candidate should opt into the 2 m/s local command envelope."""
     repo_root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- repair the guarded-PPO issue #1474 smoke handoff by forcing the candidate back onto the `socnav_state` observation contract it trained with
- harden `GuardedPPOAdapter` so it tracks `goal.current` before switching to `goal.next`, and honors array-shaped pedestrian counts from padded SocNav observations
- record issue #2006 local smoke evidence and keep the candidate prototype-gated until SLURM smoke replay / nominal escalation are explicitly approved

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_guarded_ppo.py tests/validation/test_run_policy_search_candidate.py::test_shielded_ppo_issue1474_candidate_requests_training_observation_contract -q` (24 passed)
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_policy_search_candidate.py --candidate shielded_ppo_issue1474_collision20_v1 --stage smoke --workers 1 --output-dir <ignored-worktree-artifact-dir>` (decision `pass`; success `1.0`, collision `0.0`, mean avg speed `1.9997`, guard decisions `ppo_clear=71`)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_2006_guarded_ppo_zero_motion_repair.md --path docs/context/README.md --path docs/context/policy_search/reports/2026-06-01_shielded_ppo_issue1474_collision20_v1_smoke.md --path docs/context/policy_search/candidate_registry.yaml --path docs/context/policy_search/learned_policy_registry.md --path docs/context/evidence/issue_2006_shielded_ppo_smoke_after_summary.json`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/guarded_ppo.py tests/planner/test_guarded_ppo.py tests/validation/test_run_policy_search_candidate.py`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (4,947 passed, 9 skipped; head `26a0c872`)

## Notes
- Local machine context has `allow_slurm_submission: false`, so this PR does not claim SLURM smoke replay, nominal, stress, or full-matrix benchmark evidence.
- Refs #2006.
