### PR TITLE
docs: require scout issue verification

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -54,10 +54,23 @@ instead of reimplementing. If the issue depends on an unmerged source PR, mark i
 unavailable for clean-main work with the unblock condition "source PR merged to origin/main",
 unless the user explicitly chooses a stacked-PR route.
 
+Delegated queue-scout output is only route evidence until verified by the main agent in the target
+repository. Before using a scout recommendation to select, claim, or branch for an issue, run:
+
+```bash
+gh issue view <number> --repo ll7/robot_sf_ll7 --json number,title,state,labels,body,comments,url
+```
+
+or an equivalent REST read. Confirm the URL belongs to
+`ll7/robot_sf_ll7`, the issue is still open, ready labels/state are current, recent comments do not
+block or supersede the work, and no linked/open PR already covers it. Treat stale state, wrong
+repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected scout failure modes.
+
 ## Workflow
 
 1. Refresh credentials and branch baseline (`gh auth status`, `git fetch origin`).
-2. Resolve queue candidate and re-check issue state.
+2. Resolve queue candidate and re-check issue state with local `gh issue view` or REST evidence
+   before claim or branch, especially when a delegated scout proposed the issue.
 3. Check open PRs for duplicate coverage using the linked issue, head branch/scope, and title.
    Stop or update routing when an existing PR covers the work.
 4. If issue statement is ambiguous:

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -184,6 +184,11 @@ only proves `route_status: completed`; the parent phase is not complete until th
 reviewed the output, integrated any edits, run the required validation, updated GitHub state, and
 recorded cleanup.
 
+For delegated queue scouts, keep the scout output in the ledger as route evidence only until the
+main agent verifies issue state in `ll7/robot_sf_ll7` with local `gh issue view` or REST evidence.
+Do not claim or branch from scout text alone; stale state, wrong repo-owner URLs, missing recent
+comments, and duplicate PR coverage are known failure modes.
+
 ### Usage Pause Guard
 
 When a user-defined Codex usage threshold is active, run the configured usage-check command. For the

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -167,8 +167,19 @@ Then run one final read-only implementability audit over:
 
 If these local filters appear exhausted or dominated by blocked/SLURM-only work, run one bundled
 broad queue scout before declaring the queue empty. Prefer a cheap local or Qwen scan plus one
-substantial Copilot pass when available; treat scout output as a lead only, and confirm any proposed
-candidate with local `gh issue view` evidence before selecting, claiming, or reporting it as ready.
+substantial Copilot pass when available; treat scout output as route evidence only until the main
+agent verifies it locally. Before selecting, claiming, branching for, or reporting a scout-proposed
+issue as ready, run:
+
+```bash
+gh issue view <number> --repo ll7/robot_sf_ll7 --json number,title,state,labels,body,comments,url
+```
+
+or an equivalent REST read. Confirm the repository
+owner/name, open state, labels, body, recent comments, linked/covering PRs, and ready eligibility
+against current GitHub state. Known scout failure modes include stale open/closed/blocked state,
+wrong repo-owner URLs, missing recent comments, and duplicate PR coverage; do not acquire
+`agent-claims/issue-<number>` or create a branch from scout text alone.
 When live labels conflict with recently merged dependency PRs, closeout comments, or issue links,
 perform a stale-blocker recheck before skipping the issue. Route one scout specifically to answer
 whether the blocker is still true, then confirm the answer with REST `gh api` or local `git`


### PR DESCRIPTION
## Summary
- Treat delegated queue-scout recommendations as route evidence only until the main agent verifies issue state locally.
- Require `gh issue view <number> --repo ll7/robot_sf_ll7 --json number,title,state,labels,body,comments,url` or equivalent REST evidence before selecting, claiming, or branching.
- Document stale issue state, wrong repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected scout failure modes.

Closes #2534

## Validation
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py --preflight goal-autopilot`

## Downstream Propagation
NA: low-risk workflow documentation update. No benchmark, artifact registry, claim map, or context note requires propagation.

## Research Result Guidance
NA: workflow guidance only; no research claim, benchmark metric, or planner result is introduced.

## Delegate Outcomes
- No edit delegate used for this small docs-only change; local validation covered the acceptance criteria.
