### PR TITLE
refactor: retire legacy benchmark script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,7 +105,7 @@ reviewed public command, a compatibility shim, or a bounded debug utility.
 | --- | --- | --- |
 | `__init__.py` | canonical | Import support for tested script modules. |
 | `analyze_feature_extractors.py` | compatibility | Prefer `research/generate_extractor_report.py` for multi-extractor report generation. |
-| `benchmark.py` | archive candidate | Old profiling helper; prefer `scripts/validation/performance_smoke_test.py`. |
+| `benchmark.py` | compatibility | Fails closed; use `scripts/benchmark_workers.py` or `scripts/validation/performance_smoke_test.py`. |
 | `benchmark02.py` | compatibility | Fails closed; use `scripts/benchmark_workers.py` or `scripts/validation/performance_smoke_test.py`. |
 | `benchmark_ped_apf_models.py` | debug-only | Narrow APF comparison helper. |
 | `benchmark_ped_policy_collisions.py` | debug-only | Narrow pedestrian-policy collision analysis helper. |
@@ -244,6 +244,19 @@ uv run python scripts/classic_benchmark_full.py
 ```
 
 **Details**: Expanded parser with full benchmark flags
+
+#### `benchmark.py`
+
+**Purpose**: Retired root profiling benchmark. Fails closed with migration guidance.
+**Replacement**:
+
+```bash
+DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
+uv run python scripts/validation/performance_smoke_test.py
+```
+
+**Details**: Use `scripts/benchmark_workers.py` for worker throughput or
+`scripts/validation/performance_smoke_test.py` for a maintained smoke.
 
 #### `benchmark02.py`
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,55 +1,26 @@
-"""TODO docstring. Document this module."""
+"""Fail-closed guard for the retired root-level profiling benchmark."""
 
-import time
+from __future__ import annotations
 
-from scalene import scalene_profiler
+import sys
 
-from robot_sf.benchmark.helper_catalog import load_trained_policy
-from robot_sf.gym_env.robot_env import RobotEnv
+_MIGRATION_MESSAGE = """\
+scripts/benchmark.py is retired.
 
+Use one of the maintained benchmark or smoke entrypoints instead:
+  uv run python scripts/benchmark_workers.py --out output/benchmarks/bench_workers
+  DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/performance_smoke_test.py
 
-def benchmark():
-    """TODO docstring. Document this function."""
-    total_steps = 10000
-    env = RobotEnv()
-    model = load_trained_policy("./model/ppo_model")
-    # Gymnasium-style reset returns (obs, info)
-    obs, _info = env.reset()
-
-    # NOTE: RobotEnv exposes the underlying simulator as `simulator`; previous code
-    # referenced a non-existent `sim_env` attribute which triggered lint warnings.
-    _peds_sim = env.simulator
-
-    env.step(env.action_space.sample())  # warm-up step
-    obs, _info = env.reset()
-    print("start of simulation")
-
-    start_time = time.perf_counter()
-    scalene_profiler.start()
-
-    episode = 0
-    ep_rewards = 0
-    for step in range(total_steps):
-        action, _ = model.predict(obs, deterministic=True)
-        obs, reward, terminated, truncated, _info_step = env.step(action)
-        done = terminated or truncated
-        ep_rewards += reward
-        # print(f'step {step}, reward {reward} (peds: {peds_sim.peds.size()})')
-
-        if done:
-            episode += 1
-            print(
-                f"end of episode {episode}, total rewards {ep_rewards:.3f}, remaining steps {total_steps - step}",
-            )
-            ep_rewards = 0
-            obs, _info = env.reset()
-
-    print("end of simulation")
-    scalene_profiler.stop()
-
-    end_time = time.perf_counter()
-    print(f"benchmark took {end_time - start_time} seconds")
+For benchmark campaigns, prefer config-driven tools under scripts/tools/ or
+scripts/validation/ and record outputs under output/.
+"""
 
 
-if __name__ == "__main__":
-    benchmark()
+def main(_argv: object = None) -> int:
+    """Exit non-zero with supported benchmark alternatives."""
+    sys.stderr.write(_MIGRATION_MESSAGE)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #2053.

Retires the legacy root-level `scripts/benchmark.py` profiling helper by replacing its old `scalene`/direct-`RobotEnv` body with a fail-closed compatibility guard. The guard points users to maintained benchmark/smoke paths and exits non-zero, matching the nearby retired-script pattern.

## Scope

- Replace `scripts/benchmark.py` with a migration-message guard returning exit code `2`.
- Update `scripts/README.md` from `archive candidate` to `compatibility` for `benchmark.py`.
- Add a small README detail entry matching the existing `benchmark02.py` retired-script section.
- No benchmark campaign, runtime behavior claim, or other archive-candidate script retirement.

## Validation

- `rtk scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark.py` -> exit code `2`, prints migration guidance to stderr
- `rtk scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/benchmark.py`
- `rtk git diff --check HEAD~1..HEAD`
- `rg -n 'scalene|RobotEnv\(|TODO docstring' scripts/benchmark.py || true` -> no matches

## Delegated Review

OpenCode Zen read-only scout confirmed the existing retired-script guard pattern and recommended no new test because the repo has no established retired-script guard test pattern.
