### PR TITLE
feat: gate oracle imitation training artifacts

### DIFF
--- a/configs/training/ppo_imitation/README.md
+++ b/configs/training/ppo_imitation/README.md
@@ -17,11 +17,15 @@ This directory hosts configuration files used by the expert-policy, trajectory c
 * `oracle_dataset_issue_1397_launch_packet.yaml` – pre-Slurm oracle-imitation dataset launch
   packet. Validate with
   `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json`.
+  Downstream imitation training must use the stricter gate:
+  `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json --require-training-ready`.
+  That gate intentionally fails while Issue #2620 remains `artifact_retrieval_blocked`.
 * Additional files describe scenario coverage manifests referenced by trajectory collection commands.
 
 ## Usage Notes
 
-1. Always version-control changes alongside the corresponding manifests under `output/`.
+1. Do not treat worktree-local `output/` files as durable training inputs; promote required
+   manifests or datasets before downstream launch packets consume them.
 2. Keep seed lists consistent across configs when running comparative studies.
 3. Document any temporary overrides in the run manifest to preserve reproducibility.
 4. For Optuna launcher configs, prefer `log_level: WARNING` by default and override only when debugging.

--- a/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+++ b/configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
@@ -65,6 +65,12 @@ checksums:
   docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json: eb5ef938d15725ff29a013a196216d093dd549ae58ae805e642c98441777529f
 artifact_promotion_policy:
   raw_outputs_are_durable: false
+  downstream_training_ready: false
+  training_gate: >
+    Downstream imitation training must run the validator with --require-training-ready and must
+    fail closed until train_trace_jsonl_uri, validation_trace_jsonl_uri, evaluation_trace_jsonl_uri,
+    and trace_source_manifest_uri point at concrete durable aliases. Issue #2620 currently records
+    artifact_retrieval_blocked for the Issue #2441 raw traces.
   required_before_collection:
     - "Replace :pending W&B artifact aliases with concrete aliases or run ids."
     - "Record checksums for the generated dataset and manifest before imitation training starts."

--- a/docs/context/issue_2271_oracle_imitation_trace_preflight.md
+++ b/docs/context/issue_2271_oracle_imitation_trace_preflight.md
@@ -105,6 +105,24 @@ Next smallest proof step: promote the generated train/validation trace manifests
 a durable artifact store with concrete retrieval aliases, or revise/rerun before any imitation
 training treats these local outputs as inputs.
 
+## Training Gate
+
+Issue #2569 adds a stricter downstream-consumption check to the launch-packet validator. The
+ordinary pre-Slurm preflight may still validate collection readiness, but imitation training must
+run:
+
+```bash
+uv run python scripts/validation/validate_oracle_imitation_launch_packet.py \
+  --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml \
+  --json \
+  --require-training-ready
+```
+
+That mode fails closed until concrete durable aliases exist for `train_trace_jsonl_uri`,
+`validation_trace_jsonl_uri`, `evaluation_trace_jsonl_uri`, and `trace_source_manifest_uri`. The
+current Issue #2620 audit records `artifact_retrieval_blocked`, so Issue #1496 remains blocked and
+must not start training from local-only trace files.
+
 Machine-readable summaries:
 `docs/context/evidence/issue_2441_oracle_imitation_traces_2026-06-06/summary.json`
 `docs/context/evidence/issue_2271_oracle_imitation_trace_preflight_2026-06-05/summary.json`

