### PR TITLE
docs: classify active doc checker findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,7 +518,7 @@ If your project imports from `robot_sf.util` or `robot_sf.utils` , update your i
   + All helper functions include comprehensive docstrings, error handling, and Loguru logging compliance.
 * Episode Video Artifacts (MVP):
   + New CLI flags for benchmark runner: `--no-video` and `--video-renderer=synthetic|sim-view|none`.
-  + Synthetic lightweight encoder that renders a red-dot path from robot positions and writes per‑episode MP4s under `results/videos/`.
+  + Synthetic lightweight encoder that renders a red-dot path from robot positions and writes per‑episode MP4s under `results/videos/`. <!-- active-docs-check: allow historical changelog path -->
   + Episode JSON schema extension to include optional `video` manifest `{path, format, filesize_bytes, frames, renderer}`.
   + End‑to‑end wiring through CLI → batch runner → worker → episode; deterministic file naming `video_<episode_id>.mp4`.
   + Tests: CLI integration (`tests/test_cli_run_video.py`) and programmatic API (`tests/unit/test_runner_video.py`), both skipped when MoviePy/ffmpeg unavailable.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -14,7 +14,7 @@ Optional (GPU):
 ## Install
 1) Install uv (one-time):
    - macOS (Homebrew): `brew install uv`
-   - Or: `pipx install uv` (or `pip install --user uv`)
+   - Or use the official installer: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 2) Sync dependencies (respects `uv.lock`):
    - `uv sync`

--- a/docs/UV_MIGRATION.md
+++ b/docs/UV_MIGRATION.md
@@ -66,8 +66,8 @@ This document outlines the migration from the old pip/requirements.txt setup to 
 ```bash
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
-# or
-pip install uv
+# or install with Homebrew on macOS
+brew install uv
 ```
 
 ### 2. Remove old virtual environment (if exists)

--- a/docs/benchmark_visuals.md
+++ b/docs/benchmark_visuals.md
@@ -141,7 +141,7 @@ print('Trajectory data:', 'trajectory_data' in ep)
 from pathlib import Path
 from robot_sf.benchmark.full_classic.validation import validate_visual_manifests
 
-reports_dir = Path("results/full_classic_run/reports")
+reports_dir = Path("output/benchmarks/full_classic_run/reports")
 contracts = Path("specs/127-enhance-benchmark-visual/contracts")
 validate_visual_manifests(reports_dir, contracts)
 

--- a/docs/context/issue_2141_active_doc_checker_classification.md
+++ b/docs/context/issue_2141_active_doc_checker_classification.md
@@ -1,4 +1,4 @@
-# Issue #2141 Active-Doc Checker Classification
+# Issue #2141 Active-Doc Checker Classification 2026-06-02
 
 Status: Current for PR #2141.
 

--- a/docs/context/issue_2141_active_doc_checker_classification.md
+++ b/docs/context/issue_2141_active_doc_checker_classification.md
@@ -1,0 +1,33 @@
+# Issue #2141 Active-Doc Checker Classification
+
+Status: Current for PR #2141.
+
+Issue #2141 classified the active-doc checker diagnostics introduced by
+`scripts/validation/check_active_doc_examples.py` after examples were added to the default scan.
+
+## Real Active-Doc Drift Fixed
+
+- `docs/dev_guide.md` referenced removed `examples/demo_*.py` entry points. The active demo block
+  now points at existing quickstart and advanced examples under `examples/quickstart/` and
+  `examples/advanced/`.
+- `docs/trajectory_visualization.md` referenced removed `examples/trajectory_demo.py`. The doc now
+  points at `examples/advanced/14_trajectory_visualization.py`.
+- `docs/benchmark_visuals.md`, `docs/dev/baselines/random.md`, and
+  `docs/performance_notes.md` used active `results/` artifact paths. They now use the repository
+  `output/` artifact root.
+- `docs/snqi-weight-tools/README.md` used bare `python scripts/...` commands in recommended
+  workflows. Those examples now use `uv run python`.
+- `docs/ENVIRONMENT.md`, `docs/UV_MIGRATION.md`, and `docs/dev_guide.md` preferred `pip install`
+  setup paths for uv. They now point at the official uv installer or package-manager route.
+
+## Intentional Or Historical Mentions
+
+- `CHANGELOG.md` keeps the historical `results/videos/` changelog entry with an explicit
+  `active-docs-check: allow` marker.
+- `scripts/README.md` intentionally describes a migration tool that consumes legacy artifact roots.
+  The line now names `results/` as legacy so the checker can distinguish it from current guidance.
+
+## Validation
+
+- `uv run python scripts/validation/check_active_doc_examples.py`
+- `git diff --check`

