### PR TITLE
docs: add active delegation ledger convention

### DIFF
--- a/.agents/skills/gh-pr-merger/SKILL.md
+++ b/.agents/skills/gh-pr-merger/SKILL.md
@@ -70,6 +70,8 @@ Do not retry preflight on the same PR without a state change.
    ```
 2. For each PR:
    - Run preflight checks.
+   - Update the active delegation ledger from `.agents/skills/goal-autopilot/SKILL.md` with the PR
+     number, head SHA, preflight status, merge command status, cleanup status, and next action.
    - If all pass, record the PR head SHA and merge using squash merge:
      ```bash
      HEAD_SHA=$(gh pr view <number> --json headRefOid --jq .headRefOid)
@@ -79,6 +81,9 @@ Do not retry preflight on the same PR without a state change.
      the lookup failure before attempting the merge.
    - If merge fails, run diagnostics and handle the failure (see Merge
      Command Failure below) before continuing to the next PR.
+   - Update the active ledger after remote merge verification, branch deletion, claim release, and
+     worktree/artifact cleanup decisions. Keep remote merge success separate from local cleanup
+     failures.
 3. Report merged PRs, skipped PRs with reasons, and any failures.
 
 Do not merge multiple PRs in parallel. Process sequentially.

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -110,6 +110,45 @@ labels or project state; resolve review threads; or make final benchmark, paper,
 unless the user explicitly grants that permission. Their output is route evidence that must be
 reviewed and validated before phase completion.
 
+### Active Delegation Ledger
+
+For long-running or delegated goal runs, maintain one compact active-state ledger in the common Git
+directory so it survives linked worktrees, context compaction, and branch cleanup without entering
+the PR diff:
+
+```bash
+LEDGER_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
+mkdir -p "$LEDGER_DIR"
+```
+
+Use a short Markdown or YAML file such as
+`$LEDGER_DIR/issue-<number>-delegation-ledger.md` or `$LEDGER_DIR/pr-<number>-delegation-ledger.md`.
+This ledger is a handoff checklist, not a replacement for GitHub issues, PR bodies, issue-claim
+refs, worker artifacts, validation logs, or final summaries.
+
+Track only the fields needed to resume safely in under one minute:
+
+- route: provider/tool, model or agent role, run ID or artifact path, and route status;
+- task state: issue/PR number, phase, branch, worktree, claim ref/status, and next action;
+- ownership: files or modules the delegate may read or edit;
+- validation: commands planned/run, pass/fail state, and any blocker signature;
+- PR/CI: PR URL or number, head SHA, review state, CI state, and merge-ready state;
+- cleanup: app-agent or worker close status, claim release status, worktree/artifact decision.
+
+Distinguish route success from task success. A delegate command exiting zero or producing a report
+only proves `route_status: completed`; the parent phase is not complete until the main agent has
+reviewed the output, integrated any edits, run the required validation, updated GitHub state, and
+recorded cleanup.
+
+Update the ledger:
+
+- after a claim is acquired and the implementation worktree/branch is created;
+- after each delegated route starts, including `delegation_skipped: <reason>` entries;
+- after worker completion, failure, or cancellation;
+- after PR creation, before any CI wait, and after CI/review state changes;
+- after merge success/failure, claim release, worker close, and worktree/artifact cleanup;
+- before any compaction-prone wait, handoff, or final response while active work remains.
+
 Transitions:
 - After `implement`, proceed to `review`.
 - After `review`, proceed to `merge`.

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -117,7 +117,7 @@ directory so it survives linked worktrees, context compaction, and branch cleanu
 the PR diff:
 
 ```bash
-LEDGER_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
+LEDGER_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)/codex-agent-runs/active"
 mkdir -p "$LEDGER_DIR"
 ```
 

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -319,14 +319,20 @@ Route remaining issues by their blocker:
 4. Make the successful claim visible in the issue/project surfaces: move the issue to `In progress`
    or `state:running`, assign the actor when practical, and add a concise issue comment with the
    claim ref, machine/thread, planned branch, and stale-claim cleanup condition.
-5. Create/checkout the isolated implementation branch. For non-trivial local changes, prefer a
+5. Create or update the active delegation ledger described in
+   `.agents/skills/goal-autopilot/SKILL.md` with the claim ref/status, issue, branch/worktree,
+   owned files or modules, route/run IDs, validation plan, cleanup status, and next action. Update
+   it after every delegated worker start/completion/failure, before any CI wait or compaction-prone
+   pause, and after PR creation and claim release. Record route success separately from task
+   success.
+6. Create/checkout the isolated implementation branch. For non-trivial local changes, prefer a
    linked worktree and follow `AGENTS.md` "Fresh Worktree Bootstrap" for location, naming,
    machine-context symlink, environment setup, and early `origin/main` freshness.
-6. Implement only in-scope behavior and required tests/docs.
-7. Validate using the narrowest meaningful level first, then expand.
-8. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
-9. Prepare proof and branch handoff via `gh-pr-opener`.
-10. Open PR, release the transient claim with
+7. Implement only in-scope behavior and required tests/docs.
+8. Validate using the narrowest meaningful level first, then expand.
+9. If validation fails and failure is fixable, adjust and rerun; otherwise record blocker.
+10. Prepare proof and branch handoff via `gh-pr-opener`.
+11. Open PR, release the transient claim with
     `uv run python scripts/dev/issue_claim.py release <issue-number>` once the PR visibly covers the
     issue, then report and move to next queue item. If the run abandons the issue before PR opening,
     release the claim only after recording the blocker or handoff.

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -90,6 +90,9 @@ Avoid loops:
 2. Sort/prioritize queue (or follow explicit user order).
 3. For each PR:
    - capture issue link and head SHA,
+   - create or update the active delegation ledger from
+     `.agents/skills/goal-autopilot/SKILL.md` with the PR, head SHA, route/run IDs, validation
+     plan/status, review/CI state, cleanup status, and next action,
    - run `implementation-verification` for contract alignment,
    - classify findings as fixable now, deferred, or blocker.
 4. Fix actionable items on writable branches; commit and push.
@@ -99,6 +102,8 @@ Avoid loops:
 7. Resolve review threads only after the post-push thread snapshot confirms the fixes still cover all
    actionable comments.
 8. Update `merge-ready` only after full proof bar closes.
+9. Update the active ledger before any CI wait or final handoff. Route completion is not task
+   completion until the main agent has verified proof, GitHub state, and cleanup.
 
 ## Proof and Validation
 


### PR DESCRIPTION
## Summary
- Add a compaction-safe active delegation ledger convention to goal-autopilot.
- Hook the ledger update points into implementation, review, and merge workflows.
- Keep the convention lightweight, gitignored/common-Git-dir based, and separate route success from task success.

Closes #2385

## Validation
- PASS: `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
- PASS: `uv run python scripts/dev/check_skills.py --preflight goal-issue-implementation`
- PASS: `uv run python scripts/dev/check_skills.py --preflight goal-pr-review`
- PASS: `uv run python scripts/dev/check_skills.py --preflight gh-pr-merger`
- PASS: `git diff --check`

## Artifact / Output Decision
- No tracked generated outputs.
- Active example ledger and scout self-review note are intentionally gitignored under `.git/codex-agent-runs/`.

## Downstream Propagation
- Updated repo-local goal skills directly; no benchmark, registry, or context note propagation needed.

## Research Result Guidance
- NA: workflow/docs-only change; it supports autonomous research throughput but makes no research claim.

## Next Empirical Action
- Use the active ledger during the next delegated/autonomous PR wait and verify a compacted agent can resume claim, PR, CI, cleanup, and next-action state without reconstructing from chat.