### PR TITLE
feat: add mechanism signal checker

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -229,6 +229,10 @@ knowledge, not every transient iteration detail.
 
   [issue_2434_ammv_scenario_sweep.md](issue_2434_ammv_scenario_sweep.md)
 
+* Issue #2463 Mechanism Signal Checker:
+
+  [issue_2463_mechanism_signal_checker.md](issue_2463_mechanism_signal_checker.md)
+
 * Issue #2263 mechanism activation report fields:
 
   [issue_2263_mechanism_activation_report_fields.md](issue_2263_mechanism_activation_report_fields.md)
@@ -553,6 +557,8 @@ knowledge, not every transient iteration detail.
   [issue_2038_real_trace_viewer_smoke.md](issue_2038_real_trace_viewer_smoke.md)
 * Issue #2236 Trace Mechanism Evidence Rubric (2026-06-04):
   [issue_2236_trace_mechanism_evidence_rubric.md](issue_2236_trace_mechanism_evidence_rubric.md)
+* Issue #2463 Mechanism Signal Checker (2026-06-06):
+  [issue_2463_mechanism_signal_checker.md](issue_2463_mechanism_signal_checker.md)
 * Issue #2263 Mechanism Activation Report Fields (2026-06-05):
   [issue_2263_mechanism_activation_report_fields.md](issue_2263_mechanism_activation_report_fields.md)
 * Issue #2227 Mechanism Panel Readiness (2026-06-04):

--- a/docs/context/issue_2463_mechanism_signal_checker.md
+++ b/docs/context/issue_2463_mechanism_signal_checker.md
@@ -1,0 +1,44 @@
+# Issue 2463 Mechanism Signal Checker
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/2463>
+
+## What Was Implemented
+
+`scripts/validation/check_mechanism_signal.py` classifies a baseline/intervention trace pair before
+the pair is routed as mechanism evidence.
+
+Example:
+
+```bash
+uv run python scripts/validation/check_mechanism_signal.py \
+  --baseline-trace <baseline-trace.json> \
+  --intervention-trace <intervention-trace.json>
+```
+
+Output is JSON under `mechanism_signal`:
+
+- `schema_version`
+- `trajectory_delta_nonzero`
+- `command_delta_nonzero`
+- `mechanism_field_delta_nonzero`
+- `activation_delta_nonzero`
+- `outcome_delta_nonzero`
+- `classification`
+
+## Classification Boundary
+
+- `rendering_sanity`: no trajectory, command, mechanism, activation, or outcome delta was found.
+- `qualitative_illustration`: trajectory, command, or outcome changed, but no mechanism or
+  activation field changed.
+- `mechanism_difference_candidate`: at least one mechanism or activation field changed.
+
+The checker is a routing guard only. A nonzero signal does not establish planner superiority,
+transfer, benchmark success, or paper-grade mechanism proof.
+
+Mechanism and activation detection uses conservative key-fragment matching across the trace payload.
+False positives should route a pair to follow-up review, not to a stronger claim.
+
+## Proof Surface
+
+`tests/validation/test_check_mechanism_signal.py` covers zero-delta, behavior-only delta,
+mechanism/activation delta, and CLI JSON output cases using synthetic trace fixtures.

