### PR TITLE
feat: add static trace viewer

### DIFF
--- a/docs/debug_visualization.md
+++ b/docs/debug_visualization.md
@@ -51,9 +51,80 @@ uv run python scripts/tools/rerun_debug_export.py \
 If `rerun-sdk` is absent, the command fails closed with an install hint instead of adding a required
 dependency to the repository.
 
+## Three.js Trace Viewer
+
+For browser-based qualitative review of `simulation_trace_export.v1` fixtures, use the static
+Three.js trace viewer:
+
+```bash
+uv run python -m robot_sf.render.trace_viewer \
+  tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json \
+  --output-dir output/trace_viewer
+```
+
+Open `output/trace_viewer/index.html` in a browser. The viewer provides:
+
+- Timeline scrub with frame-by-frame robot pose/heading and pedestrian positions.
+- HUD overlay showing trace ID, scenario, planner, seed, step, time, planner action
+  (linear/angular velocity), event type, and event ID when available.
+- Trajectory polyline rendered from cumulative robot positions.
+- Optional annotation embedding when paired with a `trace_annotation_set.v1` fixture:
+
+```bash
+uv run python -m robot_sf.render.trace_viewer \
+  tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json \
+  --annotations tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json \
+  --output-dir output/trace_viewer
+```
+
+The viewer reuses the same `robot_sf/render/web_assets/` static assets (Three.js CDN, dark theme)
+as the JSONL-playback viewer. Map bounds are auto-computed from trace positions; no SVG map
+geometry is available in this mode.
+
+### Annotation Span Markers
+
+When paired with a `trace_annotation_set.v1` fixture, the timeline displays colored span markers
+for each annotation's frame range (`frame_start` to `frame_end`). The HUD overlays show matching
+annotation summaries when the scrubber lands on an annotated frame. Annotation anchors carry
+`event_ids`, `entities`, and `details` for the frontend to surface during interactive review.
+
+```bash
+uv run python -m robot_sf.render.trace_viewer \
+  tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json \
+  --annotations tests/fixtures/analysis_workbench/trace_annotation_set_v1/issue_1962_planner_sanity_open_annotations.json \
+  --output-dir output/trace_viewer
+```
+
+The HUD also displays the source fixture path and a `[diagnostic-only]` badge. Annotation summaries
+appear inline in the HUD bar for every frame within an annotation span.
+
+### Source Fixture Path
+
+The viewer HUD shows the source fixture path (`src=`) when available, making it easy to identify
+which tracked fixture produced the current view.
+
+### Diagnostic-Only Status
+
+The scene metadata carries `diagnostic_only: true` and the HUD displays a `[diagnostic-only]`
+badge. The limitations list also states that the viewer is diagnostic-only and not benchmark
+evidence. These diagnostics identify the artifact as qualitative review tooling and prevent
+mistaking it for benchmark evidence.
+
+Programmatic usage:
+
+```python
+from pathlib import Path
+from robot_sf.analysis_workbench.simulation_trace_export import load_simulation_trace_export
+from robot_sf.render.trace_viewer import export_trace_viewer
+
+trace = load_simulation_trace_export(Path("path/to/trace.json"))
+result = export_trace_viewer(trace, "output/trace_viewer")
+print(f"Viewer files in {result.output_dir}")
+```
+
 ## Evidence Boundary
 
-Debug timelines are diagnostic visualization artifacts. They do not replace episode JSONL,
-publication bundles, release manifests, benchmark summaries, or paper-facing evidence contracts.
-Keep generated timeline files under ignored `output/` unless a compact review fixture is explicitly
-needed.
+Debug timelines and trace viewer exports are diagnostic visualization artifacts. They do not replace
+episode JSONL, publication bundles, release manifests, benchmark summaries, or paper-facing evidence
+contracts. Keep generated viewer and timeline files under ignored `output/` unless a compact review
+fixture is explicitly needed.

--- a/examples/advanced/34_trace_threejs_viewer.py
+++ b/examples/advanced/34_trace_threejs_viewer.py
@@ -1,0 +1,74 @@
+"""Export a simulation_trace_export.v1 trace to a static browser viewer.
+
+Usage:
+    uv run python examples/advanced/34_trace_threejs_viewer.py
+    uv run python examples/advanced/34_trace_threejs_viewer.py path/to/trace.json
+    uv run python examples/advanced/34_trace_threejs_viewer.py path/to/trace.json --annotations path/to/annotations.json
+
+Expected Output:
+    - Static viewer files under `output/trace_viewer/`.
+
+Limitations:
+    - This is a diagnostic-only qualitative viewer. It is not benchmark evidence.
+    - Map bounds are auto-computed from trace positions; no SVG map geometry is available.
+    - The browser loads Three.js from a CDN, so offline use requires vendoring that asset first.
+"""
+
+import sys
+from pathlib import Path
+
+from robot_sf.render.trace_viewer import main as viewer_main
+
+
+def main() -> int:
+    """Run the trace viewer exporter against a provided or fixture trace.
+
+    Returns:
+        int: Process exit status code.
+    """
+    args = sys.argv[1:]
+    if not args or args[0].startswith("-"):
+        default_args = _default_fixture_args()
+        if default_args is None:
+            return 1
+        args = [*default_args, *args]
+    return viewer_main(args)
+
+
+def _default_fixture_args() -> list[str] | None:
+    """Return default trace/annotation arguments for demo runs.
+
+    Returns:
+        CLI argument list, or ``None`` when the tracked fixture is unavailable.
+    """
+    fixture_dir = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "fixtures"
+        / "analysis_workbench"
+        / "simulation_trace_export_v1"
+    )
+    fixture = fixture_dir / "planner_sanity_open_episode_0000.json"
+    fallback_fixture = fixture_dir / "minimal_trace.json"
+    annotation_fixture = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "fixtures"
+        / "analysis_workbench"
+        / "trace_annotation_set_v1"
+        / "issue_1962_planner_sanity_open_annotations.json"
+    )
+    if fixture.exists() and annotation_fixture.exists():
+        return [
+            str(fixture),
+            "--annotations",
+            str(annotation_fixture),
+        ]
+    if fallback_fixture.exists():
+        return [str(fallback_fixture)]
+    sys.stderr.write(f"Fixture not found: {fixture}\n")
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/examples_manifest.yaml
+++ b/examples/examples_manifest.yaml
@@ -220,6 +220,15 @@ examples:
     ci_reason: null
     doc_reference: docs/dev_guide.md#advanced-feature-demos
     tags: [visualization, recording, threejs]
