### PR TITLE
feat: add active docs example checker

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -599,6 +599,7 @@ from robot_sf.common import Vec2D, RobotPose, set_global_seed
 - Avoid mass docstring sweeps; improve documentation incrementally as code changes.
 - Use `uv run python scripts/validation/check_docstring_todos.py --mode report` to inspect the current placeholder backlog by top-level area and file.
 - `scripts/validation/docstring_todo_baseline.json` is an increase-only ratchet. Update it with `--mode write-baseline` only after an intentional cleanup or maintainer-approved backlog change.
+- Use `uv run python scripts/validation/check_active_doc_examples.py` to report stale active-doc command and artifact examples. Add `--fail-on-diagnostic` when a PR or CI lane should fail on new hits, and use an inline `active-docs-check: allow` marker only for intentional examples.
 
 ### Map Bounds Format
 

--- a/scripts/validation/check_active_doc_examples.py
+++ b/scripts/validation/check_active_doc_examples.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Check active documentation for stale command and artifact examples."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+
+ALLOW_MARKERS = ("active-docs-check: allow", "active-docs: allow")
+DEFAULT_EXCLUDED_DIRS = (
+    Path("docs/context"),
+    Path("docs/context_packs"),
+    Path("docs/dev/issues"),
+    Path("docs/experiments"),
+    Path("docs/superpowers"),
+)
+DEFAULT_ROOT_FILES = (
+    Path("README.md"),
+    Path("AGENTS.md"),
+    Path("CHANGELOG.md"),
+    Path("ACKNOWLEDGMENTS.md"),
+)
+DEFAULT_SCAN_ROOTS = (Path("docs"), Path("scripts"))
+SPEC_DOC_NAMES = {"quickstart.md", "readme.md"}
+TEXT_SUFFIXES = {".md", ".py", ".rst", ".txt"}
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One stale active-documentation example."""
+
+    path: Path
+    line: int
+    rule: str
+    message: str
+    text: str
+
+
+@dataclass(frozen=True)
+class Rule:
+    """Line-oriented active-docs rule."""
+
+    name: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+RULES = (
+    Rule(
+        name="legacy-results-path",
+        pattern=re.compile(r"(?<![\w/-])results/"),
+        message="legacy results/ path should use output/ unless the line is explicitly historical",
+    ),
+    Rule(
+        name="nested-output-results-path",
+        pattern=re.compile(r"\boutput/results/"),
+        message="output/results/ is stale; use a canonical output/<artifact-family>/ path",
+    ),
+    Rule(
+        name="benchmark-quickstart-output-path",
+        pattern=re.compile(r"\boutput/benchmark_quickstart/"),
+        message="output/benchmark_quickstart/ is stale; use output/benchmarks/ or a named demo root",
+    ),
+    Rule(
+        name="bare-python-scripts-command",
+        pattern=re.compile(r"\bpython\s+scripts/"),
+        message="script commands should normally use uv run python scripts/...",
+    ),
+    Rule(
+        name="setup-pip-install",
+        pattern=re.compile(r"\bpip\s+install\b"),
+        message="setup docs should prefer uv sync, uv run, or the official uv installer",
+    ),
+    Rule(
+        name="unsupported-robot-sf-bench-run-flag",
+        pattern=re.compile(
+            r"\brobot_sf_bench\s+run\b[^\n`]*(?:--suite|--episodes|--snqi-|--quiet|--fail-fast)"
+        ),
+        message="robot_sf_bench run examples should use the current --matrix/--out contract",
+    ),
+)
+SCRIPT_COMMAND_RE = re.compile(
+    r"(?:uv\s+run\s+)?python\s+(?P<script>scripts/[A-Za-z0-9_./-]+\.py)\b"
+)
+
+
+def _repo_root() -> Path:
+    """Return the repository root for the current checkout."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "failed to resolve repository root")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return whether a repository-relative path is at or below root."""
+    return path == root or root in path.parents
+
+
+def _has_allow_marker(line: str) -> bool:
+    """Return whether a source line carries an explicit active-docs allow marker."""
+    return any(marker in line for marker in ALLOW_MARKERS)
+
+
+def _looks_historical_line(line: str) -> bool:
+    """Return whether a single line explicitly describes historical or legacy state."""
+    lowered = line.lower()
+    return "legacy" in lowered or "historical" in lowered or "migrated" in lowered
+
+
+def _root_doc_paths(repo_root: Path) -> set[Path]:
+    """Return existing top-level active documentation files."""
+    return {path for path in DEFAULT_ROOT_FILES if (repo_root / path).is_file()}
+
+
+def _is_default_scan_candidate(relative: Path, *, include_cli_sources: bool) -> bool:
+    """Return whether a repository-relative path is in the default active-doc set."""
+    if relative.suffix.lower() not in TEXT_SUFFIXES:
+        return False
+    if any(_is_within(relative, excluded) for excluded in DEFAULT_EXCLUDED_DIRS):
+        return False
+    if relative.suffix == ".py" and not include_cli_sources:
+        return False
+    return not (
+        relative.parts[0] == "scripts" and relative.suffix != ".md" and not include_cli_sources
+    )
+
+
+def _scan_root_doc_paths(repo_root: Path, *, include_cli_sources: bool) -> set[Path]:
+    """Return active docs found below default scan roots."""
+    paths: set[Path] = set()
+    for root in DEFAULT_SCAN_ROOTS:
+        absolute_root = repo_root / root
+        if not absolute_root.exists():
+            continue
+        for candidate in absolute_root.rglob("*"):
+            if not candidate.is_file():
+                continue
+            relative = candidate.relative_to(repo_root)
+            if _is_default_scan_candidate(relative, include_cli_sources=include_cli_sources):
+                paths.add(relative)
+    return paths
+
+
+def _spec_doc_paths(repo_root: Path) -> set[Path]:
+    """Return specs quickstart/readme paths for explicit opt-in scans."""
+    specs_root = repo_root / "specs"
+    if not specs_root.exists():
+        return set()
+    return {
+        candidate.relative_to(repo_root)
+        for candidate in specs_root.rglob("*.md")
+        if candidate.name.lower() in SPEC_DOC_NAMES
+    }
+
+
+def _default_paths(
+    repo_root: Path, *, include_specs: bool, include_cli_sources: bool
+) -> list[Path]:
+    """Return default active documentation paths."""
+    paths = _root_doc_paths(repo_root)
+    paths.update(_scan_root_doc_paths(repo_root, include_cli_sources=include_cli_sources))
+
+    if include_specs:
+        paths.update(_spec_doc_paths(repo_root))
+
+    return sorted(paths)
+
+
+def _normalize_explicit_paths(paths: Sequence[str], repo_root: Path) -> list[Path]:
+    """Normalize explicit CLI paths into repository-relative paths."""
+    normalized: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_absolute():
+            try:
+                path = path.resolve().relative_to(repo_root)
+            except ValueError as exc:
+                raise ValueError(f"path is outside repository: {raw_path}") from exc
+        if ".." in path.parts:
+            raise ValueError(f"path must stay inside repository: {raw_path}")
+        normalized.append(path)
+    return normalized
+
+
+def _phantom_script_diagnostics(
+    path: Path, line_no: int, line: str, repo_root: Path
+) -> list[Diagnostic]:
+    """Return diagnostics for script commands that reference missing script files."""
+    diagnostics: list[Diagnostic] = []
+    for match in SCRIPT_COMMAND_RE.finditer(line):
+        script_path = Path(match.group("script"))
+        if any(token in script_path.as_posix() for token in ("...", "<", ">")):
+            continue
+        if (repo_root / script_path).is_file():
+            continue
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                line=line_no,
+                rule="phantom-script-path",
+                message=f"referenced script does not exist: {script_path.as_posix()}",
+                text=line.strip(),
+            )
+        )
+    return diagnostics
+
+
+def _rule_matches(rule: Rule, line: str) -> bool:
+    """Return whether rule matches a line after rule-specific false-positive handling."""
+    for match in rule.pattern.finditer(line):
+        if rule.name == "bare-python-scripts-command" and "uv run" in line[: match.start()]:
+            continue
+        return True
+    return False
+
+
+def scan_file(path: Path, repo_root: Path) -> list[Diagnostic]:
+    """Scan one repository-relative text file."""
+    absolute_path = repo_root / path
+    try:
+        lines = absolute_path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return []
+
+    diagnostics: list[Diagnostic] = []
+    for line_no, line in enumerate(lines, start=1):
+        if _has_allow_marker(line):
+            continue
+        for rule in RULES:
+            if not _rule_matches(rule, line):
+                continue
+            if rule.name == "legacy-results-path" and _looks_historical_line(line):
+                continue
+            diagnostics.append(
+                Diagnostic(
+                    path=path,
+                    line=line_no,
+                    rule=rule.name,
+                    message=rule.message,
+                    text=line.strip(),
+                )
+            )
+        diagnostics.extend(_phantom_script_diagnostics(path, line_no, line, repo_root))
+    return diagnostics
+
+
+def scan_paths(paths: Iterable[Path], repo_root: Path) -> list[Diagnostic]:
+    """Scan repository-relative paths and return all diagnostics."""
+    diagnostics: list[Diagnostic] = []
+    for path in paths:
+        if (repo_root / path).is_file():
+            diagnostics.extend(scan_file(path, repo_root))
+    return diagnostics
+
+
+def _format_diagnostic(diagnostic: Diagnostic) -> str:
+    """Format one diagnostic for terminal output."""
+    return (
+        f"{diagnostic.path}:{diagnostic.line}: {diagnostic.rule}: "
+        f"{diagnostic.message}\n    {diagnostic.text}"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Optional repository-relative files to scan instead of the default active-doc set.",
+    )
+    parser.add_argument(
+        "--include-specs",
+        action="store_true",
+        help="Include specs/** quickstart/readme files in the default scan.",
+    )
+    parser.add_argument(
+        "--include-cli-sources",
+        action="store_true",
+        help="Include Python CLI sources under docs/scripts surfaces.",
+    )
+    parser.add_argument(
+        "--fail-on-diagnostic",
+        action="store_true",
+        help="Exit non-zero when stale active-doc examples are found.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the active-doc examples check."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = _repo_root()
+
+    try:
+        paths = (
+            _normalize_explicit_paths(args.paths, repo_root)
+            if args.paths
+            else _default_paths(
+                repo_root,
+                include_specs=args.include_specs,
+                include_cli_sources=args.include_cli_sources,
+            )
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    diagnostics = scan_paths(paths, repo_root)
+    if diagnostics:
+        for diagnostic in diagnostics:
+            print(_format_diagnostic(diagnostic))
+        print(f"\nFound {len(diagnostics)} active-doc example diagnostic(s).", file=sys.stderr)
+        return 1 if args.fail_on_diagnostic else 0
+
+    print(f"Scanned {len(paths)} active-doc file(s); no stale examples found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_active_doc_examples.py
+++ b/scripts/validation/check_active_doc_examples.py
@@ -29,7 +29,7 @@ DEFAULT_ROOT_FILES = (
     Path("CHANGELOG.md"),
     Path("ACKNOWLEDGMENTS.md"),
 )
-DEFAULT_SCAN_ROOTS = (Path("docs"), Path("scripts"))
+DEFAULT_SCAN_ROOTS = (Path("docs"), Path("examples"), Path("scripts"))
 SPEC_DOC_NAMES = {"quickstart.md", "readme.md"}
 TEXT_SUFFIXES = {".md", ".py", ".rst", ".txt"}
 
@@ -186,11 +186,11 @@ def _normalize_explicit_paths(paths: Sequence[str], repo_root: Path) -> list[Pat
     normalized: list[Path] = []
     for raw_path in paths:
         path = Path(raw_path)
-        if path.is_absolute():
-            try:
-                path = path.resolve().relative_to(repo_root)
-            except ValueError as exc:
-                raise ValueError(f"path is outside repository: {raw_path}") from exc
+        absolute_path = path if path.is_absolute() else repo_root / path
+        try:
+            path = absolute_path.resolve().relative_to(repo_root)
+        except ValueError:
+            raise ValueError(f"path must stay inside repository: {raw_path}")
         if ".." in path.parts:
             raise ValueError(f"path must stay inside repository: {raw_path}")
         normalized.append(path)
@@ -223,14 +223,29 @@ def _phantom_script_diagnostics(
 def _rule_matches(rule: Rule, line: str) -> bool:
     """Return whether rule matches a line after rule-specific false-positive handling."""
     for match in rule.pattern.finditer(line):
-        if rule.name == "bare-python-scripts-command" and "uv run" in line[: match.start()]:
+        if rule.name == "bare-python-scripts-command" and _is_uv_run_python_match(
+            line, match.start()
+        ):
             continue
         return True
     return False
 
 
+def _is_uv_run_python_match(line: str, python_start: int) -> bool:
+    """Return whether the matched ``python scripts/...`` belongs to a ``uv run`` command."""
+    prefix = line[:python_start]
+    command_segment = re.split(r"&&|\|\||;|`", prefix)[-1]
+    return re.search(r"\buv\s+run\b", command_segment) is not None
+
+
 def scan_file(path: Path, repo_root: Path) -> list[Diagnostic]:
-    """Scan one repository-relative text file."""
+    """Scan one repository-relative text file and return stale-example diagnostics.
+
+    The scanner reads UTF-8 text, returns no diagnostics for undecodable binary-ish files, skips
+    lines with explicit active-doc allow markers, applies each line rule with rule-specific
+    false-positive handling, ignores historical legacy-results mentions, and appends diagnostics
+    for missing script paths found by command examples.
+    """
     absolute_path = repo_root / path
     try:
         lines = absolute_path.read_text(encoding="utf-8").splitlines()

--- a/scripts/validation/check_active_doc_examples.py
+++ b/scripts/validation/check_active_doc_examples.py
@@ -72,8 +72,8 @@ RULES = (
     ),
     Rule(
         name="bare-python-scripts-command",
-        pattern=re.compile(r"\bpython\s+scripts/"),
-        message="script commands should normally use uv run python scripts/...",
+        pattern=re.compile(r"\bpython\s+(?:scripts|examples)/"),
+        message="script and example commands should normally use uv run python ...",
     ),
     Rule(
         name="setup-pip-install",
@@ -89,7 +89,7 @@ RULES = (
     ),
 )
 SCRIPT_COMMAND_RE = re.compile(
-    r"(?:uv\s+run\s+)?python\s+(?P<script>scripts/[A-Za-z0-9_./-]+\.py)\b"
+    r"(?:uv\s+run\s+)?python\s+(?P<script>(?:scripts|examples)/[A-Za-z0-9_./-]+\.py)\b"
 )
 
 

--- a/tests/validation/test_check_active_doc_examples.py
+++ b/tests/validation/test_check_active_doc_examples.py
@@ -1,0 +1,83 @@
+"""Tests for active documentation example validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validation import check_active_doc_examples as checker
+
+
+def test_scan_file_reports_known_bad_active_doc_patterns(tmp_path: Path) -> None:
+    """Known stale command and artifact examples should be reported."""
+    doc = tmp_path / "docs" / "quickstart.md"
+    doc.parent.mkdir()
+    doc.write_text(
+        "\n".join(
+            [
+                "Run `python scripts/missing_tool.py --demo`.",
+                "Old output is under `output/results/demo.json`.",
+                "Use `robot_sf_bench run --suite core --episodes 10`.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = checker.scan_file(Path("docs/quickstart.md"), tmp_path)
+
+    rules = {diagnostic.rule for diagnostic in diagnostics}
+    assert "bare-python-scripts-command" in rules
+    assert "nested-output-results-path" in rules
+    assert "unsupported-robot-sf-bench-run-flag" in rules
+    assert "phantom-script-path" in rules
+
+
+def test_scan_file_allows_marked_and_historical_lines(tmp_path: Path) -> None:
+    """Historical mentions and explicit allows should not fail active docs."""
+    doc = tmp_path / "docs" / "README.md"
+    doc.parent.mkdir()
+    doc.write_text(
+        "Legacy `results/` paths have been migrated.\n"
+        "`python scripts/old_example.py` <!-- active-docs-check: allow -->\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = checker.scan_file(Path("docs/README.md"), tmp_path)
+
+    assert diagnostics == []
+
+
+def test_default_paths_exclude_context_notes_and_include_spec_quickstarts(tmp_path: Path) -> None:
+    """Default path selection should separate active docs from historical context notes."""
+    (tmp_path / "docs" / "context").mkdir(parents=True)
+    (tmp_path / "docs" / "context" / "issue_1.md").write_text("results/run.json\n")
+    (tmp_path / "docs" / "README.md").write_text("hello\n")
+    (tmp_path / "specs" / "001-demo").mkdir(parents=True)
+    (tmp_path / "specs" / "001-demo" / "quickstart.md").write_text("hello\n")
+
+    without_specs = checker._default_paths(
+        tmp_path,
+        include_specs=False,
+        include_cli_sources=False,
+    )
+    with_specs = checker._default_paths(
+        tmp_path,
+        include_specs=True,
+        include_cli_sources=False,
+    )
+
+    assert Path("docs/README.md") in without_specs
+    assert Path("docs/context/issue_1.md") not in without_specs
+    assert Path("specs/001-demo/quickstart.md") in with_specs
+
+
+def test_main_fail_on_diagnostic_controls_exit_code(tmp_path: Path, monkeypatch) -> None:
+    """The checker can report by default and fail when CI asks it to."""
+    doc = tmp_path / "docs" / "quickstart.md"
+    doc.parent.mkdir()
+    doc.write_text("Run `python scripts/missing_tool.py`.\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(checker, "_repo_root", lambda: tmp_path)
+
+    assert checker.main(["docs/quickstart.md"]) == 0
+    assert checker.main(["--fail-on-diagnostic", "docs/quickstart.md"]) == 1

--- a/tests/validation/test_check_active_doc_examples.py
+++ b/tests/validation/test_check_active_doc_examples.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from _pytest.monkeypatch import MonkeyPatch
+
 from scripts.validation import check_active_doc_examples as checker
 
 
@@ -26,10 +28,42 @@ def test_scan_file_reports_known_bad_active_doc_patterns(tmp_path: Path) -> None
     diagnostics = checker.scan_file(Path("docs/quickstart.md"), tmp_path)
 
     rules = {diagnostic.rule for diagnostic in diagnostics}
+    assert len(diagnostics) == 4
     assert "bare-python-scripts-command" in rules
     assert "nested-output-results-path" in rules
     assert "unsupported-robot-sf-bench-run-flag" in rules
     assert "phantom-script-path" in rules
+
+
+def test_scan_file_distinguishes_uv_run_from_later_bare_python(tmp_path: Path) -> None:
+    """A uv-prefixed command should not hide a later bare Python script command."""
+    doc = tmp_path / "docs" / "quickstart.md"
+    script = tmp_path / "scripts" / "real_tool.py"
+    doc.parent.mkdir()
+    script.parent.mkdir()
+    script.write_text("print('ok')\n", encoding="utf-8")
+    doc.write_text(
+        "`uv run python scripts/real_tool.py && python scripts/real_tool.py`\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = checker.scan_file(Path("docs/quickstart.md"), tmp_path)
+
+    assert [diagnostic.rule for diagnostic in diagnostics] == ["bare-python-scripts-command"]
+
+
+def test_scan_file_allows_uv_run_options_before_python(tmp_path: Path) -> None:
+    """uv run commands may pass dependency options before invoking Python."""
+    doc = tmp_path / "docs" / "quickstart.md"
+    script = tmp_path / "scripts" / "real_tool.py"
+    doc.parent.mkdir()
+    script.parent.mkdir()
+    script.write_text("print('ok')\n", encoding="utf-8")
+    doc.write_text("`uv run --group imitation python scripts/real_tool.py`\n", encoding="utf-8")
+
+    diagnostics = checker.scan_file(Path("docs/quickstart.md"), tmp_path)
+
+    assert diagnostics == []
 
 
 def test_scan_file_allows_marked_and_historical_lines(tmp_path: Path) -> None:
@@ -52,6 +86,8 @@ def test_default_paths_exclude_context_notes_and_include_spec_quickstarts(tmp_pa
     (tmp_path / "docs" / "context").mkdir(parents=True)
     (tmp_path / "docs" / "context" / "issue_1.md").write_text("results/run.json\n")
     (tmp_path / "docs" / "README.md").write_text("hello\n")
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "demo.md").write_text("hello\n")
     (tmp_path / "specs" / "001-demo").mkdir(parents=True)
     (tmp_path / "specs" / "001-demo" / "quickstart.md").write_text("hello\n")
 
@@ -67,11 +103,24 @@ def test_default_paths_exclude_context_notes_and_include_spec_quickstarts(tmp_pa
     )
 
     assert Path("docs/README.md") in without_specs
+    assert Path("examples/demo.md") in without_specs
     assert Path("docs/context/issue_1.md") not in without_specs
     assert Path("specs/001-demo/quickstart.md") in with_specs
 
 
-def test_main_fail_on_diagnostic_controls_exit_code(tmp_path: Path, monkeypatch) -> None:
+def test_normalize_explicit_paths_resolves_relative_paths(tmp_path: Path) -> None:
+    """Explicit paths should resolve before repository-boundary checks."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "quickstart.md").write_text("hello\n")
+
+    paths = checker._normalize_explicit_paths(["docs/../docs/quickstart.md"], tmp_path)
+
+    assert paths == [Path("docs/quickstart.md")]
+
+
+def test_main_fail_on_diagnostic_controls_exit_code(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     """The checker can report by default and fail when CI asks it to."""
     doc = tmp_path / "docs" / "quickstart.md"
     doc.parent.mkdir()

--- a/tests/validation/test_check_active_doc_examples.py
+++ b/tests/validation/test_check_active_doc_examples.py
@@ -17,6 +17,7 @@ def test_scan_file_reports_known_bad_active_doc_patterns(tmp_path: Path) -> None
         "\n".join(
             [
                 "Run `python scripts/missing_tool.py --demo`.",
+                "Run `python examples/missing_example.py --demo`.",
                 "Old output is under `output/results/demo.json`.",
                 "Use `robot_sf_bench run --suite core --episodes 10`.",
             ]
@@ -28,7 +29,7 @@ def test_scan_file_reports_known_bad_active_doc_patterns(tmp_path: Path) -> None
     diagnostics = checker.scan_file(Path("docs/quickstart.md"), tmp_path)
 
     rules = {diagnostic.rule for diagnostic in diagnostics}
-    assert len(diagnostics) == 4
+    assert len(diagnostics) == 6
     assert "bare-python-scripts-command" in rules
     assert "nested-output-results-path" in rules
     assert "unsupported-robot-sf-bench-run-flag" in rules


### PR DESCRIPTION
## Summary
Adds a repository-level active-doc examples checker for stale command and artifact examples, with focused tests and a dev-guide reference.

## Linked Issues
- Closes `#2136`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/validation/check_active_doc_examples.py` to report known stale active-doc patterns: legacy `results/`, `output/results/`, `output/benchmark_quickstart/`, bare `python scripts/...`, setup `pip install`, missing script references, and stale `robot_sf_bench run` flags.
- Excludes historical context-note surfaces by default and provides opt-ins for specs quickstarts and CLI source scanning.
- Added focused pytest coverage for true positives, allow/historical handling, default path selection, and hard-fail mode.
- Documented the new checker in `docs/dev_guide.md`.

## Why It Matters
- Added value: recurring command/path drift can now be found by one cheap validation entry point.
- Expected impact: future active-doc cleanup can use report mode first and `--fail-on-diagnostic` once existing hits are classified.
- Why this is worth merging now: it turns the recent repeated cleanup pattern into a reusable guard.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; workflow guard only.
- Comparator or baseline, if applicable: existing manual grep cleanup.
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: checker reports known stale examples and focused tests cover fail/report behavior.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
  - `uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_env; print('Import successful')"`
  - `uv run python scripts/validation/check_active_doc_examples.py`
  - `uv run pytest tests/validation/test_check_active_doc_examples.py -q`
  - `uv run ruff check scripts/validation/check_active_doc_examples.py tests/validation/test_check_active_doc_examples.py docs/dev_guide.md`
  - `uv run ruff format --check scripts/validation/check_active_doc_examples.py tests/validation/test_check_active_doc_examples.py`
- Evidence that the change works here: focused tests passed (`4 passed`); Ruff passed; checker ran successfully and reported 14 current diagnostics as backlog while exiting zero in report mode.
- Benchmarks or smoke tests, if applicable: NA; validation-tooling change only.

## Risks / Rollout
- Compatibility risks: low; new checker is report-only by default.
- Failure modes: `--fail-on-diagnostic` should not be wired into broad CI until current report hits are intentionally fixed, allowed, or classified.
- Rollback or fallback plan: remove the new script/test and dev-guide bullet.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`
- Relevant design or provenance notes: issue `#2136`
- Any assumptions that need to be preserved: specs quickstarts are opt-in for now because existing stale spec backlog still needs classification.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes `#2136`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not applicable because: this is a local workflow validation helper, not benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: classify or fix the 14 current report-mode diagnostics before enabling hard-fail mode broadly.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify whether the default active-doc surface is appropriately conservative.
- Known limitation: report mode intentionally exits zero while the existing active-doc backlog is still being classified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation tool to scan documentation and identify stale example patterns and outdated references.

* **Documentation**
  * Updated developer guide with instructions for running documentation validation checks.

* **Tests**
  * Added comprehensive test coverage for the new validation tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->