### PR TITLE
perf: cache range sensor scan noise array

### DIFF
--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -131,6 +131,8 @@ class LidarScannerSettings:
         scan_noise: Two probabilities ``[loss, corruption]``. Loss replaces a
             ray with ``max_scan_dist``; corruption scales the clipped range by a
             random factor in ``[0, 1)``.
+        scan_noise_array: Cached ndarray derived from ``scan_noise``, allocated
+            once at settings init to avoid per-scan array creation.
         detect_other_robots: When true, dynamic objects exposed by the
             occupancy source are treated as circular obstacles.
         angle_opening: Derived symmetric angular interval in radians, populated
@@ -143,16 +145,18 @@ class LidarScannerSettings:
     scan_noise: list[float] = field(default_factory=lambda: [0.005, 0.002])
     detect_other_robots: bool = True
     angle_opening: Range = field(init=False)
+    scan_noise_array: np.ndarray = field(init=False)
     ray_offsets: np.ndarray = field(init=False)
 
     def __post_init__(self):
-        """Validate scanner settings and derive the symmetric angular opening.
+        """Validate scanner settings and derive derived fields.
 
         ``visual_angle_portion`` is a fraction of a full circle, so ``1.0``
         scans 360 degrees and ``1 / 3`` scans 120 degrees. ``scan_noise`` stores
         scan-loss and corruption probabilities, both constrained to ``[0, 1]``.
         ``ray_offsets`` is a cached heading-independent linspace of ray angles
-        relative to the sensor heading.
+        relative to the sensor heading. ``scan_noise_array`` is a read-only
+        float64 ndarray pre-converted from ``scan_noise``.
         """
         if not 0 < self.visual_angle_portion <= 1:
             raise ValueError("Scan angle portion needs to be within (0, 1]!")
@@ -165,6 +169,9 @@ class LidarScannerSettings:
 
         self.angle_opening = (-np.pi * self.visual_angle_portion, np.pi * self.visual_angle_portion)
         self.ray_offsets = lidar_ray_offsets(self.num_rays, self.visual_angle_portion)
+        scan_noise_arr = np.array(self.scan_noise, dtype=np.float64)
+        scan_noise_arr.flags.writeable = False
+        self.scan_noise_array = scan_noise_arr
 
     @classmethod
     def ego_pedestrian_lidar(cls) -> "LidarScannerSettings":
@@ -456,7 +463,7 @@ def lidar_ray_scan(
     """
 
     (pos_x, pos_y), robot_orient = pose
-    scan_noise = np.array(settings.scan_noise)
+    scan_noise = settings.scan_noise_array
     scan_dist = settings.max_scan_dist
 
     ped_pos = occ.pedestrian_coords

--- a/tests/test_range_sensor.py
+++ b/tests/test_range_sensor.py
@@ -571,3 +571,36 @@ def test_lidar_ray_scan_orientation_equivalence():
     _ranges, ray_angles = lidar_ray_scan(((0.0, 0.0), 0.0), occ, settings)
     expected = np.mod(lidar_ray_offsets(8, 1.0), 2.0 * np.pi)
     assert np.allclose(ray_angles, expected, atol=1e-12, rtol=1e-12)
+
+
+def test_scan_noise_array_values_match_noise():
+    """scan_noise_array element-wise equals the original scan_noise list."""
+    settings = LidarScannerSettings(scan_noise=[0.1, 0.2])
+    assert np.allclose(settings.scan_noise_array, [0.1, 0.2])
+    assert settings.scan_noise_array.dtype == np.float64
+
+
+def test_scan_noise_array_is_read_only():
+    """scan_noise_array is not writeable to protect shared settings state."""
+    settings = LidarScannerSettings(scan_noise=[0.005, 0.002])
+    assert not settings.scan_noise_array.flags.writeable
+    with pytest.raises(ValueError):
+        settings.scan_noise_array[0] = 0.0
+
+
+def test_scan_noise_array_zero_noise_preserved():
+    """Zero-noise scan produces unchanged deterministic ranges via scan_noise_array."""
+    obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
+    ped_coords = np.empty((0, 2), dtype=np.float64)
+    occ = ContinuousOccupancy(
+        width=10.0,
+        height=10.0,
+        get_agent_coords=lambda: (1.0, 1.0),
+        get_goal_coords=lambda: (9.0, 9.0),
+        get_obstacle_coords=lambda: obstacle_coords,
+        get_pedestrian_coords=lambda: ped_coords,
+    )
+    settings = LidarScannerSettings(max_scan_dist=10.0, num_rays=4, scan_noise=[0.0, 0.0])
+    ranges_1, _ = lidar_ray_scan(((1.0, 1.0), 0.0), occ, settings)
+    ranges_2, _ = lidar_ray_scan(((1.0, 1.0), 0.0), occ, settings)
+    assert np.array_equal(ranges_1, ranges_2)


### PR DESCRIPTION
## Summary
- add a settings-level read-only scan_noise_array derived from LidarScannerSettings.scan_noise
- reuse the cached array in lidar_ray_scan instead of allocating np.array(settings.scan_noise) per scan
- add focused tests for cached values, immutability, and zero-noise deterministic scan behavior

Closes #2333.

## Validation
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_range_sensor.py -q
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/range_sensor.py tests/test_range_sensor.py
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/range_sensor.py tests/test_range_sensor.py

## Diagnostic Note
Helper-level microbench for 1,000,000 scan-noise accesses: old per-scan np.array(settings.scan_noise) 0.170742s, cached attribute 0.005802s, 29.427x. This is diagnostic helper evidence only, not an end-to-end simulator speed or benchmark claim.

## Downstream Propagation
NA: simulator-speed fallback helper change; no benchmark report, artifact registry, or research synthesis surface updated.

## Research Result Guidance
NA: no research claim. This is a bounded simulator-speed fallback improvement because the ready research lane currently requires SLURM execution unavailable on this local machine.