### PR TITLE
docs: add Slurm early-stop criteria guidance

### DIFF
--- a/.agents/skills/goal-slurm-experiment/SKILL.md
+++ b/.agents/skills/goal-slurm-experiment/SKILL.md
@@ -123,6 +123,9 @@ Do not use it for:
      candidate-specific helper under `scripts/dev/`.
    - Use a short skill-owned job name: `gse-<issue>-<slug>`.
    - Capture job id, branch, commit, config path, SLURM script, output root, and stdout/stderr path.
+   - For long-running training, capture the predeclared early-stop criteria from the experiment card
+     or launch packet: metric, threshold, check cadence, minimum runtime/timesteps, cancel
+     condition, and diagnostic-preservation action.
    - Immediately check `squeue`, `sacct`, and early stderr when the job starts.
 
 8. Monitor with long, low-churn intervals.
@@ -134,6 +137,10 @@ Do not use it for:
    - Do not open a PR or commit for every scheduled eval gate. Preserve interim eval metrics in an
      issue comment or local note only when they change the operational decision, expose a new
      failure mode, or the user explicitly wants live reporting.
+   - If a predeclared low-signal cancel condition is met, complete the preservation action before
+     cancelling or immediately after cancellation: record branch, commit, config, logs, manifest,
+     output root, and durable artifact status. Label the result diagnostic or failed as appropriate,
+     not benchmark proof.
    - Make the durable context-note update and PR after the job finishes, fails, or reaches a
      campaign decision point that changes what should run next.
    - Keep interim metrics labeled as live training state, not benchmark or guarded-policy evidence.
@@ -167,6 +174,8 @@ fresh rerun is the stated next action.
   decision-changing signal before opening durable follow-up PRs.
 - Do not treat queued, running, fallback, degraded, or local-only `output/` artifacts as completed
   evidence.
+- Do not treat a cancelled low-signal run as useful diagnostic evidence unless the early-stop
+  criteria were declared before submission and the preservation action was completed.
 - Do not spend a training allocation on a bug that can be fixed from logs, config inspection, a
   validator, or a cheap local preflight.
 - Keep benchmark and paper-facing claims conditional until durable artifacts and analysis exist.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -41,12 +41,21 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
      compute-node-only dependency, GPU, queue/runtime parity proof, or explicit maintainer approval;
    - when a short run is submitted to SLURM anyway, label it as a smoke/probe in the job label,
      handoff note, issue comment, and PR text, not as completed campaign evidence.
-5. Run any campaign-specific launch-packet validator before `sbatch` when one exists under `scripts/validation/`.
-6. Submit with explicit config and job name; capture job ID plus stdout/stderr paths.
-7. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
-8. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
-9. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
-10. After completion, route results before rerunning: `completed_needs_analysis` goes to the
+5. For long-running training submissions, confirm the experiment card or launch packet predeclares
+   early-stop criteria: metric, threshold, check cadence, minimum runtime or timesteps, cancel
+   condition, and diagnostic-preservation action. If these are missing, classify the candidate as
+   `blocked-needs-scope` until the card is updated.
+6. Run any campaign-specific launch-packet validator before `sbatch` when one exists under `scripts/validation/`.
+7. Submit with explicit config and job name; capture job ID plus stdout/stderr paths.
+8. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
+9. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
+10. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
+11. After completion or predeclared cancellation, route results before rerunning:
+    - cancelled runs may be diagnostic evidence only when the early-stop criteria were declared and
+      the configured preservation action captured logs, manifest, config, commit, and artifact
+      status;
+    - unplanned cancellations stay `failed_preflight`, `blocked`, or `inconclusive` until triaged;
+    - `completed_needs_analysis` goes to the
     relevant analysis skill or context note, while `failed_preflight` or early wrapper failures must
     be fixed in a worktree before resubmission.
 
@@ -55,6 +64,8 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 - Do not infer live cluster capacity from stale logs.
 - Do not submit from an unintended branch or dirty tree without calling that out.
 - Do not treat a queued job as completed evidence.
