### PR TITLE
feat: capture scenario belief uncertainty contract

### DIFF
--- a/configs/representation/scenario_belief_uncertainty_issue_2478.yaml
+++ b/configs/representation/scenario_belief_uncertainty_issue_2478.yaml
@@ -1,0 +1,115 @@
+schema_version: scenario-belief-uncertainty-contract.v1
+name: scenario_belief_uncertainty_issue_2478
+issue: 2478
+parent_issue: 2469
+predecessor_issue: 2477
+evidence_tier: proposal_with_executable_contract
+benchmark_evidence: false
+status: implemented_interface_contract
+claim_boundary: >
+  This manifest pins uncertainty-aware ScenarioBelief field semantics for object class,
+  pose, velocity, and covariance. It is interface and fixture evidence only. It does not
+  prove planner benefit, perception realism, real-sensor calibration, or benchmark performance.
+
+contract_surfaces:
+  implementation: robot_sf/representation/scenario_belief.py
+  package_exports: robot_sf/representation/__init__.py
+  base_contract_manifest: configs/representation/scenario_belief_contract_issue_2477.yaml
+  base_contract_note: docs/context/issue_2477_scenario_belief_contract.md
+  uncertainty_note: docs/context/issue_2478_uncertainty_scenario_belief.md
+  tests:
+    - tests/representation/test_scenario_belief.py
+    - tests/representation/test_scenario_belief_uncertainty_manifest.py
+
+uncertainty_fields:
+  object_class:
+    dataclass: EntityBelief
+    primary_field: entity_type
+    distribution_field: class_probabilities
+    distribution_shape: tuple[label, probability]
+    probability_units: unitless_probability
+    compatibility_rule: entity_type remains the primary backward-compatible class label
+  pose:
+    dataclass: Estimate2D
+    owning_entity_field: position
+    mean_field: mean_xy
+    covariance_field: covariance_xy
+    frame_field: frame_id
+    default_frame: map
+    mean_units: m
+    covariance_units: m^2
+  velocity:
+    dataclass: Estimate2D
+    owning_entity_field: velocity
+    mean_field: mean_xy
+    covariance_field: covariance_xy
+    frame_field: frame_id
+    default_frame: map
+    mean_units: m/s
+    covariance_units: (m/s)^2
+  scalar_confidence:
+    dataclass: Estimate2D
+    field: confidence
+    units: unitless_probability
+    semantics: confidence is a compact diagnostic score, not a calibrated likelihood guarantee
+  existence_probability:
+    dataclass: EntityBelief
+    field: existence_probability
+    units: unitless_probability
+    semantics: probability that the entity exists in the represented local scenario
+
+covariance_semantics:
+  matrix_shape: 2x2
+  coordinate_order: [x, y]
+  covariance_kind: covariance of the paired mean_xy estimate in the same frame
+  covariance_units_rule: covariance_units must square the corresponding mean units
+  diagonal_convention: isotropic adapter fixtures use equal diagonal variance and zero off-diagonal covariance
+  positive_semidefinite_requirement: downstream calibrated adapters should emit positive semidefinite matrices
+
+producer_expectations:
+  - key: simulator_oracle
+    position_units: m
+    velocity_units: m/s
+    expected_position_variance: near_zero_synthetic
+    expected_velocity_variance: near_zero_synthetic
+    class_probability_rule: primary class probability is 1.0 for synthetic oracle entities
+  - key: visibility_limited_simulator
+    position_units: m
+    velocity_units: m/s
+    expected_uncertainty_behavior: non-visible agents lower confidence and increase covariance
+    class_probability_rule: primary class probability follows the synthetic visibility confidence
+
+consumer_boundaries:
+  - key: socnav_struct_projection
+    method: ScenarioBelief.to_socnav_struct
+    uncertainty_behavior: drops covariance, class probabilities, provenance, and confidence
+    compatibility_rule: preserve existing SOCNAV_STRUCT key layout
+  - key: debug_json
+    method: ScenarioBelief.to_debug_dict
+    uncertainty_behavior: exposes class probabilities, mean, covariance, frame, units, confidence, source, visibility, and missing fields
+    compatibility_rule: deterministic JSON/YAML-ready diagnostics
+  - key: diagnostic_summary
+    method: ScenarioBelief.diagnostic_summary
+    uncertainty_behavior: summarizes visibility and missing-data counts only
+    compatibility_rule: diagnostic-only summary, not planner or benchmark improvement evidence
+
+known_gaps:
+  - heading uncertainty is not represented yet; heading remains a scalar legacy field
+  - covariance is synthetic in current adapters and should not be treated as sensor-calibrated
+  - policy projections intentionally drop uncertainty until a consumer contract explicitly accepts it
+
+first_fixture_or_smoke_path:
+  tests:
+    - tests/representation/test_scenario_belief.py
+    - tests/representation/test_scenario_belief_uncertainty_manifest.py
+  validates:
+    - class probabilities appear in debug output without changing SOCNAV_STRUCT keys
+    - position covariance uses meter-squared units in map frame
+    - velocity covariance uses squared-meter-per-second units in map frame
+    - non-visible synthetic agents have lower confidence and larger covariance than oracle agents
+
+recommended_next_spike:
+  title: scenario-belief uncertainty consumer spike
+  rationale: >
+    Add a planner- or analysis-facing consumer that reads covariance directly before claiming
+    uncertainty-aware planner benefit.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -527,6 +527,8 @@ knowledge, not every transient iteration detail.
   [issue_1966_scenario_belief_interface.md](issue_1966_scenario_belief_interface.md)
 * Issue #2477 ScenarioBelief Contract Bridge (2026-06-06):
   [issue_2477_scenario_belief_contract.md](issue_2477_scenario_belief_contract.md)
