### PR TITLE
feat: add evidence bundle packaging

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -502,6 +502,8 @@ knowledge, not every transient iteration detail.
   [issue_2037_artifact_compiler_smoke.md](issue_2037_artifact_compiler_smoke.md)
 * Issue #2040 Artifact Publication Workflow (2026-06-01):
   [issue_2040_artifact_publication_workflow.md](issue_2040_artifact_publication_workflow.md)
+* Issue #2460 Evidence Bundle v1:
+  [issue_2460_evidence_bundle_v1.md](issue_2460_evidence_bundle_v1.md)
 * Issue #2034 Platformization Roadmap (2026-06-01):
   [issue_2034_platformization_roadmap.md](issue_2034_platformization_roadmap.md)
 * Issue #1395 Learned Risk Model Launch Packet:
@@ -646,7 +648,8 @@ knowledge, not every transient iteration detail.
 ## Evidence Bundles
 
 * [Evidence Bundles](evidence/README.md) documents the narrow policy for promoting small generated
-  artifacts out of `output/` into git. Current bundles include the
+  artifacts out of `output/` into git. [Issue #2460 Evidence Bundle v1](issue_2460_evidence_bundle_v1.md)
+  defines the explicit-file helper and schema contract. Current bundles include the
   [h500 policy-search evidence](evidence/policy_search_h500_2026-05-06/README.md),
   [issue 1023 candidate-augmented preflight](evidence/issue_1023_candidate_augmented_preflight_2026-05-06/README.md),
   [issue 1023 candidate-augmented local full campaign](evidence/issue_1023_candidate_augmented_local_full_2026-05-06/README.md),

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -37,6 +37,49 @@ evidence is not exempt from review merely because broad CSV filters exist: inspe
 representative rows, provenance fields, parent-issue conclusion alignment, and explicit claim
 boundary before merging an evidence-producing PR.
 
+## Evidence Bundle v1
+
+Use `evidence_bundle.v1` for the smallest reproducible packet that lets a future reviewer recover
+what compact evidence supported a claim boundary without depending on local `output/` contents.
+The helper is intentionally explicit-file-only:
+
+```bash
+uv run python scripts/tools/benchmark_publication_bundle.py evidence-bundle \
+  --source-root docs/context/evidence/<source-or-fixture> \
+  --out-dir docs/context/evidence \
+  --bundle-name <issue-or-claim-bundle> \
+  --file summary.json \
+  --file metric_table.csv \
+  --file trace_manifest.yaml \
+  --file claim_boundary.md \
+  --command "<canonical reproduction or validation command>" \
+  --commit <git-commit> \
+  --claim-boundary diagnostic_only_not_benchmark_evidence
+```
+
+Each bundle writes:
+
+- `payload/`: exactly the selected compact files;
+- `evidence_bundle_manifest.json`: `schema_version: evidence_bundle.v1`, command, commit,
+  claim boundary, source root, file index, sizes, SHA-256 checksums, and policy caveats;
+- `checksums.sha256`: checksum lines for every payload file.
+
+The schema contract lives at `robot_sf/benchmark/schemas/evidence_bundle.v1.json`.
+
+Required provenance fields:
+
+- `command`: the command that produced or validates the evidence;
+- `commit`: the repository commit associated with the evidence;
+- `claim_boundary`: the conservative interpretation boundary for the bundle;
+- `files`: compact, reviewable payload entries with `path`, `size_bytes`, `sha256`, and `kind`.
+
+Policy caveats:
+
+- large raw logs, videos, checkpoints, raw episode streams, and mirrored `output/` trees stay out;
+- a bundle makes evidence references reproducible, but does not by itself establish a
+  benchmark-strength, paper-grade, or scientifically sufficient claim;
+- fallback/degraded/diagnostic status must be preserved in `claim_boundary` or a payload note.
+
 ## Current Bundles
 
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that

--- a/docs/context/issue_2460_evidence_bundle_v1.md
+++ b/docs/context/issue_2460_evidence_bundle_v1.md
@@ -1,0 +1,42 @@
+# Issue 2460 Evidence Bundle v1
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/2460>
+
+## What Was Implemented
+
+`scripts/tools/benchmark_publication_bundle.py` now has an `evidence-bundle` subcommand for compact
+research evidence packets. It is backed by `export_evidence_bundle` in
+`robot_sf/benchmark/artifact_publication.py`.
+
+The bundle writes:
+
+- `payload/` with exactly the selected compact files;
+- `evidence_bundle_manifest.json` with `schema_version: evidence_bundle.v1`;
+- `checksums.sha256` for all payload files.
+
+The schema contract lives at `robot_sf/benchmark/schemas/evidence_bundle.v1.json`.
+
+## Claim Boundary
+
+An evidence bundle is a provenance and reproducibility aid. It does not by itself establish that a
+research claim is benchmark-strength, paper-grade, or scientifically sufficient. The bundle must
+carry the conservative `claim_boundary`, including diagnostic-only, fallback, degraded, blocked, or
+not-benchmark-evidence status when applicable.
+
+## Scope Decisions
+
+- The first helper is explicit-file-only rather than run-directory auto-selection. This keeps the
+  initial contract minimum and prevents accidental mirroring of large `output/` trees.
+- Large raw logs, videos, checkpoints, raw episode streams, and model caches remain excluded unless
+  a separate durable artifact path is chosen.
+- Existing publication-bundle and release-helper contracts are unchanged.
+
+## Proof Surface
+
+Targeted CLI tests cover:
+
+- manifest/checksum generation for a compact fixture;
+- validation against `evidence_bundle.v1.json`;
+- fail-closed behavior for missing requested files.
+
+The user-facing command and required fields are documented in `docs/context/evidence/README.md`.

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -24,6 +24,7 @@ import numpy as np
 from robot_sf.common.artifact_paths import get_repository_root
 
 PUBLICATION_BUNDLE_SCHEMA_VERSION = "benchmark-publication-bundle.v2"
+EVIDENCE_BUNDLE_SCHEMA_VERSION = "evidence_bundle.v1"
 SIZE_REPORT_SCHEMA_VERSION = "benchmark-artifact-size-report.v1"
 _VIDEO_SUFFIXES = {".mp4", ".gif", ".webm", ".mov"}
 _MARKER_FILES = ("manifest.json", "run_meta.json", "episodes.jsonl", "summary.json", "report.json")
@@ -53,6 +54,17 @@ class PublicationBundleResult:
 
     bundle_dir: Path
     archive_path: Path
+    manifest_path: Path
+    checksums_path: Path
+    file_count: int
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class EvidenceBundleResult:
+    """Paths and summary values produced by :func:`export_evidence_bundle`."""
+
+    bundle_dir: Path
     manifest_path: Path
     checksums_path: Path
     file_count: int
@@ -390,6 +402,134 @@ def _resolve_bundle_output_paths(
     if not bundle_dir.is_relative_to(target_root) or not archive_path.is_relative_to(target_root):
         raise ValueError("Bundle output must remain within out_dir")
     return target_root, bundle_dir, archive_path
+
+
+def _resolve_evidence_files(source_root: Path, files: list[Path]) -> list[Path]:
+    """Resolve user-selected evidence files relative to ``source_root``.
+
+    Returns:
+        Sorted source-root-relative paths.
+    """
+    root = source_root.resolve()
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(f"Evidence source root does not exist: {root}")
+    if not files:
+        raise ValueError("At least one evidence file is required")
+
+    resolved: list[Path] = []
+    for file_path in files:
+        candidate = file_path if file_path.is_absolute() else root / file_path
+        candidate = candidate.resolve()
+        if not candidate.is_relative_to(root):
+            raise ValueError(f"Evidence file escapes source root: {file_path}")
+        if not candidate.exists() or not candidate.is_file():
+            raise FileNotFoundError(f"Evidence file does not exist: {candidate}")
+        if candidate.is_symlink():
+            raise ValueError(f"Evidence bundle refuses symlink payloads: {candidate}")
+        resolved.append(candidate.relative_to(root))
+    return sorted(set(resolved), key=lambda value: value.as_posix())
+
+
+def export_evidence_bundle(
+    source_root: Path,
+    out_dir: Path,
+    *,
+    bundle_name: str,
+    files: list[Path],
+    command: str,
+    commit: str,
+    claim_boundary: str,
+    overwrite: bool = False,
+) -> EvidenceBundleResult:
+    """Export a compact reproducible evidence bundle.
+
+    The bundle layout contains:
+    - ``payload/``: exactly the selected compact evidence files.
+    - ``evidence_bundle_manifest.json``: schema-tagged provenance + file index.
+    - ``checksums.sha256``: SHA-256 checksums for all payload files.
+
+    Returns:
+        Paths and totals describing the exported bundle artifacts.
+    """
+    if not command.strip():
+        raise ValueError("Evidence bundle command is required")
+    if not commit.strip():
+        raise ValueError("Evidence bundle commit is required")
+    if not claim_boundary.strip():
+        raise ValueError("Evidence bundle claim_boundary is required")
+
+    target_name = bundle_name.strip()
+    _validate_bundle_name(target_name)
+    target_root = out_dir.resolve()
+    target_root.mkdir(parents=True, exist_ok=True)
+    bundle_dir = (target_root / target_name).resolve()
+    if not bundle_dir.is_relative_to(target_root):
+        raise ValueError("Evidence bundle output must remain within out_dir")
+
+    if overwrite:
+        if bundle_dir.exists():
+            if bundle_dir == target_root:
+                raise ValueError("Refusing to delete out_dir via overwrite")
+            shutil.rmtree(bundle_dir)
+    elif bundle_dir.exists():
+        raise FileExistsError(f"Evidence bundle output already exists: {bundle_dir}")
+
+    source = source_root.resolve()
+    selected_files = _resolve_evidence_files(source, files)
+    payload_root = bundle_dir / "payload"
+    payload_root.mkdir(parents=True, exist_ok=True)
+
+    entries: list[PublicationFileEntry] = []
+    total_bytes = 0
+    for rel in selected_files:
+        src = source / rel
+        dst = payload_root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        size_bytes = int(dst.stat().st_size)
+        total_bytes += size_bytes
+        entries.append(
+            PublicationFileEntry(
+                path=rel.as_posix(),
+                size_bytes=size_bytes,
+                sha256=_sha256_file(dst),
+                kind=_kind_for_path(rel),
+            )
+        )
+
+    entries = sorted(entries, key=lambda entry: entry.path)
+    checksums_path = bundle_dir / "checksums.sha256"
+    checksums_path.write_text(
+        "".join(f"{entry.sha256}  {entry.path}\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+    manifest_payload = {
+        "schema_version": EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        "created_at_utc": _utc_now_iso(),
+        "bundle_name": target_name,
+        "source_root": _to_repo_relative(source),
+        "command": command.strip(),
+        "commit": commit.strip(),
+        "claim_boundary": claim_boundary.strip(),
+        "policy": {
+            "large_raw_artifacts": "excluded",
+            "output_tree_mirroring": "forbidden",
+            "paper_or_benchmark_claim": "not_established_by_bundle_alone",
+        },
+        "totals": {"file_count": len(entries), "total_bytes": total_bytes},
+        "files": [asdict(entry) for entry in entries],
+    }
+    manifest_path = bundle_dir / "evidence_bundle_manifest.json"
+    manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+
+    return EvidenceBundleResult(
+        bundle_dir=bundle_dir,
+        manifest_path=manifest_path,
+        checksums_path=checksums_path,
+        file_count=len(entries),
+        total_bytes=total_bytes,
+    )
 
 
 def export_publication_bundle(

--- a/robot_sf/benchmark/schemas/evidence_bundle.v1.json
+++ b/robot_sf/benchmark/schemas/evidence_bundle.v1.json
@@ -1,0 +1,117 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/robot-sf/evidence_bundle.v1.json",
+    "title": "Robot SF Evidence Bundle (v1)",
+    "type": "object",
+    "required": [
+        "schema_version",
+        "created_at_utc",
+        "bundle_name",
+        "source_root",
+        "command",
+        "commit",
+        "claim_boundary",
+        "policy",
+        "totals",
+        "files"
+    ],
+    "properties": {
+        "schema_version": {
+            "const": "evidence_bundle.v1"
+        },
+        "created_at_utc": {
+            "type": "string"
+        },
+        "bundle_name": {
+            "type": "string",
+            "minLength": 1
+        },
+        "source_root": {
+            "type": "string",
+            "minLength": 1
+        },
+        "command": {
+            "type": "string",
+            "minLength": 1
+        },
+        "commit": {
+            "type": "string",
+            "minLength": 1
+        },
+        "claim_boundary": {
+            "type": "string",
+            "minLength": 1
+        },
+        "policy": {
+            "type": "object",
+            "required": [
+                "large_raw_artifacts",
+                "output_tree_mirroring",
+                "paper_or_benchmark_claim"
+            ],
+            "properties": {
+                "large_raw_artifacts": {
+                    "const": "excluded"
+                },
+                "output_tree_mirroring": {
+                    "const": "forbidden"
+                },
+                "paper_or_benchmark_claim": {
+                    "const": "not_established_by_bundle_alone"
+                }
+            },
+            "additionalProperties": true
+        },
+        "totals": {
+            "type": "object",
+            "required": [
+                "file_count",
+                "total_bytes"
+            ],
+            "properties": {
+                "file_count": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "total_bytes": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "additionalProperties": true
+        },
+        "files": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "path",
+                    "size_bytes",
+                    "sha256",
+                    "kind"
+                ],
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "size_bytes": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "sha256": {
+                        "type": "string",
+                        "pattern": "^[0-9a-f]{64}$"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "additionalProperties": true
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from robot_sf.benchmark.artifact_publication import (
+    export_evidence_bundle,
     export_publication_bundle,
     measure_artifact_size_ranges,
 )
@@ -99,6 +100,60 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow replacing an existing bundle directory/archive with the same name.",
     )
+
+    evidence = subparsers.add_parser(
+        "evidence-bundle",
+        help="Package selected compact evidence files with checksums and claim-boundary metadata.",
+    )
+    evidence.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Directory containing the compact evidence files to include.",
+    )
+    evidence.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Destination directory for the evidence bundle folder.",
+    )
+    evidence.add_argument(
+        "--bundle-name",
+        type=str,
+        required=True,
+        help="Output bundle directory name.",
+    )
+    evidence.add_argument(
+        "--file",
+        type=Path,
+        action="append",
+        default=[],
+        help="Evidence file to include, relative to --source-root. Repeat for multiple files.",
+    )
+    evidence.add_argument(
+        "--command",
+        type=str,
+        dest="evidence_command",
+        required=True,
+        help="Canonical command that produced or validates the evidence.",
+    )
+    evidence.add_argument(
+        "--commit",
+        type=str,
+        required=True,
+        help="Repository commit associated with the evidence.",
+    )
+    evidence.add_argument(
+        "--claim-boundary",
+        type=str,
+        required=True,
+        help="Conservative claim boundary for the evidence bundle.",
+    )
+    evidence.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow replacing an existing evidence bundle directory with the same name.",
+    )
     return parser
 
 
@@ -141,6 +196,29 @@ def _run_export(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_evidence_bundle(args: argparse.Namespace) -> int:
+    """Execute the ``evidence-bundle`` subcommand."""
+    result = export_evidence_bundle(
+        args.source_root,
+        args.out_dir,
+        bundle_name=args.bundle_name,
+        files=list(args.file),
+        command=str(args.evidence_command),
+        commit=str(args.commit),
+        claim_boundary=str(args.claim_boundary),
+        overwrite=bool(args.overwrite),
+    )
+    payload = {
+        "bundle_dir": str(result.bundle_dir),
+        "manifest_path": str(result.manifest_path),
+        "checksums_path": str(result.checksums_path),
+        "file_count": result.file_count,
+        "total_bytes": result.total_bytes,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run benchmark publication helper CLI and return a POSIX exit code."""
     parser = _build_parser()
@@ -149,6 +227,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_size_report(args)
     if args.command == "export":
         return _run_export(args)
+    if args.command == "evidence-bundle":
+        return _run_evidence_bundle(args)
     parser.error(f"Unsupported command: {args.command}")
     return 2  # pragma: no cover
 

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import jsonschema
+import pytest
+
 from scripts.tools import benchmark_publication_bundle
+
+_EVIDENCE_BUNDLE_SCHEMA = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "evidence_bundle.v1.json"
+)
 
 
 def _write(path: Path, payload: str) -> None:
@@ -74,3 +85,103 @@ def test_export_command_creates_bundle_artifacts(tmp_path: Path, capsys) -> None
     assert Path(payload["checksums_path"]).exists()
     assert Path(payload["archive_path"]).exists()
     assert payload["file_count"] > 0
+
+
+def _make_evidence_source(source_root: Path) -> None:
+    """Create a compact evidence source fixture."""
+    _write(source_root / "summary.json", '{"result_classification":"diagnostic-only"}\n')
+    _write(source_root / "metric_table.csv", "metric,value\nsuccess_rate,0.5\n")
+    _write(source_root / "trace_manifest.yaml", "trace_count: 1\n")
+    _write(source_root / "claim_boundary.md", "# Claim Boundary\n\nDiagnostic only.\n")
+
+
+def test_evidence_bundle_command_creates_manifest_and_checksums(tmp_path: Path, capsys) -> None:
+    """CLI evidence-bundle should copy selected compact files with provenance metadata."""
+    source_root = tmp_path / "evidence_source"
+    _make_evidence_source(source_root)
+    out_dir = tmp_path / "bundles"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "evidence-bundle",
+            "--source-root",
+            str(source_root),
+            "--out-dir",
+            str(out_dir),
+            "--bundle-name",
+            "issue_2460_example",
+            "--file",
+            "summary.json",
+            "--file",
+            "metric_table.csv",
+            "--file",
+            "trace_manifest.yaml",
+            "--file",
+            "claim_boundary.md",
+            "--command",
+            "uv run python scripts/example.py --config tracked.yaml",
+            "--commit",
+            "abc123",
+            "--claim-boundary",
+            "diagnostic_only_not_benchmark_evidence",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    bundle_dir = Path(payload["bundle_dir"])
+    manifest_path = Path(payload["manifest_path"])
+    checksums_path = Path(payload["checksums_path"])
+    assert bundle_dir.exists()
+    assert manifest_path.exists()
+    assert checksums_path.exists()
+    assert payload["file_count"] == 4
+    assert (bundle_dir / "payload" / "summary.json").exists()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(_EVIDENCE_BUNDLE_SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=manifest, schema=schema)
+    assert manifest["schema_version"] == "evidence_bundle.v1"
+    assert manifest["command"] == "uv run python scripts/example.py --config tracked.yaml"
+    assert manifest["commit"] == "abc123"
+    assert manifest["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+    assert manifest["policy"]["large_raw_artifacts"] == "excluded"
+    assert [entry["path"] for entry in manifest["files"]] == [
+        "claim_boundary.md",
+        "metric_table.csv",
+        "summary.json",
+        "trace_manifest.yaml",
+    ]
+    checksums = checksums_path.read_text(encoding="utf-8")
+    assert "summary.json" in checksums
+    assert "metric_table.csv" in checksums
+
+
+def test_evidence_bundle_command_fails_closed_for_missing_file(tmp_path: Path) -> None:
+    """Evidence bundles should fail before writing manifests when a requested file is missing."""
+    source_root = tmp_path / "evidence_source"
+    _make_evidence_source(source_root)
+
+    with pytest.raises(FileNotFoundError):
+        benchmark_publication_bundle.main(
+            [
+                "evidence-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "bundles"),
+                "--bundle-name",
+                "missing_file",
+                "--file",
+                "summary.json",
+                "--file",
+                "missing.json",
+                "--command",
+                "uv run python scripts/example.py",
+                "--commit",
+                "abc123",
+                "--claim-boundary",
+                "diagnostic_only",
+            ]
+        )


### PR DESCRIPTION
## Summary
Adds an explicit-file `evidence-bundle` packaging path for compact research evidence packets, with `evidence_bundle.v1` manifests, checksums, and a JSON Schema contract.

## Linked Issues
- Closes `#2460`
- Relates to `#2451`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `export_evidence_bundle(...)` in `robot_sf/benchmark/artifact_publication.py`.
- Added `benchmark_publication_bundle.py evidence-bundle` for selected compact files.
- Added `robot_sf/benchmark/schemas/evidence_bundle.v1.json`.
- Added CLI/schema/fail-closed tests and docs/context note.

## Why It Matters
- Added value: research claims can point to compact, checksum-backed evidence packets instead of local `output/` trees.
- Expected impact: better reproducibility and cleaner claim-boundary review for diagnostic and benchmark-adjacent work.
- Why this is worth merging now: it supports the mechanism-aware research roadmap without changing existing publication bundle contracts.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: improves durable evidence packaging for research claim boundaries.
- Comparator or baseline, if applicable: existing publication bundle helper is DOI/export oriented; no minimum explicit-file `evidence_bundle.v1` helper existed.
- Evidence tier: targeted smoke / workflow fixture.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: merge if helper creates manifest/checksum bundles, validates schema, and fails closed on missing files.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2460_evidence_bundle_v1.md` and `docs/context/evidence/README.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: helper used on committed synthetic test fixture in `tests/tools/test_benchmark_publication_bundle.py`; no benchmark claim.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA, workflow helper only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: optional future run-directory selector if explicit-file bundles prove too manual.

## Next Empirical Action
- Rerun needed: no for this helper contract.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no external artifact required; proof uses committed tests/schema/docs.
- Stop / revise / continue decision: continue using explicit-file bundles for compact evidence packets.
- Proposed child issue or existing follow-up: none opened.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/tools/test_benchmark_publication_bundle.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_artifact_publication.py tests/tools/test_benchmark_publication_bundle.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
  - `git diff --check`
- Evidence that the change works here: 13 combined artifact/publication tests passed; Ruff and format checks passed.
- Benchmarks or smoke tests, if applicable: no benchmark run; targeted workflow fixture only.

## Risks / Rollout
- Compatibility risks: low; existing `size-report` and publication `export` contracts are unchanged.
- Failure modes: users could include too much evidence manually; docs and manifest policy explicitly forbid output-tree mirroring and large raw artifacts.
- Rollback or fallback plan: remove the new subcommand/helper/schema; existing publication helper remains intact.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/README.md`.
- Relevant design or provenance notes: `docs/context/issue_2460_evidence_bundle_v1.md`.
- Any assumptions that need to be preserved: a bundle improves reproducibility but does not by itself establish benchmark-strength or paper-grade claims.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR links close #2460; #2451 related.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context README and #2460 note updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is a support workflow helper, not a benchmark-result PR.

## Follow-Up Issues
- Deferred work: optional auto-selection/run-dir profile if explicit-file selection becomes too repetitive.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: explicit-file selection and missing-file fail-closed behavior.
- Any known limitations: no archive output and no run-directory auto-selection in v1 by design.