### PR TITLE
refactor: emit criticality summary v1 evidence

### DIFF
--- a/scripts/validation/run_scenario_perturbation_criticality_pilot.py
+++ b/scripts/validation/run_scenario_perturbation_criticality_pilot.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Run a tiny paired planner pilot over materialized scenario perturbations."""
+"""Run a tiny paired planner pilot over materialized scenario perturbations.
+
+Routes the compact evidence summary through
+``robot_sf.scenario_certification.criticality_summary`` v1 helpers
+(``build_criticality_summary_from_pilot``,
+``criticality_summary_to_dict``, ``validate_criticality_summary``)
+instead of maintaining duplicate row-status/completed-pair summary logic
+here. The raw local ``summary.json`` under ``output/`` retains the
+original schema for backward compatibility.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +23,11 @@ import yaml
 
 from robot_sf.benchmark.map_runner import run_map_batch
 from robot_sf.scenario_certification import materialize_perturbation_pilot_matrix
+from robot_sf.scenario_certification.criticality_summary import (
+    build_criticality_summary_from_pilot,
+    criticality_summary_to_dict,
+    validate_criticality_summary,
+)
 from robot_sf.training.scenario_loader import load_scenarios
 
 SCHEMA_VERSION = "scenario_perturbation_criticality_pilot.v1"
