### PR TITLE
feat: add canonical benchmark table exporter

### DIFF
--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -642,6 +642,23 @@ failure, fallback, degraded execution, or availability. Continue to interpret
 benchmark evidence through `availability_status`, `benchmark_success`, and the
 fail-closed fallback policy above.
 
+Canonical table exporter:
+
+```bash
+uv run robot_sf_bench export-canonical-table \
+  --table-id planner_outcome_summary \
+  --rows output/benchmarks/camera_ready/<campaign_id>/reports/planner_rows.json \
+  --out-dir output/benchmarks/camera_ready/<campaign_id>/reports/canonical_tables \
+  --source output/benchmarks/camera_ready/<campaign_id>/reports/campaign_summary.json
+```
+
+The exporter writes `csv`, `md`, and `tex` fragments plus
+`<table-id>.metadata.json` with source checksums, command, commit, row count, selected columns, and
+generated output paths. Named table contracts currently cover planner outcome, scenario-family,
+seed-variability, execution-mode, and artifact-source summaries. Fallback, degraded, failed, and
+not-available rows remain explicit table rows; the exporter only formats rows and records
+provenance, and does not recompute benchmark metrics or reinterpret row status.
+
 ## Notes on Experimental Planners
 
 Experimental planners are executed with explicit profile and prereq policy from

--- a/robot_sf/benchmark/canonical_table_export.py
+++ b/robot_sf/benchmark/canonical_table_export.py
@@ -271,9 +271,7 @@ def _latex_escape(text: str) -> str:
         "~": r"\textasciitilde{}",
         "^": r"\textasciicircum{}",
     }
