### PR TITLE
perf: reduce map-runner force and write overhead

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from dataclasses import fields
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, TextIO
 
 import numpy as np
 import yaml
@@ -3410,12 +3410,11 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     forces_arr = np.array(forces, dtype=float, copy=True)
                     if forces_arr.shape != peds.shape:
                         forces_arr = np.zeros_like(peds, dtype=float)
-            else:
-                forces_arr = np.zeros_like(peds, dtype=float)
 
             robot_positions.append(robot_pos)
             ped_positions.append(peds)
-            ped_forces.append(forces_arr)
+            if record_forces:
+                ped_forces.append(forces_arr)
 
             meta = info.get("meta", {}) if isinstance(info, dict) else {}
             step_collision = collision_event(info)
@@ -3475,7 +3474,11 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         robot_pos_arr, config.sim_config.time_per_step_in_secs
     )
     ped_pos_arr = _stack_ped_positions(ped_positions)
-    ped_forces_arr = _stack_ped_positions(ped_forces, fill_value=np.nan)
+    ped_forces_arr = (
+        _stack_ped_positions(ped_forces, fill_value=np.nan)
+        if record_forces
+        else np.zeros_like(ped_pos_arr, dtype=float)
+    )
 
     obstacles = (
         sample_obstacle_points(map_def.obstacles, map_def.bounds) if map_def is not None else None
@@ -3684,12 +3687,22 @@ def _scenario_with_episode_seed_defaults(
 
 def _write_validated(out_path: Path, schema: dict[str, Any], record: dict[str, Any]) -> None:
     """Validate an episode record and append it as JSONL."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("a", encoding="utf-8") as handle:
+        _write_validated_to_handle(handle, schema, record)
+
+
+def _write_validated_to_handle(
+    handle: TextIO,
+    schema: dict[str, Any],
+    record: dict[str, Any],
+) -> None:
+    """Validate one episode record and append it to an open JSONL handle."""
     violations = validate_episode_success_integrity(record)
     if violations:
         raise ValueError("Episode integrity contradictions detected: " + "; ".join(violations))
     validate_episode(record, schema)
-    with out_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    handle.write(json.dumps(record, sort_keys=True) + "\n")
 
 
 def _run_map_job_worker(
@@ -4248,28 +4261,32 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     }
     batch_started = time.perf_counter()
     if workers <= 1:
-        for scenario, seed in jobs:
-            try:
-                rec = _run_map_job_worker((scenario, seed, fixed_params))
-                bridge_update = _apply_worker_metadata_bridge(
-                    rec,
-                    feasibility_totals=feasibility_totals,
-                    runtime_algorithm_contract=runtime_algorithm_contract,
-                )
-                adapter_samples_seen = adapter_samples_seen or bridge_update.adapter_requested_seen
-                adapter_native_steps += bridge_update.adapter_native_steps
-                adapter_adapted_steps += bridge_update.adapter_adapted_steps
-                runtime_algorithm_contract = bridge_update.runtime_algorithm_contract
-                _write_validated(out_path, schema, rec)
-                wrote += 1
-            except Exception as exc:  # pragma: no cover - error path
-                failures.append(
-                    {
-                        "scenario_id": scenario.get("name", "unknown"),
-                        "seed": seed,
-                        "error": repr(exc),
-                    }
-                )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("a", encoding="utf-8") as handle:
+            for scenario, seed in jobs:
+                try:
+                    rec = _run_map_job_worker((scenario, seed, fixed_params))
+                    bridge_update = _apply_worker_metadata_bridge(
+                        rec,
+                        feasibility_totals=feasibility_totals,
+                        runtime_algorithm_contract=runtime_algorithm_contract,
+                    )
+                    adapter_samples_seen = (
+                        adapter_samples_seen or bridge_update.adapter_requested_seen
+                    )
+                    adapter_native_steps += bridge_update.adapter_native_steps
+                    adapter_adapted_steps += bridge_update.adapter_adapted_steps
+                    runtime_algorithm_contract = bridge_update.runtime_algorithm_contract
+                    _write_validated_to_handle(handle, schema, rec)
+                    wrote += 1
+                except Exception as exc:  # pragma: no cover - error path
+                    failures.append(
+                        {
+                            "scenario_id": scenario.get("name", "unknown"),
+                            "seed": seed,
+                            "error": repr(exc),
+                        }
+                    )
     else:
         results_by_idx: dict[int, dict[str, Any]] = {}
         with ProcessPoolExecutor(max_workers=int(workers)) as ex:
@@ -4301,20 +4318,22 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             "error": repr(exc),
                         }
                     )
-        for idx in sorted(results_by_idx):
-            try:
-                _write_validated(out_path, schema, results_by_idx[idx])
-                wrote += 1
-            except Exception as exc:  # pragma: no cover - write/validate path
-                rec = results_by_idx[idx]
-                failures.append(
-                    {
-                        "scenario_id": rec.get("scenario_id")
-                        or rec.get("scenario", {}).get("name", "unknown"),
-                        "seed": rec.get("seed", -1),
-                        "error": repr(exc),
-                    }
-                )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("a", encoding="utf-8") as handle:
+            for idx in sorted(results_by_idx):
+                try:
+                    _write_validated_to_handle(handle, schema, results_by_idx[idx])
+                    wrote += 1
+                except Exception as exc:  # pragma: no cover - write/validate path
+                    rec = results_by_idx[idx]
+                    failures.append(
+                        {
+                            "scenario_id": rec.get("scenario_id")
+                            or rec.get("scenario", {}).get("name", "unknown"),
+                            "seed": rec.get("seed", -1),
+                            "error": repr(exc),
+                        }
+                    )
 
     impact_contract = algo_contract.get("adapter_impact")
     if (

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -49,12 +49,12 @@ def test_resume_identity_is_algorithm_aware(
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
-    def _fake_write(_out: Path, _schema: dict, record: dict[str, str]) -> None:
+    def _fake_write(_handle, _schema: dict, record: dict[str, str]) -> None:
         """Record written episode IDs without touching JSONL output."""
         written_ids.add(record["episode_id"])
 
     monkeypatch.setattr(map_runner, "_run_map_job_worker", _fake_worker)
-    monkeypatch.setattr(map_runner, "_write_validated", _fake_write)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", _fake_write)
 
     out_path = tmp_path / "episodes.jsonl"
     out_path.write_text("", encoding="utf-8")
@@ -123,7 +123,7 @@ def test_resume_identity_uses_identity_algo_observation_mode(
         "_run_map_job_worker",
         lambda job: runs.append(job) or {"algorithm_metadata": {}},
     )
-    monkeypatch.setattr(map_runner, "_write_validated", lambda *args, **kwargs: None)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", lambda *args, **kwargs: None)
 
     monkeypatch.setattr(
         map_runner,
@@ -191,7 +191,7 @@ def test_resume_identity_uses_identity_algo_observation_level(
         "_run_map_job_worker",
         lambda job: runs.append(job) or {"algorithm_metadata": {}},
     )
-    monkeypatch.setattr(map_runner, "_write_validated", lambda *args, **kwargs: None)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", lambda *args, **kwargs: None)
 
     monkeypatch.setattr(
         map_runner,
@@ -241,12 +241,12 @@ def test_resume_identity_includes_algo_config_hash(
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
-    def _fake_write(_out: Path, _schema: dict, record: dict[str, str]) -> None:
+    def _fake_write(_handle, _schema: dict, record: dict[str, str]) -> None:
         """Record written episode IDs for resume-index simulation."""
         written_ids.add(record["episode_id"])
 
     monkeypatch.setattr(map_runner, "_run_map_job_worker", _fake_worker)
-    monkeypatch.setattr(map_runner, "_write_validated", _fake_write)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", _fake_write)
 
     cfg_a = tmp_path / "algo_a.yaml"
     cfg_b = tmp_path / "algo_b.yaml"
@@ -416,12 +416,12 @@ def test_resume_identity_uses_effective_latency_profile_dt(
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
-    def _fake_write(_out: Path, _schema: dict, record: dict[str, str]) -> None:
+    def _fake_write(_handle, _schema: dict, record: dict[str, str]) -> None:
         """Record written episode IDs without touching JSONL output."""
         written_ids.add(record["episode_id"])
 
     monkeypatch.setattr(map_runner, "_run_map_job_worker", _fake_worker)
-    monkeypatch.setattr(map_runner, "_write_validated", _fake_write)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", _fake_write)
 
     out_path = tmp_path / "episodes.jsonl"
     out_path.write_text("", encoding="utf-8")
@@ -538,12 +538,12 @@ def test_resume_identity_uses_identity_benchmark_track(
         )
         return {"episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed))}
 
-    def _fake_write(_out: Path, _schema: dict, record: dict[str, str]) -> None:
+    def _fake_write(_handle, _schema: dict, record: dict[str, str]) -> None:
         """Record written episode IDs without touching JSONL output."""
         written_ids.add(record["episode_id"])
 
     monkeypatch.setattr(map_runner, "_run_map_job_worker", _fake_worker)
-    monkeypatch.setattr(map_runner, "_write_validated", _fake_write)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", _fake_write)
 
     out_path = tmp_path / "episodes.jsonl"
     out_path.write_text("", encoding="utf-8")

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -3208,7 +3208,7 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
         _fake_run_map_job_worker,
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
 
@@ -3383,18 +3383,17 @@ def test_run_map_batch_parallel_writes_results_in_job_order(
             time.sleep(0.05)
         return {"episode_id": f"{scenario['name']}-{seed}"}
 
-    def fake_write(out_path_arg, schema, record):
+    def fake_write(handle, schema, record):
         """Capture JSONL writes for the parallel test."""
-        out_path_arg.parent.mkdir(parents=True, exist_ok=True)
-        with out_path_arg.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        del schema
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
 
     monkeypatch.setattr(
         "robot_sf.benchmark.map_runner.ProcessPoolExecutor",
         ThreadPoolExecutor,
     )
     monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_job_worker", fake_run)
-    monkeypatch.setattr("robot_sf.benchmark.map_runner._write_validated", fake_write)
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._write_validated_to_handle", fake_write)
 
     result = run_map_batch(
         [scenario_one, scenario_two],
@@ -3445,7 +3444,7 @@ def test_run_map_batch_parallel_write_failure_prefers_top_level_scenario_id(
         raise RuntimeError("forced write failure")
 
     monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_job_worker", fake_run)
-    monkeypatch.setattr("robot_sf.benchmark.map_runner._write_validated", fake_write)
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._write_validated_to_handle", fake_write)
 
     result = run_map_batch(
         scenarios,
@@ -3488,7 +3487,7 @@ def test_run_map_batch_filters_and_validation(
         lambda job: {"episode_id": "ep1"},
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
     result = run_map_batch(
@@ -3600,7 +3599,7 @@ def test_run_map_batch_filters_per_scenario_kinematics_preflight(
         lambda job: {"episode_id": f"{job[0]['name']}-{job[1]}"},
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
 
@@ -3676,7 +3675,7 @@ def test_run_map_batch_validates_effective_scenario_algo_overrides(
         lambda job: {"episode_id": f"{job[0]['name']}-{job[1]}"},
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
 
@@ -3711,7 +3710,7 @@ def test_run_map_batch_preserves_runtime_planner_contract_in_summary(
     )
     monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
 
@@ -3785,7 +3784,7 @@ def test_run_map_batch_parallel_preserves_runtime_metadata_bridge(
         ThreadPoolExecutor,
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner._write_validated",
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
         lambda *args, **kwargs: None,
     )
 
@@ -4042,6 +4041,132 @@ def test_run_map_batch_hrvo_smoke_writes_episode_jsonl(
     lines = out_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 1
     assert "hrvo_smoke" in lines[0]
+
+
+def test_run_map_episode_skips_force_buffer_reads_when_not_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """record_forces=False should avoid per-step force reads and preserve zero semantics."""
+
+    class _DummySim:
+        """Simulator stub whose force buffer must not be read in this test."""
+
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+            self.ped_pos = np.array([[1.2, 0.0]], dtype=float)
+            self.goal_pos = [np.array([2.0, 0.0], dtype=float)]
+            self.map_def = map_def
+
+        @property
+        def last_ped_forces(self) -> np.ndarray:
+            raise AssertionError("last_ped_forces should not be read when record_forces=False")
+
+        def iter_obstacle_segments(self):
+            """Return obstacle segments exposed by the simulator stub."""
+            return [((0.5, -0.5), (0.5, 0.5))]
+
+    class _DummyEnv:
+        """Environment stub for map-runner episode tests."""
+
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.simulator = _DummySim(map_def)
+            self.action_space = None
+
+        def reset(self, seed: int | None = None):
+            """Return a compact map-runner observation."""
+            _ = seed
+            obs = {
+                "robot": {
+                    "position": np.array([0.0, 0.0], dtype=np.float32),
+                    "heading": np.array([0.0], dtype=np.float32),
+                    "speed": np.array([0.0, 0.0], dtype=np.float32),
+                    "radius": np.array([0.5], dtype=np.float32),
+                },
+                "goal": {
+                    "current": np.array([2.0, 0.0], dtype=np.float32),
+                    "next": np.array([0.0, 0.0], dtype=np.float32),
+                },
+                "pedestrians": {
+                    "positions": np.array([[1.2, 0.0]], dtype=np.float32),
+                    "velocities": np.zeros((1, 2), dtype=np.float32),
+                    "radius": np.array([0.4], dtype=np.float32),
+                    "count": np.array([1.0], dtype=np.float32),
+                },
+                "map": {"size": np.array([5.0, 4.0], dtype=np.float32)},
+                "sim": {"timestep": np.array([0.1], dtype=np.float32)},
+            }
+            return obs, {}
+
+        def step(self, action):
+            """Move once and terminate successfully."""
+            _ = action
+            obs, _ = self.reset()
+            return obs, 0.0, True, False, {"meta": {"is_route_complete": True}}
+
+        def close(self) -> None:
+            """Accept cleanup from map-runner code."""
+            return None
+
+    dummy_config = type(
+        "Cfg",
+        (),
+        {
+            "sim_config": type("SC", (), {"time_per_step_in_secs": 0.1})(),
+            "robot_config": HolonomicDriveSettings(
+                max_speed=1.0,
+                max_angular_speed=1.0,
+                command_mode="vx_vy",
+            ),
+        },
+    )
+    captured: dict[str, np.ndarray] = {}
+
+    def fake_compute_all_metrics(ep, *args, **kwargs):
+        """Capture metric inputs and return a successful terminal metric."""
+        del args, kwargs
+        captured["ped_forces"] = ep.ped_forces
+        captured["peds_pos"] = ep.peds_pos
+        return {"success": 1.0, "collisions": 0.0}
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_env_config",
+        lambda scenario, scenario_path: dummy_config,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.make_robot_env",
+        lambda config, seed, debug: _DummyEnv(_minimal_map_def()),
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_shortest_path_length",
+        lambda *args: 1.0,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_all_metrics", fake_compute_all_metrics
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.sample_obstacle_points",
+        lambda segments, spacing: np.array([[0.5, 0.0], [0.5, 0.25]], dtype=float),
+    )
+
+    record = _run_map_episode(
+        {"name": "no_force_recording", "simulation_config": {"max_episode_steps": 1}},
+        123,
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        scenario_path=tmp_path / "scenarios.yaml",
+    )
+
+    assert record["scenario_id"] == "no_force_recording"
+    assert captured["ped_forces"].shape == captured["peds_pos"].shape
+    assert np.array_equal(captured["ped_forces"], np.zeros_like(captured["peds_pos"]))
 
 
 def _normalize_episode_record(record: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- Avoid per-step zero force-buffer allocation/append when `record_forces=False` in map-runner episodes; build one zero tensor after pedestrian positions are stacked.
- Reuse one JSONL output handle for sequential and ordered parallel map-runner writes while preserving per-record validation and deterministic output order.
- Add targeted coverage that `record_forces=False` does not read `last_ped_forces` and preserves all-zero force semantics.

Closes #2184

## Research Result Guidance
NA. This is simulator/benchmark throughput support work, not a research-result or benchmark-claim PR.

## Downstream Propagation
- No benchmark results, claim map, model registry, or artifact catalog updates.
- Generated coverage/probe outputs were inspected and deleted; no `output/` artifacts are needed as durable evidence.

## Validation
- `ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py`
- `pytest tests/benchmark/test_map_runner_utils.py -q` -> 104 passed
- `pytest tests/test_runner_resume_parallel.py tests/test_runner_batch.py tests/benchmark/test_runner_latency_stress_pass_through.py -q` -> 4 passed, 2 warnings
- `pytest tests/test_metrics.py -k "force_sample_stats or force_quantiles" -q` -> 7 passed, 62 deselected
- `python scripts/benchmark_workers.py --max-workers 2 --repeats 2 --out output/benchmarks/bench_workers_issue2184_probe` -> workers 1/2 wrote 2 jobs each
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional force data collection to prevent undefined buffers from being written to trajectory records when the feature is disabled
  * Improved episode record validation and integrity checking before persistence

* **Performance**
  * Optimized batch simulation execution by consolidating file write operations, reducing I/O overhead during large-scale benchmark runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->