### PR TITLE
docs: sync local CI phase list

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -243,7 +243,7 @@ EOF
 `scripts/dev/run_ci_local.sh` is the local CI-equivalent entrypoint for the shared
 validation phases. By default it runs `uv sync --all-extras --frozen`, migrates legacy artifacts,
 then delegates to `scripts/dev/ci_driver.sh` so local runs and `.github/workflows/ci.yml`
-share the same phase definitions (`lint`, `typecheck`, `test`, `smoke`, and
+share the same phase definitions (`lint`, `typecheck`, `test`, `examples-smoke`, `smoke`, and
 `artifact-policy`). Pass explicit phases to scope a run, for example
 `scripts/dev/run_ci_local.sh lint test`. After dependencies are already current, use
 `scripts/dev/run_ci_local.sh --no-setup lint test` for faster repeat local feedback.


### PR DESCRIPTION
## Summary
Updated the local CI phase list in `docs/dev_guide.md` so it includes `examples-smoke`, matching `scripts/dev/ci_driver.sh`.

## Linked Issues
- Closes `#2109`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `examples-smoke` to the documented shared CI phase list in `docs/dev_guide.md`.

## Why It Matters
- Added value: local CI docs now match the actual driver phase contract.
- Expected impact: contributors see the complete six-phase local CI list.
- Why this is worth merging now: it closes a ready docs drift issue with a one-line correction.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA

## Validation / Proof
- Commands run:
  - `scripts/dev/ci_driver.sh --list-phases`
  - `git diff --check`
- Evidence that the change works here: `ci_driver.sh --list-phases` prints `lint`, `typecheck`, `test`, `examples-smoke`, `smoke`, `artifact-policy`; the docs diff now matches that order.
- Benchmarks or smoke tests, if applicable: NA; docs-only phase-list sync.

## Risks / Rollout
- Compatibility risks: low; docs-only.
- Failure modes: another doc surface could separately mention stale phases, but the issue scope named `docs/dev_guide.md`.
- Rollback or fallback plan: revert the one-line docs change.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`.
- Relevant design or provenance notes: issue #2109.
- Any assumptions that need to be preserved: developer pre-push quality gate examples are not canonical CI phase lists and were left unchanged.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: docs-only local CI phase-list correction with no benchmark, registry, artifact, model, or claim-map effect.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: that the docs list matches `scripts/dev/ci_driver.sh --list-phases`.
- Any known limitations: full PR readiness was not run; targeted docs validation covers the issue contract.
