### PR TITLE
feat: add scenario belief projection diagnostics

### DIFF
--- a/docs/context/issue_1966_scenario_belief_interface.md
+++ b/docs/context/issue_1966_scenario_belief_interface.md
@@ -353,6 +353,35 @@ git diff --check
 - Complexity risk: graph, grid, ray, image, and fused projections can expand quickly; keep the first
   implementation slice narrow.
 
+### Issue #2157 Diagnostics Slice 2026-06-03
+
+Issue #2157 extends the MVP with diagnostic metadata and projection-diff tools for
+representation-quality inspection. The slice adds:
+
+- `TrackedAgentMetadata` dataclass with detection count, missed detections, track age,
+  last-detection timestamp, and coasted flag.
+- `EntityBelief.tracking` optional field populated for non-visible agents.
+- `AgentProjectionDiff` and `ProjectionDiff` dataclasses for structured oracle-vs-partial
+  comparison.
+- `compute_projection_diff()` function that returns a per-agent diff with visibility,
+  confidence, missing-fields, and policy-membership changes.
+- `ScenarioBelief.diagnostic_summary()` method returning a compact dict with
+  per-visibility-state counts, missing-data counts, not-observed-this-step counts, and
+  tracking-metadata counts.
+
+Claim boundary: this is representation/diagnostic-only evidence. It does not claim benchmark
+improvement, SNQI movement, calibrated real-sensor uncertainty, or paper-facing performance.
+Existing `SOCNAV_STRUCT` projection keys are unchanged.
+
+Validation recorded for the diagnostics slice:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/representation/test_scenario_belief.py -q
+scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/representation tests/representation
+scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/representation tests/representation
+git diff --check
+```
+
 ## Design-Only Validation
 
 Use cheap validation for this design-only note:

--- a/robot_sf/representation/__init__.py
+++ b/robot_sf/representation/__init__.py
@@ -1,21 +1,29 @@
 """Sensor-agnostic scenario representation adapters and projections."""
 
 from robot_sf.representation.scenario_belief import (
+    AgentProjectionDiff,
     BeliefSource,
     EntityBelief,
     Estimate2D,
+    ProjectionDiff,
     ScenarioBelief,
+    TrackedAgentMetadata,
     VisibilityState,
+    compute_projection_diff,
     scenario_belief_from_simulator_oracle,
     scenario_belief_from_visibility_limited_simulator,
 )
 
 __all__ = [
+    "AgentProjectionDiff",
     "BeliefSource",
     "EntityBelief",
     "Estimate2D",
+    "ProjectionDiff",
     "ScenarioBelief",
+    "TrackedAgentMetadata",
     "VisibilityState",
+    "compute_projection_diff",
     "scenario_belief_from_simulator_oracle",
     "scenario_belief_from_visibility_limited_simulator",
 ]

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -31,6 +31,33 @@ class VisibilityState(StrEnum):
 
 
 @dataclass(frozen=True)
+class TrackedAgentMetadata:
+    """Tracking-specific diagnostic metadata for tracked-agent beliefs.
+
+    This is representation/diagnostic-only evidence. It does not claim real-sensor
+    calibration, benchmark improvement, or SNQI movement.
+    """
+
+    track_id: str
+    detection_count: int = 0
+    missed_detections: int = 0
+    track_age_s: float = 0.0
+    last_detection_s: float = 0.0
+    is_coasted: bool = False
+
+    def to_debug_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON/YAML-ready tracking metadata."""
+        return {
+            "track_id": self.track_id,
+            "detection_count": self.detection_count,
+            "missed_detections": self.missed_detections,
+            "track_age_s": round(float(self.track_age_s), 6),
+            "last_detection_s": round(float(self.last_detection_s), 6),
+            "is_coasted": self.is_coasted,
+        }
+
+
+@dataclass(frozen=True)
 class BeliefSource:
     """Provenance for a value or entity inside a ScenarioBelief."""
 
@@ -100,10 +127,11 @@ class EntityBelief:
     source: BeliefSource
     last_observed_age_s: float = 0.0
     missing_fields: tuple[str, ...] = ()
+    tracking: TrackedAgentMetadata | None = None
 
     def to_debug_dict(self) -> dict[str, Any]:
         """Return deterministic JSON/YAML-ready entity metadata."""
-        return {
+        result: dict[str, Any] = {
             "entity_id": self.entity_id,
             "entity_type": self.entity_type,
             "position": self.position.to_debug_dict(),
@@ -116,6 +144,9 @@ class EntityBelief:
             "last_observed_age_s": round(float(self.last_observed_age_s), 6),
             "missing_fields": list(self.missing_fields),
         }
+        if self.tracking is not None:
+            result["tracking"] = self.tracking.to_debug_dict()
+        return result
 
 
 @dataclass(frozen=True)
@@ -132,6 +163,80 @@ class GoalBelief:
             "current": self.current.to_debug_dict(),
             "next": self.next.to_debug_dict(),
             "source": self.source.to_debug_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class AgentProjectionDiff:
+    """Per-agent comparison entry for projection/diagnostics inspection.
+
+    This is representation/diagnostic-only evidence. It does not claim benchmark
+    improvement, SNQI movement, or paper-facing performance.
+    """
+
+    entity_id: str
+    position_diff: float
+    velocity_diff: float
+    visibility_oracle: str
+    visibility_partial: str
+    confidence_oracle: float
+    confidence_partial: float
+    missing_fields_oracle: tuple[str, ...]
+    missing_fields_partial: tuple[str, ...]
+    in_policy_oracle: bool
+    in_policy_partial: bool
+
+    def to_debug_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON/YAML-ready agent diff entry."""
+        return {
+            "entity_id": self.entity_id,
+            "position_diff": round(float(self.position_diff), 6),
+            "velocity_diff": round(float(self.velocity_diff), 6),
+            "visibility_oracle": self.visibility_oracle,
+            "visibility_partial": self.visibility_partial,
+            "confidence_oracle": round(float(self.confidence_oracle), 6),
+            "confidence_partial": round(float(self.confidence_partial), 6),
+            "missing_fields_oracle": list(self.missing_fields_oracle),
+            "missing_fields_partial": list(self.missing_fields_partial),
+            "in_policy_oracle": self.in_policy_oracle,
+            "in_policy_partial": self.in_policy_partial,
+        }
+
+
+@dataclass(frozen=True)
+class ProjectionDiff:
+    """Compact structured diff between two ScenarioBelief projections.
+
+    This is representation/diagnostic-only evidence. It does not claim benchmark
+    improvement, SNQI movement, or paper-facing performance.
+    """
+
+    agent_diffs: tuple[AgentProjectionDiff, ...]
+    total_agents_oracle: int
+    total_agents_partial: int
+    visible_agents_oracle: int
+    visible_agents_partial: int
+    ego_position_diff: float
+    ego_heading_diff: float
+    goal_current_diff: float
+    goal_next_diff: float
+    agent_count_match: bool
+    policy_key_set_match: bool
+
+    def to_debug_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON/YAML-ready projection diff."""
+        return {
+            "agent_diffs": [d.to_debug_dict() for d in self.agent_diffs],
+            "total_agents_oracle": self.total_agents_oracle,
+            "total_agents_partial": self.total_agents_partial,
+            "visible_agents_oracle": self.visible_agents_oracle,
+            "visible_agents_partial": self.visible_agents_partial,
+            "ego_position_diff": round(float(self.ego_position_diff), 6),
+            "ego_heading_diff": round(float(self.ego_heading_diff), 6),
+            "goal_current_diff": round(float(self.goal_current_diff), 6),
+            "goal_next_diff": round(float(self.goal_next_diff), 6),
+            "agent_count_match": self.agent_count_match,
+            "policy_key_set_match": self.policy_key_set_match,
         }
 
 
@@ -156,6 +261,39 @@ class ScenarioBelief:
     pedestrian_radius: float
     schema_version: str = SCENARIO_BELIEF_SCHEMA_VERSION
     design_parent_issue: int = DESIGN_PARENT_ISSUE
+
+    def diagnostic_summary(self) -> dict[str, Any]:
+        """Return compact diagnostic summary for quick representation-quality inspection.
+
+        This is diagnostic-only evidence. It does not claim benchmark improvement,
+        SNQI movement, or paper-facing performance.
+        """
+        vis_counts: dict[str, int] = {}
+        for state in VisibilityState:
+            vis_counts[state.value] = 0
+        for agent in self.agents:
+            vis_counts[agent.visibility_state.value] += 1
+
+        return {
+            "frame_id": self.frame_id,
+            "sim_time_s": round(float(self.sim_time_s), 6),
+            "schema_version": self.schema_version,
+            "adapter": self.source_summary.adapter,
+            "total_agents": len(self.agents),
+            "visible_count": vis_counts[VisibilityState.VISIBLE.value],
+            "occluded_count": vis_counts[VisibilityState.OCCLUDED.value],
+            "out_of_range_count": vis_counts[VisibilityState.OUT_OF_RANGE.value],
+            "outside_fov_count": vis_counts[VisibilityState.OUTSIDE_FOV.value],
+            "unknown_count": vis_counts[VisibilityState.UNKNOWN.value],
+            "agents_with_missing_data": sum(1 for a in self.agents if a.missing_fields),
+            "agents_not_observed_this_step": sum(
+                1 for a in self.agents if a.last_observed_age_s > 0.0
+            ),
+            "agents_with_tracking_meta": sum(1 for a in self.agents if a.tracking is not None),
+            "coasted_agents": sum(
+                1 for a in self.agents if a.tracking is not None and a.tracking.is_coasted
+            ),
+        }
 
     def policy_projection_keys(self) -> tuple[str, ...]:
         """Return the stable top-level key set used by the SOCNAV_STRUCT projection."""
@@ -248,6 +386,133 @@ class ScenarioBelief:
         """
         position_cap = np.asarray(self.map_size, dtype=np.float32)
         return np.clip(values, 0.0, position_cap).astype(np.float32)
+
+
+def _in_policy_projection(
+    agents: tuple[EntityBelief, ...],
+    robot_pos: np.ndarray,
+    max_pedestrians: int,
+) -> frozenset[str]:
+    """Return entity_ids that pass the visibility + sort + cap policy filter.
+
+    This mirrors the agent-selection logic in ``ScenarioBelief.to_socnav_struct``
+    so diagnostic code can check per-agent policy membership without reimplementing
+    the full projection.
+    """
+    visible = [a for a in agents if a.visibility_state is VisibilityState.VISIBLE]
+    sorted_visible = sorted(
+        visible,
+        key=lambda a: (
+            float(np.linalg.norm(a.position.as_array() - robot_pos)),
+            a.entity_id,
+        ),
+    )[:max_pedestrians]
+    return frozenset(a.entity_id for a in sorted_visible)
+
+
+def compute_projection_diff(
+    oracle: ScenarioBelief,
+    partial: ScenarioBelief,
+    *,
+    max_pedestrians: int | None = None,
+) -> ProjectionDiff:
+    """Compute a compact structured diff between an oracle and partial-observation belief.
+
+    This is diagnostic-only evidence. It does not claim benchmark improvement,
+    SNQI movement, or paper-facing performance.
+
+    Args:
+        oracle: High-confidence oracle-source ScenarioBelief.
+        partial: Visibility-limited or otherwise degraded ScenarioBelief.
+        max_pedestrians: Cap for policy-projection membership (defaults to oracle's).
+
+    Returns:
+        ProjectionDiff: Per-agent and summary diff metadata.
+    """
+    if max_pedestrians is None:
+        max_pedestrians = oracle.max_pedestrians
+
+    oracle_by_id = {a.entity_id: a for a in oracle.agents}
+    partial_by_id = {a.entity_id: a for a in partial.agents}
+    all_ids = sorted(set(oracle_by_id.keys()) | set(partial_by_id.keys()))
+
+    robot_pos_oracle = oracle.ego.position.as_array()
+    robot_pos_partial = partial.ego.position.as_array()
+
+    oracle_policy_set = _in_policy_projection(oracle.agents, robot_pos_oracle, max_pedestrians)
+    partial_policy_set = _in_policy_projection(partial.agents, robot_pos_partial, max_pedestrians)
+
+    agent_diffs: list[AgentProjectionDiff] = []
+    for eid in all_ids:
+        oa = oracle_by_id.get(eid)
+        pa = partial_by_id.get(eid)
+
+        pos_oa = oa.position.as_array() if oa else np.zeros(2, dtype=np.float32)
+        pos_pa = pa.position.as_array() if pa else np.zeros(2, dtype=np.float32)
+        vel_oa = oa.velocity.as_array() if oa else np.zeros(2, dtype=np.float32)
+        vel_pa = pa.velocity.as_array() if pa else np.zeros(2, dtype=np.float32)
+
+        pos_diff = float(np.linalg.norm(pos_oa - pos_pa))
+        vel_diff = float(np.linalg.norm(vel_oa - vel_pa))
+
+        agent_diffs.append(
+            AgentProjectionDiff(
+                entity_id=eid,
+                position_diff=pos_diff,
+                velocity_diff=vel_diff,
+                visibility_oracle=oa.visibility_state.value
+                if oa
+                else VisibilityState.UNKNOWN.value,
+                visibility_partial=pa.visibility_state.value
+                if pa
+                else VisibilityState.UNKNOWN.value,
+                confidence_oracle=oa.position.confidence if oa else 0.0,
+                confidence_partial=pa.position.confidence if pa else 0.0,
+                missing_fields_oracle=oa.missing_fields if oa else (),
+                missing_fields_partial=pa.missing_fields if pa else (),
+                in_policy_oracle=eid in oracle_policy_set,
+                in_policy_partial=eid in partial_policy_set,
+            )
+        )
+
+    ego_pos_diff = float(np.linalg.norm(robot_pos_oracle - robot_pos_partial))
+    ego_heading_diff = _wrap_angle(oracle.ego.heading - partial.ego.heading)
+
+    oracle_goal = oracle.goals[0] if oracle.goals else _empty_goal(oracle.source_summary)
+    partial_goal = partial.goals[0] if partial.goals else _empty_goal(partial.source_summary)
+    goal_current_diff = float(
+        np.linalg.norm(
+            np.asarray(oracle_goal.current.mean_xy, dtype=np.float32)
+            - np.asarray(partial_goal.current.mean_xy, dtype=np.float32),
+        )
+    )
+    goal_next_diff = float(
+        np.linalg.norm(
+            np.asarray(oracle_goal.next.mean_xy, dtype=np.float32)
+            - np.asarray(partial_goal.next.mean_xy, dtype=np.float32),
+        )
+    )
+
+    oracle_keys = set(oracle.to_socnav_struct().keys())
+    partial_keys = set(partial.to_socnav_struct().keys())
+
+    return ProjectionDiff(
+        agent_diffs=tuple(agent_diffs),
+        total_agents_oracle=len(oracle.agents),
+        total_agents_partial=len(partial.agents),
+        visible_agents_oracle=sum(
+            1 for a in oracle.agents if a.visibility_state is VisibilityState.VISIBLE
+        ),
+        visible_agents_partial=sum(
+            1 for a in partial.agents if a.visibility_state is VisibilityState.VISIBLE
+        ),
+        ego_position_diff=ego_pos_diff,
+        ego_heading_diff=ego_heading_diff,
+        goal_current_diff=goal_current_diff,
+        goal_next_diff=goal_next_diff,
+        agent_count_match=len(oracle.agents) == len(partial.agents),
+        policy_key_set_match=oracle_keys == partial_keys,
+    )
 
 
 def scenario_belief_from_simulator_oracle(
@@ -404,6 +669,18 @@ def _agent_belief(
     confidence = 0.98 if visible else 0.35
     variance = 0.01 if visible else 1.0
     missing_fields = () if visible else ("policy_position", "policy_velocity")
+    tracking = (
+        None
+        if visible
+        else TrackedAgentMetadata(
+            track_id=f"track_ped_{idx:03d}",
+            detection_count=0,
+            missed_detections=3,
+            track_age_s=1.0,
+            last_detection_s=1.0,
+            is_coasted=True,
+        )
+    )
     return EntityBelief(
         entity_id=f"ped_{idx:03d}",
         entity_type="pedestrian",
@@ -416,6 +693,7 @@ def _agent_belief(
         source=source,
         last_observed_age_s=0.0 if visible else 1.0,
         missing_fields=missing_fields,
+        tracking=tracking,
     )
 
 

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -9,7 +9,9 @@ import pytest
 
 from robot_sf.gym_env.unified_config import ObservationVisibilitySettings, RobotSimulationConfig
 from robot_sf.representation import (
+    TrackedAgentMetadata,
     VisibilityState,
+    compute_projection_diff,
     scenario_belief_from_simulator_oracle,
     scenario_belief_from_visibility_limited_simulator,
 )
@@ -169,3 +171,174 @@ def test_adapter_falls_back_when_pedestrian_velocity_shape_mismatches() -> None:
 
     obs = belief.to_socnav_struct()
     np.testing.assert_allclose(obs["pedestrians"]["velocities"], np.zeros((4, 2), dtype=np.float32))
+
+
+def test_tracking_metadata_populated_for_non_visible_agents() -> None:
+    """Non-visible agents should carry TrackedAgentMetadata diagnostics."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=90.0,
+    )
+    simulator = _simulator_fixture()
+    partial = scenario_belief_from_visibility_limited_simulator(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    visible_agents = [a for a in partial.agents if a.visibility_state is VisibilityState.VISIBLE]
+    non_visible_agents = [
+        a for a in partial.agents if a.visibility_state is not VisibilityState.VISIBLE
+    ]
+
+    for agent in visible_agents:
+        assert agent.tracking is None, f"visible agent {agent.entity_id} should not have tracking"
+
+    for agent in non_visible_agents:
+        assert agent.tracking is not None, f"non-visible agent {agent.entity_id} missing tracking"
+        assert agent.tracking.is_coasted is True
+        assert agent.tracking.missed_detections == 3
+        assert agent.tracking.track_age_s == pytest.approx(1.0)
+        debug = agent.tracking.to_debug_dict()
+        assert debug["track_id"] == f"track_{agent.entity_id}"
+        assert debug["is_coasted"] is True
+
+
+def test_diagnostic_summary_reports_visibility_counts() -> None:
+    """diagnostic_summary should report per-visibility-state counts and metadata."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=90.0,
+    )
+    simulator = _simulator_fixture()
+    partial = scenario_belief_from_visibility_limited_simulator(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+    oracle = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    oracle_summary = oracle.diagnostic_summary()
+    assert oracle_summary["total_agents"] == 2
+    assert oracle_summary["visible_count"] == 2
+    assert oracle_summary["occluded_count"] == 0
+    assert oracle_summary["agents_with_missing_data"] == 0
+    assert oracle_summary["agents_not_observed_this_step"] == 0
+    assert oracle_summary["coasted_agents"] == 0
+    assert oracle_summary["adapter"] == "simulator_oracle"
+
+    partial_summary = partial.diagnostic_summary()
+    assert partial_summary["total_agents"] == 2
+    assert partial_summary["visible_count"] == 1
+    assert partial_summary["outside_fov_count"] == 1
+    assert partial_summary["agents_with_missing_data"] == 1
+    assert partial_summary["agents_not_observed_this_step"] == 1
+    assert partial_summary["agents_with_tracking_meta"] == 1
+    assert partial_summary["coasted_agents"] == 1
+    assert partial_summary["adapter"] == "visibility_limited_simulator"
+
+
+def test_compute_projection_diff_detects_oracle_vs_partial_differences() -> None:
+    """compute_projection_diff should report per-agent and summary diffs."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=90.0,
+    )
+    simulator = _simulator_fixture()
+    oracle = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+    partial = scenario_belief_from_visibility_limited_simulator(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    diff = compute_projection_diff(oracle, partial)
+
+    assert diff.total_agents_oracle == 2
+    assert diff.total_agents_partial == 2
+    assert diff.visible_agents_oracle == 2
+    assert diff.visible_agents_partial == 1
+    assert diff.agent_count_match is True
+    assert diff.policy_key_set_match is True
+    assert diff.ego_position_diff == pytest.approx(0.0)
+
+    agent_diffs_by_id = {d.entity_id: d for d in diff.agent_diffs}
+    assert len(agent_diffs_by_id) == 2
+
+    fov_agent = agent_diffs_by_id["ped_001"]
+    assert fov_agent.visibility_oracle == "visible"
+    assert fov_agent.visibility_partial == "outside_fov"
+    assert fov_agent.in_policy_oracle is True
+    assert fov_agent.in_policy_partial is False
+    assert fov_agent.confidence_oracle > fov_agent.confidence_partial
+    assert "policy_position" in fov_agent.missing_fields_partial
+
+
+def test_compute_projection_diff_empty_agents() -> None:
+    """compute_projection_diff should handle empty agent tuples."""
+    env_config = RobotSimulationConfig()
+    empty_sim = SimpleNamespace(
+        ped_pos=np.zeros((0, 2), dtype=np.float32),
+        ped_vel=np.zeros((0, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=0.4),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=8.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+    oracle = scenario_belief_from_simulator_oracle(
+        empty_sim,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+    partial = scenario_belief_from_visibility_limited_simulator(
+        empty_sim,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    diff = compute_projection_diff(oracle, partial)
+    assert diff.total_agents_oracle == 0
+    assert diff.total_agents_partial == 0
+    assert diff.visible_agents_oracle == 0
+    assert diff.visible_agents_partial == 0
+    assert len(diff.agent_diffs) == 0
+    assert diff.agent_count_match is True
+
+
+def test_tracked_agent_metadata_to_debug_dict_produces_deterministic_output() -> None:
+    """TrackedAgentMetadata.to_debug_dict should be stable and JSON-ready."""
+    meta = TrackedAgentMetadata(
+        track_id="track_ped_001",
+        detection_count=5,
+        missed_detections=2,
+        track_age_s=3.0,
+        last_detection_s=2.5,
+        is_coasted=False,
+    )
+    debug = meta.to_debug_dict()
+    assert debug["track_id"] == "track_ped_001"
+    assert debug["detection_count"] == 5
+    assert debug["missed_detections"] == 2
+    assert debug["track_age_s"] == 3.0
+    assert debug["last_detection_s"] == 2.5
+    assert debug["is_coasted"] is False
+    # second call should match
+    assert meta.to_debug_dict() == debug


### PR DESCRIPTION
## Summary

- Adds diagnostic-only `TrackedAgentMetadata`, `diagnostic_summary()`, `AgentProjectionDiff`, `ProjectionDiff`, and `compute_projection_diff()` for ScenarioBelief oracle-vs-partial inspection.
- Exports the new representation diagnostics from `robot_sf.representation`.
- Adds focused tests that preserve existing `SOCNAV_STRUCT` policy key behavior while checking visibility, missing-data, tracking, and policy-membership diagnostics.
- Updates the ScenarioBelief context note with the #2157 diagnostic slice and claim boundary.

Closes #2157

## PR Expected Impact

This makes ScenarioBelief projection differences inspectable without changing policy-facing observation keys. It supports downstream research/debugging of oracle versus partial-observation paths while staying representation/compatibility evidence only.

## Research Result Guidance

Target claim/hypothesis: ScenarioBelief can expose source, confidence, uncertainty, visibility, missing-data, stale-track, and projection-membership differences while preserving stable policy-facing `SOCNAV_STRUCT` keys.

Evidence tier: representation / compatibility diagnostic evidence.

Result classification: diagnostic-only blocker-resolution. This PR improves inspectability and tests compatibility, but does not claim benchmark improvement, SNQI movement, calibrated real-sensor uncertainty, or paper-facing performance.

Decision/stop rule: complete when oracle and visibility-limited beliefs produce the same policy projection key set and diagnostics expose the expected visibility/missing-data/tracking differences under targeted tests.

Assumptions to preserve: tracking metadata is synthetic diagnostic metadata for current visibility-limited adapters; real tracked-agent/camera/fusion adapters may need richer fields later.

## Downstream Propagation

Parent issue updated (yes/no/NA): yes, via this PR closing #2157.

Claim map / benchmark report updated (yes/no/NA): yes, the ScenarioBelief context note is updated; no benchmark report is involved.

Leaderboard / artifact catalog updated (yes/no/NA): NA; no benchmark artifact or leaderboard output is produced.

Registry or config index updated (yes/no/NA): NA; no config registry changes.

Context index / memory note updated (yes/no/NA): yes, `docs/context/issue_1966_scenario_belief_interface.md` records the slice.

Follow-up issue opened for deferred propagation (yes/no/NA): NA; future real tracked-agent/camera/fusion adapter work can be scoped separately when concrete adapter inputs are selected.

Not applicable because: this is representation-code and diagnostics, not an evidence-producing benchmark campaign.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/representation/test_scenario_belief.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests -k "scenario_belief or representation" -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/representation tests/representation/test_scenario_belief.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/representation tests/representation/test_scenario_belief.py`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

Ignored local validation byproducts observed but not staged: `.venv/`, `output/coverage/`, and local OpenCode route scaffolding.

## Follow-Up Issues

Known limitations: diagnostics are synthetic/representation-level. Real tracked-agent or camera-detection adapters may need extra fields such as detection confidence, class distributions, sensor timestamps, or filter state once those adapter inputs are selected.
