### PR TITLE
perf: replace scalar drive clip dispatch

### DIFF
--- a/robot_sf/common/math_utils.py
+++ b/robot_sf/common/math_utils.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from math import atan2, cos, pi, sin
 
 
+def clip_scalar(value: float, lower: float, upper: float) -> float:
+    """Clip a scalar value to inclusive bounds without NumPy dispatch.
+
+    Comparison-based clipping preserves ``np.clip`` scalar NaN behavior because
+    both comparisons are false for NaN and the original value is returned.
+
+    Returns:
+        float: The bounded scalar, or the original value when already in range.
+    """
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
 def wrap_angle_pi(angle: float) -> float:
     """Wrap an angle to the ``[-pi, pi)`` interval.
 

--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -6,7 +6,7 @@ from math import cos, sin, tan
 import numpy as np
 from gymnasium import spaces
 
-from robot_sf.common.math_utils import normalize_angle_atan2
+from robot_sf.common.math_utils import clip_scalar, normalize_angle_atan2
 from robot_sf.common.types import PedPose, PolarVec2D, UnicycleAction, Vec2D
 
 
@@ -86,12 +86,12 @@ class UnicycleMotion:
         velocity = state.velocity
 
         # Apply limits to the acceleration and calculate new velocity
-        acceleration = np.clip(acceleration, -self.config.max_accel, self.config.max_accel)
+        acceleration = clip_scalar(acceleration, -self.config.max_accel, self.config.max_accel)
         new_velocity = velocity + d_t * acceleration
-        new_velocity = np.clip(new_velocity, self.config.min_velocity, self.config.max_velocity)
+        new_velocity = clip_scalar(new_velocity, self.config.min_velocity, self.config.max_velocity)
 
         # Apply limits to the steering angle
-        steering_angle = np.clip(steering_angle, -self.config.max_steer, self.config.max_steer)
+        steering_angle = clip_scalar(steering_angle, -self.config.max_steer, self.config.max_steer)
 
         # Calculate angular velocity based on velocity and steering angle
         angular_velocity = new_velocity * tan(steering_angle)

--- a/robot_sf/robot/action_adapters.py
+++ b/robot_sf/robot/action_adapters.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from robot_sf.common.math_utils import clip_scalar
 from robot_sf.common.math_utils import wrap_angle_pi as _wrap_angle
 
 if TYPE_CHECKING:
@@ -61,16 +62,16 @@ def holonomic_to_diff_drive_action(
     heading_error = _wrap_angle(desired_heading - heading)
 
     angular = float(
-        np.clip(cfg.angular_gain * heading_error, -max_angular_speed, max_angular_speed),
+        clip_scalar(cfg.angular_gain * heading_error, -max_angular_speed, max_angular_speed),
     )
     slowdown = max(0.0, 1.0 - cfg.heading_slowdown * abs(heading_error) / pi)
     linear = speed * slowdown
     if cfg.allow_backwards and abs(heading_error) > (pi / 2):
         linear *= -1.0
     if cfg.allow_backwards:
-        linear = float(np.clip(linear, -max_linear_speed, max_linear_speed))
+        linear = float(clip_scalar(linear, -max_linear_speed, max_linear_speed))
     else:
-        linear = float(np.clip(linear, 0.0, max_linear_speed))
+        linear = float(clip_scalar(linear, 0.0, max_linear_speed))
 
     return np.array([linear, angular], dtype=float)
 

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -6,7 +6,7 @@ from math import cos, sin, tan
 import numpy as np
 from gymnasium import spaces
 
-from robot_sf.common.math_utils import normalize_angle_atan2
+from robot_sf.common.math_utils import clip_scalar, normalize_angle_atan2
 from robot_sf.common.types import BicycleAction, PolarVec2D, RobotPose, Vec2D
 
 
@@ -87,12 +87,12 @@ class BicycleMotion:
         velocity = state.velocity
 
         # Apply limits to the acceleration and calculate new velocity
-        acceleration = np.clip(acceleration, -self.config.max_accel, self.config.max_accel)
+        acceleration = clip_scalar(acceleration, -self.config.max_accel, self.config.max_accel)
         new_velocity = velocity + d_t * acceleration
-        new_velocity = np.clip(new_velocity, self.config.min_velocity, self.config.max_velocity)
+        new_velocity = clip_scalar(new_velocity, self.config.min_velocity, self.config.max_velocity)
 
         # Apply limits to the steering angle
-        steering_angle = np.clip(steering_angle, -self.config.max_steer, self.config.max_steer)
+        steering_angle = clip_scalar(steering_angle, -self.config.max_steer, self.config.max_steer)
 
         # Calculate angular velocity based on velocity and steering angle
         angular_velocity = new_velocity * tan(steering_angle) / self.config.wheelbase

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -6,6 +6,7 @@ from math import cos, sin
 import numpy as np
 from gymnasium import spaces
 
+from robot_sf.common.math_utils import clip_scalar
 from robot_sf.common.types import DifferentialDriveAction, PolarVec2D, RobotPose, Vec2D
 
 WheelSpeedState = tuple[float, float]
@@ -110,9 +111,9 @@ class DifferentialDriveMotion:
         """
         dot_x = velocity[0] + action[0]
         dot_orient = velocity[1] + action[1]
