### PR TITLE
feat: add safe SLURM submission queue

### DIFF
--- a/.agents/skills/goal-slurm-experiment/SKILL.md
+++ b/.agents/skills/goal-slurm-experiment/SKILL.md
@@ -119,6 +119,12 @@ Do not use it for:
      is exploratory.
 
 7. Submit exactly one training job.
+   - When the selected candidate has or should have a queue entry, update
+     `experiments/submission_queue.yaml` and run
+     `uv run python scripts/dev/submit_training_jobs.py --dry-run` before submission.
+   - Use `uv run python scripts/dev/submit_training_jobs.py --submit` for auto-submit only after
+     the entry is `ready_to_submit`, `auto_submit: true`, local machine policy allows SLURM, and
+     duplicate checks pass.
    - Submit through existing wrappers such as `scripts/dev/sbatch_use_max_time.sh` or a
      candidate-specific helper under `scripts/dev/`.
    - Use a short skill-owned job name: `gse-<issue>-<slug>`.
@@ -164,6 +170,9 @@ fresh rerun is the stated next action.
 ## Guardrails
 
 - Never submit more than one `gse-` training job at a time.
+- Never bypass `scripts/dev/submit_training_jobs.py` for a queue-backed training candidate unless
+  the queue entry is blocked or the helper cannot represent the existing launcher; document that
+  exception in the handoff.
 - Never count `slurm_pr_gate` validation jobs as the active training job.
 - Do not run full PR readiness or all-tests gates locally; submit them to SLURM.
 - Do not submit from an unintended branch, dirty worktree, or stale `origin/main` base without

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -46,11 +46,15 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
    condition, and diagnostic-preservation action. If these are missing, classify the candidate as
    `blocked-needs-scope` until the card is updated.
 6. Run any campaign-specific launch-packet validator before `sbatch` when one exists under `scripts/validation/`.
-7. Submit with explicit config and job name; capture job ID plus stdout/stderr paths.
-8. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
-9. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
-10. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
-11. After completion or predeclared cancellation, route results before rerunning:
+7. For queue-backed training jobs, run
+   `uv run python scripts/dev/submit_training_jobs.py --dry-run` and submit through
+   `uv run python scripts/dev/submit_training_jobs.py --submit` only when the generated manifest
+   shows the intended config, launcher, job name, output root, and duplicate-check evidence.
+8. Submit non-queue campaigns with explicit config and job name; capture job ID plus stdout/stderr paths.
+9. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
+10. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
+11. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
+12. After completion or predeclared cancellation, route results before rerunning:
     - cancelled runs may be diagnostic evidence only when the early-stop criteria were declared and
       the configured preservation action captured logs, manifest, config, commit, and artifact
       status;
@@ -62,6 +66,8 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 ## Guardrails
 
 - Do not infer live cluster capacity from stale logs.
+- Do not bypass `scripts/dev/submit_training_jobs.py` for queue-backed training jobs unless the
+  helper cannot represent the launcher; record the exception and the equivalent duplicate checks.
 - Do not submit from an unintended branch or dirty tree without calling that out.
 - Do not treat a queued job as completed evidence.
 - Do not cancel a low-signal training job as diagnostic evidence unless the early-stop rule was

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -23,6 +23,48 @@ The wrapper:
 This keeps new submissions aligned with the live cluster policy even if the script still
 contains an older fallback value.
 
+## Training submission queue
+
+Use `experiments/submission_queue.yaml` for reviewable planned training submissions that should be
+safe for agents to dry-run and, on SLURM-capable hosts, auto-submit after all gates pass. The queue
+is planned intent only: GitHub issues remain the backlog, and submitted/running/completed state
+belongs in issue comments or `docs/context/issue_1544_slurm_experiment_state_ledger.md`.
+
+Run a dry-run manifest before any submission:
+
+```bash
+uv run python scripts/dev/submit_training_jobs.py --dry-run
+```
+
+This validates queue entries, records branch/commit/dirty-tree state, builds the wrapper command,
+checks local duplicate evidence such as existing output roots, and writes a timestamped manifest
+under `output/slurm/submissions/`.
+
+Submit eligible entries only from a SLURM-capable host:
+
+```bash
+uv run python scripts/dev/submit_training_jobs.py --submit
+```
+
+Submit mode additionally requires:
+
+- `local.machine.md` must explicitly set `allow_slurm_submission: true`;
+- the entry status is `ready_to_submit`;
+- `auto_submit: true`;
+- the config or launcher path exists;
+- the output root is absent;
+- live `squeue` and recent `sacct` checks do not show an equivalent job;
+- no other active `gse-` training job is present;
+- the existing wrapper exits successfully and returns a job id.
+
+Equivalent submissions are duplicates when they match the same issue/objective lane, config or
+launcher, seed set, commit or declared code version, target cluster, job name, or output root. A
+duplicate blocks `--submit`; reruns should use a new queue id, changed output root, and documented
+reason.
+
+Final reports should include the generated manifest path, job id, cluster/host, command, branch,
+commit SHA, config, launcher, seed set, output/log paths, skipped entries, and monitoring command.
+
 ## Examples
 
 Dry run before submitting:

--- a/experiments/submission_queue.yaml
+++ b/experiments/submission_queue.yaml
@@ -1,0 +1,35 @@
+schema_version: slurm-submission-queue.v1
+description: >
+  Reviewable queue for planned SLURM training submissions. GitHub issues remain the central
+  backlog, and submitted/running/completed state belongs in issue trails and the SLURM experiment
+  state ledger. Entries become runnable only after they are marked ready_to_submit and pass
+  scripts/dev/submit_training_jobs.py gates.
+entries:
+  - id: issue-1977-bc-warm-start-ppo
+    status: planned
+    issue: 1977
+    objective: >
+      Rerun the clean BC warm-start PPO follow-up from the preserved issue #1108 artifact.
+    config: configs/training/ppo_imitation/ppo_finetune_issue_1977_bc_warm_start_rerun.yaml
+    launcher: SLURM/Auxme/issue_1977_bc_warm_start_ppo.sl
+    target:
+      cluster: auxme
+      host: licca
+    resources:
+      gpus: 1
+      cpus: 8
+      memory: 32G
+      walltime: 1-12:00:00
+    seeds:
+      - 0
+    output_root: output/slurm/issue1977-bc-warm-start-ppo
+    log_path: output/slurm/%j-issue1977-bc-warm-start-ppo.out
+    priority_reason: >
+      Issue #1977 is a concrete rerun lane with tracked config and launcher surfaces.
+    auto_submit: false
+    job_name: gse-1977-bcppo
+    wrapper: scripts/dev/sbatch_issue1977_bc_warm_start_ppo.sh
+    wrapper_args:
+      - --config
+      - configs/training/ppo_imitation/ppo_finetune_issue_1977_bc_warm_start_rerun.yaml
+      - --no-status

