### PR TITLE
test: add Three.js browser pixel smoke

### DIFF
--- a/docs/debug_visualization.md
+++ b/docs/debug_visualization.md
@@ -51,6 +51,20 @@ uv run python scripts/tools/rerun_debug_export.py \
 If `rerun-sdk` is absent, the command fails closed with an install hint instead of adding a required
 dependency to the repository.
 
+For static Three.js viewer exports, run the optional browser pixel smoke when browser automation is
+available:
+
+```bash
+uv sync --extra browser
+uv run python -m playwright install chromium
+uv run python scripts/validation/smoke_threejs_viewer_browser.py \
+  --viewer-dir output/threejs_viewer
+```
+
+The smoke serves the static viewer locally, opens it in headless Chromium, captures the canvas, and
+fails if the screenshot is blank or contains only the viewer background. Missing Playwright or
+Chromium support is reported as an actionable validation failure, not as a successful skip.
+
 ## Evidence Boundary
 
 Debug timelines are diagnostic visualization artifacts. They do not replace episode JSONL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ viz = [
     "matplotlib>=3.9.2",
     "seaborn>=0.13.2",
 ]
+browser = [
+    "playwright>=1.56.0",
+]
 sacadrl = [
     "tensorflow>=2.15.0",
 ]

--- a/scripts/validation/smoke_threejs_viewer_browser.py
+++ b/scripts/validation/smoke_threejs_viewer_browser.py
@@ -1,0 +1,249 @@
+"""Browser pixel smoke for static Three.js viewer exports.
+
+The command intentionally treats missing browser automation as a validation failure with an
+actionable dependency hint. It is a diagnostic smoke gate, not benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import http.server
+import sys
+import threading
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+EXIT_OK = 0
+EXIT_RENDER_FAILED = 1
+EXIT_BROWSER_UNAVAILABLE = 2
+EXIT_INPUT_ERROR = 3
+
+DEFAULT_BACKGROUND_RGB = (17, 24, 39)
+REQUIRED_VIEWER_FILES = ("index.html", "viewer.js", "scene.json")
+
+
+@dataclass(frozen=True)
+class CanvasSmokeResult:
+    """Pixel-classification result for a captured viewer canvas."""
+
+    rendered: bool
+    distinct_colors: int
+    non_background_pixels: int
+    reason: str
+
+
+def classify_canvas_screenshot(
+    screenshot_path: str | Path,
+    *,
+    background_rgb: tuple[int, int, int] = DEFAULT_BACKGROUND_RGB,
+    min_non_background_pixels: int = 1,
+    min_distinct_colors: int = 2,
+) -> CanvasSmokeResult:
+    """Classify whether a canvas screenshot contains rendered non-background pixels."""
+    image = Image.open(screenshot_path).convert("RGB")
+    pixels = list(image.getdata())
+    distinct_colors = len(set(pixels))
+    non_background_pixels = sum(pixel != background_rgb for pixel in pixels)
+
+    if distinct_colors < min_distinct_colors:
+        return CanvasSmokeResult(
+            rendered=False,
+            distinct_colors=distinct_colors,
+            non_background_pixels=non_background_pixels,
+            reason="canvas screenshot appears blank: only background color was captured",
+        )
+    if non_background_pixels < min_non_background_pixels:
+        return CanvasSmokeResult(
+            rendered=False,
+            distinct_colors=distinct_colors,
+            non_background_pixels=non_background_pixels,
+            reason=(
+                "canvas screenshot lacks enough non-background pixels "
+                f"({non_background_pixels} < {min_non_background_pixels})"
+            ),
+        )
+    return CanvasSmokeResult(
+        rendered=True,
+        distinct_colors=distinct_colors,
+        non_background_pixels=non_background_pixels,
+        reason="canvas screenshot contains non-background scene pixels",
+    )
+
+
+def run_browser_smoke(
+    viewer_dir: str | Path,
+    screenshot_path: str | Path,
+    *,
+    width: int = 960,
+    height: int = 720,
+    timeout_ms: int = 10_000,
+) -> None:
+    """Open a static viewer in Chromium and capture its canvas screenshot."""
+    viewer_dir = Path(viewer_dir)
+    screenshot_path = Path(screenshot_path)
+    screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    sync_playwright = _load_playwright()
+    server = _start_viewer_server(viewer_dir)
+    url = f"http://127.0.0.1:{server.server_port}/index.html"
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            try:
+                page = browser.new_page(viewport={"width": width, "height": height})
+                page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+                canvas = page.locator("canvas").first
+                canvas.wait_for(state="visible", timeout=timeout_ms)
+                page.wait_for_function(
+                    "() => { const canvas = document.querySelector('canvas');"
+                    " return canvas && canvas.width > 0 && canvas.height > 0; }",
+                    timeout=timeout_ms,
+                )
+                canvas.screenshot(path=str(screenshot_path))
+            finally:
+                browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _load_playwright():
+    """Load Playwright lazily so ordinary validation imports stay lightweight."""
+    from playwright.sync_api import sync_playwright
+
+    return sync_playwright
+
+
+def _start_viewer_server(viewer_dir: Path) -> http.server.ThreadingHTTPServer:
+    """Serve a viewer directory from an ephemeral localhost port."""
+    handler = partial(_QuietSimpleHTTPRequestHandler, directory=str(viewer_dir))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+class _QuietSimpleHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler variant that keeps validation output concise."""
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Suppress per-request logs from the temporary validation server."""
+
+
+def _validate_viewer_dir(viewer_dir: Path) -> list[str]:
+    """Return missing required viewer files."""
+    return [name for name in REQUIRED_VIEWER_FILES if not (viewer_dir / name).is_file()]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--viewer-dir",
+        required=True,
+        type=Path,
+        help="Directory containing index.html, viewer.js, and scene.json.",
+    )
+    parser.add_argument(
+        "--screenshot",
+        type=Path,
+        default=Path("output/validation/threejs_viewer_browser_smoke.png"),
+        help="Path for the captured canvas screenshot.",
+    )
+    parser.add_argument("--width", type=int, default=960, help="Browser viewport width.")
+    parser.add_argument("--height", type=int, default=720, help="Browser viewport height.")
+    parser.add_argument(
+        "--timeout-ms",
+        type=int,
+        default=10_000,
+        help="Browser navigation and canvas wait timeout in milliseconds.",
+    )
+    parser.add_argument(
+        "--min-non-background-pixels",
+        type=int,
+        default=1,
+        help="Minimum non-background pixels required for a rendered canvas.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the browser pixel smoke command."""
+    args = parse_args(argv)
+    missing_files = _validate_viewer_dir(args.viewer_dir)
+    if missing_files:
+        print(
+            f"Viewer directory {args.viewer_dir} is missing required files: "
+            f"{', '.join(missing_files)}",
+            file=sys.stderr,
+        )
+        return EXIT_INPUT_ERROR
+
+    try:
+        run_browser_smoke(
+            args.viewer_dir,
+            args.screenshot,
+            width=args.width,
+            height=args.height,
+            timeout_ms=args.timeout_ms,
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name != "playwright" and "playwright" not in str(exc):
+            raise
+        print(
+            "Playwright is required for the Three.js browser pixel smoke. "
+            "Install it with `uv sync --extra browser`, then run "
+            "`uv run python -m playwright install chromium` before this validation command.",
+            file=sys.stderr,
+        )
+        return EXIT_BROWSER_UNAVAILABLE
+    except Exception as exc:  # pragma: no cover - browser/runtime dependent
+        if _is_browser_dependency_error(exc):
+            print(
+                "Chromium is required for the Three.js browser pixel smoke. "
+                "Run `uv run python -m playwright install chromium` before this validation "
+                "command.",
+                file=sys.stderr,
+            )
+            return EXIT_BROWSER_UNAVAILABLE
+        print(f"Three.js browser smoke failed while driving Chromium: {exc}", file=sys.stderr)
+        return EXIT_RENDER_FAILED
+
+    with contextlib.suppress(FileNotFoundError):
+        result = classify_canvas_screenshot(
+            args.screenshot,
+            min_non_background_pixels=args.min_non_background_pixels,
+        )
+        if result.rendered:
+            print(
+                "Three.js browser smoke passed: "
+                f"{result.non_background_pixels} non-background pixels, "
+                f"{result.distinct_colors} distinct colors."
+            )
+            return EXIT_OK
+        print(f"Three.js browser smoke failed: {result.reason}", file=sys.stderr)
+        return EXIT_RENDER_FAILED
+
+    print(
+        f"Three.js browser smoke failed: screenshot not written at {args.screenshot}",
+        file=sys.stderr,
+    )
+    return EXIT_RENDER_FAILED
+
+
+def _is_browser_dependency_error(exc: Exception) -> bool:
+    """Return true for Playwright errors caused by a missing browser binary."""
+    message = str(exc)
+    return "Executable doesn't exist" in message or "playwright install chromium" in message
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/smoke_threejs_viewer_browser.py
+++ b/scripts/validation/smoke_threejs_viewer_browser.py
@@ -48,9 +48,13 @@ def classify_canvas_screenshot(
 ) -> CanvasSmokeResult:
     """Classify whether a canvas screenshot contains rendered non-background pixels."""
     image = Image.open(screenshot_path).convert("RGB")
-    pixels = list(image.getdata())
-    distinct_colors = len(set(pixels))
-    non_background_pixels = sum(pixel != background_rgb for pixel in pixels)
+    color_counts = image.getcolors(maxcolors=image.width * image.height)
+    if color_counts is None:  # pragma: no cover - defensive because maxcolors covers all pixels.
+        color_counts = [
+            (count, color) for count, color in image.getcolors(maxcolors=256 * 256 * 256) or []
+        ]
+    distinct_colors = len(color_counts)
+    non_background_pixels = sum(count for count, color in color_counts if color != background_rgb)
 
     if distinct_colors < min_distinct_colors:
         return CanvasSmokeResult(

--- a/scripts/validation/smoke_threejs_viewer_browser.py
+++ b/scripts/validation/smoke_threejs_viewer_browser.py
@@ -7,7 +7,6 @@ actionable dependency hint. It is a diagnostic smoke gate, not benchmark evidenc
 from __future__ import annotations
 
 import argparse
-import contextlib
 import http.server
 import sys
 import threading
@@ -16,7 +15,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -172,6 +171,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=1,
         help="Minimum non-background pixels required for a rendered canvas.",
     )
+    parser.add_argument(
+        "--background-rgb",
+        type=_parse_rgb,
+        default=DEFAULT_BACKGROUND_RGB,
+        help="Background RGB triplet to ignore when classifying pixels (default: 17,24,39).",
+    )
     return parser.parse_args(argv)
 
 
@@ -195,9 +200,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             height=args.height,
             timeout_ms=args.timeout_ms,
         )
