### PR TITLE
test: add ScenarioBelief uncertainty gate evidence

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -218,6 +218,8 @@ knowledge, not every transient iteration detail.
   [issue_2565_uncertainty_gating_smoke.md](issue_2565_uncertainty_gating_smoke.md)
 * Issue #2538 ScenarioBelief Planner Projection Smoke:
   [issue_2538_scenario_belief_planner_projection.md](issue_2538_scenario_belief_planner_projection.md)
+* Issue #2606 Uncertainty Gate Evaluation:
+  [issue_2606_uncertainty_gate_evaluation.md](issue_2606_uncertainty_gate_evaluation.md)
 * Issue #2526 Cyclist-Like VRU Smoke:
   [issue_2526_cyclist_vru_smoke.md](issue_2526_cyclist_vru_smoke.md)
 * Issue #2527 Waiting-Then-Crossing Fixture:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -645,6 +645,14 @@ entries:
     status: evidence
     freshness: evidence
     area: learned_policy
+  - path: docs/context/issue_2606_uncertainty_gate_evaluation.md
+    status: current
+    freshness: evidence
+    area: learned_policy
+  - path: docs/context/evidence/issue_2606_uncertainty_gate/summary.json
+    status: evidence
+    freshness: evidence
+    area: learned_policy
   - path: docs/context/issue_2479_real_trajectory_scenario_prior.md
     status: proposal
     freshness: maintained

--- a/docs/context/evidence/issue_2606_uncertainty_gate/summary.json
+++ b/docs/context/evidence/issue_2606_uncertainty_gate/summary.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "diagnostic_smoke_summary.v1",
+  "issue": 2606,
+  "date": "2026-06-11",
+  "status": "diagnostic_only",
+  "benchmark_evidence": false,
+  "claim_boundary": "ScenarioBelief.to_uncertainty_report() can feed one planner input/projection without silently dropping covariance, confidence, class_probabilities, or existence metadata. This is interface-usable evidence, not benchmark-proven.",
+  "decision": "usable",
+  "decision_rationale": "Evidence shows all four target fields (covariance, confidence, class_probabilities, existence) reach the stream_gap planner input and affect the opt-in uncertainty gate decision. 'usable' means interface-usable, not benchmark-proven.",
+  "uncertainty_gate": {
+    "input_belief": "ScenarioBelief.to_uncertainty_report()",
+    "preserved_covariance": true,
+    "class_probabilities": true,
+    "planner_projection": "project_scenario_belief_for_planner(belief, planner_key='stream_gap')",
+    "unsupported_fields": [
+      "velocity_covariance_xy",
+      "velocity_confidence",
+      "visibility_state"
+    ],
+    "fields_consumed_by_planner": [
+      "existence_probability",
+      "position_confidence",
+      "class_probabilities.pedestrian",
+      "position_covariance_xy"
+    ],
+    "fields_preserved_but_not_consumed": [
+      "velocity_covariance_xy",
+      "velocity_confidence",
+      "visibility_state"
+    ]
+  },
+  "implementation": {
+    "report_source": "robot_sf/representation/scenario_belief.py",
+    "adapter": "robot_sf/planner/scenario_belief_adapter.py",
+    "planner": "robot_sf/planner/stream_gap.py",
+    "gate_schema": "stream-gap-uncertainty-gate.v1",
+    "adapter_schema": "scenario-belief-planner-projection.v1",
+    "default_behavior_changed": false,
+    "fail_closed_conditions": [
+      "missing_uncertainty_metadata",
+      "malformed_uncertainty_metadata",
+      "sidecar_length_less_than_pedestrian_count"
+    ]
+  },
+  "field_trace": {
+    "to_uncertainty_report_agents": [
+      "entity_id",
+      "class_probabilities",
+      "position_covariance_xy",
+      "velocity_covariance_xy",
+      "position_confidence",
+      "velocity_confidence",
+      "existence_probability",
+      "visibility_state"
+    ],
+    "adapter_sidecar_agents": [
+      "entity_id",
+      "class_probabilities",
+      "position_covariance_xy",
+      "velocity_covariance_xy",
+      "position_confidence",
+      "velocity_confidence",
+      "existence_probability",
+      "visibility_state"
+    ],
+    "planner_consumed_fields": [
+      "existence_probability",
+      "position_confidence",
+      "class_probabilities.pedestrian",
+      "position_covariance_xy"
+    ],
+    "preserved_not_consumed_fields": [
+      "velocity_covariance_xy",
+      "velocity_confidence",
+      "visibility_state"
+    ]
+  },
+  "test_results": {
+    "total_tests": 17,
+    "passed": 17,
+    "failed": 0,
+    "test_classes": [
+      {
+        "name": "TestUncertaintyReportFieldPreservation",
+        "tests": 6,
+        "description": "Verifies to_uncertainty_report() preserves all required metadata fields"
+      },
+      {
+        "name": "TestAdapterFieldPreservation",
+        "tests": 5,
+        "description": "Verifies project_scenario_belief_for_planner preserves uncertainty fields in sidecar"
+      },
+      {
+        "name": "TestPlannerConsumesUncertaintyFields",
+        "tests": 4,
+        "description": "Verifies stream_gap planner reads and acts on uncertainty fields"
+      },
+      {
+        "name": "TestEndToEndGateDecision",
+        "tests": 2,
+        "description": "Verifies uncertainty fields can change the planner commit/wait decision"
+      }
+    ]
+  },
+  "validation": [
+    {
+      "command": "uv run pytest tests/planner/test_scenario_belief_uncertainty_gate.py -v",
+      "result": "17 passed"
+    },
+    {
+      "command": "uv run ruff check tests/planner/test_scenario_belief_uncertainty_gate.py",
+      "result": "passed"
+    },
+    {
+      "command": "uv run ruff format --check tests/planner/test_scenario_belief_uncertainty_gate.py",
+      "result": "passed"
+    }
+  ],
+  "limitations": [
+    "Single-fixture diagnostic cannot support planner-performance or safety claims.",
+    "velocity_covariance_xy, velocity_confidence, and visibility_state are preserved in the sidecar but not consumed by the stream_gap planner gate.",
+    "No runtime observation-builder bridge is included.",
+    "Thresholds are diagnostic defaults and are not calibrated."
+  ],
+  "next_step": "Extend to runtime ScenarioBelief producer path, or add velocity uncertainty consumption to the planner gate if velocity covariance affects planning decisions."
+}

