### PR TITLE
docs: strengthen research issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/research-validation.yml
+++ b/.github/ISSUE_TEMPLATE/research-validation.yml
@@ -13,6 +13,9 @@ body:
         Research issues should preferably explain what claim boundary, hypothesis, negative
         result, synthesis decision, or durable experiment blocker they are meant to change. Treat
         that as adapted guidance, not a hard requirement for every small support issue.
+        Prefer the smallest issue that can produce one discriminating diagnostic table, trace,
+        decision, or experiment. Blocked and diagnostic-only outcomes are valid research results
+        when the claim boundary stays explicit.
   - type: textarea
     id: goal
     attributes:
@@ -27,6 +30,48 @@ body:
       label: Hypothesis
       description: State the expected result or decision this issue should test.
       placeholder: We expect that...
+    validations:
+      required: true
+  - type: textarea
+    id: competing_explanations
+    attributes:
+      label: Competing explanations
+      description: List plausible alternatives this issue should distinguish from the preferred hypothesis, or explain why comparison is blocked.
+      placeholder: |
+        1.
+        2.
+        3.
+        N/A - blocked:
+    validations:
+      required: true
+  - type: textarea
+    id: discriminating_evidence
+    attributes:
+      label: Discriminating evidence
+      description: Name the trace, metric, table, diagnostic, or experiment that separates the competing explanations, or explain the blocker.
+      placeholder: |
+        What evidence would make one explanation more plausible than the others?
+        N/A - blocked:
+    validations:
+      required: true
+  - type: textarea
+    id: mechanism_signal_required
+    attributes:
+      label: Mechanism signal required
+      description: Name the fields or observable mechanism signals that must change before any claim-strength upgrade, or explain why this is support-only.
+      placeholder: |
+        Which planner, scenario, trace, score, activation, command, or outcome fields must move?
+        N/A - support/docs-only:
+    validations:
+      required: true
+  - type: textarea
+    id: stop_rule
+    attributes:
+      label: Stop rule
+      description: State when to retire, narrow, block, or keep the mechanism diagnostic-only.
+      placeholder: |
+        When do we stop pursuing this mechanism or classify it as blocked/diagnostic-only?
+        If blocked or diagnostic-only, why does the claim class stay unchanged?
     validations:
       required: true
   - type: dropdown
@@ -71,7 +116,7 @@ body:
         Target claim or hypothesis:
         Comparator or baseline:
         Minimum valid evidence:
-        Decision or stop rule:
+        Decision routing:
         Expected artifacts:
         Parent issue / claim map / context note to update:
     validations:

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -14,6 +14,28 @@ assignees: []
 **Hypothesis**
 <!-- What do we expect to find or prove? -->
 
+**Evidence grade / claim class**
+<!-- Mark observed, inferred, speculative, blocked, diagnostic-only, benchmark, or paper-facing. -->
+
+**Competing explanations**
+<!-- List plausible alternatives this work should distinguish, not just the preferred hypothesis. -->
+<!-- Use "N/A - blocked: ..." when blocked prerequisites prevent this comparison. -->
+1.
+2.
+3.
+
+**Discriminating evidence**
+<!-- What trace, metric, table, diagnostic, or experiment would separate the explanations above? -->
+<!-- Use "N/A - blocked: ..." when no discriminating evidence can be gathered yet. -->
+
+**Mechanism signal required**
+<!-- Which fields or observable mechanism signals must change for this to move the claim boundary? -->
+<!-- Use "N/A - support/docs-only: ..." when this is research-workflow support, not a mechanism probe. -->
+
+**Stop rule**
+<!-- When should this mechanism be retired, narrowed, marked blocked, or kept diagnostic-only? -->
+<!-- If the result is blocked or diagnostic-only, state why and keep the claim class unchanged. -->
+
 **Scientific motivation**
 <!-- Why is this research important? What gap does it fill? -->
 
@@ -62,6 +84,9 @@ assignees: []
 
 - [ ] Experimental setup is reproducible.
 - [ ] Baseline comparison is documented.
+- [ ] Competing explanations and discriminating evidence are addressed, or the result is marked blocked/diagnostic-only.
+- [ ] Evidence grade or claim class is explicit.
+- [ ] The mechanism signal and stop rule are recorded before any claim-strength upgrade.
 - [ ] Results are recorded and interpreted.
 - [ ] Analysis artifacts can be regenerated from versioned inputs.
 


### PR DESCRIPTION
## Summary
Strengthens the research issue creation surfaces so new research issues explicitly name competing explanations, discriminating evidence, required mechanism signals, and a stop rule.

## Linked Issues
- Closes #2467
- Relates to #2451

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added evidence-grade/claim-class, competing-explanation, discriminating-evidence, mechanism-signal, and stop-rule prompts to .github/ISSUE_TEMPLATE/research.md.
- Added matching required fields to .github/ISSUE_TEMPLATE/research-validation.yml, with explicit blocked/support-only fallback wording so small or blocked issues can stay honest.
- Removed duplicate stop-rule wording from the optional research-result guidance placeholder by changing it to decision routing.

## Why It Matters
- Added value: makes research issues easier to close against a specific claim boundary before work starts.
- Expected impact: fewer broad mechanism issues that cannot distinguish alternatives or define a stop condition.
- Why this is worth merging now: it complements the recently added mechanism-signal and claim-readiness workflow checks.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; workflow-only issue-intake quality improvement.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: the template now asks future issues to state this explicitly; this PR makes no research claim.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent #2451 through this PR/issue closeout.
- New research/benchmark/metric/paper-facing analysis tool, if any: none

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA; support/docs-only template change.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none for this docs-only slice

## Validation / Proof
- Commands run:
  - python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path(""".github/ISSUE_TEMPLATE/research-validation.yml""").read_text()); print("""yaml ok""")"
  - git diff --check
  - scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_issue_templates.py -q
- Evidence that the change works here: YAML parsed successfully; diff whitespace check passed; issue-template test suite passed with 6 tests.
- Benchmarks or smoke tests, if applicable: NA

## Risks / Rollout
- Compatibility risks: the structured form now asks for more required research-contract fields; blocked/support-only placeholders are included to avoid dishonest filler.
- Failure modes: users may still paste low-information boilerplate; review can ask for a smaller diagnostic table, trace, decision, or experiment.
- Rollback or fallback plan: revert the template wording if it creates too much intake friction.

## Docs / Provenance
- Updated docs: .github/ISSUE_TEMPLATE/research.md; .github/ISSUE_TEMPLATE/research-validation.yml
- Relevant design or provenance notes: Gemini review found no blocker and suggested explicit blocked/diagnostic-only claim-class wording; OpenCode free-model review found no blocker and prompted the blocked/support fallback plus duplicate stop-rule cleanup.
- Any assumptions that need to be preserved: blocked and diagnostic-only outcomes remain valid research results when the claim boundary is explicit.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via linked PR and closeout
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a research issue-template workflow update, not evidence production.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify that the added required fields are still concise enough for true research-validation issues.
- Known limitation: templates can request discriminating evidence, but reviewer discipline is still needed to reject boilerplate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced research and validation issue templates with updated guidance for research submissions
  * Added new required fields to capture competing explanations, discriminating evidence, mechanism signals, and stopping rules
  * Expanded research checklists to enforce quality standards before claim upgrades

<!-- end of auto-generated comment: release notes by coderabbit.ai -->