+- Do not cancel a low-signal training job as diagnostic evidence unless the early-stop rule was
+  predeclared and the diagnostic-preservation action has been completed.
 - Do not treat a `resource:slurm` issue as runnable when its latest comments require durable
   artifact pointers, exact commits, maintainer confirmation, or a concrete launcher first.
 - Do not let an issue's `slurm` label override the suitability gate. A `slurm` label means the

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -56,6 +56,13 @@ scripts/dev/sbatch_use_max_time.sh --time 08:00:00 SLURM/Auxme/auxme_gpu.sl
   and any issue/PR follow-up as `smoke` or `probe`, not as completed campaign evidence.
 - Do not let a GitHub `slurm` label alone justify submission. The label means cluster execution may
   be required; the config still needs a suitability check.
+- For long-running training jobs, include predeclared early-stop criteria in the experiment card or
+  launch packet before submission. The criteria must name the metric, threshold, check cadence,
+  minimum runtime or timesteps, exact cancel condition, and diagnostic-preservation action.
+- A cancelled Slurm run can be valid diagnostic evidence only when the stop rule was predeclared and
+  the branch, commit, config, logs, manifest, local output root, and durable artifact/preservation
+  status are recorded. Without that preservation trail, classify the run as failed, blocked, or
+  inconclusive rather than proof.
 - When adding a new batch script, include `#SBATCH --partition` and `#SBATCH --qos` so
   the wrapper can resolve the correct limit without extra flags.
 - If Slurm tools are unavailable in the current shell, fall back to a manual `sbatch`

--- a/scripts/tools/create_experiment_card.py
+++ b/scripts/tools/create_experiment_card.py
@@ -39,6 +39,8 @@ REQUIRED_RECORD_FIELDS = (
     "status",
 )
 
+TODO_TRACKED_FIELDS = REQUIRED_RECORD_FIELDS + ("early_stop_criteria",)
+
 TEMPLATE_NAMES = ("benchmark-analysis", "planner-ablation", "figure-table-pack")
 
 ISSUE_URL_TEMPLATE = "https://github.com/ll7/robot_sf_ll7/issues/{issue}"
@@ -310,7 +312,7 @@ def _template_figure_table_pack(experiment_id: str, output_root: Path) -> Templa
                 "durable_reference_required": True,
             },
         ],
-        early_stop_criteria=_early_stop_criteria_template(),
+        early_stop_criteria={},
         evidence_grade="proposal",
         paper_relevance="exploratory",
         status="planned",
@@ -376,22 +378,25 @@ def _build_record(
     return record
 
 
+def _contains_todo(value: Any) -> bool:
+    """Return True when a scaffold value still contains a TODO placeholder."""
+    if isinstance(value, str):
+        return "TODO" in value
+    if isinstance(value, list):
+        return any(_contains_todo(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_todo(item) for item in value.values())
+    return False
+
+
 def _find_todo_fields(record: dict[str, Any]) -> list[str]:
     fields: list[str] = []
-    for field_name in REQUIRED_RECORD_FIELDS:
+    for field_name in TODO_TRACKED_FIELDS:
         value = record.get(field_name)
         if value is None:
             fields.append(field_name)
-        elif isinstance(value, str) and "TODO" in value:
+        elif _contains_todo(value):
             fields.append(field_name)
-        elif isinstance(value, list):
-            if any(isinstance(item, str) and "TODO" in item for item in value):
-                fields.append(field_name)
-            elif any(
-                isinstance(item, dict) and any("TODO" in str(v) for v in item.values())
-                for item in value
-            ):
-                fields.append(field_name)
     return fields
 
 

--- a/scripts/tools/create_experiment_card.py
+++ b/scripts/tools/create_experiment_card.py
@@ -58,6 +58,7 @@ class TemplateDef:
     inputs: list[str] | list[dict[str, str]]
     outputs: list[dict[str, str]]
     expected_artifacts: list[dict[str, str]]
+    early_stop_criteria: dict[str, str]
     evidence_grade: str
     paper_relevance: str
     status: str
@@ -171,6 +172,7 @@ def _template_benchmark_analysis(experiment_id: str, output_root: Path) -> Templ
                 "durable_reference_required": False,
             },
         ],
+        early_stop_criteria=_early_stop_criteria_template(),
         evidence_grade="proposal",
         paper_relevance="exploratory",
         status="planned",
@@ -240,6 +242,7 @@ def _template_planner_ablation(experiment_id: str, output_root: Path) -> Templat
                 "durable_reference_required": False,
             },
         ],