-        dot_x = np.clip(dot_x, self.config.min_linear_speed, self.config.max_linear_speed)
+        dot_x = clip_scalar(dot_x, self.config.min_linear_speed, self.config.max_linear_speed)
         angular_max = self.config.max_angular_speed
-        dot_orient = np.clip(dot_orient, -angular_max, angular_max)
+        dot_orient = clip_scalar(dot_orient, -angular_max, angular_max)
         return dot_x, dot_orient
 
     def _resulting_wheel_speeds(self, movement: PolarVec2D) -> WheelSpeedState:

--- a/robot_sf/robot/holonomic_drive.py
+++ b/robot_sf/robot/holonomic_drive.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from gymnasium import spaces
 
-from robot_sf.common.math_utils import wrap_angle_pi
+from robot_sf.common.math_utils import clip_scalar, wrap_angle_pi
 
 if TYPE_CHECKING:
     from robot_sf.common.types import PolarVec2D, RobotPose
@@ -104,8 +104,8 @@ class HolonomicDriveRobot:
         cmd_x = float(action[0])
         cmd_y = float(action[1])
         if self.config.command_mode == "vx_vy":
-            vx = float(np.clip(cmd_x, -self.config.max_speed, self.config.max_speed))
-            vy = float(np.clip(cmd_y, -self.config.max_speed, self.config.max_speed))
+            vx = float(clip_scalar(cmd_x, -self.config.max_speed, self.config.max_speed))
+            vy = float(clip_scalar(cmd_y, -self.config.max_speed, self.config.max_speed))
             speed = float(np.hypot(vx, vy))
             if speed > self.config.max_speed:
                 scale = self.config.max_speed / max(speed, 1e-9)
@@ -115,9 +115,9 @@ class HolonomicDriveRobot:
             if speed > 1e-9:
                 heading = float(np.arctan2(vy, vx))
         else:
-            v = float(np.clip(cmd_x, -self.config.max_speed, self.config.max_speed))
+            v = float(clip_scalar(cmd_x, -self.config.max_speed, self.config.max_speed))
             omega = float(
-                np.clip(cmd_y, -self.config.max_angular_speed, self.config.max_angular_speed)
+                clip_scalar(cmd_y, -self.config.max_angular_speed, self.config.max_angular_speed)
             )
             heading = wrap_angle_pi(heading + omega * dt)
             vx = v * cos(heading)

--- a/tests/differential_drive_test.py
+++ b/tests/differential_drive_test.py
@@ -87,6 +87,51 @@ def test_resulting_wheel_speeds_are_angular_rates() -> None:
     assert right_wheel_rad_s == 4.0
 
 
