### PR TITLE
docs: refresh SNQI ablation artifact paths

### DIFF
--- a/docs/dev/snqi_ablation.md
+++ b/docs/dev/snqi_ablation.md
@@ -19,10 +19,10 @@ CLI usage
 
 ```bash
 robot_sf_bench snqi-ablate \
-  --in results/episodes.jsonl \
-  --out results/ablation.md \
+  --in output/benchmarks/snqi/episodes.jsonl \
+  --out output/benchmarks/snqi/ablation.md \
   --snqi-weights model/snqi_canonical_weights_v1.json \
-  --snqi-baseline results/baseline_stats.json \
+  --snqi-baseline output/benchmarks/snqi/baseline_stats.json \
   --format md
 ```
 
@@ -39,7 +39,7 @@ API usage
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.ablation import compute_snqi_ablation, format_markdown
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/snqi/episodes.jsonl")
 weights = {...}
 baseline = {...}
 rows = compute_snqi_ablation(records, weights=weights, baseline=baseline)
@@ -52,12 +52,12 @@ Limit to top-5 groups and save a summary JSON:
 
 ```bash
 robot_sf_bench snqi-ablate \
-  --in results/episodes.jsonl \
-  --out results/ablation_top5.md \
+  --in output/benchmarks/snqi/episodes.jsonl \
+  --out output/benchmarks/snqi/ablation_top5.md \
   --snqi-weights model/snqi_canonical_weights_v1.json \
-  --snqi-baseline results/baseline_stats.json \
+  --snqi-baseline output/benchmarks/snqi/baseline_stats.json \
   --top 5 \
-  --summary-out results/ablation_summary.json \
+  --summary-out output/benchmarks/snqi/ablation_summary.json \
   --format md
 ```
 


### PR DESCRIPTION
## Summary
- update `docs/dev/snqi_ablation.md` active examples from legacy `results/...` paths to `output/benchmarks/snqi/...`
- keep the existing `output/benchmarks/camera_ready/<campaign_id>` campaign-root example unchanged

Closes #2091.

## Validation
- `rg -n "results/(episodes\\.jsonl|baseline_stats\\.json|ablation\\.md|ablation_top5\\.md|ablation_summary\\.json)|output/benchmarks/snqi|output/benchmarks/camera_ready" docs/dev/snqi_ablation.md`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench snqi-ablate --help`

## Delegation / Review
- OpenCode edit constrained to `docs/dev/snqi_ablation.md`
- Copilot read-only review: no blocking findings
- Gemini read-only plan review attempted but blocked by plan-mode tool restrictions before a useful final finding

## Notes
- Full PR readiness was not run because this is a docs-only artifact-path update with no code behavior changes.
