### PR TITLE
perf: reuse temporal fusion drive-state buffers

### DIFF
--- a/robot_sf/sensor/image_sensor_fusion.py
+++ b/robot_sf/sensor/image_sensor_fusion.py
@@ -40,8 +40,8 @@ class ImageSensorFusion:
     use_next_goal: bool
     use_image_obs: bool = False
 
-    # Inherited from SensorFusion
-    drive_state_cache: deque = field(init=False, default_factory=deque)
+    # Drive-state cache stores warm-history markers; stacked_drive_state owns values.
+    drive_state_cache: deque[None] = field(init=False, default_factory=deque)
     lidar_state_cache: deque = field(init=False, default_factory=deque)
     image_state_cache: deque = field(init=False, default_factory=deque)
     cache_steps: int = field(init=False)
@@ -58,6 +58,7 @@ class ImageSensorFusion:
             lidar_shape = 5
 
         self.stacked_drive_state = np.zeros((self.cache_steps, 5), dtype=np.float32)
+        self._drive_state_buffer = np.zeros(5, dtype=np.float32)
         self.stacked_lidar_state = np.zeros((self.cache_steps, lidar_shape), dtype=np.float32)
 
         # Initialize caches for sensors
@@ -101,10 +102,9 @@ class ImageSensorFusion:
         # If not using the next goal, set the next target angle to 0.0
         next_target_angle = next_target_angle if self.use_next_goal else 0.0
 
-        # Combine the robot speed and target sensor data into the drive state
-        drive_state = np.array(
-            [speed_x, speed_rot, target_distance, target_angle, next_target_angle],
-        )
+        # Combine the robot speed and target sensor data into the reusable current-state buffer.
+        drive_state = self._drive_state_buffer
+        drive_state[:] = (speed_x, speed_rot, target_distance, target_angle, next_target_angle)
 
         # Get image state if enabled
         image_state = None
@@ -117,7 +117,7 @@ class ImageSensorFusion:
         """Initialize caches if they are empty."""
         if len(self.drive_state_cache) == 0:
             for _ in range(self.cache_steps):
-                self.drive_state_cache.append(sensor_data["drive_state"])
+                self.drive_state_cache.append(None)
                 self.lidar_state_cache.append(sensor_data["lidar_state"])
                 if self.use_image_obs and sensor_data["image_state"] is not None:
                     self.image_state_cache.append(sensor_data["image_state"])
@@ -130,7 +130,7 @@ class ImageSensorFusion:
 
     def _update_sensor_caches(self, sensor_data: dict):
         """Update sensor caches with current data."""
-        self.drive_state_cache.append(sensor_data["drive_state"])
+        self.drive_state_cache.append(None)
         self.lidar_state_cache.append(sensor_data["lidar_state"])
 
     def _update_stacked_states(self, sensor_data: dict):

--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -152,8 +152,9 @@ class SensorFusion:
         The unnormalized observation space.
     use_next_goal : bool
         Whether to use the next goal in the observation.
-    drive_state_cache : List[np.ndarray]
-        A cache of previous drive states.
+    drive_state_cache : deque[None]
+        Warm-history markers for drive state. Concrete temporal values are stored
+        in ``stacked_drive_state``.
     lidar_state_cache : List[np.ndarray]
         A cache of previous LiDAR states.
     cache_steps : int
@@ -165,7 +166,7 @@ class SensorFusion:
     target_sensor: Callable[[], tuple[float, float, float]]
     unnormed_obs_space: spaces.Dict
     use_next_goal: bool
-    drive_state_cache: list[np.ndarray] = field(init=False, default_factory=list)
+    drive_state_cache: deque[None] = field(init=False, default_factory=deque)
     lidar_state_cache: list[np.ndarray] = field(init=False, default_factory=list)
     cache_steps: int = field(init=False)
 
