### PR TITLE
perf: cache SocNav position caps

### DIFF
--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -288,6 +288,10 @@ class SocNavObservationFusion:
         self._cache_static_map_def_id = None
         self._cache_static_obstacles_id = None
         self._cache_static_prepared: list[tuple[Any, Any]] = []
+        self._cache_position_cap_map_def_id: int | None = None
+        self._cache_position_cap_value: np.ndarray | None = None
+        self._cache_position_cap_width: float | None = None
+        self._cache_position_cap_height: float | None = None
 
     def reset_cache(self) -> None:
         """Reset internal caches to match the SensorFusion interface."""
@@ -295,6 +299,39 @@ class SocNavObservationFusion:
         self._cache_static_map_def_id = None
         self._cache_static_obstacles_id = None
         self._cache_static_prepared = []
+        self._cache_position_cap_map_def_id = None
+        self._cache_position_cap_value = None
+        self._cache_position_cap_width = None
+        self._cache_position_cap_height = None
+
+    def _position_cap(self) -> np.ndarray:
+        """Return cached map position cap, refreshing when map_def identity or dimensions change.
+
+        Avoids allocating a new array every step via ``_map_position_cap``.
+        """
+        map_def = getattr(self.simulator, "map_def", None)
+        if map_def is not None:
+            width = float(getattr(map_def, "width", 0.0) or 0.0)
+            height = float(getattr(map_def, "height", 0.0) or 0.0)
+            map_def_id = id(map_def)
+            cache_valid = (
+                self._cache_position_cap_map_def_id == map_def_id
+                and self._cache_position_cap_width == width
+                and self._cache_position_cap_height == height
+            )
+            if not cache_valid:
+                self._cache_position_cap_map_def_id = map_def_id
+                self._cache_position_cap_width = width
+                self._cache_position_cap_height = height
+                self._cache_position_cap_value = _map_position_cap(map_def)
+        elif self._cache_position_cap_map_def_id is not None:
+            self._cache_position_cap_map_def_id = None
+            self._cache_position_cap_value = _map_position_cap(None)
+            self._cache_position_cap_width = None
+            self._cache_position_cap_height = None
+        if self._cache_position_cap_value is None:
+            self._cache_position_cap_value = _map_position_cap(None)
+        return self._cache_position_cap_value
 
     def _robot_velocity_xy(self, wrapped_heading: float) -> np.ndarray:
         """Return the robot world-frame planar velocity for the structured observation."""
@@ -501,7 +538,7 @@ class SocNavObservationFusion:
             else np.zeros(2, dtype=np.float32)
         )
 
-        position_cap = _map_position_cap(self.simulator.map_def)
+        position_cap = self._position_cap()
 
         def _clip_positions(values: np.ndarray) -> np.ndarray:
             """Clip world positions into the representable map extent.

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -409,3 +409,56 @@ def test_static_occlusion_edge_touch_not_occluded() -> None:
     # ped at (3, 0.0): line goes through obstacle interior -> occluded
     assert obs["pedestrians"]["count"][0] == pytest.approx(1.0)
     np.testing.assert_allclose(obs["pedestrians"]["positions"][0], [3.0, 0.5], atol=1e-6)
+
+
+def test_position_cap_cache_refreshes_on_map_def_change() -> None:
+    """Position cap should refresh when map_def identity or width/height changes."""
+    env_config = RobotSimulationConfig()
+    simulator = SimpleNamespace(
+        ped_pos=np.zeros((1, 2), dtype=np.float32),
+        ped_vel=np.zeros((1, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([0.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=120.0, height=80.0),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+    fusion = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    cap1 = fusion._position_cap()
+    cap1_id = id(cap1)
+    assert cap1.tolist() == pytest.approx([120.0, 80.0])
+
+    cap1_again = fusion._position_cap()
+    assert id(cap1_again) == cap1_id, "Same map_def should reuse cached array"
+
+    # Mutate width on same map_def object — should refresh
+    simulator.map_def.width = 200.0
+    cap2 = fusion._position_cap()
+    assert cap2.tolist() == pytest.approx([200.0, 80.0])
+    assert id(cap2) != cap1_id, "Width change should produce new cached array"
+
+    # Replace map_def entirely — should refresh
+    simulator.map_def = SimpleNamespace(width=60.0, height=60.0)
+    cap3 = fusion._position_cap()
+    assert cap3.tolist() == pytest.approx([60.0, 60.0])
+    assert id(cap3) != id(cap2), "Map def replacement should produce new cached array"
+
+    # reset_cache should clear position cap too
+    fusion.reset_cache()
+    cap4 = fusion._position_cap()
+    assert cap4.tolist() == pytest.approx([60.0, 60.0])
+
+    # Verify next_obs() also respects refreshed caps
+    cap_via_obs = fusion.next_obs()["map"]["size"]
+    np.testing.assert_array_equal(cap_via_obs, np.array([60.0, 60.0], dtype=np.float32))


### PR DESCRIPTION
## Summary
- Add a per-`SocNavObservationFusion` cache for map-aware position caps used by structured SocNav observations.
- Refresh the cache when `map_def` identity or map width/height changes, and clear it from `reset_cache()`.
- Add a focused regression test covering same-object reuse, dimension mutation, map replacement, reset, and `next_obs()` use.

Closes #2374.

## Validation
- `uv run pytest tests/test_socnav_observation.py -q` -> 11 passed
- `uv run ruff check robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py` -> passed
- `uv run ruff format --check robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py` -> passed
- First full readiness attempt failed during collection because the fresh worktree lacked optional dependency `duckdb`; root cause was unsynced extras, fixed with `uv sync --all-extras`.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5283 passed, 9 skipped, 16 warnings in 248.82s; readiness stamp `output/validation/pr_ready/issue-2374-socnav-position-cap-cache.json`; changed-file coverage warning: `robot_sf/sensor/socnav_observation.py` 94.1%.

## Performance note
A local isolated probe over 1,000,000 calls measured `_map_position_cap(map_def)` at 1.357839s vs the cached helper at 0.776262s, about 1.75x faster for that tiny control/allocation path. This is support evidence only, not benchmark evidence.

## Downstream Propagation
- Parent issue: #2374
- Claim map / benchmark report / leaderboard / registry: NA; support performance hygiene only.
- Context or memory note: NA; no reusable research result.
- Output inspection: ignored readiness, coverage, cache, and viewer outputs remained local and untracked.

## Research Result Guidance
NA. This PR does not advance a research claim; it removes repeated structured-observation bookkeeping after currently ready research work was locally blocked by SLURM/CARLA/external-data/running states.