### PR TITLE
perf: add lidar ranges-only scan path

### DIFF
--- a/robot_sf/gym_env/env_util.py
+++ b/robot_sf/gym_env/env_util.py
@@ -22,7 +22,7 @@ from robot_sf.sensor.image_sensor import (
     image_sensor_space,
 )
 from robot_sf.sensor.image_sensor_fusion import ImageSensorFusion
-from robot_sf.sensor.range_sensor import lidar_ray_scan, lidar_sensor_space
+from robot_sf.sensor.range_sensor import lidar_ray_scan_ranges_only, lidar_sensor_space
 from robot_sf.sensor.sensor_fusion import (
     SensorFusion,
     fused_sensor_space,
@@ -184,7 +184,9 @@ def init_collision_and_sensors(
             Returns:
                 np.ndarray: Ray scan distances from lidar.
             """
-            return lidar_ray_scan(sim.robots[r_id].pose, occupancies[r_id], lidar_config)[0]
+            return lidar_ray_scan_ranges_only(
+                sim.robots[r_id].pose, occupancies[r_id], lidar_config
+            )
 
         def target_sensor(r_id=r_id):
             """Capture target/goal sensor observations for the specified robot.
@@ -477,7 +479,7 @@ def init_ped_collision_and_sensors(
         Returns:
             np.ndarray: Ray scan distances from lidar.
         """
-        return lidar_ray_scan(sim.robots[r_id].pose, occupancies[r_id], lidar_config)[0]
+        return lidar_ray_scan_ranges_only(sim.robots[r_id].pose, occupancies[r_id], lidar_config)
 
     def target_sensor(r_id=0):
         """Capture target/goal sensor observations for the robot.
@@ -535,7 +537,7 @@ def init_ped_collision_and_sensors(
         Returns:
             np.ndarray: Ray scan distances from lidar for ego pedestrian.
         """
-        return lidar_ray_scan(sim.ego_ped.pose, occupancies[1], ego_ped_lidar_config)[0]
+        return lidar_ray_scan_ranges_only(sim.ego_ped.pose, occupancies[1], ego_ped_lidar_config)
 
     def target_sensor_ego_ped():
         """Capture target/goal sensor observations for the ego pedestrian.
@@ -728,7 +730,9 @@ def init_collision_and_sensors_with_image(
             Returns:
                 np.ndarray: Ray scan distances from lidar.
             """
-            return lidar_ray_scan(sim.robots[r_id].pose, occupancies[r_id], lidar_config)[0]
+            return lidar_ray_scan_ranges_only(
+                sim.robots[r_id].pose, occupancies[r_id], lidar_config
+            )
 
         def target_sensor(r_id=r_id):
             """Capture target/goal sensor observations for the specified robot.

--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -147,6 +147,7 @@ class LidarScannerSettings:
     angle_opening: Range = field(init=False)
     scan_noise_array: np.ndarray = field(init=False)
     ray_offsets: np.ndarray = field(init=False)
+    _ray_angles_buffer: np.ndarray = field(init=False)
 
     def __post_init__(self):
         """Validate scanner settings and derive derived fields.
@@ -172,6 +173,7 @@ class LidarScannerSettings:
         scan_noise_arr = np.array(self.scan_noise, dtype=np.float64)
         scan_noise_arr.flags.writeable = False
         self.scan_noise_array = scan_noise_arr
+        self._ray_angles_buffer = np.zeros(self.num_rays, dtype=np.float64)
 
     @classmethod
     def ego_pedestrian_lidar(cls) -> "LidarScannerSettings":
@@ -436,6 +438,68 @@ def lidar_ray_offsets(num_rays: int, visual_angle_portion: float) -> np.ndarray:
     return angles
 
 
+def _lidar_ray_scan_impl(
+    pose: RobotPose,
+    occ: ContinuousOccupancy,
+    settings: LidarScannerSettings,
+    ray_angles_out: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Shared scan body for public lidar_ray_scan and lidar_ray_scan_ranges_only.
+
+    Computes ray angles into the provided ``ray_angles_out`` buffer, performs
+    raycasting, and applies range postprocessing.
+
+    Args:
+        pose: ``((x, y), heading)`` scanner pose in world coordinates and radians.
+        occ: Continuous occupancy provider.
+        settings: Scanner settings.
+        ray_angles_out: Pre-allocated output buffer for ray angles. Must have
+            shape ``(settings.num_rays,)`` and dtype float64.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: ``(ranges, ray_angles)`` where ranges are
+        per-ray distances and ray_angles are the absolute ray directions.
+    """
+    (pos_x, pos_y), robot_orient = pose
+    scan_noise = settings.scan_noise_array
+    scan_dist = settings.max_scan_dist
+
+    ped_pos = occ.pedestrian_coords
+    obstacles = occ.obstacle_coords
+    dynamic_robot_circles = (
+        _dynamic_objects_to_circle_array(occ) if settings.detect_other_robots else None
+    )
+
+    np.add(robot_orient, settings.ray_offsets, out=ray_angles_out)
+    np.mod(ray_angles_out, 2.0 * np.pi, out=ray_angles_out)
+
+    if isinstance(occ, EgoPedContinuousOccupancy):
+        enemy_pos = np.array([occ.enemy_coords])
+        ranges = raycast(
+            (pos_x, pos_y),
+            obstacles,
+            scan_dist,
+            ped_pos,
+            occ.ped_radius,
+            ray_angles_out,
+            enemy_pos=enemy_pos,
+            enemy_radius=occ.enemy_radius,
+            other_robot_circles=dynamic_robot_circles,
+        )
+    else:
+        ranges = raycast(
+            (pos_x, pos_y),
+            obstacles,
+            scan_dist,
+            ped_pos,
+            occ.ped_radius,
+            ray_angles_out,
+            other_robot_circles=dynamic_robot_circles,
+        )
+    range_postprocessing(ranges, scan_noise, scan_dist)
+    return ranges, ray_angles_out
+
+
 def lidar_ray_scan(
     pose: RobotPose,
     occ: ContinuousOccupancy,
@@ -459,47 +523,34 @@ def lidar_ray_scan(
         ``ranges`` are per-ray distances with shape ``(settings.num_rays,)`` and
         ``ray_angles`` are absolute ray angles in radians with the same shape.
     """
-
-    (pos_x, pos_y), robot_orient = pose
-    scan_noise = settings.scan_noise_array
-    scan_dist = settings.max_scan_dist
-
-    ped_pos = occ.pedestrian_coords
-    obstacles = occ.obstacle_coords
-    dynamic_robot_circles = (
-        _dynamic_objects_to_circle_array(occ) if settings.detect_other_robots else None
-    )
-
-    ray_offsets = settings.ray_offsets
-    two_pi = 2.0 * np.pi
-    ray_angles = robot_orient + ray_offsets
-    np.mod(ray_angles, two_pi, out=ray_angles)
-
-    if isinstance(occ, EgoPedContinuousOccupancy):
-        enemy_pos = np.array([occ.enemy_coords])
-        ranges = raycast(
-            (pos_x, pos_y),
-            obstacles,
-            scan_dist,
-            ped_pos,
-            occ.ped_radius,
-            ray_angles,
-            enemy_pos=enemy_pos,
-            enemy_radius=occ.enemy_radius,
-            other_robot_circles=dynamic_robot_circles,
-        )
-    else:
-        ranges = raycast(
-            (pos_x, pos_y),
-            obstacles,
-            scan_dist,
-            ped_pos,
-            occ.ped_radius,
-            ray_angles,
-            other_robot_circles=dynamic_robot_circles,
-        )
-    range_postprocessing(ranges, scan_noise, scan_dist)
+    ray_angles = np.empty(settings.num_rays, dtype=np.float64)
+    ranges, ray_angles = _lidar_ray_scan_impl(pose, occ, settings, ray_angles)
     return ranges, ray_angles
+
+
+def lidar_ray_scan_ranges_only(
+    pose: RobotPose,
+    occ: ContinuousOccupancy,
+    settings: LidarScannerSettings,
+) -> np.ndarray:
+    """Simulate a radial LiDAR scan returning only ranges, no ray angles.
+
+    This lightweight variant of :func:`lidar_ray_scan` reuses a private work
+    buffer on the settings object to avoid allocating a new ray_angles array
+    on every call. Intended for hot env-internal closures that discard the
+    directional information.
+
+    Args:
+        pose: ``((x, y), heading)`` scanner pose in world coordinates and radians.
+        occ: Continuous occupancy provider.
+        settings: Scanner settings controlling range, field of view, ray count,
+            noise, and dynamic-object detection.
+
+    Returns:
+        numpy.ndarray: Per-ray distances with shape ``(settings.num_rays,)``.
+    """
+    ranges, _ray_angles = _lidar_ray_scan_impl(pose, occ, settings, settings._ray_angles_buffer)
+    return ranges
 
 
 def lidar_sensor_space(num_rays: int, max_scan_dist: float) -> spaces.Box:

--- a/tests/test_range_sensor.py
+++ b/tests/test_range_sensor.py
@@ -10,6 +10,7 @@ from robot_sf.sensor.range_sensor import (
     euclid_dist,
     lidar_ray_offsets,
     lidar_ray_scan,
+    lidar_ray_scan_ranges_only,
     lidar_sensor_space,
     lineseg_line_intersection_distance,
     range_postprocessing,
@@ -650,3 +651,87 @@ def test_scan_noise_array_zero_noise_preserved():
     ranges_1, _ = lidar_ray_scan(((1.0, 1.0), 0.0), occ, settings)
     ranges_2, _ = lidar_ray_scan(((1.0, 1.0), 0.0), occ, settings)
     assert np.array_equal(ranges_1, ranges_2)
+
+
+def test_lidar_ray_scan_ranges_only_matches_first_element():
+    """Ranges-only scan output equals lidar_ray_scan(...)[0] for various poses."""
+    obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
+    ped_coords = np.empty((0, 2), dtype=np.float64)
+    occ = ContinuousOccupancy(
+        width=10.0,
+        height=10.0,
+        get_agent_coords=lambda: (1.0, 1.0),
+        get_goal_coords=lambda: (9.0, 9.0),
+        get_obstacle_coords=lambda: obstacle_coords,
+        get_pedestrian_coords=lambda: ped_coords,
+    )
+    settings = LidarScannerSettings(max_scan_dist=10.0, num_rays=8, scan_noise=[0.0, 0.0])
+
+    for heading in [0.0, np.pi / 4, np.pi, -np.pi / 2, 2.5 * np.pi]:
+        pose = ((1.0, 1.0), heading)
+        ranges_ref = lidar_ray_scan(pose, occ, settings)[0]
+        ranges_only = lidar_ray_scan_ranges_only(pose, occ, settings)
+        np.testing.assert_array_equal(ranges_only, ranges_ref)
+
+
+def test_lidar_ray_scan_ranges_only_buffer_reuse():
+    """Repeated calls with different headings correctly overwrite the buffer."""
+    obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
+    ped_coords = np.empty((0, 2), dtype=np.float64)
+    occ = ContinuousOccupancy(
+        width=10.0,
+        height=10.0,
+        get_agent_coords=lambda: (1.0, 1.0),
+        get_goal_coords=lambda: (9.0, 9.0),
+        get_obstacle_coords=lambda: obstacle_coords,
+        get_pedestrian_coords=lambda: ped_coords,
+    )
+    settings = LidarScannerSettings(max_scan_dist=10.0, num_rays=4, scan_noise=[0.0, 0.0])
+
+    heading_a = 0.0
+    heading_b = np.pi / 3
+
+    ranges_a = lidar_ray_scan_ranges_only(((1.0, 1.0), heading_a), occ, settings)
+    ranges_b = lidar_ray_scan_ranges_only(((1.0, 1.0), heading_b), occ, settings)
+
+    ref_a = lidar_ray_scan(((1.0, 1.0), heading_a), occ, settings)[0]
+    ref_b = lidar_ray_scan(((1.0, 1.0), heading_b), occ, settings)[0]
+
+    np.testing.assert_array_equal(ranges_a, ref_a)
+    np.testing.assert_array_equal(ranges_b, ref_b)
+
+
+def test_lidar_ray_scan_angles_isolated_from_ranges_only_buffer():
+    """Public lidar_ray_scan returned angles remain correct after buffer mutation."""
+    obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
+    ped_coords = np.empty((0, 2), dtype=np.float64)
+    occ = ContinuousOccupancy(
+        width=10.0,
+        height=10.0,
+        get_agent_coords=lambda: (1.0, 1.0),
+        get_goal_coords=lambda: (9.0, 9.0),
+        get_obstacle_coords=lambda: obstacle_coords,
+        get_pedestrian_coords=lambda: ped_coords,
+    )
+    settings = LidarScannerSettings(
+        max_scan_dist=10.0,
+        num_rays=4,
+        visual_angle_portion=1.0,
+        scan_noise=[0.0, 0.0],
+    )
+
+    heading_1 = 0.0
+    heading_2 = np.pi / 2
+
+    # First scan with full API
+    _ranges_1, angles_1 = lidar_ray_scan(((1.0, 1.0), heading_1), occ, settings)
+
+    # Ranges-only call mutates private buffer
+    lidar_ray_scan_ranges_only(((1.0, 1.0), heading_2), occ, settings)
+
+    # Second full scan — must not alias or be contaminated by the buffer
+    _ranges_2, angles_2 = lidar_ray_scan(((1.0, 1.0), heading_1), occ, settings)
+
+    expected = np.mod(heading_1 + settings.ray_offsets, 2.0 * np.pi)
+    np.testing.assert_allclose(angles_1, expected, atol=1e-12, rtol=1e-12)
+    np.testing.assert_allclose(angles_2, expected, atol=1e-12, rtol=1e-12)


### PR DESCRIPTION
## Summary
- Adds `lidar_ray_scan_ranges_only` for env hot-loop call sites that only need LiDAR ranges and discard ray angles.
- Reuses a private `LidarScannerSettings` ray-angle work buffer for the ranges-only path, while preserving public `lidar_ray_scan` angle-return isolation.
- Refactors the common scan body into a private helper so both paths stay behavior-locked, and updates only the env utility closures that previously called `lidar_ray_scan(...)[0]`.

Closes #2370.

## Validation
- `uv run pytest tests/test_range_sensor.py tests/lidar_sensor_obstacle_test.py tests/lidar_sensor_pedestrian_test.py -q` -> 60 passed
- `uv run ruff check robot_sf/sensor/range_sensor.py robot_sf/gym_env/env_util.py tests/test_range_sensor.py` -> passed
- `uv run ruff format --check robot_sf/sensor/range_sensor.py robot_sf/gym_env/env_util.py tests/test_range_sensor.py` -> passed
- Caller scan: remaining `lidar_ray_scan(...)` env callers are the ones that use returned directions; angle-discarding `env_util.py` closures now use the ranges-only path.
- Micro-probe, 5000 calls, 272 rays, zero noise: `lidar_ray_scan(...)[0]` 0.057145s vs ranges-only 0.056086s, 1.02x; traced peak bytes 4888 vs 2648. This is allocation-pressure support evidence, not a throughput benchmark claim.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5282 passed, 9 skipped, readiness stamp passed at `3ff148f4224642fb37398a1875650d7ab828ad25`

## Downstream Propagation
- No benchmark report, leaderboard, artifact catalog, registry, or context note update needed. This is local simulator support/performance hygiene and does not change planner behavior, observations, rewards, metrics, schemas, or research claims.
- Ignored `output/` coverage/readiness artifacts were inspected and left untracked/disposable.

## Research Result Guidance
NA: this PR is not evidence-producing research work. The timing/allocation probe is support evidence for reduced per-scan allocation pressure only, not a benchmark throughput or planner-quality result.