### PR TITLE
feat: add figure artifact QA checks

### DIFF
--- a/docs/figures/README.md
+++ b/docs/figures/README.md
@@ -50,6 +50,28 @@ uv run python scripts/generate_figures.py \
   --dmetrics collisions,comfort_exposure --force-field
 ```
 
+## Figure QA Validation
+
+Validate generated figure artifacts with deterministic, CI-friendly checks:
+
+```bash
+# Single figure file
+uv run python scripts/validation/validate_figure_artifacts.py docs/figures/fig-my-figure.png --artifact-id fig_my_figure
+
+# With caption metadata check
+uv run python scripts/validation/validate_figure_artifacts.py docs/figures/fig-my-figure.png --artifact-id fig_my_figure --caption docs/figures/captions.md
+
+# All figures in an artifact catalog
+uv run python scripts/validation/validate_figure_artifacts.py docs/figures/catalog.yaml --catalog
+
+# Machine-readable JSON report
+uv run python scripts/validation/validate_figure_artifacts.py docs/figures/fig-my-figure.png --artifact-id fig_my_figure --json
+```
+
+Checks performed: file existence, PNG/PDF signatures, valid PNG dimensions,
+minimum file size, catalog output formats, and caption file availability.
+Failures name the `artifact_id` and the failed check.
+
 ## Related
 
 - `docs/img/` - static images (screenshots, diagrams)

--- a/robot_sf/benchmark/figure_qa.py
+++ b/robot_sf/benchmark/figure_qa.py
@@ -1,0 +1,435 @@
+"""Deterministic QA checks for generated figure artifacts.
+
+Validates figure PNG files for common issues: missing file, empty/near-empty
+image, wrong format, and missing caption metadata.  Designed for CI integration
+and test fixtures; does not require benchmark inputs or pixel-perfect golden
+comparisons.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from PIL import Image
+
+from robot_sf.benchmark.artifact_catalog import (
+    ArtifactCatalog,
+    ArtifactCatalogEntry,
+    load_artifact_catalog,
+)
+
+_MIN_PNG_DIMENSION = 10
+_MIN_PNG_FILE_SIZE = 67
+_DEFAULT_REQUIRED_FORMATS = frozenset({"png"})
+_DEFAULT_ALLOWED_FORMATS = frozenset({"png", "pdf", "svg"})
+_PDF_SIGNATURE = b"%PDF-"
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+@dataclass(frozen=True, slots=True)
+class FigureQA:
+    """One deterministic QA check result for a figure artifact.
+
+    Attributes:
+        artifact_id: Stable identifier from the artifact catalog or caller.
+        check:       Short check name (e.g. ``file_exists``, ``valid_image``).
+        message:     Human-readable description of the issue.
+    """
+
+    artifact_id: str
+    check: str
+    message: str
+
+
+def check_figure_file(
+    path: Path,
+    *,
+    artifact_id: str = "<unknown>",
+    expected_format: str = "png",
+    caption_path: Path | None = None,
+    allowed_formats: frozenset[str] = _DEFAULT_ALLOWED_FORMATS,
+) -> list[FigureQA]:
+    """Run deterministic QA checks on a single figure file.
+
+    Checks performed (in order):
+
+    1. File exists and is a regular file.
+    2. File starts with the expected format signature (PNG by default).
+    3. File is a valid image with dimensions >= ``_MIN_PNG_DIMENSION``.
+    4. File size meets the minimum threshold.
+    5. Optional caption file exists and is non-empty.
+
+    Args:
+        path:             Absolute path to the figure file.
+        artifact_id:      Stable identifier used in failure messages.
+        expected_format:  Expected image format (``"png"``, ``"pdf"``, etc.).
+        caption_path:     Optional path to a caption / description file.
+        allowed_formats:  Output formats permitted for figure artifacts.
+
+    Returns:
+        List of ``FigureQA`` results.  Empty means all checks passed.
+    """
+    issues: list[FigureQA] = []
+
+    # --- check 1: file exists and is a regular file ---
+    if not path.exists():
+        issues.append(FigureQA(artifact_id, "file_exists", f"file does not exist: {path}"))
+        return issues
+    if not path.is_file():
+        issues.append(FigureQA(artifact_id, "file_exists", f"path is not a regular file: {path}"))
+        return issues
+
+    normalized_format = expected_format.lower()
+    if normalized_format not in allowed_formats:
+        issues.append(
+            FigureQA(
+                artifact_id,
+                "format",
+                f"unsupported figure format '{expected_format}'",
+            )
+        )
+        return issues
+
+    # --- check 2: format signature ---
+    if normalized_format == "png":
+        _check_png_signature(path, artifact_id, issues)
+    elif normalized_format == "pdf":
+        _check_pdf_signature(path, artifact_id, issues)
+
+    # --- check 3: valid raster image with reasonable content ---
+    if normalized_format == "png":
+        _check_image_content(path, artifact_id, issues)
+
+    # --- check 4: file size ---
+    _check_file_size(path, artifact_id, issues)
+
+    # --- check 5: caption file ---
+    if caption_path is not None:
+        _check_caption_file(caption_path, artifact_id, issues)
+
+    return issues
+
+
+def check_figure_entry(
+    entry: ArtifactCatalogEntry,
+    *,
+    catalog_dir: Path,
+    required_formats: frozenset[str] = _DEFAULT_REQUIRED_FORMATS,
+    allowed_formats: frozenset[str] = _DEFAULT_ALLOWED_FORMATS,
+) -> list[FigureQA]:
+    """Run QA checks on a single catalog figure entry.
+
+    Args:
+        entry:       Typed artifact catalog entry (``artifact_kind`` must be
+                     ``"figure"``).
+        catalog_dir: Directory used to resolve relative file paths.
+        required_formats: Output formats that every figure entry must include.
+        allowed_formats:  Output formats permitted for figure entries.
+
+    Returns:
+        List of ``FigureQA`` results.  Empty means all checks passed.
+    """
+    if entry.artifact_kind != "figure":
+        return []
+
+    issues: list[FigureQA] = []
+    output_formats = {output_key.lower() for output_key in entry.outputs}
+    for required_format in sorted(required_formats):
+        if required_format not in output_formats:
+            issues.append(
+                FigureQA(
+                    entry.artifact_id,
+                    "format_set",
+                    f"required output format '{required_format}' is missing",
+                )
+            )
+    unexpected_formats = output_formats - allowed_formats
+    if unexpected_formats:
+        issues.append(
+            FigureQA(
+                entry.artifact_id,
+                "format_set",
+                "unexpected output formats: " + ", ".join(sorted(unexpected_formats)),
+            )
+        )
+
+    caption_path: Path | None = None
+    if entry.caption_file is None:
+        issues.append(
+            FigureQA(
+                entry.artifact_id,
+                "caption_file",
+                "figure artifact is missing caption metadata",
+            )
+        )
+    else:
+        caption_path = (catalog_dir / entry.caption_file.path).resolve()
+
+    for output_key, file_ref in entry.outputs.items():
+        figure_path = (catalog_dir / file_ref.path).resolve()
+        issues.extend(
+            check_figure_file(
+                figure_path,
+                artifact_id=entry.artifact_id,
+                expected_format=output_key,
+                caption_path=caption_path,
+                allowed_formats=allowed_formats,
+            )
+        )
+    return issues
+
+
+def validate_figures_in_catalog(
+    catalog: ArtifactCatalog,
+    *,
+    catalog_path: Path | None = None,
+    required_formats: frozenset[str] = _DEFAULT_REQUIRED_FORMATS,
+    allowed_formats: frozenset[str] = _DEFAULT_ALLOWED_FORMATS,
+) -> list[FigureQA]:
+    """Run QA checks on all figure entries in an artifact catalog.
+
+    Args:
+        catalog:      Typed artifact catalog metadata.
+        catalog_path: Path to the catalog file (used to resolve relative file
+                      paths).  Falls back to ``Path.cwd()`` when ``None``.
+        required_formats: Output formats that every figure entry must include.
+        allowed_formats:  Output formats permitted for figure entries.
+
+    Returns:
+        List of ``FigureQA`` results.  Empty means all checks passed.
+    """
+    catalog_dir = catalog_path.parent.resolve() if catalog_path else Path.cwd()
+    issues: list[FigureQA] = []
+    for entry in catalog.artifacts:
+        issues.extend(
+            check_figure_entry(
+                entry,
+                catalog_dir=catalog_dir,
+                required_formats=required_formats,
+                allowed_formats=allowed_formats,
+            )
+        )
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_png_signature(path: Path, artifact_id: str, issues: list[FigureQA]) -> None:
+    """Verify the file starts with a valid 8-byte PNG signature."""
+    _check_file_signature(
+        path,
+        artifact_id,
+        _PNG_SIGNATURE,
+        "file does not have a valid PNG signature",
+        issues,
+    )
+
+
+def _check_pdf_signature(path: Path, artifact_id: str, issues: list[FigureQA]) -> None:
+    """Verify the file starts with the PDF magic bytes."""
+    _check_file_signature(
+        path,
+        artifact_id,
+        _PDF_SIGNATURE,
+        "file does not have a valid PDF signature",
+        issues,
+    )
+
+
+def _check_file_signature(
+    path: Path,
+    artifact_id: str,
+    signature: bytes,
+    mismatch_message: str,
+    issues: list[FigureQA],
+) -> None:
+    """Verify the file starts with the expected signature bytes."""
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(len(signature))
+    except OSError as exc:
+        issues.append(FigureQA(artifact_id, "format", f"cannot read file for format check: {exc}"))
+        return
+    if header != signature:
+        issues.append(FigureQA(artifact_id, "format", mismatch_message))
+
+
+def _check_image_content(path: Path, artifact_id: str, issues: list[FigureQA]) -> None:
+    """Verify the image opens correctly and has reasonable dimensions."""
+    if not path.is_file():
+        issues.append(FigureQA(artifact_id, "valid_image", "path is not a file"))
+        return
+    try:
+        with Image.open(path) as img:
+            width, height = img.size
+            img.verify()
+    except Exception as exc:
+        issues.append(FigureQA(artifact_id, "valid_image", f"cannot verify image: {exc}"))
+        return
+
+    if width < _MIN_PNG_DIMENSION or height < _MIN_PNG_DIMENSION:
+        issues.append(
+            FigureQA(
+                artifact_id,
+                "valid_image",
+                f"image dimensions ({width}x{height}) are below minimum "
+                f"({_MIN_PNG_DIMENSION}x{_MIN_PNG_DIMENSION})",
+            )
+        )
+
+
+def _check_file_size(path: Path, artifact_id: str, issues: list[FigureQA]) -> None:
+    """Verify the file size meets the minimum threshold."""
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        issues.append(FigureQA(artifact_id, "file_size", f"cannot stat file: {exc}"))
+        return
+    if size < _MIN_PNG_FILE_SIZE:
+        issues.append(
+            FigureQA(
+                artifact_id,
+                "file_size",
+                f"file size ({size} bytes) is below minimum ({_MIN_PNG_FILE_SIZE} bytes)",
+            )
+        )
+
+
+def _check_caption_file(path: Path, artifact_id: str, issues: list[FigureQA]) -> None:
+    """Verify the caption file exists and contains non-whitespace content."""
+    if not path.exists():
+        issues.append(FigureQA(artifact_id, "caption_file", f"caption file does not exist: {path}"))
+        return
+    if not path.is_file():
+        issues.append(
+            FigureQA(
+                artifact_id,
+                "caption_file",
+                f"caption path is not a regular file: {path}",
+            )
+        )
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        issues.append(FigureQA(artifact_id, "caption_file", f"cannot read caption file: {exc}"))
+        return
+    if not text.strip():
+        issues.append(FigureQA(artifact_id, "caption_file", f"caption file is empty: {path}"))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the figure artifact QA argument parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate figure artifacts with deterministic QA checks."
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to a figure file or artifact catalog (use --catalog).",
+    )
+    parser.add_argument(
+        "--catalog",
+        action="store_true",
+        help="Treat ``path`` as an artifact catalog YAML/JSON file.",
+    )
+    parser.add_argument(
+        "--artifact-id",
+        default=None,
+        help="Artifact identifier for single-file validation (defaults to the filename stem).",
+    )
+    parser.add_argument(
+        "--caption",
+        type=Path,
+        default=None,
+        help="Caption file path for single-file validation.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON validation report.",
+    )
+    parser.add_argument(
+        "--require-format",
+        action="append",
+        default=None,
+        help="Required catalog output format; may be repeated. Defaults to png.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate figure artifacts and return a shell-friendly exit code.
+
+    Returns:
+        ``0`` when all checks pass, ``2`` when any check fails.
+    """
+    args = build_arg_parser().parse_args(argv)
+
+    if args.catalog:
+        catalog = load_artifact_catalog(args.path)
+        required_formats = (
+            frozenset(item.lower() for item in args.require_format)
+            if args.require_format
+            else _DEFAULT_REQUIRED_FORMATS
+        )
+        issues = validate_figures_in_catalog(
+            catalog,
+            catalog_path=args.path,
+            required_formats=required_formats,
+        )
+    else:
+        artifact_id = args.artifact_id or args.path.stem
+        issues = check_figure_file(
+            args.path,
+            artifact_id=artifact_id,
+            caption_path=args.caption,
+        )
+
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "schema": "figure_qa.v1",
+                    "target": str(args.path),
+                    "ok": not issues,
+                    "issues": [asdict(issue) for issue in issues],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    elif issues:
+        for issue in issues:
+            sys.stdout.write(f"[{issue.artifact_id}] {issue.check}: {issue.message}\n")
+    else:
+        sys.stdout.write(f"All figure QA checks passed: {args.path}\n")
+
+    return 0 if not issues else 2
+
+
+__all__ = [
+    "FigureQA",
+    "build_arg_parser",
+    "check_figure_entry",
+    "check_figure_file",
+    "main",
+    "validate_figures_in_catalog",
+]

--- a/scripts/validation/validate_figure_artifacts.py
+++ b/scripts/validation/validate_figure_artifacts.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Validate figure artifacts with deterministic QA checks."""
+
+from __future__ import annotations
+
+from robot_sf.benchmark.figure_qa import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/benchmark/test_figure_qa.py
+++ b/tests/benchmark/test_figure_qa.py
@@ -1,0 +1,434 @@
+"""Tests for deterministic figure artifact QA checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from PIL import Image
+
+from robot_sf.benchmark.artifact_catalog import (
+    ARTIFACT_CATALOG_SCHEMA_VERSION,
+    ArtifactCatalog,
+    ArtifactCatalogEntry,
+    ArtifactFileRef,
+    sha256_file,
+)
+from robot_sf.benchmark.figure_qa import (
+    FigureQA,
+    check_figure_entry,
+    check_figure_file,
+    main,
+    validate_figures_in_catalog,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "figure_qa"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_png(path: Path, size: tuple[int, int] = (100, 100)) -> Path:
+    """Create a small valid PNG file at *path* and return it."""
+    img = Image.new("RGB", size, color="blue")
+    img.save(path, format="PNG")
+    return path
+
+
+def _error_message(issues: list[FigureQA], check: str) -> str | None:
+    """Return the message of the first issue matching *check*, or None."""
+    for issue in issues:
+        if issue.check == check:
+            return issue.message
+    return None
+
+
+def _assert_check(issues: list[FigureQA], check: str, artifact_id: str) -> None:
+    """Assert that an issue with *check* exists and names *artifact_id*."""
+    assert any(issue.check == check and issue.artifact_id == artifact_id for issue in issues), (
+        f"Expected check={check!r} not found in {issues}"
+    )
+
+
+def _assert_not_check(issues: list[FigureQA], check: str) -> None:
+    """Assert that no issue with *check* exists."""
+    assert not any(issue.check == check for issue in issues), (
+        f"Unexpected check={check!r} found in {issues}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# valid path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_figure(tmp_path: Path) -> Path:
+    """Return a path to a valid small PNG."""
+    return _create_png(tmp_path / "valid_figure.png")
+
+
+def test_valid_figure_passes(valid_figure: Path) -> None:
+    """A valid figure should pass all checks with no issues."""
+    issues = check_figure_file(valid_figure, artifact_id="fig_test")
+    assert issues == []
+
+
+def test_valid_figure_with_caption_passes(valid_figure: Path, tmp_path: Path) -> None:
+    """A valid figure with a caption file should pass all checks."""
+    caption = tmp_path / "captions.md"
+    caption.write_text("# Valid caption\n", encoding="utf-8")
+    issues = check_figure_file(
+        valid_figure,
+        artifact_id="fig_test",
+        caption_path=caption,
+    )
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# missing file
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file() -> None:
+    """Non-existent path should report file_exists check."""
+    missing = Path("/nonexistent/fig_missing.png")
+    issues = check_figure_file(missing, artifact_id="fig_missing")
+    _assert_check(issues, "file_exists", "fig_missing")
+    assert "does not exist" in issues[0].message
+
+
+def test_directory_path(tmp_path: Path) -> None:
+    """A directory path should report file_exists."""
+    dirpath = tmp_path / "subdir"
+    dirpath.mkdir()
+    issues = check_figure_file(dirpath, artifact_id="fig_dir")
+    _assert_check(issues, "file_exists", "fig_dir")
+    assert "not a regular file" in issues[0].message
+
+
+# ---------------------------------------------------------------------------
+# empty / near-empty PNG
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file(tmp_path: Path) -> None:
+    """A zero-byte file should fail file_size and valid_image checks."""
+    empty = tmp_path / "empty.png"
+    empty.touch()
+    issues = check_figure_file(empty, artifact_id="fig_empty")
+    _assert_check(issues, "file_size", "fig_empty")
+    _assert_check(issues, "valid_image", "fig_empty")
+
+
+def test_tiny_dimensions_fail(tmp_path: Path) -> None:
+    """A 1x1 pixel image should fail the valid_image dimension check."""
+    tiny = tmp_path / "tiny.png"
+    _create_png(tiny, size=(1, 1))
+    issues = check_figure_file(tiny, artifact_id="fig_tiny")
+    _assert_check(issues, "valid_image", "fig_tiny")
+    msg = _error_message(issues, "valid_image")
+    assert msg is not None
+    assert "below minimum" in msg or "1x1" in msg
+
+
+def test_near_empty_png(tmp_path: Path) -> None:
+    """A valid PNG just below the dimension threshold should fail."""
+    small = tmp_path / "small.png"
+    _create_png(small, size=(9, 100))
+    issues = check_figure_file(small, artifact_id="fig_small")
+    _assert_check(issues, "valid_image", "fig_small")
+    msg = _error_message(issues, "valid_image")
+    assert msg is not None
+    assert "below minimum" in msg
+
+
+# ---------------------------------------------------------------------------
+# missing caption metadata
+# ---------------------------------------------------------------------------
+
+
+def test_missing_caption_file(tmp_path: Path) -> None:
+    """Missing caption path should report caption_file check."""
+    figure = tmp_path / "figure.png"
+    _create_png(figure)
+    caption = tmp_path / "missing_captions.md"
+    issues = check_figure_file(
+        figure,
+        artifact_id="fig_no_cap",
+        caption_path=caption,
+    )
+    _assert_check(issues, "caption_file", "fig_no_cap")
+    assert "does not exist" in issues[0].message
+
+
+def test_empty_caption_file(tmp_path: Path) -> None:
+    """Empty caption file should report caption_file check."""
+    figure = tmp_path / "figure.png"
+    _create_png(figure)
+    caption = tmp_path / "empty_captions.md"
+    caption.touch()
+    issues = check_figure_file(
+        figure,
+        artifact_id="fig_empty_cap",
+        caption_path=caption,
+    )
+    _assert_check(issues, "caption_file", "fig_empty_cap")
+    assert "empty" in issues[0].message
+
+
+# ---------------------------------------------------------------------------
+# unexpected format
+# ---------------------------------------------------------------------------
+
+
+def test_unexpected_format_not_png(tmp_path: Path) -> None:
+    """A non-PNG file should fail the format check when expected_format=png."""
+    not_png = tmp_path / "not_png.png"
+    not_png.write_bytes(b"\x00\x00\x00\x00\x00\x00\x00\x00")
+    issues = check_figure_file(not_png, artifact_id="fig_not_png")
+    _assert_check(issues, "format", "fig_not_png")
+
+
+def test_catalog_unexpected_format_set(tmp_path: Path) -> None:
+    """A catalog figure should fail when it advertises an unsupported format."""
+    figure = _create_png(tmp_path / "fig_unexpected.png")
+    file_ref = ArtifactFileRef(path=figure.name, sha256=sha256_file(figure))
+    caption = FIXTURE_DIR / "captions.md"
+    entry = ArtifactCatalogEntry(
+        artifact_id="fig_unexpected_format",
+        artifact_kind="figure",
+        source_kind="test",
+        source_files=[file_ref],
+        outputs={"jpg": file_ref},
+        generation_command="pytest fixture",
+        generation_commit="0000000",
+        claim_boundary="fixture only",
+        caption_file=ArtifactFileRef(path=str(caption), sha256=sha256_file(caption)),
+    )
+
+    issues = check_figure_entry(entry, catalog_dir=tmp_path)
+
+    _assert_check(issues, "format_set", "fig_unexpected_format")
+
+
+def test_catalog_custom_allowed_format_passes_format_checks(tmp_path: Path) -> None:
+    """Custom allowed formats should apply at both entry and file levels."""
+    raw = tmp_path / "fig_custom.raw"
+    raw.write_bytes(b"custom deterministic fixture" * 4)
+    file_ref = ArtifactFileRef(path=raw.name, sha256=sha256_file(raw))
+    caption = FIXTURE_DIR / "captions.md"
+    entry = ArtifactCatalogEntry(
+        artifact_id="fig_custom_format",
+        artifact_kind="figure",
+        source_kind="test",
+        source_files=[file_ref],
+        outputs={"raw": file_ref},
+        generation_command="pytest fixture",
+        generation_commit="0000000",
+        claim_boundary="fixture only",
+        caption_file=ArtifactFileRef(path=str(caption), sha256=sha256_file(caption)),
+    )
+
+    issues = check_figure_entry(
+        entry,
+        catalog_dir=tmp_path,
+        required_formats=frozenset({"raw"}),
+        allowed_formats=frozenset({"raw"}),
+    )
+
+    assert issues == []
+
+
+def test_catalog_missing_required_png_format(tmp_path: Path) -> None:
+    """A catalog figure should fail when the required PNG output is absent."""
+    pdf = tmp_path / "fig_only_pdf.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n% fixture\n")
+    file_ref = ArtifactFileRef(path=pdf.name, sha256=sha256_file(pdf))
+    caption = FIXTURE_DIR / "captions.md"
+    entry = ArtifactCatalogEntry(
+        artifact_id="fig_missing_png",
+        artifact_kind="figure",
+        source_kind="test",
+        source_files=[file_ref],
+        outputs={"pdf": file_ref},
+        generation_command="pytest fixture",
+        generation_commit="0000000",
+        claim_boundary="fixture only",
+        caption_file=ArtifactFileRef(path=str(caption), sha256=sha256_file(caption)),
+    )
+
+    issues = check_figure_entry(entry, catalog_dir=tmp_path)
+
+    _assert_check(issues, "format_set", "fig_missing_png")
+    _assert_not_check(issues, "valid_image")
+
+
+def test_valid_png_passes_format_check(tmp_path: Path) -> None:
+    """A valid PNG should pass the format signature check."""
+    figure = tmp_path / "valid.png"
+    _create_png(figure)
+    issues = check_figure_file(figure, artifact_id="fig_valid_png")
+    _assert_not_check(issues, "format")
+
+
+# ---------------------------------------------------------------------------
+# artifact catalog integration
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_validation_valid_figure(tmp_path: Path) -> None:
+    """All checks should pass for a valid figure in a minimal catalog."""
+    figure = _create_png(tmp_path / "fig_valid.png")
+    catalog = _make_minimal_catalog(figure, tmp_path)
+    issues = validate_figures_in_catalog(catalog, catalog_path=tmp_path / "catalog.yaml")
+    assert issues == []
+
+
+def test_catalog_validation_missing_output(tmp_path: Path) -> None:
+    """A missing output file in a catalog figure should be reported."""
+    figure = tmp_path / "fig_missing_output.png"
+    figure.touch()
+    catalog = _make_minimal_catalog(figure, tmp_path)
+    figure.unlink()
+    issues = validate_figures_in_catalog(catalog, catalog_path=tmp_path / "catalog.yaml")
+    any_found = any(
+        issue.check == "file_exists" and issue.artifact_id == "fig_catalog_test" for issue in issues
+    )
+    assert any_found, f"Expected file_exists check not found in {issues}"
+
+
+def test_catalog_validation_missing_caption(tmp_path: Path) -> None:
+    """A missing caption file in a catalog figure should be reported."""
+    figure = _create_png(tmp_path / "fig_no_cap_catalog.png")
+    entry = ArtifactCatalogEntry(
+        artifact_id="fig_cap_missing",
+        artifact_kind="figure",
+        source_kind="test",
+        source_files=[ArtifactFileRef(path=figure.name, sha256=sha256_file(figure))],
+        outputs={"png": ArtifactFileRef(path=figure.name, sha256=sha256_file(figure))},
+        generation_command="pytest fixture",
+        generation_commit="0000000",
+        claim_boundary="fixture only",
+        caption_file=ArtifactFileRef(path="does_not_exist.md", sha256="0" * 64),
+    )
+    issues = check_figure_entry(entry, catalog_dir=tmp_path)
+    _assert_check(issues, "caption_file", "fig_cap_missing")
+
+
+def test_catalog_validation_requires_caption_metadata(tmp_path: Path) -> None:
+    """A catalog figure should report missing caption metadata when omitted."""
+    figure = _create_png(tmp_path / "fig_no_caption_metadata.png")
+    checksum = sha256_file(figure)
+    entry = ArtifactCatalogEntry(
+        artifact_id="fig_no_caption_metadata",
+        artifact_kind="figure",
+        source_kind="test",
+        source_files=[ArtifactFileRef(path=figure.name, sha256=checksum)],
+        outputs={"png": ArtifactFileRef(path=figure.name, sha256=checksum)},
+        generation_command="pytest fixture",
+        generation_commit="0000000",
+        claim_boundary="fixture only",
+        caption_file=None,
+    )
+
+    issues = check_figure_entry(entry, catalog_dir=tmp_path)
+
+    _assert_check(issues, "caption_file", "fig_no_caption_metadata")
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_valid_figure_passes(valid_figure: Path) -> None:
+    """CLI should exit 0 for a valid figure."""
+    exit_code = main([str(valid_figure), "--artifact-id", "fig_cli"])
+    assert exit_code == 0
+
+
+def test_cli_missing_file_exits_fail(tmp_path: Path) -> None:
+    """CLI should exit 2 for a missing figure."""
+    missing = tmp_path / "not_a_file.png"
+    exit_code = main([str(missing), "--artifact-id", "fig_cli"])
+    assert exit_code == 2
+
+
+def test_cli_json_output(tmp_path: Path) -> None:
+    """CLI JSON output should have the expected schema."""
+    figure = _create_png(tmp_path / "json_test.png")
+    exit_code = main([str(figure), "--artifact-id", "fig_json", "--json"])
+    assert exit_code == 0
+
+
+def test_cli_json_failure_output(tmp_path: Path) -> None:
+    """CLI JSON output for a failure should include issues."""
+    missing = tmp_path / "missing.png"
+    exit_code = main([str(missing), "--artifact-id", "fig_json_fail", "--json"])
+    assert exit_code == 2
+
+
+def test_cli_catalog_validation_passes(tmp_path: Path) -> None:
+    """CLI catalog mode should validate a tiny checksummed figure catalog."""
+    figure = _create_png(tmp_path / "fig_cli_catalog.png")
+    caption = tmp_path / "captions.md"
+    caption.write_text("# fig_cli_catalog\n\nFixture caption.\n", encoding="utf-8")
+    payload = {
+        "schema_version": ARTIFACT_CATALOG_SCHEMA_VERSION,
+        "catalog_id": "figure_qa_cli_fixture",
+        "artifacts": [
+            {
+                "artifact_id": "fig_cli_catalog",
+                "artifact_kind": "figure",
+                "source_kind": "test",
+                "source_files": [{"path": figure.name, "sha256": sha256_file(figure)}],
+                "outputs": {"png": {"path": figure.name, "sha256": sha256_file(figure)}},
+                "caption_file": {"path": caption.name, "sha256": sha256_file(caption)},
+                "generation_command": "pytest fixture",
+                "generation_commit": "0000000",
+                "claim_boundary": "fixture only",
+            }
+        ],
+    }
+    catalog = tmp_path / "artifact_catalog.yaml"
+    catalog.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    exit_code = main([str(catalog), "--catalog"])
+
+    assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_catalog(figure_path: Path, base_dir: Path) -> ArtifactCatalog:
+    """Build a minimal artifact catalog with a single figure entry."""
+    checksum = sha256_file(figure_path)
+    file_ref = ArtifactFileRef(path=figure_path.name, sha256=checksum)
+    caption = FIXTURE_DIR / "captions.md"
+    caption_checksum = sha256_file(caption)
+    caption_ref = ArtifactFileRef(path=str(caption), sha256=caption_checksum)
+    return ArtifactCatalog(
+        schema_version=ARTIFACT_CATALOG_SCHEMA_VERSION,
+        catalog_id="figure_qa_fixture",
+        artifacts=[
+            ArtifactCatalogEntry(
+                artifact_id="fig_catalog_test",
+                artifact_kind="figure",
+                source_kind="test",
+                source_files=[file_ref],
+                outputs={"png": file_ref},
+                generation_command="pytest fixture",
+                generation_commit="0000000",
+                claim_boundary="fixture only",
+                caption_file=caption_ref,
+            )
+        ],
+    )

--- a/tests/fixtures/figure_qa/captions.md
+++ b/tests/fixtures/figure_qa/captions.md
@@ -1,0 +1,3 @@
+# Figure QA Fixture Captions
+
+`fig_qa_test_figure`: Minimal test figure for deterministic QA validation.


### PR DESCRIPTION
## Summary
Adds a deterministic visual QA helper and validation CLI for generated figure artifacts, integrated with `artifact_catalog.v1` figure entries.

## Linked Issues
- Closes `#2100`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf.benchmark.figure_qa` for file existence, PNG/PDF signature, PNG dimension, file-size, catalog format-set, and caption metadata checks.
- Added `scripts/validation/validate_figure_artifacts.py` for single-file and catalog validation.
- Added fixture-backed tests for missing files, empty/near-empty PNGs, missing caption metadata, unexpected/missing formats, and CLI catalog mode.
- Documented the figure QA command in `docs/figures/README.md`.