--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -46,12 +46,15 @@ def validate_launch_packet(
     config_path: Path,
     *,
     repo_root: Path | None = None,
+    require_training_ready: bool = False,
 ) -> dict[str, Any]:
     """Validate an oracle-imitation launch packet and return a compact report.
 
     Args:
         config_path: YAML launch-packet path.
         repo_root: Repository root. Defaults to the current working directory.
+        require_training_ready: Also require concrete durable trace artifact inputs for
+            downstream imitation training.
 
     Returns:
         Validation report with status, checked fields, and artifact paths.
@@ -80,6 +83,11 @@ def validate_launch_packet(
     _validate_relabeling(packet, errors)
     _validate_generating_commit(packet, errors)
     artifact_paths = _validate_artifacts(packet, root, errors)
+    training_ready = _validate_training_artifact_gate(
+        artifact_paths,
+        require_training_ready=require_training_ready,
+        errors=errors,
+    )
 
     if errors:
         joined = "\n- ".join(errors)
@@ -94,6 +102,7 @@ def validate_launch_packet(
         "episode_count": sum(len(packet["episode_ids_by_split"][split]) for split in _SPLITS),
         "seeds_by_split": {split: list(packet["seeds_by_split"][split]) for split in _SPLITS},
         "artifact_paths": artifact_paths,
+        "training_ready": training_ready,
     }
 
 
@@ -361,6 +370,51 @@ def _validate_artifacts(
     return normalized_paths
 
 
+def _validate_training_artifact_gate(
+    artifact_paths: dict[str, str],
+    *,
+    require_training_ready: bool,
+    errors: list[str],
+) -> bool:
+    required_trace_artifacts = {
+        "train_trace_jsonl_uri",
+        "validation_trace_jsonl_uri",
+        "evaluation_trace_jsonl_uri",
+        "trace_source_manifest_uri",
+    }
+    missing = sorted(required_trace_artifacts - artifact_paths.keys())
+    pending = sorted(
+        name for name, path_text in artifact_paths.items() if _is_pending_durable_uri(path_text)
+    )
+    non_durable_required = sorted(
+        name
+        for name in required_trace_artifacts & artifact_paths.keys()
+        if not _is_concrete_durable_uri(artifact_paths[name])
+        and not _is_pending_durable_uri(artifact_paths[name])
+    )
+
+    training_ready = not missing and not pending and not non_durable_required
+    if not require_training_ready:
+        return training_ready
+
+    if missing:
+        errors.append(
+            "training-ready oracle-imitation launch packets must include durable trace artifact "
+            f"URIs for: {', '.join(missing)}"
+        )
+    if pending:
+        errors.append(
+            "training-ready oracle-imitation launch packets must not use pending durable aliases: "
+            f"{', '.join(pending)}"
+        )
+    if non_durable_required:
+        errors.append(
+            "training-ready oracle-imitation launch packets must use concrete durable URIs for: "
+            f"{', '.join(non_durable_required)}"
+        )
+    return training_ready
+
+
 def _artifact_path_text(name: str, raw_path: Any, errors: list[str]) -> str | None:
     if not isinstance(raw_path, str) or not raw_path.strip():
         errors.append(f"artifact_paths.{name} must be a non-empty string")
@@ -376,6 +430,14 @@ def _artifact_path_text(name: str, raw_path: Any, errors: list[str]) -> str | No
 
 def _is_durable_uri(path_text: str) -> bool:
     return path_text.startswith(_DURABLE_URI_PREFIXES)
+
+
+def _is_pending_durable_uri(path_text: str) -> bool:
+    return _is_durable_uri(path_text) and path_text.rstrip().endswith(":pending")
+
+
+def _is_concrete_durable_uri(path_text: str) -> bool:
+    return _is_durable_uri(path_text) and not _is_pending_durable_uri(path_text)
 
 
 def _validate_local_artifact(

--- a/scripts/validation/validate_oracle_imitation_launch_packet.py
+++ b/scripts/validation/validate_oracle_imitation_launch_packet.py
@@ -25,6 +25,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Repository root used to resolve relative paths.",
     )
     parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    parser.add_argument(
+        "--require-training-ready",
+        action="store_true",
+        help=(
+            "Fail closed unless the packet has concrete durable train/validation/evaluation "
+            "trace artifact URIs for downstream imitation training."
+        ),
+    )
     return parser
 
 
@@ -32,7 +40,11 @@ def main(argv: list[str] | None = None) -> int:
     """Validate a launch packet and return a shell-friendly exit code."""
     args = build_arg_parser().parse_args(argv)
     try:
-        report = validate_launch_packet(args.config, repo_root=args.repo_root)
+        report = validate_launch_packet(
+            args.config,
+            repo_root=args.repo_root,
+            require_training_ready=args.require_training_ready,
+        )
     except LaunchPacketError as exc:
         if args.json:
             print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
@@ -45,7 +57,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(
             "oracle-imitation launch packet valid: "
-            f"{report['dataset_id']} ({report['episode_count']} planned episodes)"
+            f"{report['dataset_id']} ({report['episode_count']} planned episodes, "
+            f"training_ready={report['training_ready']})"
         )
     return 0
 

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -84,6 +84,16 @@ def test_issue_1397_launch_packet_validates() -> None:
     assert report["dataset_id"] == "issue_1397_oracle_imitation_v1"
     assert report["source_candidate"] == "hybrid_rule_v3_static_margin0_waypoint2"
     assert report["scenario_count"] == 6
+    assert report["training_ready"] is False
+
+
+def test_issue_1397_launch_packet_fails_training_ready_gate() -> None:
+    """The checked-in #1397 packet must not pass as downstream training input yet."""
+    with pytest.raises(LaunchPacketError, match="training-ready oracle-imitation"):
+        validate_launch_packet(
+            Path("configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml"),
+            require_training_ready=True,
+        )
 
 
 def test_validate_launch_packet_rejects_seed_overlap(tmp_path: Path) -> None:
