### PR TITLE
feat(nav): add probabilistic prediction interface

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -521,6 +521,8 @@ knowledge, not every transient iteration detail.
   [open_issues_training_split_audit_2026-05-30.md](open_issues_training_split_audit_2026-05-30.md)
 * Issue #1966 ScenarioBelief Interface Design (2026-06-01):
   [issue_1966_scenario_belief_interface.md](issue_1966_scenario_belief_interface.md)
+* Issue #2475 Probabilistic Prediction Interface (2026-06-06):
+  [issue_2475_probabilistic_prediction_interface.md](issue_2475_probabilistic_prediction_interface.md)
 * Issue #1638 local model path preflight:
   [issue_1638_model_path_preflight.md](issue_1638_model_path_preflight.md)
 * Issue #1960 local artifact retirement status:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -361,6 +361,10 @@ entries:
     status: current
     freshness: dated
     area: learned_policy
+  - path: docs/context/issue_2475_probabilistic_prediction_interface.md
+    status: current
+    freshness: dated
+    area: predictive_planner
   - path: docs/context/open_issues_training_split_audit_2026-05-30.md
     status: current
     freshness: dated

--- a/docs/context/issue_2475_probabilistic_prediction_interface.md
+++ b/docs/context/issue_2475_probabilistic_prediction_interface.md
@@ -1,0 +1,75 @@
+# Issue #2475 Probabilistic Prediction Interface
+
+Status: interface contract implemented; no prediction-quality claim, June 6, 2026.
+
+Related issue: [#2475](https://github.com/ll7/robot_sf_ll7/issues/2475)
+Parent issue: [#2469](https://github.com/ll7/robot_sf_ll7/issues/2469)
+
+## Summary
+
+Issue #2475 adds a minimal, typed contract for probabilistic pedestrian predictions:
+`TrajectoryDistribution`, `ProbabilisticPrediction`, and the runtime-checkable
+`ProbabilisticPredictor` protocol in `robot_sf/nav/predictive_types.py`.
+
+The contract gives planners a shared shape for future trajectory distributions and confidence:
+
+```yaml
+future:
+  trajectory_distribution:
+    mean: "(T, 2) float32 future positions"
+    std: "(T, 2) float32 optional diagonal uncertainty"
+    covariance: "(T, 2, 2) float32 optional full covariance"
+  confidence: "scalar in [0, 1]"
+```
+
+## Ownership Boundary
+
+- The predictor owns trajectory means, uncertainty fields, confidence, horizon, timestep, timestamp,
+  sample count, and metadata.
+- Planner adapters consume this contract but do not infer prediction accuracy from its presence.
+- SocNav-structured observations are the first input boundary. Raw model `(state, mask)` adapters
+  are a follow-up, not part of this slice.
+- Existing deterministic predictors may use `confidence=1.0`, `sample_count=1`, and omit uncertainty
+  fields to represent deterministic output.
+
+## Fixture And Smoke Contract
+
+`tests/planner/test_probabilistic_prediction_interface.py` defines a dummy predictor and compact
+SocNav-style observation fixture. The tests prove the interface is importable, runtime-checkable,
+can bundle multiple pedestrian trajectories, and keeps per-pedestrian arrays independent.
+
+This is a schema/interface smoke only. It does not exercise planner quality, predictor calibration,
+or benchmark outcomes.
+
+## Claim Boundary
+
+This slice establishes interface readiness. It does not claim:
+
+- probabilistic predictions are accurate or calibrated;
+- any planner benefits from consuming the interface;
+- heuristic probabilistic search from Issue #591 is paper-grade uncertainty evidence;
+- observation or sensor uncertainty is solved beyond the adjacent ScenarioBelief boundary from
+  `docs/context/issue_1966_scenario_belief_interface.md`.
+
+Any future planner-quality claim must provide benchmark evidence under the repository fallback and
+artifact-provenance policies.
+
+## Validation
+
+Targeted validation for this slice:
+
+```bash
+uv run ruff check robot_sf/nav/predictive_types.py robot_sf/nav/__init__.py tests/planner/test_probabilistic_prediction_interface.py
+uv run ruff format --check robot_sf/nav/predictive_types.py robot_sf/nav/__init__.py tests/planner/test_probabilistic_prediction_interface.py
+uv run pytest tests/planner/test_probabilistic_prediction_interface.py -q
+git diff --check
+```
+
+## Follow-Up Risks
+
+- Runtime integration remains future work: `PredictionPlannerAdapter` does not yet implement
+  `ProbabilisticPredictor`.
+- Input-boundary expansion to raw model tensors may be useful, but should not blur the SocNav
+  observation ownership contract.
+- Sample-based distributions may need a batched representation if future predictors expose
+  Monte-Carlo samples directly.

--- a/robot_sf/nav/__init__.py
+++ b/robot_sf/nav/__init__.py
@@ -5,6 +5,7 @@ This package provides navigation-related functionality including:
 - Motion planning adapters for grid-based planners
 - Global route management
 - Obstacle definitions
+- Probabilistic pedestrian prediction types and protocol
 """
 
 from robot_sf.nav.motion_planning_adapter import (
@@ -14,9 +15,17 @@ from robot_sf.nav.motion_planning_adapter import (
     map_definition_to_motion_planning_grid,
     visualize_grid,
 )
+from robot_sf.nav.predictive_types import (
+    ProbabilisticPrediction,
+    ProbabilisticPredictor,
+    TrajectoryDistribution,
+)
 
 __all__ = [
     "MotionPlanningGridConfig",
+    "ProbabilisticPrediction",
+    "ProbabilisticPredictor",
+    "TrajectoryDistribution",
     "count_obstacle_cells",
     "get_obstacle_statistics",
     "map_definition_to_motion_planning_grid",

--- a/robot_sf/nav/predictive_types.py
+++ b/robot_sf/nav/predictive_types.py
@@ -1,0 +1,157 @@
+"""Probabilistic pedestrian prediction types and protocol.
+
+This module defines the minimal interface contract for probabilistic pedestrian
+trajectory prediction. Planners can consume these types to obtain future
+trajectory distributions and per-pedestrian confidence without committing to any
+specific predictor implementation, training regime, or prediction quality claim.
+
+The interface is intentionally additive: existing deterministic predictors can
+emit confidence=1.0 and identity covariance to signal "no uncertainty estimate."
+Any claim about prediction accuracy or planning benefit from using these types
+requires separate benchmark evidence per the project's maintainer values.
+
+.. admonition:: Claim boundary
+   :class: note
+
+   Defining or implementing this interface does **not** constitute evidence of
+   prediction quality, calibration, or planning improvement. Benchmark runs
+   are required before any such claim may be made.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def _require_float_array(name: str, value: NDArray[np.float32], *, ndim: int) -> None:
+    """Validate a numeric prediction array enough to enforce the public contract."""
+    array = np.asarray(value)
+    if array.ndim != ndim or array.shape[-1] != 2:
+        raise ValueError(f"{name} must have shape (T, 2)" if ndim == 2 else f"{name} invalid")
+    if not np.issubdtype(array.dtype, np.floating):
+        raise ValueError(f"{name} must use a floating dtype")
+
+
+@dataclass
+class TrajectoryDistribution:
+    """Probabilistic future trajectory for a single pedestrian.
+
+    Attributes:
+        mean: Mean future positions in robot frame, shape ``(T, 2)`` where
+            ``T`` is the number of predicted timesteps and columns are
+            ``(x, y)`` in world or robot-frame coordinates.
+        std: Per-timestep per-axis standard deviation, shape ``(T, 2)``.
+            ``None`` when the predictor only emits means (deterministic mode).
+        covariance: Full per-timestep covariance matrices, shape ``(T, 2, 2)``.
+            May be ``None`` when only diagonal uncertainty is available.
+        confidence: Scalar confidence in ``[0, 1]`` reflecting the predictor's
+            own assessment of this trajectory's reliability. A deterministic
+            predictor may emit ``1.0`` (no uncertainty expressed).
+        pedestrian_id: Index or identifier for this pedestrian within the
+            observation's pedestrian array.
+    """
+
+    mean: NDArray[np.float32]
+    std: NDArray[np.float32] | None = None
+    covariance: NDArray[np.float32] | None = None
+    confidence: float = 1.0
+    pedestrian_id: int = -1
+
+    def __post_init__(self) -> None:
+        """Validate shape and confidence fields for one pedestrian trajectory."""
+        _require_float_array("mean", self.mean, ndim=2)
+        if self.std is not None:
+            _require_float_array("std", self.std, ndim=2)
+            if np.asarray(self.std).shape != np.asarray(self.mean).shape:
+                raise ValueError("std must match mean shape")
+        if self.covariance is not None:
+            covariance = np.asarray(self.covariance)
+            expected_shape = (np.asarray(self.mean).shape[0], 2, 2)
+            if covariance.shape != expected_shape:
+                raise ValueError("covariance must have shape (T, 2, 2)")
+            if not np.issubdtype(covariance.dtype, np.floating):
+                raise ValueError("covariance must use a floating dtype")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+
+
+@dataclass
+class ProbabilisticPrediction:
+    """Container for multi-agent probabilistic pedestrian predictions.
+
+    This is the top-level return type of :class:`ProbabilisticPredictor`.
+    It bundles per-pedestrian trajectory distributions together with shared
+    metadata so consumers do not need to track prediction horizon or
+    timestamps separately.
+
+    Attributes:
+        predictions: One :class:`TrajectoryDistribution` per pedestrian.
+        prediction_horizon: Forecast horizon in seconds.
+        prediction_dt: Timestep between consecutive predicted positions
+            in seconds.
+        timestamp: Simulation timestamp (seconds) at which this prediction
+            was produced. May be ``-1`` when the caller does not provide it.
+        sample_count: Number of Monte-Carlo or scenario samples used to
+            derive the uncertainty estimates. ``1`` for deterministic.
+        metadata: Free-form key-value store for predictor-specific data
+            (e.g. model version, feature schema, fallback mode).
+    """
+
+    predictions: list[TrajectoryDistribution] = field(default_factory=list)
+    prediction_horizon: float = 0.0
+    prediction_dt: float = 0.1
+    timestamp: float = -1.0
+    sample_count: int = 1
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate shared prediction metadata fields."""
+        if float(self.prediction_horizon) < 0.0:
+            raise ValueError("prediction_horizon must be non-negative")
+        if float(self.prediction_dt) <= 0.0:
+            raise ValueError("prediction_dt must be positive")
+        if int(self.sample_count) < 1:
+            raise ValueError("sample_count must be at least 1")
+
+
+@runtime_checkable
+class ProbabilisticPredictor(Protocol):
+    """Protocol for probabilistic pedestrian trajectory predictors.
+
+    Any object that implements ``predict(observation) -> ProbabilisticPrediction``
+    satisfies this protocol. The observation dict follows the SocNav-structured
+    schema produced by :class:`robot_sf.sensor.socnav_observation.SocNavObservationFusion`.
+
+    Implementing this protocol does **not** commit the predictor to any accuracy,
+    calibration, or planning-benefit claim. See module-level docstring.
+
+    Example::
+
+        class MyPredictor:
+            def predict(self, observation: dict[str, Any]) -> ProbabilisticPrediction: ...
+    """
+
+    def predict(self, observation: dict[str, Any]) -> ProbabilisticPrediction:
+        """Return probabilistic future trajectories for all observed pedestrians.
+
+        Args:
+            observation: SocNav-structured dict with keys ``"robot"``,
+                ``"goal"``, ``"pedestrians"``, ``"map"``, ``"sim"``.
+
+        Returns:
+            ProbabilisticPrediction: Per-pedestrian trajectory distributions
+            with associated uncertainty and confidence.
+        """
+
+
+__all__ = [
+    "ProbabilisticPrediction",
+    "ProbabilisticPredictor",
+    "TrajectoryDistribution",
+]

--- a/robot_sf/nav/predictive_types.py
+++ b/robot_sf/nav/predictive_types.py
@@ -45,7 +45,30 @@ def _require_float_array(
         raise ValueError(f"{name} must have shape (T, 2)" if ndim == 2 else f"{name} invalid")
     if not np.issubdtype(array.dtype, np.floating):
         raise ValueError(f"{name} must use a floating dtype")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
     return array.astype(np.float32, copy=False)
+
+
+def _require_covariance_array(value: NDArray[np.float32], *, steps: int) -> NDArray[np.float32]:
+    """Validate and normalize full per-timestep covariance matrices.
+
+    Returns:
+        Float32 array with shape ``(T, 2, 2)``.
+    """
+    covariance = np.asarray(value)
+    expected_shape = (steps, 2, 2)
+    if covariance.shape != expected_shape:
+        raise ValueError("covariance must have shape (T, 2, 2)")
+    if not np.issubdtype(covariance.dtype, np.floating):
+        raise ValueError("covariance must use a floating dtype")
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError("covariance must contain only finite values")
+    if not np.allclose(covariance, np.swapaxes(covariance, -1, -2)):
+        raise ValueError("covariance matrices must be symmetric")
+    if np.any(np.linalg.eigvalsh(covariance) < -1e-6):
+        raise ValueError("covariance matrices must be positive semidefinite")
+    return covariance.astype(np.float32, copy=False)
 
 
 @dataclass
@@ -80,14 +103,13 @@ class TrajectoryDistribution:
             self.std = _require_float_array("std", self.std, ndim=2)
             if self.std.shape != self.mean.shape:
                 raise ValueError("std must match mean shape")
+            if np.any(self.std < 0.0):
+                raise ValueError("std must be non-negative")
         if self.covariance is not None:
-            covariance = np.asarray(self.covariance)
-            expected_shape = (self.mean.shape[0], 2, 2)
-            if covariance.shape != expected_shape:
-                raise ValueError("covariance must have shape (T, 2, 2)")
-            if not np.issubdtype(covariance.dtype, np.floating):
-                raise ValueError("covariance must use a floating dtype")
-            self.covariance = covariance.astype(np.float32, copy=False)
+            self.covariance = _require_covariance_array(
+                self.covariance,
+                steps=self.mean.shape[0],
+            )
         self.confidence = float(self.confidence)
         self.pedestrian_id = int(self.pedestrian_id)
         if not 0.0 <= self.confidence <= 1.0:
@@ -135,6 +157,13 @@ class ProbabilisticPrediction:
             raise ValueError("prediction_dt must be positive")
         if self.sample_count < 1:
             raise ValueError("sample_count must be at least 1")
+        if self.predictions:
+            expected_steps = self.prediction_horizon / self.prediction_dt
+            for prediction in self.predictions:
+                if not np.isclose(prediction.mean.shape[0], expected_steps):
+                    raise ValueError(
+                        "prediction_horizon must equal trajectory steps multiplied by prediction_dt"
+                    )
 
 
 @runtime_checkable

--- a/robot_sf/nav/predictive_types.py
+++ b/robot_sf/nav/predictive_types.py
@@ -29,13 +29,23 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-def _require_float_array(name: str, value: NDArray[np.float32], *, ndim: int) -> None:
-    """Validate a numeric prediction array enough to enforce the public contract."""
+def _require_float_array(
+    name: str,
+    value: NDArray[np.float32],
+    *,
+    ndim: int,
+) -> NDArray[np.float32]:
+    """Validate and normalize a numeric prediction array for the public contract.
+
+    Returns:
+        Float32 array with the same shape as the input.
+    """
     array = np.asarray(value)
     if array.ndim != ndim or array.shape[-1] != 2:
         raise ValueError(f"{name} must have shape (T, 2)" if ndim == 2 else f"{name} invalid")
     if not np.issubdtype(array.dtype, np.floating):
         raise ValueError(f"{name} must use a floating dtype")
+    return array.astype(np.float32, copy=False)
 
 
 @dataclass
@@ -65,19 +75,22 @@ class TrajectoryDistribution:
 
     def __post_init__(self) -> None:
         """Validate shape and confidence fields for one pedestrian trajectory."""
-        _require_float_array("mean", self.mean, ndim=2)
+        self.mean = _require_float_array("mean", self.mean, ndim=2)
         if self.std is not None:
-            _require_float_array("std", self.std, ndim=2)
-            if np.asarray(self.std).shape != np.asarray(self.mean).shape:
+            self.std = _require_float_array("std", self.std, ndim=2)
+            if self.std.shape != self.mean.shape:
                 raise ValueError("std must match mean shape")
         if self.covariance is not None:
             covariance = np.asarray(self.covariance)
-            expected_shape = (np.asarray(self.mean).shape[0], 2, 2)
+            expected_shape = (self.mean.shape[0], 2, 2)
             if covariance.shape != expected_shape:
                 raise ValueError("covariance must have shape (T, 2, 2)")
             if not np.issubdtype(covariance.dtype, np.floating):
                 raise ValueError("covariance must use a floating dtype")
-        if not 0.0 <= float(self.confidence) <= 1.0:
+            self.covariance = covariance.astype(np.float32, copy=False)
+        self.confidence = float(self.confidence)
+        self.pedestrian_id = int(self.pedestrian_id)
+        if not 0.0 <= self.confidence <= 1.0:
             raise ValueError("confidence must be in [0, 1]")
 
 
@@ -112,11 +125,15 @@ class ProbabilisticPrediction:
 
     def __post_init__(self) -> None:
         """Validate shared prediction metadata fields."""
-        if float(self.prediction_horizon) < 0.0:
+        self.prediction_horizon = float(self.prediction_horizon)
+        self.prediction_dt = float(self.prediction_dt)
+        self.timestamp = float(self.timestamp)
+        self.sample_count = int(self.sample_count)
+        if self.prediction_horizon < 0.0:
             raise ValueError("prediction_horizon must be non-negative")
-        if float(self.prediction_dt) <= 0.0:
+        if self.prediction_dt <= 0.0:
             raise ValueError("prediction_dt must be positive")
-        if int(self.sample_count) < 1:
+        if self.sample_count < 1:
             raise ValueError("sample_count must be at least 1")
 
 

--- a/tests/planner/test_probabilistic_prediction_interface.py
+++ b/tests/planner/test_probabilistic_prediction_interface.py
@@ -102,6 +102,30 @@ class TestTrajectoryDistribution:
         assert td.confidence == 0.85
         assert td.pedestrian_id == 3
 
+    def test_arrays_and_scalar_fields_are_normalized(self) -> None:
+        """Float arrays and numpy scalars should be normalized for consumers."""
+        mean = np.zeros((8, 2), dtype=np.float64)
+        std = np.full((8, 2), 0.05, dtype=np.float64)
+        cov = np.tile(np.eye(2, dtype=np.float64) * 0.0025, (8, 1, 1))
+
+        td = TrajectoryDistribution(
+            mean=mean,
+            std=std,
+            covariance=cov,
+            confidence=np.float64(0.75),
+            pedestrian_id=np.int64(4),
+        )
+
+        assert td.mean.dtype == np.float32
+        assert td.std is not None
+        assert td.std.dtype == np.float32
+        assert td.covariance is not None
+        assert td.covariance.dtype == np.float32
+        assert type(td.confidence) is float
+        assert td.confidence == 0.75
+        assert type(td.pedestrian_id) is int
+        assert td.pedestrian_id == 4
+
     def test_invalid_confidence_is_rejected(self) -> None:
         """Confidence must stay in the documented [0, 1] interval."""
         mean = np.zeros((8, 2), dtype=np.float32)
@@ -151,6 +175,21 @@ class TestProbabilisticPrediction:
         assert pred.timestamp == 10.0
         assert pred.sample_count == 16
         assert pred.metadata["mode"] == "cvar"
+
+    def test_metadata_scalar_fields_are_normalized(self) -> None:
+        """Numpy scalar metadata should be normalized to plain Python scalars."""
+        pred = ProbabilisticPrediction(
+            prediction_horizon=np.float32(1.6),
+            prediction_dt=np.float64(0.2),
+            timestamp=np.float64(10.0),
+            sample_count=np.int64(16),
+        )
+
+        assert type(pred.prediction_horizon) is float
+        assert type(pred.prediction_dt) is float
+        assert type(pred.timestamp) is float
+        assert type(pred.sample_count) is int
+        assert pred.sample_count == 16
 
     def test_invalid_prediction_metadata_is_rejected(self) -> None:
         """Prediction horizon, timestep, and sample count should be contract-checked."""

--- a/tests/planner/test_probabilistic_prediction_interface.py
+++ b/tests/planner/test_probabilistic_prediction_interface.py
@@ -141,6 +141,37 @@ class TestTrajectoryDistribution:
         with pytest.raises(ValueError, match="std"):
             TrajectoryDistribution(mean=mean, std=std)
 
+    def test_nonfinite_trajectory_values_are_rejected(self) -> None:
+        """Mean trajectories should not carry NaN or infinite coordinates."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        mean[0, 0] = np.nan
+
+        with pytest.raises(ValueError, match="finite"):
+            TrajectoryDistribution(mean=mean)
+
+    def test_negative_std_is_rejected(self) -> None:
+        """Diagonal uncertainty should stay physically non-negative."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        std = np.zeros((8, 2), dtype=np.float32)
+        std[0, 0] = -0.1
+
+        with pytest.raises(ValueError, match="non-negative"):
+            TrajectoryDistribution(mean=mean, std=std)
+
+    def test_nonphysical_covariance_is_rejected(self) -> None:
+        """Full covariance matrices should be symmetric positive semidefinite."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        nonsymmetric = np.tile(np.eye(2, dtype=np.float32), (8, 1, 1))
+        nonsymmetric[0, 0, 1] = 0.5
+
+        with pytest.raises(ValueError, match="symmetric"):
+            TrajectoryDistribution(mean=mean, covariance=nonsymmetric)
+
+        negative_variance = np.tile(np.eye(2, dtype=np.float32), (8, 1, 1))
+        negative_variance[0, 0, 0] = -0.1
+        with pytest.raises(ValueError, match="positive semidefinite"):
+            TrajectoryDistribution(mean=mean, covariance=negative_variance)
+
 
 class TestProbabilisticPrediction:
     """ProbabilisticPrediction dataclass contract."""
@@ -175,6 +206,20 @@ class TestProbabilisticPrediction:
         assert pred.timestamp == 10.0
         assert pred.sample_count == 16
         assert pred.metadata["mode"] == "cvar"
+
+    def test_prediction_horizon_matches_trajectory_steps(self) -> None:
+        """Shared horizon metadata should agree with each trajectory length."""
+        trajectory = TrajectoryDistribution(
+            mean=np.zeros((8, 2), dtype=np.float32),
+            pedestrian_id=0,
+        )
+
+        with pytest.raises(ValueError, match="prediction_horizon"):
+            ProbabilisticPrediction(
+                predictions=[trajectory],
+                prediction_horizon=1.4,
+                prediction_dt=0.2,
+            )
 
     def test_metadata_scalar_fields_are_normalized(self) -> None:
         """Numpy scalar metadata should be normalized to plain Python scalars."""

--- a/tests/planner/test_probabilistic_prediction_interface.py
+++ b/tests/planner/test_probabilistic_prediction_interface.py
@@ -1,0 +1,212 @@
+"""Tests for the probabilistic pedestrian prediction interface contract.
+
+These tests validate that the data types (TrajectoryDistribution,
+ProbabilisticPrediction) and the ProbabilisticPredictor protocol are
+well-formed, importable, and behave as documented. They do **not** test
+prediction accuracy, calibration, or planning benefit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from robot_sf.nav.predictive_types import (
+    ProbabilisticPrediction,
+    ProbabilisticPredictor,
+    TrajectoryDistribution,
+)
+
+
+class _DummyPredictor:
+    """Minimal ProbabilisticPredictor implementation for protocol testing."""
+
+    def predict(self, observation: dict[str, Any]) -> ProbabilisticPrediction:
+        horizon_steps = 8
+        ped_count = 2
+        mean = np.zeros((horizon_steps, 2), dtype=np.float32)
+        std = np.full((horizon_steps, 2), 0.05, dtype=np.float32)
+        predictions = [
+            TrajectoryDistribution(
+                mean=mean.copy(),
+                std=std.copy(),
+                confidence=0.95,
+                pedestrian_id=i,
+            )
+            for i in range(ped_count)
+        ]
+        return ProbabilisticPrediction(
+            predictions=predictions,
+            prediction_horizon=1.6,
+            prediction_dt=0.2,
+            timestamp=42.0,
+            sample_count=8,
+            metadata={"model_id": "dummy_v1", "fallback": False},
+        )
+
+
+def _make_socnav_obs(ped_count: int = 2) -> dict[str, Any]:
+    """Build a minimal SocNav-structured observation for predictor tests."""
+    return {
+        "robot": {
+            "position": np.array([0.0, 0.0], dtype=np.float32),
+            "heading": np.array([0.0], dtype=np.float32),
+            "speed": np.array([0.5, 0.0], dtype=np.float32),
+            "radius": np.array([0.3], dtype=np.float32),
+        },
+        "goal": {
+            "current": np.array([5.0, 0.0], dtype=np.float32),
+            "next": np.array([5.0, 0.0], dtype=np.float32),
+        },
+        "pedestrians": {
+            "positions": np.zeros((ped_count, 2), dtype=np.float32),
+            "velocities": np.zeros((ped_count, 2), dtype=np.float32),
+            "radius": np.array([0.3], dtype=np.float32),
+            "count": np.array([float(ped_count)], dtype=np.float32),
+        },
+        "map": {"size": np.array([10.0, 10.0], dtype=np.float32)},
+        "sim": {"timestep": np.array([0.2], dtype=np.float32)},
+    }
+
+
+class TestTrajectoryDistribution:
+    """TrajectoryDistribution dataclass contract."""
+
+    def test_default_confidence_is_one(self) -> None:
+        """Default confidence should be 1.0 (deterministic fallback)."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        td = TrajectoryDistribution(mean=mean, pedestrian_id=0)
+        assert td.confidence == 1.0
+        assert td.std is None
+        assert td.covariance is None
+
+    def test_full_uncertainty_fields(self) -> None:
+        """All optional fields should be settable."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        std = np.full((8, 2), 0.05, dtype=np.float32)
+        cov = np.tile(np.eye(2, dtype=np.float32) * 0.0025, (8, 1, 1))
+        td = TrajectoryDistribution(
+            mean=mean,
+            std=std,
+            covariance=cov,
+            confidence=0.85,
+            pedestrian_id=3,
+        )
+        assert td.mean.shape == (8, 2)
+        assert td.std is not None
+        assert td.std.shape == (8, 2)
+        assert td.covariance is not None
+        assert td.covariance.shape == (8, 2, 2)
+        assert td.confidence == 0.85
+        assert td.pedestrian_id == 3
+
+    def test_invalid_confidence_is_rejected(self) -> None:
+        """Confidence must stay in the documented [0, 1] interval."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="confidence"):
+            TrajectoryDistribution(mean=mean, confidence=1.5)
+
+    def test_invalid_uncertainty_shape_is_rejected(self) -> None:
+        """Uncertainty arrays must match the mean trajectory shape."""
+        mean = np.zeros((8, 2), dtype=np.float32)
+        std = np.zeros((7, 2), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="std"):
+            TrajectoryDistribution(mean=mean, std=std)
+
+
+class TestProbabilisticPrediction:
+    """ProbabilisticPrediction dataclass contract."""
+
+    def test_empty_prediction(self) -> None:
+        """Empty prediction should be valid with zero pedestrians."""
+        pred = ProbabilisticPrediction()
+        assert pred.predictions == []
+        assert pred.prediction_horizon == 0.0
+        assert pred.sample_count == 1
+
+    def test_bundles_predictions(self) -> None:
+        """Should bundle multiple pedestrian predictions with shared metadata."""
+        peds = [
+            TrajectoryDistribution(
+                mean=np.zeros((8, 2), dtype=np.float32),
+                pedestrian_id=i,
+            )
+            for i in range(3)
+        ]
+        pred = ProbabilisticPrediction(
+            predictions=peds,
+            prediction_horizon=1.6,
+            prediction_dt=0.2,
+            timestamp=10.0,
+            sample_count=16,
+            metadata={"mode": "cvar"},
+        )
+        assert len(pred.predictions) == 3
+        assert pred.prediction_horizon == 1.6
+        assert pred.prediction_dt == 0.2
+        assert pred.timestamp == 10.0
+        assert pred.sample_count == 16
+        assert pred.metadata["mode"] == "cvar"
+
+    def test_invalid_prediction_metadata_is_rejected(self) -> None:
+        """Prediction horizon, timestep, and sample count should be contract-checked."""
+        with pytest.raises(ValueError, match="prediction_dt"):
+            ProbabilisticPrediction(prediction_dt=0.0)
+
+        with pytest.raises(ValueError, match="sample_count"):
+            ProbabilisticPrediction(sample_count=0)
+
+
+class TestProbabilisticPredictorProtocol:
+    """ProbabilisticPredictor protocol contract."""
+
+    def test_dummy_satisfies_protocol(self) -> None:
+        """A class with a predict() method should satisfy the protocol."""
+        predictor: ProbabilisticPredictor = _DummyPredictor()
+        assert isinstance(predictor, ProbabilisticPredictor)
+
+    def test_predict_returns_expected_structure(self) -> None:
+        """predict() should return a ProbabilisticPrediction with correct shapes."""
+        predictor: ProbabilisticPredictor = _DummyPredictor()
+        obs = _make_socnav_obs(ped_count=2)
+        result = predictor.predict(obs)
+        assert isinstance(result, ProbabilisticPrediction)
+        assert len(result.predictions) == 2
+        for ped_pred in result.predictions:
+            assert isinstance(ped_pred, TrajectoryDistribution)
+            assert ped_pred.mean.shape == (8, 2)
+            assert ped_pred.std is not None
+            assert ped_pred.std.shape == (8, 2)
+            assert 0.0 <= ped_pred.confidence <= 1.0
+        assert result.prediction_horizon == 1.6
+        assert result.prediction_dt == 0.2
+        assert result.sample_count == 8
+
+    def test_protocol_runtime_checkable(self) -> None:
+        """@runtime_checkable should allow isinstance checks."""
+        predictor = _DummyPredictor()
+        assert isinstance(predictor, ProbabilisticPredictor)
+
+    def test_non_predictor_rejected(self) -> None:
+        """An object without predict() should not pass isinstance check."""
+        assert not isinstance(42, ProbabilisticPredictor)
+        assert not isinstance("string", ProbabilisticPredictor)
+
+    def test_protocol_does_not_require_observation_specific_output_count(self) -> None:
+        """The protocol shape is independent from a predictor's filtering policy."""
+        predictor: ProbabilisticPredictor = _DummyPredictor()
+        obs = _make_socnav_obs(ped_count=0)
+        result = predictor.predict(obs)
+        assert len(result.predictions) == 2  # dummy ignores observation
+
+    def test_predictions_are_independent(self) -> None:
+        """Each pedestrian's prediction should be an independent object."""
+        predictor: ProbabilisticPredictor = _DummyPredictor()
+        result = predictor.predict(_make_socnav_obs())
+        orig_1 = float(result.predictions[1].mean[0, 0])
+        result.predictions[0].mean[0, 0] = 999.0
+        assert float(result.predictions[1].mean[0, 0]) == orig_1


### PR DESCRIPTION
## Summary
Adds a minimal probabilistic pedestrian prediction interface for future trajectory distributions and confidence, plus focused contract tests and a context note for the claim boundary.

## Linked Issues
- Closes `#2475`
- Relates to `#2469`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf/nav/predictive_types.py` with `TrajectoryDistribution`, `ProbabilisticPrediction`, and runtime-checkable `ProbabilisticPredictor`.
- Re-exported the new interface from `robot_sf.nav`.
- Added shape, confidence, timestep, and sample-count validation for the interface objects.
- Added focused tests and a compact context note at `docs/context/issue_2475_probabilistic_prediction_interface.md`.
- Updated context discovery metadata in `docs/context/README.md` and `docs/context/catalog.yaml`.

## Why It Matters
- Added value: planners now have a shared, additive contract for consuming probabilistic pedestrian futures.
- Expected impact: future prediction-aware planner work can target one typed schema instead of ad hoc arrays.
- Why this is worth merging now: #2476 and related prediction benchmark work need this interface boundary before fair comparison.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: minimal interface readiness for probabilistic pedestrian predictions.
- Comparator or baseline, if applicable: existing heuristic probabilistic planner work from #591 has no shared typed interface.
- Evidence tier: targeted smoke / interface contract tests.
- Result classification: blocker-resolution for interface scoping; no prediction-quality result.
- Decision or stop rule, if applicable: interface is ready when required fields, ownership boundary, fixture/smoke, and claim boundary are documented and tested.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2475_probabilistic_prediction_interface.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - interface/schema helper, not an analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - interface contract only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: Runtime integration into `PredictionPlannerAdapter` remains future work.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: continue to adapter/runtime integration or benchmark work after interface review.
- Proposed child issue or existing follow-up: #2476 is the likely next benchmark consumer after this interface lands.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `uv run ruff check robot_sf/nav/predictive_types.py robot_sf/nav/__init__.py tests/planner/test_probabilistic_prediction_interface.py`
  - `uv run ruff format --check robot_sf/nav/predictive_types.py robot_sf/nav/__init__.py tests/planner/test_probabilistic_prediction_interface.py`
  - `uv run pytest tests/planner/test_probabilistic_prediction_interface.py -q`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- Evidence that the change works here: focused pytest passed with 13 tests; docs/proof consistency passed for the catalog update.
- Benchmarks or smoke tests, if applicable: NA - no benchmark claim.

## Risks / Rollout
- Compatibility risks: low; additive module and re-exports only.
- Failure modes: future adapters could overclaim prediction quality from interface presence; the module and context note explicitly forbid that.
- Rollback or fallback plan: revert the additive interface and tests if a richer representation supersedes it.

## Docs / Provenance
- Updated docs: `docs/context/issue_2475_probabilistic_prediction_interface.md`, `docs/context/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: #591 probabilistic planner search and #1966 ScenarioBelief interface.
- Any assumptions that need to be preserved: SocNav-structured observations are the first input boundary; raw `(state, mask)` model input remains follow-up.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR closes #2475; parent #2469 linked.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): yes, context README/catalog and issue note.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; #2476 already exists as likely consumer.
- Not applicable because: this is interface readiness, not benchmark or paper-facing evidence.

## Follow-Up Issues
- Deferred work: wire a runtime predictor/adapter to the protocol; compare prediction-aware planners after the contract lands.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that the interface stays additive and does not imply prediction accuracy, calibration, or planning benefit.
- Ignored `output/coverage/*` was generated by pytest and intentionally left untracked/disposable.