### PR TITLE
feat: add dissertation artifact bundle export

### DIFF
--- a/docs/benchmark_artifact_publication.md
+++ b/docs/benchmark_artifact_publication.md
@@ -113,6 +113,60 @@ Compiler evidence map:
 | `tab_campaign_table` | `tables/campaign_table.{csv,md,tex}` | `captions.md`, `checksums.sha256`, and `artifact_catalog.yaml` | Formatted campaign rows; preserves fallback, degraded, failed, and `not_available` caveats. |
 | `tab_not_available_inputs` | `tables/not_available_inputs.md`, `not_available_inputs.json` | `captions.md`, `checksums.sha256`, and `artifact_catalog.yaml` | Missing optional compiler inputs; documents limitations instead of filling gaps. |
 
+## Dissertation Figure/Table Export
+
+Use `scripts/tools/benchmark_publication_bundle.py dissertation-bundle` when a
+small set of figure/table candidates needs a dissertation-facing handoff without
+turning local `output/` files into durable evidence. The command copies selected
+artifacts into a disposable bundle and writes:
+
+- `artifact_manifest.yaml`: JSON-compatible YAML with `schema_version:
+  dissertation_artifact_bundle.v1`;
+- `checksums.sha256`: checksums for files under `payload/artifacts/`;
+- per-artifact rows with `artifact_id`, `source_path`, `source_artifact`,
+  `output_path`, `sha256`, `source_commit`, `generation_command`,
+  `caption_draft`, `claim_boundary`, `recommended_manuscript_use`, and
+  `fallback_degraded_summary`.
+
+The artifact spec is a compact JSON file so reviewers can see exactly which
+figure/table candidates are being handed off:
+
+```json
+{
+  "artifacts": [
+    {
+      "artifact_id": "tab_campaign_table",
+      "source_path": "tables/campaign_table.md",
+      "source_artifact": "release-backed campaign table candidate",
+      "caption_draft": "Campaign table preserving fallback and degraded rows.",
+      "claim_boundary": "Formatted table only; not new benchmark evidence.",
+      "recommended_manuscript_use": "discussion",
+      "fallback_degraded_summary": "Fallback and degraded rows remain visible."
+    }
+  ]
+}
+```
+
+Allowed `recommended_manuscript_use` values are `results`, `methodology`,
+`discussion`, `outlook`, and `do-not-use`; unsupported values fail closed.
+
+Example command:
+
+```bash
+uv run python scripts/tools/benchmark_publication_bundle.py dissertation-bundle \
+  --source-root output/benchmarks/publication_candidates/<campaign_id> \
+  --out-dir output/dissertation_export \
+  --bundle-name <campaign_id>_figure_table_bundle \
+  --artifact-spec output/benchmarks/publication_candidates/<campaign_id>/dissertation_artifacts.json \
+  --command "uv run python scripts/tools/compile_benchmark_artifacts.py --campaign-root output/benchmarks/camera_ready/<campaign_id> --output output/benchmarks/publication_candidates/<campaign_id>" \
+  --commit "$(git rev-parse HEAD)"
+```
+
+This bundle is a provenance and review workflow only. It does not create new
+benchmark evidence, dissertation prose, or paper-grade claims; durable use still
+requires a release asset, DOI, tracked compact evidence copy, or another
+explicit artifact pointer.
+
 ## Command Path (Reproducible)
 
 1. Measure current benchmark artifact sizes (optional but recommended):

--- a/docs/benchmark_artifact_publication.md
+++ b/docs/benchmark_artifact_publication.md
@@ -120,7 +120,7 @@ small set of figure/table candidates needs a dissertation-facing handoff without
 turning local `output/` files into durable evidence. The command copies selected
 artifacts into a disposable bundle and writes:
 
