### PR TITLE
perf: reuse SocNav observation padding buffers

### DIFF
--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -274,7 +274,7 @@ class SocNavObservationFusion:
     _last_heading: float | None = None
 
     def __post_init__(self) -> None:
-        """Initialize optional predictive foresight encoder."""
+        """Initialize optional predictive foresight encoder and reusable buffers."""
         if bool(getattr(self.env_config, "predictive_foresight_enabled", False)):
             self._predictive_foresight = PredictiveForesightEncoder(
                 predictive_foresight_config_from_source(
@@ -282,6 +282,8 @@ class SocNavObservationFusion:
                     default_max_agents=self.max_pedestrians,
                 )
             )
+        self._buf_ped_positions = np.zeros((self.max_pedestrians, 2), dtype=np.float32)
+        self._buf_ped_velocities = np.zeros((self.max_pedestrians, 2), dtype=np.float32)
 
     def reset_cache(self) -> None:
         """No-op to match the SensorFusion interface."""
@@ -435,10 +437,10 @@ class SocNavObservationFusion:
 
         ped_positions = ped_positions[: self.max_pedestrians]
         ped_velocities = ped_velocities[: self.max_pedestrians]
-        padded = np.zeros((self.max_pedestrians, 2), dtype=np.float32)
-        padded_vel = np.zeros((self.max_pedestrians, 2), dtype=np.float32)
+        self._buf_ped_positions.fill(0.0)
+        self._buf_ped_velocities.fill(0.0)
         if ped_positions.size > 0:
-            padded[: ped_positions.shape[0]] = ped_positions
+            self._buf_ped_positions[: ped_positions.shape[0]] = ped_positions
         if ped_velocities.size > 0:
             # Convert pedestrian velocities to ego frame (rotate by -heading)
             cos_h = np.cos(heading)
@@ -448,8 +450,8 @@ class SocNavObservationFusion:
             ego_vx = cos_h * vx + sin_h * vy
             ego_vy = -sin_h * vx + cos_h * vy
             valid_velocity_count = ped_velocities.shape[0]
-            padded_vel[:valid_velocity_count, 0] = ego_vx
-            padded_vel[:valid_velocity_count, 1] = ego_vy
+            self._buf_ped_velocities[:valid_velocity_count, 0] = ego_vx
+            self._buf_ped_velocities[:valid_velocity_count, 1] = ego_vy
 
         goal = np.asarray(self.simulator.goal_pos[self.robot_index], dtype=np.float32)
         next_goal = self.simulator.next_goal_pos[self.robot_index]
@@ -472,7 +474,7 @@ class SocNavObservationFusion:
         robot_pos_clipped = _clip_positions(robot_pos)
         goal_clipped = _clip_positions(goal)
         next_goal_clipped = _clip_positions(next_goal_arr)
-        padded = _clip_positions(padded)
+        np.clip(self._buf_ped_positions, 0.0, position_cap, out=self._buf_ped_positions)
         map_size = np.array(
             [self.simulator.map_def.width, self.simulator.map_def.height],
             dtype=np.float32,
@@ -501,8 +503,8 @@ class SocNavObservationFusion:
                 "next": next_goal_clipped,
             },
             "pedestrians": {
-                "positions": padded,
-                "velocities": padded_vel,
+                "positions": self._buf_ped_positions.copy(),
+                "velocities": self._buf_ped_velocities.copy(),
                 "radius": np.array(
                     [min(self.env_config.sim_config.ped_radius, float(np.max(position_cap)))],
                     dtype=np.float32,

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -226,3 +226,68 @@ def test_socnav_observation_visibility_filters_dynamic_occluded_pedestrian() -> 
     assert obs["pedestrians"]["count"][0] == pytest.approx(2.0)
     assert obs["pedestrians"]["positions"][0].tolist() == pytest.approx([2.0, 0.0])
     assert obs["pedestrians"]["positions"][1].tolist() == pytest.approx([4.0, 1.0])
+
+
+def test_socnav_observation_no_stale_pedestrian_data_on_shrink() -> None:
+    """Stale padded values from prior next_obs() calls must not leak into unfilled
+    buffer rows when simulated pedestrian count shrinks."""
+    env_config = RobotSimulationConfig()
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], dtype=np.float32),
+        ped_vel=np.array([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]], dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+    fusion = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    obs1 = fusion.next_obs()
+    assert obs1["pedestrians"]["count"][0] == pytest.approx(3.0)
+    pos1_row2 = obs1["pedestrians"]["positions"][2].copy()
+    vel1_row2 = obs1["pedestrians"]["velocities"][2].copy()
+
+    # Shrink from 3 pedestrians to 1 for the second call
+    simulator.ped_pos = np.array([[1.0, 1.0]], dtype=np.float32)
+    simulator.ped_vel = np.array([[1.0, 0.0]], dtype=np.float32)
+    obs2 = fusion.next_obs()
+
+    assert obs2["pedestrians"]["count"][0] == pytest.approx(1.0)
+    np.testing.assert_array_equal(
+        obs2["pedestrians"]["positions"][0],
+        np.array([1.0, 1.0], dtype=np.float32),
+    )
+    for i in range(1, 4):
+        np.testing.assert_array_equal(
+            obs2["pedestrians"]["positions"][i],
+            np.zeros(2, dtype=np.float32),
+            err_msg=f"Stale position leaked at padded row {i}",
+        )
+        np.testing.assert_array_equal(
+            obs2["pedestrians"]["velocities"][i],
+            np.zeros(2, dtype=np.float32),
+            err_msg=f"Stale velocity leaked at padded row {i}",
+        )
+
+    # Verify snapshot semantics: first observation arrays must not be mutated
+    np.testing.assert_array_equal(
+        obs1["pedestrians"]["positions"][2],
+        pos1_row2,
+        err_msg="Snapshot semantics violated: first observation position mutated",
+    )
+    np.testing.assert_array_equal(
+        obs1["pedestrians"]["velocities"][2],
+        vel1_row2,
+        err_msg="Snapshot semantics violated: first observation velocity mutated",
+    )


### PR DESCRIPTION
## Summary
- Reuse internal SocNav pedestrian position/velocity padding buffers across next_obs() calls.
- Clip pedestrian padding in place, while returning copies to preserve observation snapshot semantics.
- Add a shrink regression test so stale padded rows cannot leak when pedestrian count drops.

Closes #2335

## Validation
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_socnav_observation.py -q
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py
- rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py
- Diagnostic-only helper microbench: old_padding_path=0.561101s, reused_buffer_path=0.542311s, speedup=1.035x over 200000 loops at max_pedestrians=64, active=12. This is allocation/locality evidence only, not benchmark evidence.

## Downstream Propagation
NA: simulator-speed fallback cleanup only; no benchmark report, artifact registry, claim map, or context index update required.

## Research Result Guidance
NA: this PR does not assert a research result or benchmark conclusion. It is a narrow simulator-speed maintenance optimization while the local research lane is blocked on SLURM-only work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale pedestrian position and velocity data appearing in observations when the active pedestrian count decreases between successive calls, ensuring clean padded arrays.

* **Performance**
  * Improved observation generation efficiency by adopting reusable memory buffers for pedestrian data instead of allocating new buffers per call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->