+* Issue #2478 Uncertainty-Aware ScenarioBelief Contract (2026-06-06):
+  [issue_2478_uncertainty_scenario_belief.md](issue_2478_uncertainty_scenario_belief.md)
 * Issue #2475 Probabilistic Prediction Interface (2026-06-06):
   [issue_2475_probabilistic_prediction_interface.md](issue_2475_probabilistic_prediction_interface.md)
 * Issue #1638 local model path preflight:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -365,6 +365,10 @@ entries:
     status: current
     freshness: maintained
     area: learned_policy
+  - path: docs/context/issue_2478_uncertainty_scenario_belief.md
+    status: current
+    freshness: maintained
+    area: learned_policy
   - path: docs/context/issue_2475_probabilistic_prediction_interface.md
     status: current
     freshness: dated

--- a/docs/context/issue_2478_uncertainty_scenario_belief.md
+++ b/docs/context/issue_2478_uncertainty_scenario_belief.md
@@ -1,0 +1,55 @@
+# Issue #2478 Uncertainty-Aware ScenarioBelief Contract (2026-06-06)
+
+Status: implemented interface contract, not benchmark evidence.
+
+Related surfaces:
+
+- GitHub issue: https://github.com/ll7/robot_sf_ll7/issues/2478
+- Parent roadmap issue: https://github.com/ll7/robot_sf_ll7/issues/2469
+- Predecessor contract: `docs/context/issue_2477_scenario_belief_contract.md`
+- Uncertainty manifest: `configs/representation/scenario_belief_uncertainty_issue_2478.yaml`
+- Implementation: `robot_sf/representation/scenario_belief.py`
+- Tests: `tests/representation/test_scenario_belief_uncertainty_manifest.py`
+
+## Result
+
+Issue #2478 asked for an uncertainty-aware scenario belief interface covering object class, pose,
+velocity, and covariance. The existing `ScenarioBelief` implementation already carried
+`Estimate2D.mean_xy`, `Estimate2D.covariance_xy`, and `Estimate2D.confidence`; this pass makes the
+units and object-class semantics explicit and executable.
+
+The contract now records:
+
+- object class through `EntityBelief.entity_type` plus `class_probabilities`;
+- pose estimates in map-frame meters with meter-squared covariance;
+- velocity estimates in map-frame meters per second with squared-meter-per-second covariance;
+- confidence and existence probability as diagnostic unitless probabilities;
+- the consumer boundary where `ScenarioBelief.to_socnav_struct()` drops uncertainty to preserve the
+  existing policy-observation key layout.
+
+## Claim Boundary
+
+This is interface and fixture evidence only. It does not prove planner benefit, real-sensor
+calibration, perception realism, or benchmark performance. Current adapter covariance is synthetic:
+oracle values are near-zero variance and visibility-limited values increase variance when an agent
+is not visible.
+
+## Validation
+
+Targeted validation:
+
+```bash
+uv run pytest tests/representation/test_scenario_belief.py \
+  tests/representation/test_scenario_belief_contract_manifest.py \
+  tests/representation/test_scenario_belief_uncertainty_manifest.py -q
+uv run ruff check robot_sf/representation tests/representation/test_scenario_belief_uncertainty_manifest.py
+uv run ruff format --check robot_sf/representation tests/representation/test_scenario_belief_uncertainty_manifest.py
+uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml
+git diff --check
+```
+
+## Follow-Up Boundary
+
+Heading uncertainty is still a known gap because heading remains a scalar legacy field. The next
+useful spike is a planner- or analysis-facing consumer that reads covariance directly; until then,
+uncertainty-aware planner improvement should remain unclaimed.

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -81,9 +81,21 @@ class Estimate2D:
     mean_xy: tuple[float, float]
     covariance_xy: tuple[tuple[float, float], tuple[float, float]]
     confidence: float
