### PR TITLE
feat: delegate autopilot CI waits

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -98,7 +98,8 @@ Each cycle iteration follows a fixed phase order:
 Before each phase, run a delegation checkpoint:
 
 - Choose the routed helper role for the phase when `ai-delegation-routing` is active:
-  queue scout, PR blocker reviewer, bounded editor, validation verifier, or discovery scout.
+  queue scout, PR blocker reviewer, bounded editor, validation verifier, CI wait monitor, or
+  discovery scout.
 - Start at least one eligible routed worker or Spark sidecar for any phase likely to exceed about
   10 minutes, unless the next action is a local-only publication step or all routes are unavailable.
 - If no helper is used, record `delegation_skipped: <reason>` with one of: `tiny`,
@@ -109,6 +110,39 @@ Publication and final judgment remain local: delegates must not push, open, or m
 labels or project state; resolve review threads; or make final benchmark, paper, or safety claims
 unless the user explicitly grants that permission. Their output is `route_evidence` that must be
 reviewed and validated before phase completion, not benchmark or claim proof by itself.
+
+### Async CI Wait Policy
+
+Do not idle the main autopilot thread on routine GitHub CI waits when other safe work remains.
+When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
+
+1. Record the PR number, expected head SHA, current CI state, and static wait budget in the active
+   ledger. The default budget is `ceil(920s * 1.3) = 1196s`, unless a newer committed skill/doc
+   baseline has replaced it.
+2. Start one read-only `ci_wait_monitor` route or Codex app/Spark sidecar for that PR:
+
+   ```bash
+   uv run python scripts/dev/watch_pr_ci_status.py <pr-number> \
+     --expected-head-sha <head-sha> --json
+   ```
+
+3. Continue with non-conflicting work on the main thread: review other PRs, merge already-green
+   `merge-ready` PRs, or run bounded discovery. Do not mutate the waiting PR branch or resolve its
+   final readiness while its monitor is active.
+4. When the monitor returns, the main agent must review the result against the current PR head SHA
+   before applying `merge-ready`, merging, or reporting completion.
+
+The wait helper uses the stable default budget on normal runs. It samples recent successful CI
+runtime only when CI is still pending after the budget expires, and then reports drift evidence plus
+a recommended baseline. Do not change the committed default wait baseline after one ordinary slow
+run; update it only after repeated over-budget evidence or an obvious CI workflow change.
+
+Treat monitor exit states as follows:
+
+- `success`: CI is green for the expected head SHA; reassess readiness locally.
+- `failure`: leave the PR open, record the failing checks, and continue the cycle.
+- `timeout`: keep the PR in `awaiting_ci`, record the drift sample, and continue other work.
+- `error`: record stale head, auth, API, or parsing failure; do not trust the waiter for readiness.
 
 ### Active Delegation Ledger
 
@@ -136,6 +170,8 @@ Track only the fields needed to resume safely in under one minute:
 - ownership: files or modules the delegate may read or edit;
 - validation: commands planned/run, pass/fail state, and any blocker signature;
 - PR/CI: PR URL or number, head SHA, review state, CI state, and merge-ready state;
+- CI wait: baseline seconds, multiplier, budget seconds, poll interval, deadline, monitor
+  route/run ID, expected head SHA, final status, and drift sample when collected;
 - cleanup: app-agent or worker close status, claim release status, worktree/artifact decision.
 
 Distinguish route success from task success. A delegate command exiting zero or producing a report

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -102,7 +102,10 @@ Avoid loops:
 7. Resolve review threads only after the post-push thread snapshot confirms the fixes still cover all
    actionable comments.
 8. Update `merge-ready` only after full proof bar closes.
