### PR TITLE
feat: add claim readiness checker

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -66,6 +66,22 @@ Each bundle writes:
 
 The schema contract lives at `robot_sf/benchmark/schemas/evidence_bundle.v1.json`.
 
+## Claim Readiness Check
+
+Before promoting compact evidence into a stronger claim, run the claim-readiness guardrail against
+the claim note and evidence path:
+
+```bash
+uv run python scripts/validation/check_claim_readiness.py \
+  --claim-file docs/context/issue_1542_manuscript_claim_evidence_map.md \
+  --evidence docs/context/evidence/<bundle-or-report>
+```
+
+The checker reports missing fields for evidence tier, comparator or baseline, mechanism activation,
+trace support, artifact provenance, seed or slice boundary, claim boundary, and fallback/degraded
+limitation handling. It is a guardrail only: readiness output does not establish scientific truth,
+benchmark success, safety, or paper-grade sufficiency.
+
 Required provenance fields:
 
 - `command`: the command that produced or validates the evidence;

--- a/scripts/validation/check_claim_readiness.py
+++ b/scripts/validation/check_claim_readiness.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Report whether compact evidence contains the fields needed for a stated claim."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+TEXT_SUFFIXES = {".csv", ".json", ".jsonl", ".md", ".txt", ".yaml", ".yml"}
+READY_STATUS_BY_CLASS = {
+    "diagnostic": "ready_for_diagnostic_review",
+    "blocked": "ready_for_blocked_review",
+    "fallback_or_degraded": "ready_for_limitation_review",
+    "benchmark": "ready_for_benchmark_review",
+    "paper_facing": "ready_for_paper_facing_review",
+}
+SCHEMA_VERSION = "claim_readiness.v1"
+
+
+@dataclass(frozen=True)
+class ReadinessField:
+    """One readiness field and its text markers."""
+
+    name: str
+    description: str
+    patterns: tuple[re.Pattern[str], ...]
+
+    def is_present(self, text: str) -> bool:
+        """Return whether this field is present in a combined claim/evidence text."""
+        return any(pattern.search(text) for pattern in self.patterns)
+
+
+READINESS_FIELDS = (
+    ReadinessField(
+        name="evidence_tier",
+        description="Evidence tier or class is explicit.",
+        patterns=(
+            re.compile(r"\bevidence[_ -]?tier\s*[:=]"),
+            re.compile(r"\bclaim[_ -]?scope\s*[:=]\s*diagnostic[_ -]?only\b"),
+            re.compile(r"\bevidence[_ -]?tier\s*[:=]\s*benchmark[-_ ]strength\b"),
+            re.compile(r"\bevidence[_ -]?tier\s*[:=]\s*paper[-_ ]facing\b"),
+        ),
+    ),
+    ReadinessField(
+        name="comparator_or_baseline",
+        description="Comparator, baseline, or control surface is named.",
+        patterns=(
+            re.compile(r"\bcompar(?:ator|ison)\s*[:=]"),
+            re.compile(r"\bbaseline\s*[:=]"),
+            re.compile(r"\bcontrol\s*[:=]"),
+            re.compile(r"\bvs\.?\s+[^.\n]+"),
+        ),
+    ),
+    ReadinessField(
+        name="mechanism_activation",
+        description="Mechanism activation or mechanism-signal surface is described.",
+        patterns=(
+            re.compile(r"\bmechanism[_ -]?activation\s*[:=]"),
+            re.compile(r"\bactivation[_ -]?count\s*[:=]"),
+            re.compile(r"\bmechanism[_ -]?signal\s*[:=]"),
+            re.compile(r'"(?:activation_count|mechanism_signal)"\s*:'),
+        ),
+    ),
+    ReadinessField(
+        name="trace_support",
+        description="Trace, frame, step, or trajectory support is identified.",
+        patterns=(
+            re.compile(r"\btrace[_ -]?support\s*[:=]"),
+            re.compile(r"\bsimulation_trace\b"),
+            re.compile(r"\btrace[_ -]?(?:file|path|frames?)\s*[:=]"),
+            re.compile(r'"(?:frames|steps|trajectory)"\s*:'),
+        ),
+    ),
+    ReadinessField(
+        name="artifact_provenance",
+        description="Command, commit, checksum, or artifact provenance is present.",
+        patterns=(
+            re.compile(r"\bartifact[_ -]?provenance\s*[:=]"),
+            re.compile(r"\bcommand\s*[:=]"),
+            re.compile(r"\bcommit\s*[:=]"),
+            re.compile(r"\bsha-?256\s*[:=]"),
+            re.compile(r"\bchecksum\s*[:=]"),
+            re.compile(r'"(?:command|commit|sha256|checksum)"\s*:'),
+            re.compile(r"\bevidence_bundle_manifest\b"),
+        ),
+    ),
+    ReadinessField(
+        name="seed_slice_boundary",
+        description="Seed, scenario, slice, family, or horizon boundary is stated.",
+        patterns=(
+            re.compile(r"\bseed[/_ -]?slice[_ -]?boundary\s*[:=]"),
+            re.compile(r"\bscenario\s*[:=]"),
+            re.compile(r"\bseed\s*[:=]"),
+            re.compile(r"\bhorizon\s*[:=]"),
+            re.compile(r'"(?:scenario|seed|horizon|slice)"\s*:'),
+        ),
+    ),
+    ReadinessField(
+        name="claim_boundary",
+        description="Claim boundary or claim scope is explicit.",
+        patterns=(
+            re.compile(r"\bclaim[_ -]?boundary\s*[:=]"),
+            re.compile(r"\bclaim[_ -]?scope\s*[:=]"),
+            re.compile(r"\bdoes not establish\b"),
+            re.compile(r"\bnot benchmark(?: evidence)?\b"),
+            re.compile(r"\bnot paper(?:[-_ ]facing|[-_ ]grade)?\b"),
+        ),
+    ),
+    ReadinessField(
+        name="fallback_degraded_limitations",
+        description="Fallback, degraded, unavailable, or fail-closed limitations are handled.",
+        patterns=(
+            re.compile(r"\bfallback[/_ -]?degraded[_ -]?limitations\s*[:=]"),
+            re.compile(r"\bfallback[_ -]?or[_ -]?degraded\s*[:=]"),
+            re.compile(r"\bfail[- ]closed\s*[:=]"),
+            re.compile(r"\bnot[_ -]?available\s*[:=]"),
+            re.compile(r"\bnot benchmark evidence\b"),
+        ),
+    ),
+)
+
+
+def _read_text(path: Path) -> str:
+    """Read a text-like file with replacement for odd encodings."""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _evidence_files(path: Path) -> list[Path]:
+    """Return compact evidence files to scan."""
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise FileNotFoundError(f"Evidence path does not exist: {path}")
+    return sorted(
+        candidate
+        for candidate in path.rglob("*")
+        if candidate.is_file() and candidate.suffix.lower() in TEXT_SUFFIXES
+    )
+
+
+def _combined_text(claim_file: Path, evidence_path: Path) -> tuple[str, str, list[Path]]:
+    """Return normalized combined claim/evidence text and scanned evidence files."""
+    if not claim_file.is_file():
+        raise FileNotFoundError(f"Claim file does not exist: {claim_file}")
+    evidence_files = _evidence_files(evidence_path)
+    claim_text = _read_text(claim_file).lower()
+    chunks = [claim_text]
+    chunks.extend(_read_text(path) for path in evidence_files)
+    return claim_text, "\n".join(chunks).lower(), evidence_files
+
+
+def _claim_class(text: str) -> str:
+    """Return the strongest apparent claim class in the scanned material."""
+    if re.search(r"\bpaper[-_ ]facing\b|\bpaper[-_ ]grade\b|\bmanuscript\b", text):
+        return "paper_facing"
+    if re.search(r"\bbenchmark[-_ ]strength\b|\bbenchmark[_ -]?success\b", text):
+        return "benchmark"
+    if re.search(r"\bdiagnostic[_ -]?only\b|\bdiagnostic\b", text):
+        return "diagnostic"
+    if re.search(r"\bfallback\b|\bdegraded\b", text):
+        return "fallback_or_degraded"
+    if re.search(r"\bblocked\b|\bnot[_ -]?available\b|\bfail[- ]closed\b", text):
+        return "blocked"
+    return "diagnostic"
+
+
+def _warnings_for_claim_class(claim_class: str, text: str) -> list[str]:
+    """Return conservative caveat warnings for the detected claim class."""
+    warnings: list[str] = []
+    if claim_class in {"benchmark", "paper_facing"} and re.search(
+        r"\bfallback\b|\bdegraded\b|\bdiagnostic[_ -]?only\b",
+        text,
+    ):
+        warnings.append(
+            "benchmark_or_paper_claim_mentions_fallback_degraded_or_diagnostic_only_evidence"
+        )
+    if claim_class == "paper_facing" and "sha256" not in text and "checksum" not in text:
+        warnings.append("paper_facing_claim_without_checksum_marker")
+    return warnings
+
+
+def evaluate_claim_readiness(claim_file: Path, evidence_path: Path) -> dict[str, Any]:
+    """Evaluate whether claim/evidence material contains readiness guardrail fields."""
+    claim_text, text, evidence_files = _combined_text(claim_file, evidence_path)
+    present_fields = [field.name for field in READINESS_FIELDS if field.is_present(text)]
+    missing_fields = [field.name for field in READINESS_FIELDS if field.name not in present_fields]
+    claim_class = _claim_class(claim_text)
+    warnings = _warnings_for_claim_class(claim_class, text)
+    if missing_fields:
+        status = "not_ready_missing_fields"
+    elif warnings:
+        status = "not_ready_claim_boundary_warning"
+    else:
+        status = READY_STATUS_BY_CLASS[claim_class]
+    return {
+        "claim_readiness": {
+            "schema_version": SCHEMA_VERSION,
+            "status": status,
+            "claim_class": claim_class,
+            "present_fields": present_fields,
+            "missing_fields": missing_fields,
+            "warnings": warnings,
+            "claim_file": str(claim_file),
+            "evidence_path": str(evidence_path),
+            "scanned_evidence_files": [str(path) for path in evidence_files],
+            "claim_boundary": (
+                "Guardrail and missing-field report only; readiness does not establish "
+                "scientific truth, benchmark success, safety, or paper-grade sufficiency."
+            ),
+        }
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--claim-file", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run claim readiness checks."""
+    args = build_parser().parse_args(argv)
+    result = evaluate_claim_readiness(args.claim_file, args.evidence)
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+    return 0 if result["claim_readiness"]["status"].startswith("ready_for_") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/validation/test_check_claim_readiness.py
+++ b/tests/validation/test_check_claim_readiness.py
@@ -1,0 +1,143 @@
+"""Tests for the claim-readiness guardrail checker."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.validation import check_claim_readiness
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, text: str) -> Path:
+    """Write test text and return the path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_ready_diagnostic_claim_reports_diagnostic_review_status(tmp_path: Path) -> None:
+    """A complete diagnostic bundle should be ready only for diagnostic review."""
+    claim = _write(
+        tmp_path / "claim.md",
+        """
+        evidence_tier: diagnostic_only
+        comparator: baseline planner row
+        mechanism activation: activation_count changed on selected steps
+        trace support: simulation_trace frames show step-level behavior
+        seed/slice boundary: scenario classic, seed 111, horizon 160
+        claim_boundary: diagnostic_only_not_benchmark_success
+        fallback/degraded limitations: fallback rows are not benchmark evidence
+        """,
+    )
+    evidence_dir = tmp_path / "evidence"
+    _write(
+        evidence_dir / "summary.json",
+        """
+        {
+          "command": "uv run python scripts/demo/reproduce_mechanism_report.py",
+          "commit": "abc123",
+          "sha256": "0"
+        }
+        """,
+    )
+
+    result = check_claim_readiness.evaluate_claim_readiness(claim, evidence_dir)["claim_readiness"]
+
+    assert result["schema_version"] == "claim_readiness.v1"
+    assert result["status"] == "ready_for_diagnostic_review"
+    assert result["claim_class"] == "diagnostic"
+    assert result["missing_fields"] == []
+    assert result["warnings"] == []
+
+
+def test_missing_fields_report_is_not_ready(tmp_path: Path) -> None:
+    """Sparse material should report missing fields instead of passing readiness."""
+    claim = _write(tmp_path / "claim.md", "claim_boundary: diagnostic only")
+    evidence = _write(tmp_path / "summary.json", '{"command": "uv run ..."}')
+
+    result = check_claim_readiness.evaluate_claim_readiness(claim, evidence)["claim_readiness"]
+
+    assert result["status"] == "not_ready_missing_fields"
+    assert "comparator_or_baseline" in result["missing_fields"]
+    assert "trace_support" in result["missing_fields"]
+    assert "artifact_provenance" in result["present_fields"]
+
+
+def test_benchmark_claim_with_diagnostic_or_fallback_evidence_warns(tmp_path: Path) -> None:
+    """Benchmark/paper claims should not silently absorb diagnostic/fallback evidence."""
+    claim = _write(
+        tmp_path / "claim.md",
+        """
+        evidence_tier: benchmark-strength
+        comparator: baseline
+        mechanism activation: mechanism_signal present
+        trace support: trace frames
+        artifact provenance: command, commit, sha256
+        seed/slice boundary: scenario x seed 1
+        claim_boundary: benchmark_success
+        fallback/degraded limitations: degraded rows and diagnostic_only evidence are caveats
+        """,
+    )
+    evidence = _write(tmp_path / "evidence.md", "fallback rows are diagnostic_only caveats")
+
+    result = check_claim_readiness.evaluate_claim_readiness(claim, evidence)["claim_readiness"]
+
+    assert result["claim_class"] == "benchmark"
+    assert result["status"] == "not_ready_claim_boundary_warning"
+    assert result["missing_fields"] == []
+    assert result["warnings"] == [
+        "benchmark_or_paper_claim_mentions_fallback_degraded_or_diagnostic_only_evidence"
+    ]
+
+
+def test_evidence_tokens_do_not_override_claim_class(tmp_path: Path) -> None:
+    """Incidental evidence text should not upgrade a diagnostic claim class."""
+    claim = _write(
+        tmp_path / "claim.md",
+        """
+        evidence_tier: diagnostic_only
+        comparator: baseline
+        mechanism activation: activation_count changed
+        trace support: simulation_trace frames
+        artifact provenance: command, commit, sha256
+        seed/slice boundary: scenario x seed 1
+        claim_boundary: diagnostic_only_not_benchmark_success
+        fallback/degraded limitations: fallback rows are caveats
+        """,
+    )
+    evidence = _write(
+        tmp_path / "evidence.md",
+        "Historical benchmark-strength manuscript note; not the claim under review.",
+    )
+
+    result = check_claim_readiness.evaluate_claim_readiness(claim, evidence)["claim_readiness"]
+
+    assert result["claim_class"] == "diagnostic"
+    assert result["status"] == "ready_for_diagnostic_review"
+
+
+def test_cli_writes_json_and_sets_exit_code(tmp_path: Path, capsys) -> None:
+    """CLI should print/write JSON and return readiness as the exit code."""
+    claim = _write(tmp_path / "claim.md", "claim_boundary: diagnostic only")
+    evidence = _write(tmp_path / "summary.json", '{"command": "uv run ..."}')
+    output_json = tmp_path / "readiness.json"
+
+    exit_code = check_claim_readiness.main(
+        [
+            "--claim-file",
+            str(claim),
+            "--evidence",
+            str(evidence),
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert stdout_payload == file_payload
+    assert file_payload["claim_readiness"]["status"] == "not_ready_missing_fields"


### PR DESCRIPTION
## Summary
- add `scripts/validation/check_claim_readiness.py` to report whether a claim/evidence pair contains required readiness fields
- favor explicit field-like markers for readiness detection and derive claim class from the claim file, not incidental evidence text
- distinguish diagnostic, blocked, fallback/degraded, benchmark, and paper-facing review classes while refusing to upgrade missing or caveated evidence silently
- document the checker in `docs/context/evidence/README.md`

Closes #2466.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_claim_readiness.py -q` -> 5 passed
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_active_doc_examples.py -q` -> 7 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/validation/check_claim_readiness.py tests/validation/test_check_claim_readiness.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/validation/check_claim_readiness.py tests/validation/test_check_claim_readiness.py` -> passed
- `git diff --check` -> passed
- CLI smoke with disposable `output/issue_2466/ready/*` files -> `ready_for_diagnostic_review` with all eight readiness fields present

## Research Result Guidance
- Target claim/hypothesis/blocker: prevent diagnostic, blocked, fallback/degraded, or incomplete evidence from being silently promoted into stronger benchmark or paper-facing claims.
- Comparator/baseline: synthetic ready and missing-field fixtures in `tests/validation/test_check_claim_readiness.py`.
- Evidence tier: validation/support tooling, not benchmark evidence.
- Result classification: guardrail checker and missing-field reporter.
- Decision/stop rule: checker exits 0 only for ready review classes and exits nonzero for missing fields or boundary warnings.
- Synthesis surface/update target: `docs/context/evidence/README.md`.

## Downstream Propagation
- Parent issue/claim map: #2466 closes this child under #2451; no claim map update because this adds guardrail tooling rather than a claim result.
- Benchmark report/leaderboard/artifact catalog: NA, no benchmark output generated.
- Registry/config index: NA, no planner/config registry contract changed.
- Context index/memory note: evidence workflow docs updated in `docs/context/evidence/README.md`.