### PR TITLE
docs: harden GitHub publication guidance

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -94,6 +94,16 @@ repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected 
    `In progress`, add or preserve `state:running` when using state labels, assign the local actor
    when practical, and add a short issue comment naming the claim ref, machine/thread, intended
    implementation branch, and stale-claim cleanup condition.
+
+   Publication rule: use `scripts/dev/gh_comment.sh`, `gh issue/pr comment --body-file`, or REST
+   JSON input for Markdown-heavy comments. Do not put bodies containing backticks, YAML, commands,
+   or multiline Markdown into inline shell strings. Use REST endpoints for simple label writes when
+   `gh` would route through GraphQL, for example:
+
+   ```bash
+   gh api repos/ll7/robot_sf_ll7/issues/<number>/labels -f labels[]=state:running
+   gh api -X DELETE repos/ll7/robot_sf_ll7/issues/<number>/labels/state:ready
+   ```
 7. Create the issue branch in a linked worktree for non-trivial implementation. Prefer the
    `AGENTS.md` "Fresh Worktree Bootstrap" location, naming, machine-context symlink, and branch
    freshness rules; use an in-place branch only for tiny or explicitly requested main-checkout work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,11 @@ For shared local + VS Code + Codex workflows, prefer:
 - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
 - `scripts/dev/gh_comment.sh` for multiline `gh` PR/issue comments (stdin or `--body-file`, avoids literal `\n` formatting issues)
 
+For GitHub comments with Markdown-heavy bodies, do not pass the body as an inline shell string.
+Use `scripts/dev/gh_comment.sh`, `gh issue/pr comment --body-file`, or REST JSON input. This is
+mandatory when the body contains backticks, YAML, shell commands, multiline Markdown, or anything
+the shell could expand before `gh` receives it.
+
 ## Config-First Strategy
 Prefer a config-first workflow for reproducibility and reviewability. Add or update YAML files under `configs/` for stable experiments and document the canonical command using `--config <path>`. Use CLI flags only for short-lived overrides while iterating locally.
 
@@ -356,6 +361,14 @@ When working issue batches or Project #5 updates:
   current maintainer direction or fresh evidence,
 - use REST (`gh api repos/...`) for ordinary issue/PR/label/comment operations when GraphQL quota
   is low or when the operation does not need Projects v2,
+- prefer REST endpoints for simple label/comment publication writes even before quota is low when
+  `gh` routes through brittle GraphQL surfaces; PR #2520 hit a classic Projects deprecation error
+  via `gh pr edit --add-label merge-ready` while the REST issue-label endpoint worked immediately,
+- for labels, use `gh api repos/:owner/:repo/issues/<number>/labels -f labels[]=<label>` to add
+  and `gh api -X DELETE repos/:owner/:repo/issues/<number>/labels/<label>` to remove,
+- for comment creation or patching, use body files or JSON payloads such as
+  `gh api repos/:owner/:repo/issues/<number>/comments -F body=@body.md` and
+  `gh api -X PATCH repos/:owner/:repo/issues/comments/<comment-id> -F body=@body.md`,
 - use local `git` for branch, diff, merge-base, and commit state instead of asking GitHub,
 - clean up issue text and labels first,
 - route Project #5 metadata in a separate pass,


### PR DESCRIPTION
## Summary
- require body files, REST JSON, or `scripts/dev/gh_comment.sh` for Markdown-heavy issue/PR comments
- document REST-first label/comment publication writes when `gh` routes through brittle GraphQL surfaces
- add examples for issue label add/remove and comment create/patch commands

Closes #2532.
Closes #2533.

## Validation
- `bash scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Downstream Propagation
No generated artifacts or `output/` files were created. This is workflow guidance only and should reduce future autopilot publication failures without changing GitHub auth or Project v2 routing.

## Research Result Guidance
NA: workflow/docs-only hardening. No research, benchmark, metric, or paper-facing claim is created.
