### PR TITLE
feat: expose signal-state proxy trace fields

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3053,9 +3053,14 @@ def _intent_trace_payload(metadata: dict[str, Any], velocity: np.ndarray) -> dic
         "claim_boundary": metadata["claim_boundary"],
         "behavior_parameters": metadata["behavior_parameters"],
     }
-    signal_payload = _signal_state_trace_payload(metadata.get("signal_state"), phase)
-    if signal_payload is not None:
-        payload["signal_state"] = signal_payload
+    proxy_payload = _signal_state_proxy_wrapper(
+        metadata.get("signal_state"),
+        phase,
+        metadata["intent_label"],
+        metadata["intent_source"],
+    )
+    if proxy_payload is not None:
+        payload["signal_state"] = proxy_payload
     return payload
 
 
@@ -3098,6 +3103,76 @@ def _signal_state_trace_payload(signal_state: Any, intent_phase: str) -> dict[st
             signal_state.get("claim_boundary")
             or "Proxy signal-state metadata only; not benchmark evidence."
         ),
+    }
+
+
+_PROXY_TRACE_FIELDS_PRESENT = [
+    "signal_phase",
+    "pedestrian_intent",
+    "robot_stop_or_yield_expectation",
+    "claim_boundary",
+    "trace_fields_present",
+    "signal_state",
+]
+
+
+def _synth_robot_stop_or_yield_expectation(
+    robot_right_of_way: bool,
+    pedestrian_right_of_way: bool,
+    legality_state: str,
+) -> str:
+    """Synthesize a robot stop-or-yield expectation from proxy right-of-way fields.
+
+    Returns:
+        str: Diagnostic expectation label for trace/summary metadata.
+    """
+    if legality_state == "pedestrian_wait_required" and robot_right_of_way:
+        return "proceed_clear"
+    if legality_state == "pedestrian_crossing_allowed" and pedestrian_right_of_way:
+        return "yield_to_pedestrian"
+    if pedestrian_right_of_way:
+        return "yield_to_pedestrian"
+    return "proceed_clear"
+
+
+def _signal_state_proxy_wrapper(
+    signal_state: Any,
+    intent_phase: str,
+    intent_label: str,
+    intent_source: str,
+) -> dict[str, Any] | None:
+    """Wrap signal-state proxy with bounded diagnostic fields for trace/summary export.
+
+    This wrapper adds pedestrian_intent, robot_stop_or_yield_expectation,
+    trace_fields_present, and claim_boundary=proxy_diagnostic on top of the
+    existing signal-state trace payload. It does not add runtime simulation
+    behavior or planner-observable signal-phase semantics.
+
+    Returns:
+        dict[str, Any] | None: Proxy diagnostic payload, or None when the
+        input signal_state is absent.
+    """
+    base = _signal_state_trace_payload(signal_state, intent_phase)
+    if base is None:
+        return None
+
+    pedestrian_intent = {
+        "intent_label": intent_label,
+        "intent_phase": intent_phase,
+        "intent_source": intent_source,
+    }
+    robot_stop_or_yield_expectation = _synth_robot_stop_or_yield_expectation(
+        base["robot_right_of_way"],
+        base["pedestrian_right_of_way"],
+        base["legality_state"],
+    )
+    return {
+        **base,
+        "signal_phase": base["phase"],
+        "pedestrian_intent": pedestrian_intent,
+        "robot_stop_or_yield_expectation": robot_stop_or_yield_expectation,
+        "trace_fields_present": list(_PROXY_TRACE_FIELDS_PRESENT),
+        "claim_boundary": "proxy_diagnostic",
     }
 
 
@@ -3198,25 +3273,42 @@ def _intent_conditioned_behavior_summary(
         None,
     )
     if isinstance(signal_state, dict):
