### PR TITLE
docs: refresh seed variance artifact paths

### DIFF
--- a/docs/snqi-weight-tools/seed_variance_analysis.md
+++ b/docs/snqi-weight-tools/seed_variance_analysis.md
@@ -5,9 +5,9 @@ Quantify variability across seeds using coefficient of variation (CV = std/mean)
 CLI usage
 
 - Compute seed variance grouped by scenario id:
-  - robot_sf_bench seed-variance --in results/episodes.jsonl --out results/seed_var.json --group-by scenario_id
+  - robot_sf_bench seed-variance --in output/benchmarks/episodes.jsonl --out output/benchmarks/seed_var.json --group-by scenario_id
 - Select metrics only:
-  - robot_sf_bench seed-variance --in results/episodes.jsonl --out results/seed_var_a.json --metrics success,collisions,curvature_mean
+  - robot_sf_bench seed-variance --in output/benchmarks/episodes.jsonl --out output/benchmarks/seed_var_a.json --metrics success,collisions,curvature_mean
 
 Output format
 
@@ -20,6 +20,6 @@ Programmatic usage
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.seed_variance import compute_seed_variance
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/episodes.jsonl")
 sv = compute_seed_variance(records, group_by="scenario_id", metrics=["success", "collisions"]) 
 ```

--- a/scripts/seed_variance.py
+++ b/scripts/seed_variance.py
@@ -8,8 +8,8 @@ for each group. The output is a JSON mapping group → summary statistics.
 Typical usage (via uv):
 
     uv run python scripts/seed_variance.py \
-      --episodes results/episodes.jsonl \
-      --out results/seed_variance.json \
+      --episodes output/benchmarks/episodes.jsonl \
+      --out output/benchmarks/seed_variance.json \
       --group-by scenario_params.algo
 
 Inputs


### PR DESCRIPTION
## Summary
- replace legacy `results/...` seed-variance examples with `output/benchmarks/...`
- update the seed-variance helper docstring to match the current benchmark artifact root

Closes #2082

## Validation
- `git diff --check`
- `rg -n "results/|output/benchmarks" docs/snqi-weight-tools/seed_variance_analysis.md scripts/seed_variance.py`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench seed-variance --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/seed_variance.py --help`

Full PR readiness was not run because this is a low-risk docs/docstring path refresh.