--- a/docs/context/issue_2606_uncertainty_gate_evaluation.md
+++ b/docs/context/issue_2606_uncertainty_gate_evaluation.md
@@ -1,0 +1,72 @@
+# Issue #2606 Uncertainty Gate Evaluation (2026-06-11)
+
+Status: diagnostic only, not benchmark evidence.
+
+Related surfaces:
+
+- Issue: https://github.com/ll7/robot_sf_ll7/issues/2606
+- Predecessors:
+  - [issue_2528_scenario_belief_consumer_smoke.md](issue_2528_scenario_belief_consumer_smoke.md)
+  - [issue_2565_uncertainty_gating_smoke.md](issue_2565_uncertainty_gating_smoke.md)
+  - [issue_2538_scenario_belief_planner_projection.md](issue_2538_scenario_belief_planner_projection.md)
+- Report source: `robot_sf/representation/scenario_belief.py` (`ScenarioBelief.to_uncertainty_report`)
+- Adapter: `robot_sf/planner/scenario_belief_adapter.py` (`project_scenario_belief_for_planner`)
+- Planner consumer: `robot_sf/planner/stream_gap.py` (`StreamGapPlannerAdapter._uncertainty_keep_mask`)
+- Tests: `tests/planner/test_scenario_belief_uncertainty_gate.py`
+- Evidence summary: [evidence/issue_2606_uncertainty_gate/summary.json](evidence/issue_2606_uncertainty_gate/summary.json)
+
+## Question
+
+Can `ScenarioBelief.to_uncertainty_report()` feed one planner input/projection without
+silently dropping covariance, confidence, class_probabilities, or existence metadata?
+
+## Result
+
+Yes. Evidence shows the full chain preserves all four target fields:
+
+1. **to_uncertainty_report()** produces agent rows with all 8 metadata fields:
+   `entity_id`, `class_probabilities`, `position_covariance_xy`, `velocity_covariance_xy`,
+   `position_confidence`, `velocity_confidence`, `existence_probability`, `visibility_state`.
+
+2. **project_scenario_belief_for_planner()** copies all 8 fields into the sidecar
+   without transformation. The sidecar matches the report exactly.
+
+3. **stream_gap planner** consumes 4 of 8 fields for gating decisions:
+   `existence_probability`, `position_confidence`, `class_probabilities.pedestrian`,
+   `position_covariance_xy` (as variance via trace/2).
+
+4. **3 fields are preserved but not consumed** by the stream_gap gate:
+   `velocity_covariance_xy`, `velocity_confidence`, `visibility_state`. These are
+   available for future planner extensions.
+
+5. The gate can change the planner's commit/wait decision based on uncertainty:
+   a low-confidence blocker is dropped (v > 0) while a high-confidence blocker is
+   kept (v == 0).
+
+## Decision: usable
+
+"Usable" means interface-usable: the fields reach the planner input and affect the
+opt-in gate. It does NOT mean benchmark-proven, safety-improved, or paper-facing.
+
+## Claim Boundary
+
+This is diagnostic-only evidence. It proves field preservation through the full
+ScenarioBelief-to-planner pipeline and that the stream_gap uncertainty gate reads
+and acts on the four consumed fields. It does not prove benchmark improvement,
+safety improvement, planner performance, perception calibration, or paper-facing
+result.
+
+## Validation
+
+```bash
+uv run pytest tests/planner/test_scenario_belief_uncertainty_gate.py -v
+uv run ruff check tests/planner/test_scenario_belief_uncertainty_gate.py
+uv run ruff format --check tests/planner/test_scenario_belief_uncertainty_gate.py
+```
+
+## Follow-Up
+
+- If velocity covariance should affect planning, extend `_uncertainty_row_metrics`
+  to consume `velocity_covariance_xy` and `velocity_confidence`.
+- Connect a runtime ScenarioBelief producer to the planner projection path.
+- Calibrate uncertainty thresholds for non-diagnostic use.

