### PR TITLE
docs: record issue 2029 smoke replay

### DIFF
--- a/configs/policy_search/candidate_sets/issue2029_shielded_ppo_smoke_replay.txt
+++ b/configs/policy_search/candidate_sets/issue2029_shielded_ppo_smoke_replay.txt
@@ -1,0 +1,1 @@
+shielded_ppo_issue1474_collision20_v1

--- a/docs/context/issue_2006_guarded_ppo_zero_motion_repair.md
+++ b/docs/context/issue_2006_guarded_ppo_zero_motion_repair.md
@@ -54,8 +54,26 @@ The repaired local smoke passed the launch-packet smoke gate:
 The guard diagnostics were `decision_counts.ppo_clear=71`, replacing the previous
 `decision_counts.goal_reached=80` zero-motion timeout.
 
+## SLURM Replay
+
+Issue #2029 replayed the repaired handoff through SLURM on 2026-06-02:
+
+- job: `12700_0` / `rsf-pol-smoke`, `COMPLETED`, exit `0:0`, elapsed `00:00:58`;
+- commit: `2b86ef4cf5c10553ae2a0cf32c91a243164c44d2`;
+- run id: `issue2029_shielded_ppo_smoke_replay`;
+- summary:
+  `output/policy_search/shielded_ppo_issue1474_collision20_v1/smoke/issue2029_shielded_ppo_smoke_replay/summary.json`;
+- report:
+  `docs/context/policy_search/reports/2026-06-02_shielded_ppo_issue1474_collision20_v1_smoke.md`;
+- decision: `pass`;
+- smoke metrics: `success_rate=1.0`, `collision_rate=0.0`, `near_miss_rate=0.0`,
+  `mean_avg_speed=1.9997802215217393`;
+- guard diagnostics: `shield_decision_count=71`, `shield_intervention_count=0`,
+  `shield_override_count=0`, `decision_counts.ppo_clear=71`.
+
 ## Boundary
 
-This is local smoke evidence, not benchmark promotion evidence. The local machine context forbids
-SLURM submission from this host, so SLURM smoke replay remains a follow-up gate before any
-nominal-sanity, stress, or full-matrix escalation.
+The zero-motion handoff blocker is repaired for both local and SLURM smoke. This remains
+single-episode smoke evidence, not benchmark promotion evidence. Nominal-sanity is the next gate;
+do not run stress or full-matrix escalation unless nominal-sanity passes with guard diagnostics and
+artifact provenance recorded.

--- a/docs/context/policy_search/candidate_registry.yaml
+++ b/docs/context/policy_search/candidate_registry.yaml
@@ -716,8 +716,9 @@ candidates:
       learned progress to pass the shielded-PPO smoke and nominal-sanity stop
       gates. The first post-training smoke failed the launch-packet success
       gate with an overconservative zero-motion timeout; issue #2006 repaired
-      the local smoke handoff, but the row stays prototype-gated until SLURM
-      smoke replay and nominal-sanity escalation are explicitly approved.
+      the handoff and issue #2029 replayed the smoke gate successfully on
+      SLURM, but the row stays prototype-gated until nominal-sanity escalation
+      is explicitly approved and interpreted.
     required_stages:
       - smoke
       - nominal_sanity

--- a/docs/context/policy_search/learned_policy_registry.md
+++ b/docs/context/policy_search/learned_policy_registry.md
@@ -109,7 +109,7 @@ adapter-only proof are useful planning evidence, but they are not benchmark evid
 | --- | --- | --- | --- | --- | --- |
 | `ppo_issue791_best_v1` | `learned_baseline` | `implemented` | `comparison_available` | `comparison_available` | Best current learned-only baseline for success-oriented comparison; not a safety promotion because paper-matrix collision rate is worse than ORCA. |
 | `guarded_ppo_orca_prior` | `guarded_policy` | `implemented` | `smoke_proven` | `not_benchmark_evidence` | Inference-only guarded variants are exhausted as a tuning lane; further value requires training a residual or learned risk component. |
-| `shielded_ppo_issue1474_collision20_v1` | `guarded_policy` | `staged` | `smoke_failed` | `blocked` | Issue #1474 retrained the PPO proposal policy with the launch-packet collision-20 reward delta and W&B artifact provenance; the first runtime-guarded smoke timed out with zero motion, so nominal-sanity escalation is blocked until the guard handoff is repaired. |
+| `shielded_ppo_issue1474_collision20_v1` | `guarded_policy` | `staged` | `smoke_proven` | `smoke_only` | Issue #1474 retrained the PPO proposal policy with the launch-packet collision-20 reward delta and W&B artifact provenance; issue #2006 repaired the zero-motion handoff, and #2029 replayed the smoke gate successfully on SLURM. Nominal-sanity remains required before any promotion or stress/full-matrix escalation. |
 | `orca_residual_guarded_ppo_v0` | `residual_policy` | `staged` | `launch_packet` | `smoke_only` | Runtime residual surface exists, but learned residual training/checkpoint lineage is pending and fallback/degraded rows remain caveats. |
 | `learned_risk_model_v1` | `auxiliary_risk` | `staged` | `launch_packet` | `not_benchmark_evidence` | Pre-SLURM launch packet only; hard guards remain authoritative and learned risk may only add auxiliary candidate cost. |
 | `predictive_planner_v1` | `predictive_model` | `implemented` | `comparison_available` | `comparison_available` | Uses a learned pedestrian predictor inside a planner stack; evidence applies to the configured predictive planner, not a general learned local policy. |
