### PR TITLE
docs: replace phantom artifact catalog command

### DIFF
--- a/docs/artifact_catalog.md
+++ b/docs/artifact_catalog.md
@@ -50,7 +50,7 @@ artifacts:
       tex:
         path: tables/tab_planner_execution_modes.tex
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-    generation_command: uv run python scripts/tools/compile_benchmark_artifacts.py --campaign-root output/benchmarks/camera_ready/<campaign_id> --output output/benchmarks/publication_candidates/camera_ready_tables_v1 --catalog-id camera_ready_tables_v1
+    generation_command: uv run python scripts/tools/compile_benchmark_artifacts.py --campaign-root output/benchmarks/camera_ready/<campaign_id> --output output/benchmarks/publication_candidates/<campaign_id> --catalog-id camera_ready_tables_v1
     generation_commit: fbc7e125
     claim_boundary: Benchmark summary table; not raw episode evidence.
 ```

--- a/docs/artifact_catalog.md
+++ b/docs/artifact_catalog.md
@@ -50,7 +50,7 @@ artifacts:
       tex:
         path: tables/tab_planner_execution_modes.tex
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-    generation_command: uv run python scripts/tools/export_benchmark_tables.py --catalog
+    generation_command: uv run python scripts/tools/compile_benchmark_artifacts.py --campaign-root output/benchmarks/camera_ready/<campaign_id> --output output/benchmarks/publication_candidates/camera_ready_tables_v1 --catalog-id camera_ready_tables_v1
     generation_commit: fbc7e125
     claim_boundary: Benchmark summary table; not raw episode evidence.
 ```


### PR DESCRIPTION
## Summary
- Closes #2073.
- Replaces the artifact catalog example command for nonexistent `scripts/tools/export_benchmark_tables.py`.
- Points the example at existing `scripts/tools/compile_benchmark_artifacts.py` tooling using canonical `output/benchmarks/...` paths.

## Validation
- `rg -n "export_benchmark_tables|generation_command|artifact_catalog|results/camera_ready|output/benchmarks" docs/artifact_catalog.md tests/fixtures/artifact_catalog/v1/valid_catalog.yaml scripts/tools/compile_benchmark_artifacts.py`
- `git diff --check HEAD~1..HEAD`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/validate_artifact_catalog.py tests/fixtures/artifact_catalog/v1/valid_catalog.yaml`

## Delegation
- OpenCode Go made the initial one-file docs edit.
- Local review corrected the replacement command to use canonical `output/benchmarks/...` paths before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated artifact catalog documentation with clarified command examples for benchmark artifact generation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->