--- a/tests/planner/test_scenario_belief_uncertainty_gate.py
+++ b/tests/planner/test_scenario_belief_uncertainty_gate.py
@@ -64,6 +64,13 @@ def _belief_with_known_uncertainty():
             confidence=0.92,
             variance=0.1,
         ),
+        velocity=Estimate2D.point(
+            agent.velocity.mean_xy,
+            confidence=0.88,
+            variance=0.05,
+            units="m/s",
+            covariance_units="(m/s)^2",
+        ),
         existence_probability=0.95,
         class_probabilities=(("pedestrian", 0.98),),
     )
@@ -71,7 +78,7 @@ def _belief_with_known_uncertainty():
 
 
 def _belief_with_low_uncertainty():
-    """Return a ScenarioBelief with low uncertainty that should be gate-dropped.
+    """Return a ScenarioBelief with high uncertainty that should be gate-dropped.
 
     The agent has:
     - existence_probability = 0.2 (below gate threshold 0.5)
@@ -147,7 +154,7 @@ class TestUncertaintyReportFieldPreservation:
         agent_row = report["agents"][0]
 
         assert agent_row["position_confidence"] == pytest.approx(0.92)
-        assert isinstance(agent_row["velocity_confidence"], float)
+        assert agent_row["velocity_confidence"] == pytest.approx(0.88)
 
     def test_report_preserves_existence_probability(self) -> None:
         """Existence probability must match the belief source."""
@@ -164,7 +171,7 @@ class TestUncertaintyReportFieldPreservation:
         agent_row = report["agents"][0]
 
         vel_cov = np.asarray(agent_row["velocity_covariance_xy"])
-        assert np.all(np.isfinite(vel_cov))
+        assert np.allclose(vel_cov, np.diag([0.05, 0.05]), atol=1e-4)
 
 
 class TestAdapterFieldPreservation:

--- a/tests/planner/test_scenario_belief_uncertainty_gate.py
+++ b/tests/planner/test_scenario_belief_uncertainty_gate.py
@@ -1,0 +1,348 @@
+"""Diagnostic acceptance test for issue #2606: ScenarioBelief uncertainty gate evaluation.
+
+This test answers one bounded question: can ScenarioBelief.to_uncertainty_report() feed
+one planner input/projection without silently dropping covariance, confidence,
+class_probabilities, or existence metadata?
+
+Claim boundary: diagnostic only. Does not prove benchmark improvement, safety improvement,
+planner performance, perception calibration, or paper-facing result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.planner.scenario_belief_adapter import project_scenario_belief_for_planner
+from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, StreamGapPlannerConfig
+from robot_sf.representation import Estimate2D, scenario_belief_from_simulator_oracle
+
+
+def _blocking_belief():
+    """Return a ScenarioBelief with one blocking pedestrian at known metadata values."""
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[0.8, 0.0]], dtype=np.float32),
+        ped_vel=np.array([[0.0, 0.0]], dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=0.4),
+            )
+        ],
+        goal_pos=[np.array([4.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=8.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+    return scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+
+
+def _belief_with_known_uncertainty():
+    """Return a ScenarioBelief with explicit, distinguishable uncertainty metadata.
+
+    The agent has:
+    - existence_probability = 0.95 (high, above gate threshold)
+    - position confidence = 0.92 (high)
+    - class_probabilities = {"pedestrian": 0.98} (high)
+    - position_covariance_xy = [[0.1, 0.0], [0.0, 0.1]] (low variance, below gate threshold)
+    """
+    belief = _blocking_belief()
+    agent = belief.agents[0]
+    known_agent = replace(
+        agent,
+        position=Estimate2D.point(
+            agent.position.mean_xy,
+            confidence=0.92,
+            variance=0.1,
+        ),
+        existence_probability=0.95,
+        class_probabilities=(("pedestrian", 0.98),),
+    )
+    return replace(belief, agents=(known_agent,))
+
+
+def _belief_with_low_uncertainty():
+    """Return a ScenarioBelief with low uncertainty that should be gate-dropped.
+
+    The agent has:
+    - existence_probability = 0.2 (below gate threshold 0.5)
+    - position confidence = 0.2 (below gate threshold 0.5)
+    - class_probabilities = {"pedestrian": 0.2} (below gate threshold 0.5)
+    - position_covariance_xy = [[4.0, 0.0], [0.0, 4.0]] (high variance, above gate threshold 1.0)
+    """
+    belief = _blocking_belief()
+    agent = belief.agents[0]
+    known_agent = replace(
+        agent,
+        position=Estimate2D.point(
+            agent.position.mean_xy,
+            confidence=0.2,
+            variance=4.0,
+        ),
+        existence_probability=0.2,
+        class_probabilities=(("pedestrian", 0.2),),
+    )
+    return replace(belief, agents=(known_agent,))
+
+
+# --- Required fields in the uncertainty report agent row ---
+
+_REPORT_AGENT_REQUIRED_FIELDS = (
+    "entity_id",
+    "class_probabilities",
+    "position_covariance_xy",
+    "velocity_covariance_xy",
+    "position_confidence",
+    "velocity_confidence",
+    "existence_probability",
+    "visibility_state",
+)
+
+
+class TestUncertaintyReportFieldPreservation:
+    """Verify that to_uncertainty_report() preserves all required metadata fields."""
+
+    def test_report_has_all_required_agent_fields(self) -> None:
+        """Each agent row in the uncertainty report must carry all metadata fields."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+
+        assert len(report["agents"]) == 1
+        agent_row = report["agents"][0]
+        for field in _REPORT_AGENT_REQUIRED_FIELDS:
+            assert field in agent_row, f"missing field: {field}"
+
+    def test_report_preserves_class_probabilities(self) -> None:
+        """Class probabilities must match the belief's source data."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        agent_row = report["agents"][0]
+
+        assert agent_row["class_probabilities"] == {"pedestrian": pytest.approx(0.98)}
+
+    def test_report_preserves_covariance_shape(self) -> None:
+        """Position and velocity covariance must be 2x2 matrices."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        agent_row = report["agents"][0]
+
+        pos_cov = np.asarray(agent_row["position_covariance_xy"])
+        vel_cov = np.asarray(agent_row["velocity_covariance_xy"])
+        assert pos_cov.shape == (2, 2)
+        assert vel_cov.shape == (2, 2)
+
+    def test_report_preserves_confidence_values(self) -> None:
+        """Position and velocity confidence must match the belief source."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        agent_row = report["agents"][0]
+
+        assert agent_row["position_confidence"] == pytest.approx(0.92)
+        assert isinstance(agent_row["velocity_confidence"], float)
+
+    def test_report_preserves_existence_probability(self) -> None:
+        """Existence probability must match the belief source."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        agent_row = report["agents"][0]
+
+        assert agent_row["existence_probability"] == pytest.approx(0.95)
+
+    def test_report_preserves_velocity_covariance(self) -> None:
+        """Velocity covariance must survive the report even though stream_gap doesn't use it."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        agent_row = report["agents"][0]
+
+        vel_cov = np.asarray(agent_row["velocity_covariance_xy"])
+        assert np.all(np.isfinite(vel_cov))
+
+
+class TestAdapterFieldPreservation:
+    """Verify that project_scenario_belief_for_planner preserves uncertainty fields."""
+
+    def test_adapter_copies_all_agent_fields_to_sidecar(self) -> None:
+        """The uncertainty sidecar injected by the adapter must contain all report fields."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        assert projection.compatibility["status"] == "compatible"
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        assert len(sidecar) == 1
+        agent_row = sidecar[0]
+
+        for field in _REPORT_AGENT_REQUIRED_FIELDS:
+            assert field in agent_row, f"sidecar missing field: {field}"
+
+    def test_adapter_sidecar_matches_report_exactly(self) -> None:
+        """Sidecar agent rows must be equal to the uncertainty report agents."""
+        belief = _belief_with_known_uncertainty()
+        report = belief.to_uncertainty_report()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        assert sidecar[0] == report["agents"][0]
+
+    def test_adapter_preserves_covariance_in_sidecar(self) -> None:
+        """Covariance matrices must survive the adapter projection."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        pos_cov = np.asarray(sidecar[0]["position_covariance_xy"])
+        assert pos_cov.shape == (2, 2)
+        assert np.allclose(pos_cov, np.diag([0.1, 0.1]), atol=1e-4)
+
+    def test_adapter_preserves_class_probabilities_in_sidecar(self) -> None:
+        """Class probabilities must survive the adapter projection."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        assert sidecar[0]["class_probabilities"]["pedestrian"] == pytest.approx(0.98)
+
+    def test_adapter_preserves_existence_in_sidecar(self) -> None:
+        """Existence probability must survive the adapter projection."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        assert sidecar[0]["existence_probability"] == pytest.approx(0.95)
+
+
+class TestPlannerConsumesUncertaintyFields:
+    """Verify that the stream_gap planner actually reads and acts on uncertainty fields."""
+
+    def test_high_confidence_agent_is_kept_by_planner(self) -> None:
+        """A high-confidence blocker should remain after gating (not dropped)."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        planner = StreamGapPlannerAdapter(
+            StreamGapPlannerConfig(
+                uncertainty_gating_enabled=True,
+                uncertainty_min_existence_probability=0.5,
+                uncertainty_min_position_confidence=0.5,
+                uncertainty_min_class_probability=0.5,
+                uncertainty_max_position_variance=1.0,
+            )
+        )
+        v, _ = planner.plan(projection.observation)
+
+        assert v == 0.0
+        assert planner.last_uncertainty_gate["status"] == "applied"
+        assert planner.last_uncertainty_gate["kept_count"] == 1
+        assert planner.last_uncertainty_gate["dropped_count"] == 0
+
+    def test_low_confidence_agent_is_dropped_by_planner(self) -> None:
+        """A low-confidence blocker should be dropped when gating is enabled."""
+        belief = _belief_with_low_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        planner = StreamGapPlannerAdapter(
+            StreamGapPlannerConfig(
+                uncertainty_gating_enabled=True,
+                uncertainty_min_existence_probability=0.5,
+                uncertainty_min_position_confidence=0.5,
+                uncertainty_min_class_probability=0.5,
+                uncertainty_max_position_variance=1.0,
+            )
+        )
+        v, _ = planner.plan(projection.observation)
+
+        assert v > 0.0
+        assert planner.last_uncertainty_gate["status"] == "applied"
+        assert planner.last_uncertainty_gate["dropped_count"] == 1
+        reasons = set(planner.last_uncertainty_gate["dropped_reasons"][0]["reasons"])
+        assert "existence_probability_below_threshold" in reasons
+        assert "position_confidence_below_threshold" in reasons
+        assert "class_probability_below_threshold" in reasons
+        assert "position_variance_above_threshold" in reasons
+
+    def test_planner_reads_all_four_gating_fields(self) -> None:
+        """The planner must parse existence, confidence, class_prob, and variance from each row."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+        sidecar = projection.observation["pedestrians"]["uncertainty"]
+        agent_row = sidecar[0]
+
+        planner = StreamGapPlannerAdapter(StreamGapPlannerConfig(uncertainty_gating_enabled=True))
+        metrics = planner._uncertainty_row_metrics(agent_row)
+
+        assert metrics is not None
+        existence, confidence, class_probability, variance = metrics
+        assert existence == pytest.approx(0.95)
+        assert confidence == pytest.approx(0.92)
+        assert class_probability == pytest.approx(0.98)
+        assert variance == pytest.approx(0.1)
+
+    def test_planner_gate_disabled_preserves_all_rows(self) -> None:
+        """When gating is disabled, all rows must survive regardless of uncertainty values."""
+        belief = _belief_with_low_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        planner = StreamGapPlannerAdapter(StreamGapPlannerConfig(uncertainty_gating_enabled=False))
+        v, _ = planner.plan(projection.observation)
+
+        assert v == 0.0
+        assert planner.last_uncertainty_gate["status"] == "disabled"
+        assert planner.last_uncertainty_gate["kept_count"] == 1
+        assert planner.last_uncertainty_gate["dropped_count"] == 0
+
+
+class TestEndToEndGateDecision:
+    """Verify that uncertainty fields can change the planner's commit/wait decision."""
+
+    def test_uncertainty_gate_changes_planner_decision(self) -> None:
+        """With the same geometry, gating must change v from 0 to >0 for a low-confidence blocker."""
+        belief = _belief_with_low_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        deterministic = StreamGapPlannerAdapter(StreamGapPlannerConfig())
+        v_det, _ = deterministic.plan(projection.observation)
+
+        gated = StreamGapPlannerAdapter(
+            StreamGapPlannerConfig(
+                uncertainty_gating_enabled=True,
+                uncertainty_min_existence_probability=0.5,
+                uncertainty_min_position_confidence=0.5,
+                uncertainty_min_class_probability=0.5,
+                uncertainty_max_position_variance=1.0,
+            )
+        )
+        v_gated, _ = gated.plan(projection.observation)
+
+        assert v_det == 0.0
+        assert v_gated > 0.0
+        assert gated.last_uncertainty_gate["status"] == "applied"
+
+    def test_high_confidence_uncertainty_does_not_change_decision(self) -> None:
+        """A high-confidence blocker should keep the planner waiting even with gating enabled."""
+        belief = _belief_with_known_uncertainty()
+        projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+        deterministic = StreamGapPlannerAdapter(StreamGapPlannerConfig())
+        v_det, _ = deterministic.plan(projection.observation)
+
+        gated = StreamGapPlannerAdapter(
+            StreamGapPlannerConfig(
+                uncertainty_gating_enabled=True,
+                uncertainty_min_existence_probability=0.5,
+                uncertainty_min_position_confidence=0.5,
+                uncertainty_min_class_probability=0.5,
+                uncertainty_max_position_variance=1.0,
+            )
+        )
+        v_gated, _ = gated.plan(projection.observation)
+
+        assert v_det == 0.0
+        assert v_gated == 0.0