@@ -121,6 +131,47 @@ def test_validate_launch_packet_rejects_output_artifact_paths(tmp_path: Path) ->
         validate_launch_packet(_write_packet(tmp_path, broken))
 
 
+def test_validate_launch_packet_accepts_training_ready_trace_artifacts(tmp_path: Path) -> None:
+    """Concrete durable trace pointers satisfy the downstream training gate."""
+    packet = _valid_packet(tmp_path)
+    packet["artifact_paths"].update(
+        {
+            "train_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/train:v1",
+            "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/val:v1",
+            "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/eval:v1",
+            "trace_source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/manifest:v1",
+        }
+    )
+    packet["artifact_paths"]["future_dataset_npz_uri"] = "wandb-artifact://robot-sf/demo-dataset:v1"
+
+    report = validate_launch_packet(
+        _write_packet(tmp_path, packet),
+        require_training_ready=True,
+    )
+
+    assert report["training_ready"] is True
+
+
+def test_validate_launch_packet_rejects_pending_training_artifacts(tmp_path: Path) -> None:
+    """Pending aliases are placeholders, not durable training inputs."""
+    packet = _valid_packet(tmp_path)
+    packet["artifact_paths"].update(
+        {
+            "train_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/train:pending",
+            "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/val:v1",
+            "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/oracle-imitation/eval:v1",
+            "trace_source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/manifest:v1",
+        }
+    )
+
+    with pytest.raises(LaunchPacketError, match="must not use pending durable aliases") as exc_info:
+        validate_launch_packet(
+            _write_packet(tmp_path, packet),
+            require_training_ready=True,
+        )
+    assert "must use concrete durable URIs" not in str(exc_info.value)
+
+
 def test_validate_launch_packet_cli_reports_json() -> None:
     """The CLI should expose the same validation report for automation."""
     exit_code = validate_cli_main(
@@ -132,6 +183,20 @@ def test_validate_launch_packet_cli_reports_json() -> None:
     )
 
     assert exit_code == 0
+
+
+def test_validate_launch_packet_cli_training_ready_gate_fails_closed() -> None:
+    """Automation can request the stricter downstream training gate."""
+    exit_code = validate_cli_main(
+        [
+            "--config",
+            "configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml",
+            "--json",
+            "--require-training-ready",
+        ]
+    )
+
+    assert exit_code == 2
 
 
 def test_seed_manifest_missing_file_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `--require-training-ready` to the oracle-imitation launch-packet validator
- report `training_ready` in normal validation while preserving collection preflight compatibility
- document that Issue #1496/#2569 remain blocked by Issue #2620 until concrete durable trace URIs exist

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/oracle_imitation_launch_packet.py scripts/validation/validate_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_imitation_launch_packet.py scripts/validation/validate_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_launch_packet.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json`
- expected fail-closed: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --json --require-training-ready` exits 2 and names missing trace URIs/pending aliases
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Research Result Guidance
- Target claim / blocker: closes the Issue #2569 training-consumption gate by making downstream oracle-imitation training fail closed while durable trace access is unresolved.
- Comparator / baseline: current collection preflight accepted the #1397 launch packet even though training artifacts were pending; this PR keeps that preflight valid but adds the stricter downstream gate.
- Evidence tier: blocked-asset/training gate, not training evidence and not benchmark evidence.
- Result classification: gate implemented; current packet reports `training_ready=false`, and strict mode fails closed because Issue #2620 records `artifact_retrieval_blocked`.
- Decision / stop rule: do not start Issue #1496 or related oracle-imitation training until `train_trace_jsonl_uri`, `validation_trace_jsonl_uri`, `evaluation_trace_jsonl_uri`, and `trace_source_manifest_uri` are concrete durable aliases.
- Synthesis surface: `docs/context/issue_2271_oracle_imitation_trace_preflight.md`, `docs/context/issue_2620_oracle_artifact_access.md`, and Issue #2569.

## Downstream Propagation
- Parent issue / blocker: updates Issue #2569 and leaves Issue #1496 gated on Issue #2620 artifact recovery.
- Claim map / benchmark report / leaderboard: NA; no benchmark or policy-quality claim.
- Artifact catalog / registry / config index: updates `configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml` and its README with the strict gate.
- Context index / memory note: updates the existing oracle trace preflight context note; no new context index entry needed because the note was already indexed.
- Follow-up issue: NA; the exact artifact recovery/promotion blocker remains tracked by Issue #2620/#2561 and Issue #1470.

Closes #2569.
