### PR TITLE
feat: add human interaction proxy metrics

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -759,6 +759,9 @@ knowledge, not every transient iteration detail.
 * [Issue #1085 Pedestrian-Impact Aggregate Metrics](issue_1085_pedestrian_impact_metrics.md)
   defines the schema-backed `pedestrian-impact.v1` block, canonical aggregate reductions, and
   opt-in CLI path for pedestrian-impact benchmark outputs.
+* [Issue #2458 Human-Interaction Proxy Metrics](issue_2458_human_interaction_proxy_metrics.md)
+  defines the schema-backed `human-interaction-proxy.v1` block, simulation-proxy formulas, and
+  claim boundary for human-centered mechanism-report reductions.
 * [Issue #1092 Multi-AMV First Slice](issue_1092_multi_amv_first_slice.md)
   records the minimal multi-robot scenario surface, smoke runner, inter-robot metrics, and deferred
   fleet-integration boundary.

--- a/docs/context/issue_2458_human_interaction_proxy_metrics.md
+++ b/docs/context/issue_2458_human_interaction_proxy_metrics.md
@@ -1,0 +1,46 @@
+# Issue 2458 Human-Interaction Proxy Metrics
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/2458>
+
+## What Was Implemented
+
+`robot_sf/benchmark/metrics.py` now supports an optional diagnostic metric group behind:
+
+```bash
+compute_all_metrics(..., experimental_human_interaction_proxy=True)
+```
+
+The opt-in path emits flat `human_proxy_*` fields plus a structured
+`metrics.human_interaction_proxy` block with
+`schema_version: human-interaction-proxy.v1`.
+
+Canonical reductions:
+
+- `human_discomfort_exposure_m_s`
+- `intrusion_duration_s`
+- `time_to_yield_s`
+- `robot_yield_distance_m`
+- `pedestrian_path_deviation_proxy_m`
+- `group_split_intrusion_available`
+
+## Claim Boundary
+
+These are simulation proxies for mechanism reports only. They are not validated human comfort,
+human-subject, safety, or paper-grade social-compliance metrics.
+
+`group_split_intrusion_available` is false in the current implementation because `EpisodeData` does
+not carry group-membership labels. Group-split intrusion should remain excluded until a grouped
+pedestrian contract exists.
+
+## Proof Surface
+
+Targeted tests cover:
+
+- opt-in behavior and empty-crowd stability,
+- a crafted trajectory with exact formula checks for discomfort exposure, intrusion duration,
+  time-to-yield, and robot-yield distance,
+- post-processing into the structured `human_interaction_proxy` block,
+- episode schema validation,
+- aggregate flattening from schema-backed records.
+
+The formula and unit contract is documented in `docs/ped_metrics/metrics_spec.md`.

--- a/docs/ped_metrics/metrics_spec.md
+++ b/docs/ped_metrics/metrics_spec.md
@@ -169,6 +169,44 @@ Canonical pilot reductions:
 Missing pedestrian trajectories fail gracefully: availability is false, counts and intrusion
 reductions are zero, and minimum clearance is omitted from sanitized JSON output when unavailable.
 
+### Human-Interaction Proxy Metrics
+
+`compute_all_metrics(..., experimental_human_interaction_proxy=True)` emits a bounded
+`human_proxy_*` metric family plus a structured `metrics.human_interaction_proxy` block with
+`schema_version: human-interaction-proxy.v1`. These metrics are simulation proxies for
+mechanism-report discussion only. They are not validated human comfort, human-subject, safety, or
+paper-grade social-compliance metrics.
+
+Default parameters:
+
+- `human_proxy_proxemic_radius_m`: `1.2` meters of robot-pedestrian surface clearance.
+- `human_proxy_yield_speed_mps`: `0.15` meters per second robot-speed threshold for proxy yielding.
+
+Canonical reductions:
+
+- `human_discomfort_exposure_m_s`: sum of
+  `max(human_proxy_proxemic_radius_m - clearance_m, 0) * dt` across pedestrians and timesteps.
+  Unit: meter-seconds (`m*s`).
+- `intrusion_duration_s`: number of timesteps where at least one pedestrian has surface clearance
+  below `human_proxy_proxemic_radius_m`, multiplied by `dt`. Unit: seconds.
+- `time_to_yield_s`: elapsed time from the first proxemic intrusion timestep to the first later
+  timestep where robot speed is at or below `human_proxy_yield_speed_mps`. Omitted from sanitized
+  JSON output when no intrusion or no proxy-yield timestep exists.
+- `robot_yield_distance_m`: nearest center-to-center robot-pedestrian distance at the proxy-yield
+  timestep. Omitted when `time_to_yield_s` is unavailable.
+- `pedestrian_path_deviation_proxy_m`: mean per-pedestrian extra path length over straight-line
+  displacement. This is a trajectory irregularity proxy, not a measured intent or discomfort
+  signal.
+- `group_split_intrusion_available`: false for the current `EpisodeData` path because the episode
+  container does not include social-group membership labels. Group-split intrusion remains excluded
+  until a grouped-pedestrian contract exists.
+
+Episode records preserve the flat fields and include a structured block with parameters, units,
+sample counts, canonical reductions, exclusions, and an interpretation string. Aggregation flattens
+the structured block into scalar columns such as `human_discomfort_exposure_m_s`,
+`intrusion_duration_s`, `time_to_yield_s`, `robot_yield_distance_m`, and
+`pedestrian_path_deviation_proxy_m`.
+
 ### Motion Quality Metrics
 
 #### Smoothness (Jerk)

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -395,6 +395,35 @@ def _flatten_social_acceptability_block(base: dict[str, Any], social_acceptabili
             base[target_key] = proxemic.get(source_key)
 
 
+def _flatten_human_interaction_proxy_block(
+    base: dict[str, Any],
+    human_interaction_proxy: Any,
+) -> None:
+    """Flatten schema-backed human-interaction proxy reductions into ``base``."""
+    if not isinstance(human_interaction_proxy, dict):
+        return
+    base["human_proxy_available"] = human_interaction_proxy.get("available")
+    parameters = human_interaction_proxy.get("parameters") or {}
+    if isinstance(parameters, dict):
+        base["human_proxy_proxemic_radius_m"] = parameters.get("proxemic_radius_m")
+        base["human_proxy_yield_speed_mps"] = parameters.get("yield_speed_mps")
+    sample_counts = human_interaction_proxy.get("sample_counts") or {}
+    if isinstance(sample_counts, dict):
+        base["human_proxy_ped_count"] = sample_counts.get("pedestrians")
+        base["human_proxy_timestep_count"] = sample_counts.get("timesteps")
+    reductions = human_interaction_proxy.get("canonical_reductions") or {}
+    if isinstance(reductions, dict):
+        for source_key in (
+            "human_discomfort_exposure_m_s",
+            "intrusion_duration_s",
+            "time_to_yield_s",
+            "robot_yield_distance_m",
+            "pedestrian_path_deviation_proxy_m",
+            "group_split_intrusion_available",
+        ):
+            base[source_key] = reductions.get(source_key)
+
+
 def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     """Flatten metrics dict into a flat per-episode row.
 
@@ -410,6 +439,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     fq = metrics.pop("force_quantiles", {}) or {}
     ped_impact = metrics.pop("pedestrian_impact", {}) or {}
     social_acceptability = metrics.pop("social_acceptability", {}) or {}
+    human_interaction_proxy = metrics.pop("human_interaction_proxy", {}) or {}
     inter_robot = metrics.pop("inter_robot", {}) or {}
     # Flatten known force quantiles
     for qk in ("q50", "q90", "q95"):
@@ -419,6 +449,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     # legacy flat ped_impact_* keys.
     _flatten_pedestrian_impact_block(base, ped_impact)
     _flatten_social_acceptability_block(base, social_acceptability)
+    _flatten_human_interaction_proxy_block(base, human_interaction_proxy)
     if isinstance(inter_robot, dict):
         for key, value in inter_robot.items():
             base[str(key)] = value

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -25,7 +25,9 @@ Implemented categories:
   socnavbench_path_irregularity.
 - Experimental (optional): pedestrian-impact deltas for acceleration and
   heading turn-rate near-vs-far from the robot (enabled via
-  ``compute_all_metrics(..., experimental_ped_impact=True)``).
+  ``compute_all_metrics(..., experimental_ped_impact=True)``), plus diagnostic
+  human-interaction exposure proxies (enabled via
+  ``compute_all_metrics(..., experimental_human_interaction_proxy=True)``).
 
 Missing/optional data handling:
 - Empty pedestrian sets (K=0) return 0.0 for collision counts and ``NaN`` for distances where
@@ -550,6 +552,122 @@ def experimental_social_acceptability_metrics(
     metrics["social_proxemic_intrusion_area_m_s"] = float(np.sum(intrusion_depth) * data.dt)
     metrics["social_proxemic_min_clearance_m"] = float(np.min(clearances[finite]))
     return metrics
+
+
+def experimental_human_interaction_proxy_metrics(
+    data: EpisodeData,
+    *,
+    proxemic_radius_m: float = 1.2,
+    yield_speed_mps: float = 0.15,
+) -> dict[str, float]:
+    """Compute simulation-proxy human-interaction exposure metrics.
+
+    These reductions use only robot/pedestrian trajectories and footprint radii.
+    They are diagnostic simulation proxies for mechanism reports, not validated
+    human comfort, social compliance, or safety metrics.
+
+    Formulas:
+    - discomfort exposure: ``sum(max(radius - clearance, 0) * dt)`` in ``m*s``.
+    - intrusion duration: count of timesteps with any personal-space intrusion times ``dt``.
+    - time to yield: seconds from first intrusion to the first later robot speed below
+      ``yield_speed_mps``.
+    - robot yield distance: nearest center-distance to a pedestrian at the yield timestep.
+    - pedestrian path deviation proxy: mean per-pedestrian extra path length over straight-line
+      displacement, in meters.
+
+    Returns:
+        Mapping of ``human_proxy_*`` scalar metrics.
+    """
+    radius = (
+        float(proxemic_radius_m)
+        if math.isfinite(proxemic_radius_m) and proxemic_radius_m > 0.0
+        else 1.2
+    )
+    yield_speed = (
+        float(yield_speed_mps)
+        if math.isfinite(yield_speed_mps) and yield_speed_mps >= 0.0
+        else 0.15
+    )
+    dt = float(data.dt) if math.isfinite(float(data.dt)) and float(data.dt) > 0.0 else 1.0
+    step_count = int(data.robot_pos.shape[0]) if data.robot_pos.ndim >= 2 else 0
+    ped_count = int(data.peds_pos.shape[1]) if data.peds_pos.ndim >= 2 else 0
+    metrics: dict[str, float] = {
+        "human_proxy_available": 1.0 if step_count > 0 and ped_count > 0 else 0.0,
+        "human_proxy_proxemic_radius_m": radius,
+        "human_proxy_yield_speed_mps": yield_speed,
+        "human_proxy_ped_count": float(ped_count),
+        "human_proxy_timestep_count": float(step_count),
+        "human_discomfort_exposure_m_s": 0.0,
+        "intrusion_duration_s": 0.0,
+        "time_to_yield_s": float("nan"),
+        "robot_yield_distance_m": float("nan"),
+        "pedestrian_path_deviation_proxy_m": float("nan"),
+        "group_split_intrusion_available": 0.0,
+    }
+    if step_count <= 0 or ped_count == 0:
+        return metrics
+
+    clearances = _compute_clearance_matrix(data)
+    center_dists = _compute_distance_matrix(data)
+    finite_clearance = np.isfinite(clearances)
+    if finite_clearance.any():
+        intrusion_depth = np.where(
+            finite_clearance,
+            np.maximum(radius - clearances, 0.0),
+            0.0,
+        )
+        intrusion_mask = intrusion_depth > 0.0
+        intrusion_by_step = np.any(intrusion_mask, axis=1)
+        metrics["human_discomfort_exposure_m_s"] = float(np.sum(intrusion_depth) * dt)
+        metrics["intrusion_duration_s"] = float(np.count_nonzero(intrusion_by_step) * dt)
+
+        intrusion_indices = np.flatnonzero(intrusion_by_step)
+        if intrusion_indices.size > 0:
+            first_intrusion = int(intrusion_indices[0])
+            robot_speeds = _robot_speed_samples(data, dt=dt)
+            search_speeds = robot_speeds[first_intrusion:]
+            yield_offsets = np.flatnonzero(search_speeds <= yield_speed)
+            if yield_offsets.size > 0:
+                yield_step = first_intrusion + int(yield_offsets[0])
+                metrics["time_to_yield_s"] = float((yield_step - first_intrusion) * dt)
+                finite_dists = center_dists[yield_step, np.isfinite(center_dists[yield_step])]
+                if finite_dists.size > 0:
+                    metrics["robot_yield_distance_m"] = float(np.min(finite_dists))
+
+    metrics["pedestrian_path_deviation_proxy_m"] = _pedestrian_path_deviation_proxy(data.peds_pos)
+    return metrics
+
+
+def _robot_speed_samples(data: EpisodeData, *, dt: float) -> np.ndarray:
+    """Return one robot speed sample per trajectory timestep."""
+    if data.robot_vel.shape == data.robot_pos.shape and np.isfinite(data.robot_vel).any():
+        return np.linalg.norm(np.where(np.isfinite(data.robot_vel), data.robot_vel, 0.0), axis=1)
+    if data.robot_pos.shape[0] < 2:
+        return np.zeros((data.robot_pos.shape[0],), dtype=float)
+    step_vel = np.diff(data.robot_pos, axis=0) / dt
+    speeds = np.linalg.norm(np.where(np.isfinite(step_vel), step_vel, 0.0), axis=1)
+    return np.concatenate(([speeds[0]], speeds))
+
+
+def _pedestrian_path_deviation_proxy(peds_pos: np.ndarray) -> float:
+    """Return mean per-pedestrian extra path length over straight-line displacement."""
+    if peds_pos.ndim != 3 or peds_pos.shape[0] < 2 or peds_pos.shape[1] == 0:
+        return float("nan")
+
+    deviations: list[float] = []
+    for ped_idx in range(peds_pos.shape[1]):
+        traj = peds_pos[:, ped_idx, :]
+        finite_mask = np.isfinite(traj).all(axis=1)
+        finite_traj = traj[finite_mask]
+        if finite_traj.shape[0] < 2:
+            continue
+        segment_lengths = np.linalg.norm(np.diff(finite_traj, axis=0), axis=1)
+        path_length = float(np.sum(segment_lengths))
+        displacement = float(np.linalg.norm(finite_traj[-1] - finite_traj[0]))
+        deviations.append(max(path_length - displacement, 0.0))
+    if not deviations:
+        return float("nan")
+    return float(np.mean(deviations))
 
 
 # --- Metric stub functions ---
@@ -2411,16 +2529,18 @@ METRIC_NAMES: list[str] = [
 ]
 
 
-def compute_all_metrics(
+def compute_all_metrics(  # noqa: PLR0913
     data: EpisodeData,
     *,
     horizon: int,
     shortest_path_len: float | None = None,
     robot_max_speed: float | None = None,
     experimental_ped_impact: bool = False,
+    experimental_human_interaction_proxy: bool = False,
     ped_impact_radius_m: float = 2.0,
     ped_impact_window_steps: int = 5,
     social_proxemic_radius_m: float = 1.2,
+    human_proxy_yield_speed_mps: float = 0.15,
 ) -> dict[str, float]:
     """Compute all defined metrics for an episode and return them as a mapping.
 
@@ -2436,12 +2556,15 @@ def compute_all_metrics(
             ``None``, observed max speed (fallback ``1.0``) is used.
         experimental_ped_impact: Enable optional experimental ``ped_impact_*`` metrics that
             estimate near-vs-far pedestrian acceleration and turn-rate deltas.
+        experimental_human_interaction_proxy: Enable optional diagnostic ``human_proxy_*`` metrics
+            for mechanism reports. These are simulation proxies only.
         ped_impact_radius_m: Near/far distance threshold in meters used by experimental pedestrian
             impact metrics.
         ped_impact_window_steps: Trailing smoothing window length (timesteps) used by
             experimental pedestrian impact metrics.
         social_proxemic_radius_m: Personal-space radius used by exploratory social acceptability
             metrics when ``experimental_ped_impact`` is enabled.
+        human_proxy_yield_speed_mps: Robot speed threshold used to detect proxy yielding.
 
     Returns:
         dict[str, float]: Mapping from metric name (e.g., ``success``, ``force_q50``,
@@ -2542,6 +2665,14 @@ def compute_all_metrics(
                 proxemic_radius_m=social_proxemic_radius_m,
             )
         )
+    if experimental_human_interaction_proxy:
+        values.update(
+            experimental_human_interaction_proxy_metrics(
+                data,
+                proxemic_radius_m=social_proxemic_radius_m,
+                yield_speed_mps=human_proxy_yield_speed_mps,
+            )
+        )
     return values
 
 
@@ -2586,6 +2717,8 @@ def post_process_metrics(
         "ped_impact_turn_rate_delta_valid",
         "social_proxemic_ped_count",
         "social_proxemic_intrusion_steps",
+        "human_proxy_ped_count",
+        "human_proxy_timestep_count",
         "shield_decision_count",
         "shield_intervention_count",
         "shield_override_count",
@@ -2600,6 +2733,8 @@ def post_process_metrics(
         "time_to_goal_success_only_valid",
         "time_to_goal_ideal_ratio_valid",
         "social_proxemic_available",
+        "human_proxy_available",
+        "group_split_intrusion_available",
     ):
         if valid_key in metrics and metrics[valid_key] is not None:
             try:
@@ -2608,6 +2743,7 @@ def post_process_metrics(
                 pass
     _attach_pedestrian_impact_block(metrics)
     _attach_social_acceptability_block(metrics)
+    _attach_human_interaction_proxy_block(metrics)
     return _sanitize_metrics(metrics)
 
 
@@ -2687,6 +2823,51 @@ def _attach_social_acceptability_block(metrics: dict[str, Any]) -> None:
     }
 
 
+def _attach_human_interaction_proxy_block(metrics: dict[str, Any]) -> None:
+    """Attach a schema-backed human-interaction proxy block when flat metrics are present."""
+    if "human_proxy_proxemic_radius_m" not in metrics:
+        return
+
+    metrics["human_interaction_proxy"] = {
+        "schema_version": "human-interaction-proxy.v1",
+        "status": "simulation_proxy",
+        "parameters": {
+            "proxemic_radius_m": metrics.get("human_proxy_proxemic_radius_m"),
+            "yield_speed_mps": metrics.get("human_proxy_yield_speed_mps"),
+        },
+        "units": {
+            "discomfort_exposure": "m*s",
+            "duration": "s",
+            "time_to_yield": "s",
+            "distance": "m",
+            "path_deviation": "m",
+            "sample_counts": "count",
+        },
+        "available": metrics.get("human_proxy_available"),
+        "sample_counts": {
+            "pedestrians": metrics.get("human_proxy_ped_count"),
+            "timesteps": metrics.get("human_proxy_timestep_count"),
+        },
+        "canonical_reductions": {
+            "human_discomfort_exposure_m_s": metrics.get("human_discomfort_exposure_m_s"),
+            "intrusion_duration_s": metrics.get("intrusion_duration_s"),
+            "time_to_yield_s": metrics.get("time_to_yield_s"),
+            "robot_yield_distance_m": metrics.get("robot_yield_distance_m"),
+            "pedestrian_path_deviation_proxy_m": metrics.get("pedestrian_path_deviation_proxy_m"),
+            "group_split_intrusion_available": metrics.get("group_split_intrusion_available"),
+        },
+        "exclusions": {
+            "group_split_intrusion": (
+                "Not computed without group-membership or social-group labels in EpisodeData."
+            ),
+        },
+        "interpretation": (
+            "Diagnostic simulation-proxy metrics for mechanism reports only; not validated "
+            "human comfort, human-subject, safety, or paper-grade social-compliance evidence."
+        ),
+    }
+
+
 def _sanitize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
     """Remove NaN/inf metric entries to keep JSON serialization clean.
 
@@ -2724,6 +2905,7 @@ __all__ = [
     "curvature_mean",
     "distance_to_human_min",
     "energy",
+    "experimental_human_interaction_proxy_metrics",
     "experimental_social_acceptability_metrics",
     "failure_to_progress",
     "force_exceed_events",

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -712,6 +712,126 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "human_interaction_proxy": {
+                    "type": "object",
+                    "description": "Schema-backed diagnostic simulation-proxy block for human-centered interaction exposure reductions.",
+                    "required": [
+                        "schema_version",
+                        "status",
+                        "parameters",
+                        "units",
+                        "available",
+                        "sample_counts",
+                        "canonical_reductions",
+                        "interpretation"
+                    ],
+                    "properties": {
+                        "schema_version": {
+                            "const": "human-interaction-proxy.v1"
+                        },
+                        "status": {
+                            "const": "simulation_proxy"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "proxemic_radius_m": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0
+                                },
+                                "yield_speed_mps": {
+                                    "type": "number",
+                                    "minimum": 0
+                                }
+                            },
+                            "required": [
+                                "proxemic_radius_m",
+                                "yield_speed_mps"
+                            ],
+                            "additionalProperties": true
+                        },
+                        "units": {
+                            "type": "object",
+                            "properties": {
+                                "discomfort_exposure": {
+                                    "const": "m*s"
+                                },
+                                "duration": {
+                                    "const": "s"
+                                },
+                                "time_to_yield": {
+                                    "const": "s"
+                                },
+                                "distance": {
+                                    "const": "m"
+                                },
+                                "path_deviation": {
+                                    "const": "m"
+                                },
+                                "sample_counts": {
+                                    "const": "count"
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "available": {
+                            "type": "boolean"
+                        },
+                        "sample_counts": {
+                            "type": "object",
+                            "properties": {
+                                "pedestrians": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "timesteps": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "canonical_reductions": {
+                            "type": "object",
+                            "properties": {
+                                "human_discomfort_exposure_m_s": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "intrusion_duration_s": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "time_to_yield_s": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "robot_yield_distance_m": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "pedestrian_path_deviation_proxy_m": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
+                                "group_split_intrusion_available": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "exclusions": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "interpretation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": true
                 }
             },
             "additionalProperties": {

--- a/tests/contract/test_episode_schema.py
+++ b/tests/contract/test_episode_schema.py
@@ -170,6 +170,65 @@ def test_episode_schema_validates_social_acceptability_block() -> None:
         jsonschema.validate(instance=record, schema=schema)
 
 
+def test_episode_schema_validates_human_interaction_proxy_block() -> None:
+    """The human-interaction proxy block should be schema-backed when present."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_human_interaction_proxy",
+        "version": "v1",
+        "scenario_id": "sc_human_interaction_proxy",
+        "seed": 123,
+        "metrics": {
+            "collisions": 0,
+            "near_misses": 0,
+            "human_interaction_proxy": {
+                "schema_version": "human-interaction-proxy.v1",
+                "status": "simulation_proxy",
+                "parameters": {"proxemic_radius_m": 1.2, "yield_speed_mps": 0.1},
+                "units": {
+                    "discomfort_exposure": "m*s",
+                    "duration": "s",
+                    "time_to_yield": "s",
+                    "distance": "m",
+                    "path_deviation": "m",
+                    "sample_counts": "count",
+                },
+                "available": True,
+                "sample_counts": {"pedestrians": 1, "timesteps": 4},
+                "canonical_reductions": {
+                    "human_discomfort_exposure_m_s": 0.9,
+                    "intrusion_duration_s": 1.0,
+                    "time_to_yield_s": 0.5,
+                    "robot_yield_distance_m": 1.5,
+                    "pedestrian_path_deviation_proxy_m": 0.2,
+                    "group_split_intrusion_available": False,
+                },
+                "exclusions": {
+                    "group_split_intrusion": "No group-membership labels in EpisodeData.",
+                },
+                "interpretation": "Diagnostic simulation-proxy metrics only.",
+            },
+        },
+        "termination_reason": "max_steps",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+    }
+
+    jsonschema.validate(instance=record, schema=schema)
+    record["metrics"]["human_interaction_proxy"]["schema_version"] = "wrong"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+    record["metrics"]["human_interaction_proxy"]["schema_version"] = "human-interaction-proxy.v1"
+    record["metrics"]["human_interaction_proxy"]["sample_counts"]["pedestrians"] = 1.5
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+
 def test_episode_schema_rejects_collision_event_without_collision_metric() -> None:
     """New v1 records should not report collision_event=true with zero collision count."""
     schema = _load_schema()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -418,6 +418,91 @@ def test_compute_aggregates_flattens_social_acceptability_block() -> None:
     assert metrics["social_proxemic_intrusion_area_m_s"]["mean"] == 0.6
 
 
+def test_compute_aggregates_flattens_human_interaction_proxy_block() -> None:
+    """Schema-backed human-interaction proxy reductions should aggregate as scalars."""
+    records = [
+        {
+            "episode_id": "ep-1",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metric_parameters": {
+                "threshold_signature": "default",
+                "threshold_profile": {
+                    "profile_id": "default",
+                    "collision_distance_m": 0.3,
+                    "near_miss_distance_m": 0.6,
+                    "comfort_force_threshold": 2.0,
+                },
+            },
+            "metrics": {
+                "success": True,
+                "human_interaction_proxy": {
+                    "schema_version": "human-interaction-proxy.v1",
+                    "status": "simulation_proxy",
+                    "parameters": {"proxemic_radius_m": 1.2, "yield_speed_mps": 0.1},
+                    "available": True,
+                    "sample_counts": {"pedestrians": 1, "timesteps": 4},
+                    "canonical_reductions": {
+                        "human_discomfort_exposure_m_s": 0.9,
+                        "intrusion_duration_s": 1.0,
+                        "time_to_yield_s": 0.5,
+                        "robot_yield_distance_m": 1.5,
+                        "pedestrian_path_deviation_proxy_m": 0.2,
+                        "group_split_intrusion_available": False,
+                    },
+                },
+            },
+        },
+        {
+            "episode_id": "ep-2",
+            "scenario_id": "sc-1",
+            "seed": 2,
+            "algo": "planner-a",
+            "metric_parameters": {
+                "threshold_signature": "default",
+                "threshold_profile": {
+                    "profile_id": "default",
+                    "collision_distance_m": 0.3,
+                    "near_miss_distance_m": 0.6,
+                    "comfort_force_threshold": 2.0,
+                },
+            },
+            "metrics": {
+                "success": True,
+                "human_interaction_proxy": {
+                    "schema_version": "human-interaction-proxy.v1",
+                    "status": "simulation_proxy",
+                    "parameters": {"proxemic_radius_m": 1.2, "yield_speed_mps": 0.1},
+                    "available": True,
+                    "sample_counts": {"pedestrians": 1, "timesteps": 4},
+                    "canonical_reductions": {
+                        "human_discomfort_exposure_m_s": 0.3,
+                        "intrusion_duration_s": 0.5,
+                        "time_to_yield_s": 0.0,
+                        "robot_yield_distance_m": 2.0,
+                        "pedestrian_path_deviation_proxy_m": 0.4,
+                        "group_split_intrusion_available": False,
+                    },
+                },
+            },
+        },
+    ]
+
+    flat = flatten_metrics(records[0])
+    assert "human_interaction_proxy" not in flat
+    assert flat["human_discomfort_exposure_m_s"] == 0.9
+    assert flat["human_proxy_yield_speed_mps"] == 0.1
+
+    summary = compute_aggregates(records, group_by="algo")
+
+    metrics = summary["planner-a"]
+    assert metrics["human_discomfort_exposure_m_s"]["mean"] == 0.6
+    assert metrics["intrusion_duration_s"]["mean"] == 0.75
+    assert metrics["time_to_yield_s"]["mean"] == 0.25
+    assert metrics["pedestrian_path_deviation_proxy_m"]["mean"] == pytest.approx(0.3)
+
+
 def _paired_contrast_records() -> list[dict]:
     """Build synthetic records with a planted paired effect for group B over group A."""
     values_a = [1.0, 2.0, 3.0, 4.0, 5.0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -654,6 +654,8 @@ def test_experimental_ped_impact_metrics_are_opt_in() -> None:
     base = compute_all_metrics(ep, horizon=10)
     assert not any(key.startswith("ped_impact_") for key in base)
     assert not any(key.startswith("social_proxemic_") for key in base)
+    assert not any(key.startswith("human_proxy_") for key in base)
+    assert "human_discomfort_exposure_m_s" not in base
 
     enabled = compute_all_metrics(ep, horizon=10, experimental_ped_impact=True)
     assert "ped_impact_radius_m" in enabled
@@ -670,6 +672,69 @@ def test_experimental_ped_impact_metrics_are_opt_in() -> None:
         social_proxemic_radius_m=0.75,
     )
     assert custom_radius["social_proxemic_radius_m"] == 0.75
+
+
+def test_experimental_human_interaction_proxy_metrics_are_opt_in() -> None:
+    """Human-centered interaction proxy keys should only appear when explicitly enabled."""
+    ep = _make_episode(T=4, K=1)
+    ep.peds_pos[:, 0, 0] = 1.0
+
+    base = compute_all_metrics(ep, horizon=4)
+    assert "human_proxy_proxemic_radius_m" not in base
+
+    enabled = compute_all_metrics(ep, horizon=4, experimental_human_interaction_proxy=True)
+    assert enabled["human_proxy_available"] == 1.0
+    assert enabled["human_proxy_proxemic_radius_m"] == 1.2
+    assert enabled["human_proxy_yield_speed_mps"] == 0.15
+    assert "human_discomfort_exposure_m_s" in enabled
+
+
+def test_experimental_human_interaction_proxy_fixture() -> None:
+    """Human-interaction proxies should follow documented formulas on a crafted trajectory."""
+    ep = _make_episode(T=4, K=1)
+    ep.dt = 0.5
+    ep.robot_pos[:] = 0.0
+    ep.robot_vel[:, 0] = np.array([1.0, 0.8, 0.05, 0.0])
+    radii_sum = ep.robot_radius + ep.ped_radius
+    clearances = np.array([1.5, 0.5, 0.1, 2.0])
+    ep.peds_pos[:, 0, 0] = radii_sum + clearances
+    ep.peds_pos[:, 0, 1] = np.array([0.0, 0.4, -0.4, 0.0])
+
+    vals = compute_all_metrics(
+        ep,
+        horizon=4,
+        experimental_human_interaction_proxy=True,
+        social_proxemic_radius_m=1.2,
+        human_proxy_yield_speed_mps=0.1,
+    )
+
+    assert vals["human_proxy_available"] == 1.0
+    assert vals["human_proxy_ped_count"] == 1.0
+    assert vals["human_proxy_timestep_count"] == 4.0
+    center_distances = np.linalg.norm(ep.peds_pos[:, 0, :] - ep.robot_pos, axis=1)
+    actual_clearances = center_distances - radii_sum
+    expected_exposure = np.sum(np.maximum(1.2 - actual_clearances, 0.0)) * ep.dt
+    assert vals["human_discomfort_exposure_m_s"] == pytest.approx(expected_exposure)
+    assert vals["intrusion_duration_s"] == pytest.approx(1.0)
+    assert vals["time_to_yield_s"] == pytest.approx(0.5)
+    assert vals["robot_yield_distance_m"] == pytest.approx(center_distances[2])
+    assert vals["pedestrian_path_deviation_proxy_m"] > 0.0
+    assert vals["group_split_intrusion_available"] == 0.0
+
+
+def test_experimental_human_interaction_proxy_handles_empty_crowd() -> None:
+    """Human-interaction proxies should expose unavailable status for K=0."""
+    ep = _make_episode(T=4, K=0)
+    vals = compute_all_metrics(ep, horizon=4, experimental_human_interaction_proxy=True)
+
+    assert vals["human_proxy_available"] == 0.0
+    assert vals["human_proxy_ped_count"] == 0.0
+    assert vals["human_proxy_timestep_count"] == 4.0
+    assert vals["human_discomfort_exposure_m_s"] == 0.0
+    assert vals["intrusion_duration_s"] == 0.0
+    assert math.isnan(vals["time_to_yield_s"])
+    assert math.isnan(vals["robot_yield_distance_m"])
+    assert math.isnan(vals["pedestrian_path_deviation_proxy_m"])
 
 
 def test_experimental_social_acceptability_proxemic_intrusion() -> None:
@@ -797,6 +862,41 @@ def test_post_process_metrics_adds_social_acceptability_pilot_block() -> None:
     assert block["sample_counts"] == {"pedestrians": 2, "timesteps": 3}
     assert block["proxemic"]["intrusion_area_m_s"] == 0.8
     assert "not a replacement for SNQI" in block["interpretation"]
+
+
+def test_post_process_metrics_adds_human_interaction_proxy_block() -> None:
+    """Post-processing should expose human-interaction proxies with claim boundaries."""
+    metrics = post_process_metrics(
+        {
+            "success": 1.0,
+            "collisions": 0.0,
+            "human_proxy_available": 1.0,
+            "human_proxy_proxemic_radius_m": 1.2,
+            "human_proxy_yield_speed_mps": 0.1,
+            "human_proxy_ped_count": 2.0,
+            "human_proxy_timestep_count": 4.0,
+            "human_discomfort_exposure_m_s": 0.9,
+            "intrusion_duration_s": 1.0,
+            "time_to_yield_s": 0.5,
+            "robot_yield_distance_m": 1.5,
+            "pedestrian_path_deviation_proxy_m": 0.25,
+            "group_split_intrusion_available": 0.0,
+        },
+        snqi_weights=None,
+        snqi_baseline=None,
+    )
+
+    assert metrics["human_proxy_available"] is True
+    assert metrics["human_proxy_ped_count"] == 2
+    block = metrics["human_interaction_proxy"]
+    assert block["schema_version"] == "human-interaction-proxy.v1"
+    assert block["status"] == "simulation_proxy"
+    assert block["parameters"] == {"proxemic_radius_m": 1.2, "yield_speed_mps": 0.1}
+    assert block["sample_counts"] == {"pedestrians": 2, "timesteps": 4}
+    assert block["canonical_reductions"]["time_to_yield_s"] == 0.5
+    assert block["canonical_reductions"]["group_split_intrusion_available"] is False
+    assert "human-subject" in block["interpretation"]
+    assert "group-membership" in block["exclusions"]["group_split_intrusion"]
 
 
 def test_experimental_ped_impact_handles_empty_crowd() -> None:


### PR DESCRIPTION
## Summary
Adds an opt-in `human_interaction_proxy` metric block for mechanism reports, with schema-backed episode output and aggregate flattening. The new metrics are explicitly labeled as simulation proxies, not validated human comfort or paper-grade social-compliance evidence.

## Linked Issues
- Closes `#2458`
- Relates to `#2451`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `compute_all_metrics(..., experimental_human_interaction_proxy=True)` and `experimental_human_interaction_proxy_metrics`.
- Added flat reductions plus `metrics.human_interaction_proxy` with `schema_version: human-interaction-proxy.v1`.
- Added aggregate flattening for schema-backed human-interaction proxy records.
- Added episode schema validation, formula fixture tests, post-processing tests, aggregate tests, and docs/context note.

## Why It Matters
- Added value: mechanism reports can discuss human-centered exposure proxies beyond success/failure and collision counts.
- Expected impact: bounded research-report vocabulary with formulas, units, sample counts, and explicit exclusions.
- Why this is worth merging now: it gives upcoming mechanism-report work a tested metric surface without claiming human-subject validity.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: improves mechanism-report instrumentation for human-centered interaction exposure proxies.
- Comparator or baseline, if applicable: existing metrics had proxemic/social-acceptability pilot fields but no dedicated `human_interaction_proxy.v1` block for time-to-yield, yield distance, and path-deviation proxy reductions.
- Evidence tier: targeted smoke / metric fixture proof.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: merge if the formula fixtures, schema validation, and aggregate flattening prove the intended computation path.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2458_human_interaction_proxy_metrics.md` and `docs/ped_metrics/metrics_spec.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: metric-facing proxy block used on committed synthetic fixtures in `tests/test_metrics.py`, `tests/test_aggregate.py`, and `tests/contract/test_episode_schema.py`.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA, this PR adds metric instrumentation rather than a planner mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? The crafted fixture contains proxemic intrusion and proxy-yield conditions for metric validation only.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: group-split intrusion remains excluded until `EpisodeData` has group-membership labels.

## Next Empirical Action
- Rerun needed: no for this metric-fixture contract.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable external artifact needed; proof uses committed fixtures/tests.
- Stop / revise / continue decision: continue using these as diagnostic-only proxies in mechanism reports.
- Proposed child issue or existing follow-up: none opened; group-split intrusion should wait for a grouped-pedestrian contract if it becomes necessary.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/metrics.py robot_sf/benchmark/aggregate.py tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/metrics.py robot_sf/benchmark/aggregate.py tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py`
  - `git diff --check`
- Evidence that the change works here: 104 targeted tests passed; Ruff check/format-check passed; whitespace check passed.
- Benchmarks or smoke tests, if applicable: targeted metric fixtures only; no benchmark run because this changes opt-in diagnostic metric surfaces.

## Risks / Rollout
- Compatibility risks: low; new metrics are opt-in and existing episode schema remains permissive for existing records.
- Failure modes: callers could overstate proxy meanings; docs and block interpretation explicitly mark these as simulation proxies only.
- Rollback or fallback plan: remove the opt-in flag/block and retain existing proxemic/social-acceptability pilot metrics.

## Docs / Provenance
- Updated docs: `docs/ped_metrics/metrics_spec.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_2458_human_interaction_proxy_metrics.md`.
- Any assumptions that need to be preserved: no group-split metric until grouped-pedestrian labels exist.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR links close #2458; #2451 related.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context README and #2458 context note updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is an opt-in diagnostic metric surface, not a benchmark-result PR.

## Follow-Up Issues
- Deferred work: group-split intrusion requires future grouped-pedestrian data contract.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: formula semantics for `time_to_yield_s` and `robot_yield_distance_m`.
- Any known limitations: these are simulation proxies only and should not be used as human-subject comfort or safety claims.