### PR TITLE
fix: add ci step timer help path

### DIFF
--- a/scripts/dev/ci_step_timer.sh
+++ b/scripts/dev/ci_step_timer.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  echo "Usage: scripts/dev/ci_step_timer.sh <label> <command> [args...]"
+  exit 0
+fi
+
 if [[ $# -lt 2 ]]; then
   echo "Usage: scripts/dev/ci_step_timer.sh <label> <command> [args...]" >&2
   exit 2

--- a/tests/dev/test_ci_step_timer.py
+++ b/tests/dev/test_ci_step_timer.py
@@ -13,6 +13,38 @@ def test_ci_step_timer_shell_syntax():
     assert subprocess.run(["bash", "-n", str(script)], check=False).returncode == 0
 
 
+def test_ci_step_timer_help_flag():
+    """--help prints usage and exits 0 without running any command."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    result = subprocess.run(
+        ["bash", str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "ci_step_timer step_start" not in result.stdout
+    assert "ci_step_timer step_end" not in result.stdout
+    assert "::group::" not in result.stdout
+
+
+def test_ci_step_timer_h_flag():
+    """-h prints usage and exits 0 without running any command."""
+    script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"
+    result = subprocess.run(
+        ["bash", str(script), "-h"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "ci_step_timer step_start" not in result.stdout
+    assert "ci_step_timer step_end" not in result.stdout
+    assert "::group::" not in result.stdout
+
+
 def test_ci_step_timer_requires_label_and_command():
     """Ensure the helper exits with usage info when arguments are missing."""
     script = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_step_timer.sh"


### PR DESCRIPTION
## Summary

- Add `--help` / `-h` handling to `scripts/dev/ci_step_timer.sh` before the missing-args guard.
- Preserve the existing no-argument exit-2 behavior.
- Add tests proving help exits 0 and does not emit timed-command markers.

Closes #2097.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/dev/test_ci_step_timer.py -q` — 6 passed
- `scripts/dev/ci_step_timer.sh --help`
- `scripts/dev/ci_step_timer.sh -h`
- `bash -n scripts/dev/ci_step_timer.sh`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check tests/dev/test_ci_step_timer.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/dev/test_ci_step_timer.py`

## Notes

Low-risk workflow-script help-path fix. Full PR readiness was not run; focused tests and direct smoke checks cover the changed behavior.
