### PR TITLE
perf: avoid fast-pysf force summation intermediates

### DIFF
--- a/fast-pysf/pysocialforce/simulator.py
+++ b/fast-pysf/pysocialforce/simulator.py
@@ -54,6 +54,18 @@ class ForceContext(Protocol):
 ForceFactory = Callable[[ForceContext, SimulatorConfig], list[forces.Force]]
 
 
+def _sum_forces_explicitly(force_list: list[forces.Force], ped_state: PedState) -> np.ndarray:
+    """Accumulate force components without generator-sum intermediate arrays.
+
+    Returns:
+        np.ndarray: Combined force array for all pedestrians.
+    """
+    combined = np.zeros_like(ped_state.pos())
+    for force in force_list:
+        combined += force()
+    return combined
+
+
 def make_forces(sim: ForceContext, config: SimulatorConfig) -> list[forces.Force]:
     """Initialize forces required for simulation.
 
@@ -183,7 +195,7 @@ class Simulator_v2:
         """
         Performs a single step in the simulation.
         """
-        forces = sum(force() for force in self.forces)
+        forces = _sum_forces_explicitly(self.forces, self.peds)
         self.peds.step(forces)
         for behavior in self.behaviors:
             behavior.step()
@@ -237,7 +249,7 @@ class Simulator:
         Returns:
             np.ndarray: Combined force array for all pedestrians.
         """
-        return sum(force() for force in self.forces)
+        return _sum_forces_explicitly(self.forces, self.peds)
 
     @property
     def current_state(self) -> SimState:

--- a/fast-pysf/tests/test_simulator.py
+++ b/fast-pysf/tests/test_simulator.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 import pysocialforce as pysf
+from pysocialforce.ped_grouping import PedestrianGroupings, PedestrianStates
 from pysocialforce.scene import PedState
 
 
@@ -32,6 +33,61 @@ def test_can_simulate_with_populated_map():
     for _ in range(10):
         simulator.step()
         print(simulator.states.ped_positions)
+
+
+def test_compute_forces_accumulates_multiple_force_components():
+    """compute_forces should sum each force component explicitly into an array."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+        ],
+        dtype=float,
+    )
+
+    def make_forces(_, __):
+        return [
+            lambda: np.array([[1.0, 2.0], [3.0, 4.0]], dtype=float),
+            lambda: np.array([[5.0, 6.0], [7.0, 8.0]], dtype=float),
+        ]
+
+    simulator = pysf.Simulator(state=state, make_forces=make_forces)
+    forces = simulator.compute_forces()
+
+    assert isinstance(forces, np.ndarray)
+    assert forces.shape == (2, 2)
+    assert np.array_equal(forces, np.array([[6.0, 8.0], [10.0, 12.0]], dtype=float))
+
+
+def test_simulator_v2_step_accumulates_multiple_force_components():
+    """Simulator_v2 stepping should feed the combined force array to pedestrian state."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+        ],
+        dtype=float,
+    )
+    captured_forces = []
+
+    def populate(_, __):
+        states = PedestrianStates(state)
+        groupings = PedestrianGroupings(states, {})
+        return states, groupings, []
+
+    def make_forces(_, __):
+        return [
+            lambda: np.array([[1.0, 2.0], [3.0, 4.0]], dtype=float),
+            lambda: np.array([[5.0, 6.0], [7.0, 8.0]], dtype=float),
+        ]
+
+    simulator = pysf.Simulator_v2(make_forces=make_forces, populate=populate)
+    simulator.peds.step = lambda force: captured_forces.append(force.copy())
+
+    simulator.step()
+
+    assert len(captured_forces) == 1
+    assert np.array_equal(captured_forces[0], np.array([[6.0, 8.0], [10.0, 12.0]], dtype=float))
 
 
 def test_capped_velocity_handles_zero_desired_speed_without_runtime_warning():


### PR DESCRIPTION
## Summary
- Replace generator `sum(...)` force aggregation with explicit NumPy accumulation for both `Simulator_v2` stepping and legacy `Simulator.compute_forces`.
- Add focused regression coverage that multiple force components are combined correctly in both simulator paths.

Closes #2186

## Research Result Guidance
NA. This is simulator-speed support plumbing, not a research-result or benchmark-claim PR. The perf test entry point was run but skipped by its own conditions, so no throughput claim is made.

## Downstream Propagation
- No benchmark report, claim map, registry, or artifact catalog update is needed.
- Generated coverage output was inspected and removed; no `output/` artifacts are durable evidence for this PR.

## Validation
- `pytest fast-pysf/tests/test_simulator.py fast-pysf/tests/test_forces.py -q` -> 9 passed
- `pytest fast-pysf/tests -q` -> 16 passed
- `pytest tests/perf/test_simulation_speed_perf.py -q` -> 1 skipped by test conditions
- `ruff check fast-pysf/pysocialforce/simulator.py fast-pysf/tests/test_simulator.py`
- `ruff format --check fast-pysf/pysocialforce/simulator.py fast-pysf/tests/test_simulator.py`
- `git diff --check`