### PR TITLE
fix: classify legacy PR status contexts

### DIFF
--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -15,6 +15,7 @@ from typing import Any
 
 FAILURE_CONCLUSIONS = {
     "failure",
+    "error",
     "cancelled",
     "timed_out",
     "action_required",
@@ -63,6 +64,31 @@ def _parse_pr_view_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]
     return data, None
 
 
+def _rollup_conclusion(check: dict[str, Any]) -> str:
+    """Return a normalized conclusion for check-run and legacy-status rollup entries."""
+    conclusion = check.get("conclusion")
+    if conclusion:
+        return str(conclusion).lower()
+    state = check.get("state")
+    if state:
+        return str(state).lower()
+    return "pending"
+
+
+def _rollup_status(check: dict[str, Any]) -> str:
+    """Return a normalized lifecycle status for check-run and legacy-status rollup entries."""
+    status = check.get("status")
+    if status:
+        return str(status).lower()
+    state = check.get("state")
+    if not state:
+        return "completed"
+    state_str = str(state).lower()
+    if state_str in {"success", "failure", "error"}:
+        return "completed"
+    return state_str
+
+
 def _fetch_ci_status(
     pr_number: str,
     backoff: float = 0.0,
@@ -106,17 +132,16 @@ def _fetch_ci_status(
     # Classify overall CI state.
     conclusions: dict[str, int] = {}
     for check in rollup:
-        c = str(check.get("conclusion") or "pending").lower()
+        c = _rollup_conclusion(check)
         conclusions[c] = conclusions.get(c, 0) + 1
 
     states: dict[str, int] = {}
     for check in rollup:
-        s = str(check.get("status") or "completed").lower()
+        s = _rollup_status(check)
         states[s] = states.get(s, 0) + 1
 
     failure_count = sum(conclusions.get(conclusion, 0) for conclusion in FAILURE_CONCLUSIONS)
     pending_count = sum(states.get(status, 0) for status in PENDING_STATUSES)
-    pending_count += conclusions.get("pending", 0)
     if failure_count:
         overall = "failure"
     elif pending_count or not rollup:

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scripts.dev.check_pr_ci_status import _fetch_ci_status, _format_human, main
+from scripts.dev.check_pr_ci_status import (
+    _fetch_ci_status,
+    _format_human,
+    _rollup_conclusion,
+    _rollup_status,
+    main,
+)
 
 
 def test_format_human_success() -> None:
@@ -159,6 +165,133 @@ def test_main_with_explicit_pr_and_success(
     captured = capsys.readouterr()
     assert "PR #1" in captured.out
     assert "checks: success" in captured.out
+
+
+def test_main_treats_successful_legacy_status_as_success(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Legacy commit statuses expose state without conclusion/status fields."""
+    mock_data = json.dumps(
+        {
+            "number": 2537,
+            "title": "legacy status",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "legacy-status",
+            "statusCheckRollup": [
+                {"conclusion": "success", "status": "completed", "name": "ci"},
+                {"state": "success", "name": "CodeRabbit"},
+            ],
+            "reviews": [{"state": "COMMENTED"}],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["2537", "--json"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["checks"]["overall"] == "success"
+    assert payload["checks"]["by_conclusion"] == {"success": 2}
+    assert payload["checks"]["by_status"] == {"completed": 2}
+    assert payload["checks"]["names"] == ["CodeRabbit", "ci"]
+
+
+def test_main_preserves_pending_legacy_status(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Pending legacy commit statuses should still block success."""
+    mock_data = json.dumps(
+        {
+            "number": 2,
+            "title": "pending legacy",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "pending-legacy",
+            "statusCheckRollup": [
+                {"conclusion": "success", "status": "completed", "name": "ci"},
+                {"state": "pending", "name": "external-status"},
+            ],
+            "reviews": [],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["2", "--json"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["checks"]["overall"] == "pending"
+    assert payload["checks"]["by_conclusion"] == {"success": 1, "pending": 1}
+    assert payload["checks"]["by_status"] == {"completed": 1, "pending": 1}
+
+
+def test_main_treats_error_legacy_status_as_failure(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Legacy error states should fail CI preflight."""
+    mock_data = json.dumps(
+        {
+            "number": 3,
+            "title": "error legacy",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "error-legacy",
+            "statusCheckRollup": [
+                {"state": "error", "name": "external-status"},
+            ],
+            "reviews": [],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["3"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "checks: failure" in captured.out
+    assert "error=1" in captured.out
+
+
+@pytest.mark.parametrize(
+    ("check", "expected"),
+    [
+        ({"conclusion": "SUCCESS", "state": "failure"}, "success"),
+        ({"conclusion": None, "state": "SUCCESS"}, "success"),
+        ({"state": ""}, "pending"),
+        ({}, "pending"),
+    ],
+)
+def test_rollup_conclusion_prefers_conclusion_then_state(
+    check: dict[str, object],
+    expected: str,
+) -> None:
+    """Conclusion normalization should handle check-run and legacy-status entries."""
+    assert _rollup_conclusion(check) == expected
+
+
+@pytest.mark.parametrize(
+    ("check", "expected"),
+    [
+        ({"status": "IN_PROGRESS", "state": "success"}, "in_progress"),
+        ({"status": "", "state": "SUCCESS"}, "completed"),
+        ({"state": "FAILURE"}, "completed"),
+        ({"state": "ERROR"}, "completed"),
+        ({"state": "PENDING"}, "pending"),
+        ({}, "completed"),
+    ],
+)
+def test_rollup_status_prefers_status_then_legacy_state(
+    check: dict[str, object],
+    expected: str,
+) -> None:
+    """Lifecycle status normalization should avoid double-counting legacy pending checks."""
+    assert _rollup_status(check) == expected
 
 
 def test_main_json_output(capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Summary

Closes #2541.

- Normalizes `statusCheckRollup` entries from both check runs and legacy commit statuses.
- Treats legacy `state: success` as success instead of pending when `conclusion` is absent.
- Preserves pending legacy statuses and treats legacy `state: error` as failure.
- Adds focused deterministic tests for success, pending, and error legacy status contexts.

## Validation

- `PYTHONPATH=. scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_ci_status.py -q`  
  Result: 16 passed.
- `PYTHONPATH=. scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`  
  Result: passed.
- `PYTHONPATH=. scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`  
  Result: passed.
- `PYTHONPATH=. scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py 2537 --json`  
  Result: `overall: success`, `success=6`, confirming the original stuck PR shape.
- `PYTHONPATH=. scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py 2539 --json`  
  Result: still pending while GitHub Actions jobs were in progress, preserving pending behavior.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`  
  Result: passed; 5404 passed, 9 skipped, 17 warnings; clean tree stamp at `output/validation/pr_ready/issue-2541-ci-status-helper-legacy-status.json`.

## Downstream Propagation

- Parent issue / claim lane: #2541 is a workflow-tooling fix created from the #2537 guarded-merge blocker.
- Claim map / benchmark report: NA; no benchmark or research claim changed.
- Registry / config index: NA.
- Context index / memory note: NA; implementation is self-contained in the helper and tests.
- Artifact catalog: no durable artifacts added; local coverage/readiness outputs remain ignored.

## Research Result Guidance

NA. This is workflow tooling only; it makes the CI helper match GitHub status semantics and does not alter benchmark evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI status check logic to better handle error states and legacy GitHub status field support, enhancing pull request CI validation.

* **Tests**
  * Added comprehensive test coverage for CI status normalization and legacy status field compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->