### PR TITLE
docs: refresh benchmark helper artifact examples

### DIFF
--- a/docs/dev/evaluation/README.md
+++ b/docs/dev/evaluation/README.md
@@ -4,7 +4,7 @@ This folder documents small, programmatic helpers to analyze benchmark episode o
 Each script works on the JSONL produced by the benchmark runner and writes summaries to CSV/JSON/Markdown.
 
 - Location: `scripts/`
-- Input: episodes JSONL (`results/episodes.jsonl` or similar)
+- Input: episodes JSONL (`output/benchmarks/helper_examples/episodes.jsonl` or similar)
 - Grouping keys use dotted paths into the episode record (e.g., `scenario_params.algo`).
 
 ## 1) Seed variance (SNQI)
@@ -19,8 +19,8 @@ Example:
 
 ```bash
 uv run python scripts/seed_variance.py \
-  --episodes results/episodes.jsonl \
-  --out results/seed_variance.json \
+  --episodes output/benchmarks/helper_examples/episodes.jsonl \
+  --out output/benchmarks/helper_examples/seed_variance.json \
   --group-by scenario_params.algo
 ```
 
@@ -36,9 +36,9 @@ Example:
 
 ```bash
 uv run python scripts/ranking_table.py \
-  --episodes results/episodes.jsonl \
-  --out-csv results/ranking_snqi.csv \
-  --out-md results/ranking_snqi.md \
+  --episodes output/benchmarks/helper_examples/episodes.jsonl \
+  --out-csv output/benchmarks/helper_examples/ranking_snqi.csv \
+  --out-md output/benchmarks/helper_examples/ranking_snqi.md \
   --metric snqi \
   --group-by scenario_params.algo
 ```
@@ -57,16 +57,16 @@ Examples:
 ```bash
 # Lowest SNQI (worst), top-20
 uv run python scripts/failure_extractor.py \
-  --episodes results/episodes.jsonl \
-  --out results/worst_snqi.json \
+  --episodes output/benchmarks/helper_examples/episodes.jsonl \
+  --out output/benchmarks/helper_examples/worst_snqi.json \
   --metric metrics.snqi \
   --direction min \
   --top-k 20
 
 # Highest collision count, top-50
 uv run python scripts/failure_extractor.py \
-  --episodes results/episodes.jsonl \
-  --out results/most_collisions.json \
+  --episodes output/benchmarks/helper_examples/episodes.jsonl \
+  --out output/benchmarks/helper_examples/most_collisions.json \
   --metric metrics.collisions \
   --direction max \
   --top-k 50

--- a/docs/dev/failure_extractor.md
+++ b/docs/dev/failure_extractor.md
@@ -6,11 +6,11 @@ Find and export episodes that meet failure-like criteria across metrics.
 
 - Write JSON with episode IDs only:
 
-  robot_sf_bench extract-failures --in results/episodes.jsonl --out results/fail_ids.json --collision-threshold 1 --comfort-threshold 0.2 --near-miss-threshold 0 --ids-only
+  robot_sf_bench extract-failures --in output/benchmarks/helper_examples/episodes.jsonl --out output/benchmarks/helper_examples/fail_ids.json --collision-threshold 1 --comfort-threshold 0.2 --near-miss-threshold 0 --ids-only
 
 - Write matching full records as JSONL:
 
-  robot_sf_bench extract-failures --in results/episodes.jsonl --out results/failures.jsonl --collision-threshold 1 --comfort-threshold 0.2
+  robot_sf_bench extract-failures --in output/benchmarks/helper_examples/episodes.jsonl --out output/benchmarks/helper_examples/failures.jsonl --collision-threshold 1 --comfort-threshold 0.2
 
 ## Options
 
@@ -27,6 +27,6 @@ Find and export episodes that meet failure-like criteria across metrics.
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.failure_extractor import extract_failures
 
-records = read_jsonl("results/episodes.jsonl")
+records = read_jsonl("output/benchmarks/helper_examples/episodes.jsonl")
 fails = extract_failures(records, collision_threshold=1, comfort_threshold=0.2)
 ```

--- a/scripts/failure_extractor.py
+++ b/scripts/failure_extractor.py
@@ -9,8 +9,8 @@ Typical usage:
 
         # Lowest SNQI (worst), top-20
         uv run python scripts/failure_extractor.py \
-            --episodes results/episodes.jsonl \
-            --out results/worst_snqi.json \
+            --episodes output/benchmarks/helper_examples/episodes.jsonl \
+            --out output/benchmarks/helper_examples/worst_snqi.json \
             --metric metrics.snqi \
             --direction min \
             --top-k 20

--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -5,7 +5,7 @@ and optionally scenario thumbnails plus a montage.
 
 Usage (example):
   uv run python scripts/generate_figures.py \
-    --episodes results/episodes.jsonl \
+    --episodes output/benchmarks/helper_examples/episodes.jsonl \
     --out-dir docs/figures \
     --pareto-x collisions --pareto-y comfort_exposure --pareto-pdf \
     --dmetrics collisions,comfort_exposure --dists-pdf \

--- a/scripts/ranking_table.py
+++ b/scripts/ranking_table.py
@@ -8,9 +8,9 @@ better). It can export to CSV and/or Markdown.
 Typical usage:
 
     uv run python scripts/ranking_table.py \
-      --episodes results/episodes.jsonl \
-      --out-csv results/ranking_snqi.csv \
-      --out-md results/ranking_snqi.md \
+      --episodes output/benchmarks/helper_examples/episodes.jsonl \
+      --out-csv output/benchmarks/helper_examples/ranking_snqi.csv \
+      --out-md output/benchmarks/helper_examples/ranking_snqi.md \
       --metric snqi \
       --group-by scenario_params.algo
 


### PR DESCRIPTION
## Summary
- update active helper docs/docstrings from legacy `results/...` paths to `output/benchmarks/helper_examples/...`
- keep runtime behavior unchanged and leave historical `docs/dev/issues/` notes out of scope

Closes #2093.

## Validation
- `! rg -n "results/(episodes\\.jsonl|seed_variance\\.json|ranking_snqi\\.(csv|md)|worst_snqi\\.json|most_collisions\\.json|fail_ids\\.json|failures\\.jsonl)" docs/dev/evaluation/README.md docs/dev/failure_extractor.md scripts/ranking_table.py scripts/failure_extractor.py scripts/generate_figures.py`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench extract-failures --help`
- `scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench rank --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/ranking_table.py --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/failure_extractor.py --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/generate_figures.py --help`

## Delegation / Review
- OpenCode edit constrained to the five scoped files
- Copilot read-only review: no blocking findings

## Notes
- Full PR readiness was not run because this is a docs/docstring example-path update with no runtime behavior changes.
