### PR TITLE
perf: use hypot for SNQI jerk proxy

### DIFF
--- a/robot_sf/gym_env/snqi_proxy.py
+++ b/robot_sf/gym_env/snqi_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -198,7 +199,7 @@ def compute_snqi_step_proxies(
                 acc = (vel - proxy_state.prev_robot_vel) / dt
                 if proxy_state.prev_robot_acc is not None:
                     jerk = (acc - proxy_state.prev_robot_acc) / dt
-                    jerk_mag = float(np.linalg.norm(jerk))
+                    jerk_mag = math.hypot(float(jerk[0]), float(jerk[1]))
                     if np.isfinite(jerk_mag):
                         proxy_state.jerk_sum += jerk_mag
                         proxy_state.jerk_count += 1


### PR DESCRIPTION
## Summary
- Replaces the 2D SNQI step-proxy jerk magnitude `np.linalg.norm` call with `math.hypot`.
- Preserves finite checks, return type, and running jerk accumulation behavior.
- Keeps the change scoped to `robot_sf/gym_env/snqi_proxy.py`; existing focused tests already cover the running jerk mean.

Closes #2380.

## Validation
- uv run pytest tests/gym_env/test_snqi_step_proxy.py tests/gym_env/test_robot_env_snqi_step_metadata.py -q (13 passed)
- uv run ruff check robot_sf/gym_env/snqi_proxy.py tests/gym_env/test_snqi_step_proxy.py tests/gym_env/test_robot_env_snqi_step_metadata.py
- uv run ruff format --check robot_sf/gym_env/snqi_proxy.py tests/gym_env/test_snqi_step_proxy.py tests/gym_env/test_robot_env_snqi_step_metadata.py
- PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh (5284 passed, 9 skipped; changed-file coverage warning only: snqi_proxy.py 94.9%)

## Discovery
- OpenCode Go read-only scout `20260606T042127Z_opencode_opencode_speed_candidate_scout_7` recommended this candidate and made no file changes.

## Downstream Propagation
NA - local support/performance cleanup only; no benchmark result, schema, artifact registry, or context index update is required. Pytest generated ignored `output/coverage/` and `output/validation/` files, treated as disposable local validation artifacts.

## Research Result Guidance
NA - this is support/performance cleanup, not a research claim or benchmark conclusion.
