### PR TITLE
perf: reduce occupancy combined-channel temporary

### DIFF
--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -749,10 +749,13 @@ class OccupancyGrid:
                 idx for idx, ch in enumerate(self.config.channels) if ch != GridChannel.COMBINED
             ]
             if source_indices:
-                combined = np.max(self._grid_data[source_indices], axis=0)
+                np.maximum.reduce(
+                    self._grid_data[source_indices],
+                    axis=0,
+                    out=self._grid_data[combined_idx],
+                )
             else:
-                combined = np.zeros_like(self._grid_data[combined_idx])
-            self._grid_data[combined_idx] = combined.astype(self.config.dtype, copy=False)
+                self._grid_data[combined_idx].fill(0)
             logger.debug("Generated combined channel from %s indices", source_indices)
 
         # Cache obstacle polygons for direct spatial queries

--- a/tests/test_occupancy_grid.py
+++ b/tests/test_occupancy_grid.py
@@ -194,6 +194,7 @@ class TestGridStaticObstacleLayerCache:
         np.testing.assert_array_equal(second, expected)
         np.testing.assert_array_equal(second[0], first[0])
         assert not np.array_equal(second[1], first[1])
+        np.testing.assert_array_equal(second[2], np.maximum(second[0], second[1]))
 
     def test_world_frame_cache_refreshes_when_obstacles_change(self, monkeypatch):
         """Obstacle input changes must refresh the cached static layer."""


### PR DESCRIPTION
## Summary
- Replace the combined occupancy channel temporary array with `np.maximum.reduce(..., out=...)` directly into the preallocated combined channel.
- Add coverage that the cached obstacle/pedestrian grid still produces a combined channel equal to the max of its sources.

Closes #2352

## Validation
- Baseline before edit: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_occupancy_grid.py tests/test_occupancy_gymnasium.py -q` -> 52 passed, 1 warning in 26.20s.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/nav/occupancy_grid.py tests/test_occupancy_grid.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/nav/occupancy_grid.py tests/test_occupancy_grid.py` -> passed.
- `git diff --check` -> passed.
- Post-edit focused tests: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_occupancy_grid.py tests/test_occupancy_gymnasium.py -q` -> 52 passed, 1 warning in 19.77s.
- Timing probe for the new `np.maximum.reduce(..., out=...)` path: 3x64x64 254k calls/s, 3x128x128 161k calls/s, 4x200x200 46.9k calls/s, 6x200x200 23.1k calls/s.

The pytest warning is the pre-existing torch CUDA initialization warning on this host. `output/coverage/` was generated by pytest and left ignored/disposable.

## Downstream Propagation
NA: simulator performance micro-optimization only; no benchmark, metric, schema, registry, or research-result surface changes.

## Research Result Guidance
NA: this is simulator speed support work after the available local research lane was blocked/exhausted; it makes no benchmark or paper-facing claim.