### PR TITLE
fix: preflight analytics deps for PR readiness

### DIFF
--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -19,6 +19,30 @@ worktree_state() {
   fi
 }
 
+check_final_readiness_dependencies() {
+  local missing_output
+  if ! missing_output="$(uv run python - <<'PY' 2>&1
+from __future__ import annotations
+
+import importlib.util
+
+missing = [
+    module_name
+    for module_name in ("duckdb", "pyarrow")
+    if importlib.util.find_spec(module_name) is None
+]
+if missing:
+    print(", ".join(missing))
+    raise SystemExit(1)
+PY
+  )"; then
+    printf 'Final PR readiness requires analytics dependencies: duckdb and pyarrow.\n' >&2
+    printf 'Missing or unavailable modules: %s\n' "$missing_output" >&2
+    printf 'Run `uv sync --all-extras` in this worktree, then rerun final PR readiness.\n' >&2
+    exit 2
+  fi
+}
+
 pr_ready_mode_lower=$(printf '%s' "$PR_READY_MODE" | tr '[:upper:]' '[:lower:]')
 case "$pr_ready_mode_lower" in
   "")
@@ -45,6 +69,10 @@ if [[ "$pr_ready_final" == "1" && "$(worktree_state)" != "clean" ]]; then
   printf 'Commit or remove local changes, or run without PR_READY_MODE=final for interim feedback.\n' >&2
   git status --short --untracked-files=normal >&2
   exit 2
+fi
+
+if [[ "$pr_ready_final" == "1" ]]; then
+  check_final_readiness_dependencies
 fi
 
 "$SCRIPT_DIR/ruff_fix_format.sh"

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -21,7 +21,7 @@ worktree_state() {
 
 check_final_readiness_dependencies() {
   local missing_output
-  if ! missing_output="$(uv run python - <<'PY' 2>&1
+  if ! missing_output="$(uv run python - <<'PY'
 from __future__ import annotations
 
 import importlib.util

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -200,7 +200,7 @@ def test_pr_ready_check_final_mode_preflights_analytics_dependencies(tmp_path: P
             [
                 "#!/usr/bin/env bash",
                 'if [[ "$1" == "run" && "$2" == "python" ]]; then',
-                "  echo 'duckdb, pyarrow' >&2",
+                "  echo 'duckdb, pyarrow'",
                 "  exit 1",
                 "fi",
                 "echo 'unexpected uv invocation' >&2",

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -180,6 +180,83 @@ def test_pr_ready_check_exposes_final_committed_head_mode() -> None:
     assert "pr_ready_freshness.py" in script_text
 
 
+def test_pr_ready_check_final_mode_preflights_analytics_dependencies(tmp_path: Path) -> None:
+    """Final PR proof should fail early when analytics extras are missing."""
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    for script_name in ("pr_ready_check.sh", "common_setup.sh"):
+        source = ROOT / "scripts" / "dev" / script_name
+        target = script_dir / script_name
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        target.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [[ "$1" == "run" && "$2" == "python" ]]; then',
+                "  echo 'duckdb, pyarrow' >&2",
+                "  exit 1",
+                "fi",
+                "echo 'unexpected uv invocation' >&2",
+                "exit 99",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "test fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script_dir / "pr_ready_check.sh")],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "PR_READY_MODE": "final",
+            "BASE_REF": "origin/main",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Final PR readiness requires analytics dependencies" in result.stderr
+    assert "uv sync --all-extras" in result.stderr
+    assert "duckdb, pyarrow" in result.stderr
+    assert "ruff_fix_format" not in result.stderr
+
+
 def test_worktree_shared_venv_helper_pins_current_checkout_imports() -> None:
     """Shared-venv validation must import from the active worktree, not the owning checkout."""
     script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a final-mode `pr_ready_check.sh` preflight for `duckdb` and `pyarrow`
- fail early with an actionable `uv sync --all-extras` message when analytics extras are missing
- cover the missing-extra path with an executable shell-contract test using a fake `uv`

## Validation
- Missing-extra proof: `UV_NO_SYNC=1 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` failed early with the new analytics dependency message before expensive gates
- `uv sync --all-extras`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py tests/benchmark/test_parquet_export.py -q` (`21 passed`)
- `bash -n scripts/dev/pr_ready_check.sh`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/test_ci_script_contract.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check tests/test_ci_script_contract.py`
- `UV_NO_SYNC=1 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`4970 passed, 10 skipped`; clean-tree freshness stamp for `13f0f853`)

Closes #2024.
