### PR TITLE
docs: clarify analysis tool first-use rule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -34,7 +34,9 @@ to `NA` and state why.
 - Parent issue, claim map, registry, context note, or synthesis surface to update:
 - New research/benchmark/metric/paper-facing analysis tool, if any: representative use on
   durable/versioned input, or a linked follow-up issue that names the decision, claim boundary, or
-  synthesis surface it will update:
+  synthesis surface it will update. Examples: trace-panel generators, topology-score
+  instrumentation, seed-sufficiency analysis, and why-report generation. For support helpers that
+  do not interpret research evidence, state `NA - support helper` with the reason:
 
 ## Falsification / Non-Transfer Check
 Required for research-result PRs when the expected mechanism did not improve the measured outcome,
@@ -66,6 +68,9 @@ synthesis surface the tool will update. Local-only `output/` files are
 not durable proof unless promoted or represented by a tracked manifest.
 Small support helpers (formatters, CLI wrappers, quick diagnostics)
 that make no research/benchmark/metric/paper claim are exempt.
+Examples that do need first use or a concrete follow-up include trace-panel generators,
+topology-score instrumentation, seed-sufficiency analysis, and why-report generation. Support
+helpers that do not interpret research evidence should state `NA - support helper` with the reason.
 
 - Commands run:
 - Evidence that the change works here:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,10 @@ resolving lint or test failures locally before requesting review.
   decision, claim boundary, benchmark report, registry, context note, or synthesis surface the tool
   will update. Disposable local `output/` files do not count as durable proof unless represented by
   a tracked manifest, registry entry, context note, or external artifact pointer. Small support
-  helpers that are not intended to support research interpretation may state `NA` with that reason.
+  helpers that are not intended to support research interpretation may state `NA - support helper`
+  with that reason. Trace-panel generators, topology-score instrumentation, seed-sufficiency
+  analysis, and why-report generation are research-facing examples that need first use or a
+  concrete follow-up.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1437,7 +1437,10 @@ See `docs/training/dreamerv3_rllib_drive_state_rays.md` for the Auxme launch/mon
   artifact), or link a concrete follow-up issue that names the decision, claim boundary, or
   synthesis surface the tool will update. Local-only `output/` files are not durable proof unless
   promoted or represented by a tracked manifest. Small support helpers (formatters, CLI wrappers,
-  quick diagnostics) that make no research/benchmark/metric/paper claim are exempt.
+  quick diagnostics) that make no research/benchmark/metric/paper claim should state
+  `NA - support helper` with the reason. Trace-panel generators, topology-score instrumentation,
+  seed-sufficiency analysis, and why-report generation are research-facing examples that need first
+  use or a concrete follow-up.
 - Ruff clean and “Check Code Quality (Ruff + advisory ty)” reviewed locally.
 - Advisory typecheck reviewed. Fix practical findings in touched files and stable contracts, and
   document any meaningful remaining findings in the PR when they affect the change.


### PR DESCRIPTION
## Summary
Clarifies the first-use rule for new research-facing analysis tools across the PR template and contributor guidance.

## Linked Issues
- Closes #2465
- Relates to #2451

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added concrete research-facing examples: trace-panel generators, topology-score instrumentation, seed-sufficiency analysis, and why-report generation.
- Tightened the support-helper escape hatch to `NA - support helper` with a reason.
- Kept the durable-evidence boundary that local `output/` files do not count unless promoted or represented by a tracked manifest.

## Why It Matters
- Added value: makes the existing first-use rule easier to apply in PR review.
- Expected impact: fewer research analysis tools land without either one representative use or a concrete follow-up tied to a claim boundary or synthesis surface.
- Why this is worth merging now: follows #2467 by tightening the PR-side contract for research workflow discipline.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; workflow-only guidance update.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: future research-tool PRs must state first use or a concrete follow-up; this PR makes no research claim.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent #2451 through this PR/issue closeout.
- New research/benchmark/metric/paper-facing analysis tool, if any: none

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA; support/docs-only guidance change.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none for this docs-only slice

## Validation / Proof
- Commands run:
  - git diff --check
  - scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_issue_templates.py -q
  - rg -n "NA - support helper|Trace-panel|trace-panel|topology-score|seed-sufficiency|why-report" .github/PULL_REQUEST_TEMPLATE/pr_default.md AGENTS.md docs/dev_guide.md
- Evidence that the change works here: diff whitespace check passed; issue-template suite passed with 6 tests; expected examples and NA path are present in all touched guidance surfaces.
- Benchmarks or smoke tests, if applicable: NA

## Risks / Rollout
- Compatibility risks: low; docs/template wording only.
- Failure modes: reviewers may still accept `NA - support helper` too broadly; the examples should make research-facing tools harder to misclassify.
- Rollback or fallback plan: revert the guidance wording if it creates confusion.

## Docs / Provenance
- Updated docs: .github/PULL_REQUEST_TEMPLATE/pr_default.md; AGENTS.md; docs/dev_guide.md
- Relevant design or provenance notes: Gemini CLI attempt hit model-capacity 429; OpenCode free-model review found no blockers or wording risks.
- Any assumptions that need to be preserved: disposable local `output/` files remain insufficient durable proof by themselves.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via linked PR and closeout
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is guidance/template wording, not evidence production.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify that `NA - support helper` remains narrow and does not exempt research-interpretation tools.
- Known limitation: the rule is reviewer-enforced, not a CI parser.