### PR TITLE
feat: add ScenarioBelief uncertainty consumer smoke (#2528)

### DIFF
--- a/configs/representation/scenario_belief_uncertainty_issue_2478.yaml
+++ b/configs/representation/scenario_belief_uncertainty_issue_2478.yaml
@@ -17,6 +17,7 @@ contract_surfaces:
   base_contract_manifest: configs/representation/scenario_belief_contract_issue_2477.yaml
   base_contract_note: docs/context/issue_2477_scenario_belief_contract.md
   uncertainty_note: docs/context/issue_2478_uncertainty_scenario_belief.md
+  consumer_smoke_note: docs/context/issue_2528_scenario_belief_consumer_smoke.md
   tests:
     - tests/representation/test_scenario_belief.py
     - tests/representation/test_scenario_belief_uncertainty_manifest.py
@@ -92,6 +93,11 @@ consumer_boundaries:
     method: ScenarioBelief.diagnostic_summary
     uncertainty_behavior: summarizes visibility and missing-data counts only
     compatibility_rule: diagnostic-only summary, not planner or benchmark improvement evidence
+  - key: uncertainty_report
+    method: ScenarioBelief.to_uncertainty_report
+    uncertainty_behavior: preserves covariance, class probabilities, confidence, and existence probability for all projection-eligible agents
+    compatibility_rule: diagnostic report, not a policy observation; agents are visibility-filtered and capped per max_pedestrians
+    parent_issue: 2528
 
 known_gaps:
   - heading uncertainty is not represented yet; heading remains a scalar legacy field

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -552,6 +552,8 @@ knowledge, not every transient iteration detail.
   [issue_2477_scenario_belief_contract.md](issue_2477_scenario_belief_contract.md)
 * Issue #2478 Uncertainty-Aware ScenarioBelief Contract (2026-06-06):
   [issue_2478_uncertainty_scenario_belief.md](issue_2478_uncertainty_scenario_belief.md)
+* Issue #2528 ScenarioBelief Consumer Smoke (2026-06-07):
+  [issue_2528_scenario_belief_consumer_smoke.md](issue_2528_scenario_belief_consumer_smoke.md)
 * Issue #2479 Real-Trajectory Scenario Prior Scope (2026-06-06):
   [issue_2479_real_trajectory_scenario_prior.md](issue_2479_real_trajectory_scenario_prior.md)
 * Issue #2474 Signalized Pedestrian Crossing Benchmark Scope (2026-06-06):

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -413,6 +413,10 @@ entries:
     status: current
     freshness: maintained
     area: learned_policy
+  - path: docs/context/issue_2528_scenario_belief_consumer_smoke.md
+    status: current
+    freshness: evidence
+    area: learned_policy
   - path: docs/context/issue_2479_real_trajectory_scenario_prior.md
     status: proposal
     freshness: maintained

--- a/docs/context/issue_2478_uncertainty_scenario_belief.md
+++ b/docs/context/issue_2478_uncertainty_scenario_belief.md
@@ -50,6 +50,10 @@ git diff --check
 
 ## Follow-Up Boundary
 
-Heading uncertainty is still a known gap because heading remains a scalar legacy field. The next
-useful spike is a planner- or analysis-facing consumer that reads covariance directly; until then,
-uncertainty-aware planner improvement should remain unclaimed.
+Heading uncertainty is still a known gap because heading remains a scalar legacy field.
+
+Issue #2528 adds `ScenarioBelief.to_uncertainty_report()` as the first uncertainty-preserving
+consumer projection, with fail-closed tests proving that `to_socnav_struct()` drops all uncertainty
+fields. That is the consumer path that reads covariance directly; uncertainty-aware planner
+improvement beyond this diagnostic consumer should remain unclaimed unless a planner-facing
+projection is added and benchmarked.

--- a/docs/context/issue_2528_scenario_belief_consumer_smoke.md
+++ b/docs/context/issue_2528_scenario_belief_consumer_smoke.md
@@ -1,0 +1,51 @@
+# Issue #2528 ScenarioBelief Consumer Smoke (2026-06-07)
+
+Status: diagnostic smoke evidence, not benchmark evidence.
+
+Related surfaces:
+
+- Issue: https://github.com/ll7/robot_sf_ll7/issues/2528
+- Parent issue: https://github.com/ll7/robot_sf_ll7/issues/2521
+- Predecessor uncertainty contract: `docs/context/issue_2478_uncertainty_scenario_belief.md`
+- Implementation: `robot_sf/representation/scenario_belief.py` (`ScenarioBelief.to_uncertainty_report`)
+- Tests:
+  - `tests/representation/test_scenario_belief.py` (`test_to_uncertainty_report_preserves_covariance_and_class_probabilities`, `test_to_socnav_struct_fails_closed_for_uncertainty_consumption`)
+  - `tests/representation/test_scenario_belief_uncertainty_manifest.py` (`test_uncertainty_manifest_consumer_boundary_uncertainty_report_exists`, `test_uncertainty_manifest_keeps_non_benchmark_claim_boundary`)
+- Uncertainty manifest: `configs/representation/scenario_belief_uncertainty_issue_2478.yaml`
+
+## Result
+
+Issue #2528 adds a minimal ScenarioBelief consumer smoke for local planner observation projection:
+
+- `ScenarioBelief.to_uncertainty_report()` — a diagnostic method that preserves covariance_xy,
+  class_probabilities, position_confidence, velocity_confidence, and existence_probability for
+  all visibility-filtered, distance-sorted, capped agents. This is the first projection that
+  reads uncertainty fields directly rather than dropping them.
+- `to_socnav_struct()` remains the legacy projection, with tests that explicitly prove it drops
+  all uncertainty fields (fail-closed for uncertainty consumption).
+- The uncertainty manifest records `to_uncertainty_report` as a consumer_boundary entry with
+  parent issue 2528.
+
+## Claim Boundary
+
+This is diagnostic smoke evidence only. It proves that a ScenarioBelief can be produced, one
+consumer projection (`to_uncertainty_report`) preserves covariance and class-probability fields,
+and the legacy projection (`to_socnav_struct`) is fail-closed for uncertainty consumption. It
+does not claim planner benefit, benchmark improvement, perception realism, or SNQI movement.
+
+## Validation
+
+```bash
+uv run pytest tests/representation/test_scenario_belief.py \
+  tests/representation/test_scenario_belief_uncertainty_manifest.py -q
+uv run ruff check robot_sf/representation tests/representation/test_scenario_belief.py \
+  tests/representation/test_scenario_belief_uncertainty_manifest.py
+uv run ruff format --check robot_sf/representation tests/representation/test_scenario_belief.py \
+  tests/representation/test_scenario_belief_uncertainty_manifest.py
+```
+
+## Follow-Up
+
+The next step would be a planner-facing projection that converts covariance into a planner-compatible
+cost or constraint (e.g., covariance-weighted risk field, expanded safety radius, or uncertainty-aware
+collision-checking tolerance).

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -445,7 +445,7 @@ class ScenarioBelief:
                 ],
                 "position_confidence": round(float(self.ego.position.confidence), 6),
                 "velocity_confidence": round(float(self.ego.velocity.confidence), 6),