-        summary["signal_state"] = {
-            "schema_version": str(signal_state.get("schema_version") or "signal-state-proxy.v1"),
-            "status": str(signal_state.get("status") or "proxy_diagnostic_only"),
-            "signal_id": str(signal_state.get("signal_id") or "unknown_signal"),
-            "conflict_zone_id": str(
-                signal_state.get("conflict_zone_id") or "unknown_conflict_zone"
+        first_intent = next(
+            (
+                metadata
+                for metadata in summarized_pedestrians
+                if isinstance(metadata, dict) and metadata.get("intent_label")
             ),
-            "planner_observable": bool(signal_state.get("planner_observable", False)),
-            "observation_mode": str(signal_state.get("observation_mode") or "trace_metadata_only"),
-            "benchmark_evidence": bool(signal_state.get("benchmark_evidence", False)),
-            "claim_boundary": str(
-                signal_state.get("claim_boundary")
-                or "Proxy signal-state metadata only; not benchmark evidence."
-            ),
-            "trace_fields": [
-                "pedestrians[].signal_state",
-                "pedestrians[].intent_phase",
-            ],
-        }
+            {},
+        )
+        phases = first_intent.get("intent_phases")
+        first_phase = str(phases[0]) if isinstance(phases, list) and phases else "unknown"
+        proxy_payload = _signal_state_proxy_wrapper(
+            signal_state,
+            first_phase,
+            str(first_intent.get("intent_label", "unknown")),
+            str(first_intent.get("intent_source", "unknown")),
+        )
+        summary["signal_state"] = (
+            proxy_payload
+            if proxy_payload is not None
+            else {
+                "schema_version": str(
+                    signal_state.get("schema_version") or "signal-state-proxy.v1"
+                ),
+                "status": str(signal_state.get("status") or "proxy_diagnostic_only"),
+                "signal_id": str(signal_state.get("signal_id") or "unknown_signal"),
+                "conflict_zone_id": str(
+                    signal_state.get("conflict_zone_id") or "unknown_conflict_zone"
+                ),
+                "planner_observable": bool(signal_state.get("planner_observable", False)),
+                "observation_mode": str(
+                    signal_state.get("observation_mode") or "trace_metadata_only"
+                ),
+                "benchmark_evidence": bool(signal_state.get("benchmark_evidence", False)),
+                "claim_boundary": "proxy_diagnostic",
+            }
+        )
     return summary
 
 

--- a/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
@@ -9,6 +9,7 @@ import yaml
 
 from robot_sf.benchmark.map_runner import (
     _intent_conditioned_behavior_summary,
+    _signal_state_proxy_wrapper,
     _single_pedestrian_intent_metadata,
     _trace_pedestrians,
 )
@@ -77,19 +78,41 @@ def test_issue_2527_intent_metadata_reaches_trace_and_summary_fields() -> None:
     assert waiting_frame["intent_source"] == "authored_scenario_metadata"
     assert "not data-grounded" in waiting_frame["claim_boundary"]
     assert waiting_frame["signal_state"]["phase"] == "robot_green_pedestrian_dont_walk"
+    assert waiting_frame["signal_state"]["claim_boundary"] == "proxy_diagnostic"
+    assert waiting_frame["signal_state"]["pedestrian_intent"] == {
+        "intent_label": "waiting_then_crossing",
+        "intent_phase": "waiting",
+        "intent_source": "authored_scenario_metadata",
+    }
+    assert waiting_frame["signal_state"]["robot_stop_or_yield_expectation"] == "proceed_clear"
+    assert {
+        "signal_phase",
+        "pedestrian_intent",
+        "robot_stop_or_yield_expectation",
+        "claim_boundary",
+        "trace_fields_present",
+    }.issubset(waiting_frame["signal_state"]["trace_fields_present"])
     assert waiting_frame["signal_state"]["pedestrian_right_of_way"] is False
     assert crossing_frame["intent_phase"] == "crossing"
     assert crossing_frame["signal_state"]["phase"] == "pedestrian_walk_robot_red"
+    assert crossing_frame["signal_state"]["pedestrian_intent"]["intent_phase"] == "crossing"
+    assert (
+        crossing_frame["signal_state"]["robot_stop_or_yield_expectation"] == "yield_to_pedestrian"
+    )
     assert crossing_frame["signal_state"]["pedestrian_right_of_way"] is True
     assert summary is not None
     assert summary["status"] == "diagnostic_metadata_only"
     assert summary["benchmark_evidence"] is False
     assert summary["trace_field_source"].endswith("pedestrians[]")
     assert summary["signal_state"]["status"] == "proxy_diagnostic_only"
-    assert summary["signal_state"]["trace_fields"] == [
-        "pedestrians[].signal_state",
-        "pedestrians[].intent_phase",
-    ]
+    assert summary["signal_state"]["claim_boundary"] == "proxy_diagnostic"
+    assert summary["signal_state"]["pedestrian_intent"] == {
+        "intent_label": "waiting_then_crossing",
+        "intent_phase": "waiting",
+        "intent_source": "authored_scenario_metadata",
+    }
+    assert summary["signal_state"]["robot_stop_or_yield_expectation"] == "proceed_clear"
+    assert "trace_fields_present" in summary["signal_state"]
 
 
 def test_issue_2527_mixed_single_pedestrian_intent_metadata_stays_aligned() -> None:
@@ -120,3 +143,66 @@ def test_issue_2527_mixed_single_pedestrian_intent_metadata_stays_aligned() -> N
     assert "pedestrian_id" not in frames[1]
     assert summary is not None
     assert [ped["pedestrian_id"] for ped in summary["pedestrians"]] == ["h1"]
+
+
+def test_signal_state_proxy_wrapper_exposes_bounded_diagnostic_fields() -> None:
+    """The proxy wrapper must expose all five required fields with claim_boundary=proxy_diagnostic."""
+    scenario = _scenario_payload()
+    signal_state = scenario["metadata"]["signal_state"]
+
+    waiting_proxy = _signal_state_proxy_wrapper(
+        signal_state, "waiting", "waiting_then_crossing", "authored_scenario_metadata"
+    )
+    crossing_proxy = _signal_state_proxy_wrapper(
+        signal_state, "crossing", "waiting_then_crossing", "authored_scenario_metadata"
+    )
+
+    assert waiting_proxy is not None
+    assert crossing_proxy is not None
+
+    for proxy in (waiting_proxy, crossing_proxy):
+        assert "signal_phase" in proxy
+        assert "pedestrian_intent" in proxy
+        assert "robot_stop_or_yield_expectation" in proxy
+        assert "trace_fields_present" in proxy
+        assert proxy["claim_boundary"] == "proxy_diagnostic"
+        assert "intent_label" in proxy["pedestrian_intent"]
+        assert "intent_phase" in proxy["pedestrian_intent"]
+        assert "intent_source" in proxy["pedestrian_intent"]
+
+    assert waiting_proxy["signal_phase"] == "robot_green_pedestrian_dont_walk"
+    assert waiting_proxy["robot_stop_or_yield_expectation"] == "proceed_clear"
+    assert waiting_proxy["pedestrian_intent"]["intent_phase"] == "waiting"
+
+    assert crossing_proxy["signal_phase"] == "pedestrian_walk_robot_red"
+    assert crossing_proxy["robot_stop_or_yield_expectation"] == "yield_to_pedestrian"
+    assert crossing_proxy["pedestrian_intent"]["intent_phase"] == "crossing"
+
+    assert "signal_state" in waiting_proxy["trace_fields_present"]
+    assert "pedestrian_intent" in waiting_proxy["trace_fields_present"]
+
+
+def test_intent_summary_handles_missing_or_empty_intent_phases() -> None:
+    """Malformed phase metadata should fall back to unknown instead of crashing summaries."""
+    scenario = _scenario_payload()
+    signal_state = scenario["metadata"]["signal_state"]
+
+    for malformed_phases in (None, []):
+        summary = _intent_conditioned_behavior_summary(
+            scenario,
+            [
+                {
+                    "pedestrian_id": "h1",
+                    "intent_label": "waiting_then_crossing",
+                    "intent_phases": malformed_phases,
+                    "intent_source": "authored_scenario_metadata",
+                    "claim_boundary": "diagnostic_metadata_only",
+                    "behavior_parameters": {},
+                    "signal_state": signal_state,
+                }
+            ],
+        )
+
+        assert summary is not None
+        assert summary["signal_state"]["pedestrian_intent"]["intent_phase"] == "unknown"
+        assert summary["signal_state"]["signal_phase"] == "robot_green_pedestrian_dont_walk"


### PR DESCRIPTION
## Summary

- Add a bounded signal-state proxy wrapper around the existing waiting-then-crossing trace payload.
- Expose the requested diagnostic fields: `signal_phase`, `pedestrian_intent`, `robot_stop_or_yield_expectation`, `trace_fields_present`, and `claim_boundary=proxy_diagnostic`.
- Extend focused fixture tests so waiting and crossing phases prove the proxy field contract without implying planner-observable traffic-light semantics.

Closes #2605.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py -q` — 9 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py` — passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py` — passed

## Downstream Propagation

- Parent/synthesis surface: #2521 remains the parent research lane.
- Existing context/evidence surfaces from #2564 already document the proxy smoke and compact tracked evidence; this PR narrows the runtime trace/summary field contract to match #2605 acceptance.
- No new large `output/` artifacts are committed. Coverage output from local pytest was discarded.
- No benchmark report, leaderboard, or planner registry update is required because this is diagnostic trace metadata only.

## Research Result Guidance

- Target claim/hypothesis/blocker: signal-state proxy metadata can be preserved through the waiting-then-crossing diagnostic path with explicit stop/yield expectation fields.
- Comparator/baseline: existing #2555/#2564 waiting-then-crossing fixture and signal-state trace payload before the explicit #2605 wrapper fields.
- Evidence tier: targeted smoke/unit proof over the trace/summary metadata contract.
- Result classification: diagnostic-only proxy metadata.
- Decision/stop rule: stop at proxy trace metadata; do not promote to planner-observable signal semantics, full traffic-light simulation, planner ranking, benchmark-strength improvement, or paper-facing evidence.
- Synthesis surface/update target: #2605 and parent #2521; existing #2564 context note remains the compact smoke evidence pointer.