+  - path: advanced/34_trace_threejs_viewer.py
+    name: "34 Trace Three.js Viewer"
+    summary: "Export a simulation_trace_export.v1 trace to a static browser viewer."
+    category_slug: advanced
+    prerequisites: []
+    ci_enabled: true
+    ci_reason: null
+    doc_reference: docs/debug_visualization.md#threejs-trace-viewer
+    tags: [visualization, trace, annotation, threejs]
   - path: advanced/08_multi_pedestrian.py
     name: "08 Multi-Pedestrian"
     summary: "Build a multi-pedestrian scenario using map definitions."

--- a/robot_sf/render/__init__.py
+++ b/robot_sf/render/__init__.py
@@ -5,8 +5,18 @@ and managing video recording outputs.
 """
 
 from robot_sf.render.helper_catalog import capture_frames, ensure_output_dir
+from robot_sf.render.trace_viewer import (
+    TRACE_VIEWER_SCENE_VERSION,
+    TraceViewerResult,
+    build_trace_scene,
+    export_trace_viewer,
+)
 
 __all__ = [
+    "TRACE_VIEWER_SCENE_VERSION",
+    "TraceViewerResult",
+    "build_trace_scene",
     "capture_frames",
     "ensure_output_dir",
+    "export_trace_viewer",
 ]

--- a/robot_sf/render/trace_viewer.py
+++ b/robot_sf/render/trace_viewer.py
@@ -1,0 +1,329 @@
+"""Export ``simulation_trace_export.v1`` traces for a static Three.js viewer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SimulationTraceExport,
+    load_simulation_trace_export,
+)
+from robot_sf.analysis_workbench.trace_annotation import load_trace_annotation_set
+from robot_sf.render.threejs_viewer import SCENE_SCHEMA_VERSION
+
+TRACE_VIEWER_SCENE_VERSION = "trace-viewer.v1"
+
+
+@dataclass(frozen=True)
+class TraceViewerResult:
+    """Files written for a browser-viewable trace export."""
+
+    output_dir: Path
+    html_path: Path
+    scene_path: Path
+
+
+def build_trace_scene(
+    trace: SimulationTraceExport,
+    *,
+    source: str | None = None,
+    annotations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the renderer-neutral scene payload from a simulation trace export.
+
+    Args:
+        trace: A loaded simulation trace export.
+        source: Optional source identifier for the scene payload.
+        annotations: Optional list of annotation dicts to embed in the scene.
+
+    Returns:
+        dict[str, Any]: JSON-safe scene payload with auto-computed map bounds,
+        animation frames, trace metadata, and optional annotations.
+    """
+    frames = [_trace_frame_to_scene_frame(frame) for frame in trace.frames]
+    if not frames:
+        raise ValueError("Trace viewer export requires at least one trace frame")
+
+    map_payload = _compute_trace_map(trace)
+    trajectory = [
+        frame["robot"]["position"]
+        for frame in frames
+        if frame.get("robot") and frame["robot"].get("position")
+    ]
+
+    diagnostic_only = True
+
+    scene: dict[str, Any] = {
+        "schema_version": SCENE_SCHEMA_VERSION,
+        "trace_viewer_version": TRACE_VIEWER_SCENE_VERSION,
+        "source": source,
+        "trace_id": trace.trace_id,
+        "episode_id": trace.source.episode_id,
+        "metadata": {
+            "schema_version": trace.schema_version,
+            "coordinate_frame": trace.coordinate_frame,
+            "units": {key: str(val) for key, val in (trace.units or {}).items()},
+            "evidence_boundary": trace.evidence_boundary,
+            "diagnostic_only": diagnostic_only,
+            "source": {
+                "scenario_id": trace.source.scenario_id,
+                "seed": trace.source.seed,
+                "planner_id": trace.source.planner_id,
+                "episode_id": trace.source.episode_id,
+                "generated_by": trace.source.generated_by,
+            },
+        },
+        "map": map_payload,
+        "frames": frames,
+        "trajectory": trajectory,
+        "reset_points": [],
+        "limitations": [
+            "Trace viewer for qualitative review of simulation_trace_export.v1 fixtures.",
+            "Map bounds are auto-computed from trace positions; no SVG map geometry is available.",
+            "This viewer is diagnostic-only; not benchmark evidence.",
+        ],
+    }
+    if annotations:
+        scene["annotations"] = list(annotations)
+    return scene
+
+
+def _compute_trace_map(trace: SimulationTraceExport) -> dict[str, Any]:
+    """Auto-compute map bounds and a minimal empty layout from trace positions.
+
+    Returns:
+        dict[str, Any]: Map payload with computed bounds and empty obstacle/zone lists.
+    """
+    all_x: list[float] = []
+    all_y: list[float] = []
+    for frame in trace.frames:
+        robot_pos = frame.robot.get("position")
+        if isinstance(robot_pos, (list, tuple)) and len(robot_pos) >= 2:
+            all_x.append(float(robot_pos[0]))
+            all_y.append(float(robot_pos[1]))
+        for ped in frame.pedestrians:
+            ped_pos = ped.get("position")
+            if isinstance(ped_pos, (list, tuple)) and len(ped_pos) >= 2:
+                all_x.append(float(ped_pos[0]))
+                all_y.append(float(ped_pos[1]))
+
+    if not all_x or not all_y:
+        origin_x, origin_y = 0.0, 0.0
+        width, height = 10.0, 10.0
+    else:
+        min_x, max_x = min(all_x), max(all_x)
+        min_y, max_y = min(all_y), max(all_y)
+        padding = max((max_x - min_x) * 0.2, (max_y - min_y) * 0.2, 1.0)
+        origin_x = min_x - padding
+        origin_y = min_y - padding
+        width = max_x - min_x + padding * 2
+        height = max_y - min_y + padding * 2
+
+    return {
+        "origin": [origin_x, origin_y],
+        "width": width,
+        "height": height,
+        "bounds": [
+            [origin_x, origin_x + width, origin_y, origin_y],
+            [origin_x, origin_x + width, origin_y + height, origin_y + height],
+            [origin_x, origin_x, origin_y, origin_y + height],
+            [origin_x + width, origin_x + width, origin_y, origin_y + height],
+        ],
+        "obstacles": [],
+        "robot_spawn_zones": [],
+        "robot_goal_zones": [],
+        "ped_spawn_zones": [],
+        "ped_goal_zones": [],
+        "ped_crowded_zones": [],
+        "_padding": max(padding, 1.0) if all_x else 1.0,
+    }
+
+
+def _trace_frame_to_scene_frame(frame: Any) -> dict[str, Any]:
+    """Convert one simulation trace frame to a Three.js-compatible animation frame.
+
+    Returns:
+        dict[str, Any]: Frame dict with robot pose, pedestrians, and planner metadata.
+    """
+    robot_pose = frame.robot
+    robot_payload: dict[str, Any] | None = None
+    if robot_pose.get("position") is not None:
+        pos = robot_pose["position"]
+        robot_payload = {
+            "position": [float(pos[0]), float(pos[1])],
+            "heading": float(robot_pose.get("heading", 0.0)),
+            "velocity": (
+                [float(v) for v in robot_pose["velocity"]] if robot_pose.get("velocity") else None
+            ),
+        }
+
+    pedestrians: list[dict[str, Any]] = []
+    for ped in frame.pedestrians:
+        ped_pos = ped.get("position")
+        if ped_pos is not None:
+            ped_entry: dict[str, Any] = {
+                "id": str(ped.get("id", "")),
+                "position": [float(ped_pos[0]), float(ped_pos[1])],
+            }
+            if ped.get("velocity"):
+                ped_entry["velocity"] = [float(v) for v in ped["velocity"]]
+            pedestrians.append(ped_entry)
+
+    planner = frame.planner
+    scene_frame: dict[str, Any] = {
+        "frame_idx": frame.step,
+        "timestep": frame.step,
+        "time_s": frame.time_s,
+        "robot": robot_payload,
+        "pedestrians": pedestrians,
+        "rays": [],
+        "planned_path": [],
+    }
+
+    event = planner.get("event")
+    if event is not None:
+        scene_frame["event"] = str(event)
+    event_id = planner.get("event_id")
+    if event_id is not None:
+        scene_frame["event_id"] = str(event_id)
+
+    selected_action = planner.get("selected_action")
+    if selected_action is not None:
+        scene_frame["planner_action"] = {
+            "linear_velocity": float(selected_action.get("linear_velocity", 0.0)),
+            "angular_velocity": float(selected_action.get("angular_velocity", 0.0)),
+        }
+
+    return scene_frame
+
+
+def export_trace_viewer(
+    trace: SimulationTraceExport,
+    output_dir: str | Path,
+    *,
+    source: str | None = None,
+    annotations: list[dict[str, Any]] | None = None,
+) -> TraceViewerResult:
+    """Export a simulation trace export into static browser viewer files.
+
+    Args:
+        trace: A loaded simulation trace export.
+        output_dir: Directory for the viewer files.
+        source: Optional source identifier.
+        annotations: Optional annotations to embed.
+
+    Returns:
+        TraceViewerResult: Paths to the generated viewer directory, HTML file, and scene JSON.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    scene = build_trace_scene(trace, source=source, annotations=annotations)
+
+    scene_path = output_path / "scene.json"
+    scene_path.write_text(json.dumps(scene, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    html_path = output_path / "index.html"
+    _copy_web_asset("index.html", html_path)
+    _copy_web_asset("viewer.js", output_path / "viewer.js")
+
+    return TraceViewerResult(output_dir=output_path, html_path=html_path, scene_path=scene_path)
+
+
+def _copy_web_asset(asset_name: str, destination: Path) -> None:
+    """Copy a packaged static web asset into an export directory."""
+    asset = resources.files("robot_sf.render.web_assets").joinpath(asset_name)
+    with resources.as_file(asset) as asset_path:
+        shutil.copyfile(asset_path, destination)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for exporting a static Three.js trace viewer.
+
+    Returns:
+        int: Process exit status code.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", help="Path to a simulation_trace_export.v1 JSON fixture")
+    parser.add_argument(
+        "--output-dir",
+        default="output/trace_viewer",
+        help="Directory for index.html, viewer.js, and scene.json",
+    )
+    parser.add_argument(
+        "--annotations",
+        default=None,
+        help="Optional path to a trace_annotation_set.v1 JSON fixture",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        trace_path = Path(args.trace)
+        trace = load_simulation_trace_export(trace_path)
+        annotations_payload = _load_annotation_payload(
+            Path(args.annotations) if args.annotations else None,
+            trace_id=trace.trace_id,
+        )
+        result = export_trace_viewer(
+            trace,
+            args.output_dir,
+            source=str(trace_path),
+            annotations=annotations_payload,
+        )
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
+    logger.info("Wrote trace viewer: {}", result.html_path)
+    logger.info("Wrote scene payload: {}", result.scene_path)
+    return 0
+
+
+def _load_annotation_payload(
+    annotation_path: Path | None,
+    *,
+    trace_id: str,
+) -> list[dict[str, Any]] | None:
+    """Load optional annotation payload and ensure it matches the selected trace.
+
+    Returns:
+        Annotation dictionaries for the scene payload, or ``None`` when no annotation path is
+        supplied.
+    """
+    if annotation_path is None:
+        return None
+    annotation_set = load_trace_annotation_set(annotation_path)
+    if annotation_set.timeline.trace_id != trace_id:
+        raise ValueError(
+            "annotation trace_id does not match supplied trace: "
+            f"{annotation_set.timeline.trace_id!r} != {trace_id!r}"
+        )
+    return [
+        {
+            "annotation_id": a.annotation_id,
+            "category": a.category,
+            "evidence_type": a.evidence_type,
+            "anchor": {
+                "frame_start": a.anchor.frame_start,
+                "frame_end": a.anchor.frame_end,
+                "event_ids": list(a.anchor.event_ids),
+                "entities": [{"type": e.type, "id": e.id} for e in a.anchor.entities],
+            },
+            "summary": a.summary,
+            "details": a.details,
+        }
+        for a in annotation_set.annotations
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robot_sf/render/web_assets/index.html
+++ b/robot_sf/render/web_assets/index.html
@@ -20,16 +20,60 @@
         position: fixed;
         left: 16px;
         top: 16px;
+        max-width: 80%;
         padding: 10px 12px;
         border-radius: 8px;
         background: rgb(15 23 42 / 88%);
-        font-size: 14px;
+        font-size: 13px;
+        line-height: 1.5;
+        word-break: break-all;
       }
-      #timeline {
+      #hud .diagnostic-badge {
+        display: inline-block;
+        padding: 0 6px;
+        border-radius: 4px;
+        background: #f59e0b;
+        color: #111827;
+        font-weight: 600;
+        font-size: 11px;
+      }
+      .annotation-label {
+        display: inline-block;
+        padding: 0 4px;
+        border-radius: 3px;
+        font-size: 11px;
+        line-height: 1.4;
+      }
+      .annotation-label.planner_action {
+        background: #f97316;
+        color: #111827;
+      }
+      .annotation-label.interaction {
+        background: #ec4899;
+        color: #fff;
+      }
+      .annotation-label.safety_margin {
+        background: #14b8a6;
+        color: #111827;
+      }
+      .annotation-label.data_quality {
+        background: #8b5cf6;
+        color: #fff;
+      }
+      #controls {
         position: fixed;
         left: 16px;
         right: 16px;
         bottom: 16px;
+      }
+      #markers {
+        display: none;
+        height: 40px;
+        margin-bottom: 4px;
+        image-rendering: pixelated;
+      }
+      #timeline {
+        width: 100%;
       }
       input[type="range"] {
         width: 100%;
@@ -39,7 +83,10 @@
   <body>
     <div id="viewer"></div>
     <div id="hud">Loading scene...</div>
-    <input id="timeline" type="range" min="0" max="0" value="0" />
+    <div id="controls">
+      <div id="markers"></div>
+      <input id="timeline" type="range" min="0" max="0" value="0" />
+    </div>
     <script type="module" src="./viewer.js"></script>
   </body>
 </html>

--- a/robot_sf/render/web_assets/viewer.js
+++ b/robot_sf/render/web_assets/viewer.js
@@ -212,6 +212,10 @@ function annotationFrameRange(scenePayload, annotation) {
   const startStep = annotation.anchor.frame_start;
   const endStep = annotation.anchor.frame_end;
   const frames = scenePayload.frames;
+  if (!frames.length) return [null, null];
+  const firstStep = frames[0].timestep ?? 0;
+  const lastStep = frames[frames.length - 1].timestep ?? frames.length - 1;
+  if (endStep < firstStep || startStep > lastStep) return [null, null];
   let start = frames.findIndex((frame) => frame.timestep === startStep);
   let end = frames.findIndex((frame) => frame.timestep === endStep);
   if (start < 0) {

--- a/robot_sf/render/web_assets/viewer.js
+++ b/robot_sf/render/web_assets/viewer.js
@@ -3,6 +3,7 @@ import * as THREE from "https://unpkg.com/three@0.164.1/build/three.module.js";
 const root = document.querySelector("#viewer");
 const hud = document.querySelector("#hud");
 const timeline = document.querySelector("#timeline");
+const markers = document.querySelector("#markers");
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x111827);
@@ -39,6 +40,7 @@ fetch("./scene.json")
     buildStaticMap(scenePayload.map);
     timeline.max = Math.max(scenePayload.frames.length - 1, 0);
     fitCamera(scenePayload.map);
+    buildTimelineMarkers(scenePayload);
     drawFrame(0);
     animate();
   })
