### PR TITLE
docs: add research result guidance

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -137,6 +137,14 @@ Prioritize by:
 - less semantic risk,
 - older queue age.
 
+When the user asks for research progress rather than generic issue throughput, treat this as
+adapted guidance: prefer issues that should close or revise a hypothesis, move a claim boundary,
+record a useful negative result, synthesize accumulated diagnostics, or unblock a durable
+experiment. Do not treat this as a hard eligibility rule; support issues may still be the right next
+step when they remove a concrete blocker. If the remaining queue is mostly docs cleanup or another
+diagnostic extension under an already-expanded research parent, propose a synthesis issue or
+synthesis pass before adding more exploratory children.
+
 ## Queue Exhaustion Audit
 
 Before declaring the implementation queue exhausted, first run the closed-issue state-label hygiene
@@ -154,6 +162,11 @@ before claiming that the active implementation queue is exhausted.
 Then run one final read-only implementability audit over:
 - open issues labeled `state:ready`,
 - open issues that lack any `state:*` label.
+
+If these local filters appear exhausted or dominated by blocked/SLURM-only work, run one bundled
+broad queue scout before declaring the queue empty. Prefer a cheap local or Qwen scan plus one
+substantial Copilot pass when available; treat scout output as a lead only, and confirm any proposed
+candidate with local `gh issue view` evidence before selecting, claiming, or reporting it as ready.
 
 The audit should classify whether each remaining issue is actually implementable on the current
 machine and with the available durable artifacts. If a supposedly ready issue needs unavailable

--- a/.github/ISSUE_TEMPLATE/research-validation.yml
+++ b/.github/ISSUE_TEMPLATE/research-validation.yml
@@ -10,6 +10,9 @@ body:
       value: |
         Use this form for research-validation work that needs a clear hypothesis, evidence grade,
         artifact policy, and executable validation path before implementation starts.
+        Research issues should preferably explain what claim boundary, hypothesis, negative
+        result, synthesis decision, or durable experiment blocker they are meant to change. Treat
+        that as adapted guidance, not a hard requirement for every small support issue.
   - type: textarea
     id: goal
     attributes:
@@ -53,12 +56,26 @@ body:
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: What must be true before this research issue is done?
+      description: What should be true before this research issue is done?
       placeholder: |
         - [ ] ...
         - [ ] ...
     validations:
       required: true
+  - type: textarea
+    id: research_result_guidance
+    attributes:
+      label: Research result guidance
+      description: Optional adapted guidance for claim movement, synthesis, or decision routing.
+      placeholder: |
+        Target claim or hypothesis:
+        Comparator or baseline:
+        Minimum valid evidence:
+        Decision or stop rule:
+        Expected artifacts:
+        Parent issue / claim map / context note to update:
+    validations:
+      required: false
   - type: textarea
     id: validation_command
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -21,6 +21,12 @@ What changed, in one or two sentences.
 - Expected impact:
 - Why this is worth merging now:
 
+## Research Result Guidance
+- Target claim / hypothesis / blocker this should affect:
+- Comparator or baseline, if applicable:
+- Result classification: positive / negative / inconclusive / diagnostic-only / blocker-resolution / NA
+- Decision or stop rule, if applicable:
+
 ## Validation / Proof
 - Commands run:
 - Evidence that the change works here:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,26 @@ Research progress is the primary goal. Verification should be strong where claim
 cheap where risk is low. Any benchmark-facing, metric-facing, schema-facing, skill, or test change
 must still be backed by concrete evidence appropriate to the risk.
 
+For research-producing work, use the following as adapted guidance rather than a hard gate:
+research issues and PRs should prefer work that moves a claim boundary, closes or revises a
+hypothesis, records a useful negative result, synthesizes accumulated diagnostics, or unblocks a
+durable experiment. If a result remains diagnostic-only, label it that way and avoid treating it as
+claim movement.
+
+When practical, research issue contracts should name:
+
+- target claim or hypothesis;
+- comparator or baseline;
+- minimum valid evidence;
+- decision or stop rule;
+- expected artifacts and provenance plan;
+- parent issue, claim map, registry, context note, or synthesis surface to update.
+
+After several diagnostic child PRs under one research parent, prefer a synthesis pass before adding
+more exploratory families. The synthesis should classify what was learned, what stayed
+inconclusive, which families are redundant or negative, and what follow-up experiment, if any,
+should run next.
+
 - New local planners must be proven with an actual benchmark or targeted execution path that shows
   they run correctly in this repository.
 - Metric changes must include a clear proof that the updated metric now computes the intended values


### PR DESCRIPTION
## Summary

- Add adapted research-result guidance to `AGENTS.md` so research work names claim movement, negative results, synthesis needs, and durable experiment blockers without making that a hard gate.
- Extend the research-validation issue template with optional research result guidance fields.
- Add a PR-template section for research result guidance and update the issue-implementation skill to prefer synthesis/claim-moving work when the user asks for research progress.

## Validation

- `git diff --check`
- `uv run python - <<'PY' ... yaml.safe_load('.github/ISSUE_TEMPLATE/research-validation.yml') ... PY`

## Notes

This preserves support/tooling issues as valid when they remove concrete blockers; the new language is explicitly adapted guidance rather than mandatory eligibility.
