### PR TITLE
test: guard shell helper help paths

### DIFF
--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./common_setup.sh
-source "$SCRIPT_DIR/common_setup.sh"
-
-readonly PHASES=("lint" "typecheck" "test" "examples-smoke" "smoke" "artifact-policy")
-
 show_help() {
   cat <<'EOF'
 Usage: scripts/dev/ci_driver.sh [--list-phases] <phase> [<phase> ...]
@@ -31,6 +25,17 @@ Examples:
   scripts/dev/ci_driver.sh --list-phases
 EOF
 }
+
+if [[ "$#" -gt 0 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
+  show_help
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
+
+readonly PHASES=("lint" "typecheck" "test" "examples-smoke" "smoke" "artifact-policy")
 
 list_phases() {
   printf "%s\n" "${PHASES[@]}"
@@ -281,11 +286,6 @@ fi
 
 if [[ "$1" == "--list-phases" ]]; then
   list_phases
-  exit 0
-fi
-
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-  show_help
   exit 0
 fi
 

--- a/scripts/dev/run_ci_local.sh
+++ b/scripts/dev/run_ci_local.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./common_setup.sh
-source "$SCRIPT_DIR/common_setup.sh"
-
 show_help() {
   cat <<'EOF'
 Usage: scripts/dev/run_ci_local.sh [--no-setup] [<phase> ...]
@@ -25,6 +21,15 @@ Examples:
   CI_DRIVER_EVENT_NAME=workflow_dispatch scripts/dev/run_ci_local.sh smoke
 EOF
 }
+
+if [[ "$#" -gt 0 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  show_help
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
 
 load_default_phases() {
   mapfile -t default_phases < <("$SCRIPT_DIR/ci_driver.sh" --list-phases)

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./common_setup.sh
-source "$SCRIPT_DIR/common_setup.sh"
-
 show_help() {
   cat <<'EOF'
 Usage: scripts/dev/run_tests_parallel.sh [wrapper-options] [pytest-args...]
@@ -32,6 +28,15 @@ Examples:
   scripts/dev/run_tests_parallel.sh --no-fast-fail tests
 EOF
 }
+
+if [[ "$#" -gt 0 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  show_help
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
 
 fast_fail="${PYTEST_FAST_FAIL:-1}"
 dist_mode="${PYTEST_XDIST_DIST:-load}"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -1,4 +1,27 @@
-"""Guard CI shell wrappers against drift in shared script contracts."""
+"""Guard CI shell wrappers against drift in shared script contracts.
+
+Help-behaviour contract
+-----------------------
+Selected ``scripts/dev/*.sh`` helpers with --help / -h usage support must
+handle both forms as cheap success paths: exit 0, print usage to stdout,
+and return before sourcing common_setup.sh or invoking heavy dependencies
+(uv, ruff, pytest, gh, etc.).
+
+Covered scripts (8 total):
+  pr_ready_check.sh, gh_comment.sh, run_worktree_shared_venv.sh,
+  run_tests_parallel.sh, run_ci_local.sh, ci_driver.sh,
+  check_runtime_requirements.sh, check_carla_runtime.sh
+
+Also covered (in tests/dev/): ci_step_timer.sh
+
+Excluded by policy (SLURM/training-oriented, not general-purpose helpers):
+  auxme_partition_status.sh, sbatch_*.sh
+
+Excluded (no usage/help support at all):
+  ruff_fix_format.sh, check_changed_coverage.sh, check_docstring_todos_diff.sh,
+  check_docstring_todos_ratchet.sh, check_docs_proof_consistency_diff.sh,
+  common_setup.sh (sourced, not invoked directly)
+"""
 
 from __future__ import annotations
 
@@ -6,6 +29,8 @@ import os
 import subprocess
 import tomllib
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
@@ -15,6 +40,8 @@ RUN_TESTS_PARALLEL = ROOT / "scripts" / "dev" / "run_tests_parallel.sh"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
 PR_READY_CHECK = ROOT / "scripts" / "dev" / "pr_ready_check.sh"
 RUN_WORKTREE_SHARED_VENV = ROOT / "scripts" / "dev" / "run_worktree_shared_venv.sh"
+CHECK_RUNTIME_REQUIREMENTS = ROOT / "scripts" / "dev" / "check_runtime_requirements.sh"
+CHECK_CARLA_RUNTIME = ROOT / "scripts" / "dev" / "check_carla_runtime.sh"
 
 
 def test_ci_driver_smoke_uses_runtime_schema_and_output_matrix_path() -> None:
@@ -532,3 +559,167 @@ def test_gh_comment_invalid_target_exits_2() -> None:
     assert result.returncode == 2
     assert "target must be 'pr' or 'issue'" in result.stderr
     assert "Usage:" in result.stdout
+
+
+# Help-behaviour contract tests.
+
+HELP_COVERED_SCRIPTS = [
+    PR_READY_CHECK,
+    GH_COMMENT,
+    RUN_WORKTREE_SHARED_VENV,
+    RUN_TESTS_PARALLEL,
+    RUN_CI_LOCAL,
+    CI_DRIVER,
+    CHECK_RUNTIME_REQUIREMENTS,
+    CHECK_CARLA_RUNTIME,
+]
+
+
+def _script_name(path: Path) -> str:
+    return path.name
+
+
+def _make_help_fixture_repo(
+    tmp_path: Path,
+    script_names: tuple[str, ...],
+) -> tuple[Path, Path, dict[str, str]]:
+    """Create a tiny repo where help paths prove they do not invoke uv-backed setup."""
+
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    for script_name in script_names:
+        source = ROOT / "scripts" / "dev" / script_name
+        target = script_dir / script_name
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        target.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        '#!/usr/bin/env bash\necho "uv should not be called for --help" >&2\nexit 99\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "test fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+    }
+    return repo, script_dir, env
+
+
+@pytest.mark.parametrize("script", HELP_COVERED_SCRIPTS, ids=_script_name)
+def test_help_long_usage(script: Path) -> None:
+    """Every contract-covered script exits 0 with Usage: for --help."""
+    result = subprocess.run(
+        [str(script), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"{script.name} --help failed: {result.stderr}"
+    assert "Usage:" in result.stdout
+
+
+@pytest.mark.parametrize("script", HELP_COVERED_SCRIPTS, ids=_script_name)
+def test_help_short_usage(script: Path) -> None:
+    """Every contract-covered script exits 0 with Usage: for -h."""
+    result = subprocess.run(
+        [str(script), "-h"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"{script.name} -h failed: {result.stderr}"
+    assert "Usage:" in result.stdout
+
+
+# Cheap help: --help must not invoke heavy gates.
+
+
+def test_ci_driver_help_does_not_invoke_phases(tmp_path: Path) -> None:
+    """ci_driver.sh --help exits 0 before sourcing common_setup or running phases."""
+    repo, script_dir, env = _make_help_fixture_repo(tmp_path, ("ci_driver.sh", "common_setup.sh"))
+    result = subprocess.run(
+        [str(script_dir / "ci_driver.sh"), "--help"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
+def test_run_tests_parallel_help_does_not_invoke_pytest(tmp_path: Path) -> None:
+    """run_tests_parallel.sh --help exits 0 before sourcing common_setup."""
+    repo, script_dir, env = _make_help_fixture_repo(
+        tmp_path,
+        ("run_tests_parallel.sh", "common_setup.sh"),
+    )
+    result = subprocess.run(
+        [str(script_dir / "run_tests_parallel.sh"), "--help"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
+def test_run_ci_local_help_does_not_invoke_setup(tmp_path: Path) -> None:
+    """run_ci_local.sh --help exits 0 before sourcing common_setup or running phases."""
+    repo, script_dir, env = _make_help_fixture_repo(
+        tmp_path,
+        ("run_ci_local.sh", "common_setup.sh", "ci_driver.sh"),
+    )
+    result = subprocess.run(
+        [str(script_dir / "run_ci_local.sh"), "--help"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "uv should not be called" not in result.stderr


### PR DESCRIPTION
## Summary
Added a focused shell-helper help contract for selected `scripts/dev/*.sh` helpers and fixed three helpers so `--help`/`-h` exit before sourcing shared setup.

## Linked Issues
- Closes `#2107`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added parametrized contract tests for selected general-purpose dev helpers with `--help`/`-h` support.
- Documented covered helpers and exclusions in `tests/test_ci_script_contract.py`.
- Moved help handling before `common_setup.sh` sourcing in `scripts/dev/ci_driver.sh`, `scripts/dev/run_ci_local.sh`, and `scripts/dev/run_tests_parallel.sh`.

## Why It Matters
- Added value: future shell-helper help regressions are caught in one focused place.
- Expected impact: help paths stay cheap and safe; normal command behavior is unchanged.
- Why this is worth merging now: it closes a ready workflow issue created from repeated one-off help fixes.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/dev tests/test_ci_script_contract.py -k 'help or ci_step_timer or gh_comment or pr_ready_check' -v`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -v`
  - `uv run ruff format tests/test_ci_script_contract.py --check && uv run ruff check tests/test_ci_script_contract.py`
  - `bash -n scripts/dev/run_tests_parallel.sh scripts/dev/run_ci_local.sh scripts/dev/ci_driver.sh && git diff --check`
- Evidence that the change works here: focused selection passed `42 passed, 84 deselected`; full contract file passed `44 passed`; ruff, shell syntax, and whitespace checks passed.
- Benchmarks or smoke tests, if applicable: NA; workflow helper contract only.

## Risks / Rollout
- Compatibility risks: low; only help-path ordering changed for the three scripts.
- Failure modes: a script intentionally excluded from the first guard could still regress until consciously opted in.
- Rollback or fallback plan: revert the test additions and early help-path moves.

## Docs / Provenance
- Updated docs: `tests/test_ci_script_contract.py` module docstring documents the convention, covered scripts, and exclusions.
- Relevant design or provenance notes: issue #2107.
- Any assumptions that need to be preserved: SLURM-oriented helpers and scripts with no usage/help support stay excluded from the first guard.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a local workflow test/help-path guard with no benchmark, registry, artifact, model, or claim-map effect.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: that the covered/excluded helper list is appropriately narrow.
- Any known limitations: full PR readiness was not run; targeted validation covers this low-risk workflow issue.
