### PR TITLE
feat: add DuckDB benchmark SQL recipes

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -216,3 +216,29 @@ ORDER BY e.algo, e.scenario_family;
 
 Use `--overwrite` only when replacing a known derived export. The metadata file records that the
 Parquet files are derived views so downstream reports can trace back to the canonical JSONL input.
+
+### Curated DuckDB Recipes
+
+For repeatable analysis without notebooks, run a curated SQL recipe against the Parquet export:
+
+```bash
+uv run python scripts/tools/run_benchmark_sql_recipe.py \
+  --recipe planner_outcome_summary \
+  --export-dir output/benchmarks/classic_interactions/parquet \
+  --output-csv output/benchmarks/classic_interactions/tables/planner_outcome_summary.csv \
+  --output-markdown output/benchmarks/classic_interactions/tables/planner_outcome_summary.md
+```
+
+Recipes live under `scripts/tools/benchmark_sql_recipes/` with a manifest that records stable
+recipe IDs, required tables and columns, output columns, and caveats. The runner validates required
+Parquet files and columns before executing SQL so schema drift fails closed instead of producing
+misleading zeros.
+
+Initial recipes:
+
+- `planner_outcome_summary`: planner-by-scenario-family success, collision, and safety summary.
+- `failure_near_miss_mining`: rows for failures, collisions, and low-minimum-TTC episodes.
+- `seed_variability_by_planner`: seed-level success variability by planner and scenario family.
+
+Recipe outputs are derived analysis artifacts. Use them as inputs to table or figure generation
+only together with the source Parquet export metadata and the original JSONL provenance.

--- a/scripts/tools/benchmark_sql_recipes/manifest.yaml
+++ b/scripts/tools/benchmark_sql_recipes/manifest.yaml
@@ -1,0 +1,83 @@
+schema_version: benchmark_sql_recipes.v1
+recipes:
+  - recipe_id: planner_outcome_summary
+    title: Planner-by-scenario-family outcome summary
+    sql_file: sql/planner_outcome_summary.sql
+    required_tables:
+      - episodes
+      - metrics
+    required_columns:
+      episodes:
+        - episode_id
+        - algo
+        - scenario_family
+      metrics:
+        - episode_id
+        - metric_path
+        - value_bool
+        - value_number
+    output_columns:
+      - algo
+      - scenario_family
+      - episode_count
+      - success_rate
+      - collision_rate
+      - mean_min_ttc
+      - mean_clearance
+    caveats:
+      - Derived from Parquet exports; JSONL remains the source of truth.
+      - Success and collision rates reflect exported metric rows, not recomputed metrics.
+  - recipe_id: failure_near_miss_mining
+    title: Failure and near-miss mining
+    sql_file: sql/failure_near_miss_mining.sql
+    required_tables:
+      - episodes
+      - metrics
+    required_columns:
+      episodes:
+        - episode_id
+        - algo
+        - scenario_family
+        - seed
+        - termination_reason
+      metrics:
+        - episode_id
+        - metric_path
+        - value_number
+    output_columns:
+      - episode_id
+      - algo
+      - scenario_family
+      - seed
+      - termination_reason
+      - collisions
+      - min_ttc
+      - clearance
+    caveats:
+      - Near-miss threshold is a recipe filter for triage, not a benchmark metric change.
+      - Missing metric rows are surfaced as nulls except for collision filtering.
+  - recipe_id: seed_variability_by_planner
+    title: Seed variability by planner and scenario family
+    sql_file: sql/seed_variability_by_planner.sql
+    required_tables:
+      - episodes
+      - metrics
+    required_columns:
+      episodes:
+        - episode_id
+        - algo
+        - scenario_family
+        - seed
+      metrics:
+        - episode_id
+        - metric_path
+        - value_bool
+    output_columns:
+      - algo
+      - scenario_family
+      - seed_count
+      - mean_seed_success_rate
+      - success_rate_stddev
+    caveats:
+      - Stddev is null when fewer than two seeds are present.
+      - Use as a diagnostic for follow-up design, not as standalone benchmark evidence.

