### PR TITLE
docs: require research result PR fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -22,10 +22,16 @@ What changed, in one or two sentences.
 - Why this is worth merging now:
 
 ## Research Result Guidance
+Required for research-labelled, benchmark-labelled, metric-facing, paper-facing, or other
+evidence-producing PRs. For support/tooling/docs-only PRs that make no research claim, set fields
+to `NA` and state why.
+
 - Target claim / hypothesis / blocker this should affect:
 - Comparator or baseline, if applicable:
+- Evidence tier: full benchmark / targeted smoke / diagnostic probe / launch packet / docs-only / NA
 - Result classification: positive / negative / inconclusive / diagnostic-only / blocker-resolution / NA
 - Decision or stop rule, if applicable:
+- Parent issue, claim map, registry, context note, or synthesis surface to update:
 
 ## Validation / Proof
 - Commands run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,8 @@ resolving lint or test failures locally before requesting review.
   context index/catalog so the evidence remained discoverable after worktree cleanup.
 - For research-labelled, benchmark-labelled, metric-facing, paper-facing, or other
   evidence-producing PRs, fill the `Research Result Guidance` section with the target
-  claim/hypothesis, comparator, evidence tier, result classification, stop rule, and update target.
+  claim/hypothesis/blocker, comparator/baseline, evidence tier, result classification,
+  decision/stop rule, and synthesis surface/update target.
   For support/tooling/docs-only PRs with no research claim, use `NA` and state why.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,10 @@ resolving lint or test failures locally before requesting review.
   low-risk or not-applicable changes, state the reason explicitly instead of deleting the section.
   PR #2044 is a recent small example: it promoted a compact trace-viewer screenshot and updated the
   context index/catalog so the evidence remained discoverable after worktree cleanup.
+- For research-labelled, benchmark-labelled, metric-facing, paper-facing, or other
+  evidence-producing PRs, fill the `Research Result Guidance` section with the target
+  claim/hypothesis, comparator, evidence tier, result classification, stop rule, and update target.
+  For support/tooling/docs-only PRs with no research claim, use `NA` and state why.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.


### PR DESCRIPTION
## Summary
Tightens the PR template and contributor guidance so research/benchmark/evidence-producing PRs state their claim boundary explicitly.

## Linked Issues
- Closes `#2137`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Expanded `Research Result Guidance` in `.github/PULL_REQUEST_TEMPLATE/pr_default.md` with scope text, evidence tier, and update-target fields.
- Added matching `AGENTS.md` guidance for research-labelled, benchmark-labelled, metric-facing, paper-facing, or evidence-producing PRs.
- Preserved an explicit `NA` path for support/tooling/docs-only PRs that make no research claim.

## Why It Matters
- Added value: evidence-producing PRs now have a stronger template contract for claim boundaries.
- Expected impact: less ambiguity between diagnostic-only, blocker-resolution, and benchmark-strength results.
- Why this is worth merging now: recent workflow changes improved evidence handling, and this makes the PR handoff surface match that guidance.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: PR template and contributor workflow completeness for evidence-producing PRs.
- Comparator or baseline, if applicable: previous template fields without evidence tier or update-target field.
- Evidence tier: docs-only
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: template names claim, comparator, evidence tier, result classification, stop rule, and update target, while retaining NA path.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#2137`

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `test -f docs/context/issue_1512_issue_archetypes.md && test -f docs/context/issue_691_benchmark_fallback_policy.md && test -f .github/PULL_REQUEST_TEMPLATE/pr_default.md`
- Evidence that the change works here: diff is limited to PR template and AGENTS guidance; referenced policy/template paths exist.
- Benchmarks or smoke tests, if applicable: NA; docs/workflow-only change.

## Risks / Rollout
- Compatibility risks: low; template text only.
- Failure modes: could feel heavier for small PRs, mitigated by explicit NA path.
- Rollback or fallback plan: revert the template/guidance additions.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE/pr_default.md`
- Relevant design or provenance notes: issue `#2137`
- Any assumptions that need to be preserved: stronger fields apply to research/benchmark/evidence-producing PRs, not ordinary support/tooling PRs with no research claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes `#2137`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not applicable because: this is a workflow/template contract change, not benchmark or paper evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that the NA path is clear enough for support/tooling/docs-only PRs.