### PR DESCRIPTION
## Summary
- Adds a targeted ScenarioBelief uncertainty-gate acceptance test for issue #2606.
- Records a diagnostic-only context note and compact evidence summary showing which uncertainty fields are preserved, consumed, and not consumed by the stream-gap projection/gate.
- Indexes the new evidence surface in the context README and catalog.

## Linked Issues
- Closes #2606

## Stack / Dependency
- Base dependency: none
- Required prior PRs: existing ScenarioBelief uncertainty/report/projection work is already on `origin/main`.
- Stack follow-up issues: none required.
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `tests/planner/test_scenario_belief_uncertainty_gate.py`.
- Added `docs/context/issue_2606_uncertainty_gate_evaluation.md`.
- Added `docs/context/evidence/issue_2606_uncertainty_gate/summary.json`.
- Updated `docs/context/README.md` and `docs/context/catalog.yaml` for discoverability.

## Why It Matters
- Added value: turns ScenarioBelief uncertainty preservation into a planner-facing diagnostic instead of another isolated representation smoke.
- Expected impact: future planner work can see that covariance, confidence, class probabilities, and existence metadata reach the stream-gap input path and which fields remain unused.
- Why this is worth merging now: #2606 is a bounded research-value issue with local validation and no benchmark campaign required.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: `ScenarioBelief.to_uncertainty_report()` can feed one planner input/projection without silently dropping the target uncertainty metadata.
- Comparator or baseline, if applicable: legacy deterministic `to_socnav_struct()` projection and the existing opt-in stream-gap uncertainty sidecar.
- Evidence tier: targeted unit/diagnostic smoke plus tracked compact evidence summary.
- Result classification: diagnostic-only; interface usable for this planner input.
- Decision or stop rule, if applicable: `usable` means fields reach the selected planner input and affect the opt-in gate; it does not mean benchmark or safety improvement.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2606_uncertainty_gate_evaluation.md` and `docs/context/catalog.yaml`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no broad analysis tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? The uncertainty gate applies when explicitly enabled in `StreamGapPlannerAdapter`.
- Did the intervention change command source, selected command, trajectory, or route progress? The unit diagnostic changes a local planner commit/wait decision for the same geometry; no trajectory or benchmark run is claimed.
- Did the scenario actually contain the targeted failure mode? The fixture contains a blocking pedestrian with low-confidence uncertainty metadata for the gate to drop.
- Result route: narrow diagnostic smoke.
- Follow-up question or issue for weak, negative, or non-transfer results: runtime ScenarioBelief producer/observation-builder bridge remains future work.

## Next Empirical Action
- Rerun needed: no for this diagnostic proof.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no.
- Stop / revise / continue decision: continue only toward runtime producer integration or velocity-uncertainty consumption; do not claim planner performance from this PR.
- Proposed child issue or existing follow-up: none opened.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/planner/test_scenario_belief_uncertainty_gate.py -v`
  - `rtk uv run ruff check tests/planner/test_scenario_belief_uncertainty_gate.py`
  - `rtk uv run ruff format --check tests/planner/test_scenario_belief_uncertainty_gate.py`
  - `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_2606_uncertainty_gate_evaluation.md --path docs/context/evidence/issue_2606_uncertainty_gate/summary.json --path docs/context/README.md --path docs/context/catalog.yaml`
  - `rtk git diff --check HEAD~1..HEAD`
