### PR TITLE
feat: add bounded PR check polling

### DIFF
--- a/.agents/skills/gh-pr-merger/SKILL.md
+++ b/.agents/skills/gh-pr-merger/SKILL.md
@@ -55,6 +55,10 @@ Before each merge operation, verify:
 2. PR is not a draft. If draft, skip and report.
 3. PR targets `main` (or the explicitly allowed base branch).
 4. CI checks are passing (use `uv run python scripts/dev/check_pr_ci_status.py <number>`).
+   In non-TTY agent sessions, prefer bounded polling over `gh pr checks --watch`:
+   `uv run python scripts/dev/check_pr_ci_status.py <number> --poll-attempts 20 --poll-interval 30`.
+   Exit code `2` means checks were still queued or in progress after the polling budget; inspect the
+   listed check URLs or run `gh run view <run-id> --json status,conclusion,jobs` for job state.
 5. No merge conflicts exist (`gh pr view <number> --json mergeable`).
 6. The PR has no unresolved review threads or pending/requested reviewers.
 7. Branch protection rules on `main` allow merges from the current actor.
@@ -99,6 +103,10 @@ Do not merge multiple PRs in parallel. Process sequentially.
   - Do not merge. Report the failing check name and URL.
   - Do not override CI failure unless the user explicitly requests override, and
     only after recording the override rationale.
+  - If checks are queued or in progress, do not use unbounded watch mode in non-TTY sessions.
+    Poll with `scripts/dev/check_pr_ci_status.py --poll-attempts ... --poll-interval ...`; logs
+    may be unavailable until a job completes, so use `gh run view <run-id> --json status,conclusion,jobs`
+    to distinguish queued, in-progress, and completed states before fetching logs.
 
 - Auth/permission failure:
   - Stop immediately. Report the failing command, exit code, and stderr.

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -119,11 +119,14 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
 1. Record the PR number, expected head SHA, current CI state, and static wait budget in the active
    ledger. The default budget is `ceil(920s * 1.3) = 1196s`, unless a newer committed skill/doc
    baseline has replaced it.
-2. Start one read-only `ci_wait_monitor` route or Codex app/Spark sidecar for that PR:
+2. Start one read-only `ci_wait_monitor` route or Codex app/Spark sidecar for that PR. In non-TTY
+   agent sessions, use bounded one-shot polling rather than `gh pr checks --watch`:
 
    ```bash
-   uv run python scripts/dev/watch_pr_ci_status.py <pr-number> \
-     --expected-head-sha <head-sha> --json
+   uv run python scripts/dev/check_pr_ci_status.py <pr-number> \
+     --poll-attempts 40 \
+     --poll-interval 30 \
+     --json
    ```
 
 3. Continue with non-conflicting work on the main thread: review other PRs, merge already-green
@@ -132,16 +135,18 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
 4. When the monitor returns, the main agent must review the result against the current PR head SHA
    before applying `merge-ready`, merging, or reporting completion.
 
-The wait helper uses the stable default budget on normal runs. It samples recent successful CI
-runtime only when CI is still pending after the budget expires, and then reports drift evidence plus
-a recommended baseline. Do not change the committed default wait baseline after one ordinary slow
-run; update it only after repeated over-budget evidence or an obvious CI workflow change.
+The polling helper prints queued, in-progress, failed, and passed check summaries. Use
+`gh run view <run-id> --json status,conclusion,jobs` when a job URL needs deeper state, and fetch
+logs only after the relevant job has completed. Do not change committed polling budgets after one
+ordinary slow run; update them only after repeated over-budget evidence or an obvious CI workflow
+change.
 
 Treat monitor exit states as follows:
 
 - `success`: CI is green for the expected head SHA; reassess readiness locally.
 - `failure`: leave the PR open, record the failing checks, and continue the cycle.
-- `timeout`: keep the PR in `awaiting_ci`, record the drift sample, and continue other work.
+- `pending timeout` / exit code `2`: keep the PR in `awaiting_ci`, record the pending checks, and
+  continue other work.
 - `error`: record stale head, auth, API, or parsing failure; do not trust the waiter for readiness.
 
 ### Active Delegation Ledger

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -102,9 +102,14 @@ Avoid loops:
 7. Resolve review threads only after the post-push thread snapshot confirms the fixes still cover all
    actionable comments.
 8. Update `merge-ready` only after full proof bar closes.
