### PR TITLE
docs: add autonomous usage pause guard

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -181,9 +181,10 @@ recorded cleanup.
 
 ### Usage Pause Guard
 
-When a user-defined Codex usage threshold is active, treat a `codex-usage-status`
-`threshold_decision.status: stop` result as a hard paused state for the autopilot
-loop, not as another recoverable phase outcome.
+When a user-defined Codex usage threshold is active, run the configured usage-check command. For the
+external `codex-usage-status` skill, that means its `read_codex_usage.py` helper with
+`--stop-below-remaining <percent> --json`. Treat a `threshold_decision.status: stop` result as a
+hard paused state for the autopilot loop, not as another recoverable phase outcome.
 
 Persist the stop decision in the common Git directory before returning so repeated
 automatic continue prompts can short-circuit without rereading repo state, rerunning

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -184,8 +184,13 @@ recorded cleanup.
 When a user-defined Codex usage threshold is active, run the configured usage-check command. For the
 external `codex-usage-status` skill, use the skill's `read_codex_usage.py` helper with
 `--stop-below-remaining <percent> --json`. That helper returns a `threshold_decision` object with
-`status: continue`, `status: stop`, or `status: unavailable`; treat `status: stop` as a hard paused
-state for the autopilot loop, not as another recoverable phase outcome.
+`status: continue`, `status: stop`, or `status: unavailable`. Handle every status explicitly:
+
+- `continue`: proceed with the next autopilot phase without creating or refreshing a pause record.
+- `stop`: enter a hard paused state for the autopilot loop, not another recoverable phase outcome.
+- `unavailable`: treat missing, malformed, or incomplete `threshold_decision` output as uncertain;
+  log the raw helper output in the ledger, do not create a hard pause record, and continue only with
+  conservative cleanup or handoff work unless the user explicitly permits a normal phase to proceed.
 
 Persist the stop decision in the common Git directory before returning so repeated
 automatic continue prompts can short-circuit without rereading repo state, rerunning
@@ -198,9 +203,11 @@ mkdir -p "$PAUSE_DIR"
 # $PAUSE_DIR/usage-pause.md
 ```
 
-The pause record should include the observed timestamp, threshold window,
-remaining percentage, threshold percentage, and whether the user may explicitly
-override the guardrail.
+The pause record should include the observed timestamp, threshold window, remaining percentage,
+threshold percentage, whether the user may explicitly override the guardrail, `lastUsageCheckAt`,
+and `usageCheckCooldownSeconds`. The default cooldown is 900 seconds. A caller may set a longer
+cooldown in the pause record, but automatic "continue" prompts must compare the current time against
+`lastUsageCheckAt + usageCheckCooldownSeconds` before invoking usage-check tooling again.
 
 While the usage pause is active:
 

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -179,6 +179,44 @@ only proves `route_status: completed`; the parent phase is not complete until th
 reviewed the output, integrated any edits, run the required validation, updated GitHub state, and
 recorded cleanup.
 
+### Usage Pause Guard
+
+When a user-defined Codex usage threshold is active, treat a `codex-usage-status`
+`threshold_decision.status: stop` result as a hard paused state for the autopilot
+loop, not as another recoverable phase outcome.
+
+Persist the stop decision in the common Git directory before returning so repeated
+automatic continue prompts can short-circuit without rereading repo state, rerunning
+GitHub operations, or restarting delegation:
+
+```bash
+PAUSE_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)/codex-agent-runs/active"
+mkdir -p "$PAUSE_DIR"
+# Write compact JSON/YAML/Markdown such as:
+# $PAUSE_DIR/usage-pause.md
+```
+
+The pause record should include the observed timestamp, threshold window,
+remaining percentage, threshold percentage, and whether the user may explicitly
+override the guardrail.
+
+While the usage pause is active:
+
+- do not run repo, worktree, GitHub, benchmark, validation, or delegation commands;
+- do not call usage-check tooling again on automatic "continue" prompts unless a
+  recorded cooldown has elapsed or the user explicitly asks for current usage;
+- do not load broad skill or repository context just to restate the pause;
+- respond to repeated automatic continue prompts with one compact sentence such as
+  `Paused: weekly remaining 13% < 28%. No actions.`;
+- keep the active goal incomplete unless a real completion audit already proved
+  all requirements before the pause fired.
+
+Resume only when the user explicitly overrides the stop guardrail, or when a fresh
+usage check requested by the user or allowed by the cooldown reports remaining
+budget at or above the threshold. If the first stop check happens while required
+cleanup is already in progress, finish only the minimal cleanup or follow-up issue
+creation named by the user's guardrail, then enter the persisted paused state.
+
 Update the ledger:
 
 - after a claim is acquired and the implementation worktree/branch is created;

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -151,7 +151,7 @@ directory so it survives linked worktrees, context compaction, and branch cleanu
 the PR diff:
 
 ```bash
