### PR TITLE
fix: refresh benchmark artifact producer metadata

### DIFF
--- a/robot_sf/common/artifact_paths.py
+++ b/robot_sf/common/artifact_paths.py
@@ -75,7 +75,7 @@ DEFAULT_ARTIFACT_CATEGORIES: dict[str, ArtifactCategory] = {
         relative_path=Path("benchmarks"),
         description="Benchmark summaries, JSONL outputs, and performance reports.",
         retention_hint="keep-latest",
-        producers=("scripts/benchmark02.py", "scripts/validation/performance_smoke_test.py"),
+        producers=("scripts/benchmark_workers.py", "scripts/validation/performance_smoke_test.py"),
     ),
     "recordings": ArtifactCategory(
         name="recordings",


### PR DESCRIPTION
## Summary
Refreshed benchmark artifact producer metadata so the active `benchmarks` category no longer points at retired `scripts/benchmark02.py`.

## Linked Issues
- Closes `#2110`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated `robot_sf/common/artifact_paths.py` to list `scripts/benchmark_workers.py` as the benchmark artifact producer alongside `scripts/validation/performance_smoke_test.py`.

## Why It Matters
- Added value: artifact metadata now points at maintained benchmark/smoke producer paths rather than a retired compatibility script.
- Expected impact: less misleading provenance for generated benchmark artifacts.
- Why this is worth merging now: it closes a ready workflow/provenance cleanup issue with a one-line metadata correction.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark artifact producer provenance metadata.
- Comparator or baseline, if applicable: retired `scripts/benchmark02.py` metadata entry.
- Result classification: blocker-resolution / metadata cleanup only.
- Decision or stop rule, if applicable: active benchmark artifact producer metadata no longer references retired `scripts/benchmark02.py`.

## Validation / Proof
- Commands run:
  - `test -f scripts/benchmark_workers.py && test -f scripts/validation/performance_smoke_test.py && rg -n 'benchmark02\.py|scripts/benchmark_workers.py|scripts/validation/performance_smoke_test.py' robot_sf/common/artifact_paths.py scripts/README.md scripts/benchmark02.py`
  - `uv run pytest tests/test_guard/test_artifact_paths.py -v`
  - `uv run ruff check robot_sf/common/artifact_paths.py`
  - `uv run ruff format --check robot_sf/common/artifact_paths.py`
  - `git diff --check`
- Evidence that the change works here: the active metadata now names `scripts/benchmark_workers.py`; focused artifact path tests passed `12 passed`; ruff/format/whitespace checks passed.
- Benchmarks or smoke tests, if applicable: no benchmark run; this is metadata/provenance cleanup and makes no benchmark success claim.

## Risks / Rollout
- Compatibility risks: low; metadata string only.
- Failure modes: downstream tooling expecting the retired producer string may need to treat this as metadata drift, but no tests indicate that dependency.
- Rollback or fallback plan: revert the one-line producer tuple change.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #2110; `scripts/README.md` already describes `benchmark02.py` as retired compatibility.
- Any assumptions that need to be preserved: `scripts/benchmark02.py` remains retired/fail-closed and was not deleted or behaviorally changed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this updates local artifact category metadata only; no benchmark result, model, registry entry, or claim-map evidence changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: that `scripts/benchmark_workers.py` is the intended maintained replacement producer for benchmark artifacts.
- Any known limitations: full PR readiness was not run; targeted metadata validation covers this narrow issue.
