### PR TITLE
perf: profile benchmark worker scaling

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -161,6 +161,10 @@ knowledge, not every transient iteration detail.
 
   [issue_2170_one_factor_hybrid_component_manifest.md](issue_2170_one_factor_hybrid_component_manifest.md)
 
+* Issue #2172 benchmark worker scaling diagnostic:
+
+  [issue_2172_benchmark_worker_scaling.md](issue_2172_benchmark_worker_scaling.md)
+
 * Issue #1530 optional planner preflight audit:
   [issue_1530_optional_preflight_audit.md](issue_1530_optional_preflight_audit.md)
 * Issue #1348 capability-aware map catalog design:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -89,6 +89,10 @@ entries:
     status: current
     freshness: maintained
     area: benchmark_release
+  - path: docs/context/issue_2172_benchmark_worker_scaling.md
+    status: current
+    freshness: maintained
+    area: benchmark_release
   - path: docs/context/issue_750_paper_results_handoff.md
     status: current
     freshness: maintained

--- a/docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/README.md
+++ b/docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/README.md
@@ -1,0 +1,25 @@
+# Issue #2172 Benchmark Worker Scaling Evidence
+
+Status: diagnostic-only local runtime evidence.
+
+This directory contains the compact comparison promoted from a local worker-scaling profile. Raw
+episode JSONL files and per-run summaries remain under ignored `output/` paths.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/profile_benchmark_worker_scaling.py \
+  --candidate hybrid_rule_v3_fast_progress --stage nominal_sanity --workers 1 2 --horizon 80 \
+  --output-root output/issue_2172/helper_nominal_h80
+```
+
+## Result
+
+| Workers | Jobs | Episodes | Runtime sec | Sec/job | Speedup |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 18 | 18 | 86.314 | 4.795 | 1.000 |
+| 2 | 18 | 18 | 48.140 | 2.674 | 1.793 |
+
+The planner gate decision was `revise` for both rows. This evidence only supports the simulator
+runtime direction: the same local slice ran faster with two workers. It is not a planner-quality,
+promotion, paper-facing, or benchmark-strength claim.

--- a/docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/summary.json
+++ b/docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/summary.json
@@ -1,0 +1,40 @@
+{
+  "candidate": "hybrid_rule_v3_fast_progress",
+  "claim_boundary": "diagnostic-only",
+  "generated_at": "2026-06-03T18:29:20.359314+00:00",
+  "git_hash": "2159fd43d119d764259814d8f9cbac388fa9a0ca",
+  "horizon": 80,
+  "issue": 2172,
+  "rows": [
+    {
+      "batch_runtime_sec": 86.30838280700846,
+      "batch_workers": 1,
+      "decision": "revise",
+      "episodes": 18,
+      "exit_code": 0,
+      "jobs": 18,
+      "parallel_execution": false,
+      "runtime_sec": 86.31387022102717,
+      "seconds_per_job": 4.795215012279288,
+      "speedup_vs_min_workers": 1.0,
+      "status": "ok",
+      "workers": 1
+    },
+    {
+      "batch_runtime_sec": 48.13376480201259,
+      "batch_workers": 2,
+      "decision": "revise",
+      "episodes": 18,
+      "exit_code": 0,
+      "jobs": 18,
+      "parallel_execution": true,
+      "runtime_sec": 48.139501333003864,
+      "seconds_per_job": 2.674416740722437,
+      "speedup_vs_min_workers": 1.792994688996735,
+      "status": "ok",
+      "workers": 2
+    }
+  ],
+  "schema_version": "robot-sf-benchmark-worker-scaling-profile.v1",
+  "stage": "nominal_sanity"
+}

--- a/docs/context/issue_2172_benchmark_worker_scaling.md
+++ b/docs/context/issue_2172_benchmark_worker_scaling.md
@@ -1,0 +1,45 @@
+# Issue #2172 Benchmark Worker Scaling Diagnostic
+
+Status: current, diagnostic-only.
+
+Issue #2172 asked for a simulator-speed fallback lane after the research queue was exhausted. This
+slice adds a repeatable profiling helper and records one local worker-scaling result for the
+policy-search candidate runner.
+
+## What Changed
+
+- Added `workers`, `parallel_execution`, and `batch_runtime_sec` to the `run_map_batch` summary so
+  candidate-runner `summary.json` files identify the worker count and batch wall time directly.
+- Added `scripts/tools/profile_benchmark_worker_scaling.py`, a thin wrapper around
+  `scripts/validation/run_policy_search_candidate.py` that runs one candidate/stage across worker
+  counts and writes a compact comparison JSON.
+- Promoted compact evidence under
+  `docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/`; raw JSONL outputs remain
+  ignored under `output/`.
+
+## Diagnostic Result
+
+Command:
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/profile_benchmark_worker_scaling.py \
+  --candidate hybrid_rule_v3_fast_progress --stage nominal_sanity --workers 1 2 --horizon 80 \
+  --output-root output/issue_2172/helper_nominal_h80
+```
+
+Result on commit `2159fd43d119d764259814d8f9cbac388fa9a0ca`:
+
+| Workers | Jobs | Episodes | Runtime sec | Sec/job | Speedup |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 18 | 18 | 86.314 | 4.795 | 1.000 |
+| 2 | 18 | 18 | 48.140 | 2.674 | 1.793 |
+
+Interpretation: this local 18-job h80 nominal-sanity slice showed useful parallel speedup, while
+the one-episode smoke slice was dominated by startup overhead and was not a meaningful scaling
+probe. The candidate gate decision stayed `revise`; this is runtime-diagnostic evidence only.
+
+## Follow-Up Direction
+
+The next smallest useful optimization question is whether worker counts above two improve
+throughput enough to justify their CPU and memory cost on pedestrian-heavy slices. Use repeated
+profiles and report median runtime before changing benchmark defaults.