+def test_over_limit_linear_speed_clipped() -> None:
+    """Over-limit linear delta is clipped to max_linear_speed."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(max_linear_speed=2.0, max_angular_speed=5.0)
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    # Apply a huge positive linear delta
+    motion.move(state, (100.0, 0.0), 1.0)
+    dot_x, _ = state.velocity
+    assert dot_x == 2.0
+
+
+def test_over_limit_angular_speed_clipped() -> None:
+    """Over-limit angular delta is clipped to max_angular_speed."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(max_linear_speed=5.0, max_angular_speed=1.0)
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    motion.move(state, (0.0, 100.0), 1.0)
+    _, dot_orient = state.velocity
+    assert dot_orient == 1.0
+
+
+def test_over_limit_negative_linear_speed_clipped() -> None:
+    """Over-limit negative linear delta is clipped to min_linear_speed."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(max_linear_speed=2.0, max_angular_speed=5.0)
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    motion.move(state, (-100.0, 0.0), 1.0)
+    dot_x, _ = state.velocity
+    assert dot_x == 0.0  # allow_backwards=False
+
+
+def test_over_limit_negative_angular_speed_clipped() -> None:
+    """Negative over-limit angular delta is clipped."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(max_linear_speed=5.0, max_angular_speed=1.0)
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    motion.move(state, (0.0, -100.0), 1.0)
+    _, dot_orient = state.velocity
+    assert dot_orient == -1.0
+
+
 def test_in_place_rotation_matches_kinematics() -> None:
     """Verify in-place rotation math to prevent drift in heading updates."""
     motion = DifferentialDriveMotion(

--- a/tests/test_action_adapters.py
+++ b/tests/test_action_adapters.py
@@ -63,3 +63,42 @@ def test_holonomic_to_diff_drive_allows_backwards():
         config=DiffDriveAdapterConfig(allow_backwards=True),
     )
     assert action_backwards[0] < 0.0
+
+
+def test_holonomic_to_diff_drive_clamps_angular():
+    """Over-limit angular gain * heading_error clips to max_angular_speed."""
+    pose = ((0.0, 0.0), 0.0)
+    action = holonomic_to_diff_drive_action(
+        np.array([0.0, 1.0]),
+        pose,
+        max_linear_speed=1.0,
+        max_angular_speed=0.1,
+    )
+    # Desired heading is pi/2 => heading_error ~ pi/2 => angular_gain * heading_error > 0.1
+    assert abs(action[1]) <= 0.1 + 1e-9
+
+
+def test_holonomic_to_diff_drive_clamps_linear_forward():
+    """Over-limit speed clamped to max_linear_speed (no backwards)."""
+    pose = ((0.0, 0.0), 0.0)
+    action = holonomic_to_diff_drive_action(
+        np.array([10.0, 0.0]),
+        pose,
+        max_linear_speed=0.5,
+        max_angular_speed=1.0,
+        config=DiffDriveAdapterConfig(allow_backwards=False),
+    )
+    assert 0.0 <= action[0] <= 0.5 + 1e-9
+
+
+def test_holonomic_to_diff_drive_clamps_linear_backwards():
+    """Over-limit backwards speed clamped to max_linear_speed (allow_backwards)."""
+    pose = ((0.0, 0.0), 0.0)
+    action = holonomic_to_diff_drive_action(
+        np.array([-10.0, 0.0]),
+        pose,
+        max_linear_speed=0.5,
+        max_angular_speed=1.0,
+        config=DiffDriveAdapterConfig(allow_backwards=True),
+    )
+    assert -0.5 - 1e-9 <= action[0] <= 0.0

--- a/tests/test_bicycle_drive.py
+++ b/tests/test_bicycle_drive.py
@@ -1,0 +1,58 @@
+"""Tests for bicycle-drive kinematics and action-limit clipping."""
+
+from robot_sf.robot.bicycle_drive import (
+    BicycleDriveSettings,
+    BicycleDriveState,
+    BicycleMotion,
+)
+
+
+def test_bicycle_over_limit_acceleration_clipped():
+    """Acceleration beyond max_accel is clipped."""
+    motion = BicycleMotion(BicycleDriveSettings(max_accel=1.0))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (100.0, 0.0), 1.0)
+    assert state.velocity == 1.0
+
+
+def test_bicycle_over_limit_deceleration_clipped():
+    """Deceleration beyond max_accel in negative direction is clipped."""
+    motion = BicycleMotion(BicycleDriveSettings(max_accel=1.0, allow_backwards=True))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (-100.0, 0.0), 1.0)
+    assert state.velocity == -1.0
+
+
+def test_bicycle_over_limit_forward_velocity_clipped():
+    """Velocity exceeding max_velocity is clipped."""
+    motion = BicycleMotion(BicycleDriveSettings(max_velocity=2.0, max_accel=100.0))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (100.0, 0.0), 1.0)
+    assert state.velocity == 2.0
+
+
+def test_bicycle_velocity_not_below_zero_when_backwards_disabled():
+    """Velocity cannot go negative when allow_backwards is False."""
+    motion = BicycleMotion(BicycleDriveSettings(max_velocity=2.0, max_accel=100.0))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (-100.0, 0.0), 1.0)
+    assert state.velocity == 0.0
+
+
+def test_bicycle_over_limit_steering_clipped_positive():
+    """Steering angle beyond max_steer is clipped (positive)."""
+    motion = BicycleMotion(BicycleDriveSettings(max_steer=0.5, max_velocity=1.0, max_accel=100.0))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 1.0)
+    motion.move(state, (0.0, 100.0), 1.0)
+    pos_after, _ = state.pose
+    # With max_steer=0.5 the turn should be bounded: check robot moved
+    assert pos_after[0] > 0.0
+
+
+def test_bicycle_over_limit_steering_clipped_negative():
+    """Steering angle beyond max_steer is clipped (negative)."""
+    motion = BicycleMotion(BicycleDriveSettings(max_steer=0.5, max_velocity=1.0, max_accel=100.0))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 1.0)
+    motion.move(state, (0.0, -100.0), 1.0)
+    pos_after, _ = state.pose
+    assert pos_after[0] > 0.0

