### PR TITLE
docs: align SNQI setup guidance with uv

### DIFF
--- a/docs/benchmark_visuals.md
+++ b/docs/benchmark_visuals.md
@@ -95,14 +95,14 @@ but new code should migrate to the Full Classic pipeline.
 #### Plots Not Generating
 **Symptoms**: No PDF files created, or empty/placeholder PDFs
 **Causes**:
-- Missing matplotlib: `pip install matplotlib`
+- Missing matplotlib: run `uv sync --all-extras`
 - Invalid episode data: Check JSONL format and metric fields
 - Permission issues: Ensure output directory is writable
 
 **Solutions**:
 ```bash
 # Install dependencies
-uv add matplotlib
+uv sync --all-extras
 
 # Check episode data
 uv run python -c "import json; print(json.loads(open('episodes.jsonl').readline()))"
@@ -111,14 +111,14 @@ uv run python -c "import json; print(json.loads(open('episodes.jsonl').readline(
 #### Videos Not Generating
 **Symptoms**: No MP4 files created, or placeholder videos
 **Causes**:
-- Missing moviepy: `pip install moviepy`
+- Missing moviepy: run `uv sync --all-extras`
 - No trajectory data: Episodes lack position/time data
 - Environment issues: Factory functions unavailable
 
 **Solutions**:
 ```bash
 # Install dependencies  
-uv add moviepy
+uv sync --all-extras
 
 # Check trajectory data
 uv run python -c "
@@ -170,7 +170,7 @@ validate_visual_manifests(reports_dir, contracts)
 ```
 VisualizationError: Missing visualization dependencies: matplotlib
 ```
-**Solution**: Install missing packages with `uv add matplotlib moviepy`
+**Solution**: Install the repository extras with `uv sync --all-extras`
 
 #### "No episode data found"
 ```

--- a/scripts/QUICK_START.md
+++ b/scripts/QUICK_START.md
@@ -7,7 +7,7 @@ This directory contains scripts for recomputing and analyzing Social Navigation 
 Run the validation script to verify everything works:
 
 ```bash
-python scripts/validate_snqi_scripts.py
+uv run python scripts/validate_snqi_scripts.py
 ```
 
 ## Demo Workflow
@@ -15,7 +15,7 @@ python scripts/validate_snqi_scripts.py
 See a complete example with generated data:
 
 ```bash
-python scripts/example_snqi_workflow.py
+uv run python scripts/example_snqi_workflow.py
 ```
 
 ## Basic Usage
@@ -24,7 +24,7 @@ python scripts/example_snqi_workflow.py
 
 ```bash
 # Compare all weight strategies
-python scripts/recompute_snqi_weights.py \
+uv run python scripts/recompute_snqi_weights.py \
     --episodes your_episodes.jsonl \
     --baseline your_baseline_stats.json \
     --compare-strategies \
@@ -35,7 +35,7 @@ python scripts/recompute_snqi_weights.py \
 
 ```bash
 # Run differential evolution optimization with sensitivity analysis
-python scripts/snqi_weight_optimization.py \
+uv run python scripts/snqi_weight_optimization.py \
     --episodes your_episodes.jsonl \
     --baseline your_baseline_stats.json \
     --output optimized_weights.json \
@@ -47,7 +47,7 @@ python scripts/snqi_weight_optimization.py \
 
 ```bash
 # Full sensitivity analysis with visualizations
-python scripts/snqi_sensitivity_analysis.py \
+uv run python scripts/snqi_sensitivity_analysis.py \
     --episodes your_episodes.jsonl \
     --baseline your_baseline_stats.json \
     --weights optimized_weights.json \
@@ -85,7 +85,7 @@ Optional (for visualizations):
 
 Install with:
 ```bash
-pip install numpy scipy matplotlib seaborn pandas
+uv sync --all-extras
 ```
 
 ## Key Features

--- a/scripts/README_SNQI_WEIGHTS.md
+++ b/scripts/README_SNQI_WEIGHTS.md
@@ -32,14 +32,14 @@ norm_metric = (value - baseline_median) / (baseline_p95 - baseline_median)
 **Usage**:
 ```bash
 # Recompute weights using Pareto optimization
-python scripts/recompute_snqi_weights.py \
+uv run python scripts/recompute_snqi_weights.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --strategy pareto \
     --output weights_optimized.json
 
 # Compare all strategies
-python scripts/recompute_snqi_weights.py \
+uv run python scripts/recompute_snqi_weights.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --compare-strategies \
@@ -70,7 +70,7 @@ python scripts/recompute_snqi_weights.py \
 **Usage**:
 ```bash
 # Run optimization with both methods
