### PR TITLE
perf: vectorize occupancy circle bounds

### DIFF
--- a/robot_sf/nav/occupancy_grid_utils.py
+++ b/robot_sf/nav/occupancy_grid_utils.py
@@ -373,35 +373,33 @@ def get_affected_cells(
         clamped_x, clamped_y, config, grid_origin_x, grid_origin_y
     )
 
-    affected = []
+    row_min = max(0, center_row - cell_radius)
+    row_max = min(config.grid_height - 1, center_row + cell_radius)
+    col_min = max(0, center_col - cell_radius)
+    col_max = min(config.grid_width - 1, center_col + cell_radius)
+
+    if row_min > row_max or col_min > col_max:
+        return []
+
+    rows = np.arange(row_min, row_max + 1)
+    cols = np.arange(col_min, col_max + 1)
     half_res = config.resolution * 0.5
 
-    for dr in range(-cell_radius, cell_radius + 1):
-        for dc in range(-cell_radius, cell_radius + 1):
-            row = center_row + dr
-            col = center_col + dc
+    row_centers = grid_origin_y + (rows.astype(float) + 0.5) * config.resolution
+    col_centers = grid_origin_x + (cols.astype(float) + 0.5) * config.resolution
+    cell_min_y = row_centers[:, None] - half_res
+    cell_max_y = row_centers[:, None] + half_res
+    cell_min_x = col_centers[None, :] - half_res
+    cell_max_x = col_centers[None, :] + half_res
 
-            # Check bounds
-            if not (0 <= row < config.grid_height and 0 <= col < config.grid_width):
-                continue
+    # Circle-rectangle intersection for every candidate cell in one bounded slice.
+    closest_x = np.clip(world_x, cell_min_x, cell_max_x)
+    closest_y = np.clip(world_y, cell_min_y, cell_max_y)
+    dist_sq = (closest_x - world_x) ** 2 + (closest_y - world_y) ** 2
+    mask = dist_sq <= radius**2
 
-            # Get cell bounds (cell is a square)
-            cell_world_x, cell_world_y = grid_indices_to_world(
-                row, col, config, grid_origin_x, grid_origin_y
-            )
-            cell_min_x = cell_world_x - half_res
-            cell_max_x = cell_world_x + half_res
-            cell_min_y = cell_world_y - half_res
-            cell_max_y = cell_world_y + half_res
-
-            # Circle-rectangle intersection: find closest point on rectangle to circle center
-            closest_x = np.clip(world_x, cell_min_x, cell_max_x)
-            closest_y = np.clip(world_y, cell_min_y, cell_max_y)
-
-            # Check if closest point is within circle radius
-            dist = np.sqrt((closest_x - world_x) ** 2 + (closest_y - world_y) ** 2)
-
-            if dist <= radius:
-                affected.append((row, col))
-
-    return affected
+    row_indices, col_indices = np.nonzero(mask)
+    return [
+        (int(rows[row_idx]), int(cols[col_idx]))
+        for row_idx, col_idx in zip(row_indices, col_indices, strict=False)
+    ]

--- a/tests/test_occupancy_circle_overlap.py
+++ b/tests/test_occupancy_circle_overlap.py
@@ -18,8 +18,10 @@ import pytest
 from loguru import logger
 
 from robot_sf.common.types import Circle2D
+from robot_sf.nav import occupancy_grid_utils
 from robot_sf.nav.occupancy_grid import GridConfig, OccupancyGrid
 from robot_sf.nav.occupancy_grid_rasterization import rasterize_circle, rasterize_circle_fast
+from robot_sf.nav.occupancy_grid_utils import get_affected_cells
 
 
 class TestCircleCenterOutsideButOverlapping:
@@ -198,6 +200,31 @@ def test_circle_boundary_detection(
         assert occupied == 0, (
             f"{description}: Circle at ({center_x}, {center_y}) should not overlap grid (got {occupied} cells)"
         )
+
+
+def test_affected_cells_avoids_per_cell_world_conversion(monkeypatch):
+    """Affected-cell bounds should not recompute world centers once per candidate cell."""
+    config = GridConfig(resolution=0.05, width=20.0, height=20.0)
+
+    def fail_per_cell_conversion(*_args, **_kwargs):
+        raise AssertionError(
+            "get_affected_cells should precompute cell bounds without per-cell conversion"
+        )
+
+    monkeypatch.setattr(occupancy_grid_utils, "grid_indices_to_world", fail_per_cell_conversion)
+
+    inside_cells = get_affected_cells(10.0, 10.0, 1.25, config)
+    outside_cells = get_affected_cells(20.75, 10.0, 1.0, config)
+
+    assert inside_cells
+    assert outside_cells
+    assert all(
+        0 <= row < config.grid_height and 0 <= col < config.grid_width for row, col in inside_cells
+    )
+    assert all(
+        0 <= row < config.grid_height and 0 <= col < config.grid_width for row, col in outside_cells
+    )
+    assert any(col == config.grid_width - 1 for _, col in outside_cells)
 
 
 class TestCircleOverlapWithOccupancyGrid:


### PR DESCRIPTION
## Summary
- vectorizes `get_affected_cells` over the bounded row/column slice instead of recomputing cell bounds through per-cell `grid_indices_to_world` calls
- keeps the circle-rectangle overlap semantics for inside-grid and outside-grid overlap circles
- adds a regression test that fails if the affected-cell path falls back to per-cell world conversion

Closes #2636

## Validation
- RED: `uv run pytest tests/test_occupancy_circle_overlap.py -k avoids_per_cell_world_conversion -q` failed on the old per-cell conversion path
- GREEN: `uv run pytest tests/test_occupancy_circle_overlap.py -k avoids_per_cell_world_conversion -q`
- `uv run pytest tests/test_occupancy_circle_overlap.py tests/test_occupancy_grid.py -q`
- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy ROBOT_SF_PERF_ENFORCE=0 uv run pytest tests/perf/test_simulation_speed_perf.py -k test_simulation_step_throughput -q`
- `uv run ruff format robot_sf/nav/occupancy_grid_utils.py tests/test_occupancy_circle_overlap.py`
- `uv run ruff check robot_sf/nav/occupancy_grid_utils.py tests/test_occupancy_circle_overlap.py`
- `git diff --check`

## Local Timing Check
Small inline harness compared the previous scalar loop shape against the new function and asserted identical affected-cell lists:

- inside dense case: 2056 cells, legacy 7.775229s, vectorized 0.199448s, 38.98x faster over 200 calls
- outside right overlap: 108 cells, legacy 2.979132s, vectorized 0.021726s, 137.12x faster over 200 calls

These are local diagnostic timings, not benchmark-grade claims.

## Downstream Propagation
- No benchmark label, planner status, artifact registry, or public claim changes.
- Ignored `output/coverage` artifacts were generated by pytest and left untracked/disposable.
- #2536 discovery note remains the synthesis surface for why this child issue was selected.

## Research Result Guidance
- Target claim/hypothesis/blocker: bounded simulator-speed optimization candidate from #2536.
- Comparator/baseline: previous scalar affected-cell loop shape.
- Evidence tier: local diagnostic timing plus correctness tests.
- Result classification: local implementation evidence; not paper-facing benchmark evidence.
- Decision/stop rule: merge if correctness tests, perf smoke, and CI pass without semantic regressions.
- Synthesis surface/update target: #2636 and `docs/context/issue_2536_speed_discovery.md`.