--- a/tests/test_holonomic_drive.py
+++ b/tests/test_holonomic_drive.py
@@ -57,6 +57,34 @@ def test_holonomic_drive_unicycle_mode_updates_heading() -> None:
     assert robot.current_speed[1] == pytest.approx(1.0)
 
 
+def test_holonomic_drive_vx_vy_over_limit_clipped() -> None:
+    """Over-limit vx/vy commands clip to max_speed."""
+    cfg = HolonomicDriveSettings(max_speed=1.0, command_mode="vx_vy")
+    robot = HolonomicDriveRobot(cfg)
+    robot.apply_action((100.0, 100.0), d_t=1.0)
+    vx, vy = robot.state.velocity_xy
+    speed = np.hypot(vx, vy)
+    # Should be bounded at or below max_speed
+    assert speed <= 1.0 + 1e-9
+
+
+def test_holonomic_drive_unicycle_over_limit_linear_clipped() -> None:
+    """Over-limit linear speed in unicycle mode clips to max_speed."""
+    cfg = HolonomicDriveSettings(max_speed=1.0, max_angular_speed=5.0, command_mode="unicycle_vw")
+    robot = HolonomicDriveRobot(cfg)
+    robot.apply_action((100.0, 0.0), d_t=1.0)
+    assert robot.state.velocity_vw[0] <= 1.0 + 1e-9
+
+
+def test_holonomic_drive_unicycle_over_limit_angular_clipped() -> None:
+    """Over-limit angular speed in unicycle mode clips to max_angular_speed."""
+    cfg = HolonomicDriveSettings(max_speed=5.0, max_angular_speed=0.5, command_mode="unicycle_vw")
+    robot = HolonomicDriveRobot(cfg)
+    robot.apply_action((0.0, 100.0), d_t=1.0)
+    assert robot.current_speed[1] <= 0.5 + 1e-9
+    assert robot.current_speed[1] >= -0.5 - 1e-9
+
+
 def test_holonomic_drive_invalid_command_mode_rejected() -> None:
     """Invalid command_mode values should fail during settings construction."""
     with pytest.raises(ValueError, match="command_mode"):

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from math import atan2, cos, pi, sin
+from math import atan2, cos, isnan, pi, sin
 
 import pytest
 
 from robot_sf.common.math_utils import (
+    clip_scalar,
     normalize_angle_atan2,
     wrap_angle_pi,
     wrap_angle_pi_closed,
@@ -48,3 +49,23 @@ def test_normalize_angle_atan2_matches_drive_model_formula(angle: float) -> None
     """Drive model helper preserves the previous atan2(sin, cos) formula."""
     expected = atan2(sin(angle), cos(angle))
     assert normalize_angle_atan2(angle) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("value", "lower", "upper", "expected"),
+    [
+        (-2.0, -1.0, 1.0, -1.0),
+        (0.25, -1.0, 1.0, 0.25),
+        (2.0, -1.0, 1.0, 1.0),
+    ],
+)
+def test_clip_scalar_clips_bounds(
+    value: float, lower: float, upper: float, expected: float
+) -> None:
+    """Scalar clipping matches inclusive bound semantics without NumPy dispatch."""
+    assert clip_scalar(value, lower, upper) == expected
+
+
+def test_clip_scalar_preserves_nan() -> None:
+    """Scalar clipping keeps np.clip scalar NaN behavior."""
+    assert isnan(clip_scalar(float("nan"), -1.0, 1.0))

