### PR TITLE
perf: reuse ego pedestrian position view

### DIFF
--- a/robot_sf/gym_env/env_util.py
+++ b/robot_sf/gym_env/env_util.py
@@ -44,6 +44,9 @@ def _pedestrian_coords_with_ego(sim: PedSimulator) -> np.ndarray:
     Returns:
         np.ndarray: Combined ``(N + 1, 2)`` coordinate array.
     """
+    combined_positions = getattr(sim, "ped_and_ego_pos", None)
+    if combined_positions is not None:
+        return combined_positions
     return np.concatenate((sim.ped_pos, np.asarray(sim.ego_ped_pos)[None, :]), axis=0)
 
 

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -489,6 +489,11 @@ class PedSimulator(Simulator):
         return self.pysf_state.ped_positions[:-1]  # Exclude the ego pedestrian
 
     @property
+    def ped_and_ego_pos(self):
+        """Return current NPC and ego pedestrian positions as one PySF-backed view."""
+        return self.pysf_state.ped_positions
+
+    @property
     def ped_vel(self):
         """Return current velocities for NPC pedestrians only."""
         return self.pysf_state.ped_velocities[:-1]

--- a/tests/sim/test_simulator_action_count.py
+++ b/tests/sim/test_simulator_action_count.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
 from robot_sf.common.types import Line2D, Rect
@@ -9,7 +12,7 @@ from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSim
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
 from robot_sf.sim.sim_config import SimulationSettings
-from robot_sf.sim.simulator import init_ped_simulators, init_simulators
+from robot_sf.sim.simulator import PedSimulator, init_ped_simulators, init_simulators
 
 
 def _minimal_map() -> MapDefinition:
@@ -156,3 +159,12 @@ def test_ped_simulator_step_once_forwards_cached_group_lists(monkeypatch) -> Non
     simulator.step_once([(0.0, 0.0)], ego_ped_actions=[(0.0, 0.0)])
 
     assert captured["groups"] is initial_group_lists
+
+
+def test_ped_simulator_ped_and_ego_pos_returns_pysf_position_view() -> None:
+    """Combined pedestrian positions should reuse the PySF state position view."""
+    positions = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=float)
+    simulator = PedSimulator.__new__(PedSimulator)
+    simulator.pysf_state = SimpleNamespace(ped_positions=positions)
+
+    assert simulator.ped_and_ego_pos is positions

--- a/tests/test_ego_ped_emits_sf.py
+++ b/tests/test_ego_ped_emits_sf.py
@@ -182,6 +182,26 @@ def test_ego_position_correct_in_states(env):
         ), "Ego pedestrian position does not match the simulator state"
 
 
+def test_combined_pedestrian_position_view_includes_ego_row(env) -> None:
+    """PedSimulator should expose the full PySF pedestrian position array."""
+    _, _ = env.reset()
+
+    old_stacked_output = np.concatenate(
+        (
+            env.simulator.ped_pos,
+            np.asarray(env.simulator.ego_ped_pos)[None, :],
+        ),
+        axis=0,
+    )
+
+    combined_positions = env.simulator.ped_and_ego_pos
+
+    assert np.shares_memory(combined_positions, env.simulator.pysf_state.pysf_states())
+    assert combined_positions.shape[0] == env.simulator.ped_pos.shape[0] + 1
+    np.testing.assert_allclose(combined_positions, old_stacked_output)
+    np.testing.assert_allclose(combined_positions[-1], env.simulator.ego_ped_pos)
+
+
 def test_ego_social_force_state_preserves_tau_and_uses_cartesian_velocity(env) -> None:
     """Keep the ego row compatible with PySF's state layout while syncing motion."""
     _, _ = env.reset()

--- a/tests/test_env_util_additional_coverage.py
+++ b/tests/test_env_util_additional_coverage.py
@@ -215,7 +215,7 @@ def test_init_ped_spaces_and_collision_sensor_initialization() -> None:
 
 
 def test_pedestrian_coords_with_ego_preserves_order_and_shape() -> None:
-    """Pedestrian coordinate helper should append ego pedestrian as final row."""
+    """Fallback pedestrian coordinate helper should append ego pedestrian as final row."""
     map_def = _minimal_map_def()
     sim = _FakePedSim(map_def)
     sim.ped_pos = np.array([[1.8, 1.8], [2.1, 2.4]], dtype=np.float64)
@@ -226,6 +226,25 @@ def test_pedestrian_coords_with_ego_preserves_order_and_shape() -> None:
     assert coords.shape == (3, 2)
     assert np.array_equal(coords[:2], sim.ped_pos)
     assert np.array_equal(coords[2], sim.ego_ped_pos)
+
+
+def test_pedestrian_coords_with_ego_prefers_combined_simulator_view() -> None:
+    """Pedestrian coordinate helper should use the simulator-provided combined view."""
+    map_def = _minimal_map_def()
+    sim = _FakePedSim(map_def)
+    sim.ped_pos = np.array([[1.8, 1.8], [2.1, 2.4]], dtype=np.float64)
+    sim.ego_ped_pos = np.array([1.4, 1.1], dtype=np.float64)
+    combined = np.array([[1.8, 1.8], [2.1, 2.4], [1.4, 1.1]], dtype=np.float64)
+    sim.ped_and_ego_pos = combined
+    expected_old_stacked_output = np.concatenate(
+        (sim.ped_pos, np.asarray(sim.ego_ped_pos)[None, :]),
+        axis=0,
+    )
+
+    coords = _pedestrian_coords_with_ego(sim)
+
+    assert coords is combined
+    np.testing.assert_array_equal(coords, expected_old_stacked_output)
 
 
 def test_create_spaces_with_image_error_paths_and_grid_extension() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ped_and_ego_pos` property to the simulator, exposing combined pedestrian position data including the ego pedestrian.

* **Performance**
  * Optimized coordinate retrieval to prefer precomputed combined data when available, with fallback to previous concatenation method.

* **Tests**
  * Added regression tests verifying new property behavior, data integrity, and fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->