- Evidence that the change works here: 17 targeted tests passed at branch head; ruff and docs/proof checks passed; committed diff whitespace check passed.
- Benchmarks or smoke tests, if applicable: targeted unit/diagnostic smoke only; no benchmark evidence generated.

## Risks / Rollout
- Compatibility risks: low; default planner behavior is unchanged because uncertainty gating remains opt-in.
- Failure modes: reviewers could read `usable` too broadly, so docs/evidence define it as interface-usable only.
- Rollback or fallback plan: revert the diagnostic test and context/evidence entries.

## Docs / Provenance
- Updated docs: `docs/context/issue_2606_uncertainty_gate_evaluation.md`, `docs/context/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: `docs/context/issue_2528_scenario_belief_consumer_smoke.md`, `docs/context/issue_2538_scenario_belief_planner_projection.md`, `docs/context/issue_2565_uncertainty_gating_smoke.md`.
- Any assumptions that need to be preserved: `usable` is not a benchmark, safety, calibration, or paper-facing performance claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2606.
- Claim map / benchmark report updated (yes/no/NA): NA; this is not benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context README and catalog updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this PR adds diagnostic interface evidence only, not a benchmark result or artifact dependency.

## Follow-Up Issues
- Deferred work: optional runtime ScenarioBelief producer bridge or velocity-uncertainty gate extension.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the evidence summary distinguishes fields consumed by stream-gap from fields preserved but not consumed.
- Any known limitations: no runtime observation-builder path, no calibrated thresholds, and no performance/safety claim.