--- a/tests/unicycle_drive_test.py
+++ b/tests/unicycle_drive_test.py
@@ -97,3 +97,38 @@ def test_unicycle_acceleration():
     motion.move(state, deceleration_action, 1.0)
     speed = state.velocity
     assert speed == 0  # assert not moving backwards
+
+
+def test_unicycle_over_limit_acceleration_clipped():
+    """Acceleration beyond max_accel is clipped."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_accel=1.0))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (100.0, 0.0), 1.0)
+    assert state.velocity == 1.0
+
+
+def test_unicycle_over_limit_deceleration_clipped():
+    """Deceleration beyond max_accel in negative direction is clipped."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_accel=1.0, allow_backwards=True))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(state, (-100.0, 0.0), 1.0)
+    assert state.velocity == -1.0
+
+
+def test_unicycle_over_limit_steering_clipped():
+    """Steering angle beyond max_steer is clipped."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_steer=0.78))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 1.0)
+    motion.move(state, (0.0, 100.0), 1.0)
+    # state should have moved with clipped steering; check position changed
+    pos_after, _ = state.pose
+    assert pos_after[0] > 0.0
+
+
+def test_unicycle_over_limit_negative_steering_clipped():
+    """Negative steering angle beyond max_steer is clipped."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_steer=0.78))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 1.0)
+    motion.move(state, (0.0, -100.0), 1.0)
+    pos_after, _ = state.pose
+    assert pos_after[0] > 0.0


### PR DESCRIPTION
## Summary
- Adds `clip_scalar` for scalar bound checks without NumPy dispatch while preserving `np.clip` scalar NaN behavior.
- Replaces per-step/action-adapter scalar `np.clip` calls in bicycle, unicycle, differential-drive, holonomic, and diff-drive adapter paths.
- Adds focused over-limit clamp coverage across the touched drive/action paths plus math helper NaN/bound tests.

Closes #2368.

## Validation
- `uv run pytest tests/differential_drive_test.py tests/unicycle_drive_test.py tests/test_holonomic_drive.py tests/test_action_adapters.py tests/test_bicycle_drive.py tests/test_math_utils.py -q` -> 58 passed
- `uv run ruff check robot_sf/common/math_utils.py robot_sf/robot/bicycle_drive.py robot_sf/robot/differential_drive.py robot_sf/robot/holonomic_drive.py robot_sf/robot/action_adapters.py robot_sf/ped_ego/unicycle_drive.py tests/differential_drive_test.py tests/unicycle_drive_test.py tests/test_holonomic_drive.py tests/test_action_adapters.py tests/test_bicycle_drive.py tests/test_math_utils.py` -> passed
- `uv run ruff format --check robot_sf/common/math_utils.py robot_sf/robot/bicycle_drive.py robot_sf/robot/differential_drive.py robot_sf/robot/holonomic_drive.py robot_sf/robot/action_adapters.py robot_sf/ped_ego/unicycle_drive.py tests/differential_drive_test.py tests/unicycle_drive_test.py tests/test_holonomic_drive.py tests/test_action_adapters.py tests/test_bicycle_drive.py tests/test_math_utils.py` -> passed
- Micro-probe: `np.clip` scalar 1.496132s/1,000,000 vs `clip_scalar` 0.025316s/1,000,000, 59.10x faster; NaN preserved: true
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5279 passed, 9 skipped, readiness stamp passed at `1d86b297d3be5be46108e7e61a85f1cb8cda2e03`

## Downstream Propagation
- No benchmark report, leaderboard, artifact catalog, registry, or context note update needed. This is local simulator support/performance hygiene and does not alter planner behavior, observations, rewards, metrics, schemas, or research claims.
- Ignored `output/` coverage/readiness artifacts were inspected and left untracked/disposable.

## Research Result Guidance
NA: this PR is not evidence-producing research work. The timing probe is support evidence for scalar dispatch overhead only, not a benchmark throughput claim or planner-quality result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Motion commands are now properly constrained within configured velocity and steering angle limits across all robot drive modes (differential, bicycle, unicycle, and holonomic).

* **Tests**
  * Added extensive test coverage validating that acceleration, deceleration, forward/backward velocity, and steering commands respect their configured limits across all drive systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->