### PR TITLE
fix: align baseline default output path

### DIFF
--- a/robot_sf/benchmark/baseline_stats.py
+++ b/robot_sf/benchmark/baseline_stats.py
@@ -32,7 +32,7 @@ DEFAULT_METRICS: list[str] = [
     "energy",
 ]
 
-DEFAULT_BASELINE_JSONL_PATH = Path("output/benchmarks") / "baseline_episodes.jsonl"
+DEFAULT_BASELINE_JSONL_PATH: Path = Path("output/benchmarks") / "baseline_episodes.jsonl"
 
 
 def _extract_metric_values(records: list[dict[str, Any]], key: str) -> list[float]:

--- a/robot_sf/benchmark/baseline_stats.py
+++ b/robot_sf/benchmark/baseline_stats.py
@@ -32,6 +32,8 @@ DEFAULT_METRICS: list[str] = [
     "energy",
 ]
 
+DEFAULT_BASELINE_JSONL_PATH = Path("output/benchmarks") / "baseline_episodes.jsonl"
+
 
 def _extract_metric_values(records: list[dict[str, Any]], key: str) -> list[float]:
     """Extract metric values from episode records.
@@ -101,8 +103,7 @@ def run_and_compute_baseline(  # noqa: PLR0913
     if out_jsonl is not None:
         tmp_jsonl = str(out_jsonl)
     else:
-        # default temp path under results/
-        tmp_jsonl = str(Path("output/results") / "baseline_episodes.jsonl")
+        tmp_jsonl = str(DEFAULT_BASELINE_JSONL_PATH)
 
     run_batch(
         scenarios_or_path,
@@ -133,6 +134,7 @@ def run_and_compute_baseline(  # noqa: PLR0913
 
 
 __all__ = [
+    "DEFAULT_BASELINE_JSONL_PATH",
     "DEFAULT_METRICS",
     "compute_baseline_stats_from_records",
     "run_and_compute_baseline",

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -1424,7 +1424,7 @@ def _add_baseline_subparser(
         default=None,
         help=(
             "Optional path to write intermediate episode JSONL "
-            f"(default {DEFAULT_BASELINE_JSONL_PATH})"
+            f"(default {DEFAULT_BASELINE_JSONL_PATH!s})"
         ),
     )
     p.add_argument("--schema", default=DEFAULT_SCHEMA_PATH, help="Schema path for validation")

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -29,7 +29,10 @@ from robot_sf.benchmark.aggregate import compute_aggregates as _agg_compute
 from robot_sf.benchmark.aggregate import compute_aggregates_with_ci as _agg_compute_ci
 from robot_sf.benchmark.aggregate import read_jsonl as _agg_read_jsonl
 from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
-from robot_sf.benchmark.baseline_stats import run_and_compute_baseline
+from robot_sf.benchmark.baseline_stats import (
+    DEFAULT_BASELINE_JSONL_PATH,
+    run_and_compute_baseline,
+)
 from robot_sf.benchmark.benchmark_claim import (
     BenchmarkClaimError,
     build_benchmark_claim,
@@ -1419,7 +1422,10 @@ def _add_baseline_subparser(
     p.add_argument(
         "--jsonl",
         default=None,
-        help="Optional path to write intermediate episode JSONL (default output/results/baseline_episodes.jsonl)",
+        help=(
+            "Optional path to write intermediate episode JSONL "
+            f"(default {DEFAULT_BASELINE_JSONL_PATH})"
+        ),
     )
     p.add_argument("--schema", default=DEFAULT_SCHEMA_PATH, help="Schema path for validation")
     p.add_argument("--base-seed", type=int, default=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from robot_sf.benchmark import baseline_stats
+from robot_sf.benchmark import cli as benchmark_cli
 from robot_sf.benchmark.cli import cli_main
 
 if TYPE_CHECKING:
@@ -138,6 +139,58 @@ def test_run_and_compute_baseline_uses_default_jsonl_path_when_omitted(
     assert seen["records"] == [{"metrics": {"collisions": 0}}]
     assert stats == {"collisions": {"med": 0.0, "p95": 0.0}}
     assert json.loads(out_json.read_text(encoding="utf-8")) == stats
+
+
+def test_cli_baseline_omitted_jsonl_forwards_default_sentinel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """TODO docstring. Document this function.
+
+    Args:
+        tmp_path: TODO docstring.
+        monkeypatch: TODO docstring.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_run_and_compute_baseline(
+        scenarios_or_path,
+        *,
+        out_json,
+        out_jsonl,
+        schema_path,
+        **_kwargs,
+    ):
+        seen["scenarios_or_path"] = scenarios_or_path
+        seen["out_json"] = out_json
+        seen["out_jsonl"] = out_jsonl
+        seen["schema_path"] = schema_path
+        return {"collisions": {"med": 0.0, "p95": 0.0}}
+
+    monkeypatch.setattr(
+        benchmark_cli,
+        "run_and_compute_baseline",
+        fake_run_and_compute_baseline,
+    )
+
+    out_json = tmp_path / "baseline.json"
+    rc = cli_main(
+        [
+            "baseline",
+            "--matrix",
+            "configs/baselines/example_matrix.yaml",
+            "--out",
+            str(out_json),
+            "--schema",
+            SCHEMA_PATH,
+        ],
+    )
+
+    assert rc == 0
+    assert seen["scenarios_or_path"] == "configs/baselines/example_matrix.yaml"
+    assert seen["out_json"] == str(out_json)
+    assert seen["out_jsonl"] is None
+    assert seen["schema_path"] == SCHEMA_PATH
 
 
 def test_cli_list_scenarios(tmp_path: Path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
+from robot_sf.benchmark import baseline_stats
 from robot_sf.benchmark.cli import cli_main
 
 if TYPE_CHECKING:
@@ -78,6 +81,63 @@ def test_cli_baseline_subcommand(tmp_path: Path, capsys):
     # Should contain at least some baseline keys
     assert "time_to_goal_norm" in data
     assert "collisions" in data
+
+
+def test_cli_baseline_help_mentions_default_jsonl_path(capsys):
+    """TODO docstring. Document this function.
+
+    Args:
+        capsys: TODO docstring.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main(["baseline", "--help"])
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert "output/benchmarks/baseline_episodes.jsonl" in captured.out
+    assert "output/results/baseline_episodes.jsonl" not in captured.out
+
+
+def test_run_and_compute_baseline_uses_default_jsonl_path_when_omitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """TODO docstring. Document this function.
+
+    Args:
+        tmp_path: TODO docstring.
+        monkeypatch: TODO docstring.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_run_batch(*_args, **kwargs):
+        seen["out_path"] = kwargs["out_path"]
+
+    def fake_read_jsonl(path):
+        seen["read_path"] = path
+        return [{"metrics": {"collisions": 0}}]
+
+    def fake_compute(records, metrics=None):
+        seen["records"] = records
+        seen["metrics"] = metrics
+        return {"collisions": {"med": 0.0, "p95": 0.0}}
+
+    monkeypatch.setattr(baseline_stats, "run_batch", fake_run_batch)
+    monkeypatch.setattr(baseline_stats, "read_jsonl", fake_read_jsonl)
+    monkeypatch.setattr(baseline_stats, "compute_baseline_stats_from_records", fake_compute)
+
+    out_json = tmp_path / "baseline.json"
+    stats = baseline_stats.run_and_compute_baseline(
+        [],
+        out_json=out_json,
+        schema_path=SCHEMA_PATH,
+    )
+
+    assert seen["out_path"] == str(baseline_stats.DEFAULT_BASELINE_JSONL_PATH)
+    assert seen["read_path"] == str(baseline_stats.DEFAULT_BASELINE_JSONL_PATH)
+    assert seen["records"] == [{"metrics": {"collisions": 0}}]
+    assert stats == {"collisions": {"med": 0.0, "p95": 0.0}}
+    assert json.loads(out_json.read_text(encoding="utf-8")) == stats
 
 
 def test_cli_list_scenarios(tmp_path: Path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,11 +85,7 @@ def test_cli_baseline_subcommand(tmp_path: Path, capsys):
 
 
 def test_cli_baseline_help_mentions_default_jsonl_path(capsys):
-    """TODO docstring. Document this function.
-
-    Args:
-        capsys: TODO docstring.
-    """
+    """Verify baseline help advertises the current default JSONL path."""
     with pytest.raises(SystemExit) as excinfo:
         cli_main(["baseline", "--help"])
 
@@ -103,12 +99,7 @@ def test_run_and_compute_baseline_uses_default_jsonl_path_when_omitted(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """TODO docstring. Document this function.
-
-    Args:
-        tmp_path: TODO docstring.
-        monkeypatch: TODO docstring.
-    """
+    """Verify the helper uses the default JSONL path when none is provided."""
     seen: dict[str, object] = {}
 
     def fake_run_batch(*_args, **kwargs):
@@ -145,12 +136,7 @@ def test_cli_baseline_omitted_jsonl_forwards_default_sentinel(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """TODO docstring. Document this function.
-
-    Args:
-        tmp_path: TODO docstring.
-        monkeypatch: TODO docstring.
-    """
+    """Verify the CLI forwards omitted --jsonl as the helper's default sentinel."""
     seen: dict[str, object] = {}
 
     def fake_run_and_compute_baseline(


### PR DESCRIPTION
## Summary
- move the omitted-`--jsonl` baseline intermediate default from `output/results/baseline_episodes.jsonl` to `output/benchmarks/baseline_episodes.jsonl`
- derive baseline CLI help text from the same default path constant
- add focused tests for help text and omitted-`--jsonl` default behavior while preserving explicit `--jsonl` coverage

Closes #2085

## Validation
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_cli.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/baseline_stats.py robot_sf/benchmark/cli.py tests/test_cli.py`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench baseline --help`

Ignored `output/coverage/` artifacts were generated by the focused pytest run and left untracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the default output path for baseline episode JSONL files.
  * Updated help text to dynamically display the correct default path.

* **Tests**
  * Added tests to verify the default JSONL path is correctly referenced in CLI help and used when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->