### PR TITLE
fix: harden benchmark SQL recipe runner

### DIFF
--- a/scripts/tools/run_benchmark_sql_recipe.py
+++ b/scripts/tools/run_benchmark_sql_recipe.py
@@ -74,7 +74,12 @@ def load_recipe_manifest(recipe_root: Path = DEFAULT_RECIPE_ROOT) -> RecipeManif
     """Load the curated SQL recipe manifest."""
 
     manifest_path = recipe_root / "manifest.yaml"
-    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not manifest_path.is_file():
+        raise RecipeValidationError(f"Recipe manifest file not found: {manifest_path}")
+    try:
+        payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise RecipeValidationError(f"Failed to parse manifest {manifest_path}: {exc}") from exc
     if not isinstance(payload, dict):
         raise RecipeValidationError(f"{manifest_path}: expected mapping payload")
     schema_version = str(payload.get("schema_version", ""))
@@ -83,9 +88,10 @@ def load_recipe_manifest(recipe_root: Path = DEFAULT_RECIPE_ROOT) -> RecipeManif
             f"{manifest_path}: expected schema_version {RECIPE_SCHEMA_VERSION}, "
             f"got {schema_version!r}"
         )
-    recipes = tuple(
-        _recipe_from_payload(item, recipe_root=recipe_root) for item in payload["recipes"]
-    )
+    recipe_payloads = payload.get("recipes")
+    if not isinstance(recipe_payloads, list):
+        raise RecipeValidationError(f"{manifest_path}: recipes must be a list")
+    recipes = tuple(_recipe_from_payload(item, recipe_root=recipe_root) for item in recipe_payloads)
     return RecipeManifest(schema_version=schema_version, recipes=recipes)
 
 
