### PR TITLE
docs: add controlled issue split batches

### DIFF
--- a/.agents/skills/issue-contract-maintainer/SKILL.md
+++ b/.agents/skills/issue-contract-maintainer/SKILL.md
@@ -32,6 +32,8 @@ Use this skill when an issue needs contract maintenance before implementation: t
 - `apply-user-decision`: update issue text, labels, and Project #5 state after the user resolves a readiness question.
 - `split-parent-to-child`: hand a parent, epic, decision, or research issue to `issue-splitter`
   when one smallest independently implementable child can be extracted without changing intent.
+  Controlled multi-child batches are allowed only when the maintainer explicitly requested a
+  bounded batch from a reviewed source plan; otherwise keep the one-child default.
 
 For `audit-template-compliance`, treat the `## Archetype Metadata` YAML block as part of the issue
 contract. Preserve the block, validate `archetype` and `evidence_tier` against
@@ -52,7 +54,8 @@ flag malformed YAML or invalid values instead of inventing replacements.
 
 - Do not expand the issue beyond the original intent.
 - Do not implement the issue from this skill; hand ready work to `gh-issue-autopilot`.
-- Do not split a parent into more than one child in a single pass.
+- Do not split a parent into more than one child in a single pass unless the maintainer explicitly
+  requested `issue-splitter` controlled multi-child mode for a bounded reviewed plan.
 - Ask one readiness-blocking question at a time when user input is needed.
 - Keep issue-body edits auditable and mention source comments when applying decisions.
 

--- a/.agents/skills/issue-splitter/SKILL.md
+++ b/.agents/skills/issue-splitter/SKILL.md
@@ -21,6 +21,9 @@ aliases:
 
 Use this skill when an open parent, epic, decision, or research issue is too broad to implement
 directly, but contains enough context to extract one smallest independently implementable child.
+The default path remains one child per run. Use controlled multi-child mode only when the
+maintainer explicitly asks for a bounded batch from an already-reviewed split plan or parent issue
+set.
 
 Prefer this skill after an implementation queue audit finds no immediately implementable issue, or
 when `issue-contract-maintainer` selects `split-parent-to-child` for a parent issue.
@@ -31,7 +34,8 @@ creating speculative children that do not have a clear validation path.
 ## Workflow
 
 1. Read the parent issue body, labels, linked issues/PRs, and recent comments.
-2. Identify whether the parent can yield exactly one smallest independently implementable child.
+2. Identify whether the parent can yield exactly one smallest independently implementable child,
+   unless controlled multi-child mode is explicitly authorized.
 3. Run a duplicate check before drafting anything:
    - search open and closed issues by parent issue number, distinctive title words, and likely child
      labels,
@@ -43,6 +47,31 @@ creating speculative children that do not have a clear validation path.
 6. Update the parent with `Next Implementable Child` only when the relationship is clear and the
    child issue was actually created. Otherwise, return the draft and the exact duplicate check
    query results.
+
+## Controlled Multi-Child Mode
+
+Controlled multi-child mode is disabled by default. Enable it only when all of these are true:
+
+- the maintainer explicitly asks for multiple children or a bounded batch,
+- the source is an already-reviewed split plan or parent issue set, not a vague backlog area,
+- the batch size is explicit and small, with a default maximum of five children unless the
+  maintainer names a smaller limit,
+- each candidate has its own duplicate check, `codex_ready_child` contract, scope, non-goals,
+  validation path, and `Blocked by` value,
+- each created child links the parent, and the parent receives either one batch summary comment or
+  body update after creation.
+
+In controlled multi-child mode, do not create a candidate when it is already bounded enough for a
+direct PR, cleanly blocked, speculative, a duplicate, or lacking a validation path. Record those
+rows as skipped instead of forcing issue creation.
+
+The batch summary must report:
+
+- `created`: children actually created,
+- `skipped_duplicate`: candidates skipped because equivalent issues already exist,
+- `skipped_blocked`: candidates whose proof path is blocked,
+- `skipped_too_broad`: candidates too broad or speculative for a child issue,
+- `follow_up`: decisions, parent updates, or maintainer questions left after the batch.
 
 ## Child Issue Contract
 
