### PR TITLE
perf: replace sensor fusion marker deques

### DIFF
--- a/robot_sf/sensor/image_sensor_fusion.py
+++ b/robot_sf/sensor/image_sensor_fusion.py
@@ -2,7 +2,6 @@
 Extended sensor fusion that includes image observations.
 """
 
-from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -40,10 +39,7 @@ class ImageSensorFusion:
     use_next_goal: bool
     use_image_obs: bool = False
 
-    # Drive-state cache stores warm-history markers; stacked_drive_state owns values.
-    drive_state_cache: deque[None] = field(init=False, default_factory=deque)
-    lidar_state_cache: deque = field(init=False, default_factory=deque)
-    image_state_cache: deque = field(init=False, default_factory=deque)
+    _initialized: bool = field(init=False, default=False)
     cache_steps: int = field(init=False)
 
     def __post_init__(self):
@@ -61,11 +57,7 @@ class ImageSensorFusion:
         self._drive_state_buffer = np.zeros(5, dtype=np.float32)
         self.stacked_lidar_state = np.zeros((self.cache_steps, lidar_shape), dtype=np.float32)
 
-        # Initialize caches for sensors
-        self.drive_state_cache = deque(maxlen=self.cache_steps)
-        self.lidar_state_cache = deque(maxlen=self.cache_steps)
-        if self.use_image_obs:
-            self.image_state_cache = deque(maxlen=self.cache_steps)
+        self._initialized = False
 
     def next_obs(self) -> dict[str, np.ndarray]:
         """
@@ -78,7 +70,6 @@ class ImageSensorFusion:
         """
         sensor_data = self._collect_sensor_data()
         self._initialize_caches_if_empty(sensor_data)
-        self._update_sensor_caches(sensor_data)
         self._update_stacked_states(sensor_data)
 
         return self._build_observation(sensor_data)
@@ -115,23 +106,14 @@ class ImageSensorFusion:
 
     def _initialize_caches_if_empty(self, sensor_data: dict):
         """Initialize caches if they are empty."""
-        if len(self.drive_state_cache) == 0:
-            for _ in range(self.cache_steps):
-                self.drive_state_cache.append(None)
-                self.lidar_state_cache.append(sensor_data["lidar_state"])
-                if self.use_image_obs and sensor_data["image_state"] is not None:
-                    self.image_state_cache.append(sensor_data["image_state"])
+        if not self._initialized:
+            self._initialized = True
             self.stacked_drive_state = fill_history_stack(
                 self.stacked_drive_state, sensor_data["drive_state"]
             )
             self.stacked_lidar_state = fill_history_stack(
                 self.stacked_lidar_state, sensor_data["lidar_state"]
             )
-
-    def _update_sensor_caches(self, sensor_data: dict):
-        """Update sensor caches with current data."""
-        self.drive_state_cache.append(None)
-        self.lidar_state_cache.append(sensor_data["lidar_state"])
 
     def _update_stacked_states(self, sensor_data: dict):
         """Update stacked states with current sensor data."""
@@ -172,7 +154,6 @@ class ImageSensorFusion:
                 shape = getattr(space, "shape", None)
                 img = np.zeros(shape, dtype=np.float32) if shape is not None else None
             if img is not None:
-                self.image_state_cache.append(img)
                 # Images are already normalized in the sensor
                 # Note: Images are intentionally NOT stacked like drive/lidar states
                 # to match the observation space design where images represent current frame only
@@ -195,10 +176,7 @@ class ImageSensorFusion:
         """
         Clear the caches of previous states.
         """
-        self.drive_state_cache.clear()
-        self.lidar_state_cache.clear()
-        if self.use_image_obs:
-            self.image_state_cache.clear()
+        self._initialized = False
 
         # Reset stacked states to zeros
         self.stacked_drive_state = reset_history_stack(self.stacked_drive_state)

--- a/robot_sf/sensor/sensor_fusion.py
+++ b/robot_sf/sensor/sensor_fusion.py
@@ -3,7 +3,6 @@ The `sensor_fusion.py` file defines a `SensorFusion` class that combines data fr
 It also provides a function `fused_sensor_space` to create a combined observation space.
 """
 
-from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -155,12 +154,6 @@ class SensorFusion:
     unnormed_obs_space : spaces.Dict
         The unnormalized observation space.
     use_next_goal : bool
