### PR TITLE
docs: align factory perf baseline path

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -136,6 +136,6 @@ img_env = make_image_robot_env(render_options=RenderOptions(max_fps_override=24)
 Each factory emits an INFO creation line with effective recording and fps settings plus WARNING lines for precedence events.
 
 ### Performance Guard
-Test `tests/perf/test_factory_creation_perf.py` ensures mean creation time remains within the regression budget relative to `results/factory_perf_baseline.json`.
+Test `tests/perf/test_factory_creation_perf.py` ensures mean creation time remains within the regression budget relative to `output/benchmarks/factory_perf_baseline.json`.
 
 See detailed migration guidance in `docs/dev/issues/130-improve-environment-factory/migration.md`.


### PR DESCRIPTION
## Summary
- Closes #2069.
- Updates `docs/ENVIRONMENT.md` to point the factory performance guard at the canonical `output/benchmarks/factory_perf_baseline.json` path.
- Leaves performance guard code unchanged; source/tests already use the output-root path.

## Validation
- `rg 'results/factory_perf_baseline|output/benchmarks/factory_perf_baseline' docs/ENVIRONMENT.md tests/perf/test_factory_creation_perf.py scripts/perf/baseline_factory_creation.py`\n- `git diff --check HEAD~1..HEAD`\n\n## Notes\n- Docs-only, low-risk path-alignment fix.\n- Full PR readiness gate not run because no code, schema, benchmark, or workflow behavior changed.\n