### PR TITLE
perf: vectorize social graph star edges

### DIFF
--- a/robot_sf/sensor/social_graph_observation.py
+++ b/robot_sf/sensor/social_graph_observation.py
@@ -524,20 +524,17 @@ def _build_star_edges(
     Returns:
         Edge index array and integer edge-type labels.
     """
-    sources: list[int] = []
-    edge_types: list[int] = []
-    for idx, active in enumerate(pedestrian_mask, start=1):
-        if active:
-            sources.append(idx)
-            edge_types.append(0)
+    active_ped_indices = np.flatnonzero(pedestrian_mask).astype(np.int64) + 1
+    num_ped = active_ped_indices.shape[0]
     static_offset = 1 + pedestrian_mask.shape[0]
-    for idx, active in enumerate(static_obstacle_mask, start=static_offset):
-        if active:
-            sources.append(idx)
-            edge_types.append(1)
-    if not sources:
+    active_static_indices = np.flatnonzero(static_obstacle_mask).astype(np.int64) + static_offset
+    num_static = active_static_indices.shape[0]
+    total_edges = num_ped + num_static
+    if total_edges == 0:
         return np.zeros((2, 0), dtype=np.int64), np.zeros((0,), dtype=np.int64)
-    return (
-        np.asarray([sources, [0] * len(sources)], dtype=np.int64),
-        np.asarray(edge_types, dtype=np.int64),
-    )
+    edge_index = np.zeros((2, total_edges), dtype=np.int64)
+    edge_index[0, :num_ped] = active_ped_indices
+    edge_index[0, num_ped:] = active_static_indices
+    edge_type = np.zeros((total_edges,), dtype=np.int64)
+    edge_type[num_ped:] = 1
+    return edge_index, edge_type

--- a/tests/test_social_graph_observation.py
+++ b/tests/test_social_graph_observation.py
@@ -67,6 +67,7 @@ def test_empty_pedestrians_emit_zero_features_and_masks() -> None:
     assert graph["pedestrian_mask"].tolist() == [False, False, False]
     assert graph["pedestrian_count"].tolist() == [0]
     assert graph["edge_index"].shape == (2, 0)
+    assert graph["edge_type"].shape == (0,)
     np.testing.assert_allclose(graph["pedestrian_features"], 0.0)
 
 
@@ -202,6 +203,39 @@ def test_flat_and_nested_socnav_inputs_match() -> None:
 
     for key in nested_graph:
         np.testing.assert_array_equal(nested_graph[key], flat_graph[key])
+
+
+def test_edge_index_orders_pedestrians_first_then_static_obstacles() -> None:
+    """Edge index must list active pedestrian sources first, then static obstacle sources."""
+    graph = build_social_graph_observation(
+        _nested_obs(ped_positions=[[2.0, 0.0], [3.0, 0.0]]),
+        config=SocialGraphObservationConfig(
+            max_pedestrians=4,
+            include_static_obstacles=True,
+            max_static_obstacles=2,
+        ),
+        obstacle_segments=[[1.0, -1.0, 1.0, 1.0]],
+    )
+    assert graph["edge_type"].tolist() == [0, 0, 1]
+    assert graph["edge_index"][0].tolist() == [1, 2, 5]
+    assert graph["edge_index"][1].tolist() == [0, 0, 0]
+
+
+def test_edge_index_supports_static_obstacles_without_pedestrians() -> None:
+    """Static obstacle edges should be valid when no pedestrian rows are active."""
+    graph = build_social_graph_observation(
+        _nested_obs(),
+        config=SocialGraphObservationConfig(
+            max_pedestrians=3,
+            include_static_obstacles=True,
+            max_static_obstacles=2,
+        ),
+        obstacle_segments=[[1.0, -1.0, 1.0, 1.0]],
+    )
+
+    assert graph["edge_type"].tolist() == [1]
+    assert graph["edge_index"][0].tolist() == [4]
+    assert graph["edge_index"][1].tolist() == [0]
 
 
 def test_future_like_deployment_fields_fail_closed() -> None:


### PR DESCRIPTION
## Summary
- Vectorize `_build_star_edges()` by extracting active pedestrian/static-obstacle source indices from masks with NumPy and filling preallocated output arrays.
- Preserve pedestrian-first ordering, target node 0, edge type labels, empty output shapes, and int64 dtypes.
- Strengthen social-graph tests for empty edge types, explicit pedestrian/static edge ordering, and static-obstacle-only edges.

Closes #2337

## Validation
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_social_graph_observation.py -q` (12 passed, final commit)
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/social_graph_observation.py tests/test_social_graph_observation.py`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/social_graph_observation.py tests/test_social_graph_observation.py`
- Diagnostic-only helper microbench: old_star_edges=1.672105s, vectorized_star_edges=0.742391s, speedup=2.252x over 200000 loops with 128 pedestrian slots and 64 static slots. This is helper-level timing only, not benchmark evidence.

## Downstream Propagation
NA: simulator-speed fallback cleanup only; no benchmark report, artifact registry, claim map, or context index update required.

## Research Result Guidance
NA: this PR does not assert a research result or benchmark conclusion. It is a narrow simulator-speed maintenance optimization while the local research lane is blocked on SLURM-only work.