--- a/scripts/validation/check_mechanism_signal.py
+++ b/scripts/validation/check_mechanism_signal.py
@@ -1,0 +1,231 @@
+"""Classify whether a trace pair contains nonzero mechanism-relevant signal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_MECHANISM_KEY_FRAGMENTS = (
+    "mechanism",
+    "ammv",
+    "static_recenter",
+    "topology",
+    "corridor_subgoal",
+    "recovery",
+)
+_ACTIVATION_KEY_FRAGMENTS = ("activation", "activated")
+_OUTCOME_KEYS = ("outcome", "terminal_outcome", "termination_reason", "status")
+_NUMERIC_EPS = 1e-9
+
+
+def _load_payload(path: Path) -> Any:
+    """Load a JSON or JSONL trace payload."""
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        raise ValueError(f"Trace input is empty: {path}")
+    if path.suffix == ".jsonl":
+        records = [json.loads(line) for line in text.splitlines() if line.strip()]
+        if len(records) == 1:
+            return records[0]
+        return records
+    return json.loads(text)
+
+
+def _frames(payload: Any) -> list[dict[str, Any]]:
+    """Return simulation-trace frames when present."""
+    if isinstance(payload, dict) and isinstance(payload.get("frames"), list):
+        return [frame for frame in payload["frames"] if isinstance(frame, dict)]
+    if isinstance(payload, list):
+        return [frame for frame in payload if isinstance(frame, dict)]
+    return []
+
+
+def _normalize_scalar(value: Any) -> Any:
+    """Normalize scalar values for stable recursive comparison."""
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+    return value
+
+
+def _canonical(value: Any) -> Any:
+    """Return a JSON-like canonical form for recursive equality checks."""
+    if isinstance(value, dict):
+        return {str(key): _canonical(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, list):
+        return [_canonical(item) for item in value]
+    return _normalize_scalar(value)
+
+
+def _values_equal(left: Any, right: Any) -> bool:
+    """Return whether two values are equal within numeric tolerance."""
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return math.isclose(float(left), float(right), rel_tol=0.0, abs_tol=_NUMERIC_EPS)
+    return _canonical(left) == _canonical(right)
+
+
+def _path_contains(path: str, fragments: tuple[str, ...]) -> bool:
+    """Return true if any lowercase fragment is present in a dotted path."""
+    lowered = path.lower()
+    return any(fragment in lowered for fragment in fragments)
+
+
+def _iter_paths(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
+    """Return recursive paths and values from a nested JSON-like object."""
+    paths = [(prefix, value)] if prefix else []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            paths.extend(_iter_paths(item, child_prefix))
+        return paths
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            child_prefix = f"{prefix}[{index}]"
+            paths.extend(_iter_paths(item, child_prefix))
+        return paths
+    return paths
+
+
+def _selected_actions(frames: list[dict[str, Any]]) -> list[Any]:
+    """Extract planner selected actions from trace frames."""
+    actions: list[Any] = []
+    for frame in frames:
+        planner = frame.get("planner")
+        if isinstance(planner, dict):
+            actions.append(planner.get("selected_action"))
+    return actions
+
+
+def _trajectory_points(frames: list[dict[str, Any]]) -> list[Any]:
+    """Extract robot and pedestrian position samples from trace frames."""
+    points: list[Any] = []
+    for frame in frames:
+        robot = frame.get("robot")
+        pedestrians = frame.get("pedestrians")
+        points.append(
+            {
+                "robot_position": robot.get("position") if isinstance(robot, dict) else None,
+                "pedestrians": [
+                    ped.get("position") if isinstance(ped, dict) else None for ped in pedestrians
+                ]
+                if isinstance(pedestrians, list)
+                else None,
+            }
+        )
+    return points
+
+
+def _leaf_delta_for_fragments(
+    baseline: Any,
+    intervention: Any,
+    fragments: tuple[str, ...],
+) -> bool:
+    """Return true when any matching leaf path differs across payloads."""
+    left = {path: value for path, value in _iter_paths(baseline) if _path_contains(path, fragments)}
+    right = {
+        path: value for path, value in _iter_paths(intervention) if _path_contains(path, fragments)
+    }
+    for path in sorted(set(left) | set(right)):
+        if not _values_equal(left.get(path), right.get(path)):
+            return True
+    return False
+
+
+def _outcome_delta(baseline: Any, intervention: Any) -> bool:
+    """Return true when common outcome/status surfaces differ."""
+    if not isinstance(baseline, dict) or not isinstance(intervention, dict):
+        return False
+    for key in _OUTCOME_KEYS:
+        if key in baseline or key in intervention:
+            if not _values_equal(baseline.get(key), intervention.get(key)):
+                return True
+    return False
+
+
+def classify_mechanism_signal(baseline: Any, intervention: Any) -> dict[str, Any]:
+    """Classify nonzero mechanism-signal fields for a baseline/intervention trace pair."""
+    baseline_frames = _frames(baseline)
+    intervention_frames = _frames(intervention)
+
+    trajectory_delta = not _values_equal(
+        _trajectory_points(baseline_frames),
+        _trajectory_points(intervention_frames),
+    )
+    command_delta = not _values_equal(
+        _selected_actions(baseline_frames),
+        _selected_actions(intervention_frames),
+    )
+    mechanism_delta = _leaf_delta_for_fragments(
+        baseline,
+        intervention,
+        _MECHANISM_KEY_FRAGMENTS,
+    )
+    activation_delta = _leaf_delta_for_fragments(
+        baseline,
+        intervention,
+        _ACTIVATION_KEY_FRAGMENTS,
+    )
+    outcome_delta = _outcome_delta(baseline, intervention)
+
+    if mechanism_delta or activation_delta:
+        classification = "mechanism_difference_candidate"
+    elif trajectory_delta or command_delta or outcome_delta:
+        classification = "qualitative_illustration"
+    else:
+        classification = "rendering_sanity"
+
+    return {
+        "mechanism_signal": {
+            "schema_version": "mechanism_signal_check.v1",
+            "trajectory_delta_nonzero": trajectory_delta,
+            "command_delta_nonzero": command_delta,
+            "mechanism_field_delta_nonzero": mechanism_delta,
+            "activation_delta_nonzero": activation_delta,
+            "outcome_delta_nonzero": outcome_delta,
+            "classification": classification,
+            "claim_boundary": (
+                "Routing guard only; nonzero signal does not establish planner superiority, "
+                "transfer, benchmark success, or paper-grade mechanism proof."
+            ),
+        }
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-trace", type=Path, required=True)
+    parser.add_argument("--intervention-trace", type=Path, required=True)
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path to write the JSON classification payload.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the mechanism-signal checker."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    result = classify_mechanism_signal(
+        _load_payload(args.baseline_trace),
+        _load_payload(args.intervention_trace),
+    )
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validation/test_check_mechanism_signal.py
+++ b/tests/validation/test_check_mechanism_signal.py
@@ -1,0 +1,143 @@
+"""Tests for the trace-pair mechanism-signal checker."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.validation import check_mechanism_signal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _trace(
+    *,
+    x: float = 0.0,
+    command: float = 0.1,
+    activation_count: int = 0,
+    mechanism_score: float = 0.0,
+    outcome: str = "timeout",
+) -> dict[str, object]:
+    """Return a tiny simulation-trace-like payload."""
+    return {
+        "schema_version": "simulation_trace_export.v1",
+        "trace_id": "fixture",
+        "terminal_outcome": outcome,
+        "algorithm_metadata": {
+            "static_recenter": {
+                "activation_count": activation_count,
+                "mechanism_score": mechanism_score,
+            }
+        },
+        "frames": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "robot": {"position": [0.0, 0.0]},
+                "pedestrians": [],
+                "planner": {"selected_action": {"linear_velocity": 0.1}},
+            },
+            {
+                "step": 1,
+                "time_s": 0.1,
+                "robot": {"position": [x, 0.0]},
+                "pedestrians": [],
+                "planner": {"selected_action": {"linear_velocity": command}},
+            },
+        ],
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    """Write a JSON fixture payload."""
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_identical_pair_classifies_as_rendering_sanity() -> None:
+    """Zero-delta pairs should not be routed as mechanism evidence."""
+    result = check_mechanism_signal.classify_mechanism_signal(_trace(), _trace())
+
+    signal = result["mechanism_signal"]
+    assert signal["schema_version"] == "mechanism_signal_check.v1"
+    assert signal["trajectory_delta_nonzero"] is False
+    assert signal["command_delta_nonzero"] is False
+    assert signal["mechanism_field_delta_nonzero"] is False
+    assert signal["activation_delta_nonzero"] is False
+    assert signal["outcome_delta_nonzero"] is False
+    assert signal["classification"] == "rendering_sanity"
+
+
+def test_trajectory_or_command_only_delta_is_qualitative_illustration() -> None:
+    """Nonzero behavior without mechanism fields should remain qualitative-only."""
+    baseline = _trace(x=0.0, command=0.1)
+    intervention = _trace(x=0.2, command=0.2)
+
+    signal = check_mechanism_signal.classify_mechanism_signal(
+        baseline,
+        intervention,
+    )["mechanism_signal"]
+
+    assert signal["trajectory_delta_nonzero"] is True
+    assert signal["command_delta_nonzero"] is True
+    assert signal["mechanism_field_delta_nonzero"] is False
+    assert signal["activation_delta_nonzero"] is False
+    assert signal["classification"] == "qualitative_illustration"
+
+
+def test_activation_or_mechanism_delta_is_candidate() -> None:
+    """Mechanism or activation field deltas should become mechanism candidates."""
+    baseline = _trace(activation_count=0, mechanism_score=0.0)
+    intervention = _trace(activation_count=2, mechanism_score=1.5)
+
+    signal = check_mechanism_signal.classify_mechanism_signal(
+        baseline,
+        intervention,
+    )["mechanism_signal"]
+
+    assert signal["mechanism_field_delta_nonzero"] is True
+    assert signal["activation_delta_nonzero"] is True
+    assert signal["classification"] == "mechanism_difference_candidate"
+    assert "does not establish planner superiority" in signal["claim_boundary"]
+
+
+def test_empty_mechanism_section_presence_is_candidate() -> None:
+    """Mechanism-section presence should count even without scalar leaves."""
+    baseline = _trace()
+    intervention = _trace()
+    baseline["algorithm_metadata"] = {}
+    intervention["algorithm_metadata"] = {"static_recenter": {}}
+
+    signal = check_mechanism_signal.classify_mechanism_signal(
+        baseline,
+        intervention,
+    )["mechanism_signal"]
+
+    assert signal["mechanism_field_delta_nonzero"] is True
+    assert signal["classification"] == "mechanism_difference_candidate"
+
+
+def test_cli_writes_json_output(tmp_path: Path, capsys) -> None:
+    """CLI should print and optionally persist the classification payload."""
+    baseline = tmp_path / "baseline.json"
+    intervention = tmp_path / "intervention.json"
+    output_json = tmp_path / "signal.json"
+    _write_json(baseline, _trace())
+    _write_json(intervention, _trace(activation_count=1))
+
+    exit_code = check_mechanism_signal.main(
+        [
+            "--baseline-trace",
+            str(baseline),
+            "--intervention-trace",
+            str(intervention),
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    assert exit_code == 0
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+    assert file_payload["mechanism_signal"]["classification"] == "mechanism_difference_candidate"


### PR DESCRIPTION
## Summary
- add `scripts/validation/check_mechanism_signal.py` to compare baseline/intervention trace pairs for trajectory, command, mechanism-field, activation, and outcome deltas
- classify pairs as `rendering_sanity`, `qualitative_illustration`, or `mechanism_difference_candidate` before routing them as mechanism evidence
- document the conservative claim boundary and index the context note

Closes #2463.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_mechanism_signal.py -q` -> 5 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/validation/check_mechanism_signal.py tests/validation/test_check_mechanism_signal.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/validation/check_mechanism_signal.py tests/validation/test_check_mechanism_signal.py` -> passed
- `git diff --check` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_mechanism_signal.py --baseline-trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --intervention-trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --output-json output/issue_2463/minimal_trace_signal.json` -> `rendering_sanity`

## Research Result Guidance
- Target claim/hypothesis/blocker: reduce false routing of replay pairs as mechanism evidence when the traces only prove rendering sanity or qualitative behavior changes.
- Comparator/baseline: baseline/intervention trace-pair JSON inputs.
- Evidence tier: validation helper plus synthetic unit tests and one fixture smoke path.
- Result classification: support/tooling; not benchmark evidence.
- Decision/stop rule: pairs with no mechanism/activation delta should not be described as mechanism-difference evidence by this checker.
- Synthesis surface/update target: `docs/context/issue_2463_mechanism_signal_checker.md` and `docs/context/README.md`.

## Downstream Propagation
- Parent issue/claim map: #2463 is closed by this PR; no claim map update because this does not establish a benchmark or paper-facing result.
- Benchmark report/leaderboard/artifact catalog: NA, no benchmark results generated.
- Registry/config index: NA, no config or artifact registry contract changed.
- Context index/memory note: updated `docs/context/README.md` and added `docs/context/issue_2463_mechanism_signal_checker.md`.