+        early_stop_criteria=_early_stop_criteria_template(),
         evidence_grade="proposal",
         paper_relevance="exploratory",
         status="planned",
@@ -307,6 +310,7 @@ def _template_figure_table_pack(experiment_id: str, output_root: Path) -> Templa
                 "durable_reference_required": True,
             },
         ],
+        early_stop_criteria=_early_stop_criteria_template(),
         evidence_grade="proposal",
         paper_relevance="exploratory",
         status="planned",
@@ -324,6 +328,20 @@ _TEMPLATES = {
     "planner-ablation": _template_planner_ablation,
     "figure-table-pack": _template_figure_table_pack,
 }
+
+
+def _early_stop_criteria_template() -> dict[str, str]:
+    """Return the predeclared early-stop block for Slurm training launch packets."""
+    return {
+        "metric": "TODO: primary progress metric, e.g. eval/success_rate",
+        "threshold": "TODO: minimum acceptable value or trend",
+        "check_cadence": "TODO: eval interval or wall-clock cadence",
+        "minimum_runtime_or_timesteps": "TODO: do not cancel before this floor",
+        "cancel_condition": "TODO: exact condition that justifies cancellation",
+        "diagnostic_preservation_action": (
+            "TODO: manifest/log/artifact/context note to preserve before cancellation is complete"
+        ),
+    }
 
 
 def _build_record(
@@ -348,6 +366,7 @@ def _build_record(
         "inputs": tpl.inputs,
         "outputs": tpl.outputs,
         "expected_artifacts": tpl.expected_artifacts,
+        "early_stop_criteria": tpl.early_stop_criteria,
         "evidence_grade": tpl.evidence_grade,
         "paper_relevance": tpl.paper_relevance,
         "status": tpl.status,
@@ -427,6 +446,7 @@ def _write_checklist(path: Path, todo_fields: list[str], template_name: str) -> 
             "### Evidence Promotion",
             "",
             "- [ ] Run experiment and verify outputs match `expected_artifacts`",
+            "- [ ] Fill `early_stop_criteria` before submitting long Slurm training jobs",
             "- [ ] Promote durable artifacts (W&B / release storage / docs/context/evidence/)",
             "- [ ] Add `durable_reference` to each artifact in the record",
             "- [ ] Update `evidence_grade` (proposal to observed) and `paper_relevance` if applicable",
@@ -436,6 +456,20 @@ def _write_checklist(path: Path, todo_fields: list[str], template_name: str) -> 
             "",
             "  Local `output/` paths are disposable worktree artifacts.",
             "  Until `durable_reference` is set, these are not paper-facing evidence.",
+            "",
+            "### Slurm Early-Stop Criteria",
+            "",
+            "Before submitting a long Slurm training job, predeclare:",
+            "",
+            "- [ ] metric",
+            "- [ ] threshold",
+            "- [ ] check cadence",
+            "- [ ] minimum runtime or timesteps",
+            "- [ ] cancel condition",
+            "- [ ] diagnostic preservation action",
+            "",
+            "A cancelled run can be useful diagnostic evidence only when the stop rule was",
+            "predeclared and the logs, manifest, config, commit, and relevant outputs are preserved.",
             "",
             "### Update Flow",
             "",

--- a/tests/tools/test_create_experiment_card.py
+++ b/tests/tools/test_create_experiment_card.py
@@ -155,8 +155,8 @@ def test_output_and_expected_artifacts_have_artifact_ids() -> None:
             )
 
 
-def test_each_template_includes_slurm_early_stop_criteria() -> None:
-    """Experiment cards should predeclare stop rules before long Slurm training runs."""
+def test_training_templates_include_slurm_early_stop_criteria() -> None:
+    """Training-oriented experiment cards should predeclare Slurm stop rules."""
     expected_fields = {
         "metric",
         "threshold",
@@ -165,7 +165,8 @@ def test_each_template_includes_slurm_early_stop_criteria() -> None:
         "cancel_condition",
         "diagnostic_preservation_action",
     }
-    for template_name in TEMPLATE_NAMES:
+    training_templates = {"benchmark-analysis", "planner-ablation"}
+    for template_name in training_templates:
         record = _build_record(
             experiment_id=f"test_{template_name.replace('-', '_')}",
             issue="9999",
@@ -177,6 +178,21 @@ def test_each_template_includes_slurm_early_stop_criteria() -> None:
         assert all(
             str(value).startswith("TODO:") for value in record["early_stop_criteria"].values()
         )
+        assert "early_stop_criteria" in _find_todo_fields(record)
+
+
+def test_figure_table_pack_omits_slurm_early_stop_criteria() -> None:
+    """Figure/table rendering from existing records does not launch long Slurm training."""
+    record = _build_record(
+        experiment_id="test_figure_table_pack",
+        issue="9999",
+        issue_url="https://example.com/9999",
+        template_name="figure-table-pack",
+        output_root=Path("output/experiments"),
+    )
+
+    assert record["early_stop_criteria"] == {}
+    assert "early_stop_criteria" not in _find_todo_fields(record)
 
 
 def test_invalid_template_name_raises_key_error() -> None:

--- a/tests/tools/test_create_experiment_card.py
+++ b/tests/tools/test_create_experiment_card.py
@@ -155,6 +155,30 @@ def test_output_and_expected_artifacts_have_artifact_ids() -> None:
             )
 
 
+def test_each_template_includes_slurm_early_stop_criteria() -> None:
+    """Experiment cards should predeclare stop rules before long Slurm training runs."""
+    expected_fields = {
+        "metric",
+        "threshold",
+        "check_cadence",
+        "minimum_runtime_or_timesteps",
+        "cancel_condition",
+        "diagnostic_preservation_action",
+    }
+    for template_name in TEMPLATE_NAMES:
+        record = _build_record(
+            experiment_id=f"test_{template_name.replace('-', '_')}",
+            issue="9999",
+            issue_url="https://example.com/9999",
+            template_name=template_name,
+            output_root=Path("output/experiments"),
+        )
+        assert set(record["early_stop_criteria"]) == expected_fields
+        assert all(
+            str(value).startswith("TODO:") for value in record["early_stop_criteria"].values()
+        )
+
+
 def test_invalid_template_name_raises_key_error() -> None:
     """Passing an unrecognised template name should raise KeyError."""
     with pytest.raises(KeyError):
@@ -188,3 +212,7 @@ def test_cli_writes_to_requested_output_root(tmp_path: Path) -> None:
     assert (output_root / "issue_2103_smoke.yaml").is_file()
     assert (output_root / "CHECKLIST.md").is_file()
     assert not (output_root / "issue_2103_smoke" / "issue_2103_smoke.yaml").exists()
+
+    checklist = (output_root / "CHECKLIST.md").read_text(encoding="utf-8")
+    assert "Slurm Early-Stop Criteria" in checklist
+    assert "diagnostic preservation action" in checklist


### PR DESCRIPTION
## Summary
- closes #2138
- adds `early_stop_criteria` to generated experiment-card records
- adds checklist, Slurm submission, and Slurm skill guidance for predeclared low-signal cancellation criteria

## Validation
- `uv run pytest tests/tools/test_create_experiment_card.py -q`
- `uv run ruff check scripts/tools/create_experiment_card.py tests/tools/test_create_experiment_card.py`
- `uv run ruff format --check scripts/tools/create_experiment_card.py tests/tools/test_create_experiment_card.py`
- `git diff --check`
- generated-card smoke verified `early_stop_criteria` and checklist text while registry validation still passed

## Downstream Propagation
- Parent issue updated by this PR: yes, closes #2138.
- Claim map / benchmark report updated: NA, no benchmark result produced.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA; generated records gain optional metadata only.
- Context index / memory note updated: NA, no new durable result note needed.
- Follow-up issue opened for deferred propagation: NA.
- Full readiness gate not run because this is a low-risk docs/tooling guidance change with focused tests and path checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experiment cards now include an early-stop criteria section with required fields (metric, threshold, cadence, minimum runtime, cancel condition, and diagnostic preservation action).

* **Documentation**
  * Updated guidance on declaring and handling early-stop criteria for long-running training jobs.
  * Clarified how cancelled runs are classified as valid diagnostic evidence.

* **Tests**
  * Added test coverage for early-stop criteria field population in experiment card templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->