### PR TITLE
research: rerun selector h80 with orca extra

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -173,6 +173,10 @@ knowledge, not every transient iteration detail.
 
   [issue_2176_remaining_one_factor_h80.md](issue_2176_remaining_one_factor_h80.md)
 
+* Issue #2178 selector ORCA-extra h80 rerun:
+
+  [issue_2178_selector_orca_extra_h80.md](issue_2178_selector_orca_extra_h80.md)
+
 * Issue #1530 optional planner preflight audit:
   [issue_1530_optional_preflight_audit.md](issue_1530_optional_preflight_audit.md)
 * Issue #1348 capability-aware map catalog design:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -101,6 +101,10 @@ entries:
     status: current
     freshness: maintained
     area: benchmark_release
+  - path: docs/context/issue_2178_selector_orca_extra_h80.md
+    status: current
+    freshness: maintained
+    area: benchmark_release
   - path: docs/context/issue_750_paper_results_handoff.md
     status: current
     freshness: maintained

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -121,3 +121,6 @@ to leave it ignored or delete it locally once the durable summary/report evidenc
 - `issue_2176_remaining_one_factor_h80_2026-06-03/`: compact diagnostic-only h80 summary for the
   remaining selected Issue #2170 one-factor hybrid component comparisons, including the partial
   selector-only row caveat.
+- `issue_2178_selector_orca_extra_h80_2026-06-03/`: compact diagnostic-only h80 summary for the
+  corrected selector-only one-factor comparison after syncing the `orca` extra and proving `rvo2`
+  availability.

--- a/docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/README.md
+++ b/docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/README.md
@@ -1,0 +1,31 @@
+# Issue #2178 Selector ORCA-Extra h80 Evidence
+
+Status: diagnostic-only local evidence; complete 18/18 selector rerun.
+
+This directory preserves the compact summary from the Issue #2178 rerun of the partial Issue #2176
+selector-only comparison. The worktree was synced with the `orca` extra, and `rvo2` import was
+proven before running the comparison.
+
+## Commands
+
+```bash
+CMAKE_BUILD_PARALLEL_LEVEL=8 uv sync --extra orca
+uv run python -c 'import rvo2; print(rvo2.__name__)'
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py \
+  --comparison-id selector_only_minus_grouped_static --horizon 80 --workers 2 \
+  --output-dir output/issue_2178/selector_h80_w2
+```
+
+## Result
+
+| Comparison | Status | Success delta | Collision delta | Near-miss delta | Avg-speed delta | Runtime delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| selector_only_minus_grouped_static | ok | 0.000 | 0.000 | 0.000 | -0.096 | -9.865s |
+
+Both candidates wrote 18/18 rows with zero failed jobs. The corrected selector-only h80 row removes
+the denominator caveat from Issue #2176. It still does not move headline outcome rates at h80; the
+only observed deltas are lower average speed and lower local runtime versus the grouped static
+comparator.
+
+Treat this as a setup correction plus diagnostic h80 evidence only. It is not h500 benchmark
+evidence and does not support a planner-promotion or component-causality claim by itself.

--- a/docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/summary.json
+++ b/docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/summary.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "robot-sf-one-factor-ablation-pilot.v1",
+  "issue": 2178,
+  "parent_issue": 2104,
+  "predecessor_issue": 2176,
+  "manifest_issue": 2170,
+  "claim_boundary": "diagnostic-only",
+  "result_classification": "complete_h80_selector_rerun",
+  "generated_at": "2026-06-03T19:55:55.288787+00:00",
+  "git_hash": "7e26c28980d4ed3671c3d1583979d37423b066ab",
+  "horizon": 80,
+  "workers": 2,
+  "orca_import_proof": {
+    "command": "uv run python -c 'import rvo2; print(rvo2.__name__)'",
+    "exit_code": 0,
+    "stdout": "rvo2"
+  },
+  "manifest": "configs/policy_search/ablation_manifests/issue_2170_one_factor_hybrid_component_manifest.yaml",
+  "selected_comparisons": [
+    "selector_only_minus_grouped_static"
+  ],
+  "candidate_results": {
+    "hybrid_rule_v3_fast_progress_static_escape": {
+      "candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.4858860664338829,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 66.38080525497207,
+        "success_rate": 0.0
+      }
+    },
+    "issue_2170_scenario_adaptive_orca_selector_only": {
+      "candidate": "issue_2170_scenario_adaptive_orca_selector_only",
+      "decision": "tracked",
+      "episodes": 18,
+      "exit_code": 0,
+      "failed_jobs": 0,
+      "status": "ok",
+      "total_jobs": 18,
+      "written": 18,
+      "summary": {
+        "collision_rate": 0.1111111111111111,
+        "mean_avg_speed": 1.389458389062321,
+        "near_miss_rate": 0.2777777777777778,
+        "runtime_sec": 56.51612786803162,
+        "success_rate": 0.0
+      }
+    }
+  },
+  "effect_rows": [
+    {
+      "comparison_id": "selector_only_minus_grouped_static",
+      "a_candidate": "issue_2170_scenario_adaptive_orca_selector_only",
+      "b_candidate": "hybrid_rule_v3_fast_progress_static_escape",
+      "interpretation": "static scenario-adaptive ORCA selector",
+      "status": "ok",
+      "success_rate_delta": 0.0,
+      "collision_rate_delta": 0.0,
+      "near_miss_rate_delta": 0.0,
+      "mean_avg_speed_delta": -0.09642767737156177,
+      "runtime_sec_delta": -9.864677386940457
+    }
+  ]
+}

