### PR TITLE
perf: cache lidar tracked-agent ray angles

### DIFF
--- a/robot_sf/planner/lidar_tracked_agents.py
+++ b/robot_sf/planner/lidar_tracked_agents.py
@@ -10,6 +10,7 @@ fail-closed benchmark plumbing smoke, not as a perception tracker claim.
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
+from functools import lru_cache
 from typing import Any
 
 import numpy as np
@@ -103,8 +104,12 @@ def _latest_row(values: Any, *, name: str) -> np.ndarray:
     return arr.astype(float, copy=False)
 
 
+@lru_cache(maxsize=32)
 def lidar_ray_angles(num_rays: int, *, visual_angle_portion: float = 1.0) -> np.ndarray:
     """Return ray angles matching :mod:`robot_sf.sensor.range_sensor` convention.
+
+    Results are cached by ``(num_rays, visual_angle_portion)``. Returned
+    arrays are read-only.
 
     Returns:
         np.ndarray: Ego-frame ray angles in radians.
@@ -115,7 +120,9 @@ def lidar_ray_angles(num_rays: int, *, visual_angle_portion: float = 1.0) -> np.
         raise ValueError("visual_angle_portion must be within (0, 1]")
     lower = -np.pi * visual_angle_portion
     upper = np.pi * visual_angle_portion
-    return np.linspace(lower, upper, int(num_rays) + 1, dtype=float)[:-1]
+    angles = np.linspace(lower, upper, int(num_rays) + 1, dtype=float)[:-1]
+    angles.flags.writeable = False
+    return angles
 
 
 def _contiguous_clusters(indices: np.ndarray, *, max_gap: int) -> list[np.ndarray]:

--- a/tests/planner/test_lidar_tracked_agents.py
+++ b/tests/planner/test_lidar_tracked_agents.py
@@ -20,6 +20,28 @@ def test_lidar_ray_angles_match_range_sensor_endpoint_convention() -> None:
     np.testing.assert_allclose(angles, [-np.pi, -np.pi / 2.0, 0.0, np.pi / 2.0])
 
 
+def test_lidar_ray_angles_cache_reuses_array_for_same_args() -> None:
+    """Identical (num_rays, visual_angle_portion) should return the cached object."""
+    a = lidar_ray_angles(4, visual_angle_portion=1.0)
+    b = lidar_ray_angles(4, visual_angle_portion=1.0)
+    assert a is b
+
+
+def test_lidar_ray_angles_cache_distinguishes_different_args() -> None:
+    """Different (num_rays, visual_angle_portion) should produce distinct arrays."""
+    a = lidar_ray_angles(4, visual_angle_portion=1.0)
+    b = lidar_ray_angles(4, visual_angle_portion=0.5)
+    assert a is not b
+
+
+def test_lidar_ray_angles_returned_array_is_read_only() -> None:
+    """Returned angle arrays should not be writeable."""
+    angles = lidar_ray_angles(4, visual_angle_portion=1.0)
+    assert not angles.flags.writeable
+    with pytest.raises(ValueError):
+        angles[0] = 0.0
+
+
 def test_lidar_rays_to_tracked_agents_clusters_adjacent_hits() -> None:
     """Adjacent finite returns should become one visible endpoint track."""
     cfg = LidarTrackedAgentsConfig(


### PR DESCRIPTION
## Summary
- cache tracked-agent LiDAR ray-angle arrays with a bounded LRU cache
- return read-only cached arrays so callers cannot mutate shared state
- add tests for cache reuse, parameter separation, and immutability

Closes #2327.

## Validation
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_lidar_tracked_agents.py tests/planner/test_lidar_occupancy_grid.py -q
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/lidar_tracked_agents.py tests/planner/test_lidar_tracked_agents.py
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/planner/lidar_tracked_agents.py tests/planner/test_lidar_tracked_agents.py

## Diagnostic Note
Helper-level microbench for 200k lidar_ray_angles(272) calls: old inline linspace 0.549334s, cached 0.025344s, 21.675x. This is diagnostic helper evidence only, not an end-to-end simulator speed claim.

## Downstream Propagation
NA: simulator-speed fallback helper change; no benchmark report, artifact registry, or research synthesis surface updated.

## Research Result Guidance
NA: no research claim. This is a bounded simulator-speed fallback improvement after the local research lane was blocked by SLURM policy.