--- a/scripts/dev/submit_training_jobs.py
+++ b/scripts/dev/submit_training_jobs.py
@@ -89,7 +89,11 @@ class QueueEntry:
         if not isinstance(auto_submit, bool):
             raise QueueValidationError(f"{queue_id}: auto_submit must be boolean")
 
-        wrapper = payload.get("wrapper", "scripts/dev/sbatch_use_max_time.sh")
+        wrapper_default = "scripts/dev/sbatch_use_max_time.sh"
+        wrapper_raw = payload.get("wrapper")
+        if wrapper_raw is not None and not isinstance(wrapper_raw, str):
+            raise QueueValidationError(f"{queue_id}: wrapper must be a string")
+        wrapper = wrapper_raw or wrapper_default
         wrapper_path = repo_root / wrapper
         if not wrapper_path.is_file():
             raise QueueValidationError(f"{queue_id}: wrapper not found: {wrapper}")
@@ -113,7 +117,7 @@ class QueueEntry:
             priority_reason=str(payload["priority_reason"]),
             auto_submit=auto_submit,
             job_name=str(payload.get("job_name") or f"gse-{payload['issue']}-{queue_id}"),
-            wrapper=str(wrapper),
+            wrapper=wrapper,
             wrapper_args=wrapper_args,
             sbatch_args=sbatch_args,
         )