--- a/docs/dev/baselines/random.md
+++ b/docs/dev/baselines/random.md
@@ -19,7 +19,7 @@ from robot_sf.benchmark.runner import run_batch
 
 summary = run_batch(
     scenarios_or_path="configs/baselines/example_matrix.yaml",
-    out_path="results/episodes_random.jsonl",
+    out_path="output/benchmarks/episodes_random.jsonl",
     algo="random",
     algo_config_path="configs/baselines/random.yaml",
     workers=2,
@@ -32,7 +32,7 @@ CLI:
 ```bash
 robot_sf_bench run \
   --matrix configs/baselines/example_matrix.yaml \
-  --out results/episodes_random.jsonl \
+  --out output/benchmarks/episodes_random.jsonl \
   --algo random \
   --algo-config configs/baselines/random.yaml
 ```
@@ -74,4 +74,3 @@ Notes:
 
 - Establish a naive lower bound for metrics and SNQI
 - Validate scenario setups and pipeline correctness before benchmarking stronger baselines
-

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1306,10 +1306,10 @@ summary = compute_aggregates_with_ci(
 ## Training and examples
 ### Available demos
 ```bash
-uv run python examples/demo_offensive.py
-uv run python examples/demo_defensive.py
-uv run python examples/demo_pedestrian.py
-uv run python examples/demo_refactored_environments.py
+uv run python examples/quickstart/01_basic_robot.py
+uv run python examples/quickstart/02_trained_model.py
+uv run python examples/quickstart/03_custom_map.py
+uv run python examples/advanced/06_pedestrian_env_factory.py
 ```
 
 ### Training scripts
@@ -1397,7 +1397,7 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
 
 ## Common issues and solutions
 ### Build issues
-- uv not found → `pip install uv` (or use official installer)
+- uv not found → `curl -LsSf https://astral.sh/uv/install.sh | sh` (or use the package manager path in `docs/ENVIRONMENT.md`)
 - ffmpeg missing → `sudo apt-get install -y ffmpeg`
 
 ### Runtime issues

--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -221,7 +221,7 @@ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
 ### Development Environment Specs
 - **CPU**: M-series Apple Silicon (ARM64)
 - **Memory**: 16+ GB recommended for multi-worker runs
-- **Storage**: SSD for results/ directory  
+- **Storage**: SSD for the repository's `output/` artifact directory
 - **Display**: Headless mode using SDL_VIDEODRIVER=dummy
 
 ### Performance Scaling

--- a/docs/snqi-weight-tools/README.md
+++ b/docs/snqi-weight-tools/README.md
@@ -238,7 +238,7 @@ If visualization is requested without the required extras, commands will emit a 
 
 Install the package in editable mode for external usage (optional):
 ```bash
-uv run python -m pip install -e .
+uv sync --all-extras
 ```
 
 ## Quick Start
@@ -402,7 +402,7 @@ Use `--external-weights-file` (recompute) or `--initial-weights-file` (optimizat
 ## Recommended Workflows
 ### A. Establish Baseline & Strategy Comparison
 ```bash
-python scripts/recompute_snqi_weights.py \
+uv run python scripts/recompute_snqi_weights.py \
   --episodes episodes.jsonl \
   --baseline baseline_stats.json \
   --compare-strategies --compare-normalization \
@@ -410,17 +410,17 @@ python scripts/recompute_snqi_weights.py \
 ```
 ### B. Optimize Weights Then Validate
 ```bash
-python scripts/snqi_weight_optimization.py \
+uv run python scripts/snqi_weight_optimization.py \
   --episodes episodes.jsonl --baseline baseline_stats.json \
   --method both --sensitivity --seed 17 \
   --output optimized.json
-python scripts/snqi_sensitivity_analysis.py \
+uv run python scripts/snqi_sensitivity_analysis.py \
   --episodes episodes.jsonl --baseline baseline_stats.json \
   --weights optimized.json --output sensitivity_results/ --skip-visualizations
 ```
 ### C. Evaluate External Weight Proposal
 ```bash
-python scripts/recompute_snqi_weights.py \
+uv run python scripts/recompute_snqi_weights.py \
   --episodes episodes.jsonl --baseline baseline_stats.json \
   --external-weights-file candidate_weights.json \
   --strategy default --output eval_candidate.json

--- a/docs/trajectory_visualization.md
+++ b/docs/trajectory_visualization.md
@@ -63,10 +63,10 @@ playback.run()
 
 ### Demo Script
 
-A complete demo is available in `examples/trajectory_demo.py`:
+A complete demo is available in `examples/advanced/14_trajectory_visualization.py`:
 
 ```bash
-python examples/trajectory_demo.py path/to/recording.pkl
+uv run python examples/advanced/14_trajectory_visualization.py
 ```
 
 ### Recorded-Step Analyzer Workflow

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -693,7 +693,7 @@ uv run python scripts/tools/migrate_artifacts.py
 uv run robot-sf-migrate-artifacts
 ```
 
-**Details**: Consolidates `results/`, `recordings/`, `htmlcov/`, `coverage.json` into `output/`
+**Details**: Consolidates legacy `results/`, `recordings/`, `htmlcov/`, `coverage.json` into `output/`
 
 ### `tools/check_artifact_root.py`
 


### PR DESCRIPTION
## Summary
- closes #2141
- replaces stale active-doc examples for removed demo scripts, trajectory visualization, and legacy `results/` artifact paths
- records which checker findings were real drift versus historical or legacy-migration mentions

## Validation
- `uv run python scripts/validation/check_active_doc_examples.py`
- `git diff --check`
- referenced replacement examples checked with `test -f`

## Downstream Propagation
- Context note added at `docs/context/issue_2141_active_doc_checker_classification.md`.
- No benchmark, schema, model-provenance, or paper-facing claim changed.
- Full PR readiness gate not run because this is a low-risk docs-only cleanup validated by the active-doc checker.
