### PR TITLE
fix: update benchmark visualization guidance

### DIFF
--- a/scripts/run_social_navigation_benchmark.py
+++ b/scripts/run_social_navigation_benchmark.py
@@ -243,16 +243,48 @@ def aggregate_all_results(
 
 
 def log_manual_visualization_steps(aggregates_file: str, output_root: str) -> dict[str, Any]:
-    """Log manual visualization steps using CLI commands."""
-    logger.info("Logging manual visualization steps using CLI commands")
+    """Log manual visualization steps using valid CLI commands."""
+    logger.info("Logging manual visualization steps using valid CLI commands")
 
     try:
-        # For now, skip automatic figure generation as the API is not straightforward
-        # Users can run the CLI commands manually if needed
-        logger.info("Visualization generation skipped. Manual CLI commands available:")
-        logger.info(f"  robot_sf_bench plot-pareto --in {aggregates_file} --out-dir {output_root}")
+        # Derive the benchmark root from the aggregates file location
+        # (aggregates_file = <benchmark_root>/aggregated_results.json)
+        benchmark_root = Path(aggregates_file).resolve().parent
+        # Replace <algo> with the actual algo dir, e.g. sf_planner, ppo, random
+        episodes_placeholder = f"{benchmark_root}/<algo>/episodes/episodes.jsonl"
+
         logger.info(
-            f"  robot_sf_bench plot-distributions --in {aggregates_file} --out-dir {output_root}",
+            "Visualization generation skipped. "
+            "Manual CLI commands available (replace <algo> with a baseline directory):",
+        )
+
+        # Preferred: scripts/generate_figures.py produces all figures (Pareto,
+        # distributions, comparison table) from episodes JSONL in one invocation.
+        logger.info(
+            f"  uv run python scripts/generate_figures.py "
+            f"--episodes {episodes_placeholder} "
+            f"--out-dir {output_root} "
+            f"--pareto-x collisions --pareto-y comfort_exposure --pareto-pdf "
+            f"--dmetrics collisions,comfort_exposure --dists-pdf "
+            f"--table-metrics collisions,comfort_exposure",
+        )
+
+        # Alternative: robot_sf_bench plot-pareto (requires episodes JSONL for
+        # --in, a PNG path for --out, and both --x-metric/--y-metric).
+        logger.info(
+            f"  uv run robot_sf_bench plot-pareto "
+            f"--in {episodes_placeholder} "
+            f"--out {output_root}/pareto.png "
+            f"--x-metric collisions --y-metric comfort_exposure",
+        )
+
+        # Alternative: robot_sf_bench plot-distributions (requires episodes JSONL
+        # for --in, --out-dir, and --metrics).
+        logger.info(
+            f"  uv run robot_sf_bench plot-distributions "
+            f"--in {episodes_placeholder} "
+            f"--out-dir {output_root} "
+            f"--metrics collisions,comfort_exposure",
         )
 
         return {

--- a/tests/test_benchmark_visualization_integration.py
+++ b/tests/test_benchmark_visualization_integration.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from loguru import logger
 
 
 def test_benchmark_with_visualization_integration():
@@ -111,3 +112,59 @@ def test_benchmark_visualization_creates_output_structure():
         )  # Then: Functions return artifact lists
         assert isinstance(plots, list)
         assert isinstance(videos, list)
+
+
+def test_log_manual_visualization_steps_logs_valid_commands(tmp_path: Path) -> None:
+    """Verify log_manual_visualization_steps logs valid CLI commands.
+
+    The function must not suggest commands that use aggregate JSON as input
+    or omit required CLI arguments. It should point to
+    scripts/generate_figures.py and valid robot_sf_bench commands with
+    episodes JSONL placeholders and required metric arguments.
+    """
+    from scripts.run_social_navigation_benchmark import log_manual_visualization_steps
+
+    # Create a minimal aggregated_results.json to simulate benchmark output root
+    agg_file = tmp_path / "aggregated_results.json"
+    agg_file.write_text(json.dumps({"dummy": True}), encoding="utf-8")
+    visuals_dir = tmp_path / "visualizations"
+
+    captured: list[str] = []
+
+    def collect(msg):
+        captured.append(str(msg))
+
+    handle = logger.add(collect, level="INFO", format="{message}")
+    try:
+        result = log_manual_visualization_steps(str(agg_file), str(visuals_dir))
+    finally:
+        logger.remove(handle)
+
+    assert result["success"] is True
+    full_log = "\n".join(captured)
+
+    # Must reference scripts/generate_figures.py as the primary option
+    assert "scripts/generate_figures.py" in full_log
+
+    # Must reference episodes JSONL placeholders, never the aggregate file
+    assert "episodes.jsonl" in full_log
+    assert "aggregated_results.json" not in full_log
+
+    generate_command = next(line for line in captured if "scripts/generate_figures.py" in line)
+    pareto_command = next(line for line in captured if "plot-pareto" in line)
+    distributions_command = next(line for line in captured if "plot-distributions" in line)
+
+    assert "--episodes" in generate_command
+    assert "--pareto-x collisions" in generate_command
+    assert "--pareto-y comfort_exposure" in generate_command
+    assert "--dmetrics collisions,comfort_exposure" in generate_command
+
+    assert "--in" in pareto_command
+    assert "--out " in pareto_command
+    assert "--out-dir" not in pareto_command
+    assert "--x-metric collisions" in pareto_command
+    assert "--y-metric comfort_exposure" in pareto_command
+
+    assert "--in" in distributions_command
+    assert "--out-dir" in distributions_command
+    assert "--metrics collisions,comfort_exposure" in distributions_command


### PR DESCRIPTION
## Summary
Updates the legacy social-navigation benchmark runner so its manual visualization log messages no longer suggest stale plotting commands. Adds regression coverage for the logged command shapes.

## Linked Issues
- Closes #2065

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: N/A

## What Changed
- Replaced stale aggregate-file plotting examples with valid `scripts/generate_figures.py`, `plot-pareto`, and `plot-distributions` command shapes using episode JSONL placeholders.
- Added a regression test that captures the helper logs and checks required plotting arguments plus absence of the stale `plot-pareto --out-dir` shape.

## Why It Matters
- Added value: users following the legacy runner output get commands that match current CLI contracts.
- Expected impact: low-risk workflow/docs correctness; no benchmark semantics change.
- Why this is worth merging now: #2065 was observed during docs/figure guidance cleanup and is small enough to fix locally.

## Validation / Proof
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/run_social_navigation_benchmark.py tests/test_benchmark_visualization_integration.py`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_benchmark_visualization_integration.py -q` (`4 passed`)
- `scripts/dev/run_worktree_shared_venv.sh -- python -m py_compile scripts/run_social_navigation_benchmark.py`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench plot-pareto --help`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench plot-distributions --help`

## Risks / Rollout
- Compatibility risks: minimal; only user-facing log guidance changed.
- Failure modes: future CLI argument drift could stale the message again; the new test covers the current required arguments.
- Rollback or fallback plan: revert this small helper/test change.

## Docs / Provenance
- Updated docs: N/A, this fixes runtime guidance emitted by the legacy runner.
- Relevant design or provenance notes: issue #2065.
- Assumptions: `aggregated_results.json` lives at the benchmark root, so the helper derives `<benchmark-root>/<algo>/episodes/episodes.jsonl` as the user-editable placeholder.

## Downstream Propagation
- Parent issue updated: yes, via PR closure.
- Claim map / benchmark report updated: N/A.
- Leaderboard / artifact catalog updated: N/A.
- Registry or config index updated: N/A.
- Context index / memory note updated: N/A.
- Follow-up issue opened for deferred propagation: no.
- Not applicable because: this is a low-risk helper guidance fix, not a benchmark result or durable artifact change.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Copilot review found no blocking issues and suggested tightening the regression test; that stricter assertion pass is included in this PR.
- Pytest produced ignored local `output/coverage/*` files; they are disposable and not committed.