### PR TITLE
docs: refresh benchmark plotting artifact paths

### DIFF
--- a/docs/baseline_table.md
+++ b/docs/baseline_table.md
@@ -6,8 +6,8 @@ Generate a per-group metric table (means) across selected metrics. Useful for qu
 
 ```sh
 robot_sf_bench table \
-  --in results/episodes.jsonl \
-  --out results/baseline_table.md \
+  --in output/benchmarks/episodes.jsonl \
+  --out output/benchmarks/baseline_table.md \
   --metrics collisions,comfort_exposure,time_to_goal \
   --format md
 ```
@@ -24,10 +24,10 @@ Options:
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.report_table import compute_table, format_markdown
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/episodes.jsonl")
 rows = compute_table(records, metrics=["collisions", "comfort_exposure"]) 
 md = format_markdown(rows, metrics=["collisions", "comfort_exposure"]) 
-open("results/baseline_table.md", "w").write(md)
+open("output/benchmarks/baseline_table.md", "w").write(md)
 ```
 
 Notes:

--- a/docs/dev/ranking.md
+++ b/docs/dev/ranking.md
@@ -6,15 +6,15 @@ Produce a ranked table of groups (e.g., algorithms or scenarios) by the mean of 
 
 - Markdown table (default):
 
-  robot_sf_bench rank --in results/episodes.jsonl --out results/ranking.md --metric collisions
+  robot_sf_bench rank --in output/benchmarks/episodes.jsonl --out output/benchmarks/ranking.md --metric collisions
 
 - CSV output:
 
-  robot_sf_bench rank --in results/episodes.jsonl --out results/ranking.csv --metric snqi --format csv --descending
+  robot_sf_bench rank --in output/benchmarks/episodes.jsonl --out output/benchmarks/ranking.csv --metric snqi --format csv --descending
 
 - JSON output (raw rows):
 
-  robot_sf_bench rank --in results/episodes.jsonl --out results/ranking.json --metric comfort_exposure --format json --top 10
+  robot_sf_bench rank --in output/benchmarks/episodes.jsonl --out output/benchmarks/ranking.json --metric comfort_exposure --format json --top 10
 
 ### Options
 
@@ -31,7 +31,7 @@ Produce a ranked table of groups (e.g., algorithms or scenarios) by the mean of 
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.ranking import compute_ranking, format_markdown
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/episodes.jsonl")
 rows = compute_ranking(records, metric="collisions", group_by="scenario_params.algo")
 print(format_markdown(rows, "collisions"))
 ```

--- a/docs/distribution_plots.md
+++ b/docs/distribution_plots.md
@@ -16,8 +16,8 @@ Basic usage:
 
 ```
 robot_sf_bench plot-distributions \
-  --in results/episodes.jsonl \
-  --out-dir docs/figures \
+  --in output/benchmarks/episodes.jsonl \
+  --out-dir output/benchmarks/distributions \
   --metrics collisions,comfort_exposure
 ```
 
@@ -34,14 +34,14 @@ Options:
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.distributions import collect_grouped_values, save_distributions
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/episodes.jsonl")
 grouped = collect_grouped_values(
     records,
     metrics=["collisions", "comfort_exposure"],
     group_by="scenario_params.algo",
     fallback_group_by="scenario_id",
 )
-meta = save_distributions(grouped, out_dir="docs/figures", bins=30, kde=True, out_pdf=True)
+meta = save_distributions(grouped, out_dir="output/benchmarks/distributions", bins=30, kde=True, out_pdf=True)
 print(meta)
 ```
 

--- a/docs/pareto_plotting.md
+++ b/docs/pareto_plotting.md
@@ -12,8 +12,8 @@ Generate a PNG plot grouped by algorithm (default):
 
 ```bash
 robot_sf_bench plot-pareto \
-  --in results/episodes.jsonl \
-  --out results/pareto.png \
+  --in output/benchmarks/episodes.jsonl \
+  --out output/benchmarks/pareto.png \
   --x-metric collisions \
   --y-metric comfort_exposure
 ```
@@ -31,10 +31,10 @@ Options
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.plots import save_pareto_png
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/episodes.jsonl")
 meta = save_pareto_png(
     records,
-    out_path="results/pareto.png",
+    out_path="output/benchmarks/pareto.png",
     x_metric="collisions",
     y_metric="comfort_exposure",
     title="Collisions vs Comfort"


### PR DESCRIPTION
## Summary
- replace legacy `results/...` examples in benchmark table/ranking/plotting docs with `output/benchmarks/...`
- keep the affected `robot_sf_bench` command shapes unchanged while aligning generated artifacts with the current output root guidance

Closes #2079

## Validation
- `git diff --check`
- `rg -n "results/|output/benchmark_reports|output/benchmarks" docs/baseline_table.md docs/dev/ranking.md docs/distribution_plots.md docs/pareto_plotting.md`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench table --help`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench rank --help`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench plot-distributions --help`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench plot-pareto --help`

Full PR readiness was not run because this is a low-risk docs-only path refresh.