-- `artifact_manifest.yaml`: JSON-compatible YAML with `schema_version:
+- `artifact_manifest.json`: JSON manifest with `schema_version:
   dissertation_artifact_bundle.v1`;
 - `checksums.sha256`: checksums for files under `payload/artifacts/`;
 - per-artifact rows with `artifact_id`, `source_path`, `source_artifact`,

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -25,6 +25,7 @@ from robot_sf.common.artifact_paths import get_repository_root
 
 PUBLICATION_BUNDLE_SCHEMA_VERSION = "benchmark-publication-bundle.v2"
 EVIDENCE_BUNDLE_SCHEMA_VERSION = "evidence_bundle.v1"
+MANUSCRIPT_ARTIFACT_BUNDLE_SCHEMA_VERSION = "dissertation_artifact_bundle.v1"
 SIZE_REPORT_SCHEMA_VERSION = "benchmark-artifact-size-report.v1"
 _VIDEO_SUFFIXES = {".mp4", ".gif", ".webm", ".mov"}
 _MARKER_FILES = ("manifest.json", "run_meta.json", "episodes.jsonl", "summary.json", "report.json")
@@ -36,6 +37,13 @@ _CAMPAIGN_PREFLIGHT_REQUIRED = (
     "preflight/validate_config.json",
     "preflight/preview_scenarios.json",
 )
+_RECOMMENDED_MANUSCRIPT_USES = {
+    "results",
+    "methodology",
+    "discussion",
+    "outlook",
+    "do-not-use",
+}
 
 
 @dataclass(frozen=True)
@@ -63,6 +71,30 @@ class PublicationBundleResult:
 @dataclass(frozen=True)
 class EvidenceBundleResult:
     """Paths and summary values produced by :func:`export_evidence_bundle`."""
+
+    bundle_dir: Path
+    manifest_path: Path
+    checksums_path: Path
+    file_count: int
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class DissertationArtifactSpec:
+    """User-selected figure or table artifact for dissertation handoff."""
+
+    artifact_id: str
+    source_path: Path
+    source_artifact: str
+    caption_draft: str
+    claim_boundary: str
+    recommended_manuscript_use: str
+    fallback_degraded_summary: str
+
+
+@dataclass(frozen=True)
+class DissertationArtifactBundleResult:
+    """Paths and summary values produced by dissertation artifact bundle export."""
 
     bundle_dir: Path
     manifest_path: Path
@@ -428,6 +460,185 @@ def _resolve_evidence_files(source_root: Path, files: list[Path]) -> list[Path]:
             raise ValueError(f"Evidence bundle refuses symlink payloads: {candidate}")
         resolved.append(candidate.relative_to(root))
     return sorted(set(resolved), key=lambda value: value.as_posix())
+
+
+def _validate_non_empty(value: str, field: str, artifact_id: str) -> str:
+    """Validate a required string field from an artifact spec.
+
+    Returns:
+        The stripped string value.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"Artifact {artifact_id!r} requires non-empty {field}")
+    return stripped
+
+
+def _artifact_payload_path(artifact_id: str, source_path: Path) -> Path:
+    """Return a deterministic payload path for a dissertation artifact."""
+    suffix = source_path.suffix
+    return Path("artifacts") / f"{artifact_id}{suffix}"
+
+
+def _validate_dissertation_artifacts(
+    source_root: Path,
+    artifacts: list[DissertationArtifactSpec],
+) -> list[tuple[DissertationArtifactSpec, Path, Path]]:
+    """Validate dissertation artifact specs and resolve source/output paths.
+
+    Returns:
+        Tuples of the artifact spec, source-root-relative path, and payload path.
+    """
+    root = source_root.resolve()
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(f"Dissertation source root does not exist: {root}")
+    if not artifacts:
+        raise ValueError("At least one dissertation artifact is required")
+
+    seen_ids: set[str] = set()
+    resolved: list[tuple[DissertationArtifactSpec, Path, Path]] = []
+    for artifact in artifacts:
+        artifact_id = _validate_non_empty(artifact.artifact_id, "artifact_id", "<unknown>")
+        if "/" in artifact_id or "\\" in artifact_id or artifact_id in {".", ".."}:
+            raise ValueError(f"Invalid artifact_id: {artifact_id!r}")
+        if artifact_id in seen_ids:
+            raise ValueError(f"Duplicate artifact_id: {artifact_id!r}")
+        seen_ids.add(artifact_id)
+
+        if artifact.recommended_manuscript_use not in _RECOMMENDED_MANUSCRIPT_USES:
+            allowed = ", ".join(sorted(_RECOMMENDED_MANUSCRIPT_USES))
+            raise ValueError(
+                f"Artifact {artifact_id!r} has invalid recommended_manuscript_use "
+                f"{artifact.recommended_manuscript_use!r}; expected one of: {allowed}"
+            )
+        _validate_non_empty(artifact.source_artifact, "source_artifact", artifact_id)
+        _validate_non_empty(artifact.caption_draft, "caption_draft", artifact_id)
+        _validate_non_empty(artifact.claim_boundary, "claim_boundary", artifact_id)
+        _validate_non_empty(
+            artifact.fallback_degraded_summary,
+            "fallback_degraded_summary",
+            artifact_id,
+        )
+
+        candidate = (
+            artifact.source_path
+            if artifact.source_path.is_absolute()
+            else root / artifact.source_path
+        ).resolve()
+        if not candidate.is_relative_to(root):
+            raise ValueError(f"Artifact source escapes source root: {artifact.source_path}")
+        if not candidate.exists() or not candidate.is_file():
+            raise FileNotFoundError(f"Artifact source file does not exist: {candidate}")
+        if candidate.is_symlink():
+            raise ValueError(f"Dissertation artifact bundle refuses symlink payloads: {candidate}")
+        payload_path = _artifact_payload_path(artifact_id, candidate)
+        resolved.append((artifact, candidate.relative_to(root), payload_path))
+    return resolved
+
+
+def export_dissertation_artifact_bundle(
+    source_root: Path,
+    out_dir: Path,
+    *,
+    bundle_name: str,
+    artifacts: list[DissertationArtifactSpec],
+    command: str,
+    commit: str,
+    overwrite: bool = False,
+) -> DissertationArtifactBundleResult:
+    """Export selected figure/table artifacts with dissertation-facing provenance.
+
+    The bundle layout contains:
+    - ``payload/artifacts/``: selected figure/table source files.
+    - ``artifact_manifest.yaml``: JSON-compatible YAML manifest with caption,
+      checksum, manuscript-use, caveat, source, and claim-boundary metadata.
+    - ``checksums.sha256``: SHA-256 checksums for all payload artifacts.
+
+    Returns:
+        Paths and totals describing the exported dissertation artifact bundle.
+    """
+    if not command.strip():
+        raise ValueError("Dissertation artifact generation command is required")
+    if not commit.strip():
+        raise ValueError("Dissertation artifact source commit is required")
+
+    target_name = bundle_name.strip()
+    _validate_bundle_name(target_name)
+    target_root = out_dir.resolve()
+    target_root.mkdir(parents=True, exist_ok=True)
+    bundle_dir = (target_root / target_name).resolve()
+    if not bundle_dir.is_relative_to(target_root):
+        raise ValueError("Dissertation artifact bundle output must remain within out_dir")
+
+    if overwrite:
+        if bundle_dir.exists():
+            if bundle_dir == target_root:
+                raise ValueError("Refusing to delete out_dir via overwrite")
+            shutil.rmtree(bundle_dir)
+    elif bundle_dir.exists():
+        raise FileExistsError(f"Dissertation artifact bundle output already exists: {bundle_dir}")
+
+    source = source_root.resolve()
+    selected = _validate_dissertation_artifacts(source, artifacts)
+    payload_root = bundle_dir / "payload"
+    payload_root.mkdir(parents=True, exist_ok=True)
+
+    manifest_entries: list[dict[str, Any]] = []
+    checksums: list[str] = []
+    total_bytes = 0
+    for artifact, rel_source, payload_path in selected:
+        dst = payload_root / payload_path
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / rel_source, dst)
+        size_bytes = int(dst.stat().st_size)
+        digest = _sha256_file(dst)
+        total_bytes += size_bytes
+        checksums.append(f"{digest}  {payload_path.as_posix()}\n")
+        manifest_entries.append(
+            {
+                "artifact_id": artifact.artifact_id,
+                "source_path": rel_source.as_posix(),
+                "source_artifact": artifact.source_artifact,
+                "output_path": payload_path.as_posix(),
+                "size_bytes": size_bytes,
+                "sha256": digest,
+                "source_commit": commit.strip(),
+                "generation_command": command.strip(),
+                "caption_draft": artifact.caption_draft.strip(),
+                "claim_boundary": artifact.claim_boundary.strip(),
+                "recommended_manuscript_use": artifact.recommended_manuscript_use,
+                "fallback_degraded_summary": artifact.fallback_degraded_summary.strip(),
+            }
+        )
+
+    manifest_entries = sorted(manifest_entries, key=lambda entry: str(entry["artifact_id"]))
+    checksums_path = bundle_dir / "checksums.sha256"
+    checksums_path.write_text("".join(sorted(checksums)), encoding="utf-8")
+    manifest_payload = {
+        "schema_version": MANUSCRIPT_ARTIFACT_BUNDLE_SCHEMA_VERSION,
+        "created_at_utc": _utc_now_iso(),
+        "bundle_name": target_name,
+        "source_root": _to_repo_relative(source),
+        "source_commit": commit.strip(),
+        "generation_command": command.strip(),
+        "policy": {
+            "local_output_disposable": True,
+            "paper_or_benchmark_claim": "not_established_by_bundle_alone",
+            "fallback_or_degraded_rows": "must_remain_visible_in_caption_or_table_notes",
+        },
+        "totals": {"artifact_count": len(manifest_entries), "total_bytes": total_bytes},
+        "artifacts": manifest_entries,
+    }
+    manifest_path = bundle_dir / "artifact_manifest.yaml"
+    manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+
+    return DissertationArtifactBundleResult(
+        bundle_dir=bundle_dir,
+        manifest_path=manifest_path,
+        checksums_path=checksums_path,
+        file_count=len(manifest_entries),
+        total_bytes=total_bytes,
+    )
 
 
 def export_evidence_bundle(

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -499,8 +499,11 @@ def _validate_dissertation_artifacts(
     resolved: list[tuple[DissertationArtifactSpec, Path, Path]] = []
     for artifact in artifacts:
         artifact_id = _validate_non_empty(artifact.artifact_id, "artifact_id", "<unknown>")
-        if "/" in artifact_id or "\\" in artifact_id or artifact_id in {".", ".."}:
-            raise ValueError(f"Invalid artifact_id: {artifact_id!r}")
+        if not all(char.isalnum() or char in "_-" for char in artifact_id):
+            raise ValueError(
+                f"Invalid artifact_id: {artifact_id!r}. "
+                "Only alphanumeric characters, underscores, and hyphens are allowed."
+            )
         if artifact_id in seen_ids:
             raise ValueError(f"Duplicate artifact_id: {artifact_id!r}")
         seen_ids.add(artifact_id)
@@ -520,17 +523,20 @@ def _validate_dissertation_artifacts(
             artifact_id,
         )
 
-        candidate = (
+        unresolved = (
             artifact.source_path
             if artifact.source_path.is_absolute()
             else root / artifact.source_path
-        ).resolve()
+        )
+        if unresolved.is_symlink():
+            raise ValueError(
+                f"Dissertation artifact bundle refuses symlink payloads: {artifact.source_path}"
+            )
+        candidate = unresolved.resolve()
         if not candidate.is_relative_to(root):
             raise ValueError(f"Artifact source escapes source root: {artifact.source_path}")
-        if not candidate.exists() or not candidate.is_file():
+        if not candidate.is_file():
             raise FileNotFoundError(f"Artifact source file does not exist: {candidate}")
-        if candidate.is_symlink():
-            raise ValueError(f"Dissertation artifact bundle refuses symlink payloads: {candidate}")
         payload_path = _artifact_payload_path(artifact_id, candidate)
         resolved.append((artifact, candidate.relative_to(root), payload_path))
     return resolved
@@ -550,7 +556,7 @@ def export_dissertation_artifact_bundle(
 
     The bundle layout contains:
     - ``payload/artifacts/``: selected figure/table source files.
-    - ``artifact_manifest.yaml``: JSON-compatible YAML manifest with caption,
+    - ``artifact_manifest.json``: JSON manifest with caption,
       checksum, manuscript-use, caveat, source, and claim-boundary metadata.
     - ``checksums.sha256``: SHA-256 checksums for all payload artifacts.
 
@@ -574,7 +580,10 @@ def export_dissertation_artifact_bundle(
         if bundle_dir.exists():
             if bundle_dir == target_root:
                 raise ValueError("Refusing to delete out_dir via overwrite")
-            shutil.rmtree(bundle_dir)
+            if bundle_dir.is_dir() and not bundle_dir.is_symlink():
+                shutil.rmtree(bundle_dir)
+            else:
+                bundle_dir.unlink()
     elif bundle_dir.exists():
         raise FileExistsError(f"Dissertation artifact bundle output already exists: {bundle_dir}")
 
@@ -629,7 +638,7 @@ def export_dissertation_artifact_bundle(
         "totals": {"artifact_count": len(manifest_entries), "total_bytes": total_bytes},
         "artifacts": manifest_entries,
     }
-    manifest_path = bundle_dir / "artifact_manifest.yaml"
+    manifest_path = bundle_dir / "artifact_manifest.json"
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
 
     return DissertationArtifactBundleResult(

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from robot_sf.benchmark.artifact_publication import (
+    DissertationArtifactSpec,
+    export_dissertation_artifact_bundle,
     export_evidence_bundle,
     export_publication_bundle,
     measure_artifact_size_ranges,
@@ -154,6 +156,57 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow replacing an existing evidence bundle directory with the same name.",
     )
+
+    dissertation = subparsers.add_parser(
+        "dissertation-bundle",
+        help="Export selected figure/table artifacts with dissertation-facing provenance.",
+    )
+    dissertation.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Directory containing the selected figure/table source artifacts.",
+    )
+    dissertation.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Destination directory for the dissertation artifact bundle.",
+    )
+    dissertation.add_argument(
+        "--bundle-name",
+        type=str,
+        required=True,
+        help="Output bundle directory name.",
+    )
+    dissertation.add_argument(
+        "--artifact-spec",
+        type=Path,
+        required=True,
+        help=(
+            "JSON file containing an artifacts array with artifact_id, source_path, "
+            "source_artifact, caption_draft, claim_boundary, recommended_manuscript_use, "
+            "and fallback_degraded_summary fields."
+        ),
+    )
+    dissertation.add_argument(
+        "--command",
+        type=str,
+        dest="generation_command",
+        required=True,
+        help="Canonical command that generated or validates the selected artifacts.",
+    )
+    dissertation.add_argument(
+        "--commit",
+        type=str,
+        required=True,
+        help="Repository commit associated with the selected artifacts.",
+    )
+    dissertation.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow replacing an existing dissertation artifact bundle directory.",
+    )
     return parser
 
 
@@ -219,6 +272,56 @@ def _run_evidence_bundle(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_dissertation_artifacts(spec_path: Path) -> list[DissertationArtifactSpec]:
+    """Load dissertation artifact rows from a JSON spec file."""
+    payload = json.loads(spec_path.read_text(encoding="utf-8"))
+    rows = payload.get("artifacts") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError("Dissertation artifact spec must be a list or contain an artifacts list")
+
+    artifacts: list[DissertationArtifactSpec] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"Artifact spec row {index} must be an object")
+        try:
+            artifacts.append(
+                DissertationArtifactSpec(
+                    artifact_id=str(row["artifact_id"]),
+                    source_path=Path(str(row["source_path"])),
+                    source_artifact=str(row["source_artifact"]),
+                    caption_draft=str(row["caption_draft"]),
+                    claim_boundary=str(row["claim_boundary"]),
+                    recommended_manuscript_use=str(row["recommended_manuscript_use"]),
+                    fallback_degraded_summary=str(row["fallback_degraded_summary"]),
+                )
+            )
+        except KeyError as exc:
+            raise ValueError(f"Artifact spec row {index} missing required field: {exc}") from exc
+    return artifacts
+
+
+def _run_dissertation_bundle(args: argparse.Namespace) -> int:
+    """Execute the ``dissertation-bundle`` subcommand."""
+    result = export_dissertation_artifact_bundle(
+        args.source_root,
+        args.out_dir,
+        bundle_name=args.bundle_name,
+        artifacts=_load_dissertation_artifacts(args.artifact_spec),
+        command=str(args.generation_command),
+        commit=str(args.commit),
+        overwrite=bool(args.overwrite),
+    )
+    payload = {
+        "bundle_dir": str(result.bundle_dir),
+        "manifest_path": str(result.manifest_path),
+        "checksums_path": str(result.checksums_path),
+        "file_count": result.file_count,
+        "total_bytes": result.total_bytes,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run benchmark publication helper CLI and return a POSIX exit code."""
     parser = _build_parser()
@@ -229,6 +332,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_export(args)
     if args.command == "evidence-bundle":
         return _run_evidence_bundle(args)
+    if args.command == "dissertation-bundle":
+        return _run_dissertation_bundle(args)
     parser.error(f"Unsupported command: {args.command}")
     return 2  # pragma: no cover
 

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -284,15 +284,23 @@ def _load_dissertation_artifacts(spec_path: Path) -> list[DissertationArtifactSp
         if not isinstance(row, dict):
             raise ValueError(f"Artifact spec row {index} must be an object")
         try:
+
+            def get_str(key: str) -> str:
+                """Return a required artifact spec value without accepting JSON null."""
+                value = row[key]
+                if value is None:
+                    raise ValueError(f"Artifact spec row {index} field {key!r} cannot be null")
+                return str(value)
+
             artifacts.append(
                 DissertationArtifactSpec(
-                    artifact_id=str(row["artifact_id"]),
-                    source_path=Path(str(row["source_path"])),
-                    source_artifact=str(row["source_artifact"]),
-                    caption_draft=str(row["caption_draft"]),
-                    claim_boundary=str(row["claim_boundary"]),
-                    recommended_manuscript_use=str(row["recommended_manuscript_use"]),
-                    fallback_degraded_summary=str(row["fallback_degraded_summary"]),
+                    artifact_id=get_str("artifact_id"),
+                    source_path=Path(get_str("source_path")),
+                    source_artifact=get_str("source_artifact"),
+                    caption_draft=get_str("caption_draft"),
+                    claim_boundary=get_str("claim_boundary"),
+                    recommended_manuscript_use=get_str("recommended_manuscript_use"),
+                    fallback_degraded_summary=get_str("fallback_degraded_summary"),
                 )
             )
         except KeyError as exc:

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -95,6 +95,37 @@ def _make_evidence_source(source_root: Path) -> None:
     _write(source_root / "claim_boundary.md", "# Claim Boundary\n\nDiagnostic only.\n")
 
 
+def _make_dissertation_source(source_root: Path) -> Path:
+    """Create a source fixture for dissertation artifact bundle tests."""
+    _write(source_root / "tables" / "campaign_table.md", "| planner | status |\n| --- | --- |\n")
+    _write(source_root / "figures" / "planner_status.png", "fake png bytes\n")
+    spec_path = source_root / "artifact_spec.json"
+    spec = {
+        "artifacts": [
+            {
+                "artifact_id": "tab_campaign_table",
+                "source_path": "tables/campaign_table.md",
+                "source_artifact": "release-backed campaign table candidate",
+                "caption_draft": "Campaign table preserving fallback and degraded rows.",
+                "claim_boundary": "Formatted table only; not new benchmark evidence.",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Fallback and degraded rows remain visible.",
+            },
+            {
+                "artifact_id": "fig_planner_status",
+                "source_path": "figures/planner_status.png",
+                "source_artifact": "planner status summary figure candidate",
+                "caption_draft": "Planner status counts for export review.",
+                "claim_boundary": "Diagnostic status distribution only.",
+                "recommended_manuscript_use": "do-not-use",
+                "fallback_degraded_summary": "Do not use as performance evidence.",
+            },
+        ]
+    }
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    return spec_path
+
+
 def test_evidence_bundle_command_creates_manifest_and_checksums(tmp_path: Path, capsys) -> None:
     """CLI evidence-bundle should copy selected compact files with provenance metadata."""
     source_root = tmp_path / "evidence_source"
@@ -183,5 +214,109 @@ def test_evidence_bundle_command_fails_closed_for_missing_file(tmp_path: Path) -
                 "abc123",
                 "--claim-boundary",
                 "diagnostic_only",
+            ]
+        )
+
+
+def test_dissertation_bundle_command_creates_artifact_manifest(tmp_path: Path, capsys) -> None:
+    """CLI dissertation-bundle should emit manifest rows with provenance and caveats."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    out_dir = tmp_path / "dissertation_export"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "dissertation-bundle",
+            "--source-root",
+            str(source_root),
+            "--out-dir",
+            str(out_dir),
+            "--bundle-name",
+            "campaign_table_bundle",
+            "--artifact-spec",
+            str(spec_path),
+            "--command",
+            "uv run python scripts/tools/compile_benchmark_artifacts.py --campaign-root tracked",
+            "--commit",
+            "abc123",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    bundle_dir = Path(payload["bundle_dir"])
+    manifest_path = Path(payload["manifest_path"])
+    checksums_path = Path(payload["checksums_path"])
+    assert manifest_path.name == "artifact_manifest.yaml"
+    assert (bundle_dir / "payload" / "artifacts" / "tab_campaign_table.md").exists()
+    assert (bundle_dir / "payload" / "artifacts" / "fig_planner_status.png").exists()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "dissertation_artifact_bundle.v1"
+    assert manifest["source_commit"] == "abc123"
+    assert manifest["generation_command"].startswith("uv run python")
+    assert manifest["policy"]["paper_or_benchmark_claim"] == "not_established_by_bundle_alone"
+    rows = {row["artifact_id"]: row for row in manifest["artifacts"]}
+    table_row = rows["tab_campaign_table"]
+    assert table_row["source_artifact"] == "release-backed campaign table candidate"
+    assert table_row["recommended_manuscript_use"] == "discussion"
+    assert table_row["fallback_degraded_summary"] == "Fallback and degraded rows remain visible."
+    assert table_row["claim_boundary"] == "Formatted table only; not new benchmark evidence."
+    assert table_row["sha256"] in checksums_path.read_text(encoding="utf-8")
+
+
+def test_dissertation_bundle_command_rejects_invalid_manuscript_use(tmp_path: Path) -> None:
+    """Dissertation artifact rows should fail closed for unsupported manuscript use labels."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0]["recommended_manuscript_use"] = "appendix"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="recommended_manuscript_use"):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "bad_use",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
+            ]
+        )
+
+
+def test_dissertation_bundle_command_fails_closed_for_missing_source(tmp_path: Path) -> None:
+    """Dissertation bundle export should not write manifests for missing artifact sources."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0]["source_path"] = "tables/missing.md"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "missing_source",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
             ]
         )

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -248,7 +248,7 @@ def test_dissertation_bundle_command_creates_artifact_manifest(tmp_path: Path, c
     bundle_dir = Path(payload["bundle_dir"])
     manifest_path = Path(payload["manifest_path"])
     checksums_path = Path(payload["checksums_path"])
-    assert manifest_path.name == "artifact_manifest.yaml"
+    assert manifest_path.name == "artifact_manifest.json"
     assert (bundle_dir / "payload" / "artifacts" / "tab_campaign_table.md").exists()
     assert (bundle_dir / "payload" / "artifacts" / "fig_planner_status.png").exists()
 
@@ -294,6 +294,62 @@ def test_dissertation_bundle_command_rejects_invalid_manuscript_use(tmp_path: Pa
         )
 
 
+def test_dissertation_bundle_command_rejects_null_spec_fields(tmp_path: Path) -> None:
+    """JSON null values should not be coerced into string manifest fields."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0]["caption_draft"] = None
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cannot be null"):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "null_field",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
+            ]
+        )
+
+
+def test_dissertation_bundle_command_rejects_unsafe_artifact_id(tmp_path: Path) -> None:
+    """Artifact IDs become filenames and should allow only portable safe characters."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0]["artifact_id"] = "tab:campaign"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid artifact_id"):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "unsafe_id",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
+            ]
+        )
+
+
 def test_dissertation_bundle_command_fails_closed_for_missing_source(tmp_path: Path) -> None:
     """Dissertation bundle export should not write manifests for missing artifact sources."""
     source_root = tmp_path / "publication_candidates"
@@ -320,3 +376,71 @@ def test_dissertation_bundle_command_fails_closed_for_missing_source(tmp_path: P
                 "abc123",
             ]
         )
+
+
+def test_dissertation_bundle_command_rejects_symlink_source(tmp_path: Path) -> None:
+    """Dissertation bundle export should reject symlink payload sources before resolving paths."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    target = source_root / "tables" / "campaign_table.md"
+    link = source_root / "tables" / "campaign_table_link.md"
+    link.symlink_to(target)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0]["source_path"] = "tables/campaign_table_link.md"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="refuses symlink"):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "symlink_source",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
+            ]
+        )
+
+
+def test_dissertation_bundle_overwrite_replaces_existing_file_path(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Overwrite should replace a colliding file path instead of calling rmtree on it."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    out_dir = tmp_path / "dissertation_export"
+    out_dir.mkdir()
+    (out_dir / "file_collision").write_text("old payload\n", encoding="utf-8")
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "dissertation-bundle",
+            "--source-root",
+            str(source_root),
+            "--out-dir",
+            str(out_dir),
+            "--bundle-name",
+            "file_collision",
+            "--artifact-spec",
+            str(spec_path),
+            "--command",
+            "uv run python scripts/tools/compile_benchmark_artifacts.py",
+            "--commit",
+            "abc123",
+            "--overwrite",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert Path(payload["bundle_dir"]).is_dir()
+    assert Path(payload["manifest_path"]).name == "artifact_manifest.json"


### PR DESCRIPTION
## Summary
Adds a dissertation-facing figure/table bundle export mode to the existing benchmark publication helper. The new command copies selected artifacts into a disposable local bundle and writes an `artifact_manifest.json` with checksums, captions, manuscript-use guidance, caveats, and claim boundaries.

## Linked Issues
- Closes `#2542`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `export_dissertation_artifact_bundle(...)` and `DissertationArtifactSpec` to `robot_sf/benchmark/artifact_publication.py`.
- Added `scripts/tools/benchmark_publication_bundle.py dissertation-bundle` with JSON artifact-spec input.
- Added targeted tests for manifest fields, allowed manuscript-use validation, caveat preservation, missing-source fail-closed behavior, null rejection, safe artifact IDs, symlink refusal, and overwrite file collisions.
- Documented the command, manifest shape, allowed use labels, and claim boundary in `docs/benchmark_artifact_publication.md`.