-python scripts/snqi_weight_optimization.py \
+uv run python scripts/snqi_weight_optimization.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --output weights_optimized.json \
@@ -78,7 +78,7 @@ python scripts/snqi_weight_optimization.py \
     --sensitivity
 
 # Grid search only with custom resolution
-python scripts/snqi_weight_optimization.py \
+uv run python scripts/snqi_weight_optimization.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --output weights_grid.json \
@@ -105,14 +105,14 @@ python scripts/snqi_weight_optimization.py \
 **Usage**:
 ```bash
 # Full sensitivity analysis with visualizations
-python scripts/snqi_sensitivity_analysis.py \
+uv run python scripts/snqi_sensitivity_analysis.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --weights weights.json \
     --output analysis_results/
 
 # Quick analysis without plots
-python scripts/snqi_sensitivity_analysis.py \
+uv run python scripts/snqi_sensitivity_analysis.py \
     --episodes episodes.jsonl \
     --baseline baseline_stats.json \
     --weights weights.json \
@@ -203,7 +203,7 @@ Required Python packages:
 
 Install with:
 ```bash
-pip install numpy scipy matplotlib seaborn pandas
+uv sync --all-extras
 ```
 
 ## Example Workflow
@@ -220,7 +220,7 @@ pip install numpy scipy matplotlib seaborn pandas
 
 3. **Recompute optimal weights**:
    ```bash
-   python scripts/snqi_weight_optimization.py \
+   uv run python scripts/snqi_weight_optimization.py \
        --episodes episodes.jsonl \
        --baseline baseline_stats.json \
        --output weights_optimized.json \
@@ -229,7 +229,7 @@ pip install numpy scipy matplotlib seaborn pandas
 
 4. **Perform detailed sensitivity analysis**:
    ```bash
-   python scripts/snqi_sensitivity_analysis.py \
+   uv run python scripts/snqi_sensitivity_analysis.py \
        --episodes episodes.jsonl \
        --baseline baseline_stats.json \
        --weights weights_optimized.json \
@@ -238,7 +238,7 @@ pip install numpy scipy matplotlib seaborn pandas
 
 5. **Compare different strategies**:
    ```bash
-   python scripts/recompute_snqi_weights.py \
+   uv run python scripts/recompute_snqi_weights.py \
        --episodes episodes.jsonl \
        --baseline baseline_stats.json \
        --compare-strategies \

--- a/scripts/validation/verify_sf_implementation.py
+++ b/scripts/validation/verify_sf_implementation.py
@@ -199,9 +199,9 @@ def main():
         print("🎉 All verification tests passed!")
         print("\nImplementation is ready for use once dependencies are available.")
         print("\nNext steps:")
-        print("1. Install dependencies: pip install numpy pysocialforce pytest")
-        print("2. Run tests: pytest tests/baselines/ tests/integration/")
-        print("3. Try CLI: python -m robot_sf.benchmark.cli list-algorithms")
+        print("1. Install dependencies: uv sync --all-extras")
+        print("2. Run tests: uv run pytest tests/baselines/ tests/integration/")
+        print("3. Try CLI: uv run python -m robot_sf.benchmark.cli list-algorithms")
         return 0
     else:
         print("❌ Some tests failed - implementation needs fixes")


### PR DESCRIPTION
## Summary
- replace stale direct `pip install` troubleshooting/setup guidance with `uv sync --all-extras`
- update SNQI docs examples from bare `python` to `uv run python`
- update the social-force verification next steps to use `uv run pytest` and `uv run python -m ...`

Closes #2066.

## Validation
- `git diff --check origin/main...HEAD`
- `rg -n "pip install|uv add" docs/benchmark_visuals.md scripts/QUICK_START.md scripts/README_SNQI_WEIGHTS.md scripts/validation/verify_sf_implementation.py || true` (no matches)

## Risk
Docs/workflow text only; no dependency files, lockfiles, benchmark semantics, or generated artifacts changed.