@@ -170,6 +174,10 @@ def _validate_entry_paths(
     """Validate that an entry names at least one existing execution surface."""
     if _is_missing(config) and _is_missing(launcher):
         raise QueueValidationError(f"{queue_id}: either config or launcher is required")
+    if config is not None and not isinstance(config, str):
+        raise QueueValidationError(f"{queue_id}: config must be a string")
+    if launcher is not None and not isinstance(launcher, str):
+        raise QueueValidationError(f"{queue_id}: launcher must be a string")
     if config and not (repo_root / config).is_file():
         raise QueueValidationError(f"{queue_id}: config not found: {config}")
     if launcher and not (repo_root / launcher).is_file():
@@ -194,7 +202,9 @@ def _require_list(payload: dict[str, Any], field: str, queue_id: str) -> list[An
 
 def _optional_string_list(payload: dict[str, Any], field: str, queue_id: str) -> list[str]:
     """Return an optional list of strings."""
-    value = payload.get(field, [])
+    value = payload.get(field)
+    if value is None:
+        return []
     if not isinstance(value, list) or not all(isinstance(arg, str) for arg in value):
         raise QueueValidationError(f"{queue_id}: {field} must be a list of strings")
     return value
@@ -382,6 +392,26 @@ def _manifest_duplicate_evidence(entry: QueueEntry, *, repo_root: Path) -> list[
     return evidence
 
 
+def _parse_squeue_job_names(output: str) -> list[str]:
+    """Extract job names from squeue whitespace-separated output (column 2)."""
+    names: list[str] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] not in ("JOBID",):
+            names.append(parts[1])
+    return names
+
+
+def _parse_sacct_job_names(output: str) -> list[str]:
+    """Extract job names from sacct -P pipe-separated output (field 2)."""
+    names: list[str] = []
+    for line in output.splitlines():
+        fields = line.split("|")
+        if len(fields) >= 2 and fields[0] not in ("JobID",):
+            names.append(fields[1])
+    return names
+
+
 def _scheduler_duplicate_evidence(
     entry: QueueEntry,
     *,
@@ -390,14 +420,16 @@ def _scheduler_duplicate_evidence(
 ) -> list[str]:
     """Return scheduler reasons this entry appears to duplicate an existing run."""
     evidence: list[str] = []
-    if entry.job_name and entry.job_name in active_jobs:
+    active_names = _parse_squeue_job_names(active_jobs)
+    recent_names = _parse_sacct_job_names(recent_jobs)
+    if entry.job_name and entry.job_name in active_names:
         evidence.append(f"active job with name {entry.job_name}")
-    if entry.job_name and entry.job_name in recent_jobs:
+    if entry.job_name and entry.job_name in recent_names:
         evidence.append(f"recent job with name {entry.job_name}")
     if entry.job_name.startswith("gse-"):
-        for line in active_jobs.splitlines():
-            if "gse-" in line and entry.job_name not in line:
-                evidence.append(f"another active gse job: {line.strip()}")
+        for name in active_names:
+            if name.startswith("gse-") and name != entry.job_name:
+                evidence.append(f"another active gse job: {name}")
                 break
     return evidence
 
@@ -476,13 +508,16 @@ def _git_state(repo_root: Path) -> dict[str, Any]:
 
 def _run_git(repo_root: Path, command: list[str]) -> str:
     """Run a git command and return stripped stdout, tolerating unavailable Git in tests."""
-    completed = subprocess.run(
-        command,
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return ""
     if completed.returncode != 0:
         return ""
     return completed.stdout.strip()

--- a/scripts/dev/submit_training_jobs.py
+++ b/scripts/dev/submit_training_jobs.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Plan and safely submit queued SLURM training jobs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+QUEUE_SCHEMA_VERSION = "slurm-submission-queue.v1"
+ALLOWED_STATUSES = {"planned", "ready_to_submit", "blocked", "superseded"}
+REQUIRED_FIELDS = (
+    "id",
+    "status",
+    "issue",
+    "objective",
+    "target",
+    "resources",
+    "seeds",
+    "output_root",
+    "log_path",
+    "priority_reason",
+    "auto_submit",
+)
+
+
+class QueueValidationError(ValueError):
+    """Raised when the submission queue is malformed."""
+
+
+class SubmissionBlockedError(RuntimeError):
+    """Raised when a queued job is unsafe to submit."""
+
+
+@dataclass(frozen=True)
+class QueueEntry:
+    """One planned SLURM training submission."""
+
+    queue_id: str
+    status: str
+    issue: int | str
+    objective: str
+    config: str | None
+    launcher: str | None
+    target: dict[str, Any]
+    resources: dict[str, Any]
+    seeds: list[int | str]
+    output_root: str
+    log_path: str
+    priority_reason: str
+    auto_submit: bool
+    job_name: str
+    wrapper: str
+    wrapper_args: list[str]
+    sbatch_args: list[str]
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any], repo_root: Path) -> QueueEntry:
+        """Validate and build one queue entry from YAML data."""
+        missing = [field for field in REQUIRED_FIELDS if _is_missing(payload.get(field))]
+        if missing:
+            raise QueueValidationError(f"{payload.get('id', '<unknown>')}: missing {missing[0]}")
+
+        queue_id = str(payload["id"])
+        status = payload["status"]
+        if status not in ALLOWED_STATUSES:
+            raise QueueValidationError(
+                f"{queue_id}: status must be one of {sorted(ALLOWED_STATUSES)}"
+            )
+
+        config = payload.get("config")
+        launcher = payload.get("launcher")
+        _validate_entry_paths(queue_id, config=config, launcher=launcher, repo_root=repo_root)
+
+        target = _require_mapping(payload, "target", queue_id)
+        if _is_missing(target.get("cluster")):
+            raise QueueValidationError(f"{queue_id}: target.cluster is required")
+        resources = _require_mapping(payload, "resources", queue_id)
+        seeds = _require_list(payload, "seeds", queue_id)
+        auto_submit = payload["auto_submit"]
+        if not isinstance(auto_submit, bool):
+            raise QueueValidationError(f"{queue_id}: auto_submit must be boolean")
+
+        wrapper = payload.get("wrapper", "scripts/dev/sbatch_use_max_time.sh")
+        wrapper_path = repo_root / wrapper
+        if not wrapper_path.is_file():
+            raise QueueValidationError(f"{queue_id}: wrapper not found: {wrapper}")
+        if not os.access(wrapper_path, os.X_OK):
+            raise QueueValidationError(f"{queue_id}: wrapper is not executable: {wrapper}")
+        sbatch_args = _optional_string_list(payload, "sbatch_args", queue_id)
+        wrapper_args = _optional_string_list(payload, "wrapper_args", queue_id)
+
+        return cls(
+            queue_id=queue_id,
+            status=status,
+            issue=payload["issue"],
+            objective=str(payload["objective"]),
+            config=str(config) if config else None,
+            launcher=str(launcher) if launcher else None,
+            target=target,
+            resources=resources,
+            seeds=seeds,
+            output_root=str(payload["output_root"]),
+            log_path=str(payload["log_path"]),
+            priority_reason=str(payload["priority_reason"]),
+            auto_submit=auto_submit,
+            job_name=str(payload.get("job_name") or f"gse-{payload['issue']}-{queue_id}"),
+            wrapper=str(wrapper),
+            wrapper_args=wrapper_args,
+            sbatch_args=sbatch_args,
+        )
+
+
+@dataclass(frozen=True)
+class SubmissionPlanResult:
+    """Result of a dry-run or submit pass."""
+
+    manifest_path: Path
+    jobs: list[dict[str, Any]]
+    skipped: list[dict[str, Any]]
+
+
+def load_queue(queue_path: Path, *, repo_root: Path) -> list[QueueEntry]:
+    """Load and validate queued SLURM submissions."""
+    try:
+        payload = yaml.safe_load(queue_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise QueueValidationError(f"cannot read queue: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise QueueValidationError(f"invalid queue YAML: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise QueueValidationError("queue YAML must be a mapping")
+    if payload.get("schema_version") != QUEUE_SCHEMA_VERSION:
+        raise QueueValidationError(
+            f"expected schema_version {QUEUE_SCHEMA_VERSION!r}, found {payload.get('schema_version')!r}"
+        )
+    entries_payload = payload.get("entries")
+    if not isinstance(entries_payload, list):
+        raise QueueValidationError("entries must be a list")
+
+    entries: list[QueueEntry] = []
+    seen: set[str] = set()
+    for entry_payload in entries_payload:
+        if not isinstance(entry_payload, dict):
+            raise QueueValidationError("entry must be a mapping")
+        entry = QueueEntry.from_mapping(entry_payload, repo_root)
+        if entry.queue_id in seen:
+            raise QueueValidationError(f"duplicate id: {entry.queue_id}")
+        seen.add(entry.queue_id)
+        entries.append(entry)
+    return entries
+
+
+def _validate_entry_paths(
+    queue_id: str,
+    *,
+    config: Any,
+    launcher: Any,
+    repo_root: Path,
+) -> None:
+    """Validate that an entry names at least one existing execution surface."""
+    if _is_missing(config) and _is_missing(launcher):
+        raise QueueValidationError(f"{queue_id}: either config or launcher is required")
+    if config and not (repo_root / config).is_file():
+        raise QueueValidationError(f"{queue_id}: config not found: {config}")
+    if launcher and not (repo_root / launcher).is_file():
+        raise QueueValidationError(f"{queue_id}: launcher not found: {launcher}")
+
+
+def _require_mapping(payload: dict[str, Any], field: str, queue_id: str) -> dict[str, Any]:
+    """Return a required mapping field."""
+    value = payload[field]
+    if not isinstance(value, dict):
+        raise QueueValidationError(f"{queue_id}: {field} must be a mapping")
+    return value
+
+
+def _require_list(payload: dict[str, Any], field: str, queue_id: str) -> list[Any]:
+    """Return a required non-empty list field."""
+    value = payload[field]
+    if not isinstance(value, list) or not value:
+        raise QueueValidationError(f"{queue_id}: {field} must be a non-empty list")
+    return value
+
+
+def _optional_string_list(payload: dict[str, Any], field: str, queue_id: str) -> list[str]:
+    """Return an optional list of strings."""
+    value = payload.get(field, [])
+    if not isinstance(value, list) or not all(isinstance(arg, str) for arg in value):
+        raise QueueValidationError(f"{queue_id}: {field} must be a list of strings")
+    return value
+
+
+def deterministic_experiment_id(entry: QueueEntry, *, commit: str) -> str:
+    """Return a stable experiment id for duplicate detection and reporting."""
+    seed_part = "seed" + "-".join(str(seed) for seed in entry.seeds)
+    cluster = _slug(str(entry.target["cluster"]))
+    return f"{_slug(entry.queue_id)}_{seed_part}_{commit[:7]}_{cluster}"
+
+
+def plan_submissions(
+    *,
+    queue_path: Path,
+    repo_root: Path,
+    submit: bool,
+    now: str | None = None,
+) -> SubmissionPlanResult:
+    """Dry-run or submit safe queue entries and write a manifest."""
+    repo_root = repo_root.resolve()
+    entries = load_queue(queue_path, repo_root=repo_root)
+    git_state = _git_state(repo_root)
+    timestamp = now or _timestamp()
+    manifest_dir = repo_root / "output" / "slurm" / "submissions"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    if submit and not _local_allows_slurm(repo_root):
+        raise SubmissionBlockedError("local.machine.md does not allow_slurm_submission")
+
+    jobs: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for entry in entries:
+        if entry.status != "ready_to_submit":
+            skipped.append(
+                {
+                    "queue_id": entry.queue_id,
+                    "status": "skipped",
+                    "reason": f"entry status is {entry.status}",
+                }
+            )
+            continue
+        if submit and not entry.auto_submit:
+            raise SubmissionBlockedError(f"{entry.queue_id}: auto_submit is false")
+        duplicate_evidence = _local_duplicate_evidence(entry, repo_root=repo_root)
+        if not duplicate_evidence:
+            active_jobs = _query_active_jobs(repo_root, submit=submit)
+            recent_jobs = _query_recent_jobs(repo_root, submit=submit)
+            duplicate_evidence.extend(
+                _scheduler_duplicate_evidence(
+                    entry,
+                    active_jobs=active_jobs,
+                    recent_jobs=recent_jobs,
+                )
+            )
+        if submit:
+            _assert_submit_allowed(entry, duplicate_evidence=duplicate_evidence)
+
+        command = _build_command(entry, repo_root=repo_root, dry_run=not submit)
+        job = _job_manifest(entry, git_state=git_state, command=command, repo_root=repo_root)
+        job["duplicate_check"] = duplicate_evidence
+        if submit:
+            completed = subprocess.run(
+                command,
+                cwd=repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            job["stdout"] = completed.stdout.strip()
+            job["stderr"] = completed.stderr.strip()
+            job["exit_code"] = completed.returncode
+            if completed.returncode != 0:
+                raise SubmissionBlockedError(
+                    f"{entry.queue_id}: wrapper failed with exit {completed.returncode}"
+                )
+            job["slurm_job_id"] = _parse_job_id(completed.stdout)
+            job["status"] = "submitted"
+        else:
+            job["status"] = "dry_run"
+            job["slurm_job_id"] = "not_submitted"
+        jobs.append(job)
+
+    manifest = {
+        "schema_version": "slurm-submission-manifest.v1",
+        "created_at": timestamp,
+        "mode": "submit" if submit else "dry-run",
+        "queue_path": str(queue_path),
+        "repository": str(repo_root),
+        "git": git_state,
+        "jobs": jobs,
+        "skipped": skipped,
+    }
+    manifest_path = manifest_dir / f"{timestamp}_training_submission_manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    return SubmissionPlanResult(manifest_path=manifest_path, jobs=jobs, skipped=skipped)
+
+
+def _assert_submit_allowed(entry: QueueEntry, *, duplicate_evidence: list[str]) -> None:
+    """Raise when a queue entry may not auto-submit."""
+    if not entry.auto_submit:
+        raise SubmissionBlockedError(f"{entry.queue_id}: auto_submit is false")
+    if duplicate_evidence:
+        raise SubmissionBlockedError(f"{entry.queue_id}: {'; '.join(duplicate_evidence)}")
+
+
+def _job_manifest(
+    entry: QueueEntry,
+    *,
+    git_state: dict[str, Any],
+    command: list[str],
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Build the manifest row for one queue entry."""
+    return {
+        "queue_id": entry.queue_id,
+        "issue": entry.issue,
+        "objective": entry.objective,
+        "experiment_id": deterministic_experiment_id(entry, commit=git_state["commit"]),
+        "branch": git_state["branch"],
+        "commit": git_state["commit"],
+        "dirty_tree": git_state["dirty"],
+        "config": entry.config,
+        "launcher": entry.launcher,
+        "target": entry.target,
+        "resources": entry.resources,
+        "seeds": entry.seeds,
+        "output_root": entry.output_root,
+        "log_path": entry.log_path,
+        "priority_reason": entry.priority_reason,
+        "job_name": entry.job_name,
+        "command": [str(_display_path(arg, repo_root)) for arg in command],
+    }
+
+
+def _build_command(entry: QueueEntry, *, repo_root: Path, dry_run: bool) -> list[str]:
+    """Return the wrapper command for one queue entry."""
+    command = [str(repo_root / entry.wrapper)]
+    if dry_run:
+        command.append("--dry-run")
+    command.extend(entry.wrapper_args)
+    command.extend(["--sbatch-arg", f"--job-name={entry.job_name}"])
+    command.extend(entry.sbatch_args)
+    if entry.launcher:
+        command.append(entry.launcher)
+    return command
+
+
+def _local_duplicate_evidence(entry: QueueEntry, *, repo_root: Path) -> list[str]:
+    """Return local filesystem reasons this entry appears to duplicate a run."""
+    evidence: list[str] = []
+    output_root = repo_root / entry.output_root
+    if output_root.exists():
+        evidence.append(f"output_root exists: {entry.output_root}")
+    evidence.extend(_manifest_duplicate_evidence(entry, repo_root=repo_root))
+    return evidence
+
+
+def _manifest_duplicate_evidence(entry: QueueEntry, *, repo_root: Path) -> list[str]:
+    """Return duplicate evidence from prior generated submission manifests."""
+    manifest_dir = repo_root / "output" / "slurm" / "submissions"
+    if not manifest_dir.exists():
+        return []
+
+    evidence: list[str] = []
+    for manifest_path in sorted(manifest_dir.glob("*_training_submission_manifest.yaml")):
+        try:
+            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(manifest, dict):
+            continue
+        jobs = manifest.get("jobs", [])
+        if not isinstance(jobs, list):
+            continue
+        for job in jobs:
+            if not isinstance(job, dict) or job.get("status") != "submitted":
+                continue
+            if job.get("queue_id") == entry.queue_id:
+                evidence.append(f"prior manifest submitted queue id: {manifest_path.name}")
+                return evidence
+            if job.get("output_root") == entry.output_root:
+                evidence.append(f"prior manifest used output_root: {manifest_path.name}")
+                return evidence
+    return evidence
+
+
+def _scheduler_duplicate_evidence(
+    entry: QueueEntry,
+    *,
+    active_jobs: str,
+    recent_jobs: str,
+) -> list[str]:
+    """Return scheduler reasons this entry appears to duplicate an existing run."""
+    evidence: list[str] = []
+    if entry.job_name and entry.job_name in active_jobs:
+        evidence.append(f"active job with name {entry.job_name}")
+    if entry.job_name and entry.job_name in recent_jobs:
+        evidence.append(f"recent job with name {entry.job_name}")
+    if entry.job_name.startswith("gse-"):
+        for line in active_jobs.splitlines():
+            if "gse-" in line and entry.job_name not in line:
+                evidence.append(f"another active gse job: {line.strip()}")
+                break
+    return evidence
+
+
+def _query_active_jobs(repo_root: Path, *, submit: bool) -> str:
+    """Return live SLURM queue text, or empty text in dry-run when unavailable."""
+    if shutil.which("squeue") is None:
+        if submit:
+            raise SubmissionBlockedError("squeue is required for submit mode")
+        return ""
+    completed = subprocess.run(
+        ["squeue", "--me", "--format=%i %j %T %P %M %l %R"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        if submit:
+            raise SubmissionBlockedError(f"squeue failed: {completed.stderr.strip()}")
+        return ""
+    return completed.stdout
+
+
+def _query_recent_jobs(repo_root: Path, *, submit: bool) -> str:
+    """Return recent accounting text, or empty text in dry-run when unavailable."""
+    if shutil.which("sacct") is None:
+        if submit:
+            raise SubmissionBlockedError("sacct is required for submit mode")
+        return ""
+    completed = subprocess.run(
+        [
+            "sacct",
+            "-u",
+            os.environ.get("USER", ""),
+            "--starttime",
+            "now-3days",
+            "--format=JobID,JobName%64,State,ExitCode,Start,End",
+            "-P",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        if submit:
+            raise SubmissionBlockedError(f"sacct failed: {completed.stderr.strip()}")
+        return ""
+    return completed.stdout
+
+
+def _local_allows_slurm(repo_root: Path) -> bool:
+    """Return whether local.machine.md explicitly permits SLURM submission."""
+    machine_context = repo_root / "local.machine.md"
+    if not machine_context.exists():
+        return False
+    text = machine_context.read_text(encoding="utf-8")
+    match = re.search(r"^\s*(?:-\s*)?allow_slurm_submission:\s*(\S+)\s*$", text, re.MULTILINE)
+    if match is None:
+        return False
+    return match.group(1).lower() == "true"
+
+
+def _git_state(repo_root: Path) -> dict[str, Any]:
+    """Return branch, commit, and dirty tree summary for the manifest."""
+    branch = _run_git(repo_root, ["git", "branch", "--show-current"]) or "unknown"
+    commit = _run_git(repo_root, ["git", "rev-parse", "HEAD"]) or "unknown"
+    dirty = _run_git(repo_root, ["git", "status", "--short"])
+    return {
+        "branch": branch,
+        "commit": commit,
+        "dirty": dirty.splitlines() if dirty else [],
+    }
+
+
+def _run_git(repo_root: Path, command: list[str]) -> str:
+    """Run a git command and return stripped stdout, tolerating unavailable Git in tests."""
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def _parse_job_id(stdout: str) -> str:
+    """Extract the scheduler job id from sbatch output."""
+    match = re.search(r"Submitted batch job\s+(\S+)", stdout)
+    return match.group(1) if match else "unknown"
+
+
+def _timestamp() -> str:
+    """Return a filesystem-safe UTC timestamp."""
+    from datetime import UTC, datetime
+
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
+def _slug(value: str) -> str:
+    """Return a conservative slug suitable for experiment ids."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-").lower()
+    return slug or "unknown"
+
+
+def _display_path(value: str, repo_root: Path) -> str:
+    """Display absolute wrapper paths as repo-relative when possible."""
+    path = Path(value)
+    if not path.is_absolute():
+        return value
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return value
+
+
+def _is_missing(value: Any) -> bool:
+    """Return whether a required value is absent or empty."""
+    return value is None or value in ("", [], {})
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the queue helper CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--queue",
+        type=Path,
+        default=Path("experiments/submission_queue.yaml"),
+        help="Path to the SLURM submission queue YAML.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Write a manifest without submitting.")
+    mode.add_argument("--submit", action="store_true", help="Submit eligible queue entries.")
+    args = parser.parse_args(argv)
+
+    submit = args.submit
+    try:
+        result = plan_submissions(
+            queue_path=args.queue,
+            repo_root=Path.cwd(),
+            submit=submit,
+        )
+    except (QueueValidationError, SubmissionBlockedError) as exc:
+        print(f"submit_training_jobs: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"manifest: {result.manifest_path}")
+    print(f"jobs: {len(result.jobs)} skipped: {len(result.skipped)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/dev/test_submit_training_jobs.py
+++ b/tests/dev/test_submit_training_jobs.py
@@ -1,0 +1,335 @@
+"""Tests for the safe SLURM training submission queue helper."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from scripts.dev import submit_training_jobs
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_minimal_repo(tmp_path: Path, *, allow_slurm: bool = False) -> Path:
+    repo = tmp_path
+    (repo / "configs" / "training").mkdir(parents=True)
+    (repo / "configs" / "training" / "example.yaml").write_text("training: {}\n")
+    (repo / "SLURM" / "Auxme").mkdir(parents=True)
+    (repo / "SLURM" / "Auxme" / "example.sl").write_text("#!/usr/bin/env bash\n")
+    (repo / "scripts" / "dev").mkdir(parents=True)
+    wrapper = repo / "scripts" / "dev" / "sbatch_use_max_time.sh"
+    wrapper.write_text("#!/usr/bin/env bash\necho Submitted batch job 4242\n")
+    wrapper.chmod(0o755)
+    (repo / "local.machine.md").write_text(
+        f"allow_slurm_submission: {'true' if allow_slurm else 'false'}\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _queue_payload(**overrides: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": "issue-999-example",
+        "status": "ready_to_submit",
+        "issue": 999,
+        "objective": "Run the example training smoke on a compute node.",
+        "config": "configs/training/example.yaml",
+        "launcher": "SLURM/Auxme/example.sl",
+        "target": {"cluster": "auxme", "host": "licca"},
+        "resources": {"gpus": 1, "cpus": 4, "memory": "16G", "walltime": "02:00:00"},
+        "seeds": [0, 1],
+        "output_root": "output/slurm/issue999-example",
+        "log_path": "output/slurm/%j-issue999-example.out",
+        "priority_reason": "Covers the current training follow-up.",
+        "auto_submit": True,
+        "job_name": "gse-999-example",
+        "wrapper": "scripts/dev/sbatch_use_max_time.sh",
+    }
+    entry.update(overrides)
+    return {"schema_version": "slurm-submission-queue.v1", "entries": [entry]}
+
+
+def _write_queue(repo: Path, payload: dict[str, Any]) -> Path:
+    queue_path = repo / "experiments" / "submission_queue.yaml"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return queue_path
+
+
+def test_load_queue_rejects_missing_required_field(tmp_path: Path) -> None:
+    """Queue entries must not become runnable when required provenance is absent."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload()
+    del payload["entries"][0]["priority_reason"]
+    queue_path = _write_queue(repo, payload)
+
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="priority_reason"):
+        submit_training_jobs.load_queue(queue_path, repo_root=repo)
+
+
+def test_load_queue_rejects_duplicate_ids(tmp_path: Path) -> None:
+    """Each queue id should identify exactly one planned submission."""
+    repo = _write_minimal_repo(tmp_path)
+    first = _queue_payload()["entries"][0]
+    payload = {"schema_version": "slurm-submission-queue.v1", "entries": [first, dict(first)]}
+    queue_path = _write_queue(repo, payload)
+
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="duplicate id"):
+        submit_training_jobs.load_queue(queue_path, repo_root=repo)
+
+
+def test_load_queue_rejects_wrong_schema_version(tmp_path: Path) -> None:
+    """Queue files should declare the supported schema version."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload()
+    payload["schema_version"] = "old-schema"
+    queue_path = _write_queue(repo, payload)
+
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="schema_version"):
+        submit_training_jobs.load_queue(queue_path, repo_root=repo)
+
+
+def test_load_queue_rejects_missing_config_path(tmp_path: Path) -> None:
+    """Runnable entries should not reference absent config paths."""
+    repo = _write_minimal_repo(tmp_path)
+    queue_path = _write_queue(repo, _queue_payload(config="configs/training/missing.yaml"))
+
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="config not found"):
+        submit_training_jobs.load_queue(queue_path, repo_root=repo)
+
+
+def test_dry_run_writes_manifest_without_calling_sbatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry runs should produce reviewable manifests but never submit jobs."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=False)
+    queue_path = _write_queue(repo, _queue_payload())
+    calls: list[list[str]] = []
+    monkeypatch.setattr(submit_training_jobs.shutil, "which", lambda name: None)
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "branch"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="feature\n", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command in dry run: {cmd}")
+
+    monkeypatch.setattr(submit_training_jobs.subprocess, "run", fake_run)
+
+    result = submit_training_jobs.plan_submissions(
+        queue_path=queue_path,
+        repo_root=repo,
+        submit=False,
+        now="2026-06-11T10-30-00",
+    )
+
+    assert result.manifest_path.exists()
+    manifest = yaml.safe_load(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["mode"] == "dry-run"
+    assert manifest["jobs"][0]["queue_id"] == "issue-999-example"
+    assert manifest["jobs"][0]["status"] == "dry_run"
+    assert "--dry-run" in manifest["jobs"][0]["command"]
+    assert not any("sbatch_use_max_time.sh" in " ".join(call) for call in calls)
+
+
+def test_submit_requires_slurm_enabled_machine(tmp_path: Path) -> None:
+    """Auto-submit must honor local.machine.md and refuse non-SLURM hosts."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=False)
+    queue_path = _write_queue(repo, _queue_payload())
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="allow_slurm_submission"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_submit_requires_explicit_local_machine_allow_when_file_is_absent(tmp_path: Path) -> None:
+    """Submit mode should fail closed when local machine policy is absent."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    (repo / "local.machine.md").unlink()
+    queue_path = _write_queue(repo, _queue_payload(status="planned"))
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="allow_slurm_submission"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_submit_rejects_bulleted_local_machine_slurm_policy(tmp_path: Path) -> None:
+    """The real local.machine.md style uses Markdown bullets and must still block submit."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    (repo / "local.machine.md").write_text("- allow_slurm_submission: false\n", encoding="utf-8")
+    queue_path = _write_queue(repo, _queue_payload(status="planned"))
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="allow_slurm_submission"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_submit_invokes_wrapper_and_captures_job_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Eligible submit mode should call the existing wrapper and record the scheduler id."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    queue_path = _write_queue(repo, _queue_payload())
+    monkeypatch.setattr(submit_training_jobs.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["git", "branch"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="feature\n", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "squeue":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "sacct":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0].endswith("sbatch_use_max_time.sh"):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Submitted batch job 4242\n", stderr=""
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(submit_training_jobs.subprocess, "run", fake_run)
+
+    result = submit_training_jobs.plan_submissions(
+        queue_path=queue_path,
+        repo_root=repo,
+        submit=True,
+        now="2026-06-11T10-30-00",
+    )
+
+    manifest = yaml.safe_load(result.manifest_path.read_text(encoding="utf-8"))
+    assert result.jobs[0]["status"] == "submitted"
+    assert manifest["jobs"][0]["slurm_job_id"] == "4242"
+    assert "--dry-run" not in manifest["jobs"][0]["command"]
+
+
+def test_submit_blocks_when_auto_submit_is_false(tmp_path: Path) -> None:
+    """Submit mode should require explicit queue-level auto-submit consent."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    queue_path = _write_queue(repo, _queue_payload(auto_submit=False))
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="auto_submit is false"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_submit_blocks_when_wrapper_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed wrapper should block submission and expose the exit status."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    queue_path = _write_queue(repo, _queue_payload())
+    monkeypatch.setattr(submit_training_jobs.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["git", "branch"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="feature\n", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "squeue":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "sacct":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0].endswith("sbatch_use_max_time.sh"):
+            return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="bad wrapper")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(submit_training_jobs.subprocess, "run", fake_run)
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="wrapper failed"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_output_root_duplicate_blocks_submission(tmp_path: Path) -> None:
+    """An existing output root should prevent equivalent auto-submit attempts."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    (repo / "output" / "slurm" / "issue999-example").mkdir(parents=True)
+    queue_path = _write_queue(repo, _queue_payload())
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="output_root exists"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_recent_manifest_duplicate_blocks_submission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prior submitted manifest for the same queue id should block auto-submit."""
+    repo = _write_minimal_repo(tmp_path, allow_slurm=True)
+    queue_path = _write_queue(repo, _queue_payload())
+    manifest_dir = repo / "output" / "slurm" / "submissions"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "2026-06-10T00-00-00Z_training_submission_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "slurm-submission-manifest.v1",
+                "jobs": [
+                    {
+                        "queue_id": "issue-999-example",
+                        "status": "submitted",
+                        "experiment_id": "issue-999-example_seed0-1_abc1234_auxme",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(submit_training_jobs.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    with pytest.raises(submit_training_jobs.SubmissionBlockedError, match="prior manifest"):
+        submit_training_jobs.plan_submissions(
+            queue_path=queue_path,
+            repo_root=repo,
+            submit=True,
+            now="2026-06-11T10-30-00",
+        )
+
+
+def test_experiment_id_is_deterministic(tmp_path: Path) -> None:
+    """Experiment ids should be stable for duplicate detection and reports."""
+    repo = _write_minimal_repo(tmp_path)
+    entry = submit_training_jobs.QueueEntry.from_mapping(_queue_payload()["entries"][0], repo)
+
+    assert (
+        submit_training_jobs.deterministic_experiment_id(entry, commit="abcdef123456")
+        == "issue-999-example_seed0-1_abcdef1_auxme"
+    )

--- a/tests/dev/test_submit_training_jobs.py
+++ b/tests/dev/test_submit_training_jobs.py
@@ -333,3 +333,123 @@ def test_experiment_id_is_deterministic(tmp_path: Path) -> None:
         submit_training_jobs.deterministic_experiment_id(entry, commit="abcdef123456")
         == "issue-999-example_seed0-1_abcdef1_auxme"
     )
+
+
+def test_parse_squeue_job_names_extracts_exact_names() -> None:
+    """squeue whitespace output should yield exact job names from column 2."""
+    output = (
+        "JOBID NAME STATE PARTITION TIME LIMIT REASON\n"
+        "1234 gse-999-example RUNNING auxme 01:00:00 02:00:00 None\n"
+        "1235 other-job PENDING auxme 00:00:00 02:00:00 Priority\n"
+    )
+    names = submit_training_jobs._parse_squeue_job_names(output)
+    assert names == ["gse-999-example", "other-job"]
+
+
+def test_parse_sacct_job_names_extracts_exact_names() -> None:
+    """sacct -P pipe output should yield exact job names from field 2."""
+    output = (
+        "JobID|JobName|State|ExitCode|Start|End\n"
+        "1234|gse-999-example|COMPLETED|0:0|2026-06-10T10:00:00|2026-06-10T11:00:00\n"
+        "1234.batch|batch|COMPLETED|0:0|2026-06-10T10:00:00|2026-06-10T11:00:00\n"
+    )
+    names = submit_training_jobs._parse_sacct_job_names(output)
+    assert names == ["gse-999-example", "batch"]
+
+
+def test_scheduler_duplicate_uses_exact_name_match_not_substring(tmp_path: Path) -> None:
+    """Substring matches in squeue/sacct output should not trigger false positives."""
+    repo = _write_minimal_repo(tmp_path)
+    entry = submit_training_jobs.QueueEntry.from_mapping(
+        _queue_payload(job_name="my-train")["entries"][0], repo
+    )
+    active = (
+        "JOBID NAME STATE PARTITION TIME LIMIT REASON\n"
+        "1234 my-train-v2 RUNNING auxme 01:00:00 02:00:00 None\n"
+    )
+    recent = (
+        "JobID|JobName|State|ExitCode|Start|End\n"
+        "1234|my-train-v2|COMPLETED|0:0|"
+        "2026-06-10T10:00:00|2026-06-10T11:00:00\n"
+    )
+    evidence = submit_training_jobs._scheduler_duplicate_evidence(
+        entry, active_jobs=active, recent_jobs=recent
+    )
+    assert not evidence
+
+
+def test_run_git_returns_empty_on_file_not_found(tmp_path: Path) -> None:
+    """_run_git should return empty string when git binary is not found."""
+    result = submit_training_jobs._run_git(tmp_path, ["nonexistent-git-binary", "branch"])
+    assert result == ""
+
+
+def test_validate_entry_paths_rejects_non_string_config(tmp_path: Path) -> None:
+    """config values that are not strings should fail validation."""
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="config must be a string"):
+        submit_training_jobs._validate_entry_paths(
+            "test-id", config=42, launcher=None, repo_root=tmp_path
+        )
+
+
+def test_validate_entry_paths_rejects_non_string_launcher(tmp_path: Path) -> None:
+    """launcher values that are not strings should fail validation."""
+    with pytest.raises(
+        submit_training_jobs.QueueValidationError, match="launcher must be a string"
+    ):
+        submit_training_jobs._validate_entry_paths(
+            "test-id", config=None, launcher=True, repo_root=tmp_path
+        )
+
+
+def test_wrapper_null_falls_back_to_default(tmp_path: Path) -> None:
+    """Explicit null wrapper should silently fall back to the default wrapper."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(wrapper=None)
+    entry = submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)
+    assert entry.wrapper == "scripts/dev/sbatch_use_max_time.sh"
+
+
+def test_wrapper_empty_string_falls_back_to_default(tmp_path: Path) -> None:
+    """Explicit empty string wrapper should silently fall back to the default wrapper."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(wrapper="")
+    entry = submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)
+    assert entry.wrapper == "scripts/dev/sbatch_use_max_time.sh"
+
+
+def test_wrapper_non_string_rejected(tmp_path: Path) -> None:
+    """Non-string wrapper values should fail validation."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(wrapper=123)
+    with pytest.raises(submit_training_jobs.QueueValidationError, match="wrapper must be a string"):
+        submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)
+
+
+def test_optional_list_null_normalizes_to_empty(tmp_path: Path) -> None:
+    """Explicit null sbatch_args/wrapper_args should normalize to empty list."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(sbatch_args=None, wrapper_args=None)
+    entry = submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)
+    assert entry.sbatch_args == []
+    assert entry.wrapper_args == []
+
+
+def test_optional_list_non_list_rejected(tmp_path: Path) -> None:
+    """Non-list sbatch_args values should fail validation."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(sbatch_args="not-a-list")
+    with pytest.raises(
+        submit_training_jobs.QueueValidationError, match="sbatch_args must be a list"
+    ):
+        submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)
+
+
+def test_optional_list_non_string_entries_rejected(tmp_path: Path) -> None:
+    """Lists with non-string entries should fail validation."""
+    repo = _write_minimal_repo(tmp_path)
+    payload = _queue_payload(wrapper_args=[1, 2, 3])
+    with pytest.raises(
+        submit_training_jobs.QueueValidationError, match="wrapper_args must be a list"
+    ):
+        submit_training_jobs.QueueEntry.from_mapping(payload["entries"][0], repo)


### PR DESCRIPTION
## Summary
Adds a tracked, issue-linked SLURM training submission queue plus a deterministic helper for safe dry-run manifests and guarded auto-submit.

## Linked Issues
- Closes: NA
- Relates to: SLURM training submission safety workflow

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `experiments/submission_queue.yaml` as a reviewable planned-submission queue, seeded with an issue #1977 planned entry.
- Added `scripts/dev/submit_training_jobs.py` to validate queue entries, generate manifests, detect duplicates, enforce local machine SLURM policy, and invoke existing wrappers only when submit gates pass.
- Added focused tests for queue schema validation, duplicate-id and duplicate-manifest detection, local policy blocking, wrapper failure, auto-submit consent, job-id capture, and deterministic experiment IDs.
- Updated SLURM docs and agent skills to route queue-backed training submissions through the helper.

## Why It Matters
- Added value: turns unsafe prompt-only job submission into a reproducible, manifest-backed workflow.
- Expected impact: reduces duplicate or host-inappropriate SLURM submissions while preserving existing wrapper behavior.
- Why this is worth merging now: it gives future agents a deterministic preflight path before spending cluster resources.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling PR; no research result claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA - support helper
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; the script gates submission mechanics and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/tooling PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_submit_training_jobs.py -q`
  - `uv run ruff check scripts/dev/submit_training_jobs.py tests/dev/test_submit_training_jobs.py`
  - `uv run ruff format --check scripts/dev/submit_training_jobs.py tests/dev/test_submit_training_jobs.py`
  - `uv run python scripts/dev/submit_training_jobs.py --submit` (expected block on local `allow_slurm_submission: false`)
  - `uv run python scripts/dev/submit_training_jobs.py --dry-run` (manifest generated, planned entry skipped)
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused helper tests passed: 14 passed.
  - Full PR-ready gate passed: 5548 passed, 9 skipped, 8 warnings.
  - Freshness stamp: `output/validation/pr_ready/slurm-submission-queue.json`, head `909ac2737f1b826eac2e7987b9ca67eb61f42b1c`, status `passed`.
  - Submit mode refused this non-SLURM host via `local.machine.md`.
- Benchmarks or smoke tests, if applicable: NA - no benchmark claim.

## Risks / Rollout
- Compatibility risks: queue entries must model wrapper arguments accurately; unsupported launchers can still use existing wrappers directly with a documented exception.
- Failure modes: first real SLURM host use may expose cluster-specific wrapper assumptions not reproducible on this machine.
- Rollback or fallback plan: continue using existing `scripts/dev/sbatch_*` wrappers directly; the helper is additive.

## Docs / Provenance
- Updated docs: `docs/dev/slurm_submission.md`
- Relevant design or provenance notes: `.agents/skills/goal-slurm-experiment/SKILL.md`, `.agents/skills/slurm-campaign-submit/SKILL.md`
- Any assumptions that need to be preserved: GitHub issues remain the central backlog; queue state is planned intent, not durable execution evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): yes - added `experiments/submission_queue.yaml`
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is support tooling for safer submission mechanics and does not create research evidence or paper-facing claims.

## Follow-Up Issues
- Deferred work: First live SLURM-host use should verify cluster-specific behavior and record the generated manifest/job id.
- Issues opened for follow-up: none

## Reviewer Notes
- Review `scripts/dev/submit_training_jobs.py` closely for fail-closed submit gates and wrapper command construction.
- Routed self-review was performed with Qwen and OpenCode Zen; accepted findings were addressed by adding wrapper executable validation, fail-closed missing `local.machine.md` policy, and additional negative tests.