--- a/docs/context/issue_2104_component_ablation_pilot.md
+++ b/docs/context/issue_2104_component_ablation_pilot.md
@@ -54,3 +54,9 @@ Update 2026-06-03: Issue [#2174](https://github.com/ll7/robot_sf_ll7/issues/2174
 rows did not move success, collision, or near-miss rates; the selector-only row is partial because
 3/18 jobs failed, consistent with a local missing `rvo2` dependency. The parent research question
 therefore remains open for h500 execution or a selector-row rerun after the dependency is available.
+
+Issue [#2178](https://github.com/ll7/robot_sf_ll7/issues/2178) completes that selector rerun after
+syncing the `orca` extra. See
+[issue_2178_selector_orca_extra_h80.md](issue_2178_selector_orca_extra_h80.md). The corrected h80
+selector row writes 18/18 jobs with zero failures and stays flat on success, collision, and
+near-miss rate.

--- a/docs/context/issue_2176_remaining_one_factor_h80.md
+++ b/docs/context/issue_2176_remaining_one_factor_h80.md
@@ -71,3 +71,8 @@ selector-only failed jobs so a complete denominator can be compared before any h
 - No one-factor causality claim for the partial selector row.
 - Raw `output/` files are disposable; this note and the compact evidence bundle are the durable
   review surfaces.
+
+Update 2026-06-03: [issue_2178_selector_orca_extra_h80.md](issue_2178_selector_orca_extra_h80.md)
+reruns the selector comparison after syncing the `orca` extra and proving `import rvo2`. The rerun
+wrote 18/18 selector rows with zero failed jobs, removing this note's selector denominator caveat.
+The corrected h80 selector row remains flat on success, collision, and near-miss rates.

--- a/docs/context/issue_2178_selector_orca_extra_h80.md
+++ b/docs/context/issue_2178_selector_orca_extra_h80.md
@@ -1,0 +1,55 @@
+# Issue #2178 Selector ORCA-Extra h80 Rerun
+
+Status: current, diagnostic-only; closes the Issue #2176 selector denominator caveat.
+
+Issue #2178 reruns the `selector_only_minus_grouped_static` comparison from the Issue #2170
+one-factor manifest after syncing the local worktree with the `orca` extra. The rerun proves
+`rvo2` is importable, then executes the same h80/2-worker diagnostic comparison.
+
+## Evidence
+
+- Compact evidence bundle:
+  `docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/`
+- Predecessor note:
+  [issue_2176_remaining_one_factor_h80.md](issue_2176_remaining_one_factor_h80.md)
+- Manifest:
+  `configs/policy_search/ablation_manifests/issue_2170_one_factor_hybrid_component_manifest.yaml`
+
+Commands:
+
+```bash
+CMAKE_BUILD_PARALLEL_LEVEL=8 uv sync --extra orca
+uv run python -c 'import rvo2; print(rvo2.__name__)'
+LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py \
+  --comparison-id selector_only_minus_grouped_static --horizon 80 --workers 2 \
+  --output-dir output/issue_2178/selector_h80_w2
+```
+
+## Result
+
+The selector-only rerun completed both candidates with 18/18 rows and zero failed jobs:
+
+| Comparison | Status | Success delta | Collision delta | Near-miss delta | Avg-speed delta | Runtime delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| selector_only_minus_grouped_static | ok | 0.000 | 0.000 | 0.000 | -0.096 | -9.865s |
+
+The previous Issue #2176 partial selector row was a local dependency/setup gap, not evidence of an
+intrinsic selector failure. With the denominator corrected, the selector-only h80 comparison is
+flat on success, collision, and near-miss rate. It reduces average speed by about `-0.096` and runs
+about `9.865s` faster than the grouped static comparator in this local run.
+
+## Interpretation
+
+Confidence is about 0.75 that the selector-only component is not independently improving headline
+h80 outcome rates on this short-horizon slice. This only fixes the h80 denominator; it does not
+settle the h500 component question.
+
+Next research direction: escalate the clean one-factor comparisons to the manifest h500 horizon if
+runtime budget allows, because h80 still has a zero-success floor across these rows.
+
+## Claim Boundary
+
+- Diagnostic-only h80 local evidence.
+- Not h500 benchmark evidence.
+- No planner-promotion claim.
+- No selector causality claim beyond the corrected h80 denominator.

--- a/docs/context/policy_search/INDEX.md
+++ b/docs/context/policy_search/INDEX.md
@@ -23,6 +23,7 @@ It points to the smallest authority surface for common agent questions.
 | Worker-scaling diagnostic | `../issue_2172_benchmark_worker_scaling.md` | Local runtime profile helper and compact evidence for policy-search worker scaling. |
 | One-factor ablation pilot | `../issue_2174_one_factor_ablation_pilot.md` | First executable one-factor comparison and runner for the #2170 manifest. |
 | Remaining one-factor h80 comparisons | `../issue_2176_remaining_one_factor_h80.md` | Remaining selected h80 component comparisons; diagnostic-only with a partial selector row. |
+| Selector ORCA-extra h80 rerun | `../issue_2178_selector_orca_extra_h80.md` | Corrected selector-only comparison after proving `rvo2`; diagnostic-only h80 evidence. |
 
 ## Lifecycle Routing
 


### PR DESCRIPTION
Closes #2178

## Summary
- Synced the #2178 worktree with the `orca` extra and proved `rvo2` imports.
- Reran `selector_only_minus_grouped_static` at h80/workers=2 and got complete 18/18 rows for both candidates with zero failed jobs.
- Promoted compact diagnostic evidence and linked the successor note from #2104, #2176, the context catalog, and policy-search index.

## Research Result Guidance
- Target claim/hypothesis/blocker: resolve the partial selector-only denominator from #2176 before any h500 escalation.
- Comparator/baseline: `issue_2170_scenario_adaptive_orca_selector_only` vs `hybrid_rule_v3_fast_progress_static_escape`.
- Evidence tier: local h80 diagnostic-only evidence after ORCA import proof.
- Result classification: complete h80 selector rerun. Success, collision, and near-miss deltas are all 0.000; average speed delta is -0.096 and runtime delta is -9.865s.
- Decision/stop rule: selector denominator caveat is resolved, but h80 remains zero-success diagnostic evidence only.
- Synthesis surface/update target: docs/context/issue_2178_selector_orca_extra_h80.md and docs/context/issue_2104_component_ablation_pilot.md.

## Downstream Propagation
- Parent issue/context: #2104 context note updated.
- Prior result: #2176 note updated to point to the corrected selector rerun.
- Claim map/benchmark report: no benchmark-strength or leaderboard update.
- Registry/config index: no candidate registry changes.
- Context index/catalog: docs/context/README.md, docs/context/catalog.yaml, and docs/context/policy_search/INDEX.md updated.
- Evidence: compact summary promoted; raw output remains ignored.

## Validation
- CMAKE_BUILD_PARALLEL_LEVEL=8 uv sync --extra orca
- uv run python -c 'import rvo2; print(rvo2.__name__)'\n- LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 uv run python scripts/tools/run_one_factor_ablation_pilot.py --comparison-id selector_only_minus_grouped_static --horizon 80 --workers 2 --output-dir output/issue_2178/selector_h80_w2\n- BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh\n- uv run python -m json.tool docs/context/evidence/issue_2178_selector_orca_extra_h80_2026-06-03/summary.json >/dev/null\n- git diff --check\n- git diff --cached --check\n\nFull PR readiness was not run because this is docs/evidence-only plus a targeted local diagnostic rerun.