### PR TITLE
perf: cache pedestrian group list snapshots

### DIFF
--- a/robot_sf/ped_npc/ped_grouping.py
+++ b/robot_sf/ped_npc/ped_grouping.py
@@ -173,13 +173,24 @@ class PedestrianGroupings:
     states: PedestrianStates
     groups: dict[int, set[int]] = field(default_factory=dict)
     group_by_ped_id: dict[int, int] = field(default_factory=dict)
+    _groups_as_lists_cache: list[list[int]] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    def _invalidate_groups_as_lists_cache(self) -> None:
+        """Mark the cached numpy-friendly group list snapshot stale."""
+        self._groups_as_lists_cache = None
 
     @property
     def groups_as_lists(self) -> list[list[int]]:
         # info: this facilitates slicing over numpy arrays
         #       for some reason, numpy cannot slide over indices provided as set ...
         """Return pedestrian group ids as lists (numpy-friendly)."""
-        return [list(ped_ids) for ped_ids in self.groups.values()]
+        if self._groups_as_lists_cache is None:
+            self._groups_as_lists_cache = [list(ped_ids) for ped_ids in self.groups.values()]
+        return self._groups_as_lists_cache
 
     @property
     def group_ids(self) -> set[int]:
@@ -221,6 +232,7 @@ class PedestrianGroupings:
                 old_gid = self.group_by_ped_id[ped_id]
                 self.groups[old_gid].remove(ped_id)
             self.group_by_ped_id[ped_id] = new_gid
+        self._invalidate_groups_as_lists_cache()
         return new_gid
 
     def add_to_group(self, ped_id: int, group_id: int) -> None:
@@ -234,6 +246,7 @@ class PedestrianGroupings:
             self.groups[group_id] = set()
         self.groups[group_id].add(ped_id)
         self.group_by_ped_id[ped_id] = group_id
+        self._invalidate_groups_as_lists_cache()
 
     def ensure_group_for_ped(self, ped_id: int) -> int:
         """Ensure a pedestrian belongs to a group, creating a single-member group if needed.
@@ -251,6 +264,7 @@ class PedestrianGroupings:
         for ped_id in ped_ids:
             self.new_group({ped_id})
         self.groups[group_id].clear()
+        self._invalidate_groups_as_lists_cache()
 
     def redirect_group(self, group_id: int, new_goal: Vec2D):
         """Redirect all members of a group to a new goal."""

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -224,7 +224,6 @@ class Simulator:
         ]
 
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
-
         self.reset_state()
         for behavior in self.peds_behaviors:
             behavior.reset()

--- a/tests/ped_grouping_test.py
+++ b/tests/ped_grouping_test.py
@@ -97,6 +97,34 @@ def test_can_create_group_from_assigned_pedestrians():
     assert groups.groups[new_gid] == ped_ids
 
 
+def test_groups_as_lists_reuses_snapshot_until_grouping_changes():
+    """Group list conversion should avoid repeated list materialization when stable."""
+    groups = init_groups()
+
+    first = groups.groups_as_lists
+    second = groups.groups_as_lists
+
+    assert second is first
+
+
+def test_groups_as_lists_cache_invalidates_when_grouping_changes():
+    """Join/leave style grouping mutations should refresh the cached list snapshot."""
+    groups = init_groups()
+    first = groups.groups_as_lists
+
+    groups.add_to_group(5, 0)
+    after_join = groups.groups_as_lists
+
+    assert after_join is not first
+    assert 5 in after_join[0]
+
+    groups.new_group({5})
+    after_leave = groups.groups_as_lists
+
+    assert after_leave is not after_join
+    assert after_leave[-1] == [5]
+
+
 # def test_can_reassign_pedestrians_to_existing_group():
 #     ped_ids, old_gid, target_gid = {0, 1, 2}, 0, 1
 #     groups = init_groups()

--- a/tests/sim/test_simulator_action_count.py
+++ b/tests/sim/test_simulator_action_count.py
@@ -103,3 +103,56 @@ def test_ped_simulator_step_once_rejects_mismatched_ego_ped_action_count(ego_ped
 
     with pytest.raises(ValueError, match="expected 1 ego pedestrian action"):
         simulator.step_once([(0.0, 0.0)], ego_ped_actions=ego_ped_actions)
+
+
+def test_simulator_step_once_forwards_cached_group_lists(monkeypatch) -> None:
+    """Simulator.step_once should pass the cached group-list snapshot to PySF stepping."""
+    map_def = _minimal_map()
+    config = RobotSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.0]),
+    )
+    simulator = init_simulators(
+        config,
+        map_def,
+        num_robots=1,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+    captured: dict[str, list[list[int]] | None] = {"groups": None}
+    initial_group_lists = simulator.groups.groups_as_lists
+
+    def _capture_group_lists(_ped_forces, groups: list[list[int]]) -> None:
+        captured["groups"] = groups
+
+    monkeypatch.setattr(simulator.pysf_sim.peds, "step", _capture_group_lists)
+    simulator.step_once([(0.0, 0.0)])
+
+    assert captured["groups"] is initial_group_lists
+
+
+def test_ped_simulator_step_once_forwards_cached_group_lists(monkeypatch) -> None:
+    """PedSimulator.step_once should pass the cached group-list snapshot to PySF stepping."""
+    map_def = _minimal_map()
+    config = PedestrianSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=SimulationSettings(difficulty=0, ped_density_by_difficulty=[0.0]),
+    )
+    simulator = init_ped_simulators(
+        config,
+        map_def,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+    captured: dict[str, list[list[int]] | None] = {"groups": None}
+    initial_group_lists = simulator.groups.groups_as_lists
+
+    def _capture_group_lists(_ped_forces, groups: list[list[int]]) -> None:
+        captured["groups"] = groups
+
+    monkeypatch.setattr(simulator.pysf_sim.peds, "step", _capture_group_lists)
+    simulator.step_once([(0.0, 0.0)], ego_ped_actions=[(0.0, 0.0)])
+
+    assert captured["groups"] is initial_group_lists


### PR DESCRIPTION
## Summary
- Cache `PedestrianGroupings.groups_as_lists` and invalidate it when group membership mutates.
- Keep simulator step ordering intact so join/leave behavior updates are reflected before PySocialForce stepping.
- Add focused tests for cache reuse, mutation invalidation, and simulator forwarding of the cached snapshot.

Closes #2190

## Research Result Guidance
NA. This is simulator-speed support plumbing, not research-result or benchmark evidence. The perf entry point ran but skipped by its own guard, so no throughput claim is made.

## Downstream Propagation
- No benchmark report, claim map, registry, or artifact catalog updates.
- Generated coverage output was removed; no durable `output/` artifact is needed.

## Validation
- `ruff check robot_sf/ped_npc/ped_grouping.py robot_sf/sim/simulator.py tests/ped_grouping_test.py tests/sim/test_simulator_action_count.py`
- `pytest tests/ped_grouping_test.py tests/sim/test_simulator_action_count.py -q` -> 15 passed
- `pytest tests/perf/test_simulation_speed_perf.py -q` -> 1 skipped by test guard
- `ruff format --check robot_sf/ped_npc/ped_grouping.py robot_sf/sim/simulator.py tests/ped_grouping_test.py tests/sim/test_simulator_action_count.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Pedestrian group lists are now cached and reused until group membership changes, reducing unnecessary recalculation overhead.

* **Tests**
  * Added unit tests verifying that pedestrian grouping snapshots are properly cached and invalidated when groups are modified.
  * Added regression tests ensuring the simulator correctly forwards cached group data during step operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->