### PR TITLE
perf: reduce pedestrian sensor coordinate allocation

### DIFF
--- a/robot_sf/gym_env/env_util.py
+++ b/robot_sf/gym_env/env_util.py
@@ -38,6 +38,15 @@ class AgentType(Enum):
     PEDESTRIAN = 2
 
 
+def _pedestrian_coords_with_ego(sim: PedSimulator) -> np.ndarray:
+    """Return social pedestrian coordinates followed by ego pedestrian coordinates.
+
+    Returns:
+        np.ndarray: Combined ``(N + 1, 2)`` coordinate array.
+    """
+    return np.concatenate((sim.ped_pos, np.asarray(sim.ego_ped_pos)[None, :]), axis=0)
+
+
 def make_grid_observation_spaces(
     grid_config: GridConfig,
 ) -> tuple[spaces.Box, dict[str, spaces.Space]]:
@@ -448,8 +457,7 @@ def init_ped_collision_and_sensors(
             get_agent_pose=lambda: sim.robot_poses[0],
             get_goal_coords=lambda: sim.goal_pos[0],
             get_obstacle_coords=sim.get_obstacle_lines,
-            get_pedestrian_coords=lambda: np.vstack((sim.ped_pos, np.array([sim.ego_ped_pos]))),
-            # Add ego pedestrian to pedestrian positions, np.vstack might lead to performance issues
+            get_pedestrian_coords=lambda: _pedestrian_coords_with_ego(sim),
             agent_radius=robot_config.radius,
             ped_radius=sim_config.ped_radius,
             goal_radius=sim_config.goal_radius,

--- a/tests/test_env_util_additional_coverage.py
+++ b/tests/test_env_util_additional_coverage.py
@@ -11,6 +11,7 @@ from robot_sf.common.types import Rect
 from robot_sf.gym_env.env_config import EnvSettings, PedEnvSettings, RobotEnvSettings
 from robot_sf.gym_env.env_util import (
     AgentType,
+    _pedestrian_coords_with_ego,
     create_spaces,
     create_spaces_with_image,
     init_collision_and_sensors,
@@ -211,6 +212,20 @@ def test_init_ped_spaces_and_collision_sensor_initialization() -> None:
     assert "rays" in robot_obs
     assert "drive_state" in ego_obs
     assert "rays" in ego_obs
+
+
+def test_pedestrian_coords_with_ego_preserves_order_and_shape() -> None:
+    """Pedestrian coordinate helper should append ego pedestrian as final row."""
+    map_def = _minimal_map_def()
+    sim = _FakePedSim(map_def)
+    sim.ped_pos = np.array([[1.8, 1.8], [2.1, 2.4]], dtype=np.float64)
+    sim.ego_ped_pos = np.array([1.4, 1.1], dtype=np.float64)
+
+    coords = _pedestrian_coords_with_ego(sim)
+
+    assert coords.shape == (3, 2)
+    assert np.array_equal(coords[:2], sim.ped_pos)
+    assert np.array_equal(coords[2], sim.ego_ped_pos)
 
 
 def test_create_spaces_with_image_error_paths_and_grid_extension() -> None:


### PR DESCRIPTION
## Summary
- Add a small helper for pedestrian+ego coordinate stacking in the pedestrian sensor path.
- Replace the callback’s `np.array([sim.ego_ped_pos])` wrapper with an ego-position row view before concatenation.
- Add focused coverage for shape/order preservation.

Closes #2188

## Research Result Guidance
NA. This is simulator-speed support plumbing, not research-result or benchmark evidence.

## Downstream Propagation
- No benchmark report, claim map, registry, or artifact catalog updates.
- Generated coverage output was removed; no durable `output/` artifact is needed.

## Validation
- `ruff check robot_sf/gym_env/env_util.py tests/test_env_util_additional_coverage.py`
- `pytest tests/test_env_util_additional_coverage.py tests/benchmark/test_lidar_occupancy_adapter.py tests/benchmark/test_lidar_social_force_contract.py tests/gym_env/test_robot_env_snqi_step_metadata.py -q` -> 17 passed
- `ruff format --check robot_sf/gym_env/env_util.py tests/test_env_util_additional_coverage.py`
- `git diff --check`