### PR TITLE
feat: summarize topology selector diagnostics

### DIFF
--- a/scripts/validation/run_topology_hypothesis_diagnostics.py
+++ b/scripts/validation/run_topology_hypothesis_diagnostics.py
@@ -450,6 +450,45 @@ def _selection_score_example(row: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+def _selected_topology_hypothesis_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the selected topology hypothesis diagnostic row for one step."""
+    route_corridor = row.get("planner_route_corridor")
+    if not isinstance(route_corridor, dict):
+        return None
+
+    selected = route_corridor.get("topology_hypothesis")
+    if isinstance(selected, dict):
+        return selected
+
+    scored_hypotheses = route_corridor.get("topology_hypotheses")
+    if not isinstance(scored_hypotheses, list):
+        return None
+    for item in scored_hypotheses:
+        if isinstance(item, dict) and item.get("selection_outcome") == "selected":
+            return item
+    return None
+
+
+def _selected_topology_hypothesis_summary(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate selected-hypothesis and near-parity reason counts."""
+    selected_counts: Counter[str] = Counter()
+    near_parity_reason_counts: Counter[str] = Counter()
+
+    for row in steps:
+        selected = _selected_topology_hypothesis_row(row)
+        if selected is None:
+            continue
+        selected_counts[str(selected.get("hypothesis_id") or "unknown")] += 1
+        near_parity_reason = selected.get("near_parity_gate_reason")
+        if near_parity_reason is not None:
+            near_parity_reason_counts[str(near_parity_reason)] += 1
+
+    return {
+        "route_selector_selected_hypothesis_counts": dict(sorted(selected_counts.items())),
+        "selected_row_near_parity_gate_reasons": dict(sorted(near_parity_reason_counts.items())),
+    }
+
+
 def _reuse_penalty_diagnostic(row: dict[str, Any]) -> dict[str, Any] | None:
     """Return the topology reuse-penalty diagnostic payload for one step."""
     route_corridor = row.get("planner_route_corridor")
@@ -693,9 +732,11 @@ def _summarize_hypotheses(
             selection_score_examples.append(example)
 
     terminal = _terminal_outcome(done_info or {}, steps)
+    selected_hypothesis_summary = _selected_topology_hypothesis_summary(steps)
     return {
         "topology_status_counts": dict(sorted(availability_counts.items())),
         "selected_source_counts": dict(sorted(selected_source_counts.items())),
+        **selected_hypothesis_summary,
         "hypothesis_progress_by_rank": progress_by_rank,
         "topology_command_influence_counts": dict(sorted(influence_counts.items())),
         "hypothesis_switch_count": hypothesis_switch_count,
@@ -727,6 +768,10 @@ def _report_lines(payload: dict[str, Any], trace_path: Path) -> list[str]:
         f"- Trace JSON: `{trace_path}`",
         f"- Topology status counts: `{summary['topology_status_counts']}`",
         f"- Selected local command sources: `{summary['selected_source_counts']}`",
+        "- Route-selector selected hypotheses: "
+        f"`{summary['route_selector_selected_hypothesis_counts']}`",
+        "- Selected-row near-parity gate reasons: "
+        f"`{summary['selected_row_near_parity_gate_reasons']}`",
         f"- Topology command influence counts: `{summary['topology_command_influence_counts']}`",
         f"- Hypothesis switch count: `{summary['hypothesis_switch_count']}`",
         f"- Corrective-behavior decision: `{summary['corrective_behavior']['decision']}`",

--- a/scripts/validation/run_topology_hypothesis_diagnostics.py
+++ b/scripts/validation/run_topology_hypothesis_diagnostics.py
@@ -478,7 +478,9 @@ def _selected_topology_hypothesis_summary(steps: list[dict[str, Any]]) -> dict[s
         selected = _selected_topology_hypothesis_row(row)
         if selected is None:
             continue
-        selected_counts[str(selected.get("hypothesis_id") or "unknown")] += 1
+        hypothesis_id = selected.get("hypothesis_id")
+        hypothesis_key = str(hypothesis_id) if hypothesis_id is not None else "unknown"
+        selected_counts[hypothesis_key] += 1
         near_parity_reason = selected.get("near_parity_gate_reason")
         if near_parity_reason is not None:
             near_parity_reason_counts[str(near_parity_reason)] += 1

--- a/tests/validation/test_run_topology_hypothesis_diagnostics.py
+++ b/tests/validation/test_run_topology_hypothesis_diagnostics.py
@@ -306,6 +306,7 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
                     "topology_hypotheses": [
                         {
                             "hypothesis_id": "primary_route",
+                            "near_parity_gate_reason": "selected_primary_route",
                             "score": -8.0,
                             "score_rank": 0,
                             "score_margin_to_selected": 0.0,
@@ -318,6 +319,7 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
                         },
                         {
                             "hypothesis_id": "masked_cell_5_12",
+                            "near_parity_gate_reason": "eligible_near_parity_alternative",
                             "score": -9.5,
                             "score_rank": 1,
                             "score_margin_to_selected": 1.5,
@@ -344,6 +346,12 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
                 "topology_status": "ok",
                 "selected_local_command_source": "path_follow_0.5m",
                 "topology_command_influence": {"selected_hypothesis_id": "masked_cell_5_12"},
+                "planner_route_corridor": {
+                    "topology_hypothesis": {
+                        "hypothesis_id": "masked_cell_5_12",
+                        "near_parity_gate_reason": "eligible_near_parity_alternative",
+                    }
+                },
                 "topology_hypotheses": [
                     {
                         "rank": 0,
@@ -360,6 +368,12 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
                 "topology_status": "ok",
                 "selected_local_command_source": "topology_hypothesis",
                 "topology_command_influence": {"selected_hypothesis_id": "masked_cell_5_12"},
+                "planner_route_corridor": {
+                    "topology_hypothesis": {
+                        "hypothesis_id": "masked_cell_7_14",
+                        "near_parity_gate_reason": None,
+                    }
+                },
                 "topology_hypotheses": [
                     {
                         "rank": 0,
@@ -379,6 +393,15 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
         "dynamic_window": 1,
         "path_follow_0.5m": 1,
         "topology_hypothesis": 1,
+    }
+    assert summary["route_selector_selected_hypothesis_counts"] == {
+        "masked_cell_5_12": 1,
+        "masked_cell_7_14": 1,
+        "primary_route": 1,
+    }
+    assert summary["selected_row_near_parity_gate_reasons"] == {
+        "eligible_near_parity_alternative": 1,
+        "selected_primary_route": 1,
     }
     assert summary["hypothesis_progress_by_rank"]["0"] == {
         "samples": 3,

--- a/tests/validation/test_run_topology_hypothesis_diagnostics.py
+++ b/tests/validation/test_run_topology_hypothesis_diagnostics.py
@@ -384,17 +384,34 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
                     }
                 ],
             }
+        ]
+        + [
+            {
+                "topology_status": "ok",
+                "selected_local_command_source": "dynamic_window",
+                "planner_route_corridor": {"topology_hypothesis": {"hypothesis_id": ""}},
+                "topology_hypotheses": [
+                    {
+                        "rank": 0,
+                        "corridor_name": "left_corridor_0",
+                        "route_remaining_distance_m": 6.0,
+                        "static_clearance_min_m": 0.25,
+                        "dynamic_clearance_min_m": 1.2,
+                    }
+                ],
+            }
         ],
         {"step": 2, "terminated": True, "success": True, "meta": {}},
     )
 
-    assert summary["topology_status_counts"] == {"ok": 3}
+    assert summary["topology_status_counts"] == {"ok": 4}
     assert summary["selected_source_counts"] == {
-        "dynamic_window": 1,
+        "dynamic_window": 2,
         "path_follow_0.5m": 1,
         "topology_hypothesis": 1,
     }
     assert summary["route_selector_selected_hypothesis_counts"] == {
+        "": 1,
         "masked_cell_5_12": 1,
         "masked_cell_7_14": 1,
         "primary_route": 1,
@@ -404,12 +421,12 @@ def test_summarize_hypotheses_counts_sources_progress_and_corrective_behavior() 
         "selected_primary_route": 1,
     }
     assert summary["hypothesis_progress_by_rank"]["0"] == {
-        "samples": 3,
+        "samples": 4,
         "first_corridor_name": "left_corridor_0",
         "last_corridor_name": "left_corridor_0",
         "first_remaining_distance_m": 10.0,
-        "last_remaining_distance_m": 7.0,
-        "progress_delta_m": 3.0,
+        "last_remaining_distance_m": 6.0,
+        "progress_delta_m": 4.0,
         "min_static_clearance_m": 0.2,
         "min_dynamic_clearance_m": 1.0,
     }


### PR DESCRIPTION
## Summary
- closes #2628
- adds stable compact summary keys for topology selector diagnostics:
  - `route_selector_selected_hypothesis_counts`
  - `selected_row_near_parity_gate_reasons`
- keeps existing step-level diagnostics and `topology_reuse_penalty` summary fields intact
- surfaces the new compact counts in the Markdown report header

## Validation
- `uv run pytest tests/validation/test_run_topology_hypothesis_diagnostics.py -q` (`15 passed`)
- `uv run ruff check scripts/validation/run_topology_hypothesis_diagnostics.py tests/validation/test_run_topology_hypothesis_diagnostics.py`
- `uv run ruff format --check scripts/validation/run_topology_hypothesis_diagnostics.py tests/validation/test_run_topology_hypothesis_diagnostics.py`
- `git diff --check`
- Short CLI smoke:
  `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 PYGAME_HIDE_SUPPORT_PROMPT=1 DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_topology_hypothesis_diagnostics.py --candidate topology_guided_hybrid_rule_v0 --stage full_matrix --scenario-name classic_realworld_double_bottleneck_high --seed 111 --horizon 12 --max-hypotheses 3 --min-hypotheses 2 --output-dir output/diagnostics/issue2628_summary_fields_smoke`
- `jq` confirmed the generated JSON includes both new summary keys and preserves `summary.topology_reuse_penalty`.

## Downstream Propagation
- No durable docs/context update needed; this is a diagnostics/reportability implementation for the already-open follow-up #2628.
- Raw smoke output under `output/diagnostics/issue2628_summary_fields_smoke` remains ignored/local and disposable.

## Research Result Guidance
- Target claim/hypothesis/blocker: diagnostics report shape for topology selector gate evidence.
- Comparator/baseline: not applicable; no planner-quality claim.
- Evidence tier: reportability/tooling.
- Result classification: support/tooling only.
- Decision/stop rule: future topology diagnostics can consume stable compact selector counts without reading raw step traces.
- Synthesis surface/update target: none required beyond this PR and #2628 closure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic reports now include aggregated statistics on selected topology hypotheses and associated near-parity gate reasons.

* **Tests**
  * Updated diagnostic validation tests to cover expanded summary fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->