## Why It Matters
- Added value: gives dissertation-side figure/table handoff a compact provenance manifest without treating local `output/` as durable evidence.
- Expected impact: easier review of selected artifacts, captions, checksums, source commits, generation commands, and fallback/degraded caveats.
- Why this is worth merging now: it closes a workflow gap in the dissertation/export path while preserving the repository's conservative claim boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/provenance workflow only; it improves export structure without interpreting results.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke / support helper
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: command produces manifest/checksum bundle and fails closed on invalid/missing inputs.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#2542`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it packages already-selected artifacts and does not generate new analysis or claims.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA - no empirical claim.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for this support workflow.
- Stop / revise / continue decision: stop for #2542 after review/merge.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run ruff check scripts/tools/benchmark_publication_bundle.py robot_sf/benchmark/artifact_publication.py tests/tools/test_benchmark_publication_bundle.py`
  - `uv run ruff format --check scripts/tools/benchmark_publication_bundle.py robot_sf/benchmark/artifact_publication.py tests/tools/test_benchmark_publication_bundle.py`
  - `uv run pytest tests/tools/test_benchmark_publication_bundle.py -q`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests verify `artifact_manifest.json`, per-artifact provenance fields, checksums, allowed `recommended_manuscript_use` values, fallback/degraded caveat text, invalid spec fail-closed behavior, symlink refusal, safe artifact IDs, and overwrite file-collision handling.
