### PR TITLE
docs: add mechanism reproduction quickstart

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -35,6 +35,20 @@ These outputs are a local demo only. They are not durable benchmark evidence and
 for paper-facing or promotion claims unless promoted separately with the repository's normal
 artifact provenance and validation process.
 
+## Mechanism-Aware Diagnostic Reproduction
+
+For a bounded one-command reproduction of a mechanism-aware diagnostic case, run:
+
+```bash
+uv run python scripts/demo/reproduce_mechanism_report.py --case topology-primary-route
+```
+
+The command wraps the topology-hypothesis diagnostic for the double-bottleneck route case and
+writes disposable local artifacts under `output/demo/mechanism_report/topology_primary_route/`.
+Its claim boundary is `diagnostic_only_not_benchmark_success`: a successful run shows that the
+local diagnostic path can expose topology hypotheses for the selected case, not that the planner is
+better, benchmark-successful, or paper-grade.
+
 Benchmark outcomes are separate from dense training rewards. Benchmark claims must rely on
 schema-checked episode records, deterministic metrics, termination/outcome fields, and explicit
 runtime/readiness metadata; training reward totals are not benchmark-success evidence. See

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,9 @@ guides remain in their existing Markdown locations.
   support.
 - [Benchmark Runner And Metrics](benchmark.md) includes the local smoke benchmark demo:
   `uv run python scripts/demo/run_robot_sf_smoke.py`.
+- [Benchmark Runner And Metrics](benchmark.md) also includes a one-command mechanism-aware
+  diagnostic reproduction:
+  `uv run python scripts/demo/reproduce_mechanism_report.py --case topology-primary-route`.
 - The social-navigation benchmark quickstart lives outside the Sphinx source tree at
   `specs/120-social-navigation-benchmark-plan/quickstart.md`.
 

--- a/scripts/demo/reproduce_mechanism_report.py
+++ b/scripts/demo/reproduce_mechanism_report.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run one mechanism-aware diagnostic reproduction case from a single command."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+from loguru import logger
+
+# Keep the one-command reproduction readable by default.
+logger.remove()
+logger.add(sys.stderr, level="ERROR")
+
+from scripts.validation import run_topology_hypothesis_diagnostics  # noqa: E402
+
+DEFAULT_OUTPUT_ROOT = Path("output/demo/mechanism_report")
+CLAIM_BOUNDARY = "diagnostic_only_not_benchmark_success"
+
+
+@dataclass(frozen=True)
+class ReproductionCase:
+    """Configuration for one supported mechanism reproduction case."""
+
+    name: str
+    description: str
+    diagnostic_args: tuple[str, ...]
+    output_subdir: str
+
+
+CASES: dict[str, ReproductionCase] = {
+    "topology-primary-route": ReproductionCase(
+        name="topology-primary-route",
+        description=(
+            "Topology-hypothesis diagnostic on the double-bottleneck case used to inspect "
+            "whether the planner exposes at least two local route hypotheses."
+        ),
+        diagnostic_args=(
+            "--candidate",
+            "hybrid_rule_v3_waypoint2_route_lookahead8",
+            "--stage",
+            "full_matrix",
+            "--scenario-name",
+            "classic_realworld_double_bottleneck_high",
+            "--seed",
+            "111",
+            "--horizon",
+            "160",
+            "--min-hypotheses",
+            "2",
+        ),
+        output_subdir="topology_primary_route",
+    )
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the quickstart parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        choices=sorted(CASES),
+        default="topology-primary-route",
+        help="Mechanism-aware reproduction case to run.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help="Disposable local output root for generated diagnostic artifacts.",
+    )
+    return parser
+
+
+def diagnostic_args_for_case(case: ReproductionCase, output_root: Path) -> list[str]:
+    """Return the underlying topology diagnostic argv for a reproduction case."""
+    output_dir = output_root / case.output_subdir
+    return [*case.diagnostic_args, "--output-dir", str(output_dir)]
+
+
+def run_case(*, case_name: str, output_root: Path = DEFAULT_OUTPUT_ROOT) -> int:
+    """Run a supported reproduction case and preserve diagnostic exit semantics."""
+    case = CASES[case_name]
+    output_root = Path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+    diagnostic_argv = diagnostic_args_for_case(case, output_root)
+
+    print(f"Mechanism-aware reproduction case: {case.name}")
+    print(case.description)
+    print(f"Output root: {output_root}")
+    print(f"Claim boundary: {CLAIM_BOUNDARY}")
+    print("Running topology hypothesis diagnostic...")
+    exit_code = run_topology_hypothesis_diagnostics.main(diagnostic_argv)
+    if exit_code == 0:
+        print("Diagnostic reproduction completed.")
+    else:
+        print(
+            "Diagnostic reproduction did not produce sufficient topology hypotheses; "
+            "preserving fail-closed exit code."
+        )
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the mechanism reproduction CLI."""
+    args = build_parser().parse_args(argv)
+    return run_case(case_name=args.case, output_root=args.output_root)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/validation/run_topology_hypothesis_diagnostics.py
+++ b/scripts/validation/run_topology_hypothesis_diagnostics.py
@@ -60,7 +60,7 @@ class _RouteHypothesisPath:
     blocked_cell: tuple[int, int] | None = None
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--candidate", default="hybrid_rule_v3_waypoint2_route_lookahead8")
@@ -80,7 +80,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-hypotheses", type=int, default=2)
     parser.add_argument("--block-radius-cells", type=int, default=3)
     parser.add_argument("--block-stride-cells", type=int, default=8)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _first_float(value: Any, default: float) -> float:
@@ -633,9 +633,9 @@ def _report_lines(payload: dict[str, Any], trace_path: Path) -> list[str]:
     return lines
 
 
-def main() -> int:  # noqa: C901, PLR0915
+def main(argv: list[str] | None = None) -> int:  # noqa: C901, PLR0915
     """Run the topology-hypothesis diagnostic trace."""
-    args = parse_args()
+    args = parse_args(argv)
     funnel = _load_yaml(args.funnel_config)
     stages = funnel.get("stages")
     if not isinstance(stages, dict) or args.stage not in stages:

--- a/tests/demo/test_reproduce_mechanism_report.py
+++ b/tests/demo/test_reproduce_mechanism_report.py
@@ -1,0 +1,63 @@
+"""Tests for the one-command mechanism-aware reproduction quickstart."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.demo import reproduce_mechanism_report as quickstart
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_diagnostic_args_for_default_case_use_disposable_output(tmp_path: Path) -> None:
+    """The default case should route to a local output directory."""
+    case = quickstart.CASES["topology-primary-route"]
+
+    argv = quickstart.diagnostic_args_for_case(case, tmp_path)
+
+    assert "--candidate" in argv
+    assert "hybrid_rule_v3_waypoint2_route_lookahead8" in argv
+    assert "--stage" in argv
+    assert "full_matrix" in argv
+    assert "--scenario-name" in argv
+    assert "classic_realworld_double_bottleneck_high" in argv
+    assert "--output-dir" in argv
+    assert str(tmp_path / "topology_primary_route") in argv
+
+
+def test_run_case_preserves_underlying_exit_code(monkeypatch, tmp_path: Path, capsys) -> None:
+    """The wrapper should not hide fail-closed diagnostic exits."""
+    calls: list[list[str]] = []
+
+    def fake_main(argv: list[str]) -> int:
+        calls.append(argv)
+        return 2
+
+    monkeypatch.setattr(quickstart.run_topology_hypothesis_diagnostics, "main", fake_main)
+
+    exit_code = quickstart.run_case(
+        case_name="topology-primary-route",
+        output_root=tmp_path,
+    )
+
+    assert exit_code == 2
+    assert len(calls) == 1
+    assert "--output-dir" in calls[0]
+    stdout = capsys.readouterr().out
+    assert quickstart.CLAIM_BOUNDARY in stdout
+    assert "preserving fail-closed exit code" in stdout
+
+
+def test_main_defaults_to_topology_primary_route(monkeypatch, tmp_path: Path) -> None:
+    """The documented one-command path should default to the supported case."""
+    calls: list[tuple[str, Path]] = []
+
+    def fake_run_case(*, case_name: str, output_root: Path) -> int:
+        calls.append((case_name, output_root))
+        return 0
+
+    monkeypatch.setattr(quickstart, "run_case", fake_run_case)
+
+    assert quickstart.main(["--output-root", str(tmp_path)]) == 0
+    assert calls == [("topology-primary-route", tmp_path)]