-        Whether to use the next goal in the observation.
-    drive_state_cache : deque[None]
-        Warm-history markers for drive state. Concrete temporal values are stored
-        in ``stacked_drive_state``.
-    lidar_state_cache : List[np.ndarray]
-        A cache of previous LiDAR states.
     cache_steps : int
         The number of steps to cache.
     """
@@ -170,8 +163,7 @@ class SensorFusion:
     target_sensor: Callable[[], tuple[float, float, float]]
     unnormed_obs_space: spaces.Dict
     use_next_goal: bool
-    drive_state_cache: deque[None] = field(init=False, default_factory=deque)
-    lidar_state_cache: list[np.ndarray] = field(init=False, default_factory=list)
+    _initialized: bool = field(init=False, default=False)
     cache_steps: int = field(init=False)
 
     def __post_init__(self):
@@ -188,8 +180,7 @@ class SensorFusion:
             (self.cache_steps, len(self.lidar_sensor())),
             dtype=np.float32,
         )
-        self.drive_state_cache = deque(maxlen=self.cache_steps)
-        self.lidar_state_cache = deque(maxlen=self.cache_steps)
+        self._initialized = False
 
     def next_obs(self) -> dict[str, np.ndarray]:
         """
@@ -219,16 +210,12 @@ class SensorFusion:
         drive_state[:] = (speed_x, speed_rot, target_distance, target_angle, next_target_angle)
 
         # Populate history with the current state on first call to avoid zeros.
-        if len(self.drive_state_cache) == 0:
-            for _ in range(self.cache_steps):
-                self.drive_state_cache.append(None)
-                self.lidar_state_cache.append(lidar_state)
+        if not self._initialized:
+            self._initialized = True
             self.stacked_drive_state = fill_history_stack(self.stacked_drive_state, drive_state)
             self.stacked_lidar_state = fill_history_stack(self.stacked_lidar_state, lidar_state)
         else:
             # Add current states as the newest row so temporal stacks are oldest-to-newest.
-            self.drive_state_cache.append(None)
-            self.lidar_state_cache.append(lidar_state)
             self.stacked_drive_state = append_history_row(self.stacked_drive_state, drive_state)
             self.stacked_lidar_state = append_history_row(self.stacked_lidar_state, lidar_state)
 
@@ -244,7 +231,6 @@ class SensorFusion:
         """
         Clear the caches of previous drive and LiDAR states.
         """
-        self.drive_state_cache.clear()
-        self.lidar_state_cache.clear()
+        self._initialized = False
         self.stacked_drive_state = reset_history_stack(self.stacked_drive_state)
         self.stacked_lidar_state = reset_history_stack(self.stacked_lidar_state)

--- a/tests/test_image_sensor_fusion.py
+++ b/tests/test_image_sensor_fusion.py
@@ -224,7 +224,7 @@ class TestImageSensorFusion:
             assert obs[OBS_IMAGE].shape == (64, 64, 3)
 
     def test_reset_cache_with_image_enabled(self, mock_sensors, mock_obs_space):
-        """Test cache reset functionality with image observations."""
+        """Reset clears stacks; next_obs refills history stacks from current observation."""
         lidar_sensor, speed_sensor, target_sensor, image_sensor = mock_sensors
 
         fusion = ImageSensorFusion(
@@ -237,24 +237,25 @@ class TestImageSensorFusion:
             use_image_obs=True,
         )
 
-        # Get an observation to populate caches
+        # Get an observation to populate stacks
         _ = fusion.next_obs()
-
-        # Verify caches have data
-        assert len(fusion.drive_state_cache) > 0
-        assert len(fusion.lidar_state_cache) > 0
-        assert len(fusion.image_state_cache) > 0
+        assert not np.allclose(fusion.stacked_drive_state, 0.0)
+        assert not np.allclose(fusion.stacked_lidar_state, 0.0)
 
         # Reset cache
         fusion.reset_cache()
+        assert np.allclose(fusion.stacked_drive_state, 0.0)
+        assert np.allclose(fusion.stacked_lidar_state, 0.0)
 
-        # Verify caches are empty
-        assert len(fusion.drive_state_cache) == 0
-        assert len(fusion.lidar_state_cache) == 0
-        assert len(fusion.image_state_cache) == 0
+        # Next next_obs refills history stacks (fill_history_stack semantics)
+        obs = fusion.next_obs()
+        assert obs[OBS_DRIVE_STATE].shape == (3, 5)
+        assert obs[OBS_RAYS].shape == (3, 5)
+        assert OBS_IMAGE in obs
+        assert obs[OBS_IMAGE].shape == (64, 64, 3)
 
     def test_reset_cache_with_image_disabled(self, mock_sensors, mock_obs_space):
-        """Test cache reset functionality with image observations disabled."""
+        """Reset clears stacks; next_obs refills history stacks without image."""
         lidar_sensor, speed_sensor, target_sensor, image_sensor = mock_sensors
 
         fusion = ImageSensorFusion(
@@ -267,15 +268,21 @@ class TestImageSensorFusion:
             use_image_obs=False,
         )
 
-        # Get an observation to populate caches
+        # Get an observation to populate stacks
         _ = fusion.next_obs()
+        assert not np.allclose(fusion.stacked_drive_state, 0.0)
+        assert not np.allclose(fusion.stacked_lidar_state, 0.0)
 
-        # Reset cache should work even without image cache
+        # Reset cache
         fusion.reset_cache()
+        assert np.allclose(fusion.stacked_drive_state, 0.0)
+        assert np.allclose(fusion.stacked_lidar_state, 0.0)
 
