### PR TITLE
perf: fill social graph feature rows directly

### DIFF
--- a/robot_sf/sensor/social_graph_observation.py
+++ b/robot_sf/sensor/social_graph_observation.py
@@ -436,17 +436,13 @@ def _build_pedestrian_features(
     )
     active_count = min(config.max_pedestrians, order.shape[0])
     selected = order[:active_count]
-    features[:active_count, :] = np.column_stack(
-        [
-            rel[selected, 0],
-            rel[selected, 1],
-            rel_vel[selected, 0],
-            rel_vel[selected, 1],
-            distances[selected],
-            bearings[selected],
-            np.full((active_count,), fields.pedestrian_radius, dtype=np.float32),
-        ]
-    ).astype(np.float32)
+    features[:active_count, 0] = rel[selected, 0]
+    features[:active_count, 1] = rel[selected, 1]
+    features[:active_count, 2] = rel_vel[selected, 0]
+    features[:active_count, 3] = rel_vel[selected, 1]
+    features[:active_count, 4] = distances[selected]
+    features[:active_count, 5] = bearings[selected]
+    features[:active_count, 6] = fields.pedestrian_radius
     mask[:active_count] = True
     return features, mask
 
@@ -499,17 +495,13 @@ def _build_static_obstacle_features(
     )
     active_count = min(config.max_static_obstacles, order.shape[0])
     selected = order[:active_count]
-    features[:active_count, :] = np.column_stack(
-        [
-            rel_mid[selected, 0],
-            rel_mid[selected, 1],
-            unit_dirs[selected, 0],
-            unit_dirs[selected, 1],
-            lengths[selected],
-            distances[selected],
-            np.zeros((active_count,), dtype=np.float32),
-        ]
-    ).astype(np.float32)
+    features[:active_count, 0] = rel_mid[selected, 0]
+    features[:active_count, 1] = rel_mid[selected, 1]
+    features[:active_count, 2] = unit_dirs[selected, 0]
+    features[:active_count, 3] = unit_dirs[selected, 1]
+    features[:active_count, 4] = lengths[selected]
+    features[:active_count, 5] = distances[selected]
+    features[:active_count, 6] = 0.0
     mask[:active_count] = True
     return features, mask
 


### PR DESCRIPTION
## Summary
- Replace `np.column_stack(...).astype(np.float32)` feature-row construction with direct writes into the preallocated social-graph feature arrays.
- Preserve pedestrian/static ordering, masks, padded zero rows, dtypes, and feature-column semantics.

Closes #2339

## Validation
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_social_graph_observation.py -q` (12 passed, post-commit)
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/social_graph_observation.py tests/test_social_graph_observation.py`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/social_graph_observation.py tests/test_social_graph_observation.py`
- Diagnostic-only helper microbench: old_column_stack_fill=2.119911s, direct_column_fill=1.298251s, speedup=1.633x over 300000 loops with active=64. This is helper-level timing only, not benchmark evidence.

## Downstream Propagation
NA: simulator-speed fallback cleanup only; no benchmark report, artifact registry, claim map, or context index update required.

## Research Result Guidance
NA: this PR does not assert a research result or benchmark conclusion. It is a narrow simulator-speed maintenance optimization while the local research lane is blocked on SLURM-only work.
