### PR TITLE
perf: remove fast-pysf social force temporaries

### DIFF
--- a/robot_sf/sim/fast_pysf_wrapper.py
+++ b/robot_sf/sim/fast_pysf_wrapper.py
@@ -156,6 +156,7 @@ class FastPysfWrapper:
             return total
 
         n, n_prime, lambda_importance, gamma, factor = self._social_params()
+        factor = float(factor)
         for i in range(ped_pos.shape[0]):
             other_pos = ped_pos[i]
             other_vel = ped_vel[i]
@@ -170,7 +171,10 @@ class FastPysfWrapper:
                     float(lambda_importance),
                     float(gamma),
                 )
-                total += np.array([f_x, f_y], dtype=float) * float(factor)
+                f_x *= factor
+                f_y *= factor
+                total[0] += f_x
+                total[1] += f_y
             except (ValueError, TypeError, FloatingPointError, np.linalg.LinAlgError):
                 d = p - other_pos
                 r = np.linalg.norm(d)
@@ -190,6 +194,7 @@ class FastPysfWrapper:
             return forces
 
         n, n_prime, lambda_importance, gamma, factor = self._social_params()
+        factor = float(factor)
         query_vel = np.zeros(2, dtype=float)
         for i, point in enumerate(points):
             try:
@@ -203,7 +208,8 @@ class FastPysfWrapper:
                     float(lambda_importance),
                     float(gamma),
                 )
-                forces[i] = np.array([force_x, force_y], dtype=float) * float(factor)
+                forces[i, 0] = force_x * factor
+                forces[i, 1] = force_y * factor
             except (ValueError, TypeError, FloatingPointError, np.linalg.LinAlgError):
                 forces[i] = self._compute_social_force_at_point(point)
         return forces


### PR DESCRIPTION
## Summary
- cache the social-force scalar factor once per query method
- write social-force `x/y` components directly into existing result arrays
- avoid two-element NumPy temporary arrays in the pointwise force sampling loops

Closes #2212

## Validation
- scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/sim/fast_pysf_wrapper.py tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py
- scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py -q
- scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/sim/fast_pysf_wrapper.py tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py
- git diff --check
- git status --ignored --short -uall output

## Downstream Propagation
NA: support performance change only; no benchmark artifact, registry, claim map, or context synthesis surface changes.

## Research Result Guidance
NA: this PR does not move a research claim boundary; it removes per-point allocation overhead in fallback simulator-speed work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal social-force computation calculations to improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->