### PR DESCRIPTION
## Summary
- add `scripts/demo/reproduce_mechanism_report.py` as a one-command mechanism-aware diagnostic reproduction path
- support the bounded `--case topology-primary-route` case by wrapping the existing topology-hypothesis diagnostic with `topology_guided_hybrid_rule_v0`, whose registry `claim_scope` is `diagnostic_only`
- document the quickstart in `docs/benchmark.md` and `docs/quickstart.md` with the explicit `diagnostic_only_not_benchmark_success` claim boundary
- allow `scripts/validation/run_topology_hypothesis_diagnostics.py` to accept argv so the wrapper can preserve fail-closed exit semantics without subprocess glue

Closes #2461.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/demo/test_reproduce_mechanism_report.py tests/validation/test_run_topology_hypothesis_diagnostics.py -q` -> 12 passed
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_active_doc_examples.py -q` -> 7 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/demo/reproduce_mechanism_report.py scripts/validation/run_topology_hypothesis_diagnostics.py tests/demo/test_reproduce_mechanism_report.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/demo/reproduce_mechanism_report.py scripts/validation/run_topology_hypothesis_diagnostics.py tests/demo/test_reproduce_mechanism_report.py` -> passed
- `git diff --check` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/demo/reproduce_mechanism_report.py --case topology-primary-route --output-root output/demo/mechanism_report_diagnostic_only` -> `diagnostic_complete`, topology status counts `ok: 90`, `insufficient_hypotheses: 70`, selected-source counts include `topology_hypothesis: 33`

## Research Result Guidance
- Target claim/hypothesis/blocker: provide a reviewer-runnable mechanism-aware diagnostic reproduction path without reconstructing scattered notes.
- Comparator/baseline: existing topology-hypothesis diagnostic defaults for `topology_guided_hybrid_rule_v0` on `classic_realworld_double_bottleneck_high`, seed 111.
- Evidence tier: local diagnostic reproduction, not benchmark evidence.
- Result classification: support/docs/example; diagnostic-only research infrastructure.
- Decision/stop rule: the command must run from a synced checkout, produce compact local artifacts, and preserve fail-closed diagnostic exit semantics.
- Synthesis surface/update target: `docs/benchmark.md` and `docs/quickstart.md`.

## Downstream Propagation
- Parent issue/claim map: #2461 closes this child under #2451; no benchmark claim map update because the result is diagnostic-only.
- Benchmark report/leaderboard/artifact catalog: NA, no benchmark result or durable artifact was promoted.
- Registry/config index: NA, no candidate/config registry contract changed.
- Context index/memory note: quickstart links are in active docs; no separate context note needed for this bounded docs/example path.