### PR TITLE
docs: require downstream propagation checklist

### DIFF
--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -43,6 +43,13 @@ Freshness check:
 5. Classify generated artifacts from `output/` (discard/ignored/cache/durable evidence).
 6. Run the review audit checklist for changed workflow/skill area.
 7. Build PR body from `.github/PULL_REQUEST_TEMPLATE/pr_default.md`.
+   - For evidence-producing PRs, fill `Downstream Propagation` instead of leaving it implicit.
+     Check the parent issue, claim map or benchmark report, leaderboard or artifact catalog,
+     registry or config index, context index or memory note, and follow-up issue rows.
+   - For low-risk or non-evidence PRs, write a short `Not applicable because:` rationale so the
+     omission is intentional and reviewable.
+   - Recent example: PR #2044 promoted compact trace-viewer screenshot evidence and updated the
+     context index/catalog so the visual proof survived worktree cleanup.
 8. Open a ready PR by default using
    `gh pr create --base main --head <branch> --title "<type>: <summary> (#<n>)" --body-file <prepared_body.md>`.
    Use `--draft` only when the user explicitly requests draft status or when the branch is an
@@ -56,6 +63,7 @@ Freshness check:
   - implementation summary,
   - validation evidence,
   - artifact classification and provenance decision,
+  - downstream propagation decisions for evidence-producing changes,
   - follow-up issues, if any.
 - Do not commit large temporary artifacts from `output/`; use manifests or external artifact pointers.
 

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -114,6 +114,8 @@ Apply minimum tier by change surface:
 - scope matches contract and tests and CI proof are current for reviewed SHA,
 - unresolved review threads closed via GitHub review-thread resolution,
 - artifacts from `output/` are durably represented or explicitly excluded,
+- evidence-producing PRs complete the `Downstream Propagation` section or give an explicit
+  not-applicable rationale,
 - benchmark evidence no longer depends on fallback/degraded execution.
 
 If one condition fails, withhold label and emit a blocker comment/follow-up.

--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -39,10 +39,11 @@ What changed, in one or two sentences.
 ## Downstream Propagation
 - Parent issue updated (yes/no/NA):
 - Claim map / benchmark report updated (yes/no/NA):
+- Leaderboard / artifact catalog updated (yes/no/NA):
 - Registry or config index updated (yes/no/NA):
 - Context index / memory note updated (yes/no/NA):
 - Follow-up issue opened for deferred propagation (yes/no/NA):
-- Not-applicable rationale:
+- Not applicable because:
 
 For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
 propagation is deferred and name the issue or note that will carry it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,12 @@ resolving lint or test failures locally before requesting review.
   `[ -d output ] && git status --ignored --short -uall output`. Decide whether each output is
   disposable, should remain ignored, should be represented by a tracked manifest or registry entry,
   or must be uploaded to a durable artifact store before the branch is handed off.
+- Fill the PR template's `Downstream Propagation` section for evidence-producing PRs. Check whether
+  the parent issue, claim map or benchmark report, leaderboard or artifact catalog, registry or
+  config index, context index or memory note, and deferred follow-up issue need updates. For
+  low-risk or not-applicable changes, state the reason explicitly instead of deleting the section.
+  PR #2044 is a recent small example: it promoted a compact trace-viewer screenshot and updated the
+  context index/catalog so the evidence remained discoverable after worktree cleanup.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -12,7 +12,10 @@ Check these in order:
 3. Proof that the new or changed behavior actually works in this repository.
 4. Reproducibility of commands, configs, and artifacts.
 5. Scope discipline: no hidden workflow churn or speculative infrastructure.
-6. Test and documentation coverage proportional to the risk of the change.
+6. Downstream propagation completeness for evidence-producing PRs: parent issue, claim map or
+   benchmark report, leaderboard or artifact catalog, registry, context index, and follow-up issue
+   updates are either done or explicitly deferred.
+7. Test and documentation coverage proportional to the risk of the change.
 
 Reject changes that only add code or docs without task-appropriate proof.
 

--- a/tests/test_pull_request_template.py
+++ b/tests/test_pull_request_template.py
@@ -25,6 +25,7 @@ def test_pull_request_template_includes_proof_and_follow_up_sections() -> None:
         "## Validation / Proof",
         "## Risks / Rollout",
         "## Docs / Provenance",
+        "## Downstream Propagation",
         "## Follow-Up Issues",
         "## Reviewer Notes",
     ):
@@ -34,3 +35,10 @@ def test_pull_request_template_includes_proof_and_follow_up_sections() -> None:
     assert "Evidence that the change works here:" in text
     assert "Deferred work:" in text
     assert "Issues opened for follow-up:" in text
+    assert "Parent issue updated (yes/no/NA):" in text
+    assert "Claim map / benchmark report updated (yes/no/NA):" in text
+    assert "Leaderboard / artifact catalog updated (yes/no/NA):" in text
+    assert "Registry or config index updated (yes/no/NA):" in text
+    assert "Context index / memory note updated (yes/no/NA):" in text
+    assert "Follow-up issue opened for deferred propagation (yes/no/NA):" in text
+    assert "Not applicable because:" in text


### PR DESCRIPTION
## Summary
- closes #2036
- tightens the default PR template downstream-propagation checklist with leaderboard/artifact catalog coverage and an explicit not-applicable rationale
- updates PR opener, PR review, agent, and code-review guidance so evidence-producing PRs propagate durable findings beyond PR bodies
- adds template test coverage for the downstream-propagation section

## Linked Issues
- Closes #2036

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Added leaderboard/artifact catalog to the downstream propagation checklist.
- Replaced the old not-applicable wording with `Not applicable because:`.
- Updated `.agents/skills/gh-pr-opener/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`, `AGENTS.md`, and `docs/code_review.md`.
- Extended `tests/test_pull_request_template.py` to protect the section and checklist rows.

## Why It Matters
- Added value: evidence-producing PRs now have a visible follow-through checklist.
- Expected impact: reduces missed updates to parent issues, claim maps, catalogs, registries, and context notes.
- Why this is worth merging now: recent evidence PRs, including #2044, exposed this propagation gap.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/test_pull_request_template.py -q` -> 1 passed
  - `rtk uv run python scripts/validation/check_docs_proof_consistency.py --base origin/main` -> passed
  - `rtk uv run ruff check tests/test_pull_request_template.py` -> passed
  - `rtk git diff --check` -> passed
- Evidence that the change works here: the PR template test now fails if the downstream section or required checklist rows disappear.
- Benchmarks or smoke tests, if applicable: N/A; workflow/docs/template change only.

## Risks / Rollout
- Compatibility risks: low; additive template and docs guidance.
- Failure modes: checklist could feel noisy for tiny PRs.
- Rollback or fallback plan: revert the template/docs changes; `Not applicable because:` is the escape hatch for low-risk changes.

## Docs / Provenance
- Updated docs: `.github/PULL_REQUEST_TEMPLATE/pr_default.md`, `.agents/skills/gh-pr-opener/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`, `AGENTS.md`, `docs/code_review.md`.
- Relevant design or provenance notes: issue #2036.
- Any assumptions that need to be preserved: no CI enforcement beyond the existing template contract test.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2036.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a workflow/template guidance change and does not produce benchmark, registry, model, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: wording should stay lightweight enough for small PRs.
- Any known limitations: no GitHub-form enforcement; this is human/template guidance plus a repo-local template test.