### PR TITLE
feat: add artifact catalog validator

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -269,6 +269,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Issue #1434 Stress/Uncertainty Coverage Schema v1](./context/issue_1434_stress_uncertainty_coverage_schema.md)** - `stress_uncertainty_coverage.v1` field contract, statistical summary tiers, coverage axes, interpretation boundaries, and fail-closed consumer rules for benchmark reports
 * **[Full Classic Interaction Benchmark](./benchmark_full_classic.md)** - Complete guide: episodes, aggregation, effect sizes, adaptive precision, plots, videos, scaling metrics
 * **[Benchmark Artifact Publication](./benchmark_artifact_publication.md)** - Public artifact policy, DOI-ready export bundles, release/Zenodo workflow
+* **[Artifact Catalog v1](./artifact_catalog.md)** - Stable semantic IDs, checksums, generation commands, and claim boundaries for reusable figures and tables
 * **[Multi-AMV Benchmark First Slice](./multi_amv_benchmark.md)** - Minimal multi-robot scenario surface, validation smoke, and inter-robot metric block
 * **[Issue #1128 Multi-AMV Episode Extension](./context/issue_1128_multi_amv_episode_extension.md)** - Additive multi-AMV episode block, canonical `metrics.inter_robot` JSONL/report output, and fail-closed validation notes
 * **[Issue #1168 Multi-AMV Planner Support Classification](./context/issue_1168_multi_amv_planner_support.md)** - Planner-family support inventory, fail-closed multi-AMV preflight gate, and the boundary between smoke control and real multi-robot planner support
@@ -472,7 +473,7 @@ The benchmark layer provides:
 
 #### Figures naming and outputs
 
-See `docs/dev/issues/figures-naming/design.md` for the canonical figure folder naming scheme and migration plan. A small tracker lives at `docs/dev/issues/figures-naming/todo.md` .
+See `docs/dev/issues/figures-naming/design.md` for the canonical figure folder naming scheme and migration plan. Use `docs/artifact_catalog.md` when a generated figure or table needs a durable semantic ID that survives path regeneration. A small tracker lives at `docs/dev/issues/figures-naming/todo.md` .
 
 #### LaTeX Table Embedding (SNQI / Benchmark Tables)
 

--- a/docs/artifact_catalog.md
+++ b/docs/artifact_catalog.md
@@ -1,0 +1,75 @@
+# Artifact Catalog v1
+
+`artifact_catalog.v1` records stable semantic IDs for reusable figures and tables.
+It separates the identity of an artifact from whatever generated path currently
+stores the rendered file.
+
+Use this catalog when a report, paper draft, or follow-up workflow needs to cite
+the same figure or table across reruns.
+
+## Required Fields
+
+Each catalog has:
+
+- `schema_version: artifact_catalog.v1`
+- `catalog_id`: stable catalog identifier
+- `artifacts`: one or more figure/table rows
+
+Each artifact row has:
+
+- `artifact_id`: stable semantic ID, such as `fig_benchmark_outcome_matrix`
+- `artifact_kind`: `figure` or `table`
+- `source_kind`: source class, such as `benchmark_campaign`
+- `source_files`: tracked or durable source files with SHA-256 checksums
+- `outputs`: generated files keyed by format, each with SHA-256 checksums
+- `generation_command`: command that produced the outputs
+- `generation_commit`: commit used for generation
+- `claim_boundary`: what the artifact can and cannot support
+- `caption_file`: optional checksummed caption/source text
+
+The validator fails closed when IDs are duplicated, required files are missing,
+checksums mismatch, or a durable reference points at local-only locations such as
+`output/`, `.git/`, `.venv/`, `/tmp/`, or a worktree path.
+
+## Example
+
+```yaml
+schema_version: artifact_catalog.v1
+catalog_id: camera_ready_tables_v1
+artifacts:
+  - artifact_id: tab_planner_execution_modes
+    artifact_kind: table
+    source_kind: benchmark_campaign
+    source_files:
+      - path: reports/comparability_matrix.json
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    outputs:
+      md:
+        path: tables/tab_planner_execution_modes.md
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      tex:
+        path: tables/tab_planner_execution_modes.tex
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    generation_command: uv run python scripts/tools/export_benchmark_tables.py --catalog
+    generation_commit: fbc7e125
+    claim_boundary: Benchmark summary table; not raw episode evidence.
+```
+
+## Validation
+
+Validate a catalog with:
+
+```bash
+uv run python scripts/validation/validate_artifact_catalog.py tests/fixtures/artifact_catalog/v1/valid_catalog.yaml
+```
+
+The checked-in fixture is intentionally tiny and exists to prove the schema and
+validator contract, not to serve as benchmark evidence.
+
+## Related Work
+
+- `docs/dev/issues/figures-naming/design.md`
+- `docs/benchmark_artifact_publication.md`
+- GitHub issue #2007 tracks a future benchmark artifact compiler that can consume
+  this catalog contract.
+- GitHub issue #2008 introduced the first schema and validator slice.

--- a/docs/benchmark_artifact_publication.md
+++ b/docs/benchmark_artifact_publication.md
@@ -41,6 +41,19 @@ Export bundles are produced by
 - `checksums.sha256`: SHA-256 checksums for payload files.
 - `<bundle_name>.tar.gz`: archive for release upload.
 
+## Reusable Figure And Table IDs
+
+Use `artifact_catalog.v1` when a publication bundle or benchmark report needs
+stable semantic IDs for reusable figures and tables. The catalog records
+`artifact_id`, source files, outputs, SHA-256 checksums, generation command,
+generation commit, and claim boundary while keeping generated paths replaceable.
+
+See `docs/artifact_catalog.md` and validate catalogs with:
+
+```bash
+uv run python scripts/validation/validate_artifact_catalog.py <catalog.yaml>
+```
+
 ## Command Path (Reproducible)
 
 1. Measure current benchmark artifact sizes (optional but recommended):

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -289,6 +289,8 @@ knowledge, not every transient iteration detail.
   [issue_1474_shielded_ppo_repair_closeout.md](issue_1474_shielded_ppo_repair_closeout.md)
 * Issue #2006 Guarded-PPO Zero-Motion Repair (2026-06-01):
   [issue_2006_guarded_ppo_zero_motion_repair.md](issue_2006_guarded_ppo_zero_motion_repair.md)
+* Issue #2008 Artifact Catalog Contract (2026-06-01):
+  [issue_2008_artifact_catalog.md](issue_2008_artifact_catalog.md)
 * Issue #1395 Learned Risk Model Launch Packet:
   [issue_1395_learned_risk_launch_packet.md](issue_1395_learned_risk_launch_packet.md)
 * Issue #1686 Learned-Policy Artifact Manifest Fields (2026-05-30):

--- a/docs/context/issue_2008_artifact_catalog.md
+++ b/docs/context/issue_2008_artifact_catalog.md
@@ -1,0 +1,37 @@
+# Issue #2008 Artifact Catalog Contract (2026-06-01)
+
+## Goal
+
+Issue #2008 adds the first `artifact_catalog.v1` contract so reusable figures and
+tables can be addressed by stable semantic IDs instead of regenerated paths.
+
+## Contract
+
+- Loader and typed metadata: `robot_sf/benchmark/artifact_catalog.py`
+- JSON Schema: `robot_sf/benchmark/schemas/artifact_catalog.v1.json`
+- Validator CLI: `scripts/validation/validate_artifact_catalog.py`
+- Fixture catalog: `tests/fixtures/artifact_catalog/v1/valid_catalog.yaml`
+- User-facing docs: `docs/artifact_catalog.md`
+
+The validator fails on duplicate `artifact_id` values, missing source files,
+missing output files, checksum mismatches, and local-only durable references such
+as `output/`.
+
+## Boundary
+
+This is a schema and validation slice only. It does not choose final figure/table
+IDs for future papers, rewrite historical figure folders, or implement full
+benchmark table/figure generators.
+
+The fixture catalog is contract proof only and is not benchmark evidence.
+
+## Validation
+
+Targeted validation for this slice:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_artifact_catalog.py -q
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_artifact_catalog.py tests/fixtures/artifact_catalog/v1/valid_catalog.yaml
+python -m json.tool robot_sf/benchmark/schemas/artifact_catalog.v1.json
+git diff --check
+```

--- a/docs/dev/issues/figures-naming/design.md
+++ b/docs/dev/issues/figures-naming/design.md
@@ -56,10 +56,14 @@ Optional suffixes:
 - `robot_sf/benchmark/figures.py`: FigureOrchestrator class for automated generation
 - `scripts/generate_figures.py`: CLI interface with `--auto-out-dir` flag
 - `docs/figures/`: Output directory with canonical folder structure
+- `docs/artifact_catalog.md`: `artifact_catalog.v1` contract for stable figure/table IDs,
+  checksums, generation commands, and claim boundaries once an artifact is reused across reports
 
 ## Acceptance Criteria
 - New runs with `--auto-out-dir` produce uniquely named folders with a `meta.json` file.
 - Docs show the pattern and provide a LaTeX include snippet using `_latest.txt`-resolved path.
 - Backward compatibility maintained with existing figure references.
+- Reusable figures/tables can be registered in an `artifact_catalog.v1` file without treating
+  generated paths as the semantic identity.
 
 **Status**: ✅ Design Complete - Ready for implementation

--- a/robot_sf/benchmark/artifact_catalog.py
+++ b/robot_sf/benchmark/artifact_catalog.py
@@ -1,0 +1,459 @@
+"""Versioned artifact catalog contract for reusable benchmark figures and tables."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ARTIFACT_CATALOG_SCHEMA_VERSION = "artifact_catalog.v1"
+ARTIFACT_CATALOG_SCHEMA_FILE = Path(__file__).with_name("schemas") / "artifact_catalog.v1.json"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_LOCAL_ONLY_PREFIXES = (
+    "output/",
+    "results/",
+    ".git/",
+    ".venv/",
+    "/tmp/",
+    "/var/tmp/",
+    "/home/",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCatalogIssue:
+    """One artifact catalog validation issue."""
+
+    path: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactFileRef:
+    """Tracked file reference with checksum provenance."""
+
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCatalogEntry:
+    """One reusable figure or table artifact entry."""
+
+    artifact_id: str
+    artifact_kind: str
+    source_kind: str
+    source_files: list[ArtifactFileRef]
+    outputs: dict[str, ArtifactFileRef]
+    generation_command: str
+    generation_commit: str
+    claim_boundary: str
+    caption_file: ArtifactFileRef | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCatalog:
+    """Typed ``artifact_catalog.v1`` payload."""
+
+    schema_version: str
+    catalog_id: str
+    artifacts: list[ArtifactCatalogEntry]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the catalog to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation of the catalog.
+        """
+
+        return asdict(self)
+
+
+class ArtifactCatalogValidationError(ValueError):
+    """Raised when an artifact catalog fails validation."""
+
+    def __init__(self, issues: list[ArtifactCatalogIssue], *, source: str | Path | None = None):
+        """Build an actionable validation error from catalog issues."""
+
+        self.issues = tuple(issues)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(f"{issue.path}: {issue.message}" for issue in issues))
+
+
+def load_artifact_catalog_schema() -> dict[str, Any]:
+    """Load the public ``artifact_catalog.v1`` JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(ARTIFACT_CATALOG_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_artifact_catalog(path: Path) -> ArtifactCatalog:
+    """Load and validate a YAML or JSON artifact catalog.
+
+    Returns:
+        Typed artifact catalog metadata.
+    """
+
+    text = path.read_text(encoding="utf-8")
+    payload = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+    if not isinstance(payload, Mapping):
+        raise ArtifactCatalogValidationError(
+            [ArtifactCatalogIssue("/", "expected a mapping payload")],
+            source=path,
+        )
+    return artifact_catalog_from_dict(payload, catalog_path=path)
+
+
+def artifact_catalog_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    catalog_path: Path,
+) -> ArtifactCatalog:
+    """Validate and convert a catalog mapping into typed metadata.
+
+    Returns:
+        Typed artifact catalog metadata.
+    """
+
+    issues = validate_artifact_catalog_payload(payload, catalog_path=catalog_path)
+    if issues:
+        raise ArtifactCatalogValidationError(issues, source=catalog_path)
+    return _catalog_from_payload(payload)
+
+
+def validate_artifact_catalog(path: Path) -> list[ArtifactCatalogIssue]:
+    """Validate an artifact catalog path and return all issues.
+
+    Returns:
+        List of validation issues. Empty means valid.
+    """
+
+    try:
+        text = path.read_text(encoding="utf-8")
+        payload = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+    except Exception as exc:  # pragma: no cover - defensive CLI path
+        return [ArtifactCatalogIssue("/", f"failed to load catalog: {exc}")]
+    if not isinstance(payload, Mapping):
+        return [ArtifactCatalogIssue("/", "expected a mapping payload")]
+    return validate_artifact_catalog_payload(payload, catalog_path=path)
+
+
+def validate_artifact_catalog_payload(
+    payload: Mapping[str, Any],
+    *,
+    catalog_path: Path,
+) -> list[ArtifactCatalogIssue]:
+    """Validate schema, identity, path, checksum, and durability rules.
+
+    Returns:
+        List of validation issues. Empty means valid.
+    """
+
+    issues = _schema_validation_issues(payload)
+    issues.extend(_semantic_validation_issues(payload, catalog_path=catalog_path))
+    return issues
+
+
+def _schema_validation_issues(payload: Mapping[str, Any]) -> list[ArtifactCatalogIssue]:
+    """Return JSON Schema validation issues."""
+
+    validator = Draft202012Validator(load_artifact_catalog_schema())
+    return [
+        ArtifactCatalogIssue(_json_pointer(error.absolute_path), error.message)
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_issues(
+    payload: Mapping[str, Any],
+    *,
+    catalog_path: Path,
+) -> list[ArtifactCatalogIssue]:
+    """Return cross-field and filesystem validation issues."""
+
+    issues: list[ArtifactCatalogIssue] = []
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        return issues
+
+    seen_ids: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            continue
+        prefix = f"/artifacts/{index}"
+        artifact_id = artifact.get("artifact_id")
+        if isinstance(artifact_id, str):
+            if artifact_id in seen_ids:
+                issues.append(
+                    ArtifactCatalogIssue(
+                        f"{prefix}/artifact_id",
+                        f"duplicate artifact_id '{artifact_id}'",
+                    )
+                )
+            seen_ids.add(artifact_id)
+
+        for file_index, file_ref in enumerate(_as_list(artifact.get("source_files"))):
+            issues.extend(
+                _validate_file_ref(
+                    file_ref,
+                    catalog_path=catalog_path,
+                    pointer=f"{prefix}/source_files/{file_index}",
+                )
+            )
+        outputs = artifact.get("outputs")
+        if isinstance(outputs, Mapping):
+            for output_key, file_ref in outputs.items():
+                issues.extend(
+                    _validate_file_ref(
+                        file_ref,
+                        catalog_path=catalog_path,
+                        pointer=f"{prefix}/outputs/{output_key}",
+                    )
+                )
+        caption_file = artifact.get("caption_file")
+        if caption_file is not None:
+            issues.extend(
+                _validate_file_ref(
+                    caption_file,
+                    catalog_path=catalog_path,
+                    pointer=f"{prefix}/caption_file",
+                )
+            )
+    return issues
+
+
+def _validate_file_ref(
+    file_ref: Any,
+    *,
+    catalog_path: Path,
+    pointer: str,
+) -> list[ArtifactCatalogIssue]:
+    """Validate one path/checksum pair.
+
+    Returns:
+        List of validation issues for the file reference.
+    """
+
+    issues: list[ArtifactCatalogIssue] = []
+    if not isinstance(file_ref, Mapping):
+        return issues
+    raw_path = file_ref.get("path")
+    raw_sha = file_ref.get("sha256")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return issues
+    path_text = raw_path.strip()
+    if _is_local_only_path(path_text):
+        issues.append(
+            ArtifactCatalogIssue(
+                f"{pointer}/path",
+                f"local-only artifact reference is not durable: {path_text}",
+            )
+        )
+        return issues
+    if Path(path_text).is_absolute() or ".." in Path(path_text).parts:
+        issues.append(
+            ArtifactCatalogIssue(
+                f"{pointer}/path",
+                "path must be repository-relative or catalog-relative without '..'",
+            )
+        )
+        return issues
+
+    resolved = _resolve_catalog_path(catalog_path, path_text)
+    if not resolved.exists():
+        issues.append(ArtifactCatalogIssue(f"{pointer}/path", f"path does not exist: {path_text}"))
+        return issues
+    if not resolved.is_file():
+        issues.append(ArtifactCatalogIssue(f"{pointer}/path", f"path is not a file: {path_text}"))
+        return issues
+
+    if not isinstance(raw_sha, str) or _SHA256_RE.fullmatch(raw_sha.strip()) is None:
+        issues.append(ArtifactCatalogIssue(f"{pointer}/sha256", "must be a 64-character SHA-256"))
+        return issues
+    actual_sha = sha256_file(resolved)
+    if actual_sha != raw_sha.strip():
+        issues.append(
+            ArtifactCatalogIssue(
+                f"{pointer}/sha256",
+                f"checksum mismatch for {path_text}: expected {raw_sha.strip()}, got {actual_sha}",
+            )
+        )
+    return issues
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_catalog_path(catalog_path: Path, path_text: str) -> Path:
+    """Resolve a catalog file reference relative to catalog dir or repository root.
+
+    Returns:
+        Absolute resolved path.
+    """
+
+    catalog_relative = (catalog_path.parent / path_text).resolve()
+    if catalog_relative.exists():
+        return catalog_relative
+    return (_repo_root_for(catalog_path) / path_text).resolve()
+
+
+def _repo_root_for(path: Path) -> Path:
+    """Return the nearest repository root, falling back to the catalog directory.
+
+    Returns:
+        Repository root or catalog parent when no Git root marker exists.
+    """
+
+    resolved = path.resolve()
+    for parent in (resolved.parent, *resolved.parents):
+        if (parent / ".git").exists():
+            return parent
+    return resolved.parent
+
+
+def _is_local_only_path(value: str) -> bool:
+    """Return whether a path points at disposable local state."""
+
+    path = Path(value.strip())
+    parts = path.parts
+    local_roots = {prefix.strip("/") for prefix in _LOCAL_ONLY_PREFIXES}
+    local_roots.discard("")
+    if path.is_absolute():
+        return len(parts) > 1 and parts[1] in local_roots
+    return bool(parts) and (parts[0] in local_roots or any(".worktrees" in part for part in parts))
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Return value when it is a list, otherwise an empty list."""
+
+    return value if isinstance(value, list) else []
+
+
+def _json_pointer(path: Any) -> str:
+    """Return a JSON pointer for a schema error path."""
+
+    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
+    return "/" + "/".join(parts) if parts else "/"
+
+
+def _catalog_from_payload(payload: Mapping[str, Any]) -> ArtifactCatalog:
+    """Build typed catalog metadata from a validated payload.
+
+    Returns:
+        Typed artifact catalog metadata.
+    """
+
+    return ArtifactCatalog(
+        schema_version=str(payload["schema_version"]),
+        catalog_id=str(payload["catalog_id"]),
+        artifacts=[
+            ArtifactCatalogEntry(
+                artifact_id=str(artifact["artifact_id"]),
+                artifact_kind=str(artifact["artifact_kind"]),
+                source_kind=str(artifact["source_kind"]),
+                source_files=[
+                    ArtifactFileRef(path=str(item["path"]), sha256=str(item["sha256"]))
+                    for item in artifact["source_files"]
+                ],
+                outputs={
+                    str(key): ArtifactFileRef(
+                        path=str(file_ref["path"]),
+                        sha256=str(file_ref["sha256"]),
+                    )
+                    for key, file_ref in artifact["outputs"].items()
+                },
+                generation_command=str(artifact["generation_command"]),
+                generation_commit=str(artifact["generation_commit"]),
+                claim_boundary=str(artifact["claim_boundary"]),
+                caption_file=(
+                    ArtifactFileRef(
+                        path=str(artifact["caption_file"]["path"]),
+                        sha256=str(artifact["caption_file"]["sha256"]),
+                    )
+                    if artifact.get("caption_file") is not None
+                    else None
+                ),
+            )
+            for artifact in payload["artifacts"]
+        ],
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the catalog validator parser.
+
+    Returns:
+        Configured argument parser.
+    """
+
+    parser = argparse.ArgumentParser(description="Validate an artifact_catalog.v1 file.")
+    parser.add_argument("catalog", type=Path, help="Artifact catalog YAML/JSON path.")
+    parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate one artifact catalog and return a shell-friendly exit code.
+
+    Returns:
+        ``0`` when valid, otherwise ``2``.
+    """
+
+    args = build_arg_parser().parse_args(argv)
+    issues = validate_artifact_catalog(args.catalog)
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "schema": "artifact_catalog_validation.v1",
+                    "catalog": str(args.catalog),
+                    "ok": not issues,
+                    "issues": [asdict(issue) for issue in issues],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    elif issues:
+        for issue in issues:
+            sys.stdout.write(f"{issue.path}: {issue.message}\n")
+    else:
+        sys.stdout.write(f"artifact catalog valid: {args.catalog}\n")
+    return 0 if not issues else 2
+
+
+__all__ = [
+    "ARTIFACT_CATALOG_SCHEMA_VERSION",
+    "ArtifactCatalog",
+    "ArtifactCatalogEntry",
+    "ArtifactCatalogIssue",
+    "ArtifactCatalogValidationError",
+    "ArtifactFileRef",
+    "artifact_catalog_from_dict",
+    "load_artifact_catalog",
+    "load_artifact_catalog_schema",
+    "sha256_file",
+    "validate_artifact_catalog",
+    "validate_artifact_catalog_payload",
+]

--- a/robot_sf/benchmark/schemas/artifact_catalog.v1.json
+++ b/robot_sf/benchmark/schemas/artifact_catalog.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/artifact_catalog.v1.json",
+  "title": "Robot SF reusable artifact catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "catalog_id", "artifacts"],
+  "properties": {
+    "schema_version": {
+      "const": "artifact_catalog.v1"
+    },
+    "catalog_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_id",
+        "artifact_kind",
+        "source_kind",
+        "source_files",
+        "outputs",
+        "generation_command",
+        "generation_commit",
+        "claim_boundary"
+      ],
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "artifact_kind": {
+          "enum": ["figure", "table"]
+        },
+        "source_kind": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "source_files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/file_ref"
+          }
+        },
+        "outputs": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/file_ref"
+          },
+          "propertyNames": {
+            "pattern": "^[a-z0-9_.-]+$"
+          }
+        },
+        "caption_file": {
+          "$ref": "#/$defs/file_ref"
+        },
+        "generation_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generation_commit": {
+          "type": "string",
+          "minLength": 7
+        },
+        "claim_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "file_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/scripts/validation/validate_artifact_catalog.py
+++ b/scripts/validation/validate_artifact_catalog.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Validate ``artifact_catalog.v1`` files."""
+
+from __future__ import annotations
+
+from robot_sf.benchmark.artifact_catalog import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/benchmark/test_artifact_catalog.py
+++ b/tests/benchmark/test_artifact_catalog.py
@@ -1,0 +1,169 @@
+"""Tests for the ``artifact_catalog.v1`` contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.artifact_catalog import (
+    ARTIFACT_CATALOG_SCHEMA_VERSION,
+    ArtifactCatalogValidationError,
+    artifact_catalog_from_dict,
+    load_artifact_catalog,
+    main,
+    sha256_file,
+    validate_artifact_catalog,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "artifact_catalog" / "v1"
+VALID_CATALOG = FIXTURE_DIR / "valid_catalog.yaml"
+
+
+def _payload() -> dict[str, object]:
+    """Return a mutable valid fixture catalog payload."""
+
+    payload = yaml.safe_load(VALID_CATALOG.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_load_valid_catalog_as_typed_metadata() -> None:
+    """The fixture catalog should expose stable artifact IDs and file checksums."""
+
+    catalog = load_artifact_catalog(VALID_CATALOG)
+
+    assert catalog.schema_version == ARTIFACT_CATALOG_SCHEMA_VERSION
+    assert catalog.catalog_id == "fixture_camera_ready_artifacts"
+    assert [artifact.artifact_id for artifact in catalog.artifacts] == [
+        "fig_benchmark_outcome_matrix",
+        "tab_planner_execution_modes",
+    ]
+    assert catalog.artifacts[0].outputs["png"].path == "fig_benchmark_outcome_matrix.png"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_path", "expected_fragment"),
+    [
+        (
+            lambda payload: payload["artifacts"].append(deepcopy(payload["artifacts"][0])),
+            "/artifacts/2/artifact_id",
+            "duplicate artifact_id 'fig_benchmark_outcome_matrix'",
+        ),
+        (
+            lambda payload: payload["artifacts"][0]["source_files"][0].__setitem__(
+                "path",
+                "missing_summary.json",
+            ),
+            "/artifacts/0/source_files/0/path",
+            "path does not exist: missing_summary.json",
+        ),
+        (
+            lambda payload: payload["artifacts"][0]["outputs"]["png"].__setitem__(
+                "path",
+                "missing_output.png",
+            ),
+            "/artifacts/0/outputs/png/path",
+            "path does not exist: missing_output.png",
+        ),
+        (
+            lambda payload: payload["artifacts"][0]["outputs"]["png"].__setitem__(
+                "path",
+                "output/generated.png",
+            ),
+            "/artifacts/0/outputs/png/path",
+            "local-only artifact reference is not durable",
+        ),
+        (
+            lambda payload: payload["artifacts"][0]["outputs"]["png"].__setitem__(
+                "sha256",
+                "0" * 64,
+            ),
+            "/artifacts/0/outputs/png/sha256",
+            "checksum mismatch",
+        ),
+    ],
+)
+def test_catalog_validation_reports_actionable_issues(
+    mutate,
+    expected_path: str,
+    expected_fragment: str,
+) -> None:
+    """Catalog failures should identify the exact artifact field to fix."""
+
+    payload = _payload()
+    mutate(payload)
+
+    issues = artifact_catalog_from_dict_invalid(payload)
+
+    assert any(
+        issue.path == expected_path and expected_fragment in issue.message for issue in issues
+    )
+
+
+def artifact_catalog_from_dict_invalid(payload: dict[str, object]):
+    """Return validation issues from the typed loader failure path."""
+
+    with pytest.raises(ArtifactCatalogValidationError) as exc_info:
+        artifact_catalog_from_dict(payload, catalog_path=VALID_CATALOG)
+    return exc_info.value.issues
+
+
+def test_cli_validation_returns_issues_for_invalid_catalog(tmp_path: Path) -> None:
+    """The path-based validator should be usable by scripts and CI."""
+
+    payload = _payload()
+    payload["artifacts"][1]["outputs"]["md"]["path"] = "missing_table.md"
+    catalog_path = tmp_path / "catalog.yaml"
+    catalog_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    issues = validate_artifact_catalog(catalog_path)
+
+    assert any(issue.path == "/artifacts/1/outputs/md/path" for issue in issues)
+
+
+def test_local_only_path_check_is_component_aware(tmp_path: Path) -> None:
+    """Sibling names like output_report.md should not trip the output/ durability guard."""
+
+    source = tmp_path / "output_report.md"
+    source.write_text("source fixture\n", encoding="utf-8")
+    rendered = tmp_path / "results_table.md"
+    rendered.write_text("rendered fixture\n", encoding="utf-8")
+    catalog = {
+        "schema_version": ARTIFACT_CATALOG_SCHEMA_VERSION,
+        "catalog_id": "path_boundary_fixture",
+        "artifacts": [
+            {
+                "artifact_id": "tab_path_boundary",
+                "artifact_kind": "table",
+                "source_kind": "benchmark_campaign",
+                "source_files": [{"path": source.name, "sha256": sha256_file(source)}],
+                "outputs": {"md": {"path": rendered.name, "sha256": sha256_file(rendered)}},
+                "generation_command": "fixture",
+                "generation_commit": "44f4f364",
+                "claim_boundary": "fixture only",
+            }
+        ],
+    }
+    catalog_path = tmp_path / "catalog.yaml"
+    catalog_path.write_text(yaml.safe_dump(catalog, sort_keys=False), encoding="utf-8")
+
+    assert validate_artifact_catalog(catalog_path) == []
+
+
+def test_cli_main_fails_on_duplicate_artifact_ids(tmp_path: Path, capsys) -> None:
+    """The command-line entry point should fail closed for duplicate semantic IDs."""
+
+    payload = _payload()
+    payload["artifacts"].append(deepcopy(payload["artifacts"][0]))
+    catalog_path = tmp_path / "catalog.yaml"
+    catalog_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    exit_code = main([str(catalog_path), "--json"])
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert '"ok": false' in captured.out
+    assert "duplicate artifact_id" in captured.out

--- a/tests/fixtures/artifact_catalog/v1/captions.md
+++ b/tests/fixtures/artifact_catalog/v1/captions.md
@@ -1,0 +1,3 @@
+# Fixture Captions
+
+`fig_benchmark_outcome_matrix`: Fixture benchmark outcome matrix.

--- a/tests/fixtures/artifact_catalog/v1/fig_benchmark_outcome_matrix.png
+++ b/tests/fixtures/artifact_catalog/v1/fig_benchmark_outcome_matrix.png
@@ -1,0 +1,1 @@
+fixture-png-placeholder

--- a/tests/fixtures/artifact_catalog/v1/source_summary.json
+++ b/tests/fixtures/artifact_catalog/v1/source_summary.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "fixture-summary.v1",
+  "rows": [
+    {
+      "planner": "orca",
+      "success": 1.0,
+      "collision": 0.0
+    }
+  ]
+}

--- a/tests/fixtures/artifact_catalog/v1/tab_planner_execution_modes.md
+++ b/tests/fixtures/artifact_catalog/v1/tab_planner_execution_modes.md
@@ -1,0 +1,3 @@
+| planner | execution_mode | availability_status |
+|---|---|---|
+| orca | native | available |

--- a/tests/fixtures/artifact_catalog/v1/valid_catalog.yaml
+++ b/tests/fixtures/artifact_catalog/v1/valid_catalog.yaml
@@ -1,0 +1,32 @@
+schema_version: artifact_catalog.v1
+catalog_id: fixture_camera_ready_artifacts
+artifacts:
+  - artifact_id: fig_benchmark_outcome_matrix
+    artifact_kind: figure
+    source_kind: benchmark_campaign
+    source_files:
+      - path: source_summary.json
+        sha256: 5fc4b3bab48a71a2983fa692988668f636db992b87ca451c242468febea245ad
+    outputs:
+      png:
+        path: fig_benchmark_outcome_matrix.png
+        sha256: eedbd154d18d684d3e4963cc6e4c5180713ec6fbcb18561ae7f66997d493b3e7
+    caption_file:
+      path: captions.md
+      sha256: 31edf86d8bd42a79b573d348bb3b32ffca443b25384c8f512100103a72aa4e53
+    generation_command: uv run python scripts/tools/example_generator.py --fixture
+    generation_commit: fbc7e125
+    claim_boundary: fixture-only catalog contract; not benchmark evidence
+  - artifact_id: tab_planner_execution_modes
+    artifact_kind: table
+    source_kind: benchmark_campaign
+    source_files:
+      - path: source_summary.json
+        sha256: 5fc4b3bab48a71a2983fa692988668f636db992b87ca451c242468febea245ad
+    outputs:
+      md:
+        path: tab_planner_execution_modes.md
+        sha256: 5fb8c9672b43950ceeab0d6849b68975f25e6badba92fc3529571243984a8026
+    generation_command: uv run python scripts/tools/example_table_exporter.py --fixture
+    generation_commit: fbc7e125
+    claim_boundary: fixture-only catalog contract; not benchmark evidence


### PR DESCRIPTION
## Summary
- add `artifact_catalog.v1` schema and typed loader for stable reusable figure/table IDs
- add `scripts/validation/validate_artifact_catalog.py` so catalogs fail on duplicate IDs, missing source/output files, local-only durable references, and checksum mismatches
- add a tiny fixture catalog plus docs/context cross-links for the benchmark artifact compiler / figure naming workflow

## Linked Issues
- Closes #2008
- Relates to #2007

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #2007 can consume this catalog contract in a future compiler slice
- Safe to review independently: yes
- Review dependency reason, if any: schema/validator/docs only

## What Changed
- Added `robot_sf/benchmark/artifact_catalog.py` and `robot_sf/benchmark/schemas/artifact_catalog.v1.json`.
- Added `scripts/validation/validate_artifact_catalog.py`.
- Added fixture-backed tests and a checked-in fixture catalog under `tests/fixtures/artifact_catalog/v1/`.
- Documented the contract in `docs/artifact_catalog.md`, benchmark publication docs, figure naming docs, and `docs/context/issue_2008_artifact_catalog.md`.

## Why It Matters
- Added value: figure/table references can use semantic IDs rather than regenerated paths.
- Expected impact: future artifact compiler/table exporter work can validate durable source/output references and checksums before reports depend on them.
- Why this is worth merging now: #2007/#2009 need stable artifact identity before generating reusable tables or bundles.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_artifact_catalog.py -q` (8 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_artifact_catalog.py tests/fixtures/artifact_catalog/v1/valid_catalog.yaml --json` (`ok: true`)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/artifact_catalog.py scripts/validation/validate_artifact_catalog.py tests/benchmark/test_artifact_catalog.py`
- `python -m json.tool robot_sf/benchmark/schemas/artifact_catalog.v1.json`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/artifact_catalog.md --path docs/context/issue_2008_artifact_catalog.md --path docs/context/README.md --path docs/README.md --path docs/benchmark_artifact_publication.md --path docs/dev/issues/figures-naming/design.md`
- `git diff --check`
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` (4,965 passed, 10 skipped; head `44f4f364`)

## Risks / Rollout
- Compatibility risks: low; additive schema, loader, CLI, fixtures, and docs.
- Failure modes: catalogs with generated `output/` references, missing files, duplicate IDs, or checksum drift now fail closed.
- Rollback or fallback plan: remove the additive catalog module/schema/validator/docs and fixture tests.

## Docs / Provenance
- Updated docs: `docs/artifact_catalog.md`, `docs/benchmark_artifact_publication.md`, `docs/dev/issues/figures-naming/design.md`, `docs/README.md`, `docs/context/README.md`.
- Relevant context note: `docs/context/issue_2008_artifact_catalog.md`.
- Artifact decision: test coverage outputs under `output/coverage/` are ignored and disposable; the checked-in fixture catalog is tiny contract proof, not benchmark evidence.

## Downstream Propagation
- Parent issue updated: PR closes #2008.
- Claim map / benchmark report updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: yes.
- Follow-up issue opened for deferred propagation: NA; #2007 already tracks the compiler consumer.

## Reviewer Notes
- Please verify the durability rule is intentionally strict for `output/` references in reusable catalogs.