@@ -62,12 +64,13 @@ window.addEventListener("resize", resize);
 resize();
 
 function buildStaticMap(map) {
+  const origin = map.origin || [0, 0];
   const floor = new THREE.Mesh(
     new THREE.PlaneGeometry(map.width, map.height),
     new THREE.MeshBasicMaterial({ color: 0x243041 })
   );
   floor.rotation.x = -Math.PI / 2;
-  floor.position.set(map.width / 2, -0.02, map.height / 2);
+  floor.position.set(origin[0] + map.width / 2, -0.02, origin[1] + map.height / 2);
   world.add(floor);
 
   map.bounds.forEach((line) => world.add(makeLine(line, 0xe5e7eb)));
@@ -92,6 +95,59 @@ function addZones(zones, color) {
   });
 }
 
+function buildTimelineMarkers(scenePayload) {
+  const numFrames = scenePayload.frames.length;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(numFrames, 2);
+  canvas.height = 40;
+  const ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  let hasMarkers = false;
+
+  for (let i = 0; i < numFrames; i++) {
+    const frame = scenePayload.frames[i];
+    if (frame.event && i > 0 && frame.event !== scenePayload.frames[i - 1].event) {
+      ctx.fillStyle = "#fbbf24";
+      ctx.fillRect(i, 0, 1, 40);
+      hasMarkers = true;
+    }
+    if (frame.event_id) {
+      ctx.fillStyle = "#60a5fa";
+      ctx.fillRect(i, 30, 1, 4);
+      hasMarkers = true;
+    }
+    if (frame.planner_action) {
+      ctx.fillStyle = "#a78bfa";
+      ctx.fillRect(i, 34, 1, 4);
+      hasMarkers = true;
+    }
+  }
+
+  const annotations = scenePayload.annotations || [];
+  const annotationColors = ["#f97316", "#ec4899", "#14b8a6", "#eab308", "#8b5cf6"];
+  annotations.forEach((ann, idx) => {
+    const [start, end] = annotationFrameRange(scenePayload, ann);
+    if (start === null || end === null) return;
+    const color = annotationColors[idx % annotationColors.length];
+    ctx.fillStyle = color;
+    ctx.globalAlpha = 0.35;
+    ctx.fillRect(start, 0, end - start + 1, 40);
+    ctx.globalAlpha = 1.0;
+    ctx.fillRect(start, 24, end - start + 1, 2);
+    hasMarkers = true;
+  });
+
+  if (!hasMarkers) return;
+
+  markers.style.backgroundImage = `url(${canvas.toDataURL()})`;
+  markers.style.backgroundRepeat = "no-repeat";
+  markers.style.backgroundSize = "100% 40px";
+
+  const slider = document.querySelector("#timeline");
+  slider.style.marginTop = "0";
+  markers.style.display = "block";
+}
+
 function drawFrame(index) {
   if (!payload) return;
   currentFrame = Math.max(0, Math.min(index, payload.frames.length - 1));
@@ -105,10 +161,68 @@ function drawFrame(index) {
     setAgent(marker, { position: ped.position, heading: 0 });
     return marker;
   }));
