### PR TITLE
perf: avoid SocNav velocity stack allocation

### DIFF
--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -447,7 +447,9 @@ class SocNavObservationFusion:
             vy = ped_velocities[:, 1]
             ego_vx = cos_h * vx + sin_h * vy
             ego_vy = -sin_h * vx + cos_h * vy
-            padded_vel[: ped_velocities.shape[0]] = np.stack([ego_vx, ego_vy], axis=1)
+            valid_velocity_count = ped_velocities.shape[0]
+            padded_vel[:valid_velocity_count, 0] = ego_vx
+            padded_vel[:valid_velocity_count, 1] = ego_vy
 
         goal = np.asarray(self.simulator.goal_pos[self.robot_index], dtype=np.float32)
         next_goal = self.simulator.next_goal_pos[self.robot_index]

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -90,6 +90,38 @@ def test_socnav_observation_clips_positions_to_map_aware_cap() -> None:
     assert obs["map"]["size"].tolist() == pytest.approx([120.0, 80.0])
 
 
+def test_socnav_observation_rotates_pedestrian_velocities_to_ego_frame() -> None:
+    """Pedestrian velocities should be rotated into the robot heading frame."""
+    env_config = RobotSimulationConfig()
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[2.0, 0.0], [0.0, 3.0]], dtype=np.float32),
+        ped_vel=np.array([[1.0, 0.0], [0.0, 2.0]], dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), np.pi / 2.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+
+    obs = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    ).next_obs()
+
+    np.testing.assert_allclose(
+        obs["pedestrians"]["velocities"][:2],
+        np.array([[0.0, -1.0], [2.0, 0.0]], dtype=np.float32),
+        atol=1e-6,
+    )
+
+
 def test_socnav_observation_visibility_filters_fov_without_mutating_ground_truth() -> None:
     """Planner-facing pedestrian observations should honor opt-in FOV settings only."""
     env_config = RobotSimulationConfig()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pedestrian velocity calculation in sensor observations to ensure velocities are properly rotated to match the robot's reference frame, providing more accurate relative motion data for navigation.

* **Tests**
  * Added test coverage validating pedestrian velocity transformation in ego-frame coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->