### PR TITLE
perf: vectorize fused sensor bounds

### DIFF
--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -48,22 +48,26 @@ def fused_sensor_space(
     Tuple[spaces.Dict, spaces.Dict]
         The normalized and original combined observation spaces.
     """
-    # Create the maximum and minimum drive states for each timestep
-    max_drive_state = np.array(
-        [robot_obs.high.tolist() + target_obs.high.tolist() for t in range(timesteps)],
-        dtype=np.float32,
+    # Build one row of bounds and repeat it, avoiding per-timestep Python lists.
+    drive_high = np.concatenate(
+        (
+            np.asarray(robot_obs.high, dtype=np.float32),
+            np.asarray(target_obs.high, dtype=np.float32),
+        )
     )
-    min_drive_state = np.array(
-        [robot_obs.low.tolist() + target_obs.low.tolist() for t in range(timesteps)],
-        dtype=np.float32,
+    drive_low = np.concatenate(
+        (
+            np.asarray(robot_obs.low, dtype=np.float32),
+            np.asarray(target_obs.low, dtype=np.float32),
+        )
     )
+    max_drive_state = np.repeat(drive_high[np.newaxis, :], timesteps, axis=0)
+    min_drive_state = np.repeat(drive_low[np.newaxis, :], timesteps, axis=0)
 
-    # Create the maximum and minimum LiDAR states for each timestep
-    max_lidar_state = np.array(
-        [lidar_obs.high.tolist() for t in range(timesteps)],
-        dtype=np.float32,
-    )
-    min_lidar_state = np.array([lidar_obs.low.tolist() for t in range(timesteps)], dtype=np.float32)
+    lidar_high = np.asarray(lidar_obs.high, dtype=np.float32)
+    lidar_low = np.asarray(lidar_obs.low, dtype=np.float32)
+    max_lidar_state = np.repeat(lidar_high[np.newaxis, :], timesteps, axis=0)
+    min_lidar_state = np.repeat(lidar_low[np.newaxis, :], timesteps, axis=0)
 
     # Create the original observation spaces for the drive and LiDAR states
     orig_box_drive_state = spaces.Box(low=min_drive_state, high=max_drive_state, dtype=np.float32)

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -47,6 +47,12 @@ def test_fused_sensor_space_stack_shapes() -> None:
     assert orig_space[OBS_RAYS].shape == (timesteps, 4)
     assert norm_space[OBS_DRIVE_STATE].shape == (timesteps, 5)
     assert norm_space[OBS_RAYS].shape == (timesteps, 4)
+    assert orig_space[OBS_DRIVE_STATE].dtype == np.float32
+    assert orig_space[OBS_RAYS].dtype == np.float32
+    np.testing.assert_allclose(orig_space[OBS_DRIVE_STATE].high, np.ones((timesteps, 5)))
+    np.testing.assert_allclose(orig_space[OBS_DRIVE_STATE].low, -np.ones((timesteps, 5)))
+    np.testing.assert_allclose(orig_space[OBS_RAYS].high, np.full((timesteps, 4), 10.0))
+    np.testing.assert_allclose(orig_space[OBS_RAYS].low, np.zeros((timesteps, 4)))
 
 
 def test_sensor_fusion_stacks_history() -> None:


### PR DESCRIPTION
## Summary
- Replace per-timestep Python list and `.tolist()` construction in `fused_sensor_space` with one-row NumPy bounds repeated across timesteps.
- Add focused assertions that fused sensor original spaces preserve low/high values and `float32` dtype.

Closes #2354

## Validation
- Baseline before edit: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_sensor_fusion_stack.py tests/test_fused_sensor_space_with_image.py -q` -> 18 passed in 13.14s.
- Delegate route: OpenCode Go `opencode-go/deepseek-v4-flash` produced the initial bounded source patch; local review tightened dtype conversion and test assertions.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/sensor/sensor_fusion.py tests/test_sensor_fusion_stack.py tests/test_fused_sensor_space_with_image.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/sensor/sensor_fusion.py tests/test_sensor_fusion_stack.py tests/test_fused_sensor_space_with_image.py` -> passed.
- Post-edit focused tests: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_sensor_fusion_stack.py tests/test_fused_sensor_space_with_image.py -q` -> 18 passed in 7.11s.
- `git diff --check` -> passed.

Timing probe comparing old full-space construction to new `fused_sensor_space` for 1000 calls each, best of 5:
- timesteps=3, rays=64: old 0.1277s, new 0.1190s, speedup 1.07x
- timesteps=8, rays=256: old 0.2282s, new 0.1319s, speedup 1.73x
- timesteps=16, rays=720: old 0.7008s, new 0.1569s, speedup 4.47x

`output/coverage/` was generated by pytest and left ignored/disposable.

## Downstream Propagation
NA: simulator/support performance micro-optimization only; no benchmark, metric, schema, registry, artifact catalog, or research-result surface changes.

## Research Result Guidance
NA: no benchmark or paper-facing claim. The local research implementation lane was blocked/running-only, so this follows the requested simulator-speed fallback path.