### PR TITLE
test: warm simulation speed smoke

### DIFF
--- a/tests/perf/test_simulation_speed_perf.py
+++ b/tests/perf/test_simulation_speed_perf.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 _SOFT_STEPS_PER_SEC = float(os.environ.get("ROBOT_SF_SIM_STEPS_SOFT", "2.0"))
 _HARD_STEPS_PER_SEC = float(os.environ.get("ROBOT_SF_SIM_STEPS_HARD", "0.5"))
 _ENFORCE_PERF = os.environ.get("ROBOT_SF_PERF_ENFORCE", "0") == "1"
+_WARMUP_STEPS = int(os.environ.get("ROBOT_SF_SIM_WARMUP_STEPS", "20"))
+_MEASURED_STEPS = 10
 
 
 def _make_minimal_map() -> MapDefinition:
@@ -86,16 +88,20 @@ def test_simulation_step_throughput():
     )
     sim = sims[0]
 
-    num_steps = 10
     actions = [(0.0, 0.0)]
 
+    warmup_start = time.perf_counter()
+    for _ in range(_WARMUP_STEPS):
+        sim.step_once(actions)
+    warmup_elapsed = time.perf_counter() - warmup_start
+
     start = time.perf_counter()
-    for _ in range(num_steps):
+    for _ in range(_MEASURED_STEPS):
         sim.step_once(actions)
     elapsed = time.perf_counter() - start
 
-    steps_per_sec = num_steps / elapsed if elapsed > 0 else 0.0
-    ms_per_step = (elapsed / num_steps) * 1000 if num_steps > 0 else 0.0
+    steps_per_sec = _MEASURED_STEPS / elapsed if elapsed > 0 else 0.0
+    ms_per_step = (elapsed / _MEASURED_STEPS) * 1000 if _MEASURED_STEPS > 0 else 0.0
 
     output_dir = get_artifact_category_path("benchmarks")
     ped_pos = getattr(sim, "ped_pos", None)
@@ -103,7 +109,9 @@ def test_simulation_step_throughput():
     _write_perf_snapshot(
         output_dir / "simulation_speed_smoke.json",
         {
-            "steps": num_steps,
+            "warmup_steps": _WARMUP_STEPS,
+            "warmup_elapsed_sec": warmup_elapsed,
+            "measured_steps": _MEASURED_STEPS,
             "elapsed_sec": elapsed,
             "steps_per_sec": steps_per_sec,
             "ms_per_step": ms_per_step,


### PR DESCRIPTION
## Summary
- Add a warmup phase before timed simulation throughput measurement so cold Numba compilation is not counted as steady-state step speed.
- Record `warmup_steps`, `warmup_elapsed_sec`, and `measured_steps` separately in the smoke snapshot.

Closes #2356

## Validation
- Baseline before edit: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/perf/test_simulation_speed_perf.py -q -rs` -> 1 skipped; `Simulation throughput below soft threshold: 1.70 steps/sec < 2.00`.
- Profiling evidence before edit: cProfile showed the timed call path included `sim.step_once -> compute_forces -> _sum_forces_explicitly -> numba dispatcher compile`.
- Delegate route: OpenCode Go `opencode-go/deepseek-v4-flash` made the one-file test patch; local review renamed the warmup env var to `ROBOT_SF_SIM_WARMUP_STEPS`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/perf/test_simulation_speed_perf.py -q -rs` -> 1 passed in 12.89s.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/perf/test_simulation_speed_perf.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/perf/test_simulation_speed_perf.py` -> passed.
- `git diff --check` -> passed.

`output/coverage/` and `output/benchmarks/simulation_speed_smoke.json` were generated locally by validation and left ignored/disposable. Pytest may reroute artifact roots during the run, so local output is not treated as durable evidence.

## Downstream Propagation
NA: test/performance-smoke reliability fix only; no benchmark, metric, schema, registry, artifact catalog, or research-result surface changes.

## Research Result Guidance
NA: no benchmark or paper-facing claim. This supports the simulator-speed fallback lane by making the local speed guard measure steady-state stepping more honestly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved simulator performance testing with configurable warmup phase to increase measurement accuracy
  * Performance metrics now separately recorded for warmup duration and measured throughput

<!-- end of auto-generated comment: release notes by coderabbit.ai -->