### PR TITLE
perf: reuse fast-pysf social velocity diffs

### DIFF
--- a/robot_sf/sim/fast_pysf_wrapper.py
+++ b/robot_sf/sim/fast_pysf_wrapper.py
@@ -195,11 +195,10 @@ class FastPysfWrapper:
 
         n, n_prime, lambda_importance, gamma, factor = self._social_params()
         factor = float(factor)
-        query_vel = np.zeros(2, dtype=float)
+        vel_diffs = -np.asarray(ped_vel, dtype=float)
         for i, point in enumerate(points):
             try:
                 pos_diffs = (point - ped_pos).astype(float)
-                vel_diffs = (query_vel - ped_vel).astype(float)
                 force_x, force_y = pf_forces.social_force_single_ped(
                     pos_diffs,
                     vel_diffs,


### PR DESCRIPTION
## Summary
- precompute the zero-query velocity difference matrix once in the batched social-force path
- remove the per-query `vel_diffs` subtraction/allocation from `_compute_social_forces_at_points()`
- preserve pointwise fallback behavior and output semantics

Closes #2218

## Validation
- scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/sim/fast_pysf_wrapper.py tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py
- scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py -q
- scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/sim/fast_pysf_wrapper.py tests/test_fast_pysf_wrapper.py tests/perf/test_simulation_speed_perf.py
- git diff --check
- git status --ignored --short -uall output

## Downstream Propagation
NA: support performance change only; no benchmark artifact, registry, claim map, or context synthesis surface changes.

## Research Result Guidance
NA: this PR does not move a research claim boundary; it removes per-query allocation overhead in fallback simulator-speed work.