@@ -102,13 +108,23 @@ def run_recipe(
     manifest = load_recipe_manifest(recipe_root)
     recipe = manifest.recipe(recipe_id)
     table_paths = _validate_recipe_inputs(recipe, export_dir=export_dir)
-    sql = recipe.sql_file.read_text(encoding="utf-8").format(
-        **{table: _read_parquet_sql(path) for table, path in table_paths.items()}
-    )
-    with duckdb.connect(database=":memory:") as connection:
-        cursor = connection.execute(sql)
-        rows = tuple(tuple(row) for row in cursor.fetchall())
-        columns = tuple(str(column[0]) for column in cursor.description)
+    if not recipe.sql_file.is_file():
+        raise RecipeValidationError(f"SQL recipe file not found: {recipe.sql_file}")
+    try:
+        sql = recipe.sql_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RecipeValidationError(f"Failed to read SQL recipe {recipe.sql_file}: {exc}") from exc
+    for table, path in table_paths.items():
+        sql = sql.replace(f"{{{table}}}", _read_parquet_sql(path))
+    try:
+        with duckdb.connect(database=":memory:") as connection:
+            cursor = connection.execute(sql)
+            rows = tuple(tuple(row) for row in cursor.fetchall())
+            columns = tuple(str(column[0]) for column in cursor.description or ())
+    except Exception as exc:
+        raise RecipeValidationError(
+            f"SQL execution failed for recipe '{recipe_id}': {exc}"
+        ) from exc
     _validate_output_columns(recipe, columns)
     if output_csv is not None:
         _write_csv(output_csv, columns, rows)
@@ -193,20 +209,28 @@ def main(argv: list[str] | None = None) -> int:
 def _recipe_from_payload(payload: dict[str, Any], *, recipe_root: Path) -> SqlRecipe:
     """Build one recipe from manifest data."""
 
-    recipe_id = str(payload["recipe_id"])
-    required_columns = {
-        str(table): tuple(str(column) for column in columns)
-        for table, columns in dict(payload.get("required_columns") or {}).items()
-    }
-    return SqlRecipe(
-        recipe_id=recipe_id,
-        title=str(payload["title"]),
-        sql_file=recipe_root / str(payload["sql_file"]),
-        required_tables=tuple(str(table) for table in payload["required_tables"]),
-        required_columns=required_columns,
-        output_columns=tuple(str(column) for column in payload["output_columns"]),
-        caveats=tuple(str(caveat) for caveat in payload.get("caveats") or ()),
-    )
+    if not isinstance(payload, dict):
+        raise RecipeValidationError("Manifest recipe entries must be mappings")
+    try:
+        recipe_id = str(payload["recipe_id"])
+        required_columns = {
+            str(table): tuple(str(column) for column in columns)
+            for table, columns in dict(payload.get("required_columns") or {}).items()
+        }
+        return SqlRecipe(
+            recipe_id=recipe_id,
+            title=str(payload["title"]),
+            sql_file=recipe_root / str(payload["sql_file"]),
+            required_tables=tuple(str(table) for table in payload["required_tables"]),
+            required_columns=required_columns,
+            output_columns=tuple(str(column) for column in payload["output_columns"]),
+            caveats=tuple(str(caveat) for caveat in payload.get("caveats") or ()),
+        )
+    except KeyError as exc:
+        field = str(exc.args[0])
+        raise RecipeValidationError(f"Manifest recipe is missing required field: {field}") from exc
+    except (TypeError, ValueError) as exc:
+        raise RecipeValidationError(f"Manifest recipe has invalid structure: {exc}") from exc
 
 
 def _validate_recipe_inputs(recipe: SqlRecipe, *, export_dir: Path) -> dict[str, Path]:
@@ -235,9 +259,12 @@ def _validate_columns(recipe: SqlRecipe, *, table_name: str, table_path: Path) -
     required_columns = set(recipe.required_columns.get(table_name, ()))
     if not required_columns:
         return
-    with duckdb.connect(database=":memory:") as connection:
-        cursor = connection.execute(f"DESCRIBE SELECT * FROM {_read_parquet_sql(table_path)}")
-        columns = {str(row[0]) for row in cursor.fetchall()}
+    try:
+        with duckdb.connect(database=":memory:") as connection:
+            cursor = connection.execute(f"DESCRIBE SELECT * FROM {_read_parquet_sql(table_path)}")
+            columns = {str(row[0]) for row in cursor.fetchall()}
+    except Exception as exc:
+        raise RecipeValidationError(f"Failed to read schema from {table_path}: {exc}") from exc
     missing = sorted(required_columns - columns)
     if missing:
         missing_text = ", ".join(f"{table_name}.{column}" for column in missing)
@@ -300,6 +327,8 @@ def _markdown_cell(value: Any) -> str:
 
     if value is None:
         return ""
+    if isinstance(value, float):
+        return f"{value:.4f}"
     return str(value).replace("|", "\\|").replace("\n", " ")
 
 

--- a/tests/tools/test_run_benchmark_sql_recipe.py
+++ b/tests/tools/test_run_benchmark_sql_recipe.py
@@ -176,3 +176,190 @@ def test_missing_required_column_reports_actionable_error(tmp_path: Path) -> Non
 
     with pytest.raises(RecipeValidationError, match="episodes\\.scenario_family"):
         run_recipe("planner_outcome_summary", export_dir=export_dir)
+
+
+def _write_recipe_root(
+    root: Path,
+    *,
+    manifest_recipe: str,
+    sql: str = "SELECT COUNT(*) AS episode_count FROM {episodes}",
+) -> Path:
+    """Write a tiny custom recipe root for hardening tests."""
+
+    (root / "sql").mkdir(parents=True)
+    (root / "sql" / "recipe.sql").write_text(sql, encoding="utf-8")
+    (root / "manifest.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: benchmark_sql_recipes.v1",
+                "recipes:",
+                manifest_recipe,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _single_table_manifest_recipe() -> str:
+    """Return one manifest recipe that only depends on the episodes table."""
+
+    return "\n".join(
+        [
+            "  - recipe_id: custom",
+            "    title: Custom recipe",
+            "    sql_file: sql/recipe.sql",
+            "    required_tables:",
+            "      - episodes",
+            "    required_columns:",
+            "      episodes:",
+            "        - episode_id",
+            "    output_columns:",
+            "      - episode_count",
+            "    caveats:",
+            "      - fixture only",
+        ]
+    )
+
+
+def test_cli_reports_missing_manifest_without_traceback(tmp_path: Path, capsys) -> None:
+    """Missing manifests should fail closed through the CLI."""
+
+    export_dir = _export_fixture(tmp_path)
+
+    exit_code = main(
+        [
+            "--recipe",
+            "custom",
+            "--export-dir",
+            str(export_dir),
+            "--recipe-root",
+            str(tmp_path / "missing-recipes"),
+        ]
+    )
+
+    assert exit_code == 2
+    assert "Recipe manifest file not found" in capsys.readouterr().err
+
+
+def test_malformed_manifest_reports_recipe_validation_error(tmp_path: Path) -> None:
+    """Malformed YAML should be reported as recipe validation, not a parser traceback."""
+
+    recipe_root = tmp_path / "recipes"
+    recipe_root.mkdir()
+    (recipe_root / "manifest.yaml").write_text("recipes: [", encoding="utf-8")
+
+    with pytest.raises(RecipeValidationError, match="Failed to parse manifest"):
+        load_recipe_manifest(recipe_root)
+
+
+def test_manifest_missing_required_field_reports_actionable_error(tmp_path: Path) -> None:
+    """Missing manifest fields should name the missing field."""
+
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(
+        recipe_root,
+        manifest_recipe="\n".join(
+            [
+                "  - recipe_id: custom",
+                "    title: Custom recipe",
+            ]
+        ),
+    )
+
+    with pytest.raises(RecipeValidationError, match="missing required field: sql_file"):
+        load_recipe_manifest(recipe_root)
+
+
+def test_manifest_invalid_recipe_structure_reports_actionable_error(tmp_path: Path) -> None:
+    """Malformed recipe field shapes should not leak TypeError or ValueError."""
+
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(
+        recipe_root,
+        manifest_recipe="\n".join(
+            [
+                "  - recipe_id: custom",
+                "    title: Custom recipe",
+                "    sql_file: sql/recipe.sql",
+                "    required_tables: 42",
+                "    required_columns: not-a-mapping",
+                "    output_columns:",
+                "      - episode_count",
+            ]
+        ),
+    )
+
+    with pytest.raises(RecipeValidationError, match="invalid structure"):
+        load_recipe_manifest(recipe_root)
+
+
+def test_sql_literal_braces_do_not_break_placeholder_substitution(tmp_path: Path) -> None:
+    """SQL files may contain literal braces unrelated to table placeholders."""
+
+    export_dir = _export_fixture(tmp_path)
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(
+        recipe_root,
+        manifest_recipe=_single_table_manifest_recipe(),
+        sql="SELECT '{literal brace}' AS note, COUNT(*) AS episode_count FROM {episodes}",
+    )
+
+    result = run_recipe("custom", export_dir=export_dir, recipe_root=recipe_root)
+
+    assert result.rows == (("{literal brace}", 3),)
+
+
+def test_missing_sql_file_reports_recipe_validation_error(tmp_path: Path) -> None:
+    """Missing SQL files should fail before read_text raises FileNotFoundError."""
+
+    export_dir = _export_fixture(tmp_path)
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(recipe_root, manifest_recipe=_single_table_manifest_recipe())
+    (recipe_root / "sql" / "recipe.sql").unlink()
+
+    with pytest.raises(RecipeValidationError, match="SQL recipe file not found"):
+        run_recipe("custom", export_dir=export_dir, recipe_root=recipe_root)
+
+
+def test_sql_execution_errors_are_recipe_validation_errors(tmp_path: Path) -> None:
+    """DuckDB execution failures should be converted to clean validation errors."""
+
+    export_dir = _export_fixture(tmp_path)
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(
+        recipe_root,
+        manifest_recipe=_single_table_manifest_recipe(),
+        sql="SELECT missing_column AS episode_count FROM {episodes}",
+    )
+
+    with pytest.raises(RecipeValidationError, match="SQL execution failed"):
+        run_recipe("custom", export_dir=export_dir, recipe_root=recipe_root)
+
+
+def test_unreadable_parquet_schema_reports_recipe_validation_error(tmp_path: Path) -> None:
+    """Unreadable Parquet files should fail closed during schema validation."""
+
+    export_dir = _export_fixture(tmp_path)
+    (export_dir / "episodes.parquet").write_bytes(b"not parquet")
+    recipe_root = tmp_path / "recipes"
+    _write_recipe_root(recipe_root, manifest_recipe=_single_table_manifest_recipe())
+
+    with pytest.raises(RecipeValidationError, match="Failed to read schema"):
+        run_recipe("custom", export_dir=export_dir, recipe_root=recipe_root)
+
+
+def test_markdown_float_cells_use_compact_fixed_precision(tmp_path: Path) -> None:
+    """Markdown output should avoid noisy binary float representations."""
+
+    export_dir = _export_fixture(tmp_path)
+    md_path = tmp_path / "summary.md"
+
+    run_recipe(
+        "planner_outcome_summary",
+        export_dir=export_dir,
+        output_markdown=md_path,
+    )
+
+    assert "0.5000" in md_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Hardens the DuckDB benchmark SQL recipe runner after unresolved review feedback on merged PR #2129, converting manifest/SQL/DuckDB/Parquet failures into clean `RecipeValidationError` paths and improving Markdown float formatting.

## Linked Issues
- Closes `#2131`
- Follows up `#2129`

## Stack / Dependency
- Base dependency: `origin/main` after #2129 merged
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Manifest loading now fails closed for missing/malformed YAML and invalid `recipes` shape.
- Recipe manifest entries now report missing required fields without `KeyError` tracebacks.
- SQL files are checked before reading, and table placeholders are replaced without `str.format()` so literal braces are safe.
- DuckDB SQL execution and Parquet schema inspection failures now surface as `RecipeValidationError`.
- Markdown float cells now use fixed 4-decimal formatting.
- Added regression tests for each review-thread case.

## Why It Matters
- Added value: recipe runner CLI failures are actionable and traceback-free for bad inputs.
- Expected impact: downstream analysis automation can fail closed on malformed recipe inputs and corrupted exports.
- Why this is worth merging now: it closes the follow-up created from unresolved #2129 review threads.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: robust benchmark analysis tooling.
- Comparator or baseline, if applicable: #2129 initial runner behavior.
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: review-thread cases are covered by tests and existing recipe tests still pass.

## Validation / Proof
- RED: `uv run pytest tests/tools/test_run_benchmark_sql_recipe.py -q` failed 8 new hardening tests before the fix.
- Commands run after the fix:
  - `uv run pytest tests/tools/test_run_benchmark_sql_recipe.py -q` passed: `12 passed`
  - `uv run ruff format scripts/tools/run_benchmark_sql_recipe.py tests/tools/test_run_benchmark_sql_recipe.py`
  - `uv run ruff check scripts/tools/run_benchmark_sql_recipe.py tests/tools/test_run_benchmark_sql_recipe.py`
  - `uv run pytest tests/tools/test_run_benchmark_sql_recipe.py tests/benchmark/test_parquet_export.py -q` passed: `18 passed`
  - `python -m py_compile scripts/tools/run_benchmark_sql_recipe.py`
  - `git diff --check`
- Benchmarks or smoke tests, if applicable: not run; this is runner robustness only.

## Risks / Rollout
- Compatibility risks: SQL placeholder replacement is intentionally limited to declared table placeholders like `{episodes}`.
- Failure modes: malformed recipes now fail earlier with code 2 instead of tracebacking.
- Rollback or fallback plan: revert this PR to restore #2129 behavior.

## Docs / Provenance
- Updated docs: none; no user-facing command semantics changed.
- Relevant design or provenance notes: follow-up from unresolved review threads on #2129.
- Any assumptions that need to be preserved: this is robustness hardening, not a benchmark semantics change.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2131
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark results or paper-facing evidence are changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the literal-brace SQL substitution behavior and error boundaries.
- Any known limitations: unknown table placeholders in custom SQL remain the recipe author's responsibility unless declared in the manifest.

## Review Threads Addressed
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672690
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672701
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672716
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672725
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672729
- https://github.com/ll7/robot_sf_ll7/pull/2129#discussion_r3339672744
