### PR TITLE
docs: promote delegated workflow lessons

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -107,8 +107,8 @@ Before each phase, run a delegation checkpoint:
 
 Publication and final judgment remain local: delegates must not push, open, or merge PRs; change
 labels or project state; resolve review threads; or make final benchmark, paper, or safety claims
-unless the user explicitly grants that permission. Their output is route evidence that must be
-reviewed and validated before phase completion.
+unless the user explicitly grants that permission. Their output is `route_evidence` that must be
+reviewed and validated before phase completion, not benchmark or claim proof by itself.
 
 ### Active Delegation Ledger
 
@@ -129,6 +129,9 @@ refs, worker artifacts, validation logs, or final summaries.
 Track only the fields needed to resume safely in under one minute:
 
 - route: provider/tool, model or agent role, run ID or artifact path, and route status;
+- delegation budget: for long delegated runs, record Gemini attempts, model variant,
+  capacity/quota outcome, accepted evidence tier, and any user-defined stop threshold such as
+  weekly usage remaining;
 - task state: issue/PR number, phase, branch, worktree, claim ref/status, and next action;
 - ownership: files or modules the delegate may read or edit;
 - validation: commands planned/run, pass/fail state, and any blocker signature;
@@ -176,6 +179,9 @@ Record cleanup status in the ledger, handoff notes, or self-review companion usi
 one of:
 
 - `worker completed` — external subprocess exited cleanly, artifacts confirmed.
+- `worker_sparse_artifacts` — subprocess exited or was stopped but compact result/status/diffstat
+  artifacts are missing or empty; treat as route failure or T0 evidence until local validation
+  proves the finding independently.
 - `app agent closed` — Codex subagent session closed after integration/rejection.
 - `no active process remains` — neither subagent nor worker process remains open.
 - `cleanup_failed` — close/confirm failed; record the error and escalate.

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -169,6 +169,10 @@ If these local filters appear exhausted or dominated by blocked/SLURM-only work,
 broad queue scout before declaring the queue empty. Prefer a cheap local or Qwen scan plus one
 substantial Copilot pass when available; treat scout output as a lead only, and confirm any proposed
 candidate with local `gh issue view` evidence before selecting, claiming, or reporting it as ready.
+When live labels conflict with recently merged dependency PRs, closeout comments, or issue links,
+perform a stale-blocker recheck before skipping the issue. Route one scout specifically to answer
+whether the blocker is still true, then confirm the answer with REST `gh api` or local `git`
+evidence before changing labels or selecting the next issue.
 
 The audit should classify whether each remaining issue is actually implementable on the current
 machine and with the available durable artifacts. If a supposedly ready issue needs unavailable

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,10 @@ It is everyones guide on how to use this repository effectively.
 - For risk-proportional validation planning, use `.agents/skills/quality-playbook/SKILL.md` for
   non-trivial changes, `.agents/skills/agentic-eval/SKILL.md` for AI-workflow artifacts, and
   `.agents/skills/review-and-refactor/SKILL.md` for narrow review-then-refactor passes.
+- Treat delegated or sidecar model output as `route_evidence`: useful planning/review signal that
+  still needs local validation before it supports merge, benchmark, paper-facing, or issue-close
+  claims. Sparse or missing worker result/status artifacts are route failures, not negative
+  findings.
 - For doc synchronization, use `.agents/skills/update-docs-on-code-change/SKILL.md` when code
   changes would make docs stale.
 - Prefer GitHub MCP / GitHub app tools for interactive issue, PR, and project work.

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -99,6 +99,10 @@ Use REST-backed `gh api repos/...` calls for ordinary issue/PR/label/comment ope
 `git` for repository state. Reserve GraphQL for Projects v2, review-thread operations, and nested
 queries that are genuinely cheaper. If GraphQL quota is low, finish issue cleanup through REST and
 leave Project #5 mutations as explicit pending work rather than retry-looping.