--- a/scripts/tools/benchmark_sql_recipes/sql/failure_near_miss_mining.sql
+++ b/scripts/tools/benchmark_sql_recipes/sql/failure_near_miss_mining.sql
@@ -1,0 +1,33 @@
+WITH collision_metric AS (
+  SELECT episode_id, value_number AS collisions
+  FROM {metrics}
+  WHERE metric_path = 'collisions'
+),
+min_ttc_metric AS (
+  SELECT episode_id, value_number AS min_ttc
+  FROM {metrics}
+  WHERE metric_path = 'min_ttc'
+),
+clearance_metric AS (
+  SELECT episode_id, value_number AS clearance
+  FROM {metrics}
+  WHERE metric_path = 'clearance'
+)
+SELECT
+  e.episode_id,
+  e.algo,
+  e.scenario_family,
+  e.seed,
+  e.termination_reason,
+  COALESCE(c.collisions, 0.0) AS collisions,
+  t.min_ttc,
+  cl.clearance
+FROM {episodes} AS e
+LEFT JOIN collision_metric AS c USING (episode_id)
+LEFT JOIN min_ttc_metric AS t USING (episode_id)
+LEFT JOIN clearance_metric AS cl USING (episode_id)
+WHERE
+  e.termination_reason != 'goal_reached'
+  OR COALESCE(c.collisions, 0.0) > 0.0
+  OR t.min_ttc < 0.5
+ORDER BY COALESCE(c.collisions, 0.0) DESC, t.min_ttc ASC NULLS LAST, e.episode_id

--- a/scripts/tools/benchmark_sql_recipes/sql/planner_outcome_summary.sql
+++ b/scripts/tools/benchmark_sql_recipes/sql/planner_outcome_summary.sql
@@ -1,0 +1,35 @@
+WITH success_metric AS (
+  SELECT episode_id, CAST(value_bool AS DOUBLE) AS success
+  FROM {metrics}
+  WHERE metric_path = 'success'
+),
+collision_metric AS (
+  SELECT episode_id, value_number AS collisions
+  FROM {metrics}
+  WHERE metric_path = 'collisions'
+),
+min_ttc_metric AS (
+  SELECT episode_id, value_number AS min_ttc
+  FROM {metrics}
+  WHERE metric_path = 'min_ttc'
+),
+clearance_metric AS (
+  SELECT episode_id, value_number AS clearance
+  FROM {metrics}
+  WHERE metric_path = 'clearance'
+)
+SELECT
+  e.algo,
+  e.scenario_family,
+  COUNT(*) AS episode_count,
+  AVG(s.success) AS success_rate,
+  AVG(CASE WHEN COALESCE(c.collisions, 0.0) > 0.0 THEN 1.0 ELSE 0.0 END) AS collision_rate,
+  AVG(t.min_ttc) AS mean_min_ttc,
+  AVG(cl.clearance) AS mean_clearance
+FROM {episodes} AS e
+LEFT JOIN success_metric AS s USING (episode_id)
+LEFT JOIN collision_metric AS c USING (episode_id)
+LEFT JOIN min_ttc_metric AS t USING (episode_id)
+LEFT JOIN clearance_metric AS cl USING (episode_id)
+GROUP BY e.algo, e.scenario_family
+ORDER BY e.algo, e.scenario_family

--- a/scripts/tools/benchmark_sql_recipes/sql/seed_variability_by_planner.sql
+++ b/scripts/tools/benchmark_sql_recipes/sql/seed_variability_by_planner.sql
@@ -1,0 +1,20 @@
+WITH per_seed AS (
+  SELECT
+    e.algo,
+    e.scenario_family,
+    e.seed,
+    AVG(CAST(m.value_bool AS DOUBLE)) AS seed_success_rate
+  FROM {episodes} AS e
+  JOIN {metrics} AS m USING (episode_id)
+  WHERE m.metric_path = 'success'
+  GROUP BY e.algo, e.scenario_family, e.seed
+)
+SELECT
+  algo,
+  scenario_family,
+  COUNT(*) AS seed_count,
+  AVG(seed_success_rate) AS mean_seed_success_rate,
+  STDDEV_SAMP(seed_success_rate) AS success_rate_stddev
+FROM per_seed
+GROUP BY algo, scenario_family
+ORDER BY algo, scenario_family