-9. Update the active ledger before any CI wait or final handoff. Route completion is not task
+9. When CI is the only remaining external gate, put the PR in `awaiting_ci` and use
+   `.agents/skills/goal-autopilot/SKILL.md` "Async CI Wait Policy" instead of idling the review
+   loop when other safe PR or cycle work remains.
+10. Update the active ledger before any CI wait or final handoff. Route completion is not task
    completion until the main agent has verified proof, GitHub state, and cleanup.
 
 ## Proof and Validation

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -85,7 +85,7 @@ def _fetch_ci_status(
             "view",
             pr_number,
             "--json",
-            "number,title,state,mergeable,headRefName,statusCheckRollup,reviews",
+            "number,title,state,mergeable,headRefName,headRefOid,statusCheckRollup,reviews",
         ]
     )
     if result.returncode != 0:
@@ -143,6 +143,7 @@ def _fetch_ci_status(
         "state": data.get("state", "unknown"),
         "mergeable": data.get("mergeable", "unknown"),
         "branch": data.get("headRefName", ""),
+        "head_sha": data.get("headRefOid", ""),
         "checks": {
             "total": len(rollup),
             "overall": overall,
@@ -162,7 +163,8 @@ def _format_human(data: dict[str, Any]) -> str:
     lines: list[str] = []
     lines.append(f"PR #{data['pr']}: {data['title']}")
     lines.append(
-        f"  state: {data['state']}  |  mergeable: {data['mergeable']}  |  branch: {data['branch']}"
+        f"  state: {data['state']}  |  mergeable: {data['mergeable']}  |  "
+        f"branch: {data['branch']}  |  head: {data.get('head_sha', '')}"
     )
 
     checks = data.get("checks", {})

--- a/scripts/dev/watch_pr_ci_status.py
+++ b/scripts/dev/watch_pr_ci_status.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Watch PR CI status with a stable default wait budget.
+
+The normal path intentionally does not sample recent CI timings.  Runtime sampling is reserved for
+the drift path after the default budget is exhausted while checks are still pending.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from scripts.dev.check_pr_ci_status import _fetch_ci_status
+
+DEFAULT_BASELINE_SECONDS = 920
+DEFAULT_MULTIPLIER = 1.3
+DEFAULT_POLL_INTERVAL_SECONDS = 120
+DEFAULT_WORKFLOW = "CI"
+DEFAULT_SAMPLE_LIMIT = 10
+
+
+@dataclass(frozen=True, slots=True)
+class DriftSample:
+    """Recent successful CI timing sample collected after a timeout."""
+
+    source: str
+    workflow: str
+    sample_count: int
+    median_seconds: int | None
+    recommended_budget_seconds: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class WatchResult:
+    """Final PR CI watch result."""
+
+    pr: int | str
+    head_sha: str
+    expected_head_sha: str
+    baseline_seconds: int
+    multiplier: float
+    budget_seconds: int
+    poll_interval_seconds: int
+    final_status: str
+    checks: dict[str, Any]
+    error: str
+    drift_sample: DriftSample | None
+
+    def to_json(self) -> str:
+        """Serialize the result as deterministic JSON."""
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def wait_budget_seconds(baseline_seconds: int, multiplier: float) -> int:
+    """Return the rounded-up CI wait budget."""
+    if baseline_seconds < 0:
+        raise ValueError("baseline_seconds must be non-negative")
+    if multiplier <= 0:
+        raise ValueError("multiplier must be positive")
+    return math.ceil(baseline_seconds * multiplier)
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    """Parse a GitHub timestamp."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _duration_seconds(start: str | None, end: str | None) -> int | None:
+    """Return elapsed whole seconds for a GitHub run timestamp pair."""
+    started = _parse_timestamp(start)
+    completed = _parse_timestamp(end)
+    if started is None or completed is None:
+        return None
+    return max(int((completed - started).total_seconds()), 0)
+
+
+def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def fetch_recent_successful_ci_durations(
+    *,
+    workflow: str = DEFAULT_WORKFLOW,
+    limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> list[int]:
+    """Fetch recent successful workflow durations from `gh run list`."""
+    result = _gh(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--status",
+            "success",
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,displayTitle,status,conclusion,createdAt,updatedAt",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"gh returned exit code {result.returncode}")
+    try:
+        runs = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse gh run list JSON: {exc}") from exc
+    if not isinstance(runs, list):
+        raise RuntimeError("gh run list output is not a JSON array")
+    durations: list[int] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("conclusion", "")).lower() != "success":
+            continue
+        duration = _duration_seconds(run.get("createdAt"), run.get("updatedAt"))
+        if duration is not None:
+            durations.append(duration)
+    return durations
+
+
+def _build_drift_sample(
+    *,
+    workflow: str,
+    sample_limit: int,
+    multiplier: float,
+    fetch_durations: Callable[..., list[int]],
+) -> DriftSample:
+    """Collect optional drift evidence after the default budget is exhausted."""
+    try:
+        durations = fetch_durations(workflow=workflow, limit=sample_limit)
+    except Exception as exc:
+        return DriftSample(
+            source=f"error: {exc}",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+    if not durations:
+        return DriftSample(
+            source="gh run list",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+    median_seconds = math.ceil(statistics.median(durations))
+    return DriftSample(
+        source="gh run list",
+        workflow=workflow,
+        sample_count=len(durations),
+        median_seconds=median_seconds,
+        recommended_budget_seconds=wait_budget_seconds(median_seconds, multiplier),
+    )
+
+
+def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectable dependencies.
+    *,
+    pr_number: str,
+    expected_head_sha: str = "",
+    baseline_seconds: int = DEFAULT_BASELINE_SECONDS,
+    multiplier: float = DEFAULT_MULTIPLIER,
+    poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
+    workflow: str = DEFAULT_WORKFLOW,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    fetch_status: Callable[..., dict[str, Any]] = _fetch_ci_status,
+    fetch_durations: Callable[..., list[int]] = fetch_recent_successful_ci_durations,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> WatchResult:
+    """Poll PR CI status until success, failure, stale head, or budget timeout."""
+    budget_seconds = wait_budget_seconds(baseline_seconds, multiplier)
+    deadline = monotonic() + budget_seconds
+    last_status: dict[str, Any] = {}
+
+    while True:
+        last_status = fetch_status(pr_number)
+        head_sha = str(last_status.get("head_sha") or "")
+        if last_status.get("status") == "error":
+            return WatchResult(
+                pr=pr_number,
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status="error",
+                checks={},
+                error=str(last_status.get("error") or "unknown status error"),
+                drift_sample=None,
+            )
+        if expected_head_sha and head_sha and head_sha != expected_head_sha:
+            return WatchResult(
+                pr=last_status.get("pr", pr_number),
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status="error",
+                checks=last_status.get("checks", {}),
+                error="PR head SHA changed while waiting for CI",
+                drift_sample=None,
+            )
+
+        checks = last_status.get("checks", {})
+        overall = checks.get("overall")
+        if overall in {"success", "failure"}:
+            return WatchResult(
+                pr=last_status.get("pr", pr_number),
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status=str(overall),
+                checks=checks,
+                error="",
+                drift_sample=None,
+            )
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            drift_sample = _build_drift_sample(
+                workflow=workflow,
+                sample_limit=sample_limit,
+                multiplier=multiplier,
+                fetch_durations=fetch_durations,
+            )
+            return WatchResult(
+                pr=last_status.get("pr", pr_number),
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status="timeout",
+                checks=checks,
+                error="CI remained pending after wait budget",
+                drift_sample=drift_sample,
+            )
+        sleep(max(min(float(poll_interval_seconds), remaining), 0.0))
+
+
+def format_human(result: WatchResult) -> str:
+    """Format a compact human-readable monitor summary."""
+    lines = [
+        f"PR #{result.pr} CI watch: {result.final_status}",
+        (f"  head: {result.head_sha}  |  expected: {result.expected_head_sha or 'not set'}"),
+        (
+            f"  budget: {result.budget_seconds}s "
+            f"(baseline {result.baseline_seconds}s * {result.multiplier:g})"
+        ),
+    ]
+    if result.checks:
+        lines.append(f"  checks: {result.checks.get('overall', 'unknown')}")
+    if result.error:
+        lines.append(f"  error: {result.error}")
+    if result.drift_sample is not None:
+        sample = result.drift_sample
+        lines.append(
+            "  drift_sample: "
+            f"{sample.sample_count} runs, median={sample.median_seconds}, "
+            f"recommended_budget={sample.recommended_budget_seconds}, source={sample.source}"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pr_number", help="GitHub PR number to monitor.")
+    parser.add_argument("--expected-head-sha", default="", help="Optional PR head SHA guard.")
+    parser.add_argument(
+        "--workflow", default=DEFAULT_WORKFLOW, help="Workflow name for drift sampling."
+    )
+    parser.add_argument(
+        "--baseline-seconds",
+        type=int,
+        default=DEFAULT_BASELINE_SECONDS,
+        help="Default CI runtime baseline; recent runs are sampled only after timeout.",
+    )
+    parser.add_argument("--multiplier", type=float, default=DEFAULT_MULTIPLIER)
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=int,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+    )
+    parser.add_argument("--sample-limit", type=int, default=DEFAULT_SAMPLE_LIMIT)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    try:
+        result = watch_pr_ci_status(
+            pr_number=args.pr_number,
+            expected_head_sha=args.expected_head_sha,
+            baseline_seconds=args.baseline_seconds,
+            multiplier=args.multiplier,
+            poll_interval_seconds=args.poll_interval_seconds,
+            workflow=args.workflow,
+            sample_limit=args.sample_limit,
+            fetch_status=_fetch_ci_status,
+            fetch_durations=fetch_recent_successful_ci_durations,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        print(f"ERROR watching PR CI: {exc}", file=sys.stderr)
+        return 1
+    print(result.to_json() if args.json else format_human(result))
+    if result.final_status == "success":
+        return 0
+    if result.final_status == "timeout":
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/watch_pr_ci_status.py
+++ b/scripts/dev/watch_pr_ci_status.py
@@ -71,20 +71,26 @@ def wait_budget_seconds(baseline_seconds: int, multiplier: float) -> int:
     return math.ceil(baseline_seconds * multiplier)
 
 
-def _parse_timestamp(value: str | None) -> datetime | None:
+def _parse_timestamp(value: Any) -> datetime | None:
     """Parse a GitHub timestamp."""
-    if not value:
+    if not isinstance(value, str) or not value:
         return None
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
-def _duration_seconds(start: str | None, end: str | None) -> int | None:
+def _duration_seconds(start: Any, end: Any) -> int | None:
     """Return elapsed whole seconds for a GitHub run timestamp pair."""
     started = _parse_timestamp(start)
     completed = _parse_timestamp(end)
     if started is None or completed is None:
         return None
-    return max(int((completed - started).total_seconds()), 0)
+    try:
+        return max(int((completed - started).total_seconds()), 0)
+    except TypeError:
+        return None
 
 
 def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -210,6 +216,21 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 error=str(last_status.get("error") or "unknown status error"),
                 drift_sample=None,
             )
+        state = str(last_status.get("state") or "").upper()
+        if state in {"CLOSED", "MERGED"}:
+            return WatchResult(
+                pr=last_status.get("pr", pr_number),
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status="error",
+                checks=last_status.get("checks", {}),
+                error=f"PR is in terminal state: {state}",
+                drift_sample=None,
+            )
         if expected_head_sha and head_sha and head_sha != expected_head_sha:
             return WatchResult(
                 pr=last_status.get("pr", pr_number),
@@ -331,6 +352,9 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         print(f"ERROR watching PR CI: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: Invalid argument: {exc}", file=sys.stderr)
         return 1
     print(result.to_json() if args.json else format_human(result))
     if result.final_status == "success":

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -20,6 +20,7 @@ def test_format_human_success() -> None:
         "state": "OPEN",
         "mergeable": "MERGEABLE",
         "branch": "fix-thing",
+        "head_sha": "abc123",
         "checks": {
             "total": 3,
             "overall": "failure",
@@ -34,6 +35,7 @@ def test_format_human_success() -> None:
     assert "Fix the thing" in output
     assert "OPEN" in output
     assert "MERGEABLE" in output
+    assert "abc123" in output
     assert "checks: failure" in output
     assert "success=2" in output
     assert "failure=1" in output
@@ -81,6 +83,7 @@ def test_main_with_explicit_pr_and_failure_exit(
             "state": "OPEN",
             "mergeable": "MERGEABLE",
             "headRefName": "broken",
+            "headRefOid": "abc123",
             "statusCheckRollup": [
                 {"conclusion": "success", "status": "completed", "name": "lint"},
                 {"conclusion": "failure", "status": "completed", "name": "test"},
@@ -102,6 +105,7 @@ def test_main_with_explicit_pr_and_failure_exit(
     assert "PR #42" in captured.out
     assert "failure=1" in captured.out
     assert "checks: failure" in captured.out
+    assert "abc123" in captured.out
 
 
 def test_main_with_startup_failure_exit(capsys: pytest.CaptureFixture) -> None:
@@ -188,6 +192,7 @@ def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
     payload = json.loads(captured.out)
     assert payload["status"] == "ok"
     assert payload["pr"] == 7
+    assert payload["head_sha"] == ""
     assert payload["checks"]["overall"] == "pending"
 
 

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -1,0 +1,146 @@
+"""Tests for drift-aware PR CI waiting."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.dev.watch_pr_ci_status import (
+    DEFAULT_BASELINE_SECONDS,
+    DEFAULT_MULTIPLIER,
+    fetch_recent_successful_ci_durations,
+    main,
+    wait_budget_seconds,
+    watch_pr_ci_status,
+)
+
+
+def _status(overall: str, *, head_sha: str = "abc123") -> dict[str, object]:
+    """Return a compact check status payload."""
+    return {
+        "status": "ok",
+        "pr": 42,
+        "head_sha": head_sha,
+        "checks": {
+            "overall": overall,
+            "total": 1,
+            "by_conclusion": {overall: 1},
+            "by_status": {"completed": 1} if overall != "pending" else {"in_progress": 1},
+            "names": ["ci"],
+        },
+    }
+
+
+def test_default_wait_budget_uses_stable_baseline() -> None:
+    """The default budget should match the documented 920s baseline with 30% headroom."""
+    assert wait_budget_seconds(DEFAULT_BASELINE_SECONDS, DEFAULT_MULTIPLIER) == 1196
+
+
+def test_success_does_not_fetch_recent_runtime_samples() -> None:
+    """Normal successful waits should avoid refreshing CI timing evidence."""
+    fetch_durations = MagicMock(return_value=[1000])
+
+    result = watch_pr_ci_status(
+        pr_number="42",
+        expected_head_sha="abc123",
+        fetch_status=MagicMock(return_value=_status("success")),
+        fetch_durations=fetch_durations,
+    )
+
+    assert result.final_status == "success"
+    assert result.drift_sample is None
+    fetch_durations.assert_not_called()
+
+
+def test_failure_returns_without_drift_sampling() -> None:
+    """Failed CI is a terminal state, not runtime drift evidence."""
+    fetch_durations = MagicMock(return_value=[1000])
+
+    result = watch_pr_ci_status(
+        pr_number="42",
+        fetch_status=MagicMock(return_value=_status("failure")),
+        fetch_durations=fetch_durations,
+    )
+
+    assert result.final_status == "failure"
+    fetch_durations.assert_not_called()
+
+
+def test_stale_head_sha_returns_error() -> None:
+    """A branch update while waiting should invalidate the monitor result."""
+    result = watch_pr_ci_status(
+        pr_number="42",
+        expected_head_sha="expected",
+        fetch_status=MagicMock(return_value=_status("pending", head_sha="new-head")),
+        fetch_durations=MagicMock(return_value=[1000]),
+    )
+
+    assert result.final_status == "error"
+    assert "head SHA changed" in result.error
+
+
+def test_pending_after_budget_collects_drift_sample() -> None:
+    """Runtime sampling should happen only after the stable wait budget is exhausted."""
+    fetch_durations = MagicMock(return_value=[800, 1000, 1200])
+
+    result = watch_pr_ci_status(
+        pr_number="42",
+        baseline_seconds=0,
+        poll_interval_seconds=1,
+        fetch_status=MagicMock(return_value=_status("pending")),
+        fetch_durations=fetch_durations,
+    )
+
+    assert result.final_status == "timeout"
+    assert result.drift_sample is not None
+    assert result.drift_sample.sample_count == 3
+    assert result.drift_sample.median_seconds == 1000
+    assert result.drift_sample.recommended_budget_seconds == 1300
+    fetch_durations.assert_called_once()
+
+
+def test_fetch_recent_successful_ci_durations_parses_gh_run_list() -> None:
+    """The drift sampler should use run-list timestamps without inspecting every run."""
+    payload = json.dumps(
+        [
+            {
+                "databaseId": 1,
+                "displayTitle": "ok",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "updatedAt": "2026-06-01T00:10:00Z",
+            },
+            {
+                "databaseId": 2,
+                "displayTitle": "failed",
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "updatedAt": "2026-06-01T00:20:00Z",
+            },
+        ]
+    )
+    with patch("scripts.dev.watch_pr_ci_status._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=payload, stderr="")
+
+        durations = fetch_recent_successful_ci_durations(workflow="CI", limit=2)
+
+    assert durations == [600]
+
+
+def test_main_returns_timeout_exit_code(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI should map pending-over-budget to exit 2."""
+    with patch("scripts.dev.watch_pr_ci_status._fetch_ci_status") as fetch_status:
+        fetch_status.return_value = _status("pending")
+        with patch(
+            "scripts.dev.watch_pr_ci_status.fetch_recent_successful_ci_durations"
+        ) as samples:
+            samples.return_value = [1000]
+            rc = main(["42", "--baseline-seconds", "0", "--json"])
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["final_status"] == "timeout"

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -10,6 +10,8 @@ import pytest
 from scripts.dev.watch_pr_ci_status import (
     DEFAULT_BASELINE_SECONDS,
     DEFAULT_MULTIPLIER,
+    _duration_seconds,
+    _parse_timestamp,
     fetch_recent_successful_ci_durations,
     main,
     wait_budget_seconds,
@@ -144,3 +146,47 @@ def test_main_returns_timeout_exit_code(capsys: pytest.CaptureFixture[str]) -> N
     assert rc == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["final_status"] == "timeout"
+
+
+def test_parse_timestamp_accepts_any_and_returns_none_for_invalid() -> None:
+    """_parse_timestamp should handle Any input gracefully."""
+    assert _parse_timestamp(None) is None
+    assert _parse_timestamp("") is None
+    assert _parse_timestamp(42) is None
+    assert _parse_timestamp("not-a-timestamp") is None
+    assert _parse_timestamp("2026-06-01T00:00:00Z") is not None
+
+
+def test_duration_seconds_handles_timezone_mismatch() -> None:
+    """_duration_seconds should return None on tz-aware/naive TypeError."""
+    result = _duration_seconds("2026-06-01T00:00:00+00:00", "2026-06-01T00:10:00")
+    assert result is None
+
+
+def test_terminal_state_returns_immediate_error() -> None:
+    """CLOSED/MERGED PR state should return error without polling."""
+    fetch_status = MagicMock(
+        return_value={
+            "status": "ok",
+            "state": "CLOSED",
+            "pr": 42,
+            "head_sha": "abc123",
+            "checks": {},
+        }
+    )
+    result = watch_pr_ci_status(
+        pr_number="42",
+        fetch_status=fetch_status,
+        fetch_durations=MagicMock(),
+    )
+    assert result.final_status == "error"
+    assert "CLOSED" in result.error or "closed" in result.error
+
+
+def test_main_valueerror_on_invalid_args(capsys: pytest.CaptureFixture[str]) -> None:
+    """main should catch ValueError for invalid --multiplier."""
+    rc = main(["42", "--multiplier", "-1"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.err
+    assert "multiplier" in captured.err


### PR DESCRIPTION
## Summary
Adds drift-aware CI wait monitoring for goal autopilot so routine pending checks can be handled by a read-only monitor while the main loop continues safe work.

## Linked Issues
- Closes: NA
- Relates to: operator request to keep `goal-autopilot` efficient and parallelize CI waits where reasonable.
- Companion routing PR: https://github.com/ll7/codex-personal-skills/pull/37

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: Companion routing PR updates shared `ai-delegation-routing`; this PR includes the Robot SF helper and repo-local autopilot contract.

## What Changed
- Added `scripts/dev/watch_pr_ci_status.py`, a PR CI watcher that uses a stable default budget (`920s * 1.3 = 1196s`) and samples recent successful CI only after timeout/drift.
- Extended `scripts/dev/check_pr_ci_status.py` to report `headRefOid` as `head_sha` so wait monitors can detect stale PR heads.
- Updated `goal-autopilot` with an async CI wait policy and ledger fields for monitor runs.
- Updated `goal-pr-review` to hand `awaiting_ci` through the async wait policy instead of idling when other safe work remains.
- Added deterministic tests for success/failure/timeout/stale-head behavior and for the no-sampling-on-normal-success contract.

## Why It Matters
- Added value: goal autopilot can keep reviewing, merging already-green PRs, or discovering work while CI is pending.
- Expected impact: less main-thread idle time during the common CI wait path, without delegating readiness or merge decisions.
- Why this is worth merging now: the wait baseline is stable by default and only refreshes evidence when the budget is exceeded, matching the intended operator workflow.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling workflow improvement, no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke plus full PR readiness
- Result classification: blocker-resolution for autopilot efficiency
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it monitors GitHub CI state and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; helper and skill contract are covered.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py -q` -> `20 passed in 12.94s`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_ci_status.py scripts/dev/watch_pr_ci_status.py tests/dev/test_check_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_ci_status.py scripts/dev/watch_pr_ci_status.py tests/dev/test_check_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py --preflight goal-autopilot` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/sync_ai_config.py --check` -> passed
  - `scripts/dev/run_worktree_shared_venv.sh -- env PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> `5417 passed, 9 skipped, 8 warnings in 305.23s`, clean final stamp for `6dd97a379ce5aa2bfbbf9986dc4d2cfcdb787db6`
- Evidence that the change works here: unit tests prove default budget, success/failure exits, stale-head rejection, timeout drift sampling, and no runtime sampling on normal success.
- Benchmarks or smoke tests, if applicable: NA - no benchmark behavior changed.

## Risks / Rollout
- Compatibility risks: `watch_pr_ci_status.py` depends on GitHub CLI status JSON and run-list timestamp fields already used by repository CI tooling patterns.
- Failure modes: GitHub auth/API errors return `error`; over-budget pending checks return `timeout` with optional drift evidence; stale head SHA prevents false readiness.
- Rollback or fallback plan: continue using `scripts/dev/check_pr_ci_status.py` directly and remove the async wait policy text.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-autopilot/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`
- Relevant design or provenance notes: existing `docs/context/issue_1653_ci_runtime_slice.md` baseline supports the default `920s` runtime.
- Any assumptions that need to be preserved: do not refresh the committed CI wait baseline after one ordinary slow run; require repeated over-budget evidence or an obvious CI workflow change.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA - repo-local skill docs are the discoverable source for this workflow rule.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support/tooling workflow improvement, no benchmark/result propagation surface.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify closely that delegates only monitor CI and never own `merge-ready` or merge decisions.
- Known limitations: drift sampling runs only after timeout by design; the helper does not auto-update the committed baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced async CI wait policy for intelligent PR monitoring with configurable wait budgets and drift detection
  * Added new CI status monitoring tool with support for head SHA tracking and timeout handling

* **Documentation**
  * Updated workflow documentation to include CI waiting guidance and delegation procedures

* **Tests**
  * Added comprehensive test coverage for CI status monitoring functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->