+    frame_id: str = "map"
+    units: str = "m"
+    covariance_units: str = "m^2"
 
     @classmethod
-    def point(cls, value: Any, *, confidence: float, variance: float) -> Estimate2D:
+    def point(
+        cls,
+        value: Any,
+        *,
+        confidence: float,
+        variance: float,
+        frame_id: str = "map",
+        units: str = "m",
+        covariance_units: str = "m^2",
+    ) -> Estimate2D:
         """Build a point estimate with isotropic covariance.
 
         Returns:
@@ -97,6 +109,9 @@ class Estimate2D:
             mean_xy=(float(arr[0]), float(arr[1])),
             covariance_xy=((variance, 0.0), (0.0, variance)),
             confidence=float(confidence),
+            frame_id=frame_id,
+            units=units,
+            covariance_units=covariance_units,
         )
 
     def as_array(self) -> np.ndarray:
@@ -109,6 +124,9 @@ class Estimate2D:
             "mean_xy": [round(v, 6) for v in self.mean_xy],
             "covariance_xy": [[round(v, 6) for v in row] for row in self.covariance_xy],
             "confidence": round(self.confidence, 6),
+            "frame_id": self.frame_id,
+            "units": self.units,
+            "covariance_units": self.covariance_units,
         }
 
 
@@ -128,12 +146,18 @@ class EntityBelief:
     last_observed_age_s: float = 0.0
     missing_fields: tuple[str, ...] = ()
     tracking: TrackedAgentMetadata | None = None
+    class_probabilities: tuple[tuple[str, float], ...] = ()
 
     def to_debug_dict(self) -> dict[str, Any]:
         """Return deterministic JSON/YAML-ready entity metadata."""
+        class_probabilities = self.class_probabilities or ((self.entity_type, 1.0),)
         result: dict[str, Any] = {
             "entity_id": self.entity_id,
             "entity_type": self.entity_type,
+            "class_probabilities": {
+                label: round(float(probability), 6)
+                for label, probability in sorted(class_probabilities)
+            },
             "position": self.position.to_debug_dict(),
             "velocity": self.velocity.to_debug_dict(),
             "radius": round(float(self.radius), 6),
@@ -629,12 +653,19 @@ def _scenario_belief_from_simulator(
             entity_id=f"robot_{robot_index}",
             entity_type="ego_robot",
             position=Estimate2D.point(robot_pos, confidence=1.0, variance=1e-6),
-            velocity=Estimate2D.point(robot_velocity, confidence=1.0, variance=1e-6),
+            velocity=Estimate2D.point(
+                robot_velocity,
+                confidence=1.0,
+                variance=1e-6,
+                units="m/s",
+                covariance_units="(m/s)^2",
+            ),
             radius=float(getattr(robot.config, "radius", 0.0)),
             heading=robot_heading,
             existence_probability=1.0,
             visibility_state=VisibilityState.VISIBLE,
             source=source,
+            class_probabilities=(("ego_robot", 1.0),),
         ),
         ego_speed=robot_speed,
         goals=(
@@ -685,7 +716,13 @@ def _agent_belief(
         entity_id=f"ped_{idx:03d}",
         entity_type="pedestrian",
         position=Estimate2D.point(position, confidence=confidence, variance=variance),
-        velocity=Estimate2D.point(velocity, confidence=confidence, variance=variance),
+        velocity=Estimate2D.point(
+            velocity,
+            confidence=confidence,
+            variance=variance,
+            units="m/s",
+            covariance_units="(m/s)^2",
+        ),
         radius=radius,
         heading=0.0,
         existence_probability=confidence,
@@ -694,6 +731,7 @@ def _agent_belief(
         last_observed_age_s=0.0 if visible else 1.0,
         missing_fields=missing_fields,
         tracking=tracking,
+        class_probabilities=(("pedestrian", confidence),),
     )
 
 

--- a/tests/representation/test_scenario_belief_uncertainty_manifest.py
+++ b/tests/representation/test_scenario_belief_uncertainty_manifest.py
@@ -1,0 +1,160 @@
+"""Tests for the issue #2478 ScenarioBelief uncertainty contract."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import yaml
+
+from robot_sf.gym_env.unified_config import ObservationVisibilitySettings, RobotSimulationConfig
+from robot_sf.representation import EntityBelief, Estimate2D, ScenarioBelief
+from robot_sf.representation.scenario_belief import (
+    scenario_belief_from_simulator_oracle,
+    scenario_belief_from_visibility_limited_simulator,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "configs/representation/scenario_belief_uncertainty_issue_2478.yaml"
+
+
+def _manifest() -> dict[str, object]:
+    """Load the ScenarioBelief uncertainty contract manifest."""
+    payload = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _simulator_fixture() -> SimpleNamespace:
+    """Return a deterministic simulator-like step for uncertainty contract tests."""
+    return SimpleNamespace(
+        ped_pos=np.array([[2.0, 0.0], [0.0, 3.0]], dtype=np.float32),
+        ped_vel=np.array([[0.5, 0.0], [0.0, -0.25]], dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.1, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=0.4),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=8.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+
+
+def test_uncertainty_manifest_references_existing_surfaces() -> None:
+    """The #2478 manifest should point only at tracked repository surfaces."""
+    manifest = _manifest()
+    surfaces = manifest["contract_surfaces"]
+    assert isinstance(surfaces, dict)
+
+    for key, rel_path_or_paths in surfaces.items():
+        if key == "tests":
+            assert isinstance(rel_path_or_paths, list)
+            for rel_path in rel_path_or_paths:
+                assert (REPO_ROOT / str(rel_path)).exists(), rel_path
+            continue
+        assert (REPO_ROOT / str(rel_path_or_paths)).exists(), rel_path_or_paths
+
+
+def test_uncertainty_manifest_fields_match_dataclass_contracts() -> None:
+    """Manifest field names should resolve against the implemented dataclasses."""
+    manifest = _manifest()
+    uncertainty_fields = manifest["uncertainty_fields"]
+    assert isinstance(uncertainty_fields, dict)
+
+    estimate_fields = {field.name for field in fields(Estimate2D)}
+    entity_fields = {field.name for field in fields(EntityBelief)}
+
+    object_class = uncertainty_fields["object_class"]
+    pose = uncertainty_fields["pose"]
+    velocity = uncertainty_fields["velocity"]
+    scalar_confidence = uncertainty_fields["scalar_confidence"]
+    existence_probability = uncertainty_fields["existence_probability"]
+    assert isinstance(object_class, dict)
+    assert isinstance(pose, dict)
+    assert isinstance(velocity, dict)
+    assert isinstance(scalar_confidence, dict)
+    assert isinstance(existence_probability, dict)
+
+    assert object_class["primary_field"] in entity_fields
+    assert object_class["distribution_field"] in entity_fields
+    assert pose["owning_entity_field"] in entity_fields
+    assert velocity["owning_entity_field"] in entity_fields
+    assert pose["mean_field"] in estimate_fields
+    assert pose["covariance_field"] in estimate_fields
+    assert pose["frame_field"] in estimate_fields
+    assert velocity["mean_field"] in estimate_fields
+    assert velocity["covariance_field"] in estimate_fields
+    assert velocity["frame_field"] in estimate_fields
+    assert scalar_confidence["field"] in estimate_fields
+    assert existence_probability["field"] in entity_fields
+
+
+def test_adapter_debug_output_exposes_uncertainty_units_and_class_probabilities() -> None:
+    """Real adapter fixtures should expose class, frame, unit, and covariance semantics."""
+    simulator = _simulator_fixture()
+    oracle = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+
+    debug = oracle.to_debug_dict()
+    first_agent = debug["agents"][0]
+    assert first_agent["class_probabilities"] == {"pedestrian": 0.98}
+    assert first_agent["position"]["frame_id"] == "map"
+    assert first_agent["position"]["units"] == "m"
+    assert first_agent["position"]["covariance_units"] == "m^2"
+    assert first_agent["velocity"]["frame_id"] == "map"
+    assert first_agent["velocity"]["units"] == "m/s"
+    assert first_agent["velocity"]["covariance_units"] == "(m/s)^2"
+    assert debug["ego"]["class_probabilities"] == {"ego_robot": 1.0}
+
+
+def test_visibility_limited_adapter_increases_covariance_without_projection_key_drift() -> None:
+    """Partial observations should alter uncertainty metadata, not policy key layout."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=90.0,
+    )
+    simulator = _simulator_fixture()
+
+    oracle = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+    partial = scenario_belief_from_visibility_limited_simulator(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    oracle_agent = oracle.agents[1]
+    partial_agent = partial.agents[1]
+    assert partial_agent.position.confidence < oracle_agent.position.confidence
+    assert partial_agent.class_probabilities == (("pedestrian", partial_agent.position.confidence),)
+    assert partial_agent.position.covariance_xy[0][0] > oracle_agent.position.covariance_xy[0][0]
+    assert partial_agent.velocity.covariance_xy[0][0] > oracle_agent.velocity.covariance_xy[0][0]
+    assert partial_agent.position.units == "m"
+    assert partial_agent.velocity.units == "m/s"
+    assert set(partial.to_socnav_struct()) == set(oracle.to_socnav_struct())
+
+
+def test_uncertainty_manifest_keeps_non_benchmark_claim_boundary() -> None:
+    """The #2478 contract should not be mistaken for benchmark evidence."""
+    manifest = _manifest()
+    claim_boundary = str(manifest["claim_boundary"]).lower()
+    known_gaps = manifest["known_gaps"]
+    assert isinstance(known_gaps, list)
+
+    assert manifest["benchmark_evidence"] is False
+    assert "does not prove" in claim_boundary
+    assert any("heading uncertainty" in str(gap) for gap in known_gaps)
+    assert hasattr(ScenarioBelief, "to_socnav_struct")


### PR DESCRIPTION
## Summary
- Add explicit ScenarioBelief uncertainty metadata for `Estimate2D` frame/units/covariance units and `EntityBelief.class_probabilities`.
- Wire simulator and visibility-limited adapters to emit map-frame position covariance, map-frame velocity covariance, and class probabilities.
- Add the #2478 uncertainty contract manifest, executable manifest tests, and a context note/catalog entry.

Closes #2478.

## Validation
- `uv run pytest tests/representation/test_scenario_belief.py tests/representation/test_scenario_belief_contract_manifest.py tests/representation/test_scenario_belief_uncertainty_manifest.py -q`: 19 passed
- `uv run ruff check robot_sf/representation tests/representation/test_scenario_belief_uncertainty_manifest.py`
- `uv run ruff format --check robot_sf/representation tests/representation/test_scenario_belief_uncertainty_manifest.py`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `git diff --check`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`: 5357 passed, 9 skipped, clean tree stamp at `897fdf36101d4f4d56e35598176d9b6d05a20461`; touched-file coverage warning only for `robot_sf/representation/scenario_belief.py` at 97.4%, above the 80% gate

## Downstream Propagation
- Added `configs/representation/scenario_belief_uncertainty_issue_2478.yaml` as the durable contract surface.
- Added `docs/context/issue_2478_uncertainty_scenario_belief.md` and linked it from README/catalog.
- Ignored `output/` validation artifacts are disposable local proof outputs; no durable benchmark artifact is produced.

## Research Result Guidance
- Target claim/hypothesis/blocker: pin uncertainty-aware object class, pose, velocity, and covariance semantics after #2477.
- Comparator/baseline: #2477 ScenarioBelief contract and existing simulator/visibility-limited fixtures.
- Evidence tier: executable interface/manifest contract; not benchmark evidence.
- Result classification: research-direction contract bridge with a known heading-uncertainty gap.
- Decision/stop rule: planner-benefit claims remain blocked until a consumer reads covariance directly and benchmark evidence is produced.
- Synthesis surface/update target: `docs/context/issue_2478_uncertainty_scenario_belief.md` and the #2469 scenario-understanding stack.
