### PR TITLE
docs: require next empirical action in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -47,6 +47,16 @@ that make no research claim, set fields to `NA` and state why.
 - Result route: stop / revise / narrow / continue / NA
 - Follow-up question or issue for weak, negative, or non-transfer results:
 
+## Next Empirical Action
+Required when evidence is missing, blocked, diagnostic-only, or negative. For docs-only, support,
+or already-complete evidence PRs, set fields to `NA` and state why.
+
+- Rerun needed: yes / no / NA
+- Extractor or analysis tool needed: yes / no / NA
+- Artifact missing or unavailable:
+- Stop / revise / continue decision:
+- Proposed child issue or existing follow-up:
+
 ## Validation / Proof
 For research/benchmark/metric/paper-facing analysis-tool PRs: include one
 representative use on durable/versioned input (tracked config, model


### PR DESCRIPTION
## Summary
- add a compact `Next Empirical Action` block to the default PR template
- require explicit rerun/extractor/artifact/stop-revise-continue/follow-up fields when evidence is missing, blocked, diagnostic-only, or negative
- allow `NA` with a reason for docs-only, support, or already-complete evidence PRs

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; workflow template support only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs-only.
- Result classification: NA.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2388.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA.

## Next Empirical Action
- Rerun needed: NA; template-only change.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA.
- Proposed child issue or existing follow-up: NA.

## Validation
- Inspected `.github/PULL_REQUEST_TEMPLATE/pr_default.md` Markdown structure.
- `git diff --check`

## Downstream Propagation
- Parent issue updated: yes, claimed in #2388.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA.
- Not applicable because this is a narrow PR-template workflow prompt.

Closes #2388.