@@ -178,6 +179,7 @@ class SensorFusion:
         """
         self.cache_steps = self.unnormed_obs_space[OBS_RAYS].shape[0]
         self.stacked_drive_state = np.zeros((self.cache_steps, 5), dtype=np.float32)
+        self._drive_state_buffer = np.zeros(5, dtype=np.float32)
         self.stacked_lidar_state = np.zeros(
             (self.cache_steps, len(self.lidar_sensor())),
             dtype=np.float32,
@@ -208,22 +210,20 @@ class SensorFusion:
         # If not using the next goal, set the next target angle to 0.0
         next_target_angle = next_target_angle if self.use_next_goal else 0.0
 
-        # Combine the robot speed and target sensor data into the drive state
-        drive_state = np.array(
-            [speed_x, speed_rot, target_distance, target_angle, next_target_angle],
-            dtype=np.float32,
-        )
+        # Combine the robot speed and target sensor data into the reusable current-state buffer.
+        drive_state = self._drive_state_buffer
+        drive_state[:] = (speed_x, speed_rot, target_distance, target_angle, next_target_angle)
 
         # Populate history with the current state on first call to avoid zeros.
         if len(self.drive_state_cache) == 0:
             for _ in range(self.cache_steps):
-                self.drive_state_cache.append(drive_state)
+                self.drive_state_cache.append(None)
                 self.lidar_state_cache.append(lidar_state)
             self.stacked_drive_state = fill_history_stack(self.stacked_drive_state, drive_state)
             self.stacked_lidar_state = fill_history_stack(self.stacked_lidar_state, lidar_state)
         else:
             # Add current states as the newest row so temporal stacks are oldest-to-newest.
-            self.drive_state_cache.append(drive_state)
+            self.drive_state_cache.append(None)
             self.lidar_state_cache.append(lidar_state)
             self.stacked_drive_state = append_history_row(self.stacked_drive_state, drive_state)
             self.stacked_lidar_state = append_history_row(self.stacked_lidar_state, lidar_state)

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -124,6 +124,46 @@ def test_image_sensor_fusion_first_observation_prefills_history() -> None:
     )
 
 
+def test_image_sensor_fusion_history_is_oldest_to_newest() -> None:
+    """ImageSensorFusion should keep earlier rows stable when the current buffer is reused."""
+    robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
+    target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
+    lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
+    timesteps = 3
+
+    _norm_space, orig_space = fused_sensor_space(timesteps, robot_obs, target_obs, lidar_obs)
+    lidar_samples = iter(
+        [
+            np.array([0.0, 0.0], dtype=np.float32),
+            np.array([1.0, 1.0], dtype=np.float32),
+        ]
+    )
+    speed_samples = iter([(1.0, 0.0), (2.0, 0.0)])
+    target_samples = iter([(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)])
+    fusion = ImageSensorFusion(
+        lidar_sensor=lambda: next(lidar_samples),
+        robot_speed_sensor=lambda: next(speed_samples),
+        target_sensor=lambda: next(target_samples),
+        image_sensor=None,
+        unnormed_obs_space=orig_space,
+        use_next_goal=True,
+        use_image_obs=False,
+    )
+
+    fusion.next_obs()
+    obs = fusion.next_obs()
+
+    assert np.allclose(obs[OBS_RAYS], [[0.0, 0.0], [0.0, 0.0], [0.1, 0.1]])
+    assert np.allclose(
+        obs[OBS_DRIVE_STATE],
+        [
+            [0.1, 0.0, 0.1, 0.0, 0.0],
+            [0.1, 0.0, 0.1, 0.0, 0.0],
+            [0.2, 0.0, 0.2, 0.0, 0.0],
+        ],
+    )
+
+
 def test_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
     """Reset should clear both cache metadata and concrete temporal stack arrays."""
     robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)


### PR DESCRIPTION
## Summary
- reuse per-instance float32 drive-state buffers in SensorFusion and ImageSensorFusion instead of allocating a new array for every observation
- keep temporal history values owned by the stacked arrays so oldest-to-newest rows remain stable
- add an ImageSensorFusion repeated-observation regression for buffer reuse

Closes #2208

## Validation
- scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/sensor/sensor_fusion.py robot_sf/sensor/image_sensor_fusion.py tests/test_sensor_fusion_stack.py
- scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_sensor_fusion_stack.py -q
- scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/sensor/sensor_fusion.py robot_sf/sensor/image_sensor_fusion.py tests/test_sensor_fusion_stack.py
- git diff --check
- git status --ignored --short -uall output

## Downstream Propagation
NA: support performance change only; no benchmark artifact, registry, claim map, or context synthesis surface changes.

## Research Result Guidance
NA: this PR does not move a research claim boundary; it removes per-observation allocation overhead in fallback simulator-speed work.