@@ -177,16 +177,19 @@ adapter-only proof are useful planning evidence, but they are not benchmark evid
 - `checkpoint_availability`: W&B artifact
   `ll7/robot_sf/ppo_expert_issue_1474_shielded_repair_collision20_5m-best-success:v5`.
 - `expected_dependencies`: local repo plus W&B artifact hydration.
-- `reproducibility_status`: training complete; issue #2006 local guarded smoke passes the
-  launch-packet smoke gate after restoring the SocNav observation handoff.
-- `integration_status`: staged candidate config, prototype-gated until SLURM smoke replay or an
-  explicit maintainer escalation decision.
-- `benchmark_status`: blocked until nominal-sanity stop gates pass with guard diagnostics present.
+- `reproducibility_status`: training complete; issue #2006 local guarded smoke and issue #2029
+  SLURM replay pass the launch-packet smoke gate after restoring the SocNav observation handoff.
+- `integration_status`: staged candidate config, prototype-gated until nominal-sanity is explicitly
+  submitted and interpreted.
+- `benchmark_status`: smoke-only until nominal-sanity stop gates pass with guard diagnostics
+  present.
 - `local_anchors`:
   - `configs/policy_search/candidates/shielded_ppo_issue1474_collision20_v1.yaml`
   - `configs/training/shielded_ppo_issue_1396_launch_packet.yaml`
   - `docs/context/issue_1396_shielded_ppo_launch_packet.md`
   - `docs/context/issue_1474_shielded_ppo_repair_closeout.md`
+  - `docs/context/issue_2006_guarded_ppo_zero_motion_repair.md`
+  - `docs/context/policy_search/reports/2026-06-02_shielded_ppo_issue1474_collision20_v1_smoke.md`
 
 ### `orca_residual_guarded_ppo_v0`
 

--- a/docs/context/policy_search/reports/2026-06-02_shielded_ppo_issue1474_collision20_v1_smoke.md
+++ b/docs/context/policy_search/reports/2026-06-02_shielded_ppo_issue1474_collision20_v1_smoke.md
@@ -1,0 +1,43 @@
+# Candidate Report: shielded_ppo_issue1474_collision20_v1 (smoke)
+
+## Decision
+
+pass
+
+## Hypothesis
+
+Replacing the historical BR-06 v3 PPO checkpoint inside the frozen risk_guarded_ppo_v1 runtime guard with the issue #1474 collision-20 repair checkpoint should reduce unsafe PPO proposals while preserving enough learned progress to pass the shielded-PPO smoke and nominal-sanity stop gates. The first post-training smoke failed the launch-packet success gate with an overconservative zero-motion timeout; issue #2006 repaired the handoff, and this #2029 SLURM replay checks whether that repair survives the compute-node smoke path. The row remains prototype-gated until nominal-sanity escalation is explicitly approved and interpreted.
+
+
+## Evaluation Scope
+
+- Stage: `smoke`
+- Algorithm: `guarded_ppo`
+- Scenario matrix: `configs/scenarios/single/planner_sanity_simple.yaml`
+- Seed manifest: `suite default`
+- Summary JSON: `output/policy_search/shielded_ppo_issue1474_collision20_v1/smoke/issue2029_shielded_ppo_smoke_replay/summary.json`
+- Git commit: `2b86ef4cf5c10553ae2a0cf32c91a243164c44d2`
+
+## Aggregate Results
+
+| Episodes | Success | Collision | Near Miss | Mean MinDist | Mean AvgSpeed |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 1.0000 | 0.0000 | 0.0000 | n/a | 1.9998 |
+
+## Scenario-Family Split
+
+| Family | Episodes | Success | Collision | Near Miss |
+|---|---:|---:|---:|---:|
+| nominal | 1 | 1.0000 | 0.0000 | 0.0000 |
+
+## Failure Taxonomy
+
+- No failures recorded.
+
+## Baseline Deltas
+
+| Baseline | Success Delta | Collision Delta | Near-Miss Delta |
+|---|---:|---:|---:|
+| goal | +0.9858 | -0.2411 | n/a |
+| orca | +0.8156 | -0.0355 | n/a |
+| ppo | +0.7518 | -0.0993 | n/a |


### PR DESCRIPTION
## Summary
- add a one-candidate #2029 smoke replay set for shielded_ppo_issue1474_collision20_v1
- preserve the completed SLURM smoke replay report and update the #2006/#1474 registry boundary
- mark the candidate as smoke-proven/smoke-only, with nominal-sanity still required before promotion

## Validation
- uv sync --all-extras
- uv run python scripts/validation/validate_policy_search_registry.py docs/context/policy_search/candidate_registry.yaml --max-age-days 30
- uv run python scripts/validation/run_policy_search_candidate.py --help
- scripts/dev/sbatch_policy_search_sweep.sh --stage smoke --throttle 1 --workers 1 --run-id issue2029_shielded_ppo_smoke_replay --candidates-file configs/policy_search/candidate_sets/issue2029_shielded_ppo_smoke_replay.txt --pin-head --dry-run
- SLURM job 12700_0 completed on a30 in 00:00:58 with decision pass
- git diff --check

## Result Boundary
Smoke result: success_rate=1.0, collision_rate=0.0, near_miss_rate=0.0, shield decisions all ppo_clear. This closes #2029's replay gate only; it is not benchmark promotion and does not authorize stress/full-matrix escalation before nominal-sanity.