### PR TITLE
docs: require analysis tool follow-through

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -33,7 +33,7 @@ to `NA` and state why.
 - Decision or stop rule, if applicable:
 - Parent issue, claim map, registry, context note, or synthesis surface to update:
 - New research/benchmark/metric/paper-facing analysis tool, if any: representative use on
-  durable/versioned input, or linked follow-up issue that names the decision, claim boundary, or
+  durable/versioned input, or a linked follow-up issue that names the decision, claim boundary, or
   synthesis surface it will update:
 
 ## Validation / Proof

--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -32,8 +32,20 @@ to `NA` and state why.
 - Result classification: positive / negative / inconclusive / diagnostic-only / blocker-resolution / NA
 - Decision or stop rule, if applicable:
 - Parent issue, claim map, registry, context note, or synthesis surface to update:
+- New research/benchmark/metric/paper-facing analysis tool, if any: representative use on
+  durable/versioned input, or linked follow-up issue that names the decision, claim boundary, or
+  synthesis surface it will update:
 
 ## Validation / Proof
+For research/benchmark/metric/paper-facing analysis-tool PRs: include one
+representative use on durable/versioned input (tracked config, model
+checkpoint, committed fixture, or versioned W&B artifact), or link a
+concrete follow-up issue that names the decision, claim boundary, or
+synthesis surface the tool will update. Local-only `output/` files are
+not durable proof unless promoted or represented by a tracked manifest.
+Small support helpers (formatters, CLI wrappers, quick diagnostics)
+that make no research/benchmark/metric/paper claim are exempt.
+
 - Commands run:
 - Evidence that the change works here:
 - Benchmarks or smoke tests, if applicable:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,12 @@ resolving lint or test failures locally before requesting review.
   claim/hypothesis/blocker, comparator/baseline, evidence tier, result classification,
   decision/stop rule, and synthesis surface/update target.
   For support/tooling/docs-only PRs with no research claim, use `NA` and state why.
+- When a PR adds a new research, benchmark, metric, or paper-facing analysis tool, either use it
+  once on durable/versioned input in the same PR, or link a concrete follow-up issue that names the
+  decision, claim boundary, benchmark report, registry, context note, or synthesis surface the tool
+  will update. Disposable local `output/` files do not count as durable proof unless represented by
+  a tracked manifest, registry entry, context note, or external artifact pointer. Small support
+  helpers that are not intended to support research interpretation may state `NA` with that reason.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -78,6 +78,12 @@ incomplete.
 - docs-only guidance:
   verify every referenced path and command, and ensure the guidance matches the current repo
   workflow.
+- new research, benchmark, metric, or paper-facing analysis tool:
+  require one representative use on durable/versioned input, or a linked follow-up issue that names
+  the decision, claim boundary, benchmark report, registry, context note, or synthesis surface the
+  tool will update. Local-only `output/` files are not durable proof unless promoted or represented
+  by a tracked manifest, registry entry, context note, or external artifact pointer. Small support
+  helpers with no research-interpretation role may be marked `NA` with that reason.
 
 ## Documentation Review
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1429,6 +1429,12 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
 - Requirements clarified (with options/assumptions recorded).
 - Design doc added/updated and linked (if non‑trivial).
 - Code implemented with tests (unit/integration; GUI when needed).
+- For research/benchmark/metric/paper-facing analysis-tool PRs: include one representative use on
+  durable/versioned input (tracked config, model checkpoint, committed fixture, or versioned W&B
+  artifact) or link a concrete follow-up issue that names the decision, claim boundary, or
+  synthesis surface the tool will update. Local-only `output/` files are not durable proof unless
+  promoted or represented by a tracked manifest. Small support helpers (formatters, CLI wrappers,
+  quick diagnostics) that make no research/benchmark/metric/paper claim are exempt.
 - Ruff clean and “Check Code Quality (Ruff + advisory ty)” reviewed locally.
 - Advisory typecheck reviewed. Fix practical findings in touched files and stable contracts, and
   document any meaningful remaining findings in the PR when they affect the change.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1431,7 +1431,7 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
 - Code implemented with tests (unit/integration; GUI when needed).
 - For research/benchmark/metric/paper-facing analysis-tool PRs: include one representative use on
   durable/versioned input (tracked config, model checkpoint, committed fixture, or versioned W&B
-  artifact) or link a concrete follow-up issue that names the decision, claim boundary, or
+  artifact), or link a concrete follow-up issue that names the decision, claim boundary, or
   synthesis surface the tool will update. Local-only `output/` files are not durable proof unless
   promoted or represented by a tracked manifest. Small support helpers (formatters, CLI wrappers,
   quick diagnostics) that make no research/benchmark/metric/paper claim are exempt.


### PR DESCRIPTION
## Summary
- closes #2140
- adds PR-template guidance for new research/benchmark/metric/paper-facing analysis tools
- mirrors the rule in `AGENTS.md`, `docs/code_review.md`, and the contributor checklist in `docs/dev_guide.md`

## Validation
- `git diff --check origin/main...HEAD`
- `test -f .github/PULL_REQUEST_TEMPLATE/pr_default.md AGENTS.md docs/dev_guide.md docs/code_review.md`
- Qwen queue scout selected #2140 as the next low-risk local workflow issue
- OpenCode route contributed a bounded docs-edit candidate; final integration and validation were local

## Downstream Propagation
- Parent issue updated by this PR: yes, closes #2140.
- Claim map / benchmark report updated: NA, guidance-only change.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA, no new durable benchmark evidence or reusable context note needed.
- Follow-up issue opened for deferred propagation: NA; the guidance itself requires future analysis-tool PRs to use or queue the tool.
- Full readiness gate not run because this is a low-risk docs/workflow guidance change with referenced paths checked.