-LEDGER_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)/codex-agent-runs/active"
+LEDGER_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
 mkdir -p "$LEDGER_DIR"
 ```
 
@@ -182,16 +182,17 @@ recorded cleanup.
 ### Usage Pause Guard
 
 When a user-defined Codex usage threshold is active, run the configured usage-check command. For the
-external `codex-usage-status` skill, that means its `read_codex_usage.py` helper with
-`--stop-below-remaining <percent> --json`. Treat a `threshold_decision.status: stop` result as a
-hard paused state for the autopilot loop, not as another recoverable phase outcome.
+external `codex-usage-status` skill, use the skill's `read_codex_usage.py` helper with
+`--stop-below-remaining <percent> --json`. That helper returns a `threshold_decision` object with
+`status: continue`, `status: stop`, or `status: unavailable`; treat `status: stop` as a hard paused
+state for the autopilot loop, not as another recoverable phase outcome.
 
 Persist the stop decision in the common Git directory before returning so repeated
 automatic continue prompts can short-circuit without rereading repo state, rerunning
 GitHub operations, or restarting delegation:
 
 ```bash
-PAUSE_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)/codex-agent-runs/active"
+PAUSE_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
 mkdir -p "$PAUSE_DIR"
 # Write compact JSON/YAML/Markdown such as:
 # $PAUSE_DIR/usage-pause.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,20 @@ Canonical note:
 
 - `docs/context/issue_713_batch_first_issue_workflow.md`
 
+## Autonomous Usage Stop Guard
+
+When a goal, background task, or autopilot loop has a Codex usage stop threshold, a usage check
+below that threshold is a hard pause state for the loop. Persist the pause in the common Git dir
+under `.git/codex-agent-runs/active/`, then short-circuit repeated automatic continue prompts
+without repo, GitHub, validation, delegation, or broad context-loading work.
+
+- Do not re-run usage checks on automatic continue prompts unless a recorded cooldown has elapsed.
+- A direct user request for current usage may run one fresh usage check.
+- A direct user override may resume work, but record that the stop guard was overridden.
+- Use a compact repeated-pause response such as `Paused: weekly remaining 13% < 28%. No actions.`
+- Do not mark the active goal complete while paused unless a real completion audit already proved
+  every requirement before the pause fired.
+
 ## Key Codex Skills
 
 For issue management and delivery, use these local skills:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,9 +374,11 @@ Canonical note:
 
 When a goal, background task, or autopilot loop has a Codex usage stop threshold, a usage check
 below that threshold is a hard pause state for the loop. Persist the pause in the common Git dir
-under `$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/`, then
-short-circuit repeated automatic continue prompts without repo, GitHub, validation, delegation, or
-broad context-loading work.
+resolved with `git rev-parse --path-format=absolute --git-common-dir`, for example
+`$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/`. Do not write
+to a literal worktree-relative `.git/codex-agent-runs/active/` path, because linked worktrees may
+store `.git` as a file. After recording the pause, short-circuit repeated automatic continue
+prompts without repo, GitHub, validation, delegation, or broad context-loading work.
 
 - Do not re-run usage checks on automatic continue prompts unless a recorded cooldown has elapsed.
 - A direct user request for current usage may run one fresh usage check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,8 +374,9 @@ Canonical note:
 
 When a goal, background task, or autopilot loop has a Codex usage stop threshold, a usage check
 below that threshold is a hard pause state for the loop. Persist the pause in the common Git dir
-under `.git/codex-agent-runs/active/`, then short-circuit repeated automatic continue prompts
-without repo, GitHub, validation, delegation, or broad context-loading work.
+under `$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/`, then
+short-circuit repeated automatic continue prompts without repo, GitHub, validation, delegation, or
+broad context-loading work.
 
 - Do not re-run usage checks on automatic continue prompts unless a recorded cooldown has elapsed.
 - A direct user request for current usage may run one fresh usage check.


### PR DESCRIPTION
## Summary

- add an explicit usage pause guard to `goal-autopilot`
- document top-level autonomous-loop behavior in `AGENTS.md`
- require persisted pause state, compact repeated-pause responses, usage-check cooldowns, and explicit resume conditions

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py`

## Research Result Guidance

NA. This is workflow/instruction hardening only; it makes no benchmark, metric, model-provenance, or paper-facing research claim.

## Downstream Propagation

- Parent issue / claim map: NA; direct maintainer-requested workflow fix.
- Context index / memory note: NA for this narrow instruction update.
- Registry / config index: NA; no skill frontmatter or generated index content changed.

## Notes

This PR addresses the observed failure mode where a below-threshold Codex usage stop was respected for tool calls but not treated as a terminal paused state for repeated automatic continue prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs describing an autonomous "Usage Pause Guard": when usage limits are hit the autopilot enters a persisted hard-pause, shows a compact paused response, prevents automated repo/GitHub/validation/delegation actions and repeated auto-continues, and requires explicit user override or an allowed fresh usage check (after cooldown) to resume. Active goals won’t be auto-completed while paused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->