--- a/scripts/tools/run_benchmark_sql_recipe.py
+++ b/scripts/tools/run_benchmark_sql_recipe.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Run curated DuckDB SQL recipes against benchmark Parquet exports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import yaml
+
+RECIPE_SCHEMA_VERSION = "benchmark_sql_recipes.v1"
+DEFAULT_RECIPE_ROOT = Path(__file__).with_name("benchmark_sql_recipes")
+TABLE_FILENAMES = {
+    "episodes": "episodes.parquet",
+    "metrics": "metrics.parquet",
+    "scenario_params": "scenario_params.parquet",
+    "algorithm_metadata": "algorithm_metadata.parquet",
+}
+
+
+class RecipeValidationError(ValueError):
+    """Raised when recipe inputs do not satisfy the declared contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class SqlRecipe:
+    """One SQL recipe declared in the recipe manifest."""
+
+    recipe_id: str
+    title: str
+    sql_file: Path
+    required_tables: tuple[str, ...]
+    required_columns: dict[str, tuple[str, ...]]
+    output_columns: tuple[str, ...]
+    caveats: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeManifest:
+    """Loaded SQL recipe manifest."""
+
+    schema_version: str
+    recipes: tuple[SqlRecipe, ...]
+
+    def recipe(self, recipe_id: str) -> SqlRecipe:
+        """Return a recipe by stable ID."""
+
+        for recipe in self.recipes:
+            if recipe.recipe_id == recipe_id:
+                return recipe
+        available = ", ".join(recipe.recipe_id for recipe in self.recipes)
+        raise RecipeValidationError(f"unknown recipe_id '{recipe_id}'; available: {available}")
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeRunResult:
+    """Result metadata for a recipe execution."""
+
+    recipe_id: str
+    columns: tuple[str, ...]
+    rows: tuple[tuple[Any, ...], ...]
+    row_count: int
+    output_csv: Path | None = None
+    output_markdown: Path | None = None
+
+
+def load_recipe_manifest(recipe_root: Path = DEFAULT_RECIPE_ROOT) -> RecipeManifest:
+    """Load the curated SQL recipe manifest."""
+
+    manifest_path = recipe_root / "manifest.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RecipeValidationError(f"{manifest_path}: expected mapping payload")
+    schema_version = str(payload.get("schema_version", ""))
+    if schema_version != RECIPE_SCHEMA_VERSION:
+        raise RecipeValidationError(
+            f"{manifest_path}: expected schema_version {RECIPE_SCHEMA_VERSION}, "
+            f"got {schema_version!r}"
+        )
+    recipes = tuple(
+        _recipe_from_payload(item, recipe_root=recipe_root) for item in payload["recipes"]
+    )
+    return RecipeManifest(schema_version=schema_version, recipes=recipes)
+
+
+def run_recipe(
+    recipe_id: str,
+    *,
+    export_dir: Path,
+    output_csv: Path | None = None,
+    output_markdown: Path | None = None,
+    recipe_root: Path = DEFAULT_RECIPE_ROOT,
+) -> RecipeRunResult:
+    """Validate inputs, execute a recipe, and optionally write tabular outputs."""
+
+    manifest = load_recipe_manifest(recipe_root)
+    recipe = manifest.recipe(recipe_id)
+    table_paths = _validate_recipe_inputs(recipe, export_dir=export_dir)
+    sql = recipe.sql_file.read_text(encoding="utf-8").format(
+        **{table: _read_parquet_sql(path) for table, path in table_paths.items()}
+    )
+    with duckdb.connect(database=":memory:") as connection:
+        cursor = connection.execute(sql)
+        rows = tuple(tuple(row) for row in cursor.fetchall())
+        columns = tuple(str(column[0]) for column in cursor.description)
+    _validate_output_columns(recipe, columns)
+    if output_csv is not None:
+        _write_csv(output_csv, columns, rows)
+    if output_markdown is not None:
+        _write_markdown(output_markdown, columns, rows, recipe=recipe)
+    return RecipeRunResult(
+        recipe_id=recipe.recipe_id,
+        columns=columns,
+        rows=rows,
+        row_count=len(rows),
+        output_csv=output_csv,
+        output_markdown=output_markdown,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the recipe runner argument parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", required=True, help="Stable recipe ID to run.")
+    parser.add_argument(
+        "--export-dir",
+        type=Path,
+        required=True,
+        help="Directory containing benchmark Parquet export tables.",
+    )
+    parser.add_argument("--output-csv", type=Path, default=None, help="Optional CSV output path.")
+    parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=None,
+        help="Optional Markdown table output path.",
+    )
+    parser.add_argument(
+        "--recipe-root",
+        type=Path,
+        default=DEFAULT_RECIPE_ROOT,
+        help="Recipe manifest directory.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON run summary.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one SQL recipe and return a shell-friendly exit code."""
+
+    args = build_arg_parser().parse_args(argv)
+    try:
+        result = run_recipe(
+            args.recipe,
+            export_dir=args.export_dir,
+            output_csv=args.output_csv,
+            output_markdown=args.output_markdown,
+            recipe_root=args.recipe_root,
+        )
+    except RecipeValidationError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "schema": "benchmark_sql_recipe_run.v1",
+                    "recipe_id": result.recipe_id,
+                    "row_count": result.row_count,
+                    "columns": list(result.columns),
+                    "output_csv": str(result.output_csv) if result.output_csv else None,
+                    "output_markdown": (
+                        str(result.output_markdown) if result.output_markdown else None
+                    ),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    else:
+        sys.stdout.write(f"recipe {result.recipe_id} returned {result.row_count} rows\n")
+    return 0
+
+
+def _recipe_from_payload(payload: dict[str, Any], *, recipe_root: Path) -> SqlRecipe:
+    """Build one recipe from manifest data."""
+
+    recipe_id = str(payload["recipe_id"])
+    required_columns = {
+        str(table): tuple(str(column) for column in columns)
+        for table, columns in dict(payload.get("required_columns") or {}).items()
+    }
+    return SqlRecipe(
+        recipe_id=recipe_id,
+        title=str(payload["title"]),
+        sql_file=recipe_root / str(payload["sql_file"]),
+        required_tables=tuple(str(table) for table in payload["required_tables"]),
+        required_columns=required_columns,
+        output_columns=tuple(str(column) for column in payload["output_columns"]),
+        caveats=tuple(str(caveat) for caveat in payload.get("caveats") or ()),
+    )
+
+
+def _validate_recipe_inputs(recipe: SqlRecipe, *, export_dir: Path) -> dict[str, Path]:
+    """Validate required Parquet files and declared columns for one recipe."""
+
+    table_paths: dict[str, Path] = {}
+    for table_name in recipe.required_tables:
+        filename = TABLE_FILENAMES.get(table_name)
+        if filename is None:
+            raise RecipeValidationError(
+                f"{recipe.recipe_id}: unknown required table '{table_name}'"
+            )
+        table_path = export_dir / filename
+        if not table_path.is_file():
+            raise RecipeValidationError(
+                f"{recipe.recipe_id}: required table file is missing: {table_path}"
+            )
+        table_paths[table_name] = table_path
+        _validate_columns(recipe, table_name=table_name, table_path=table_path)
+    return table_paths
+
+
+def _validate_columns(recipe: SqlRecipe, *, table_name: str, table_path: Path) -> None:
+    """Validate declared table columns before running SQL."""
+
+    required_columns = set(recipe.required_columns.get(table_name, ()))
+    if not required_columns:
+        return
+    with duckdb.connect(database=":memory:") as connection:
+        cursor = connection.execute(f"DESCRIBE SELECT * FROM {_read_parquet_sql(table_path)}")
+        columns = {str(row[0]) for row in cursor.fetchall()}
+    missing = sorted(required_columns - columns)
+    if missing:
+        missing_text = ", ".join(f"{table_name}.{column}" for column in missing)
+        raise RecipeValidationError(f"{recipe.recipe_id}: missing required columns: {missing_text}")
+
+
+def _validate_output_columns(recipe: SqlRecipe, columns: tuple[str, ...]) -> None:
+    """Validate the SQL result exposes the documented output columns."""
+
+    missing = sorted(set(recipe.output_columns) - set(columns))
+    if missing:
+        raise RecipeValidationError(
+            f"{recipe.recipe_id}: SQL output is missing columns: {', '.join(missing)}"
+        )
+
+
+def _read_parquet_sql(path: Path) -> str:
+    """Return a DuckDB read_parquet expression for a path."""
+
+    escaped = path.as_posix().replace("'", "''")
+    return f"read_parquet('{escaped}')"
+
+
+def _write_csv(path: Path, columns: tuple[str, ...], rows: tuple[tuple[Any, ...], ...]) -> None:
+    """Write recipe rows as CSV."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(columns)
+        writer.writerows(rows)
+
+
+def _write_markdown(
+    path: Path,
+    columns: tuple[str, ...],
+    rows: tuple[tuple[Any, ...], ...],
+    *,
+    recipe: SqlRecipe,
+) -> None:
+    """Write recipe rows as a compact Markdown table with caveats."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"# {recipe.title}", ""]
+    if rows:
+        lines.append("| " + " | ".join(columns) + " |")
+        lines.append("| " + " | ".join("---" for _ in columns) + " |")
+        for row in rows:
+            lines.append("| " + " | ".join(_markdown_cell(value) for value in row) + " |")
+    else:
+        lines.append("_No rows returned._")
+    if recipe.caveats:
+        lines.extend(["", "## Caveats", ""])
+        lines.extend(f"- {caveat}" for caveat in recipe.caveats)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _markdown_cell(value: Any) -> str:
+    """Render one Markdown table cell."""
+
+    if value is None:
+        return ""
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/tools/test_run_benchmark_sql_recipe.py
+++ b/tests/tools/test_run_benchmark_sql_recipe.py
@@ -1,0 +1,178 @@
+"""Tests for DuckDB benchmark SQL recipe runner."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
+from scripts.tools.run_benchmark_sql_recipe import (
+    RecipeValidationError,
+    load_recipe_manifest,
+    main,
+    run_recipe,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _episode(
+    *,
+    episode_id: str,
+    algo: str,
+    scenario_family: str,
+    seed: int,
+    metrics: dict[str, float | bool],
+    execution_mode: str = "native",
+) -> dict[str, Any]:
+    """Build a tiny benchmark episode fixture."""
+
+    return {
+        "version": "v1",
+        "episode_id": episode_id,
+        "scenario_id": f"{scenario_family}_001",
+        "seed": seed,
+        "algo": algo,
+        "scenario_params": {"scenario_family": scenario_family},
+        "algorithm_metadata": {
+            "algorithm": algo,
+            "planner_kinematics": {"execution_mode": execution_mode},
+        },
+        "metrics": {
+            "success": metrics["success"],
+            "collisions": metrics["collisions"],
+            "min_ttc": metrics["min_ttc"],
+            "clearance": metrics["clearance"],
+        },
+        "termination_reason": "goal_reached" if metrics["success"] else "collision",
+        "outcome": {"collision_event": bool(metrics["collisions"])},
+        "integrity": {"seed": seed},
+        "timestamps": {
+            "start": "2026-05-16T08:00:00+00:00",
+            "end": "2026-05-16T08:00:01+00:00",
+        },
+        "wall_time_sec": 1.0,
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    """Write records to a JSONL fixture."""
+
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _export_fixture(tmp_path: Path) -> Path:
+    """Export a tiny benchmark fixture to Parquet and return the export dir."""
+
+    episodes_path = tmp_path / "episodes.jsonl"
+    _write_jsonl(
+        episodes_path,
+        [
+            _episode(
+                episode_id="ep-a",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=11,
+                metrics={"success": True, "collisions": 0.0, "min_ttc": 1.5, "clearance": 0.4},
+            ),
+            _episode(
+                episode_id="ep-b",
+                algo="planner_a",
+                scenario_family="crossing",
+                seed=12,
+                metrics={
+                    "success": False,
+                    "collisions": 1.0,
+                    "min_ttc": 0.1,
+                    "clearance": 0.05,
+                },
+            ),
+            _episode(
+                episode_id="ep-c",
+                algo="planner_b",
+                scenario_family="overtake",
+                seed=11,
+                metrics={"success": True, "collisions": 0.0, "min_ttc": 2.0, "clearance": 0.6},
+                execution_mode="adapter",
+            ),
+        ],
+    )
+    return export_episodes_jsonl_to_parquet(episodes_path, tmp_path / "parquet").output_dir
+
+
+def test_recipe_manifest_exposes_stable_recipe_metadata() -> None:
+    """Recipe manifest should describe stable IDs, inputs, outputs, and caveats."""
+
+    manifest = load_recipe_manifest()
+
+    recipe = manifest.recipe("planner_outcome_summary")
+    assert recipe.recipe_id == "planner_outcome_summary"
+    assert recipe.sql_file.name == "planner_outcome_summary.sql"
+    assert recipe.required_tables == ("episodes", "metrics")
+    assert "success_rate" in recipe.output_columns
+    assert recipe.caveats
+
+
+def test_run_recipe_writes_csv_and_markdown_outputs(tmp_path: Path) -> None:
+    """Runner should execute a recipe against fixture Parquet and export stable outputs."""
+
+    export_dir = _export_fixture(tmp_path)
+    csv_path = tmp_path / "planner_outcome_summary.csv"
+    md_path = tmp_path / "planner_outcome_summary.md"
+
+    result = run_recipe(
+        "planner_outcome_summary",
+        export_dir=export_dir,
+        output_csv=csv_path,
+        output_markdown=md_path,
+    )
+
+    assert result.recipe_id == "planner_outcome_summary"
+    assert result.row_count == 2
+    assert csv_path.is_file()
+    assert md_path.is_file()
+    assert "planner_a" in csv_path.read_text(encoding="utf-8")
+    assert "success_rate" in md_path.read_text(encoding="utf-8")
+
+
+def test_cli_runs_recipe_against_fixture_export(tmp_path: Path) -> None:
+    """CLI should expose the same recipe runner used by automation."""
+
+    export_dir = _export_fixture(tmp_path)
+    csv_path = tmp_path / "failure_rows.csv"
+
+    exit_code = main(
+        [
+            "--recipe",
+            "failure_near_miss_mining",
+            "--export-dir",
+            str(export_dir),
+            "--output-csv",
+            str(csv_path),
+        ]
+    )
+
+    assert exit_code == 0
+    text = csv_path.read_text(encoding="utf-8")
+    assert "ep-b" in text
+    assert "collision" in text
+
+
+def test_missing_required_column_reports_actionable_error(tmp_path: Path) -> None:
+    """Missing required columns should fail closed instead of silently filling zeros."""
+
+    export_dir = _export_fixture(tmp_path)
+    broken_episodes = export_dir / "episodes.parquet"
+    table = pq.read_table(broken_episodes).drop(["scenario_family"])
+    pq.write_table(pa.Table.from_batches(table.to_batches()), broken_episodes)
+
+    with pytest.raises(RecipeValidationError, match="episodes\\.scenario_family"):
+        run_recipe("planner_outcome_summary", export_dir=export_dir)


### PR DESCRIPTION
## Summary
Adds a curated DuckDB SQL recipe runner for benchmark Parquet exports, plus three initial analysis recipes for planner outcomes, failure/near-miss mining, and seed variability.

## Linked Issues
- Closes `#2098`

## Stack / Dependency
- Base dependency: `origin/main` after PRs #2021 and #2121 merged
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/tools/run_benchmark_sql_recipe.py` to load a YAML manifest, validate required Parquet tables/columns, run recipe SQL with DuckDB, and optionally write CSV/Markdown outputs.
- Added recipe manifest and SQL under `scripts/tools/benchmark_sql_recipes/`.
- Added fixture-backed tests covering manifest metadata, CLI execution, output writing, and fail-closed missing-column behavior.
- Documented example export/recipe commands and caveats in `docs/benchmark.md`.

## Why It Matters
- Added value: repeatable benchmark analysis entry points without notebooks or ad-hoc SQL snippets.
- Expected impact: downstream table/figure generation can consume declared recipe outputs with clearer schema checks.
- Why this is worth merging now: it turns the existing Parquet export path into a reusable analysis surface while keeping provenance and caveats explicit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock repeatable diagnostic analysis of benchmark exports.
- Comparator or baseline, if applicable: existing manual DuckDB snippets in `docs/benchmark.md`.
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: recipes must validate declared input/output columns and fail closed on schema drift.

## Validation / Proof
- Commands run:
  - `uv run ruff format scripts/tools/run_benchmark_sql_recipe.py tests/tools/test_run_benchmark_sql_recipe.py`
  - `uv run ruff check scripts/tools/run_benchmark_sql_recipe.py tests/tools/test_run_benchmark_sql_recipe.py`
  - `uv run pytest tests/tools/test_run_benchmark_sql_recipe.py tests/benchmark/test_parquet_export.py -q`
  - `python -m py_compile scripts/tools/run_benchmark_sql_recipe.py`
  - `git diff --check`
- Evidence that the change works here: targeted pytest passed `10 passed` before and after merging the latest `origin/main`.
- Benchmarks or smoke tests, if applicable: not run; this is analysis tooling over tiny Parquet fixtures, not a benchmark-result-producing PR.

## Risks / Rollout
- Compatibility risks: recipe SQL assumes the current Parquet export schema and metric path names.
- Failure modes: schema drift now raises `RecipeValidationError` instead of silently producing misleading values for declared dependencies.
- Rollback or fallback plan: remove the runner/recipe directory and continue using direct DuckDB queries from `docs/benchmark.md`.

## Docs / Provenance
- Updated docs: `docs/benchmark.md`
- Relevant design or provenance notes: recipe outputs are derived analysis artifacts; source JSONL plus Parquet export metadata remain the provenance anchors.
- Any assumptions that need to be preserved: recipe dependency columns are treated as required for each recipe so missing fields fail closed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2098
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this PR adds local analysis recipes and tests; it does not publish benchmark results or change benchmark claims.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether the initial recipes are the right minimal stable set for the Parquet schema.
- Any known limitations: recipe outputs are diagnostic/derived tables, not standalone benchmark evidence.
