### PR TITLE
research: publish remaining h80 ablation evidence

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -169,6 +169,10 @@ knowledge, not every transient iteration detail.
 
   [issue_2174_one_factor_ablation_pilot.md](issue_2174_one_factor_ablation_pilot.md)
 
+* Issue #2176 remaining one-factor hybrid component h80 comparisons:
+
+  [issue_2176_remaining_one_factor_h80.md](issue_2176_remaining_one_factor_h80.md)
+
 * Issue #1530 optional planner preflight audit:
   [issue_1530_optional_preflight_audit.md](issue_1530_optional_preflight_audit.md)
 * Issue #1348 capability-aware map catalog design:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -97,6 +97,10 @@ entries:
     status: current
     freshness: maintained
     area: benchmark_release
+  - path: docs/context/issue_2176_remaining_one_factor_h80.md
+    status: current
+    freshness: maintained
+    area: benchmark_release
   - path: docs/context/issue_750_paper_results_handoff.md
     status: current
     freshness: maintained

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -101,7 +101,7 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   the #1610 scenario perturbation criticality pilot.
 - `issue_1939_corridor_trace_response_2026-05-31/`: compact diagnostic-only closest-approach trace
   slices for the `classic_head_on_corridor_low` pedestrian-route-offset response observed in the
-  #1610/#1937 pilot.
+  Issue #1610/Issue #1937 pilot.
 - `issue_1941_ped_timing_phase_2026-05-31/`: compact diagnostic-only paired
   no-op-versus-start-delay summary for the #1610 single-pedestrian timing phase perturbation pilot.
 - `issue_1943_ped_speed_perturbation_2026-05-31/`: compact diagnostic-only paired
@@ -118,3 +118,6 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
   single-pedestrian phase grid.
 - `issue_1953_intersection_wait_speed_grid_trace_2026-06-01/`: compact diagnostic-only
   closest-approach trace slices for the strongest #1951 intersection-wait speed-grid response.
+- `issue_2176_remaining_one_factor_h80_2026-06-03/`: compact diagnostic-only h80 summary for the
+  remaining selected Issue #2170 one-factor hybrid component comparisons, including the partial
+  selector-only row caveat.