-9. When CI is the only remaining external gate, put the PR in `awaiting_ci` and use
-   `.agents/skills/goal-autopilot/SKILL.md` "Async CI Wait Policy" instead of idling the review
-   loop when other safe PR or cycle work remains.
+9. When CI is the only remaining external gate, put the PR in `awaiting_ci` and use bounded
+   one-shot polling in non-TTY agent sessions instead of `gh pr checks --watch`:
+   `uv run python scripts/dev/check_pr_ci_status.py <number> --poll-attempts 20 --poll-interval 30`.
+   The helper prints queued, in-progress, failed, and passed check summaries; exit code `2` means
+   the polling budget expired with checks still pending. Use
+   `gh run view <run-id> --json status,conclusion,jobs` for job state and fetch logs only after the
+   relevant job has completed. Use `.agents/skills/goal-autopilot/SKILL.md` "Async CI Wait Policy"
+   instead of idling the review loop when other safe PR or cycle work remains.
 10. Update the active ledger before any CI wait or final handoff. Route completion is not task
    completion until the main agent has verified proof, GitHub state, and cleanup.
 

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -89,6 +89,11 @@ def _rollup_status(check: dict[str, Any]) -> str:
     return state_str
 
 
+def _rollup_name(check: dict[str, Any]) -> str:
+    """Return a display name for check-run and legacy-status rollup entries."""
+    return str(check.get("name") or check.get("context") or "unknown")
+
+
 def _fetch_ci_status(
     pr_number: str,
     backoff: float = 0.0,
@@ -158,8 +163,17 @@ def _fetch_ci_status(
 
     name_counts: dict[str, int] = {}
     for check in rollup:
-        name = check.get("name", "unknown")
+        name = _rollup_name(check)
         name_counts[name] = name_counts.get(name, 0) + 1
+    check_details = [
+        {
+            "name": _rollup_name(check),
+            "status": _rollup_status(check),
+            "conclusion": _rollup_conclusion(check),
+            "details_url": check.get("detailsUrl", "") or check.get("targetUrl", ""),
+        }
+        for check in rollup
+    ]
 
     return {
         "status": "ok",
@@ -175,6 +189,7 @@ def _fetch_ci_status(
             "by_conclusion": conclusions,
             "by_status": states,
             "names": sorted(name_counts),
+            "details": check_details,
         },
         "reviews": review_states,
     }
@@ -203,6 +218,15 @@ def _format_human(data: dict[str, Any]) -> str:
     lines.append(
         f"  checks: {overall}  |  {total} total  |  {conclusion_str}  |  status: {status_str}"
     )
+    for check in checks.get("details", []):
+        if check.get("status") == "completed" and check.get("conclusion") == "success":
+            continue
+        url = check.get("details_url")
+        suffix = f"  |  {url}" if url else ""
+        lines.append(
+            f"    - {check.get('name', 'unknown')}: "
+            f"{check.get('status', 'unknown')}/{check.get('conclusion', 'unknown')}{suffix}"
+        )
 
     reviews = data.get("reviews", {})
     if reviews:
@@ -210,6 +234,33 @@ def _format_human(data: dict[str, Any]) -> str:
         lines.append(f"  reviews: {review_str}")
 
     return "\n".join(lines)
+
+
+def _poll_ci_status(
+    pr: str,
+    *,
+    attempts: int,
+    poll_interval: float,
+    backoff: float,
+    json_output: bool,
+) -> dict[str, Any]:
+    """Fetch CI status once or poll until checks settle or the budget expires."""
+    data: dict[str, Any] = {}
+    for attempt in range(1, attempts + 1):
+        data = _fetch_ci_status(pr, backoff=backoff if attempt == 1 else 0.0)
+        if data.get("status") == "error":
+            break
+        overall = data.get("checks", {}).get("overall")
+        if attempts > 1:
+            if json_output:
+                print(json.dumps(data), flush=True)
+            else:
+                print(f"poll attempt {attempt}/{attempts}", flush=True)
+                print(_format_human(data), flush=True)
+        if overall != "pending" or attempt == attempts:
+            break
+        time.sleep(max(0.0, poll_interval))
+    return data
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -232,11 +283,30 @@ def main(argv: list[str] | None = None) -> int:
         default=0.0,
         help="seconds to wait before fetching (for cache coherency)",
     )
+    parser.add_argument(
+        "--poll-attempts",
+        type=int,
+        default=1,
+        help="bounded polling attempts; values above 1 wait for pending checks to settle",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=30.0,
+        help="seconds between bounded polling attempts",
+    )
     args = parser.parse_args(argv)
 
     try:
         pr = _resolve_pr_number(args.pr_number)
-        data = _fetch_ci_status(pr, backoff=args.backoff)
+        attempts = max(1, args.poll_attempts)
+        data = _poll_ci_status(
+            pr,
+            attempts=attempts,
+            poll_interval=args.poll_interval,
+            backoff=args.backoff,
+            json_output=args.json,
+        )
     except FileNotFoundError:
         print("gh CLI not found. Install GitHub CLI: https://cli.github.com/", file=sys.stderr)
         return 1
@@ -251,15 +321,18 @@ def main(argv: list[str] | None = None) -> int:
         print(_format_human(data))
         return 1
 
-    if args.json:
-        print(json.dumps(data))
-    else:
-        print(_format_human(data))
+    if attempts == 1:
+        if args.json:
+            print(json.dumps(data))
+        else:
+            print(_format_human(data))
 
     # Non-zero exit when CI is failing; pending checks are cache/backoff-safe.
     overall = data.get("checks", {}).get("overall")
     if overall == "failure":
         return 1
+    if attempts > 1 and overall == "pending":
+        return 2
 
     return 0
 

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -12,6 +12,7 @@ from scripts.dev.check_pr_ci_status import (
     _fetch_ci_status,
     _format_human,
     _rollup_conclusion,
+    _rollup_name,
     _rollup_status,
     main,
 )
@@ -232,6 +233,8 @@ def test_main_preserves_pending_legacy_status(
     assert payload["checks"]["overall"] == "pending"
     assert payload["checks"]["by_conclusion"] == {"success": 1, "pending": 1}
     assert payload["checks"]["by_status"] == {"completed": 1, "pending": 1}
+    assert payload["checks"]["details"][1]["name"] == "external-status"
+    assert payload["checks"]["details"][1]["status"] == "pending"
 
 
 def test_main_treats_error_legacy_status_as_failure(
@@ -296,6 +299,13 @@ def test_rollup_status_prefers_status_then_legacy_state(
 ) -> None:
     """Lifecycle status normalization should avoid double-counting legacy pending checks."""
     assert _rollup_status(check) == expected
+
+
+def test_rollup_name_prefers_check_name_then_legacy_context() -> None:
+    """Legacy status contexts should not render as unknown checks."""
+    assert _rollup_name({"name": "ci", "context": "legacy"}) == "ci"
+    assert _rollup_name({"context": "CodeRabbit"}) == "CodeRabbit"
+    assert _rollup_name({}) == "unknown"
 
 
 def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
@@ -387,6 +397,138 @@ def test_main_with_backoff(capsys: pytest.CaptureFixture) -> None:
         rc = main(["3", "--backoff", "0.0"])
 
     assert rc == 0
+
+
+def test_format_human_lists_non_success_details() -> None:
+    """Human output should distinguish queued/in-progress/failing checks."""
+    data = {
+        "status": "ok",
+        "pr": 5,
+        "title": "details",
+        "state": "OPEN",
+        "mergeable": "UNKNOWN",
+        "branch": "details",
+        "head_sha": "abc123",
+        "checks": {
+            "total": 3,
+            "overall": "pending",
+            "by_conclusion": {"success": 1, "pending": 2},
+            "by_status": {"completed": 1, "queued": 1, "in_progress": 1},
+            "names": ["done", "queued", "running"],
+            "details": [
+                {
+                    "name": "done",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "details_url": "https://example.test/done",
+                },
+                {
+                    "name": "queued",
+                    "status": "queued",
+                    "conclusion": "pending",
+                    "details_url": "https://example.test/queued",
+                },
+                {
+                    "name": "running",
+                    "status": "in_progress",
+                    "conclusion": "pending",
+                    "details_url": "https://example.test/running",
+                },
+            ],
+        },
+        "reviews": {},
+    }
+
+    output = _format_human(data)
+
+    assert "done:" not in output
+    assert "queued: queued/pending" in output
+    assert "running: in_progress/pending" in output
+    assert "https://example.test/running" in output
+
+
+def test_main_bounded_polling_times_out_pending(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Bounded polling should return a distinct code when checks never settle."""
+    mock_data = json.dumps(
+        {
+            "number": 7,
+            "title": "pending poll",
+            "state": "OPEN",
+            "mergeable": "UNKNOWN",
+            "headRefName": "pending-poll",
+            "statusCheckRollup": [
+                {
+                    "name": "ci",
+                    "status": "queued",
+                    "conclusion": "",
+                    "detailsUrl": "https://example.test/ci",
+                }
+            ],
+            "reviews": [],
+        }
+    )
+
+    with (
+        patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run,
+        patch("scripts.dev.check_pr_ci_status.time.sleep") as mock_sleep,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["7", "--poll-attempts", "2", "--poll-interval", "0.1"])
+
+    assert rc == 2
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once_with(0.1)
+    captured = capsys.readouterr()
+    assert "poll attempt 1/2" in captured.out
+    assert "poll attempt 2/2" in captured.out
+    assert "ci: queued/pending" in captured.out
+
+
+def test_main_bounded_polling_stops_on_success(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Bounded polling should stop once pending checks pass."""
+    pending_data = json.dumps(
+        {
+            "number": 8,
+            "title": "eventual pass",
+            "state": "OPEN",
+            "mergeable": "UNKNOWN",
+            "headRefName": "eventual-pass",
+            "statusCheckRollup": [{"name": "ci", "status": "queued", "conclusion": ""}],
+            "reviews": [],
+        }
+    )
+    success_data = json.dumps(
+        {
+            "number": 8,
+            "title": "eventual pass",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "eventual-pass",
+            "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+            "reviews": [],
+        }
+    )
+
+    with (
+        patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run,
+        patch("scripts.dev.check_pr_ci_status.time.sleep") as mock_sleep,
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=pending_data, stderr=""),
+            MagicMock(returncode=0, stdout=success_data, stderr=""),
+        ]
+        rc = main(["8", "--poll-attempts", "5", "--poll-interval", "0.1"])
+
+    assert rc == 0
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once_with(0.1)
+    captured = capsys.readouterr()
+    assert "poll attempt 2/5" in captured.out
+    assert "checks: success" in captured.out
 
 
 def test_main_gh_not_installed() -> None:


### PR DESCRIPTION
## Summary
- extend `scripts/dev/check_pr_ci_status.py` with opt-in bounded polling via `--poll-attempts` / `--poll-interval`
- include non-success check details so queued, in-progress, failed, and pending states are visible without `gh pr checks --watch`
- update PR merger/review/autopilot skills to prefer bounded polling in non-TTY agent sessions and to use `gh run view` for deeper job state

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_ci_status.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py 2632 --poll-attempts 2 --poll-interval 0`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Delegate Outcomes
- Gemini read-only review route attempted and rejected: the CLI entered a tool-error loop (`run_shell_command` unavailable) and was terminated without usable findings.
- Local tests and live helper smoke were used as acceptance evidence.

## Research Result Guidance
NA. This is workflow/tooling guidance only; it does not create or strengthen benchmark, dissertation, or paper-facing evidence.

## Downstream Propagation
- Parent issue: closes #2535.
- Skills/docs: updates `.agents/skills/goal-autopilot/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`, and `.agents/skills/gh-pr-merger/SKILL.md`.
- Artifact catalog / registry / context index / memory: NA; no generated evidence artifact or research claim.
- Follow-up issues: NA.

Closes #2535.