-  replaceChildren(trajectory, [makePolyline(payload.trajectory.slice(0, currentFrame + 1), 0x86efac)]);
-  replaceChildren(rays, frame.rays.map((ray) => makeLine([ray[0][0], ray[1][0], ray[0][1], ray[1][1]], 0xf8fafc)));
+  const trajectoryPoints = (payload.trajectory || []).slice(0, currentFrame + 1);
+  replaceChildren(trajectory, [makePolyline(trajectoryPoints, 0x86efac)]);
+  replaceChildren(rays, (frame.rays || []).map((ray) => makeLine([ray[0][0], ray[1][0], ray[0][1], ray[1][1]], 0xf8fafc)));
 
-  hud.textContent = `Episode ${payload.episode_id} | frame ${currentFrame + 1}/${payload.frames.length} | t=${frame.time_s.toFixed(2)}s`;
+  const parts = [];
+  if (payload.source) parts.push(`src=${payload.source}`);
+  const traceId = payload.trace_id || payload.episode_id || "";
+  if (traceId) parts.push(`Trace ${traceId}`);
+  if (payload.metadata?.source?.scenario_id) {
+    parts.push(`scenario=${payload.metadata.source.scenario_id}`);
+  }
+  if (payload.metadata?.source?.planner_id) {
+    parts.push(`planner=${payload.metadata.source.planner_id}`);
+  }
+  if (payload.metadata?.source?.seed !== undefined) {
+    parts.push(`seed=${payload.metadata.source.seed}`);
+  }
+  if (payload.metadata?.diagnostic_only) {
+    parts.push("[diagnostic-only]");
+  }
+  parts.push(`frame ${currentFrame + 1}/${payload.frames.length}`);
+  parts.push(`step=${frame.timestep != null ? frame.timestep : currentFrame}`);
+  if (frame.time_s != null) parts.push(`t=${frame.time_s.toFixed(2)}s`);
+
+  if (frame.event) parts.push(`event=${frame.event}`);
+  if (frame.event_id) parts.push(`id=${frame.event_id}`);
+
+  if (frame.planner_action) {
+    const a = frame.planner_action;
+    parts.push(`v=${a.linear_velocity.toFixed(3)} w=${a.angular_velocity.toFixed(3)}`);
+  }
+
+  const annotations = payload.annotations || [];
+  const activeAnnotations = annotations.filter((ann) => {
+    const step = frame.timestep != null ? frame.timestep : currentFrame;
+    return step >= ann.anchor.frame_start && step <= ann.anchor.frame_end;
+  });
+  if (activeAnnotations.length > 0) {
+    parts.push("");
+    activeAnnotations.forEach((ann) => {
+      parts.push(`[${ann.category}] ${ann.summary}`);
+    });
+  }
+
+  hud.textContent = parts.join(" | ");
+}
+
+function annotationFrameRange(scenePayload, annotation) {
+  const startStep = annotation.anchor.frame_start;
+  const endStep = annotation.anchor.frame_end;
+  const frames = scenePayload.frames;
+  let start = frames.findIndex((frame) => frame.timestep === startStep);
+  let end = frames.findIndex((frame) => frame.timestep === endStep);
+  if (start < 0) {
+    start = frames.findIndex((frame) => (frame.timestep ?? 0) >= startStep);
+  }
+  if (end < 0) {
+    end = frames.findIndex((frame) => (frame.timestep ?? 0) > endStep) - 1;
+  }
+  if (end < 0) end = frames.length - 1;
+  if (start < 0 || end < start) return [null, null];
+  return [start, end];
 }
 
 function animate() {
@@ -172,11 +286,12 @@ function disposeObject(object) {
 }
 
 function fitCamera(map) {
+  const origin = map.origin || [0, 0];
   const width = root.clientWidth || window.innerWidth;
   const height = root.clientHeight || window.innerHeight;
   const aspect = width / Math.max(height, 1);
-  const centerX = map.width / 2;
-  const centerY = map.height / 2;
+  const centerX = origin[0] + map.width / 2;
+  const centerY = origin[1] + map.height / 2;
   const margin = 1.16;
   let halfWidth = (map.width * margin) / 2;
   let halfHeight = (map.height * margin) / 2;

--- a/robot_sf/render/web_assets/viewer.js
+++ b/robot_sf/render/web_assets/viewer.js
@@ -224,7 +224,7 @@ function annotationFrameRange(scenePayload, annotation) {
   if (end < 0) {
     end = frames.findIndex((frame) => (frame.timestep ?? 0) > endStep) - 1;
   }
-  if (end < 0) end = frames.length - 1;
+  if (end === -2) end = frames.length - 1;
   if (start < 0 || end < start) return [null, null];
   return [start, end];
 }

--- a/tests/render/test_trace_viewer.py
+++ b/tests/render/test_trace_viewer.py
@@ -1,0 +1,289 @@
+"""Smoke tests for the trace-export Three.js viewer."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    load_simulation_trace_export,
+)
+from robot_sf.render.threejs_viewer import SCENE_SCHEMA_VERSION
+from robot_sf.render.trace_viewer import (
+    TRACE_VIEWER_SCENE_VERSION,
+    TraceViewerResult,
+    build_trace_scene,
+    export_trace_viewer,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+)
+MINIMAL_TRACE_PATH = FIXTURE_DIR / "minimal_trace.json"
+MATERIALIZED_TRACE_PATH = FIXTURE_DIR / "planner_sanity_open_episode_0000.json"
+ANNOTATION_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "trace_annotation_set_v1"
+)
+ANNOTATION_PATH = ANNOTATION_FIXTURE_DIR / "issue_1962_planner_sanity_open_annotations.json"
+
+
+def test_build_trace_scene_contains_minimal_trace_payload() -> None:
+    """The minimal trace fixture should produce a valid scene payload."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+    scene = build_trace_scene(trace, source=str(MINIMAL_TRACE_PATH))
+
+    assert scene["schema_version"] == SCENE_SCHEMA_VERSION
+    assert scene["trace_viewer_version"] == TRACE_VIEWER_SCENE_VERSION
+    assert scene["trace_id"] == "fixture_trace_001"
+    assert scene["metadata"]["source"]["scenario_id"] == "classic_bottleneck_medium"
+    assert len(scene["frames"]) == 2
+    assert scene["frames"][0]["robot"]["position"] == [0.0, 0.0]
+    assert scene["frames"][0]["pedestrians"][0]["id"] == "ped_1"
+    assert scene["frames"][0]["pedestrians"][0]["position"] == [1.0, 0.5]
+    assert scene["frames"][0]["event"] == "start"
+    assert scene["frames"][1]["event"] == "advance"
+    assert scene["frames"][1]["planner_action"] == {
+        "linear_velocity": 0.1,
+        "angular_velocity": 0.0,
+    }
+    assert scene["frames"][1]["robot"]["velocity"] == [0.1, 0.0]
+
+
+def test_build_trace_scene_contains_event_ids() -> None:
+    """The materialized trace fixture should preserve event_id in scene frames."""
+    trace = load_simulation_trace_export(MATERIALIZED_TRACE_PATH)
+    scene = build_trace_scene(trace, source=str(MATERIALIZED_TRACE_PATH))
+
+    assert scene["trace_id"] == "planner_sanity_open-ep0-seed7-source-aae87cf6"
+    assert len(scene["frames"]) == 3
+    assert scene["frames"][0]["event_id"] == (
+        "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000"
+    )
+    assert scene["frames"][2]["event_id"] == (
+        "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002"
+    )
+    assert scene["frames"][0]["event"] == "step"
+
+
+def test_build_trace_scene_computes_map_bounds_from_positions() -> None:
+    """Map bounds should be auto-computed from robot and pedestrian positions."""
+    trace = load_simulation_trace_export(MATERIALIZED_TRACE_PATH)
+    scene = build_trace_scene(trace)
+
+    map_data = scene["map"]
+    assert map_data["origin"][0] < scene["frames"][0]["robot"]["position"][0]
+    assert map_data["origin"][1] < scene["frames"][0]["robot"]["position"][1]
+    assert map_data["width"] > 0
+    assert map_data["height"] > 0
+    assert len(map_data["bounds"]) == 4
+    assert map_data["obstacles"] == []
+    assert map_data["robot_spawn_zones"] == []
+
+
+def test_build_trace_scene_trajectory_from_robot_positions() -> None:
+    """Trajectory should be computed from robot positions across frames."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+    scene = build_trace_scene(trace)
+
+    assert scene["trajectory"] == [[0.0, 0.0], [0.01, 0.0]]
+
+
+def test_build_trace_scene_includes_source_metadata() -> None:
+    """Source metadata should be embedded in the scene for traceability."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+    scene = build_trace_scene(trace, source="test_source")
+
+    meta = scene["metadata"]
+    assert meta["schema_version"] == "simulation_trace_export.v1"
+    assert meta["evidence_boundary"] == "analysis_workbench_only"
+    assert meta["coordinate_frame"] == "world"
+    assert meta["source"]["planner_id"] == "hybrid_rule_v0_minimal"
+    assert meta["source"]["seed"] == 111
+    assert "units" in meta
+
+
+def test_build_trace_scene_with_annotations() -> None:
+    """Optional annotations should be embedded in the scene payload."""
+    trace = load_simulation_trace_export(MATERIALIZED_TRACE_PATH)
+
+    from robot_sf.analysis_workbench.trace_annotation import (
+        load_trace_annotation_set,
+    )
+
+    annotation_set = load_trace_annotation_set(ANNOTATION_PATH)
+    annotations_payload = [
+        {
+            "annotation_id": a.annotation_id,
+            "summary": a.summary,
+            "category": a.category,
+            "evidence_type": a.evidence_type,
+            "anchor": {
+                "frame_start": a.anchor.frame_start,
+                "frame_end": a.anchor.frame_end,
+                "event_ids": list(a.anchor.event_ids),
+                "entities": [{"type": e.type, "id": e.id} for e in a.anchor.entities],
+            },
+            "details": a.details,
+        }
+        for a in annotation_set.annotations
+    ]
+
+    scene = build_trace_scene(trace, annotations=annotations_payload)
+
+    assert "annotations" in scene
+    assert len(scene["annotations"]) == 3
+    assert scene["annotations"][0]["annotation_id"].startswith("issue_1962_step")
+    ann = scene["annotations"][0]
+    assert ann["category"] == "planner_action"
+    assert ann["anchor"]["frame_start"] == 1
+    assert ann["anchor"]["frame_end"] == 2
+    assert len(ann["anchor"]["event_ids"]) == 2
+    assert len(ann["anchor"]["entities"]) == 1
+    assert ann["anchor"]["entities"][0]["type"] == "robot"
+    assert ann["details"] is not None
+
+
+def test_export_trace_viewer_writes_static_assets(tmp_path: Path) -> None:
+    """A minimal trace should produce index.html, viewer.js, and scene.json."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+
+    result = export_trace_viewer(trace, tmp_path / "trace_viewer")
+
+    assert isinstance(result, TraceViewerResult)
+    assert result.html_path.exists()
+    assert (result.output_dir / "viewer.js").exists()
+    assert result.scene_path.exists()
+
+    scene = json.loads(result.scene_path.read_text(encoding="utf-8"))
+    assert scene["trace_id"] == "fixture_trace_001"
+    assert scene["trace_viewer_version"] == TRACE_VIEWER_SCENE_VERSION
+    assert len(scene["frames"]) == 2
+
+
+def test_build_trace_scene_annotation_spans_visualization_data() -> None:
+    """Annotation anchors should carry frame ranges usable for timeline span rendering."""
+    trace = load_simulation_trace_export(MATERIALIZED_TRACE_PATH)
+
+    from robot_sf.analysis_workbench.trace_annotation import (
+        load_trace_annotation_set,
+    )
+
+    annotation_set = load_trace_annotation_set(ANNOTATION_PATH)
+    annotations_payload = [
+        {
+            "annotation_id": a.annotation_id,
+            "summary": a.summary,
+            "anchor": {
+                "frame_start": a.anchor.frame_start,
+                "frame_end": a.anchor.frame_end,
+            },
+        }
+        for a in annotation_set.annotations
+    ]
+
+    scene = build_trace_scene(trace, annotations=annotations_payload)
+
+    frame_steps = {f["timestep"] for f in scene["frames"]}
+    for ann in scene["annotations"]:
+        anchor = ann["anchor"]
+        assert "frame_start" in anchor
+        assert "frame_end" in anchor
+        assert anchor["frame_end"] >= anchor["frame_start"]
+        assert anchor["frame_start"] in frame_steps
+        assert anchor["frame_end"] in frame_steps
+
+
+def test_export_trace_viewer_uses_trace_viewer_version(tmp_path: Path) -> None:
+    """The exported scene should carry the trace viewer version tag."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+
+    result = export_trace_viewer(trace, tmp_path, source="test")
+    scene = json.loads(result.scene_path.read_text(encoding="utf-8"))
+
+    assert scene["trace_viewer_version"] == TRACE_VIEWER_SCENE_VERSION
+
+
+def test_build_trace_scene_limitations_are_diagnostic_only(tmp_path: Path) -> None:
+    """Limitations should state this is for qualitative review only."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+    scene = build_trace_scene(trace)
+
+    limitations = scene["limitations"]
+    assert any("qualitative" in lim for lim in limitations)
+    assert any("simulation_trace_export.v1" in lim for lim in limitations)
+    assert any("diagnostic-only" in lim for lim in limitations)
+
+
+def test_build_trace_scene_metadata_diagnostic_flag() -> None:
+    """Scene metadata should carry diagnostic_only flag."""
+    trace = load_simulation_trace_export(MINIMAL_TRACE_PATH)
+    scene = build_trace_scene(trace)
+
+    assert scene["metadata"]["diagnostic_only"] is True
+
+
+def test_build_trace_scene_with_empty_frames_raises() -> None:
+    """An export with no frames should raise an error."""
+    from robot_sf.analysis_workbench.simulation_trace_export import (
+        SimulationTraceExport,
+        SimulationTraceSource,
+    )
+
+    empty_trace = SimulationTraceExport(
+        schema_version="simulation_trace_export.v1",
+        trace_id="empty",
+        source=SimulationTraceSource(
+            scenario_id="test",
+            seed=0,
+            planner_id="test",
+            episode_id="0",
+            generated_by="test",
+        ),
+        evidence_boundary="analysis_workbench_only",
+        coordinate_frame="world",
+        units={"position": "m", "heading": "rad", "time": "s", "velocity": "m/s"},
+        frames=[],
+    )
+
+    with pytest.raises(ValueError, match="at least one trace frame"):
+        build_trace_scene(empty_trace)
+
+
+def test_trace_viewer_cli_rejects_mismatched_annotation_trace(tmp_path: Path) -> None:
+    """The CLI should fail closed when annotation anchors point at another trace."""
+    from robot_sf.render.trace_viewer import main
+
+    exit_code = main(
+        [
+            str(MINIMAL_TRACE_PATH),
+            "--annotations",
+            str(ANNOTATION_PATH),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert exit_code == 1
+    assert not (tmp_path / "scene.json").exists()
+
+
+def test_export_trace_viewer_roundtrip_materialized_fixture(tmp_path: Path) -> None:
+    """The materialized trace fixture should roundtrip through the export pipeline."""
+    trace = load_simulation_trace_export(MATERIALIZED_TRACE_PATH)
+
+    result = export_trace_viewer(trace, tmp_path, source=str(MATERIALIZED_TRACE_PATH))
+    scene = json.loads(result.scene_path.read_text(encoding="utf-8"))
+
+    assert scene["trace_id"] == trace.trace_id
+    assert scene["episode_id"] == trace.source.episode_id
+    assert len(scene["frames"]) == len(trace.frames)
+
+    for scene_frame, trace_frame in zip(scene["frames"], trace.frames, strict=True):
+        assert scene_frame["timestep"] == trace_frame.step
+        assert abs(scene_frame["time_s"] - trace_frame.time_s) < 1e-9


### PR DESCRIPTION
## Summary

- Adds a static `simulation_trace_export.v1` → Three.js viewer exporter for tracked trace fixtures.
- Reuses the existing static web viewer assets while preserving JSONL recording viewer behavior.
- Adds timeline/event/annotation markers, diagnostic-only metadata, a documented example, and fixture-backed tests.

Closes #2017.

## Validation

- `uv run ruff format --check robot_sf/render/trace_viewer.py tests/render/test_trace_viewer.py examples/advanced/34_trace_threejs_viewer.py`
- `uv run ruff check robot_sf/render/trace_viewer.py tests/render/test_trace_viewer.py examples/advanced/34_trace_threejs_viewer.py`
- `uv run pytest tests/render/test_trace_viewer.py tests/render/test_threejs_viewer.py tests/analysis_workbench -q`
- `uv run pytest tests/test_lazy_pygame_init.py::test_headless_robot_env_creation_does_not_import_pygame -q`
- `uv run python examples/advanced/34_trace_threejs_viewer.py --output-dir output/trace_viewer_smoke`
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` — 4984 passed, 10 skipped, 8 warnings; changed-file coverage warning only for `robot_sf/render/trace_viewer.py` at 93.2%.

## Notes

- Viewer output is qualitative diagnostic support only, not benchmark evidence.
- Generated `output/` artifacts were inspected as disposable ignored outputs and removed before handoff.
- Browser pixel proof was attempted with local headless Firefox, but the snap Firefox build did not write a screenshot; static asset generation and scene JSON validation passed.