-        # Verify basic caches are empty
-        assert len(fusion.drive_state_cache) == 0
-        assert len(fusion.lidar_state_cache) == 0
+        # Next next_obs refills history stacks
+        obs = fusion.next_obs()
+        assert obs[OBS_DRIVE_STATE].shape == (3, 5)
+        assert obs[OBS_RAYS].shape == (3, 5)
+        assert OBS_IMAGE not in obs
 
     def test_normalization_consistency(self, mock_sensors, mock_obs_space):
         """Test that observations are properly normalized."""

--- a/tests/test_sensor_fusion_stack.py
+++ b/tests/test_sensor_fusion_stack.py
@@ -192,7 +192,7 @@ def test_image_sensor_fusion_history_is_oldest_to_newest() -> None:
 
 
 def test_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
-    """Reset should clear both cache metadata and concrete temporal stack arrays."""
+    """Reset should zero the stacks; next next_obs refills history from current observation."""
     robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
     target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
     lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
@@ -208,14 +208,25 @@ def test_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
     fusion.next_obs()
     fusion.reset_cache()
 
-    assert len(fusion.drive_state_cache) == 0
-    assert len(fusion.lidar_state_cache) == 0
+    # After reset, stacks are zeroed
     assert np.allclose(fusion.stacked_drive_state, 0.0)
     assert np.allclose(fusion.stacked_lidar_state, 0.0)
 
+    # Next next_obs refills history from current observation (fill_history_stack semantics)
+    obs = fusion.next_obs()
+    assert np.allclose(obs[OBS_RAYS], [[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]])
+    assert np.allclose(
+        obs[OBS_DRIVE_STATE],
+        [
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+        ],
+    )
+
 
 def test_image_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
-    """ImageSensorFusion reset should use the same temporal stack reset semantics."""
+    """ImageSensorFusion reset zeros stacks; next next_obs refills history."""
     robot_obs = spaces.Box(low=-10.0, high=10.0, shape=(2,), dtype=np.float32)
     target_obs = spaces.Box(low=-10.0, high=10.0, shape=(3,), dtype=np.float32)
     lidar_obs = spaces.Box(low=0.0, high=10.0, shape=(2,), dtype=np.float32)
@@ -233,7 +244,18 @@ def test_image_sensor_fusion_reset_cache_clears_temporal_stacks() -> None:
     fusion.next_obs()
     fusion.reset_cache()
 
-    assert len(fusion.drive_state_cache) == 0
-    assert len(fusion.lidar_state_cache) == 0
+    # After reset, stacks are zeroed
     assert np.allclose(fusion.stacked_drive_state, 0.0)
     assert np.allclose(fusion.stacked_lidar_state, 0.0)
+
+    # Next next_obs refills history from current observation (fill_history_stack semantics)
+    obs = fusion.next_obs()
+    assert np.allclose(obs[OBS_RAYS], [[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]])
+    assert np.allclose(
+        obs[OBS_DRIVE_STATE],
+        [
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+            [0.2, 0.0, 0.3, 0.0, 0.0],
+        ],
+    )


### PR DESCRIPTION
## Summary
- Replace write-only sensor-fusion marker deques with a single `_initialized` flag.
- Preserve first-frame history-fill behavior after init/reset, then use append-only rolling stack updates.
- Remove unused image sensor cache append plumbing and update reset-history tests.

Closes #2372.

## Validation
- `uv run pytest tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py -q` -> 19 passed
- `uv run ruff check robot_sf/sensor/sensor_fusion.py robot_sf/sensor/image_sensor_fusion.py tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py` -> passed
- `uv run ruff format --check robot_sf/sensor/sensor_fusion.py robot_sf/sensor/image_sensor_fusion.py tests/test_sensor_fusion_stack.py tests/test_image_sensor_fusion.py` -> passed
- `rg "drive_state_cache|lidar_state_cache|image_state_cache" robot_sf tests` -> no matches
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5282 passed, 9 skipped, 18 warnings in 265.12s; readiness stamp `output/validation/pr_ready/issue-2372-sensor-fusion-flags.json`

## Performance note
A local control-flow probe comparing the removed marker-cache bookkeeping against the flag path measured 0.586705s old vs 0.447169s new over 5x500000 iterations, about 1.31x faster for that isolated marker/update path. This is support evidence for the micro-optimization, not benchmark evidence.

## Downstream Propagation
- Parent issue: #2372
- Claim map / benchmark report / leaderboard / registry: NA; support performance hygiene only.
- Context or memory note: NA; no reusable research result.
- Output inspection: ignored readiness, coverage, cache, and viewer outputs remained local and untracked.

## Research Result Guidance
NA. This PR does not advance a research claim; it removes unnecessary simulator hot-loop bookkeeping after the research lane was locally exhausted or blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal sensor fusion caching mechanism for improved performance and memory efficiency.
  * Updated sensor cache validation tests to reflect new internal implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->