- Benchmarks or smoke tests, if applicable: full final readiness passed at `56856470068f8ac8d531a37d1baa5c814c4cb21e` with `5577 passed, 9 skipped`; changed-file coverage warning only for `robot_sf/benchmark/artifact_publication.py` at `88.8%`.

## Risks / Rollout
- Compatibility risks: low; existing `size-report`, `export`, and `evidence-bundle` commands are unchanged.
- Failure modes: malformed artifact spec, unsupported manuscript-use label, missing source file, duplicate/unsafe artifact ID, symlink source, or path escape fail closed before manifest publication.
- Rollback or fallback plan: remove the new `dissertation-bundle` subcommand and helper; existing publication/evidence bundle commands continue to work.

## Docs / Provenance
- Updated docs: `docs/benchmark_artifact_publication.md`.
- Relevant design or provenance notes: issue `#2542`; common Git-dir self-review note recorded worker route failures outside the PR diff.
- Any assumptions that need to be preserved: generated dissertation bundles under `output/` are disposable until promoted through a release asset, DOI, tracked compact evidence copy, or explicit durable pointer.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes `#2542`.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this PR adds a support/provenance export workflow and does not produce or promote benchmark evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the JSON manifest shape is sufficient for dissertation-side ingestion before adding a stricter schema.
- Any known limitations: this does not generate captions automatically, modify `ll7/diss`, or make selected artifacts durable evidence by itself.
