### PR TITLE
perf: fill sensor history stacks in place

### DIFF
--- a/robot_sf/sensor/history_stack.py
+++ b/robot_sf/sensor/history_stack.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def fill_history_stack(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
-    """Return a stack prefilled with ``current_state`` in every temporal row."""
-    return np.repeat(current_state[np.newaxis, :], stacked_state.shape[0], axis=0).astype(
-        stacked_state.dtype, copy=False
-    )
+    """Fill ``stacked_state`` in place with ``current_state`` in every temporal row.
+
+    Returns
+    -------
+    np.ndarray
+        The same ``stacked_state`` array, modified in place.
+    """
+    stacked_state[:] = current_state
+    return stacked_state
 
 
 def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> np.ndarray:
@@ -27,5 +35,12 @@ def append_history_row(stacked_state: np.ndarray, current_state: np.ndarray) -> 
 
 
 def reset_history_stack(stacked_state: np.ndarray) -> np.ndarray:
-    """Return a zero-filled stack preserving the existing shape and dtype."""
-    return np.zeros_like(stacked_state)
+    """Zero-fill ``stacked_state`` in place.
+
+    Returns
+    -------
+    np.ndarray
+        The same ``stacked_state`` array, modified in place.
+    """
+    stacked_state[:] = 0
+    return stacked_state

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 from gymnasium import spaces
 
+from robot_sf.sensor.history_stack import fill_history_stack, reset_history_stack
 from robot_sf.sensor.image_sensor_fusion import ImageSensorFusion
 from robot_sf.sensor.sensor_fusion import (
     OBS_DRIVE_STATE,
@@ -12,6 +13,26 @@ from robot_sf.sensor.sensor_fusion import (
     SensorFusion,
     fused_sensor_space,
 )
+
+
+def test_fill_history_stack_inplace() -> None:
+    """fill_history_stack should modify the input array in place and return the same object."""
+    stack = np.zeros((3, 4), dtype=np.float32)
+    current = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    result = fill_history_stack(stack, current)
+    assert result is stack
+    assert np.allclose(stack, current), (
+        f"Expected every stack row to match current, but got stack:\n{stack}\n"
+        f"and current:\n{current}"
+    )
+
+
+def test_reset_history_stack_inplace() -> None:
+    """reset_history_stack should zero the input array in place and return the same object."""
+    stack = np.ones((3, 4), dtype=np.float32)
+    result = reset_history_stack(stack)
+    assert result is stack
+    assert np.allclose(stack, 0.0)
 
 
 def test_fused_sensor_space_stack_shapes() -> None:


### PR DESCRIPTION
## Summary
- Fill sensor history stacks in place instead of allocating replacement arrays for initial prefill and reset.
- Preserve append behavior and existing SensorFusion/ImageSensorFusion call sites.
- Add focused tests proving `fill_history_stack()` and `reset_history_stack()` return the same array they mutate.

Closes #2341

## Validation
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py -q` (19 passed, final commit)
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/history_stack.py tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/history_stack.py tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py`
- Diagnostic-only helper microbench: old_repeat_fill=0.502666s, inplace_fill=0.162985s, speedup=3.084x over 500000 loops with shape=(16, 256). This is helper-level timing only, not benchmark evidence.

## Downstream Propagation
NA: simulator-speed fallback cleanup only; no benchmark report, artifact registry, claim map, or context index update required.

## Research Result Guidance
NA: this PR does not assert a research result or benchmark conclusion. It is a narrow simulator-speed maintenance optimization while the local research lane is blocked on SLURM-only work.