--- a/docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/README.md
+++ b/docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/README.md
@@ -1,0 +1,45 @@
+# Issue #2176 Remaining One-Factor h80 Evidence
+
+Status: diagnostic-only local evidence; one selector row is partial.
+
+This directory preserves the compact summary promoted from the remaining h80 comparisons in the
+Issue #2170 one-factor hybrid component manifest. Raw JSONL rows, generated candidate reports,
+temporary funnels, and seed files remain in ignored `output/` paths and are reproducible from the
+command, commit, and tracked configs.
+
+## Command
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py \
+  --comparison-id static_recenter_only_minus_base \
+  --comparison-id escape_recenter_pair_minus_static_escape_only \
+  --comparison-id grouped_transit_minus_escape_recenter_pair \
+  --comparison-id continuous_checks_minus_grouped_static \
+  --comparison-id selector_only_minus_grouped_static \
+  --comparison-id speed_progress_2p4_minus_base \
+  --horizon 80 --workers 2 \
+  --output-dir output/issue_2176/remaining_h80_w2
+```
+
+## Result
+
+| Comparison | Status | Success delta | Collision delta | Near-miss delta | Avg-speed delta | Runtime delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| static_recenter_only_minus_base | ok | 0.000 | 0.000 | 0.000 | +0.090 | +16.263s |
+| escape_recenter_pair_minus_static_escape_only | ok | 0.000 | 0.000 | 0.000 | +0.090 | +0.989s |
+| grouped_transit_minus_escape_recenter_pair | ok | 0.000 | 0.000 | 0.000 | 0.000 | -0.120s |
+| continuous_checks_minus_grouped_static | ok | 0.000 | 0.000 | 0.000 | -0.001 | +1.660s |
+| selector_only_minus_grouped_static | partial | 0.000 | +0.022 | -0.144 | -0.041 | -12.594s |
+| speed_progress_2p4_minus_base | ok | 0.000 | 0.000 | 0.000 | +0.011 | -0.099s |
+
+Seven candidate rows wrote 18/18 jobs with zero failed jobs. The
+`issue_2170_scenario_adaptive_orca_selector_only` row wrote 15/18 jobs with 3 failed jobs, so the
+selector comparison is partial and should not be used for a clean component conclusion.
+
+Local follow-up check: `uv run python -c 'import rvo2'` failed with `ModuleNotFoundError`, which is
+consistent with the selector-only failure mode reported by the run. Treat that as an environment
+dependency gap to resolve before rerunning the selector row.
+
+The run used commit `10c6142f28d2057a80408fa7c0af9e0b49817e8e`, horizon h80, and two workers. It
+is a mechanism diagnostic for local research direction only, not h500 benchmark evidence and not a
+planner-promotion claim.

--- a/docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/summary.json
+++ b/docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/summary.json
@@ -1,0 +1,233 @@
+{
+  "schema_version": "robot-sf-one-factor-ablation-pilot.v1",
+  "issue": 2176,
+  "parent_issue": 2104,
+  "manifest_issue": 2170,
+  "claim_boundary": "diagnostic-only",
+  "result_classification": "partial_h80_local_diagnostic",
+  "generated_at": "2026-06-03T19:29:55.981488+00:00",
+  "git_hash": "10c6142f28d2057a80408fa7c0af9e0b49817e8e",
+  "horizon": 80,
+  "workers": 2,
+  "manifest": "configs/policy_search/ablation_manifests/issue_2170_one_factor_hybrid_component_manifest.yaml",
+  "selected_comparisons": [
+    "static_recenter_only_minus_base",
+    "escape_recenter_pair_minus_static_escape_only",
+    "grouped_transit_minus_escape_recenter_pair",
+    "continuous_checks_minus_grouped_static",
+    "selector_only_minus_grouped_static",
+    "speed_progress_2p4_minus_base"
+  ],
+  "candidate_results": {
+    "hybrid_rule_v3_fast_progress": {
+      "candidate": "hybrid_rule_v3_fast_progress",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.3959925710567398,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 49.2400654660305,
+        "success_rate": 0.0
+      }
+    },
+    "hybrid_rule_v3_fast_progress_static_escape": {
+      "candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.4858860664338829,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 65.52505390602164,
+        "success_rate": 0.0
+      }
+    },
+    "hybrid_rule_v3_progress_2p4": {
+      "candidate": "hybrid_rule_v3_progress_2p4",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.406799162931882,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 49.141411743999925,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_continuous_static_checks_only": {
+      "candidate": "issue_2170_continuous_static_checks_only",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.4849303791156918,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 67.184579503024,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_scenario_adaptive_orca_selector_only": {
+      "candidate": "issue_2170_scenario_adaptive_orca_selector_only",
+      "decision": "tracked",
+      "episodes": 15,
+      "exit_code": 0,
+      "failed_jobs": 3,
+      "status": "partial",
+      "total_jobs": 18,
+      "written": 15,
+      "summary": {
+        "collision_rate": 0.13333333333333333,
+        "mean_avg_speed": 1.4445983656460262,
+        "near_miss_rate": 0.13333333333333333,
+        "runtime_sec": 52.93076920002932,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_static_escape_only": {
+      "candidate": "issue_2170_static_escape_only",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.3959925710567398,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 64.6563785590115,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_static_escape_recenter_no_transit": {
+      "candidate": "issue_2170_static_escape_recenter_no_transit",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.4858860664338829,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 65.64512313104933,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_static_recenter_only": {
+      "candidate": "issue_2170_static_recenter_only",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.4858860664338829,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 65.50293387006968,
+        "success_rate": 0.0
+      }
+    }
+  },
+  "effect_rows": [
+    {
+      "comparison_id": "static_recenter_only_minus_base",
+      "a_candidate": "issue_2170_static_recenter_only",
+      "b_candidate": "hybrid_rule_v3_fast_progress",
+      "interpretation": "static recentering without static escape",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": 0.08989349537714308,
+      "runtime_sec_delta": 16.26286840403918
+    },
+    {
+      "comparison_id": "escape_recenter_pair_minus_static_escape_only",
+      "a_candidate": "issue_2170_static_escape_recenter_no_transit",
+      "b_candidate": "issue_2170_static_escape_only",
+      "interpretation": "recentering effect after static escape is enabled",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": 0.08989349537714308,
+      "runtime_sec_delta": 0.988744572037831
+    },
+    {
+      "comparison_id": "grouped_transit_minus_escape_recenter_pair",
+      "a_candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "b_candidate": "issue_2170_static_escape_recenter_no_transit",
+      "interpretation": "static corridor-transit terms after escape and recentering",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": 0.0,
+      "runtime_sec_delta": -0.12006922502769157
+    },
+    {
+      "comparison_id": "continuous_checks_minus_grouped_static",
+      "a_candidate": "issue_2170_continuous_static_checks_only",
+      "b_candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "interpretation": "continuous static-clearance checks",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": -0.0009556873181910674,
+      "runtime_sec_delta": 1.6595255970023572
+    },
+    {
+      "comparison_id": "selector_only_minus_grouped_static",
+      "a_candidate": "issue_2170_scenario_adaptive_orca_selector_only",
+      "b_candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "interpretation": "static scenario-adaptive ORCA selector; partial row because 3/18 jobs failed",
+      "status": "partial",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.022222222222222227,
+      "near_miss_rate_delta": -0.14444444444444446,
+      "mean_avg_speed_delta": -0.04128770078785671,
+      "runtime_sec_delta": -12.594284705992322
+    },
+    {
+      "comparison_id": "speed_progress_2p4_minus_base",
+      "a_candidate": "hybrid_rule_v3_progress_2p4",
+      "b_candidate": "hybrid_rule_v3_fast_progress",
+      "interpretation": "grouped speed-envelope/progress-pressure sensitivity",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": 0.010806591875142102,
+      "runtime_sec_delta": -0.09865372203057632
+    }
+  ]
+}

--- a/docs/context/issue_2104_component_ablation_pilot.md
+++ b/docs/context/issue_2104_component_ablation_pilot.md
@@ -46,3 +46,11 @@ contract; see
 [issue_2170_one_factor_hybrid_component_manifest.md](issue_2170_one_factor_hybrid_component_manifest.md).
 It remains proposal/pre-execution evidence until the planned candidate rows are implemented and the
 compact matrix is run with durable effect-size outputs.
+
+Update 2026-06-03: Issue [#2174](https://github.com/ll7/robot_sf_ll7/issues/2174) and Issue
+[#2176](https://github.com/ll7/robot_sf_ll7/issues/2176) executed the h80 staged pilot. See
+[issue_2174_one_factor_ablation_pilot.md](issue_2174_one_factor_ablation_pilot.md) and
+[issue_2176_remaining_one_factor_h80.md](issue_2176_remaining_one_factor_h80.md). The clean h80
+rows did not move success, collision, or near-miss rates; the selector-only row is partial because
+3/18 jobs failed, consistent with a local missing `rvo2` dependency. The parent research question
+therefore remains open for h500 execution or a selector-row rerun after the dependency is available.

--- a/docs/context/issue_2174_one_factor_ablation_pilot.md
+++ b/docs/context/issue_2174_one_factor_ablation_pilot.md
@@ -54,3 +54,7 @@ rows are executed.
 Run the remaining selected comparisons with the same tool, preferably at the manifest h500 horizon
 or with a documented staged horizon ladder. Report each row as diagnostic-only until all comparator
 rows execute without fallback, degraded, unavailable, or failed status.
+
+Update 2026-06-03: [issue_2176_remaining_one_factor_h80.md](issue_2176_remaining_one_factor_h80.md)
+runs the remaining selected h80 comparisons. It keeps the result diagnostic-only and reports the
+selector-only row as partial because 3/18 jobs failed.

--- a/docs/context/issue_2176_remaining_one_factor_h80.md
+++ b/docs/context/issue_2176_remaining_one_factor_h80.md
@@ -1,0 +1,73 @@
+# Issue #2176 Remaining One-Factor Hybrid Component h80 Comparisons
+
+Status: current, diagnostic-only; selector-only row is partial.
+
+Issue #2176 continues the Issue #2170 one-factor manifest for parent Issue #2104 after the first
+Issue #2174 static-escape pilot. It runs the remaining selected h80 comparison rows with the
+existing `scripts/tools/run_one_factor_ablation_pilot.py` wrapper, then promotes only the compact
+summary under `docs/context/evidence/`.
+
+## Evidence
+
+- Compact evidence bundle:
+  `docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/`
+- Manifest:
+  `configs/policy_search/ablation_manifests/issue_2170_one_factor_hybrid_component_manifest.yaml`
+- Predecessor pilot:
+  [issue_2174_one_factor_ablation_pilot.md](issue_2174_one_factor_ablation_pilot.md)
+
+Command:
+
+```bash
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py \
+  --comparison-id static_recenter_only_minus_base \
+  --comparison-id escape_recenter_pair_minus_static_escape_only \
+  --comparison-id grouped_transit_minus_escape_recenter_pair \
+  --comparison-id continuous_checks_minus_grouped_static \
+  --comparison-id selector_only_minus_grouped_static \
+  --comparison-id speed_progress_2p4_minus_base \
+  --horizon 80 --workers 2 \
+  --output-dir output/issue_2176/remaining_h80_w2
+```
+
+## Result
+
+The clean h80 rows did not move success rate, collision rate, or near-miss rate. Recenter-related
+rows increased average speed by about `+0.090` on this slice, while grouped corridor-transit terms,
+continuous static checks, and the grouped speed/progress-pressure sensitivity did not produce a
+material clean h80 outcome change.
+
+| Comparison | Status | Success delta | Collision delta | Near-miss delta | Avg-speed delta | Runtime delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| static_recenter_only_minus_base | ok | 0.000 | 0.000 | 0.000 | +0.090 | +16.263s |
+| escape_recenter_pair_minus_static_escape_only | ok | 0.000 | 0.000 | 0.000 | +0.090 | +0.989s |
+| grouped_transit_minus_escape_recenter_pair | ok | 0.000 | 0.000 | 0.000 | 0.000 | -0.120s |
+| continuous_checks_minus_grouped_static | ok | 0.000 | 0.000 | 0.000 | -0.001 | +1.660s |
+| selector_only_minus_grouped_static | partial | 0.000 | +0.022 | -0.144 | -0.041 | -12.594s |
+| speed_progress_2p4_minus_base | ok | 0.000 | 0.000 | 0.000 | +0.011 | -0.099s |
+
+Seven candidate rows wrote 18/18 jobs with zero failed jobs. The selector-only candidate wrote
+15/18 jobs with 3 failed jobs despite process exit code 0; therefore its apparent near-miss
+improvement and runtime reduction are incomplete-row signals, not a valid clean component effect.
+The local check `uv run python -c 'import rvo2'` failed with `ModuleNotFoundError`, matching the
+selector row's dependency-sensitive failure mode and making the selector rerun a setup task before
+it is a research-result task.
+
+## Interpretation
+
+Confidence is about 0.70 that, on this short-horizon local slice, the remaining one-factor static
+components are not independently moving headline outcome rates. The evidence is weaker for the
+selector-only row because failed jobs change the denominator and may hide harder cases.
+
+This does not close the Issue #2104/Issue #2170 research question. It narrows the next research
+direction: either run the manifest horizon h500 rows for clean candidates, or first debug the
+selector-only failed jobs so a complete denominator can be compared before any h500 escalation.
+
+## Claim Boundary
+
+- Diagnostic-only h80 local evidence.
+- Not h500 benchmark evidence.
+- No planner-promotion claim.
+- No one-factor causality claim for the partial selector row.
+- Raw `output/` files are disposable; this note and the compact evidence bundle are the durable
+  review surfaces.

--- a/docs/context/policy_search/INDEX.md
+++ b/docs/context/policy_search/INDEX.md
@@ -22,6 +22,7 @@ It points to the smallest authority surface for common agent questions.
 | One-factor component manifest | `../issue_2170_one_factor_hybrid_component_manifest.md` | Pre-execution contract for the next one-factor hybrid component ablation slice. |
 | Worker-scaling diagnostic | `../issue_2172_benchmark_worker_scaling.md` | Local runtime profile helper and compact evidence for policy-search worker scaling. |
 | One-factor ablation pilot | `../issue_2174_one_factor_ablation_pilot.md` | First executable one-factor comparison and runner for the #2170 manifest. |
+| Remaining one-factor h80 comparisons | `../issue_2176_remaining_one_factor_h80.md` | Remaining selected h80 component comparisons; diagnostic-only with a partial selector row. |
 
 ## Lifecycle Routing
 


### PR DESCRIPTION
Closes #2176

## Summary
- Ran the remaining selected Issue #2170 one-factor h80 comparisons for parent Issue #2104.
- Promoted compact diagnostic evidence under docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/.
- Added the Issue #2176 context note and linked it from the policy-search index, context catalog, parent #2104 note, and predecessor #2174 note.

## Research Result Guidance
- Target claim/hypothesis/blocker: determine whether the remaining one-factor static hybrid components show a useful short-horizon signal before h500 escalation.
- Comparator/baseline: selected manifest comparisons against base fast-progress, static escape, grouped static escape/recenter, and grouped speed/progress rows.
- Evidence tier: local h80 diagnostic-only evidence, not h500 benchmark evidence.
- Result classification: partial h80 diagnostic. Clean rows did not move success, collision, or near-miss rates; recenter rows changed mean speed by about +0.090. Selector-only is partial because 3/18 jobs failed.
- Decision/stop rule: do not claim one-factor causality or planner promotion; next step is h500 execution for clean rows or a selector rerun after resolving the missing rvo2 dependency.
- Synthesis surface/update target: docs/context/issue_2104_component_ablation_pilot.md and docs/context/issue_2176_remaining_one_factor_h80.md.

## Downstream Propagation
- Parent issue/context: #2104 context note updated.
- Claim map/benchmark report: not benchmark-strength; no leaderboard or promoted planner update.
- Registry/config index: no candidate registry changes.
- Context index/catalog: docs/context/README.md, docs/context/catalog.yaml, and docs/context/policy_search/INDEX.md updated.
- Evidence: compact summary promoted; raw output remains ignored.

## Validation
- LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py --comparison-id static_recenter_only_minus_base --comparison-id escape_recenter_pair_minus_static_escape_only --comparison-id grouped_transit_minus_escape_recenter_pair --comparison-id continuous_checks_minus_grouped_static --comparison-id selector_only_minus_grouped_static --comparison-id speed_progress_2p4_minus_base --horizon 80 --workers 2 --output-dir output/issue_2176/remaining_h80_w2
- BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
- uv run python -m json.tool docs/context/evidence/issue_2176_remaining_one_factor_h80_2026-06-03/summary.json >/dev/null
- git diff --check
- git diff --cached --check
- uv run python -c 'import rvo2' (expected failure: ModuleNotFoundError; documented as selector dependency caveat)\n\nFull PR readiness was not run because this is docs/evidence-only plus an already-executed local diagnostic run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation and evidence bundle for remaining one-factor hybrid component comparisons at h80 horizon, including diagnostic results and performance metrics.
  * Updated documentation catalogs and cross-references to reflect new diagnostic evidence and related findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->