--- a/docs/context/policy_search/INDEX.md
+++ b/docs/context/policy_search/INDEX.md
@@ -20,6 +20,7 @@ It points to the smallest authority surface for common agent questions.
 | H500/latest policy-search analysis | `reports/2026-05-05_full_matrix_h500_analysis.md` | Current h500 leader analysis and caveats. |
 | Component ablation pilot | `../issue_2104_component_ablation_pilot.md` | Retrospective grouped-component pilot for leading hybrid candidates; diagnostic only, not one-factor proof. |
 | One-factor component manifest | `../issue_2170_one_factor_hybrid_component_manifest.md` | Pre-execution contract for the next one-factor hybrid component ablation slice. |
+| Worker-scaling diagnostic | `../issue_2172_benchmark_worker_scaling.md` | Local runtime profile helper and compact evidence for policy-search worker scaling. |
 
 ## Lifecycle Routing
 

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -4246,6 +4246,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "max_abs_delta_linear": 0.0,
         "max_abs_delta_angular": 0.0,
     }
+    batch_started = time.perf_counter()
     if workers <= 1:
         for scenario, seed in jobs:
             try:
@@ -4396,6 +4397,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
 
     summary = {
         "total_jobs": total_jobs,
+        "workers": int(workers),
+        "parallel_execution": bool(workers > 1),
+        "batch_runtime_sec": float(max(time.perf_counter() - batch_started, 0.0)),
         "written": wrote,
         "successful_jobs": wrote,
         "failed_jobs": len(failures),

--- a/scripts/tools/profile_benchmark_worker_scaling.py
+++ b/scripts/tools/profile_benchmark_worker_scaling.py
@@ -1,0 +1,184 @@
+"""Profile policy-search benchmark runtime across worker counts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object from path."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"{path}: expected JSON object")
+    return payload
+
+
+def _worker_label(worker_count: int) -> str:
+    """Return the output subdirectory label for a worker count."""
+    return f"workers_{worker_count}"
+
+
+def _run_candidate_stage(
+    *,
+    candidate: str,
+    stage: str,
+    worker_count: int,
+    output_root: Path,
+    horizon: int | None,
+    extra_args: list[str],
+) -> dict[str, Any]:
+    """Run one candidate stage and return a compact timing row."""
+    run_dir = output_root / _worker_label(worker_count)
+    display_run_dir = (
+        run_dir.relative_to(REPO_ROOT) if run_dir.is_relative_to(REPO_ROOT) else run_dir
+    )
+    command = [
+        sys.executable,
+        "scripts/validation/run_policy_search_candidate.py",
+        "--candidate",
+        candidate,
+        "--stage",
+        stage,
+        "--workers",
+        str(worker_count),
+        "--output-dir",
+        str(display_run_dir),
+    ]
+    if horizon is not None:
+        command.extend(["--horizon", str(horizon)])
+    command.extend(extra_args)
+
+    completed = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    summary_path = run_dir / "summary.json"
+    row: dict[str, Any] = {
+        "workers": int(worker_count),
+        "command": ["python", *command[1:]],
+        "exit_code": int(completed.returncode),
+        "summary_path": str(summary_path.relative_to(REPO_ROOT)),
+    }
+    if completed.returncode != 0 or not summary_path.exists():
+        row["status"] = "failed"
+        row["message"] = "candidate runner failed or did not write summary.json"
+        return row
+
+    summary_doc = _load_json(summary_path)
+    summary = summary_doc.get("summary")
+    batch_summary = summary_doc.get("batch_summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    if not isinstance(batch_summary, dict):
+        batch_summary = {}
+
+    runtime_sec = summary.get("runtime_sec")
+    jobs = batch_summary.get("total_jobs")
+    row.update(
+        {
+            "status": "ok",
+            "decision": summary_doc.get("decision"),
+            "episodes": summary.get("episodes"),
+            "runtime_sec": runtime_sec,
+            "jobs": jobs,
+            "batch_runtime_sec": batch_summary.get("batch_runtime_sec"),
+            "batch_workers": batch_summary.get("workers"),
+            "parallel_execution": batch_summary.get("parallel_execution"),
+            "seconds_per_job": (
+                float(runtime_sec) / float(jobs)
+                if isinstance(runtime_sec, int | float) and isinstance(jobs, int | float) and jobs
+                else None
+            ),
+        }
+    )
+    return row
+
+
+def _add_speedups(rows: list[dict[str, Any]]) -> None:
+    """Add speedup versus the lowest-worker successful row."""
+    ok_rows = [row for row in rows if row.get("status") == "ok"]
+    if not ok_rows:
+        return
+    baseline = min(ok_rows, key=lambda row: int(row["workers"]))
+    baseline_runtime = baseline.get("runtime_sec")
+    if not isinstance(baseline_runtime, int | float) or baseline_runtime <= 0:
+        return
+    for row in ok_rows:
+        runtime = row.get("runtime_sec")
+        if isinstance(runtime, int | float) and runtime > 0:
+            row["speedup_vs_min_workers"] = float(baseline_runtime) / float(runtime)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--stage", default="nominal_sanity")
+    parser.add_argument("--workers", type=int, nargs="+", default=[1, 2])
+    parser.add_argument("--horizon", type=int)
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("output") / "benchmark_worker_scaling" / "latest",
+    )
+    parser.add_argument(
+        "--summary-out",
+        type=Path,
+        help="Path for compact comparison JSON. Defaults to <output-root>/worker_scaling_summary.json.",
+    )
+    parser.add_argument(
+        "extra_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments passed after -- to run_policy_search_candidate.py.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the worker-scaling profile."""
+    args = parse_args(argv)
+    output_root = (REPO_ROOT / args.output_root).resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    summary_out = args.summary_out or output_root / "worker_scaling_summary.json"
+    summary_out = (
+        (REPO_ROOT / summary_out).resolve() if not summary_out.is_absolute() else summary_out
+    )
+    extra_args = list(args.extra_args)
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+
+    rows = [
+        _run_candidate_stage(
+            candidate=str(args.candidate),
+            stage=str(args.stage),
+            worker_count=int(worker_count),
+            output_root=output_root,
+            horizon=args.horizon,
+            extra_args=extra_args,
+        )
+        for worker_count in args.workers
+    ]
+    _add_speedups(rows)
+    payload = {
+        "schema_version": "robot-sf-benchmark-worker-scaling-profile.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "candidate": args.candidate,
+        "stage": args.stage,
+        "horizon": args.horizon,
+        "output_root": str(output_root.relative_to(REPO_ROOT)),
+        "rows": rows,
+        "claim_boundary": "diagnostic-only",
+    }
+    summary_out.parent.mkdir(parents=True, exist_ok=True)
+    summary_out.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if all(row.get("status") == "ok" for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -3405,6 +3405,9 @@ def test_run_map_batch_parallel_writes_results_in_job_order(
     )
 
     assert result["written"] == 2
+    assert result["workers"] == 2
+    assert result["parallel_execution"] is True
+    assert result["batch_runtime_sec"] >= 0.0
     lines = out_path.read_text(encoding="utf-8").splitlines()
     records = [json.loads(line) for line in lines]
     assert records[0]["episode_id"].startswith("slow-")
@@ -3496,6 +3499,9 @@ def test_run_map_batch_filters_and_validation(
         resume=False,
     )
     assert result["total_jobs"] == 1
+    assert result["workers"] == 1
+    assert result["parallel_execution"] is False
+    assert result["batch_runtime_sec"] >= 0.0
 
 
 def test_run_map_batch_rejects_invalid_experimental_ped_impact_controls(


### PR DESCRIPTION
## Summary
Adds a repeatable policy-search worker-scaling profiler and records a compact diagnostic result for issue #2172. Also exposes worker count and batch wall time in `run_map_batch` summaries so future runtime reports are self-describing.

## Linked Issues
- Closes `#2172`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `scripts/tools/profile_benchmark_worker_scaling.py` to run an existing policy-search candidate stage across worker counts and emit compact comparison JSON.
- Added `workers`, `parallel_execution`, and `batch_runtime_sec` to `robot_sf.benchmark.map_runner.run_map_batch` summaries.
- Added focused test assertions for sequential and parallel `run_map_batch` metadata.
- Added indexed diagnostic context/evidence notes.

## Why It Matters
- Added value: makes small benchmark worker-scaling checks reproducible.
- Expected impact: supports simulator-speed optimization decisions without changing benchmark metrics or planner semantics.
- Why this is worth merging now: research-ready work was exhausted, and this creates the fallback runtime evidence lane requested in #2172.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: diagnostic simulator-speed direction; whether small policy-search slices benefit from benchmark worker parallelism.
- Comparator or baseline, if applicable: identical `hybrid_rule_v3_fast_progress` nominal-sanity h80 slice with `workers=1` vs `workers=2`.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: do not change worker defaults from this single run; use repeated profiles/median runtime before default changes.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2172_benchmark_worker_scaling.md` and `docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use recorded in tracked compact evidence summary. Raw local JSONL remains ignored under `output/`.

## Validation / Proof
- Commands run:
  - `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/profile_benchmark_worker_scaling.py --candidate hybrid_rule_v3_fast_progress --stage nominal_sanity --workers 1 2 --horizon 80 --output-root output/issue_2172/helper_nominal_h80`
  - `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/profile_benchmark_worker_scaling.py --candidate hybrid_rule_v3_fast_progress --stage smoke --workers 1 2 --output-root output/issue_2172/helper_smoke_portable`
  - `uv run pytest tests/benchmark/test_map_runner_utils.py -k 'parallel_writes_results_in_job_order or filters_and_validation'`
  - `uv run python -m py_compile scripts/tools/profile_benchmark_worker_scaling.py`
  - `uv run ruff check scripts/tools/profile_benchmark_worker_scaling.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py`
  - `uv run ruff format --check scripts/tools/profile_benchmark_worker_scaling.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py`
  - `uv run python -m json.tool docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/summary.json`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `git diff --cached --check`
- Evidence that the change works here: branch-head helper profile wrote compact rows with `batch_runtime_sec`, `batch_workers`, and `parallel_execution`; tracked evidence records 18 jobs at 86.314s for worker=1 and 48.140s for worker=2, speedup 1.793x.
- Benchmarks or smoke tests, if applicable: candidate gate decision remained `revise`; this is runtime-diagnostic evidence only, not planner promotion evidence.

## Risks / Rollout
- Compatibility risks: low; summary keys are additive metadata.
- Failure modes: helper invokes the candidate runner sequentially and may take time on larger stages; generated summaries should be promoted only as compact evidence when needed.
- Rollback or fallback plan: remove the helper and additive summary fields; existing benchmark metrics and JSONL rows are unchanged.

## Docs / Provenance
- Updated docs: `docs/context/issue_2172_benchmark_worker_scaling.md`, `docs/context/README.md`, `docs/context/catalog.yaml`, `docs/context/policy_search/INDEX.md`.
- Relevant design or provenance notes: `docs/context/evidence/issue_2172_benchmark_worker_scaling_2026-06-03/README.md` and `summary.json`.
- Any assumptions that need to be preserved: this is one local diagnostic run on commit `2159fd43d119d764259814d8f9cbac388fa9a0ca`, not a benchmark-strength speed claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #2172.
- Claim map / benchmark report updated (yes/no/NA): NA; diagnostic-only runtime tooling.
- Leaderboard / artifact catalog updated (yes/no/NA): NA; no planner-quality result.
- Registry or config index updated (yes/no/NA): NA; no candidate/config registry change.
- Context index / memory note updated (yes/no/NA): yes, context README/catalog/policy-search index updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark metric, planner ranking, paper-facing claim, or default worker policy changed.

## Follow-Up Issues
- Deferred work: repeat worker-count profiles, including worker counts above 2 and pedestrian-heavy slices, before changing defaults.
- Issues opened for follow-up: none; the next step is captured in the context note.

## Reviewer Notes
- Please verify the helper remains a thin wrapper over the existing candidate runner and does not change benchmark semantics.
- The nominal-sanity candidate decision was `revise`; use the timing rows only for runtime direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added benchmark worker scaling profiling tool for performance analysis across worker configurations.
  * Enhanced benchmark summaries with worker count, parallelization status, and batch runtime metrics.

* **Documentation**
  * Added diagnostic guide for benchmark worker scaling with local profiling results and recommendations.
  * Added policy search worker scaling reference to documentation index.

* **Tests**
  * Updated benchmark tests to verify new worker and runtime metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->