### PR TITLE
fix: complete runtime requirements help text

### DIFF
--- a/scripts/dev/check_runtime_requirements.sh
+++ b/scripts/dev/check_runtime_requirements.sh
@@ -11,7 +11,7 @@ while optional capabilities are reported as present or missing.
 
 Options:
   --strict  Also fail when recommended CI-parity tools are missing.
-  -h, --help
+  -h, --help             Show help
 EOF
 }
 


### PR DESCRIPTION
## Summary
Completed the `scripts/dev/check_runtime_requirements.sh` help text so `-h, --help` has an explicit description.

## Linked Issues
- Closes `#2111`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added the missing `Show help` description beside `-h, --help` in `scripts/dev/check_runtime_requirements.sh`.

## Why It Matters
- Added value: keeps the runtime requirements helper consistent with the repo's shell-helper help conventions.
- Expected impact: clearer help output with no runtime behavior change.
- Why this is worth merging now: it closes a ready, low-risk workflow polish issue.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA

## Validation / Proof
- Commands run:
  - `scripts/dev/check_runtime_requirements.sh --help`
  - `scripts/dev/check_runtime_requirements.sh -h`
  - `bash -n scripts/dev/check_runtime_requirements.sh`
  - `git diff --check`
- Evidence that the change works here: both help invocations now show `-h, --help             Show help`; syntax and whitespace checks passed.
- Benchmarks or smoke tests, if applicable: NA; no benchmark/runtime behavior changed.

## Risks / Rollout
- Compatibility risks: low; help text only.
- Failure modes: accidental help-output formatting drift.
- Rollback or fallback plan: revert the one-line text change.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #2111.
- Any assumptions that need to be preserved: no existing direct test coverage for this helper's help output was changed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a one-line local workflow help-text fix with no benchmark, registry, model, artifact, or claim-map effect.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the spacing/readability of the help output.
- Any known limitations: full PR readiness was not run because this is a low-risk help-text-only change; targeted validation covered the issue contract.
