### PR TITLE
docs: align map verifier uv examples

### DIFF
--- a/docs/SVG_MAP_EDITOR.md
+++ b/docs/SVG_MAP_EDITOR.md
@@ -124,17 +124,17 @@ After creating or modifying a map, you can validate it using the map verificatio
 
 Validate a specific map:
 ```bash
-python scripts/validation/verify_maps.py --scope your_map.svg --mode local
+uv run python scripts/validation/verify_maps.py --scope your_map.svg --mode local
 ```
 
 Validate all maps:
 ```bash
-python scripts/validation/verify_maps.py --scope all --mode local
+uv run python scripts/validation/verify_maps.py --scope all --mode local
 ```
 
 Validate with structured output:
 ```bash
-python scripts/validation/verify_maps.py --scope all --output output/validation/map_verification.json
+uv run python scripts/validation/verify_maps.py --scope all --output output/validation/map_verification.json
 ```
 
 #### What Gets Checked

--- a/scripts/validation/verify_maps.py
+++ b/scripts/validation/verify_maps.py
@@ -7,16 +7,16 @@ completeness, and runtime compatibility.
 Usage Examples
 --------------
 Validate all maps locally:
-    python scripts/validation/verify_maps.py --scope all --mode local
+    uv run python scripts/validation/verify_maps.py --scope all --mode local
 
 Validate CI-enabled maps only:
-    python scripts/validation/verify_maps.py --scope ci --mode ci
+    uv run python scripts/validation/verify_maps.py --scope ci --mode ci
 
 Validate specific map:
-    python scripts/validation/verify_maps.py --scope classic_doorway.svg --mode local
+    uv run python scripts/validation/verify_maps.py --scope classic_doorway.svg --mode local
 
 Output structured JSON manifest:
-    python scripts/validation/verify_maps.py --scope all --output output/validation/map_verification.json
+    uv run python scripts/validation/verify_maps.py --scope all --output output/validation/map_verification.json
 
 See Also
 --------

--- a/specs/325-add-francis2023-maps/plan.md
+++ b/specs/325-add-francis2023-maps/plan.md
@@ -128,7 +128,7 @@
 - Verify new maps (local):
   - `source .venv/bin/activate`
   - `MPLCONFIGDIR=$PWD/output/tmp/mplconfig XDG_CACHE_HOME=$PWD/output/tmp/cache MPLBACKEND=Agg \\`
-    `python scripts/validation/verify_maps.py --scope francis2023_crowd_navigation.svg --mode local`
+    `uv run python scripts/validation/verify_maps.py --scope francis2023_crowd_navigation.svg --mode local`
   - Repeat for: `francis2023_parallel_traffic.svg`, `francis2023_perpendicular_traffic.svg`,
     `francis2023_circular_crossing.svg`, `francis2023_robot_crowding.svg`.
 - Generate previews (full style for routes/zones):


### PR DESCRIPTION
## Summary
- update SVG map editor verifier examples to use `uv run python`
- update the verifier CLI help epilog to match the repository command pattern
- align the Francis map spec verifier command with the same pattern

Closes #2070

## Validation
- `git diff --check`
- `rg -n "python scripts/validation/verify_maps.py|uv run python scripts/validation/verify_maps.py" docs specs scripts README.md .github`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/verify_maps.py --help`

## Delegated review
- OpenCode implemented the initial bounded docs/script patch.
- Copilot `gpt-5.4` reviewed the final diff and found no blockers.