+During long delegated runs, record the REST publication path that actually worked: PR create,
+head-SHA check-run polling, labels, merge, closeout comment, and cleanup. A successful REST
+operation is publication evidence only; still verify branch head, CI state, and local validation
+before applying merge-ready or calling an issue closed.
 
 The priority workflow uses [docs/project_prioritization.md](../project_prioritization.md) as an
 advisory rubric, not as hard authority over current maintainer direction or fresh evidence.
@@ -190,6 +194,10 @@ Treat it as a reviewer-lens pass, not another full test suite:
   `.git/codex-agent-runs/notes/inbox/`; use `agent-workflow-promotion` only when evidence supports
   a small durable repo change. Do not promote private logs, local paths, or weak observations, and
   do not relax benchmark or paper-facing proof rules.
+- delegated worker outputs: record useful sidecar answers as `route_evidence`, not benchmark or
+  claim proof by themselves. Classify missing or sparse compact artifacts as route failure or T0
+  evidence. If the worker produced no useful `result`, `status`, or `diffstat` summary, rely on
+  local validation or reroute instead of treating the silence as a negative finding.
 
 ### 7. Open the PR
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -298,6 +298,10 @@ For GitHub issue batches and Project #5 updates, follow the batch-first workflow
   following `docs/templates/github.project5-cache.example.json`.
 - Check `gh api rate_limit` before large batches and leave Project #5 writes pending when GraphQL
   is exhausted instead of retry-looping.
+- For low-GraphQL or long autonomous publication runs, keep a REST-first command ledger covering
+  PR creation, commit check-run polling, issue comments, labels, merge, and branch cleanup. Treat
+  remote branch deletion reporting a missing ref after merge as a cleanup caveat to record, not as
+  evidence that the merge failed; verify the merged PR or base branch SHA instead.
 
 ### Context note workflow
 
@@ -311,6 +315,10 @@ handoff context in Markdown instead of leaving them trapped in chat or PR histor
 - Link notes to the related issue/PR, canonical docs, validation commands, and replacement notes.
 - Use `.agents/skills/context-note-maintainer/SKILL.md` when the task includes creating or
   refreshing context notes.
+- For docs/context-only changes, use the cheap consistency gate by default: inspect the diff,
+  verify changed README/INDEX/catalog links, and run the docs proof consistency check or its
+  targeted tests. State explicitly when benchmark, simulator, or full PR readiness gates were not
+  run because the branch only changes discoverability or workflow text.
 
 ### Agent memory conventions
 


### PR DESCRIPTION
## Summary
- promote the last 12h delegation lessons into repo workflow docs and repo-local skills
- define delegated model output as route_evidence, not benchmark or claim proof
- add ledger fields for Gemini/quota attempts, sparse worker artifacts, stale-blocker rechecks, REST publication paths, and docs/context-only validation

## Follow-up Issues Created
- ll7/robot_sf_ll7#2488 stale-blocker queue recheck
- ll7/robot_sf_ll7#2489 sparse worker artifact classification
- ll7/robot_sf_ll7#2490 REST-first publication snippets
- ll7/robot_sf_ll7#2491 docs/context link and catalog gate
- ll7/codex-personal-skills#32 Gemini usage and capacity tracking

## Validation
- git diff --check
- scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_docs_proof_consistency.py tests/test_ci_script_contract.py -q (69 passed)
- scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/check_skills.py --preflight goal-autopilot (PASS)
- Gemini read-only synthesis and OpenCode free-model read-only review; OpenCode reported no blockers

## Research Result Guidance
NA - workflow/instruction-only change. This PR does not make benchmark, metric, model-provenance, or paper-facing research claims.

## Downstream Propagation
- Workflow docs and repo-local skills updated directly.
- Follow-up issues ll7/robot_sf_ll7#2488-#2492 capture larger script/tooling work that should not be hidden in this small docs PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated AI workflow guidelines to clarify validation requirements for delegated tasks and evidence handling.
  * Enhanced skill documentation for delegation policies, budget tracking, and cleanup procedures.
  * Improved developer contributor guidance with REST-first command ledger notes and documentation gate instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->