-    for source, replacement in replacements.items():
-        text = text.replace(source, replacement)
-    return text
+    return "".join(replacements.get(character, character) for character in text)
 
 
 def _build_metadata(

--- a/robot_sf/benchmark/canonical_table_export.py
+++ b/robot_sf/benchmark/canonical_table_export.py
@@ -1,0 +1,324 @@
+"""Canonical benchmark table exporters with provenance sidecars."""
+# ruff: noqa: DOC201
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "benchmark_canonical_table_export.v1"
+
+
+@dataclass(frozen=True)
+class CanonicalTableSpec:
+    """Column contract for one canonical benchmark table."""
+
+    table_id: str
+    columns: tuple[str, ...]
+    sort_by: tuple[str, ...]
+    description: str
+
+
+@dataclass(frozen=True)
+class CanonicalTableExportResult:
+    """Paths and metadata produced by one table export."""
+
+    table_id: str
+    output_paths: dict[str, Path]
+    metadata_path: Path
+    row_count: int
+
+
+TABLE_SPECS: dict[str, CanonicalTableSpec] = {
+    "planner_outcome_summary": CanonicalTableSpec(
+        table_id="planner_outcome_summary",
+        columns=(
+            "planner_key",
+            "execution_mode",
+            "success_mean",
+            "collisions_mean",
+            "near_misses_mean",
+            "snqi_mean",
+            "runtime_mean_sec",
+            "row_status",
+        ),
+        sort_by=("planner_key", "execution_mode", "row_status"),
+        description="Planner-level outcome summary with row status preserved.",
+    ),
+    "scenario_family_summary": CanonicalTableSpec(
+        table_id="scenario_family_summary",
+        columns=(
+            "scenario_family",
+            "planner_key",
+            "success_mean",
+            "collisions_mean",
+            "near_misses_mean",
+            "timeout_or_low_progress_mean",
+            "seed_count",
+        ),
+        sort_by=("scenario_family", "planner_key"),
+        description="Scenario-family outcome summary by planner.",
+    ),
+    "seed_variability_summary": CanonicalTableSpec(
+        table_id="seed_variability_summary",
+        columns=(
+            "planner_key",
+            "metric",
+            "mean",
+            "interval_low",
+            "interval_high",
+            "rank_stability",
+            "warning",
+        ),
+        sort_by=("planner_key", "metric"),
+        description="Seed variability summary with interval and stability fields.",
+    ),
+    "execution_mode": CanonicalTableSpec(
+        table_id="execution_mode",
+        columns=(
+            "planner_key",
+            "availability_status",
+            "execution_mode",
+            "readiness_status",
+            "exclusion_reason",
+        ),
+        sort_by=("planner_key", "execution_mode", "readiness_status"),
+        description="Planner availability and execution-mode table.",
+    ),
+    "artifact_source": CanonicalTableSpec(
+        table_id="artifact_source",
+        columns=("artifact_id", "source_files", "checksums", "command", "generated_outputs"),
+        sort_by=("artifact_id",),
+        description="Artifact source/provenance table.",
+    ),
+}
+
+
+def load_rows_json(path: str | Path) -> list[dict[str, Any]]:
+    """Load a JSON list of row mappings."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise TypeError("canonical table row input must be a JSON list")
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(payload):
+        if not isinstance(row, Mapping):
+            raise TypeError(f"canonical table row {index} must be a mapping")
+        rows.append(dict(row))
+    return rows
+
+
+def export_canonical_table(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    table_id: str,
+    output_dir: str | Path,
+    formats: Sequence[str] = ("csv", "md", "tex"),
+    precision: int = 4,
+    source_paths: Sequence[str | Path] = (),
+    command: str | None = None,
+) -> CanonicalTableExportResult:
+    """Write a canonical benchmark table in requested formats plus metadata."""
+    if table_id not in TABLE_SPECS:
+        known = ", ".join(sorted(TABLE_SPECS))
+        raise ValueError(f"unknown canonical table id {table_id!r}; expected one of: {known}")
+    normalized_formats = _normalize_formats(formats)
+    spec = TABLE_SPECS[table_id]
+    normalized_rows = _normalize_rows(rows, spec=spec, precision=precision)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    output_paths: dict[str, Path] = {}
+    for fmt in normalized_formats:
+        output_path = out_dir / f"{table_id}.{fmt}"
+        output_path.write_text(_format_rows(normalized_rows, spec.columns, fmt), encoding="utf-8")
+        output_paths[fmt] = output_path
+
+    metadata_path = out_dir / f"{table_id}.metadata.json"
+    metadata = _build_metadata(
+        spec=spec,
+        rows=normalized_rows,
+        output_paths=output_paths,
+        precision=precision,
+        source_paths=source_paths,
+        command=command,
+    )
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return CanonicalTableExportResult(
+        table_id=table_id,
+        output_paths=output_paths,
+        metadata_path=metadata_path,
+        row_count=len(normalized_rows),
+    )
+
+
+def _normalize_formats(formats: Sequence[str]) -> tuple[str, ...]:
+    """Validate and normalize requested output formats."""
+    valid = {"csv", "md", "tex"}
+    normalized = tuple(dict.fromkeys(fmt.strip().lower() for fmt in formats if fmt.strip()))
+    if not normalized:
+        raise ValueError("at least one canonical table format is required")
+    unknown = sorted(set(normalized) - valid)
+    if unknown:
+        raise ValueError(f"unknown canonical table formats: {', '.join(unknown)}")
+    return normalized
+
+
+def _normalize_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    spec: CanonicalTableSpec,
+    precision: int,
+) -> list[dict[str, str]]:
+    """Project rows onto spec columns, format values, and sort deterministically."""
+    normalized: list[dict[str, str]] = []
+    for row in rows:
+        normalized.append(
+            {column: _format_cell(row.get(column), precision=precision) for column in spec.columns}
+        )
+    normalized.sort(key=lambda row: tuple(row[column] for column in spec.sort_by))
+    return normalized
+
+
+def _format_cell(value: Any, *, precision: int) -> str:
+    """Format one table cell without dropping status strings such as degraded/fallback."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.{precision}f}"
+    if isinstance(value, list | tuple):
+        return ";".join(_format_cell(item, precision=precision) for item in value)
+    if isinstance(value, Mapping):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _format_rows(rows: Sequence[Mapping[str, str]], columns: Sequence[str], fmt: str) -> str:
+    """Format normalized rows as CSV, Markdown, or LaTeX."""
+    if fmt == "csv":
+        return _format_csv(rows, columns)
+    if fmt == "md":
+        return _format_markdown(rows, columns)
+    if fmt == "tex":
+        return _format_tex(rows, columns)
+    raise ValueError(f"unsupported canonical table format: {fmt}")
+
+
+def _format_csv(rows: Sequence[Mapping[str, str]], columns: Sequence[str]) -> str:
+    """Format rows as CSV."""
+    buf = StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(columns), lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return buf.getvalue()
+
+
+def _format_markdown(rows: Sequence[Mapping[str, str]], columns: Sequence[str]) -> str:
+    """Format rows as a GitHub-flavored Markdown table."""
+    lines = [
+        "| " + " | ".join(_markdown_escape(column) for column in columns) + " |",
+        "| " + " | ".join(["---"] * len(columns)) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_markdown_escape(row[column]) for column in columns) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def _format_tex(rows: Sequence[Mapping[str, str]], columns: Sequence[str]) -> str:
+    """Format rows as a LaTeX booktabs fragment."""
+    lines = [
+        "% Auto-generated by robot_sf.benchmark.canonical_table_export",
+        "\\begin{tabular}{" + ("l" * len(columns)) + "}",
+        "\\toprule",
+        " & ".join(_latex_escape(column) for column in columns) + " \\\\",
+        "\\midrule",
+    ]
+    for row in rows:
+        lines.append(" & ".join(_latex_escape(row[column]) for column in columns) + " \\\\")
+    lines.extend(["\\bottomrule", "\\end{tabular}"])
+    return "\n".join(lines) + "\n"
+
+
+def _markdown_escape(text: str) -> str:
+    """Escape Markdown table separators and normalize whitespace."""
+    return text.replace("\\", "\\\\").replace("|", r"\|").replace("\n", "<br>")
+
+
+def _latex_escape(text: str) -> str:
+    """Escape LaTeX-sensitive characters in text cells."""
+    replacements = {
+        "\\": r"\textbackslash{}",
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+    }
+    for source, replacement in replacements.items():
+        text = text.replace(source, replacement)
+    return text
+
+
+def _build_metadata(
+    *,
+    spec: CanonicalTableSpec,
+    rows: Sequence[Mapping[str, str]],
+    output_paths: Mapping[str, Path],
+    precision: int,
+    source_paths: Sequence[str | Path],
+    command: str | None,
+) -> dict[str, Any]:
+    """Build provenance metadata for a canonical table export."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "table_id": spec.table_id,
+        "description": spec.description,
+        "columns": list(spec.columns),
+        "sort_by": list(spec.sort_by),
+        "row_count": len(rows),
+        "formats": sorted(output_paths),
+        "outputs": {fmt: path.as_posix() for fmt, path in sorted(output_paths.items())},
+        "precision": precision,
+        "source_files": [_source_file_metadata(path) for path in source_paths],
+        "command": command,
+        "git_commit": _git_commit(),
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+    }
+
+
+def _source_file_metadata(path: str | Path) -> dict[str, Any]:
+    """Return checksum metadata for one source file path."""
+    source_path = Path(path)
+    payload: dict[str, Any] = {"path": source_path.as_posix(), "exists": source_path.is_file()}
+    if source_path.is_file():
+        payload["sha256"] = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    return payload
+
+
+def _git_commit() -> str | None:
+    """Return current Git commit when available."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):  # pragma: no cover - environment defensive
+        return None

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -34,6 +34,13 @@ from robot_sf.benchmark.benchmark_claim import (
     build_benchmark_claim,
     write_benchmark_claim,
 )
+from robot_sf.benchmark.canonical_table_export import (
+    TABLE_SPECS as _canonical_table_specs,
+)
+from robot_sf.benchmark.canonical_table_export import (
+    export_canonical_table as _export_canonical_table,
+)
+from robot_sf.benchmark.canonical_table_export import load_rows_json as _load_canonical_rows_json
 from robot_sf.benchmark.distributions import collect_grouped_values as _dist_collect
 from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.failure_extractor import extract_failures as _extract_failures
@@ -790,6 +797,42 @@ def _handle_table(args) -> int:
             logging.info("Table output written to %s", out_path)
         except Exception:
             logging.debug("Logging 'Table output' failed", exc_info=True)
+        return 0
+    except Exception:  # pragma: no cover - error path
+        return 2
+
+
+def _handle_export_canonical_table(args) -> int:
+    """Export named canonical benchmark tables from JSON row fixtures.
+
+    Returns:
+        Process exit code; zero indicates all requested outputs were written.
+    """
+    try:
+        rows = _load_canonical_rows_json(args.rows)
+        formats = [fmt.strip() for fmt in str(args.formats).split(",") if fmt.strip()]
+        result = _export_canonical_table(
+            rows,
+            table_id=str(args.table_id),
+            output_dir=args.out_dir,
+            formats=formats,
+            precision=int(args.precision),
+            source_paths=[Path(path) for path in args.source],
+            command=" ".join(sys.argv),
+        )
+        print(
+            json.dumps(
+                {
+                    "table_id": result.table_id,
+                    "row_count": result.row_count,
+                    "outputs": {
+                        fmt: path.as_posix() for fmt, path in sorted(result.output_paths.items())
+                    },
+                    "metadata": result.metadata_path.as_posix(),
+                },
+                indent=2,
+            )
+        )
         return 0
     except Exception:  # pragma: no cover - error path
         return 2
@@ -2049,6 +2092,42 @@ def _add_table_subparser(
     p.set_defaults(cmd="table")
 
 
+def _add_export_canonical_table_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the canonical table export subcommand parser."""
+    p = subparsers.add_parser(
+        "export-canonical-table",
+        help="Export a named canonical benchmark table as csv/md/tex with metadata",
+    )
+    p.add_argument(
+        "--table-id",
+        required=True,
+        choices=sorted(_canonical_table_specs),
+        help="Canonical table contract to export",
+    )
+    p.add_argument("--rows", required=True, help="JSON list of row mappings")
+    p.add_argument("--out-dir", required=True, help="Directory for table outputs and metadata")
+    p.add_argument(
+        "--formats",
+        default="csv,md,tex",
+        help="Comma-separated output formats. Supported: csv, md, tex",
+    )
+    p.add_argument(
+        "--precision",
+        type=int,
+        default=4,
+        help="Decimal places for floating point cells",
+    )
+    p.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        help="Source file to checksum in the metadata sidecar; may be repeated",
+    )
+    p.set_defaults(cmd="export-canonical-table")
+
+
 def _add_debug_seeds_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2290,6 +2369,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_snqi_ablate_subparser(subparsers)
     _add_rank_subparser(subparsers)
     _add_table_subparser(subparsers)
+    _add_export_canonical_table_subparser(subparsers)
     _add_debug_seeds_subparser(subparsers)
     _add_plot_pareto_subparser(subparsers)
     _add_plot_distributions_subparser(subparsers)
@@ -2742,6 +2822,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "snqi-ablate": _handle_snqi_ablate,
         "rank": _handle_rank,
         "table": _handle_table,
+        "export-canonical-table": _handle_export_canonical_table,
         "debug-seeds": _handle_debug_seeds,
         "plot-pareto": _handle_plot_pareto,
         "plot-distributions": _handle_plot_distributions,

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -834,7 +834,8 @@ def _handle_export_canonical_table(args) -> int:
             )
         )
         return 0
-    except Exception:  # pragma: no cover - error path
+    except Exception as exc:  # pragma: no cover - error path
+        logging.exception("Canonical table export failed: %s", exc)
         return 2
 
 

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import logging
 import os
+import shlex
 import sys
 import traceback
 from collections import Counter
@@ -818,7 +819,7 @@ def _handle_export_canonical_table(args) -> int:
             formats=formats,
             precision=int(args.precision),
             source_paths=[Path(path) for path in args.source],
-            command=" ".join(sys.argv),
+            command=str(getattr(args, "_canonical_command", shlex.join(sys.argv))),
         )
         print(
             json.dumps(
@@ -2787,6 +2788,8 @@ def cli_main(argv: list[str] | None = None) -> int:
     """
     parser = _configure_parser()
     args = parser.parse_args(argv)
+    effective_argv = list(sys.argv if argv is None else ["robot_sf_bench", *argv])
+    args._canonical_command = shlex.join(effective_argv)
     _configure_logging(getattr(args, "quiet", False), getattr(args, "log_level", "INFO"))
     # macOS safe start method for multiprocessing
     if getattr(args, "workers", 1) and int(getattr(args, "workers", 1)) > 1:

--- a/tests/benchmark/test_canonical_table_export.py
+++ b/tests/benchmark/test_canonical_table_export.py
@@ -124,3 +124,25 @@ def test_cli_export_canonical_table_writes_execution_mode_outputs(
     metadata = json.loads((out_dir / "execution_mode.metadata.json").read_text(encoding="utf-8"))
     assert metadata["source_files"][0]["path"] == rows_path.as_posix()
     assert "fallback" in (out_dir / "execution_mode.csv").read_text(encoding="utf-8")
+
+
+def test_latex_escape_is_single_pass_for_backslash_macro_output(tmp_path: Path) -> None:
+    """Backslash escaping should not re-escape braces introduced by replacement macros."""
+    result = export_canonical_table(
+        [
+            {
+                "artifact_id": r"path\with_{chars}",
+                "source_files": [],
+                "checksums": {},
+                "command": r"python tool.py --name a_b",
+                "generated_outputs": [],
+            }
+        ],
+        table_id="artifact_source",
+        output_dir=tmp_path,
+        formats=["tex"],
+    )
+
+    tex_text = result.output_paths["tex"].read_text(encoding="utf-8")
+    assert r"path\textbackslash{}with\_\{chars\}" in tex_text
+    assert r"\textbackslash\{\}" not in tex_text

--- a/tests/benchmark/test_canonical_table_export.py
+++ b/tests/benchmark/test_canonical_table_export.py
@@ -1,0 +1,126 @@
+"""Tests for canonical benchmark table export contracts."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.canonical_table_export import export_canonical_table
+from robot_sf.benchmark.cli import cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_export_planner_outcome_table_preserves_degraded_rows_and_metadata(
+    tmp_path: Path,
+) -> None:
+    """Canonical planner tables should keep degraded rows and provenance metadata."""
+    source_path = tmp_path / "campaign_summary.json"
+    source_path.write_text('{"schema": "fixture"}\n', encoding="utf-8")
+    rows = [
+        {
+            "planner_key": "zed",
+            "execution_mode": "degraded",
+            "success_mean": 0.0,
+            "collisions_mean": 0.0,
+            "near_misses_mean": 1.25,
+            "snqi_mean": None,
+            "runtime_mean_sec": 12.34567,
+            "row_status": "degraded",
+        },
+        {
+            "planner_key": "alpha|planner",
+            "execution_mode": "native",
+            "success_mean": 1.0,
+            "collisions_mean": 0.0,
+            "near_misses_mean": 0.0,
+            "snqi_mean": 0.87543,
+            "runtime_mean_sec": 1.2,
+            "row_status": "ok",
+        },
+    ]
+
+    result = export_canonical_table(
+        rows,
+        table_id="planner_outcome_summary",
+        output_dir=tmp_path / "tables",
+        source_paths=[source_path],
+        command="robot_sf_bench export-canonical-table ...",
+    )
+
+    csv_text = result.output_paths["csv"].read_text(encoding="utf-8")
+    assert csv_text.splitlines()[0] == (
+        "planner_key,execution_mode,success_mean,collisions_mean,near_misses_mean,"
+        "snqi_mean,runtime_mean_sec,row_status"
+    )
+    assert csv_text.splitlines()[1].startswith("alpha|planner,native,1.0000")
+    assert "zed,degraded,0.0000,0.0000,1.2500,,12.3457,degraded" in csv_text
+
+    md_text = result.output_paths["md"].read_text(encoding="utf-8")
+    assert "| planner_key | execution_mode |" in md_text
+    assert "alpha\\|planner" in md_text
+    assert "| zed | degraded | 0.0000 | 0.0000 | 1.2500 |  | 12.3457 | degraded |" in md_text
+
+    tex_text = result.output_paths["tex"].read_text(encoding="utf-8")
+    assert "\\begin{tabular}" in tex_text
+    assert "planner\\_key" in tex_text
+    assert "alpha|planner & native" in tex_text
+    assert "degraded" in tex_text
+
+    metadata = json.loads(result.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["schema_version"] == "benchmark_canonical_table_export.v1"
+    assert metadata["table_id"] == "planner_outcome_summary"
+    assert metadata["row_count"] == 2
+    assert metadata["source_files"][0]["sha256"]
+    assert metadata["command"] == "robot_sf_bench export-canonical-table ..."
+
+
+def test_cli_export_canonical_table_writes_execution_mode_outputs(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """CLI export should write named table outputs and a metadata sidecar."""
+    rows_path = tmp_path / "rows.json"
+    rows_path.write_text(
+        json.dumps(
+            [
+                {
+                    "planner_key": "fallback_planner",
+                    "availability_status": "not_available",
+                    "execution_mode": "fallback",
+                    "readiness_status": "fallback",
+                    "exclusion_reason": "missing optional dependency",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "canonical"
+
+    rc = cli_main(
+        [
+            "export-canonical-table",
+            "--table-id",
+            "execution_mode",
+            "--rows",
+            str(rows_path),
+            "--out-dir",
+            str(out_dir),
+            "--formats",
+            "csv,md,tex",
+            "--source",
+            str(rows_path),
+        ],
+    )
+
+    cap = capsys.readouterr()
+    assert rc == 0, cap.err
+    payload = json.loads(cap.out)
+    assert payload["table_id"] == "execution_mode"
+    assert (out_dir / "execution_mode.csv").is_file()
+    assert (out_dir / "execution_mode.md").is_file()
+    assert (out_dir / "execution_mode.tex").is_file()
+    metadata = json.loads((out_dir / "execution_mode.metadata.json").read_text(encoding="utf-8"))
+    assert metadata["source_files"][0]["path"] == rows_path.as_posix()
+    assert "fallback" in (out_dir / "execution_mode.csv").read_text(encoding="utf-8")

--- a/tests/benchmark/test_canonical_table_export.py
+++ b/tests/benchmark/test_canonical_table_export.py
@@ -123,6 +123,7 @@ def test_cli_export_canonical_table_writes_execution_mode_outputs(
     assert (out_dir / "execution_mode.tex").is_file()
     metadata = json.loads((out_dir / "execution_mode.metadata.json").read_text(encoding="utf-8"))
     assert metadata["source_files"][0]["path"] == rows_path.as_posix()
+    assert metadata["command"].startswith("robot_sf_bench export-canonical-table")
     assert "fallback" in (out_dir / "execution_mode.csv").read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
Adds a canonical benchmark table exporter with named table specs for planner outcome, scenario-family, seed-variability, execution-mode, and artifact-source summaries.

## Linked Issues
- Closes #2009

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf.benchmark.canonical_table_export` for deterministic CSV/Markdown/LaTeX fragments plus metadata sidecars.
- Added `robot_sf_bench export-canonical-table` for JSON row fixtures.
- Added tests covering degraded/fallback row preservation, source checksums, CLI output, Markdown escaping, LaTeX escaping, and programmatic CLI command provenance.
- Documented the exporter in `docs/benchmark_camera_ready.md`.

## Why It Matters
- Added value: reusable benchmark tables can now carry stable column contracts and provenance sidecars.
- Expected impact: less manual table reuse for paper/report workflows while preserving fallback/degraded rows.
- Why this is worth merging now: it is a narrow table-formatting/provenance layer and does not recompute metrics or alter benchmark semantics.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_canonical_table_export.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_canonical_table_export.py tests/test_cli_table.py tests/test_cli_table_tex.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/canonical_table_export.py robot_sf/benchmark/cli.py tests/benchmark/test_canonical_table_export.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/canonical_table_export.py robot_sf/benchmark/cli.py tests/benchmark/test_canonical_table_export.py`
  - `git diff --check`
  - `uv sync --all-extras && UV_NO_SYNC=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Full PR readiness passed at `9c28b123c36a5d4ff4b30832ff96ff1ca4cb046c`: `4960 passed, 10 skipped`.
  - Current head `0ce935ebed13b1a34ddb3d7555845ff0d673c590` targeted validation passed: canonical exporter + existing table CLI tests, ruff check/format, and `git diff --check`.
  - GitHub CI is still running for current head.
- Benchmarks or smoke tests, if applicable: not applicable; this is a table export utility and docs change.

## Risks / Rollout
- Compatibility risks: low; existing campaign table generation is unchanged.
- Failure modes: consumers must provide rows matching the named table spec; missing values render as empty cells.
- Rollback or fallback plan: remove the new module, CLI subcommand, tests, and docs section.

## Docs / Provenance
- Updated docs: `docs/benchmark_camera_ready.md`.
- Relevant design or provenance notes: metadata sidecars include source checksums, command, commit, row count, selected columns, and output paths.
- Any assumptions that need to be preserved: fallback/degraded/not-available rows stay explicit; exporter does not reinterpret benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR close linkage.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not-applicable rationale: no benchmark claims or artifact registry changes.

## Follow-Up Issues
- Deferred work: optionally wire existing camera-ready campaign report generation to this shared exporter in a later PR.
- Issues opened for follow-up: none.

## Reviewer Notes
- The exporter intentionally starts as an opt-in named-table utility; it does not replace existing campaign table artifacts in this PR.