@@ -162,196 +176,8 @@ def _scenario_metadata(scenarios: list[dict[str, Any]]) -> dict[str, dict[str, A
     return metadata
 
 
-def _nested_strings(value: Any) -> list[str]:
-    """Return lower-cased string leaves from a nested JSON-like value."""
-    strings: list[str] = []
-    if isinstance(value, str):
-        strings.append(value.strip().lower())
-    elif isinstance(value, dict):
-        for item in value.values():
-            strings.extend(_nested_strings(item))
-    elif isinstance(value, list | tuple):
-        for item in value:
-            strings.extend(_nested_strings(item))
-    return strings
-
-
-def classify_episode_status(row: dict[str, Any] | None) -> str:
-    """Classify whether an episode row can contribute to paired evidence."""
-    if row is None:
-        return "missing"
-    if isinstance(row.get("scenario_exclusion"), dict):
-        return "invalid"
-    metadata_strings = _nested_strings(row.get("algorithm_metadata"))
-    if any("fallback" in item for item in metadata_strings):
-        return "fallback"
-    if any("degraded" in item for item in metadata_strings):
-        return "degraded"
-    reason = str(row.get("termination_reason") or "").strip().lower()
-    if reason == "error":
-        return "failed"
-    return "completed"
-
-
-def _metric(row: dict[str, Any] | None, name: str) -> float | None:
-    """Read a numeric metric from an episode row."""
-    if row is None:
-        return None
-    metrics = row.get("metrics")
-    if not isinstance(metrics, dict):
-        return None
-    value = metrics.get(name)
-    try:
-        return None if value is None else float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _episode_values(row: dict[str, Any] | None) -> dict[str, Any]:
-    """Return compact outcome values for one episode row."""
-    reason = str(row.get("termination_reason") or "") if row is not None else ""
-    return {
-        "success": 1 if reason.lower() == "success" else 0,
-        "collision": 1 if reason.lower() == "collision" else 0,
-        "timeout": 1 if reason.lower() in {"max_steps", "terminated", "truncated"} else 0,
-        "min_distance": _metric(row, "min_distance"),
-        "termination_reason": reason or None,
-    }
-
-
-def _index_records_by_planner_seed(
-    records_by_planner: dict[str, list[dict[str, Any]]],
-) -> dict[tuple[str, str, int], dict[str, Any]]:
-    """Index episode records by planner, materialized scenario id, and seed."""
-    rows_by_key: dict[tuple[str, str, int], dict[str, Any]] = {}
-    for planner, records in records_by_planner.items():
-        for row in records:
-            scenario_id = str(row.get("scenario_id") or row.get("scenario") or "")
-            seed = int(row.get("seed", 0))
-            rows_by_key[(planner, scenario_id, seed)] = row
-    return rows_by_key
-
-
-def _scenarios_by_source(
-    scenario_metadata: dict[str, dict[str, Any]],
-) -> dict[str, dict[str, list[str]]]:
-    """Group materialized scenario ids by source scenario and perturbation family."""
-    grouped: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
-    for scenario_id, metadata in scenario_metadata.items():
-        source = metadata["source_scenario_id"]
-        family = metadata["family"]
-        if source and family:
-            grouped[source][family].append(scenario_id)
-    return grouped
-
-
-def _seeds_for_pair(
-    rows_by_key: dict[tuple[str, str, int], dict[str, Any]],
-    *,
-    planner: str,
-    noop_id: str,
-    variant_id: str,
-) -> list[int]:
-    """Return seeds observed for either side of one no-op/perturbed pair."""
-    return sorted(
-        {
-            seed
-            for key_planner, scenario_id, seed in rows_by_key
-            if key_planner == planner and scenario_id in {noop_id, variant_id}
-        }
-    )
-
-
-def _delta(after: int | float | None, before: int | float | None) -> float | None:
-    """Return numeric delta when both sides are available."""
-    if after is None or before is None:
-        return None
-    return float(after) - float(before)
-
-
-def build_pair_table(
-    records_by_planner: dict[str, list[dict[str, Any]]],
-    scenario_metadata: dict[str, dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Build paired no-op versus route-offset deltas for each planner and seed."""
-    rows_by_key = _index_records_by_planner_seed(records_by_planner)
-    grouped_scenarios = _scenarios_by_source(scenario_metadata)
-
-    pair_rows: list[dict[str, Any]] = []
-    for planner in sorted(records_by_planner):
-        for source_scenario_id, families in sorted(grouped_scenarios.items()):
-            noop_ids = sorted(families.get("noop", []))
-            perturbed_ids = sorted(
-                variant_id
-                for family, variant_ids in families.items()
-                if family != "noop"
-                for variant_id in variant_ids
-            )
-            if not noop_ids:
-                for variant_id in perturbed_ids:
-                    pair_rows.append(
-                        {
-                            "planner": planner,
-                            "source_scenario_id": source_scenario_id,
-                            "noop_variant_id": None,
-                            "perturbed_variant_id": variant_id,
-                            "seed": None,
-                            "pair_status": "missing_noop",
-                        }
-                    )
-                continue
-            noop_id = noop_ids[0]
-            for variant_id in perturbed_ids:
-                for seed in _seeds_for_pair(
-                    rows_by_key,
-                    planner=planner,
-                    noop_id=noop_id,
-                    variant_id=variant_id,
-                ):
-                    noop_row = rows_by_key.get((planner, noop_id, seed))
-                    perturbed_row = rows_by_key.get((planner, variant_id, seed))
-                    noop_status = classify_episode_status(noop_row)
-                    perturbed_status = classify_episode_status(perturbed_row)
-                    pair_status = (
-                        "completed"
-                        if noop_status == "completed" and perturbed_status == "completed"
-                        else "excluded"
-                    )
-                    noop_values = _episode_values(noop_row)
-                    perturbed_values = _episode_values(perturbed_row)
-                    perturbed_metadata = scenario_metadata.get(variant_id, {})
-                    pair_rows.append(
-                        {
-                            "planner": planner,
-                            "source_scenario_id": source_scenario_id,
-                            "noop_variant_id": noop_id,
-                            "perturbed_variant_id": variant_id,
-                            "perturbed_family": str(perturbed_metadata.get("family") or "unknown"),
-                            "seed": seed,
-                            "pair_status": pair_status,
-                            "noop_status": noop_status,
-                            "perturbed_status": perturbed_status,
-                            "success_delta": _delta(
-                                perturbed_values["success"], noop_values["success"]
-                            ),
-                            "collision_delta": _delta(
-                                perturbed_values["collision"], noop_values["collision"]
-                            ),
-                            "timeout_delta": _delta(
-                                perturbed_values["timeout"], noop_values["timeout"]
-                            ),
-                            "min_distance_delta": _delta(
-                                perturbed_values["min_distance"], noop_values["min_distance"]
-                            ),
-                            "noop": noop_values,
-                            "perturbed": perturbed_values,
-                        }
-                    )
-    return pair_rows
-
-
-def _summarize_pair_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate one pair-table subset."""
+def _old_format_summarize(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate one pair-table subset for the legacy raw summary format."""
     status_counts: dict[str, int] = defaultdict(int)
     delta_values: dict[str, list[float]] = defaultdict(list)
     for row in pair_rows:
@@ -378,54 +204,56 @@ def _summarize_pair_subset(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _grouped_pair_summaries(
+def _old_format_grouped_summaries(
     pair_rows: list[dict[str, Any]],
     *,
     field: str,
 ) -> dict[str, dict[str, Any]]:
-    """Aggregate pair rows by one categorical field."""
+    """Aggregate pair rows by one categorical field (legacy raw format)."""
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in pair_rows:
         key = str(row.get(field) or "unknown")
         grouped[key].append(row)
-    return {key: _summarize_pair_subset(rows) for key, rows in sorted(grouped.items())}
+    return {key: _old_format_summarize(rows) for key, rows in sorted(grouped.items())}
 
 
-def summarize_pairs(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate pair-table status counts and mean deltas."""
-    summary = _summarize_pair_subset(pair_rows)
-    summary["by_planner"] = _grouped_pair_summaries(pair_rows, field="planner")
-    summary["by_source_scenario"] = _grouped_pair_summaries(
+def _old_format_pair_summary(pair_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build legacy-format pair summary (status_counts) from v1 pair rows."""
+    summary = _old_format_summarize(pair_rows)
+    summary["by_planner"] = _old_format_grouped_summaries(pair_rows, field="planner")
+    summary["by_source_scenario"] = _old_format_grouped_summaries(
         pair_rows,
         field="source_scenario_id",
     )
-    summary["by_perturbation_family"] = _grouped_pair_summaries(
+    summary["by_perturbation_family"] = _old_format_grouped_summaries(
         pair_rows,
         field="perturbed_family",
     )
     return summary
 
 
-def _write_markdown(summary: dict[str, Any], path: Path) -> None:
-    """Write a compact Markdown summary next to the local pilot artifacts."""
+def _write_markdown_from_v1(v1_payload: dict[str, Any], path: Path) -> None:
+    """Write a compact Markdown summary from the v1 evidence payload."""
+    pair_summary = v1_payload["pair_summary"]
     lines = [
         "# Scenario Perturbation Criticality Pilot",
         "",
         "## Boundary",
         "",
-        "Diagnostic local pilot only. Raw JSONL remains ignored local output; tracked evidence should use the compact summary.",
+        "Diagnostic local pilot only. Raw JSONL remains ignored local output; tracked evidence uses the criticality_summary.v1 schema.",
         "",
         "## Aggregate",
         "",
-        f"- Planners: {', '.join(summary['planners'])}",
-        f"- Materialized variants: {summary['materialization']['variant_count']}",
-        f"- Pair rows: {summary['pair_summary']['pairs']}",
-        f"- Pair statuses: `{json.dumps(summary['pair_summary']['status_counts'], sort_keys=True)}`",
+        f"- Planners: {', '.join(v1_payload['planners'])}",
+        f"- Materialized variants: {v1_payload['materialization']['variant_count']}",
+        f"- Pair rows: {pair_summary['pairs']}",
+        "- Perturbed row status counts: "
+        f"`{json.dumps(pair_summary['row_status_counts'], sort_keys=True)}`",
         "",
         "## Mean Deltas For Completed Pairs",
         "",
     ]
-    deltas = summary["pair_summary"]["mean_deltas_completed_pairs"]
+    deltas = pair_summary["mean_deltas_completed_pairs"]
     if deltas:
         for field, value in deltas.items():
             lines.append(f"- `{field}`: `{value:.4f}`")
@@ -434,40 +262,45 @@ def _write_markdown(summary: dict[str, Any], path: Path) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _compact_tracked_summary(summary: dict[str, Any]) -> dict[str, Any]:
-    """Return the small reviewable subset suitable for docs/context/evidence."""
-    materialization = dict(summary["materialization"])
-    materialization.pop("scenario_matrix_path", None)
-    materialization.pop("summary_path", None)
-    materialization["local_artifact_boundary"] = (
-        "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored "
-        "local outputs reproducible from the tracked manifest and command"
+def build_validated_criticality_summary_payload(  # noqa: PLR0913
+    *,
+    records_by_planner: dict[str, list[dict[str, Any]]],
+    scenario_metadata: dict[str, dict[str, Any]],
+    manifest: str,
+    manifest_id: str,
+    planners: list[str],
+    horizon: int,
+    dt: float,
+    seed_limit: int,
+    materialization: dict[str, Any],
+    planner_runs: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build and validate the compact criticality_summary.v1 evidence payload."""
+    v1_summary = build_criticality_summary_from_pilot(
+        records_by_planner=records_by_planner,
+        scenario_metadata=scenario_metadata,
+        manifest=manifest,
+        manifest_id=manifest_id,
+        planners=planners,
+        horizon=horizon,
+        dt=dt,
+        seed_limit=seed_limit,
+        materialization=materialization,
+        planner_runs=planner_runs,
     )
-    return {
-        "schema_version": summary["schema_version"],
-        "manifest": summary["manifest"],
-        "planners": summary["planners"],
-        "horizon": summary["horizon"],
-        "dt": summary["dt"],
-        "seed_limit": summary["seed_limit"],
-        "materialization": materialization,
-        "planner_runs": {
-            planner: {
-                "algo": run["algo"],
-                "algo_config_path": run["algo_config_path"],
-                "source": run["source"],
-                "episodes": run["episodes"],
-            }
-            for planner, run in summary["planner_runs"].items()
-        },
-        "pair_summary": summary["pair_summary"],
-        "pair_rows": summary["pair_rows"],
-        "claim_boundary": summary["claim_boundary"],
-    }
+    v1_payload = criticality_summary_to_dict(v1_summary)
+    validate_criticality_summary(v1_payload)
+    return v1_payload, v1_summary.pair_rows
 
 
 def main() -> int:
-    """Run the scenario perturbation pilot."""
+    """Run the scenario perturbation pilot.
+
+    Builds the evidence summary through criticality_summary v1 helpers
+    (build_criticality_summary_from_pilot → criticality_summary_to_dict
+    → validate_criticality_summary). The local raw ``summary.json``
+    retains the legacy format for backward compatibility under ``output/``.
+    """
     args = _build_parser().parse_args()
     planners = args.planners or ["goal", "orca"]
     planner_specs = [
@@ -523,7 +356,49 @@ def main() -> int:
             "batch_summary": batch_summary,
         }
 
-    pair_rows = build_pair_table(records_by_planner, metadata)
+    # Build the v1 evidence summary via the criticality_summary helpers
+    v1_materialization = {
+        "schema_version": materialized.schema_version,
+        "manifest_id": materialized.manifest_id,
+        "included_variants": list(materialized.included_variants),
+        "excluded_variants": list(materialized.excluded_variants),
+        "variant_count": len(materialized.included_variants),
+        "local_artifact_boundary": (
+            "materialized scenario matrix, route overrides, and raw episode JSONL "
+            "remain ignored local outputs reproducible from the tracked manifest and command"
+        ),
+    }
+    v1_planner_runs: dict[str, dict[str, Any]] = {}
+    for label, run in planner_runs.items():
+        v1_planner_runs[label] = {
+            "algo": run["algo"],
+            "algo_config_path": run["algo_config_path"],
+            "source": run["source"],
+            "episodes": run["episodes"],
+        }
+    v1_payload, pair_rows = build_validated_criticality_summary_payload(
+        records_by_planner=records_by_planner,
+        scenario_metadata=metadata,
+        manifest=args.manifest.as_posix(),
+        manifest_id=materialized.manifest_id,
+        planners=[s.label for s in planner_specs],
+        horizon=args.horizon,
+        dt=args.dt,
+        seed_limit=args.seed_limit,
+        materialization=v1_materialization,
+        planner_runs=v1_planner_runs,
+    )
+
+    # Legacy raw summary (backward compatible format)
+    old_materialization = {
+        "schema_version": materialized.schema_version,
+        "manifest_id": materialized.manifest_id,
+        "scenario_matrix_path": materialized.scenario_matrix_path,
+        "summary_path": materialized.summary_path,
+        "included_variants": list(materialized.included_variants),
+        "excluded_variants": list(materialized.excluded_variants),
+        "variant_count": len(materialized.included_variants),
+    }
     summary = {
         "schema_version": SCHEMA_VERSION,
         "manifest": args.manifest.as_posix(),
@@ -531,17 +406,9 @@ def main() -> int:
         "horizon": args.horizon,
         "dt": args.dt,
         "seed_limit": args.seed_limit,
-        "materialization": {
-            "schema_version": materialized.schema_version,
-            "manifest_id": materialized.manifest_id,
-            "scenario_matrix_path": materialized.scenario_matrix_path,
-            "summary_path": materialized.summary_path,
-            "included_variants": list(materialized.included_variants),
-            "excluded_variants": list(materialized.excluded_variants),
-            "variant_count": len(materialized.included_variants),
-        },
+        "materialization": old_materialization,
         "planner_runs": planner_runs,
-        "pair_summary": summarize_pairs(pair_rows),
+        "pair_summary": _old_format_pair_summary(pair_rows),
         "pair_rows": pair_rows,
         "claim_boundary": (
             "diagnostic local pilot only; not benchmark-strength or paper-facing evidence"
@@ -549,13 +416,15 @@ def main() -> int:
     }
     summary_path = args.pilot_output_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    _write_markdown(summary, args.pilot_output_dir / "summary.md")
+    _write_markdown_from_v1(v1_payload, args.pilot_output_dir / "summary.md")
+
     if args.evidence_summary is not None:
         args.evidence_summary.parent.mkdir(parents=True, exist_ok=True)
         args.evidence_summary.write_text(
-            json.dumps(_compact_tracked_summary(summary), indent=2, sort_keys=True) + "\n",
+            json.dumps(v1_payload, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+
     print(
         json.dumps(
             {

--- a/scripts/validation/run_scenario_perturbation_criticality_pilot.py
+++ b/scripts/validation/run_scenario_perturbation_criticality_pilot.py
@@ -13,7 +13,12 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.map_runner import run_map_batch
-from robot_sf.scenario_certification import materialize_perturbation_pilot_matrix
+from robot_sf.scenario_certification import (
+    build_criticality_summary_from_pilot,
+    criticality_summary_to_dict,
+    materialize_perturbation_pilot_matrix,
+    validate_criticality_summary,
+)
 from robot_sf.training.scenario_loader import load_scenarios
 
 SCHEMA_VERSION = "scenario_perturbation_criticality_pilot.v1"
@@ -434,36 +439,49 @@ def _write_markdown(summary: dict[str, Any], path: Path) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _compact_tracked_summary(summary: dict[str, Any]) -> dict[str, Any]:
-    """Return the small reviewable subset suitable for docs/context/evidence."""
-    materialization = dict(summary["materialization"])
-    materialization.pop("scenario_matrix_path", None)
-    materialization.pop("summary_path", None)
-    materialization["local_artifact_boundary"] = (
-        "materialized scenario matrix, route overrides, and raw episode JSONL remain ignored "
-        "local outputs reproducible from the tracked manifest and command"
-    )
-    return {
-        "schema_version": summary["schema_version"],
-        "manifest": summary["manifest"],
-        "planners": summary["planners"],
-        "horizon": summary["horizon"],
-        "dt": summary["dt"],
-        "seed_limit": summary["seed_limit"],
-        "materialization": materialization,
-        "planner_runs": {
-            planner: {
-                "algo": run["algo"],
-                "algo_config_path": run["algo_config_path"],
-                "source": run["source"],
-                "episodes": run["episodes"],
-            }
-            for planner, run in summary["planner_runs"].items()
+def _build_evidence_summary_payload(
+    records_by_planner: dict[str, list[dict[str, Any]]],
+    scenario_metadata: dict[str, dict[str, Any]],
+    manifest_path: str,
+    materialized: Any,
+    planner_specs: list[PlannerRunSpec],
+    planner_runs: dict[str, dict[str, Any]],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    """Build a validated criticality_summary.v1 payload suitable for docs/context/evidence."""
+    clean_planner_runs: dict[str, dict[str, Any]] = {}
+    for label, run in planner_runs.items():
+        clean_planner_runs[label] = {
+            "algo": run["algo"],
+            "algo_config_path": run["algo_config_path"],
+            "source": run["source"],
+            "episodes": run["episodes"],
+        }
+    summary = build_criticality_summary_from_pilot(
+        records_by_planner=records_by_planner,
+        scenario_metadata=scenario_metadata,
+        manifest=manifest_path,
+        manifest_id=materialized.manifest_id,
+        planners=[spec.label for spec in planner_specs],
+        horizon=args.horizon,
+        dt=args.dt,
+        seed_limit=args.seed_limit,
+        materialization={
+            "schema_version": materialized.schema_version,
+            "manifest_id": materialized.manifest_id,
+            "included_variants": list(materialized.included_variants),
+            "excluded_variants": list(materialized.excluded_variants),
+            "variant_count": len(materialized.included_variants),
+            "local_artifact_boundary": (
+                "materialized scenario matrix, route overrides, and raw episode JSONL remain "
+                "ignored local outputs reproducible from the tracked manifest and command"
+            ),
         },
-        "pair_summary": summary["pair_summary"],
-        "pair_rows": summary["pair_rows"],
-        "claim_boundary": summary["claim_boundary"],
-    }
+        planner_runs=clean_planner_runs,
+    )
+    payload = criticality_summary_to_dict(summary)
+    validate_criticality_summary(payload)
+    return payload
 
 
 def main() -> int:
@@ -552,8 +570,17 @@ def main() -> int:
     _write_markdown(summary, args.pilot_output_dir / "summary.md")
     if args.evidence_summary is not None:
         args.evidence_summary.parent.mkdir(parents=True, exist_ok=True)
+        evidence = _build_evidence_summary_payload(
+            records_by_planner=records_by_planner,
+            scenario_metadata=metadata,
+            manifest_path=args.manifest.as_posix(),
+            materialized=materialized,
+            planner_specs=planner_specs,
+            planner_runs=planner_runs,
+            args=args,
+        )
         args.evidence_summary.write_text(
-            json.dumps(_compact_tracked_summary(summary), indent=2, sort_keys=True) + "\n",
+            json.dumps(evidence, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
     print(

--- a/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
+++ b/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
@@ -1,15 +1,21 @@
-"""Tests for scenario perturbation criticality pilot aggregation."""
+"""Tests for scenario perturbation criticality pilot v1 evidence summary.
+
+Row-status classification and pair-table construction now route through
+``robot_sf.scenario_certification.criticality_summary`` v1 helpers.
+"""
 
 from __future__ import annotations
 
+import json
+import sys
+from types import SimpleNamespace
+
 import pytest
 
-from scripts.validation.run_scenario_perturbation_criticality_pilot import (
-    build_pair_table,
-    classify_episode_status,
-    resolve_planner_run_spec,
-    summarize_pairs,
+from robot_sf.scenario_certification.criticality_summary import (
+    _classify_episode_row_status,
 )
+from scripts.validation import run_scenario_perturbation_criticality_pilot as pilot
 
 
 def test_resolve_planner_run_spec_uses_policy_search_candidate_registry(tmp_path) -> None:
@@ -29,7 +35,9 @@ def test_resolve_planner_run_spec_uses_policy_search_candidate_registry(tmp_path
         encoding="utf-8",
     )
 
-    spec = resolve_planner_run_spec("scenario_adaptive_demo", candidate_registry_path=registry)
+    spec = pilot.resolve_planner_run_spec(
+        "scenario_adaptive_demo", candidate_registry_path=registry
+    )
 
     assert spec.label == "scenario_adaptive_demo"
     assert spec.algo == "hybrid_rule_local_planner"
@@ -42,7 +50,7 @@ def test_resolve_planner_run_spec_keeps_unknown_planner_as_raw_algo(tmp_path) ->
     registry = tmp_path / "candidate_registry.yaml"
     registry.write_text("candidates: {}\n", encoding="utf-8")
 
-    spec = resolve_planner_run_spec("goal", candidate_registry_path=registry)
+    spec = pilot.resolve_planner_run_spec("goal", candidate_registry_path=registry)
 
     assert spec.label == "goal"
     assert spec.algo == "goal"
@@ -50,24 +58,28 @@ def test_resolve_planner_run_spec_keeps_unknown_planner_as_raw_algo(tmp_path) ->
     assert spec.source == "raw_algo"
 
 
-def test_classify_episode_status_separates_fallback_and_invalid_rows() -> None:
-    """Fallback/degraded/invalid records should not count as completed evidence."""
-    assert classify_episode_status(None) == "missing"
-    assert classify_episode_status({"scenario_exclusion": {"status": "invalid"}}) == "invalid"
+def test_classify_row_status_uses_v1_helper() -> None:
+    """Row-status classification must come from criticality_summary v1."""
+    assert _classify_episode_row_status(None) == "missing"
+    assert _classify_episode_row_status({"scenario_exclusion": {"status": "invalid"}}) == "invalid"
     assert (
-        classify_episode_status({"algorithm_metadata": {"planner": {"execution_mode": "fallback"}}})
+        _classify_episode_row_status(
+            {"algorithm_metadata": {"planner": {"execution_mode": "fallback"}}}
+        )
         == "fallback"
     )
     assert (
-        classify_episode_status({"algorithm_metadata": {"planner": {"execution_mode": "degraded"}}})
+        _classify_episode_row_status(
+            {"algorithm_metadata": {"planner": {"execution_mode": "degraded"}}}
+        )
         == "degraded"
     )
-    assert classify_episode_status({"termination_reason": "error"}) == "failed"
-    assert classify_episode_status({"termination_reason": "success"}) == "completed"
+    assert _classify_episode_row_status({"termination_reason": "error"}) == "failed"
+    assert _classify_episode_row_status({"termination_reason": "success"}) == "completed"
 
 
-def test_build_pair_table_computes_completed_pair_deltas() -> None:
-    """No-op and route-offset rows should pair by source scenario, planner, and seed."""
+def test_cli_builds_valid_v1_summary_with_row_status_counts() -> None:
+    """The pilot CLI builder must produce a schema-valid criticality_summary.v1 payload."""
     metadata = {
         "demo_noop": {
             "source_scenario_id": "demo",
@@ -97,31 +109,73 @@ def test_build_pair_table_computes_completed_pair_deltas() -> None:
         ]
     }
 
-    pairs = build_pair_table(records, metadata)
-
-    assert len(pairs) == 1
-    pair = pairs[0]
-    assert pair["pair_status"] == "completed"
-    assert pair["perturbed_family"] == "robot_route_offset"
-    assert pair["success_delta"] == pytest.approx(-1.0)
-    assert pair["timeout_delta"] == pytest.approx(1.0)
-    assert pair["collision_delta"] == pytest.approx(0.0)
-    assert pair["min_distance_delta"] == pytest.approx(-0.5)
-    assert summarize_pairs(pairs)["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(
-        -1.0
+    payload, pair_rows = pilot.build_validated_criticality_summary_payload(
+        records_by_planner=records,
+        scenario_metadata=metadata,
+        manifest="configs/scenarios/perturbations/test.yaml",
+        manifest_id="test",
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization={
+            "schema_version": "scenario_perturbation_pilot_matrix.v1",
+            "manifest_id": "test",
+            "included_variants": ["demo_noop", "demo_offset"],
+            "excluded_variants": [],
+            "variant_count": 2,
+            "local_artifact_boundary": "test boundary",
+        },
+        planner_runs={
+            "goal": {
+                "algo": "goal",
+                "algo_config_path": None,
+                "source": "raw_algo",
+                "episodes": 2,
+            },
+        },
     )
-    summary = summarize_pairs(pairs)
-    assert summary["by_planner"]["goal"]["mean_deltas_completed_pairs"][
-        "success_delta"
-    ] == pytest.approx(-1.0)
-    assert summary["by_source_scenario"]["demo"]["pairs"] == 1
-    assert summary["by_perturbation_family"]["robot_route_offset"]["status_counts"] == {
-        "completed": 1
+
+    assert payload["schema_version"] == "criticality_summary.v1"
+    assert payload["manifest_id"] == "test"
+    assert payload["planners"] == ["goal"]
+
+    row_status_counts = payload["pair_summary"]["row_status_counts"]
+    assert set(row_status_counts.keys()) == {
+        "completed",
+        "invalid",
+        "fallback",
+        "degraded",
+        "missing",
+        "failed",
     }
+    assert row_status_counts["completed"] == 1
+    for status in ("invalid", "fallback", "degraded", "missing", "failed"):
+        assert row_status_counts[status] == 0
+
+    mean_deltas = payload["pair_summary"]["mean_deltas_completed_pairs"]
+    assert mean_deltas["success_delta"] == pytest.approx(-1.0)
+    assert mean_deltas["collision_delta"] == pytest.approx(0.0)
+    assert mean_deltas["timeout_delta"] == pytest.approx(1.0)
+    assert mean_deltas["min_distance_delta"] == pytest.approx(-0.5)
+
+    assert pair_rows == payload["pair_rows"]
+    assert len(pair_rows) == 1
+    assert pair_rows[0]["pair_status"] == "completed"
+    assert pair_rows[0]["perturbed_status"] == "completed"
+
+    assert "by_planner" in payload["pair_summary"]
+    assert "by_source_scenario" in payload["pair_summary"]
+    assert "by_perturbation_family" in payload["pair_summary"]
+
+    grouped = payload["pair_summary"]["by_perturbation_family"]["robot_route_offset"]
+    assert grouped["row_status_counts"]["completed"] == 1
+    assert grouped["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(-1.0)
 
 
-def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None:
-    """Fallback perturbed rows should be visible but excluded from completed-pair means."""
+def test_cli_v1_summary_excludes_fallback_rows_from_means() -> None:
+    """Fallback perturbed rows must be counted under ``row_status_counts``
+    and excluded from ``mean_deltas_completed_pairs``."""
     metadata = {
         "demo_noop": {
             "source_scenario_id": "demo",
@@ -146,10 +200,197 @@ def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None
         ]
     }
 
-    pairs = build_pair_table(records, metadata)
-    summary = summarize_pairs(pairs)
+    payload, pair_rows = pilot.build_validated_criticality_summary_payload(
+        records_by_planner=records,
+        scenario_metadata=metadata,
+        manifest="configs/scenarios/perturbations/test.yaml",
+        manifest_id="test_fallback",
+        planners=["orca"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization={
+            "schema_version": "scenario_perturbation_pilot_matrix.v1",
+            "manifest_id": "test_fallback",
+            "included_variants": ["demo_noop", "demo_offset"],
+            "excluded_variants": [],
+            "variant_count": 2,
+            "local_artifact_boundary": "test boundary",
+        },
+        planner_runs={
+            "orca": {
+                "algo": "orca",
+                "algo_config_path": None,
+                "source": "raw_algo",
+                "episodes": 2,
+            },
+        },
+    )
 
-    assert pairs[0]["pair_status"] == "excluded"
-    assert pairs[0]["perturbed_status"] == "fallback"
-    assert summary["status_counts"] == {"excluded": 1}
-    assert summary["mean_deltas_completed_pairs"] == {}
+    assert pair_rows == payload["pair_rows"]
+    assert pair_rows[0]["pair_status"] == "excluded"
+    assert pair_rows[0]["perturbed_status"] == "fallback"
+
+    row_status_counts = payload["pair_summary"]["row_status_counts"]
+    assert row_status_counts["completed"] == 0
+    assert row_status_counts["fallback"] == 1
+
+    assert payload["pair_summary"]["mean_deltas_completed_pairs"] == {}
+
+    assert json.dumps(payload["claim_boundary"]).lower().count("diagnostic") >= 1
+    assert json.dumps(payload["claim_boundary"]).lower().count("not benchmark") >= 1
+
+
+def test_cli_v1_counts_perturbed_rows_not_completed_pairs() -> None:
+    """Completed row counts are per perturbed row even when the noop side fails."""
+    metadata = {
+        "demo_noop": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_noop",
+            "family": "noop",
+        },
+        "demo_offset": {
+            "source_scenario_id": "demo",
+            "variant_id": "demo_offset",
+            "family": "robot_route_offset",
+        },
+    }
+    records = {
+        "goal": [
+            {"scenario_id": "demo_noop", "seed": 111, "termination_reason": "error"},
+            {"scenario_id": "demo_offset", "seed": 111, "termination_reason": "success"},
+        ]
+    }
+
+    payload, pair_rows = pilot.build_validated_criticality_summary_payload(
+        records_by_planner=records,
+        scenario_metadata=metadata,
+        manifest="configs/scenarios/perturbations/test.yaml",
+        manifest_id="test_noop_failed",
+        planners=["goal"],
+        horizon=80,
+        dt=0.1,
+        seed_limit=1,
+        materialization={
+            "schema_version": "scenario_perturbation_pilot_matrix.v1",
+            "manifest_id": "test_noop_failed",
+            "included_variants": ["demo_noop", "demo_offset"],
+            "excluded_variants": [],
+            "variant_count": 2,
+            "local_artifact_boundary": "test boundary",
+        },
+        planner_runs={
+            "goal": {
+                "algo": "goal",
+                "algo_config_path": None,
+                "source": "raw_algo",
+                "episodes": 2,
+            },
+        },
+    )
+
+    assert pair_rows[0]["pair_status"] == "excluded"
+    assert pair_rows[0]["noop_status"] == "failed"
+    assert pair_rows[0]["perturbed_status"] == "completed"
+    assert payload["pair_summary"]["row_status_counts"]["completed"] == 1
+    assert payload["pair_summary"]["mean_deltas_completed_pairs"] == {}
+
+
+def test_main_writes_v1_evidence_summary_and_legacy_local_summary(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """--evidence-summary should write validated v1 JSON while local summary stays legacy."""
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("manifest_id: test\n", encoding="utf-8")
+    materialized_dir = tmp_path / "materialized"
+    pilot_dir = tmp_path / "pilot"
+    evidence_summary = tmp_path / "evidence" / "summary.json"
+    matrix_path = materialized_dir / "matrix.yaml"
+    materialized = SimpleNamespace(
+        schema_version="scenario_perturbation_pilot_matrix.v1",
+        manifest_id="test",
+        scenario_matrix_path=matrix_path.as_posix(),
+        summary_path=(materialized_dir / "summary.json").as_posix(),
+        included_variants=["demo_noop", "demo_offset"],
+        excluded_variants=[],
+    )
+    scenarios = [
+        {
+            "scenario_id": "demo_noop",
+            "metadata": {
+                "scenario_perturbation": {
+                    "source_scenario_id": "demo",
+                    "variant_id": "demo_noop",
+                    "family": "noop",
+                }
+            },
+        },
+        {
+            "scenario_id": "demo_offset",
+            "metadata": {
+                "scenario_perturbation": {
+                    "source_scenario_id": "demo",
+                    "variant_id": "demo_offset",
+                    "family": "robot_route_offset",
+                }
+            },
+        },
+    ]
+
+    def fake_run_map_batch(_matrix_path, jsonl_path, **_kwargs):
+        rows = [
+            {
+                "scenario_id": "demo_noop",
+                "seed": 111,
+                "termination_reason": "success",
+                "metrics": {"min_distance": 2.0},
+            },
+            {
+                "scenario_id": "demo_offset",
+                "seed": 111,
+                "termination_reason": "max_steps",
+                "metrics": {"min_distance": 1.5},
+            },
+        ]
+        jsonl_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+        return {"episodes": len(rows)}
+
+    monkeypatch.setattr(
+        pilot,
+        "materialize_perturbation_pilot_matrix",
+        lambda *_args, **_kwargs: materialized,
+    )
+    monkeypatch.setattr(pilot, "load_scenarios", lambda _path: scenarios)
+    monkeypatch.setattr(pilot, "run_map_batch", fake_run_map_batch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_scenario_perturbation_criticality_pilot.py",
+            manifest.as_posix(),
+            "--materialized-output-dir",
+            materialized_dir.as_posix(),
+            "--pilot-output-dir",
+            pilot_dir.as_posix(),
+            "--planner",
+            "goal",
+            "--evidence-summary",
+            evidence_summary.as_posix(),
+        ],
+    )
+
+    assert pilot.main() == 0
+
+    evidence_payload = json.loads(evidence_summary.read_text(encoding="utf-8"))
+    assert evidence_payload["schema_version"] == "criticality_summary.v1"
+    assert evidence_payload["pair_summary"]["row_status_counts"]["completed"] == 1
+    assert "jsonl_path" not in evidence_payload["planner_runs"]["goal"]
+
+    local_payload = json.loads((pilot_dir / "summary.json").read_text(encoding="utf-8"))
+    assert local_payload["schema_version"] == pilot.SCHEMA_VERSION
+    assert local_payload["pair_summary"]["status_counts"] == {"completed": 1}
+    assert local_payload["planner_runs"]["goal"]["jsonl_path"].endswith("goal.episodes.jsonl")

--- a/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
+++ b/tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from scripts.validation.run_scenario_perturbation_criticality_pilot import (
+    PlannerRunSpec,
+    _build_evidence_summary_payload,
     build_pair_table,
     classify_episode_status,
     resolve_planner_run_spec,
@@ -48,6 +52,41 @@ def test_resolve_planner_run_spec_keeps_unknown_planner_as_raw_algo(tmp_path) ->
     assert spec.algo == "goal"
     assert spec.algo_config_path is None
     assert spec.source == "raw_algo"
+
+
+def _build_script_evidence_summary(
+    records: dict[str, list[dict]],
+    metadata: dict[str, dict],
+    *,
+    planner: str,
+    episodes: int,
+) -> dict:
+    """Build the script-level evidence payload without running planners."""
+    return _build_evidence_summary_payload(
+        records_by_planner=records,
+        scenario_metadata=metadata,
+        manifest_path="dummy.yaml",
+        materialized=SimpleNamespace(
+            schema_version="scenario_perturbation_pilot_matrix.v1",
+            manifest_id="demo",
+            included_variants=["demo_noop", "demo_offset"],
+            excluded_variants=[],
+        ),
+        planner_specs=[
+            PlannerRunSpec(label=planner, algo=planner, source="raw_algo"),
+        ],
+        planner_runs={
+            planner: {
+                "algo": planner,
+                "algo_config_path": None,
+                "source": "raw_algo",
+                "jsonl_path": "output/local.episodes.jsonl",
+                "episodes": episodes,
+                "batch_summary": {"local_only": True},
+            },
+        },
+        args=SimpleNamespace(horizon=80, dt=0.1, seed_limit=1),
+    )
 
 
 def test_classify_episode_status_separates_fallback_and_invalid_rows() -> None:
@@ -119,6 +158,25 @@ def test_build_pair_table_computes_completed_pair_deltas() -> None:
         "completed": 1
     }
 
+    # The script-level --evidence-summary path emits criticality_summary.v1.
+    payload = _build_script_evidence_summary(records, metadata, planner="goal", episodes=2)
+    assert payload["schema_version"] == "criticality_summary.v1"
+    rc = payload["pair_summary"]["row_status_counts"]
+    assert rc["completed"] == 1
+    assert rc["invalid"] == 0
+    assert rc["fallback"] == 0
+    assert rc["degraded"] == 0
+    assert rc["missing"] == 0
+    assert rc["failed"] == 0
+    assert set(rc) == {"completed", "invalid", "fallback", "degraded", "missing", "failed"}
+    assert "jsonl_path" not in payload["planner_runs"]["goal"]
+    assert "batch_summary" not in payload["planner_runs"]["goal"]
+    assert "scenario_matrix_path" not in payload["materialization"]
+    assert "summary_path" not in payload["materialization"]
+    assert payload["pair_summary"]["mean_deltas_completed_pairs"]["success_delta"] == pytest.approx(
+        -1.0
+    )
+
 
 def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None:
     """Fallback perturbed rows should be visible but excluded from completed-pair means."""
@@ -153,3 +211,15 @@ def test_build_pair_table_excludes_fallback_rows_from_completed_deltas() -> None
     assert pairs[0]["perturbed_status"] == "fallback"
     assert summary["status_counts"] == {"excluded": 1}
     assert summary["mean_deltas_completed_pairs"] == {}
+
+    # The script-level --evidence-summary path records fallback separately.
+    payload = _build_script_evidence_summary(records, metadata, planner="orca", episodes=2)
+    assert payload["schema_version"] == "criticality_summary.v1"
+    rc = payload["pair_summary"]["row_status_counts"]
+    assert rc["completed"] == 0
+    assert rc["fallback"] == 1
+    assert rc["invalid"] == 0
+    assert rc["degraded"] == 0
+    assert rc["missing"] == 0
+    assert rc["failed"] == 0
+    assert payload["pair_summary"]["mean_deltas_completed_pairs"] == {}


### PR DESCRIPTION
Closes #1994.

## Summary

- Routes the optional `--evidence-summary` payload in `run_scenario_perturbation_criticality_pilot.py` through `build_criticality_summary_from_pilot`, `criticality_summary_to_dict`, and `validate_criticality_summary`.
- Removes the duplicate CLI pair/status construction path for compact evidence; local `output/summary.json` remains on the legacy pilot schema for backward compatibility.
- Tightens targeted tests so the script-level evidence payload emits `criticality_summary.v1`, strips raw local output paths, records all required perturbed row-status keys, excludes fallback rows from completed-pair means, and covers the CLI file-write path.
- Clarifies the Markdown report label to distinguish perturbed-row status counts from completed-pair means.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/validation/run_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py` -> 2 files already formatted
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/scenario_certification/test_scenario_perturbation_criticality_pilot.py tests/scenario_certification/test_criticality_summary.py -q` -> 30 passed
- `git diff --check` -> passed

## Boundary

No new perturbation campaign, planner execution semantics, benchmark-strength claim, or paper-facing claim is introduced. Ignored coverage output under `output/coverage/` was inspected and remains untracked.

## Delegation

OpenCode produced the initial patch; Gemini identified the missing CLI evidence-file coverage; Copilot reviewed the row-status semantics and prompted the perturbed-row/count-vs-pair-count edge-case test.
