### PR TITLE
perf: cache range sensor ray offsets

### DIFF
--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -7,6 +7,7 @@ settings before they are exposed as Gymnasium observation spaces.
 """
 
 from dataclasses import dataclass, field
+from functools import lru_cache
 from math import cos, sin
 
 import numba
@@ -150,8 +151,8 @@ class LidarScannerSettings:
         ``visual_angle_portion`` is a fraction of a full circle, so ``1.0``
         scans 360 degrees and ``1 / 3`` scans 120 degrees. ``scan_noise`` stores
         scan-loss and corruption probabilities, both constrained to ``[0, 1]``.
-        ``ray_offsets`` is a precomputed heading-independent linspace of ray
-        angles relative to the sensor heading, rebuilt once on construction.
+        ``ray_offsets`` is a cached heading-independent linspace of ray angles
+        relative to the sensor heading.
         """
         if not 0 < self.visual_angle_portion <= 1:
             raise ValueError("Scan angle portion needs to be within (0, 1]!")
@@ -163,9 +164,7 @@ class LidarScannerSettings:
             raise ValueError("Scan noise probabilities must be within [0, 1]!")
 
         self.angle_opening = (-np.pi * self.visual_angle_portion, np.pi * self.visual_angle_portion)
-        self.ray_offsets = np.linspace(
-            self.angle_opening[0], self.angle_opening[1], self.num_rays + 1
-        )[:-1]
+        self.ray_offsets = lidar_ray_offsets(self.num_rays, self.visual_angle_portion)
 
     @classmethod
     def ego_pedestrian_lidar(cls) -> "LidarScannerSettings":
@@ -414,6 +413,24 @@ def range_postprocessing(out_ranges: np.ndarray, scan_noise: np.ndarray, max_sca
             out_ranges[i] = out_ranges[i] * np.random.random()
 
 
+@lru_cache(maxsize=32)
+def lidar_ray_offsets(num_rays: int, visual_angle_portion: float) -> np.ndarray:
+    """Return cached heading-relative ray offsets.
+
+    Args:
+        num_rays: Number of equally spaced rays.
+        visual_angle_portion: Fraction of full circle covered.
+
+    Returns:
+        Read-only array of relative ray offsets in the same endpoint convention
+        used by :func:`lidar_ray_scan`.
+    """
+    half_span = np.pi * visual_angle_portion
+    angles = np.linspace(-half_span, half_span, num_rays + 1)[:-1]
+    angles.flags.writeable = False
+    return angles
+
+
 def lidar_ray_scan(
     pose: RobotPose,
     occ: ContinuousOccupancy,
@@ -450,7 +467,7 @@ def lidar_ray_scan(
 
     ray_offsets = settings.ray_offsets
     ray_angles = robot_orient + ray_offsets
-    ray_angles = np.mod(ray_angles + np.pi * 2, np.pi * 2)
+    ray_angles = np.mod(ray_angles, 2.0 * np.pi)
 
     if isinstance(occ, EgoPedContinuousOccupancy):
         enemy_pos = np.array([occ.enemy_coords])

--- a/tests/test_range_sensor.py
+++ b/tests/test_range_sensor.py
@@ -8,6 +8,7 @@ from robot_sf.sensor.range_sensor import (
     LidarScannerSettings,
     circle_line_intersection_distance,
     euclid_dist,
+    lidar_ray_offsets,
     lidar_ray_scan,
     lidar_sensor_space,
     lineseg_line_intersection_distance,
@@ -515,3 +516,58 @@ def test_lidar_ray_scan_uses_precomputed_offsets():
             f"ray_angles mismatch at heading={heading:.6f}"
         )
         assert ranges.shape == (settings.num_rays,)
+
+
+################################################################################
+# lidar_ray_offsets tests
+
+
+def test_lidar_ray_offsets_endpoint_convention():
+    """Cached helper produces the same values as direct relative linspace."""
+    num_rays, portion = 4, 0.3
+    half = np.pi * portion
+    expected = np.linspace(-half, half, num_rays + 1)[:-1]
+
+    result = lidar_ray_offsets(num_rays, portion)
+    assert np.allclose(result, expected, atol=1e-12, rtol=1e-12)
+    assert result.shape == (num_rays,)
+
+
+def test_lidar_ray_offsets_cache_identity():
+    """Same arguments return the identical cached array object."""
+    a = lidar_ray_offsets(8, 0.5)
+    b = lidar_ray_offsets(8, 0.5)
+    assert a is b
+
+
+def test_lidar_ray_offsets_different_portion():
+    """Different visual_angle_portion produces distinct cached arrays."""
+    a = lidar_ray_offsets(8, 0.5)
+    b = lidar_ray_offsets(8, 1.0)
+    assert not np.array_equal(a, b)
+
+
+def test_lidar_ray_offsets_read_only():
+    """Cached array is read-only; in-place mutation raises ValueError."""
+    result = lidar_ray_offsets(8, 0.5)
+    assert not result.flags.writeable
+    with pytest.raises(ValueError):
+        result[0] = 0.0
+
+
+def test_lidar_ray_scan_orientation_equivalence():
+    """Ray angles at zero orientation match normalized cached offsets."""
+    obstacle_coords = np.empty((0, 4), dtype=np.float64)
+    ped_coords = np.empty((0, 2), dtype=np.float64)
+    occ = ContinuousOccupancy(
+        width=10.0,
+        height=10.0,
+        get_agent_coords=lambda: (0.0, 0.0),
+        get_goal_coords=lambda: (9.0, 9.0),
+        get_obstacle_coords=lambda: obstacle_coords,
+        get_pedestrian_coords=lambda: ped_coords,
+    )
+    settings = LidarScannerSettings(num_rays=8, visual_angle_portion=1.0, scan_noise=[0.0, 0.0])
+    _ranges, ray_angles = lidar_ray_scan(((0.0, 0.0), 0.0), occ, settings)
+    expected = np.mod(lidar_ray_offsets(8, 1.0), 2.0 * np.pi)
+    assert np.allclose(ray_angles, expected, atol=1e-12, rtol=1e-12)


### PR DESCRIPTION
## Summary
- add a bounded read-only cache for heading-relative LiDAR ray offsets
- reuse the cached offsets when constructing LidarScannerSettings while preserving the existing ray_offsets endpoint convention
- keep lidar_ray_scan normalization vectorized and covered by range-sensor tests

Closes #2329.

## Validation
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_range_sensor.py -q
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/range_sensor.py tests/test_range_sensor.py
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/range_sensor.py tests/test_range_sensor.py

## Diagnostic Note
Helper-level microbench for 200k offset-grid calls: old inline linspace 0.485153s, cached helper 0.009192s, 52.781x. LidarScannerSettings construction with the cached helper took 0.151205s for 200k constructions. This is diagnostic helper evidence only, not an end-to-end simulator speed claim.

## Downstream Propagation
NA: simulator-speed fallback helper change; no benchmark report, artifact registry, or research synthesis surface updated.

## Research Result Guidance
NA: no research claim. This is a bounded simulator-speed fallback improvement because the ready research lane currently requires SLURM execution unavailable on this local machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized LiDAR ray offset calculations with caching mechanism
  * Simplified LiDAR ray angle normalization logic

* **Tests**
  * Added comprehensive test coverage for LiDAR ray calculations and caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->