### PR TITLE
perf: reuse predictive SocNav min distance

### DIFF
--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -3845,12 +3845,26 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
             return min(boosted, max_steps)
         return min(base_steps, max_steps)
 
-    def _risk_speed_cap_ratio(self, *, future_peds: np.ndarray, mask: np.ndarray) -> float:
+    def _risk_speed_cap_ratio(
+        self,
+        *,
+        future_peds: np.ndarray,
+        mask: np.ndarray,
+        min_pred_dist: float | None = None,
+    ) -> float:
         """Compute a near-field risk speed cap ratio.
 
         ``near-field risk`` means predicted pedestrian proximity below
         ``predictive_near_field_distance`` over the short prediction horizon.
         The returned ratio shrinks max candidate speed in dense/conflict states.
+
+        Args:
+            future_peds: Predicted pedestrian trajectories in robot frame.
+            mask: Agent validity mask.
+            min_pred_dist: Optional precomputed minimum predicted distance.
+                When provided, the internal ``_min_predicted_distance`` call is
+                skipped so callers that already hold this value can avoid
+                redundant computation.
 
         Returns:
             float: Speed cap ratio in ``[0.1, 1.0]``.
@@ -3858,11 +3872,12 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
         near_field = float(self.config.predictive_near_field_distance)
         if near_field <= 0.0:
             return 1.0
-        min_pred_dist = self._min_predicted_distance(
-            future_peds=future_peds,
-            mask=mask,
-            steps=max(2, min(int(self.config.predictive_horizon_steps), future_peds.shape[1])),
-        )
+        if min_pred_dist is None:
+            min_pred_dist = self._min_predicted_distance(
+                future_peds=future_peds,
+                mask=mask,
+                steps=max(2, min(int(self.config.predictive_horizon_steps), future_peds.shape[1])),
+            )
         if not np.isfinite(min_pred_dist):
             return 1.0
         cap = float(self.config.predictive_near_field_speed_cap)
@@ -3886,15 +3901,16 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
         Returns:
             list[tuple[float, float]]: Candidate ``(v, omega)`` commands.
         """
-        cap_ratio = self._risk_speed_cap_ratio(future_peds=future_peds, mask=mask)
+        near_field = float(self.config.predictive_near_field_distance)
+        near_horizon = max(2, min(int(self.config.predictive_horizon_steps), future_peds.shape[1]))
+        min_pred_dist = self._min_predicted_distance(
+            future_peds=future_peds, mask=mask, steps=near_horizon
+        )
+        cap_ratio = self._risk_speed_cap_ratio(
+            future_peds=future_peds, mask=mask, min_pred_dist=min_pred_dist
+        )
         base_speed_ratios = [float(v) for v in self.config.predictive_candidate_speeds]
         heading_deltas = [float(v) for v in self.config.predictive_candidate_heading_deltas]
-        near_field = float(self.config.predictive_near_field_distance)
-        min_pred_dist = self._min_predicted_distance(
-            future_peds=future_peds,
-            mask=mask,
-            steps=max(2, min(int(self.config.predictive_horizon_steps), future_peds.shape[1])),
-        )
         if np.isfinite(min_pred_dist) and min_pred_dist <= near_field:
             base_speed_ratios.extend(
                 float(v) for v in self.config.predictive_near_field_speed_samples

--- a/tests/test_socnav_planner_adapter.py
+++ b/tests/test_socnav_planner_adapter.py
@@ -671,6 +671,43 @@ def test_prediction_adapter_adaptive_lattice_expands_near_field(monkeypatch):
     assert len(candidates) > base_count
 
 
+def test_prediction_adapter_candidate_set_computes_min_pred_dist_once(monkeypatch):
+    """_candidate_set should call _min_predicted_distance exactly once for the shared near horizon."""
+
+    def _boom(self):
+        raise RuntimeError("missing predictive model")
+
+    monkeypatch.setattr(PredictionPlannerAdapter, "_build_model", _boom)
+    cfg = SocNavPlannerConfig(
+        predictive_near_field_distance=2.5,
+        predictive_candidate_speeds=(0.0, 0.5, 1.0),
+        predictive_candidate_heading_deltas=(-np.pi / 8, 0.0, np.pi / 8),
+        predictive_near_field_speed_samples=(0.1, 0.2),
+        predictive_near_field_heading_deltas=(-np.pi / 2, 0.0, np.pi / 2),
+    )
+    adapter = PredictionPlannerAdapter(cfg, allow_fallback=True)
+
+    future = np.zeros((1, 4, 2), dtype=np.float32)
+    future[0, :, 0] = 0.8
+    mask = np.array([1.0], dtype=np.float32)
+
+    call_count = 0
+    original = PredictionPlannerAdapter._min_predicted_distance
+
+    def counting_min_pred_dist(self, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(PredictionPlannerAdapter, "_min_predicted_distance", counting_min_pred_dist)
+
+    candidates = adapter._candidate_set(future_peds=future, mask=mask)
+    assert call_count == 1, f"Expected 1 call to _min_predicted_distance, got {call_count}"
+
+    base_count = len(cfg.predictive_candidate_speeds) * len(cfg.predictive_candidate_heading_deltas)
+    assert len(candidates) > base_count
+
+
 def test_prediction_adapter_reverse_candidates_appear_in_near_field(monkeypatch):
     """Reverse candidates should be added when explicitly enabled in close-contact regimes."""
 


### PR DESCRIPTION
## Summary
- Reuses the near-field minimum predicted distance inside `PredictionPlannerAdapter._candidate_set()`.
- Keeps `_risk_speed_cap_ratio()` backward-compatible with an optional precomputed distance.
- Adds a focused regression test that candidate-set construction only calls `_min_predicted_distance()` once for the shared near horizon while preserving near-field expansion behavior.

Closes #2378.

## Validation
- uv run pytest tests/test_socnav_planner_adapter.py -q (45 passed, 3 skipped)
- uv run ruff check robot_sf/planner/socnav.py tests/test_socnav_planner_adapter.py
- uv run ruff format --check robot_sf/planner/socnav.py tests/test_socnav_planner_adapter.py
- PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh (5284 passed, 9 skipped; changed-file coverage warning only: socnav.py 86.6%)

## Downstream Propagation
NA - local performance cleanup only; no benchmark result, schema, artifact registry, or context index update is required. Pytest generated ignored `output/coverage/` and `output/validation/` files, treated as disposable local validation artifacts.

## Research Result Guidance
NA - this is support/performance cleanup, not a research claim or benchmark conclusion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved social navigation planner performance by streamlining predictive distance computation—eliminating redundant calculations to enhance overall planning efficiency.

* **Tests**
  * Added test to verify the planner computes critical distance metrics only once during candidate set generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->