### PR TITLE
fix: add pr ready help path

### DIFF
--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -1,6 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/dev/pr_ready_check.sh [--help | -h]
+
+Runs PR readiness gates: ruff format/fix, pytest, coverage checks,
+docstring-todo diff/ratchet checks, and freshness stamp write.
+
+Environment variables:
+  BASE_REF            Base ref to compare against for coverage and freshness
+                      (default: origin/main)
+  PR_READY_MODE       Set to "final" for proof-on-committed-HEAD mode, or
+                      "interim" for work-in-progress feedback.
+                      Overrides PR_READY_FINAL when set.
+  PR_READY_FINAL      Legacy compatibility flag: "1", "true", "yes", or "on"
+                      for final mode; "0", "false", "no", "off" for interim.
+                      Ignored when PR_READY_MODE is set.
+EOF
+}
+
+if [ "$#" -gt 0 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  usage
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./common_setup.sh
 source "$SCRIPT_DIR/common_setup.sh"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -258,6 +258,104 @@ def test_pr_ready_check_final_mode_preflights_analytics_dependencies(tmp_path: P
     assert "ruff_fix_format" not in result.stderr
 
 
+def test_pr_ready_check_help_long() -> None:
+    """pr_ready_check.sh --help prints usage and exits 0."""
+    result = subprocess.run(
+        [str(PR_READY_CHECK), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "BASE_REF" in result.stdout
+    assert "PR_READY_MODE" in result.stdout
+    assert "PR_READY_FINAL" in result.stdout
+
+
+def test_pr_ready_check_help_short() -> None:
+    """pr_ready_check.sh -h prints usage and exits 0."""
+    result = subprocess.run(
+        [str(PR_READY_CHECK), "-h"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "BASE_REF" in result.stdout
+
+
+def test_pr_ready_check_help_does_not_invoke_gates(tmp_path: Path) -> None:
+    """--help should exit 0 before reaching heavy gate commands (uv, ruff, pytest)."""
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    for script_name in ("pr_ready_check.sh", "common_setup.sh"):
+        source = ROOT / "scripts" / "dev" / script_name
+        target = script_dir / script_name
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        target.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        '#!/usr/bin/env bash\necho "uv should not be called for --help" >&2\nexit 99\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "test fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script_dir / "pr_ready_check.sh"), "--help"],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "BASE_REF" in result.stdout
+    assert "PR_READY_MODE" in result.stdout
+    assert "PR_READY_FINAL" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
 def test_worktree_shared_venv_helper_pins_current_checkout_imports() -> None:
     """Shared-venv validation must import from the active worktree, not the owning checkout."""
     script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add a top-level `usage()` path for `scripts/dev/pr_ready_check.sh --help` and `-h`.
- Ensure help exits before sourcing common setup or running expensive readiness gates.
- Add contract tests for long/short help and a fake-`uv` guard proving the help path does not invoke gate commands.

Closes #2094.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -k pr_ready_check -v` — 6 passed, 19 deselected
- `scripts/dev/pr_ready_check.sh --help`
- `scripts/dev/pr_ready_check.sh -h`
- `bash -n scripts/dev/pr_ready_check.sh`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/test_ci_script_contract.py`

## Notes

This is a low-risk workflow-script fix. Full PR readiness was not run because the change is limited to a cheap help path plus focused contract tests.