@@ -65,9 +94,22 @@ When the child is created, add a concise parent comment or body note:
 - <child issue link> - <one-line scope>
 ```
 
+In controlled multi-child mode, use the plural form and keep the order from the reviewed source
+plan:
+
+```markdown
+## Next Implementable Children
+
+1. <child issue link> - <one-line scope>
+2. <child issue link> - <one-line scope>
+```
+
 ## Guardrails
 
-- Create at most one child issue per run.
+- Create at most one child issue per run unless controlled multi-child mode is explicitly
+  authorized by the maintainer.
+- In controlled multi-child mode, honor the requested batch size, keep the batch small, and skip
+  children that would broaden the plan, duplicate existing issues, or hide a blocker.
 - Do not mutate Project #5 fields; leave prioritization and status routing to the normal issue
   batching workflow.
 - Do not split an issue whose scope is already implementable as one PR; hand it back to
@@ -87,7 +129,14 @@ shape when the caller needs repeatable comparison across runs.
 issue_split_summary:
   schema: issue_split_summary.v1
   parent_issue: "#..."
-  mode: draft-only | created | duplicate-found | blocked
+  split_mode: single_child | controlled_batch
+  mode: draft-only | created | duplicate-found | blocked | batch-draft | batch-created | batch-partial
+  batch_request:
+    requested: false
+    requested_by: "optional maintainer/source"
+    source_plan_ref: "optional issue/comment/doc section"
+    max_children: 1
+    authorized: false
   duplicate_check:
     queries:
       - "..."
@@ -96,19 +145,36 @@ issue_split_summary:
         reason: "..."
   proposed_children:
     - title: "..."
+      child_order: 1
       issue: "#optional"
       url: "optional"
       readiness: ready_local | blocked_external | blocked_slurm | decision_required | duplicate | too_broad
+      batch_status: created | skipped_duplicate | skipped_blocked | skipped_too_broad | deferred | not_applicable
       blocker: none | "..."
       scope: "..."
       non_goals:
         - "..."
       validation:
         - "..."
+      duplicate_check:
+        queries:
+          - "..."
+        matches:
+          - issue: "#..."
+            reason: "..."
+  batch_summary:
+    requested_children: 0
+    created: 0
+    skipped_duplicate: 0
+    skipped_blocked: 0
+    skipped_too_broad: 0
+    follow_up:
+      - "..."
   recommendation:
-    action: create_child | use_existing_child | clarify_parent | stop_blocked
+    action: create_child | create_batch | use_existing_child | clarify_parent | stop_blocked
     rationale: "..."
   parent_update:
     next_implementable_child: added | skipped
+    batch_summary: added | skipped | not_applicable
     note: "..."
 ```

--- a/.agents/skills/schemas/issue_split_summary.v1.yaml
+++ b/.agents/skills/schemas/issue_split_summary.v1.yaml
@@ -1,7 +1,14 @@
 issue_split_summary:
   schema: issue_split_summary.v1
   parent_issue: '#1234'
-  mode: draft-only | created | duplicate-found | blocked
+  split_mode: single_child | controlled_batch
+  mode: draft-only | created | duplicate-found | blocked | batch-draft | batch-created | batch-partial
+  batch_request:
+    requested: false
+    requested_by: optional maintainer/source
+    source_plan_ref: optional issue/comment/doc section
+    max_children: 1
+    authorized: false
   duplicate_check:
     queries:
     - gh issue list ...
@@ -10,18 +17,35 @@ issue_split_summary:
       reason: equivalent child scope already exists
   proposed_children:
   - title: string
+    child_order: 1
     issue: '#optional'
     url: optional
     readiness: ready_local | blocked_external | blocked_slurm | decision_required | duplicate | too_broad
+    batch_status: created | skipped_duplicate | skipped_blocked | skipped_too_broad | deferred | not_applicable
     blocker: none | string
     scope: string
     non_goals:
     - string
     validation:
     - command-or-evidence-path
+    duplicate_check:
+      queries:
+      - gh issue list ...
+      matches:
+      - issue: '#1235'
+        reason: equivalent child scope already exists
+  batch_summary:
+    requested_children: 0
+    created: 0
+    skipped_duplicate: 0
+    skipped_blocked: 0
+    skipped_too_broad: 0
+    follow_up:
+    - string
   recommendation:
-    action: create_child | use_existing_child | clarify_parent | stop_blocked
+    action: create_child | create_batch | use_existing_child | clarify_parent | stop_blocked
     rationale: string
   parent_update:
     next_implementable_child: added | skipped
+    batch_summary: added | skipped | not_applicable
     note: string


### PR DESCRIPTION
## Summary
- adds controlled multi-child mode to `issue-splitter` while preserving single-child mode as the default
- extends `issue_split_summary.v1` with split mode, batch authorization metadata, per-child batch status, per-child duplicate checks, and batch summary counts
- updates `issue-contract-maintainer` so its one-child guardrail explicitly allows only maintainer-authorized bounded batches

Closes #2278.

## Validation
- `uv run python scripts/dev/check_skills.py`
- `uv run pytest tests/test_issue_templates.py::test_issue_splitter_skill_defines_parent_child_contract -q`
- `python - <<'PY' ... yaml.safe_load(...) ... PY` for `.agents` and `.codex` issue split schemas
- `rg -n "split_mode|batch_status|batch_summary|controlled_batch" .agents/skills .codex/skills`
- `git diff --check`

## Downstream Propagation
- The canonical `.agents` skill and schema were updated; compatibility mirrors resolve the same content.
- No Project #5 behavior or issue creation automation changed.
- Ignored pytest coverage output was generated locally and intentionally not promoted.

## Research Result Guidance
- NA: workflow instruction/schema change only, supporting future research issue decomposition but not making a research claim.