### PR TITLE
docs: add evidence review fallback checklist

### DIFF
--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -85,6 +85,29 @@ incomplete.
   by a tracked manifest, registry entry, context note, or external artifact pointer. Small support
   helpers with no research-interpretation role may be marked `NA` with that reason.
 
+## Evidence Artifact Fallback Review
+
+Use this checklist for evidence-producing PRs when automated AI review is rate-limited, unavailable,
+or path-filtered in a way that may skip small durable evidence files such as CSV tables under
+`docs/context/evidence/`.
+
+- Confirm every linked issue, PR, context note, config, script, and evidence path resolves from a
+  fresh checkout.
+- Confirm copied evidence files are intentionally small and reviewable. Large raw logs, videos,
+  model caches, coverage HTML, and raw episode JSONL should stay out of git unless a narrow fixture
+  reason is stated.
+- For CSV evidence, inspect the header and at least one representative row. Verify column names,
+  units, seed/scenario/planner identifiers, and status fields match the surrounding Markdown or
+  JSON summary.
+- Check that parent issue conclusions, PR text, and context-note wording agree on result
+  classification: benchmark evidence, smoke evidence, diagnostic-only, blocked, or proposal.
+- Check claim-boundary language explicitly separates observed evidence from hypotheses, future
+  work, fallback/degraded execution, and paper-facing claims.
+- Check generated evidence points back to a reproducible command, commit, config or scenario
+  matrix, seed policy, and durable artifact/provenance decision.
+- If an evidence CSV or other small table is path-filtered out of automated review, state in the PR
+  review or merge note that this manual fallback checklist covered it.
+
 ## Documentation Review
 
 Docs changes should be rejected if they:

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -29,6 +29,14 @@ deliberately versioned, non-regenerable binary fixture after an explicit maintai
 artifact can be regenerated from tracked configs, seed schedules, commands, and commits, it is fine
 to leave it ignored or delete it locally once the durable summary/report evidence is preserved.
 
+## Review Fallback
+
+When automated AI review is rate-limited, unavailable, or configured to skip a small evidence file
+under this tree, reviewers should apply the fallback checklist in `docs/code_review.md`. CSV
+evidence is not exempt from review merely because broad CSV filters exist: inspect the header,
+representative rows, provenance fields, parent-issue conclusion alignment, and explicit claim
+boundary before merging an evidence-producing PR.
+
 ## Current Bundles
 
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Evidence Artifact Fallback Review" checklist for pull requests with evidence artifacts when automated AI review is unavailable, rate-limited, or configured to skip reviews.
  * New "Review Fallback" section with guidance on validating CSV evidence, verifying metadata consistency, aligning evidence with issue classifications, separating observations from hypotheses, and linking generated evidence to reproducible commands and test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->