-    except ModuleNotFoundError as exc:
-        if exc.name != "playwright" and "playwright" not in str(exc):
-            raise
+    except ModuleNotFoundError:
         print(
             "Playwright is required for the Three.js browser pixel smoke. "
             "Install it with `uv sync --extra browser`, then run "
@@ -217,25 +220,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Three.js browser smoke failed while driving Chromium: {exc}", file=sys.stderr)
         return EXIT_RENDER_FAILED
 
-    with contextlib.suppress(FileNotFoundError):
+    try:
         result = classify_canvas_screenshot(
             args.screenshot,
+            background_rgb=args.background_rgb,
             min_non_background_pixels=args.min_non_background_pixels,
         )
-        if result.rendered:
-            print(
-                "Three.js browser smoke passed: "
-                f"{result.non_background_pixels} non-background pixels, "
-                f"{result.distinct_colors} distinct colors."
-            )
-            return EXIT_OK
-        print(f"Three.js browser smoke failed: {result.reason}", file=sys.stderr)
+    except FileNotFoundError:
+        print(
+            f"Three.js browser smoke failed: screenshot not written at {args.screenshot}",
+            file=sys.stderr,
+        )
+        return EXIT_RENDER_FAILED
+    except (OSError, UnidentifiedImageError) as exc:
+        print(f"Three.js browser smoke failed: could not read screenshot: {exc}", file=sys.stderr)
         return EXIT_RENDER_FAILED
 
-    print(
-        f"Three.js browser smoke failed: screenshot not written at {args.screenshot}",
-        file=sys.stderr,
-    )
+    if result.rendered:
+        print(
+            "Three.js browser smoke passed: "
+            f"{result.non_background_pixels} non-background pixels, "
+            f"{result.distinct_colors} distinct colors."
+        )
+        return EXIT_OK
+    print(f"Three.js browser smoke failed: {result.reason}", file=sys.stderr)
     return EXIT_RENDER_FAILED
 
 
@@ -243,6 +251,18 @@ def _is_browser_dependency_error(exc: Exception) -> bool:
     """Return true for Playwright errors caused by a missing browser binary."""
     message = str(exc)
     return "Executable doesn't exist" in message or "playwright install chromium" in message
+
+
+def _parse_rgb(value: str) -> tuple[int, int, int]:
+    """Parse an ``R,G,B`` CLI value."""
+    try:
+        red, green, blue = (int(part) for part in value.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected RGB triplet like 17,24,39") from exc
+    rgb = (red, green, blue)
+    if any(channel < 0 or channel > 255 for channel in rgb):
+        raise argparse.ArgumentTypeError("RGB channels must be in [0, 255]")
+    return rgb
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_smoke_threejs_viewer_browser.py
+++ b/tests/validation/test_smoke_threejs_viewer_browser.py
@@ -86,3 +86,88 @@ def test_missing_chromium_browser_fails_closed(
     assert exit_code == smoke.EXIT_BROWSER_UNAVAILABLE
     assert "Chromium" in captured.err
     assert "python -m playwright install chromium" in captured.err
+
+
+def test_main_success_accepts_background_override(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """The CLI should allow non-default viewer backgrounds and return success."""
+
+    def write_scene_screenshot(_viewer_dir: Path, screenshot_path: Path, **_kwargs) -> None:
+        image = Image.new("RGB", (8, 8), (1, 2, 3))
+        image.putpixel((4, 4), (34, 197, 94))
+        image.save(screenshot_path)
+
+    viewer_dir = tmp_path / "viewer"
+    viewer_dir.mkdir()
+    (viewer_dir / "index.html").write_text("<div id='viewer'></div>", encoding="utf-8")
+    (viewer_dir / "viewer.js").write_text("", encoding="utf-8")
+    (viewer_dir / "scene.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(smoke, "run_browser_smoke", write_scene_screenshot)
+
+    exit_code = smoke.main(
+        [
+            "--viewer-dir",
+            str(viewer_dir),
+            "--screenshot",
+            str(tmp_path / "scene.png"),
+            "--background-rgb",
+            "1,2,3",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == smoke.EXIT_OK
+    assert "non-background pixels" in captured.out
+
+
+def test_corrupt_screenshot_returns_render_failure(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Unreadable screenshots should fail closed without a traceback."""
+
+    def write_corrupt_screenshot(_viewer_dir: Path, screenshot_path: Path, **_kwargs) -> None:
+        screenshot_path.write_text("not a png", encoding="utf-8")
+
+    viewer_dir = tmp_path / "viewer"
+    viewer_dir.mkdir()
+    (viewer_dir / "index.html").write_text("<div id='viewer'></div>", encoding="utf-8")
+    (viewer_dir / "viewer.js").write_text("", encoding="utf-8")
+    (viewer_dir / "scene.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(smoke, "run_browser_smoke", write_corrupt_screenshot)
+
+    exit_code = smoke.main(
+        ["--viewer-dir", str(viewer_dir), "--screenshot", str(tmp_path / "bad.png")]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == smoke.EXIT_RENDER_FAILED
+    assert "could not read screenshot" in captured.err
+
+
+def test_transitive_playwright_import_error_fails_closed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Broken Playwright installs should receive the same setup hint as missing Playwright."""
+
+    def missing_transitive_dependency():
+        raise ModuleNotFoundError("No module named 'pyee'")
+
+    viewer_dir = tmp_path / "viewer"
+    viewer_dir.mkdir()
+    (viewer_dir / "index.html").write_text("<div id='viewer'></div>", encoding="utf-8")
+    (viewer_dir / "viewer.js").write_text("", encoding="utf-8")
+    (viewer_dir / "scene.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(smoke, "_load_playwright", missing_transitive_dependency)
+
+    exit_code = smoke.main(["--viewer-dir", str(viewer_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == smoke.EXIT_BROWSER_UNAVAILABLE
+    assert "Playwright" in captured.err

--- a/tests/validation/test_smoke_threejs_viewer_browser.py
+++ b/tests/validation/test_smoke_threejs_viewer_browser.py
@@ -1,0 +1,88 @@
+"""Tests for the browser-backed Three.js viewer smoke command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+from scripts.validation import smoke_threejs_viewer_browser as smoke
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_single_color_canvas_screenshot_fails_closed(tmp_path: Path) -> None:
+    """A blank canvas screenshot should not count as a rendered viewer."""
+    screenshot = tmp_path / "blank.png"
+    Image.new("RGB", (8, 8), (17, 24, 39)).save(screenshot)
+
+    result = smoke.classify_canvas_screenshot(screenshot, background_rgb=(17, 24, 39))
+
+    assert not result.rendered
+    assert result.distinct_colors == 1
+    assert "blank" in result.reason
+
+
+def test_non_background_pixels_pass_canvas_classifier(tmp_path: Path) -> None:
+    """A screenshot with scene colors beyond the background should pass the pixel check."""
+    screenshot = tmp_path / "scene.png"
+    image = Image.new("RGB", (8, 8), (17, 24, 39))
+    image.putpixel((4, 4), (34, 197, 94))
+    image.save(screenshot)
+
+    result = smoke.classify_canvas_screenshot(screenshot, background_rgb=(17, 24, 39))
+
+    assert result.rendered
+    assert result.non_background_pixels == 1
+
+
+def test_missing_playwright_dependency_fails_closed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """The CLI should fail with an actionable hint when Playwright is unavailable."""
+
+    def missing_playwright():
+        raise ModuleNotFoundError("No module named 'playwright'")
+
+    viewer_dir = tmp_path / "viewer"
+    viewer_dir.mkdir()
+    (viewer_dir / "index.html").write_text("<div id='viewer'></div>", encoding="utf-8")
+    (viewer_dir / "viewer.js").write_text("", encoding="utf-8")
+    (viewer_dir / "scene.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(smoke, "_load_playwright", missing_playwright)
+
+    exit_code = smoke.main(["--viewer-dir", str(viewer_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == smoke.EXIT_BROWSER_UNAVAILABLE
+    assert "Playwright" in captured.err
+    assert "uv sync --extra browser" in captured.err
+    assert "python -m playwright install chromium" in captured.err
+
+
+def test_missing_chromium_browser_fails_closed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Installed Playwright without Chromium should report the browser setup command."""
+
+    def missing_chromium(*_args, **_kwargs):
+        raise RuntimeError("Executable doesn't exist. Please run playwright install chromium")
+
+    viewer_dir = tmp_path / "viewer"
+    viewer_dir.mkdir()
+    (viewer_dir / "index.html").write_text("<div id='viewer'></div>", encoding="utf-8")
+    (viewer_dir / "viewer.js").write_text("", encoding="utf-8")
+    (viewer_dir / "scene.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(smoke, "run_browser_smoke", missing_chromium)
+
+    exit_code = smoke.main(["--viewer-dir", str(viewer_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == smoke.EXIT_BROWSER_UNAVAILABLE
+    assert "Chromium" in captured.err
+    assert "python -m playwright install chromium" in captured.err

--- a/uv.lock
+++ b/uv.lock
@@ -3860,6 +3860,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4255,6 +4274,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -4911,6 +4942,9 @@ analytics = [
     { name = "duckdb" },
     { name = "pyarrow" },
 ]
+browser = [
+    { name = "playwright" },
+]
 dev = [
     { name = "black" },
     { name = "jupyter" },
@@ -4990,6 +5024,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pandas", marker = "extra == 'analysis'", specifier = ">=2.2.3" },
     { name = "pillow", specifier = ">=10.4.0" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.56.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pyarrow", marker = "extra == 'analytics'", specifier = ">=23.0.0" },
@@ -5026,7 +5061,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.67.0" },
     { name = "wandb", specifier = ">=0.18.7" },
 ]
-provides-extras = ["dev", "gpu", "docs", "rllib", "progress", "analysis", "analytics", "viz", "sacadrl", "orca", "socnav"]
+provides-extras = ["dev", "gpu", "docs", "rllib", "progress", "analysis", "analytics", "viz", "browser", "sacadrl", "orca", "socnav"]
 
 [package.metadata.requires-dev]
 carla = [{ name = "carla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.9.16" }]


### PR DESCRIPTION
Closes #2026.

## Summary
- add `scripts/validation/smoke_threejs_viewer_browser.py` to serve a static Three.js viewer, drive headless Chromium with Playwright, capture the canvas, and fail closed when the screenshot is blank/background-only
- add focused validation tests for blank screenshots, non-background pixels, missing Playwright, and missing Chromium setup
- add optional `browser` extra for Playwright and document the browser smoke flow for static viewer outputs

## Validation
- `uv run ruff format --check scripts/validation/smoke_threejs_viewer_browser.py tests/validation/test_smoke_threejs_viewer_browser.py`
- `uv run ruff check scripts/validation/smoke_threejs_viewer_browser.py tests/validation/test_smoke_threejs_viewer_browser.py`
- `uv run pytest tests/validation/test_smoke_threejs_viewer_browser.py tests/render/test_threejs_viewer.py tests/render/test_trace_viewer.py -q` — 21 passed
- `uv sync --extra browser`
- `uv run python -m playwright install chromium`
- `uv run python -m robot_sf.render.trace_viewer tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --output-dir output/trace_viewer_browser_smoke`
- `uv run python scripts/validation/smoke_threejs_viewer_browser.py --viewer-dir output/trace_viewer_browser_smoke --screenshot output/validation/trace_viewer_browser_smoke.png` — passed with 502879 non-background pixels and 520 distinct colors
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` — 4989 passed, 10 skipped, 8 warnings on `e4977977370a7a5ef7a77fe9487ae4b2352f924a`

## Notes
Generated `output/` validation artifacts were inspected as disposable smoke outputs and removed before push.
