### PR TITLE
docs: clarify unproven benchmark handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,9 @@ Benchmark-specific policy:
 - If a planner, environment, or dependency cannot satisfy the contract needed for an accurate
   benchmark run, the run for that planner must fail closed with a clear error and an explicit
   `not available` or `failed` status.
+- If the intended proof fails or cannot be gathered, close the work as `blocked`, `diagnostic`, or
+  `not benchmark evidence` as appropriate, and record the next smallest proof step instead of
+  presenting the claim as complete.
 - Do not classify fallback execution as benchmark-strengthening evidence; report it as a limitation
   or exclusion reason with the exact condition that triggered it.
 - Benchmark reports and issue follow-ups should clearly identify whether a planner ran in

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -17,6 +17,10 @@ and what remains uncertain.
 Fallback or degraded benchmark execution is never success evidence. It may be useful diagnostic
 information only when labeled that way.
 
+When the intended proof fails or cannot be gathered, close the work as `blocked`, `diagnostic`, or
+`not benchmark evidence` as appropriate, and record the next smallest proof step. Do not relabel an
+unproven result as complete just to preserve momentum.
+
 ## Exploration
 
 Exploration is encouraged, including new planner families, research directions, and workflow ideas.
@@ -50,6 +54,8 @@ Use validation proportional to risk.
 - Paper-grade or benchmark-strength claims should name the exact claim, command/config/seed path,
   artifact provenance, metric/schema mode, sample size or statistics, fallback/degraded exclusions,
   limitations, and reproduction path before they are treated as established.
+- When validation cannot prove the intended claim, report the observed evidence and the failed or
+  missing proof separately, then hand off the next concrete proof step.
 
 ## Work Collection
 


### PR DESCRIPTION
## Summary
Clarifies that failed or missing proof should be reported as blocked, diagnostic, or not benchmark evidence rather than treated as complete.

## Linked Issues
- Relates to benchmark fallback and evidence-policy guidance; no specific issue was provided for this local edit.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added fail-closed handoff guidance in `AGENTS.md` for benchmark proof that cannot be gathered.
- Added the same maintainer-value guidance in `docs/maintainer_values.md`, including separate reporting for observed evidence versus missing proof.

## Why It Matters
- Added value: prevents incomplete validation from being relabeled as completion.
- Expected impact: clearer handoffs for blocked or diagnostic benchmark/planner work.
- Why this is worth merging now: it aligns agent instructions with the repository's research honesty and reproducibility policy.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; instruction-only policy clarification.
- Comparator or baseline, if applicable: NA.
- Result classification: NA.
- Decision or stop rule, if applicable: When intended proof fails or is unavailable, record the next concrete proof step and avoid presenting the claim as complete.

## Validation / Proof
- Commands run: `git diff --check -- AGENTS.md docs/maintainer_values.md`
- Evidence that the change works here: docs-only diff is whitespace-clean and limited to the intended instruction files.
- Benchmarks or smoke tests, if applicable: Not run; this is a low-risk docs/instruction change with no code or benchmark execution path touched.

## Risks / Rollout
- Compatibility risks: Low; instruction-only change.
- Failure modes: Reviewers may want different status wording for blocked versus diagnostic work.
- Rollback or fallback plan: Revert this docs commit if the guidance conflicts with maintainer direction.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/maintainer_values.md`
- Relevant design or provenance notes: The change reinforces existing fail-closed benchmark evidence policy.
- Any assumptions that need to be preserved: Fallback or degraded benchmark execution remains diagnostic only unless explicitly measured as the target behavior.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this PR changes repository instructions only and does not introduce benchmark evidence, artifact provenance, configs, schemas, or paper-facing results.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether the three status labels cover the intended maintainer workflow.
- Any known limitations: full PR readiness was not run because the change is docs-only and low risk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark and evidence policy with clearer guidance for handling incomplete proof collection and appropriate status labeling
  * Added validation procedures for documenting unproven claims and recording next proof steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->