## Why It Matters
- Added value: generated figure packs now have a lightweight structural QA layer before they are reused in reports or paper-facing docs.
- Expected impact: catches empty images, wrong formats, missing captions, and incomplete artifact packs without brittle pixel-perfect golden files.
- Why this is worth merging now: it strengthens the figure/table workflow with deterministic local checks while keeping benchmark inputs out of CI.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: figure artifact validation workflow quality.
- Comparator or baseline, if applicable: existing artifact catalog validation, which checks provenance/files but not visual structure.
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: targeted tests and CLI smoke pass for fixture-generated figures.

## Validation / Proof
- Commands run:
  - `uv run ruff format robot_sf/benchmark/figure_qa.py tests/benchmark/test_figure_qa.py scripts/validation/validate_figure_artifacts.py`
  - `uv run ruff check robot_sf/benchmark/figure_qa.py tests/benchmark/test_figure_qa.py scripts/validation/validate_figure_artifacts.py`
  - `uv run pytest tests/benchmark/test_figure_qa.py tests/benchmark/test_artifact_catalog.py -q`
  - CLI smoke with a temporary Pillow-generated PNG and caption: `uv run python scripts/validation/validate_figure_artifacts.py <tmp>/fig_smoke.png --artifact-id fig_smoke --caption <tmp>/captions.md`
  - `git diff --cached --check`
- Evidence that the change works here: focused suite passed with `31 passed`; CLI smoke reported all figure QA checks passed.
- Benchmarks or smoke tests, if applicable: no benchmark inputs used; this is a deterministic fixture/CLI validation slice.

## Risks / Rollout
- Compatibility risks: low; new helper/CLI only, with no changes to existing artifact catalog validation behavior.
- Failure modes: SVG currently gets existence/file-size/format-set checks but no SVG semantic parsing; PDF gets signature and size checks rather than rendering checks.
- Rollback or fallback plan: remove the new validation command/helper if it proves too strict for a generated artifact pack.

## Docs / Provenance
- Updated docs: `docs/figures/README.md`
- Relevant design or provenance notes: aligns with `artifact_catalog.v1` and the figure naming/output workflow.
- Any assumptions that need to be preserved: QA is structural and deterministic, not pixel-perfect visual regression testing.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2100.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this adds validation tooling and docs, not new benchmark evidence or artifact outputs.

## Follow-Up Issues
- Deferred work: none required for the accepted #2100 scope.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the format-set defaults are appropriate: catalog figure entries require `png` by default and allow `png`, `pdf`, and `svg`.
- Known limitation: the QA intentionally avoids pixel-perfect comparison and large golden images.
