### PR TITLE
perf: hoist predictive MPPI valid mask

### DIFF
--- a/robot_sf/planner/predictive_mppi.py
+++ b/robot_sf/planner/predictive_mppi.py
@@ -189,6 +189,7 @@ class PredictiveMPPIAdapter(OccupancyAwarePlannerMixin):
         prev_action = np.array([0.0, 0.0], dtype=float)
         anchor = np.asarray(anchor_action, dtype=float)
         future_steps = int(future.shape[1])
+        valid_idx = np.where(mask > 0.5)[0]
 
         for step, action in enumerate(sequence):
             v = float(action[0])
@@ -201,9 +202,9 @@ class PredictiveMPPIAdapter(OccupancyAwarePlannerMixin):
 
             ped_idx = min(step, future_steps - 1)
             ped_t = future[:, ped_idx, :]
-            if ped_t.size > 0:
+            if ped_t.size > 0 and valid_idx.size > 0:
                 dists = np.linalg.norm(ped_t - local_pos[None, :], axis=1)
-                valid_dist = dists[mask > 0.5]
+                valid_dist = dists[valid_idx]
                 if valid_dist.size > 0:
                     min_clear = min(min_clear, float(np.min(valid_dist)))
                     if step == 0:


### PR DESCRIPTION
## Summary
- Computes the Predictive MPPI valid-agent index once per `_sequence_rollout()` call.
- Reuses that index inside each rollout step instead of rebuilding the boolean mask filter.
- Preserves empty-mask, first-clearance, TTC penalty, and deterministic scoring behavior.

Closes #2382.

## Validation
- uv run pytest tests/planner/test_predictive_mppi_planner.py -q (5 passed)
- uv run ruff check robot_sf/planner/predictive_mppi.py tests/planner/test_predictive_mppi_planner.py
- uv run ruff format --check robot_sf/planner/predictive_mppi.py tests/planner/test_predictive_mppi_planner.py
- PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh (5284 passed, 9 skipped; changed-file coverage warning only: predictive_mppi.py 94.3%)

## Downstream Propagation
NA - local support/performance cleanup only; no benchmark result, schema, artifact registry, or context index update is required. Pytest generated ignored `output/coverage/` and `output/validation/` files, treated as disposable local validation artifacts.

## Research Result Guidance
NA - this is support/performance cleanup, not a research claim or benchmark conclusion.