-                "heading": round(float(self.ego.heading), 6),
+                "heading": round(float(_wrap_angle(self.ego.heading)), 6),
             },
             "goals": [
                 {

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -402,6 +402,85 @@ class ScenarioBelief:
             "agents": [agent.to_debug_dict() for agent in self.agents],
         }
 
+    def to_uncertainty_report(self) -> dict[str, Any]:
+        """Project belief into a diagnostic report preserving all uncertainty fields.
+
+        This is the uncertainty-preserving consumer projection for local planner analysis.
+        Unlike to_socnav_struct() which drops covariance, class_probabilities, and confidence
+        for backward compatibility, this report preserves all uncertainty metadata.
+
+        This is diagnostic-only evidence. It does not claim benchmark improvement,
+        SNQI movement, or paper-facing performance.
+
+        Returns:
+            dict[str, Any]: Deterministic report with covariance, class probabilities,
+                and confidence for ego, goals, and visibility-filtered agents.
+        """
+        visible_agents = tuple(
+            agent for agent in self.agents if agent.visibility_state is VisibilityState.VISIBLE
+        )
+        robot_pos = self._clip_position(self.ego.position.as_array())
+
+        ordered_agents = sorted(
+            visible_agents,
+            key=lambda agent: (
+                float(np.linalg.norm(agent.position.as_array() - robot_pos)),
+                agent.entity_id,
+            ),
+        )[: self.max_pedestrians]
+
+        return {
+            "schema_version": self.schema_version,
+            "frame_id": self.frame_id,
+            "sim_time_s": round(float(self.sim_time_s), 6),
+            "ego": {
+                "class_probabilities": {
+                    lbl: round(float(p), 6) for lbl, p in sorted(_class_probabilities(self.ego))
+                },
+                "position_covariance_xy": [
+                    [round(float(v), 6) for v in row] for row in self.ego.position.covariance_xy
+                ],
+                "velocity_covariance_xy": [
+                    [round(float(v), 6) for v in row] for row in self.ego.velocity.covariance_xy
+                ],
+                "position_confidence": round(float(self.ego.position.confidence), 6),
+                "velocity_confidence": round(float(self.ego.velocity.confidence), 6),
+                "heading": round(float(self.ego.heading), 6),
+            },
+            "goals": [
+                {
+                    "current_covariance_xy": [
+                        [round(float(v), 6) for v in row] for row in g.current.covariance_xy
+                    ],
+                    "next_covariance_xy": [
+                        [round(float(v), 6) for v in row] for row in g.next.covariance_xy
+                    ],
+                    "current_confidence": round(float(g.current.confidence), 6),
+                    "next_confidence": round(float(g.next.confidence), 6),
+                }
+                for g in self.goals
+            ],
+            "agents": [
+                {
+                    "entity_id": a.entity_id,
+                    "class_probabilities": {
+                        lbl: round(float(p), 6) for lbl, p in sorted(_class_probabilities(a))
+                    },
+                    "position_covariance_xy": [
+                        [round(float(v), 6) for v in row] for row in a.position.covariance_xy
+                    ],
+                    "velocity_covariance_xy": [
+                        [round(float(v), 6) for v in row] for row in a.velocity.covariance_xy
+                    ],
+                    "position_confidence": round(float(a.position.confidence), 6),
+                    "velocity_confidence": round(float(a.velocity.confidence), 6),
+                    "existence_probability": round(float(a.existence_probability), 6),
+                    "visibility_state": a.visibility_state.value,
+                }
+                for a in ordered_agents
+            ],
+        }
+
     def _clip_position(self, values: np.ndarray) -> np.ndarray:
         """Clip position-like values to the representable map extent.
 
@@ -410,6 +489,11 @@ class ScenarioBelief:
         """
         position_cap = np.asarray(self.map_size, dtype=np.float32)
         return np.clip(values, 0.0, position_cap).astype(np.float32)
+
+
+def _class_probabilities(entity: EntityBelief) -> tuple[tuple[str, float], ...]:
+    """Return explicit or default class-probability metadata for an entity."""
+    return entity.class_probabilities or ((entity.entity_type, 1.0),)
 
 
 def _in_policy_projection(

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -342,3 +342,63 @@ def test_tracked_agent_metadata_to_debug_dict_produces_deterministic_output() ->
     assert debug["is_coasted"] is False
     # second call should match
     assert meta.to_debug_dict() == debug
+
+
+def test_to_uncertainty_report_preserves_covariance_and_class_probabilities() -> None:
+    """to_uncertainty_report should preserve uncertainty fields that to_socnav_struct drops."""
+    env_config = RobotSimulationConfig()
+    simulator = _simulator_fixture()
+    belief = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    report = belief.to_uncertainty_report()
+
+    assert "agents" in report
+    assert "ego" in report
+    assert len(report["agents"]) == 2
+
+    first_agent = report["agents"][0]
+    assert "class_probabilities" in first_agent
+    assert "position_covariance_xy" in first_agent
+    assert "velocity_covariance_xy" in first_agent
+    assert "position_confidence" in first_agent
+    assert "velocity_confidence" in first_agent
+    assert first_agent["class_probabilities"] == {"pedestrian": 0.98}
+    assert first_agent["position_confidence"] == pytest.approx(0.98)
+
+    assert "class_probabilities" in report["ego"]
+    assert "position_covariance_xy" in report["ego"]
+    assert "velocity_covariance_xy" in report["ego"]
+    assert report["ego"]["class_probabilities"] == {"ego_robot": 1.0}
+
+    assert "goals" in report
+    assert "current_covariance_xy" in report["goals"][0]
+    assert "next_covariance_xy" in report["goals"][0]
+
+
+def test_to_socnav_struct_fails_closed_for_uncertainty_consumption() -> None:
+    """to_socnav_struct output lacks uncertainty fields; consumers must not find them."""
+    env_config = RobotSimulationConfig()
+    simulator = _simulator_fixture()
+    belief = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    obs = belief.to_socnav_struct()
+
+    # Fail-closed: the legacy projection drops covariance and class-probability keys.
+    with pytest.raises(KeyError):
+        _ = obs["position_covariance_xy"]
+    with pytest.raises(KeyError):
+        _ = obs["covariance"]
+    robot = obs["robot"]
+    assert "covariance" not in robot
+    assert "confidence" not in robot
+    pedestrians = obs["pedestrians"]
+    assert "covariance" not in pedestrians
+    assert "class_probabilities" not in pedestrians

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -348,6 +348,7 @@ def test_to_uncertainty_report_preserves_covariance_and_class_probabilities() ->
     """to_uncertainty_report should preserve uncertainty fields that to_socnav_struct drops."""
     env_config = RobotSimulationConfig()
     simulator = _simulator_fixture()
+    simulator.robots[0].pose = ((0.0, 0.0), 4.0)
     belief = scenario_belief_from_simulator_oracle(
         simulator,
         env_config=env_config,
@@ -355,6 +356,7 @@ def test_to_uncertainty_report_preserves_covariance_and_class_probabilities() ->
     )
 
     report = belief.to_uncertainty_report()
+    legacy_obs = belief.to_socnav_struct()
 
     assert "agents" in report
     assert "ego" in report
@@ -373,6 +375,7 @@ def test_to_uncertainty_report_preserves_covariance_and_class_probabilities() ->
     assert "position_covariance_xy" in report["ego"]
     assert "velocity_covariance_xy" in report["ego"]
     assert report["ego"]["class_probabilities"] == {"ego_robot": 1.0}
+    assert report["ego"]["heading"] == pytest.approx(float(legacy_obs["robot"]["heading"][0]))
 
     assert "goals" in report
     assert "current_covariance_xy" in report["goals"][0]

--- a/tests/representation/test_scenario_belief_uncertainty_manifest.py
+++ b/tests/representation/test_scenario_belief_uncertainty_manifest.py
@@ -158,3 +158,17 @@ def test_uncertainty_manifest_keeps_non_benchmark_claim_boundary() -> None:
     assert "does not prove" in claim_boundary
     assert any("heading uncertainty" in str(gap) for gap in known_gaps)
     assert hasattr(ScenarioBelief, "to_socnav_struct")
+    assert hasattr(ScenarioBelief, "to_uncertainty_report")
+
+
+def test_uncertainty_manifest_consumer_boundary_uncertainty_report_exists() -> None:
+    """The #2528 consumer boundary should reference an existing method."""
+    manifest = _manifest()
+    boundaries = manifest["consumer_boundaries"]
+    report_boundary = [
+        b for b in boundaries if b.get("method") == "ScenarioBelief.to_uncertainty_report"
+    ]
+    assert len(report_boundary) == 1, "consumer_boundaries must include uncertainty_report entry"
+    entry = report_boundary[0]
+    assert entry["uncertainty_behavior"] != ""
+    assert entry["parent_issue"] == 2528


### PR DESCRIPTION
## Summary
Adds a diagnostic ScenarioBelief uncertainty consumer smoke for issue #2528. The new `ScenarioBelief.to_uncertainty_report()` preserves covariance, confidence, class-probability, and existence metadata while the legacy `to_socnav_struct()` path remains fail-closed for uncertainty consumption.

## Linked Issues
- Closes #2528
- Relates to #2521
- Relates to #2478

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #2538
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `ScenarioBelief.to_uncertainty_report()` as a diagnostic, uncertainty-preserving consumer projection.
- Added tests proving uncertainty fields are preserved in the diagnostic report and absent from the legacy SocNav projection.
- Updated the ScenarioBelief uncertainty manifest and context catalog/README with the issue #2528 diagnostic note.

## Why It Matters
- Added value: proves a ScenarioBelief object can feed one local consumer path without losing covariance/class-probability metadata.
- Expected impact: clarifies the boundary between uncertainty-aware diagnostics and legacy policy observations.
- Why this is worth merging now: closes a ready research interface smoke and makes the next planner-facing uncertainty projection easier to scope.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: ScenarioBelief uncertainty can be consumed by a local projection path, while legacy SocNav projection fails closed for uncertainty fields.
- Comparator or baseline, if applicable: existing `to_socnav_struct()` projection, which intentionally drops uncertainty metadata.
- Evidence tier: targeted smoke
- Result classification: diagnostic-only
- Decision or stop rule, if applicable: continue only to a separate planner-facing projection if a planner consumes covariance as a cost, constraint, or fail-closed status.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2528 and `docs/context/issue_2528_scenario_belief_consumer_smoke.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `to_uncertainty_report()` is a diagnostic support projection, not a benchmark or paper-facing analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? NA, representation smoke only.
- Did the scenario actually contain the targeted failure mode? NA, interface-consumption smoke.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: next useful child is a planner-facing projection that converts covariance into a planner-compatible cost or constraint.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: continue toward a planner-facing uncertainty consumer in a separate issue.
- Proposed child issue or existing follow-up: #2538 tracks the planner-facing uncertainty consumer; #2530 is the next stronger research-priority implementation candidate from the queue scout.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/representation/test_scenario_belief.py tests/representation/test_scenario_belief_uncertainty_manifest.py -q`
  - `uv run pytest tests/representation -q`
  - `uv run ruff check robot_sf/representation/scenario_belief.py tests/representation/test_scenario_belief.py tests/representation/test_scenario_belief_uncertainty_manifest.py`
  - `uv run ruff format --check robot_sf/representation/scenario_belief.py tests/representation/test_scenario_belief.py tests/representation/test_scenario_belief_uncertainty_manifest.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed on clean branch head `6b7892c5496cd0c8398e5b47b621f14d29bc9001`; full suite reported 5404 passed and 9 skipped.
- Benchmarks or smoke tests, if applicable: targeted representation smoke tests only; no benchmark claim.

## Risks / Rollout
- Compatibility risks: low; existing `to_socnav_struct()` output is unchanged.
- Failure modes: downstream code might mistake `to_uncertainty_report()` for policy input; docs label it diagnostic-only.
- Rollback or fallback plan: remove the diagnostic method and manifest/context entries; legacy projection remains intact.

## Docs / Provenance
- Updated docs: `docs/context/issue_2528_scenario_belief_consumer_smoke.md`, `docs/context/issue_2478_uncertainty_scenario_belief.md`, `docs/context/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: predecessor contract in `docs/context/issue_2478_uncertainty_scenario_belief.md`.
- Any assumptions that need to be preserved: diagnostic-only; no planner performance, sensor realism, benchmark, or paper-facing claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2528.
- Claim map / benchmark report updated (yes/no/NA): NA, not benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA, no benchmark artifact.
- Registry or config index updated (yes/no/NA): yes, uncertainty manifest updated.
- Context index / memory note updated (yes/no/NA): yes, context README and catalog updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #2538 for planner-facing uncertainty consumption.
- Not applicable because: no benchmark or paper-facing claim is made.

## Follow-Up Issues
- Deferred work: planner-facing uncertainty consumer that uses covariance as a cost, constraint, or fail-closed status.
- Issues opened for follow-up: #2538.

## Reviewer Notes
- Verify that `to_uncertainty_report()` is treated as diagnostic-only and that `to_socnav_struct()` behavior remains unchanged.
- Known limitation: report includes visibility-filtered, capped agents rather than all tracked agents.
