### PR TITLE
test: tighten docs context proof gate (#2491)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -315,10 +315,11 @@ handoff context in Markdown instead of leaving them trapped in chat or PR histor
 - Link notes to the related issue/PR, canonical docs, validation commands, and replacement notes.
 - Use `.agents/skills/context-note-maintainer/SKILL.md` when the task includes creating or
   refreshing context notes.
-- For docs/context-only changes, use the cheap consistency gate by default: inspect the diff,
-  verify changed README/INDEX/catalog links, and run the docs proof consistency check or its
-  targeted tests. State explicitly when benchmark, simulator, or full PR readiness gates were not
-  run because the branch only changes discoverability or workflow text.
+- For docs/context-only changes, use the documented default gate: inspect the diff, verify changed
+  README/INDEX/catalog links, and run `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`.
+  The wrapper auto-detects context-only PRs and includes README/INDEX/catalog in that gate. State
+  explicitly when benchmark, simulator, or full PR readiness gates were not run because the branch only
+  changes discoverability or workflow text.
 
 ### Agent memory conventions
 

--- a/scripts/dev/check_docs_proof_consistency_diff.sh
+++ b/scripts/dev/check_docs_proof_consistency_diff.sh
@@ -31,6 +31,9 @@ if [ -z "$changed_files" ]; then
   docs_context_only=0
 else
   while IFS= read -r file; do
+    if [ -z "$file" ]; then
+      continue
+    fi
     if [[ "$file" != docs/context/* ]]; then
       docs_context_only=0
       break

--- a/scripts/dev/check_docs_proof_consistency_diff.sh
+++ b/scripts/dev/check_docs_proof_consistency_diff.sh
@@ -6,5 +6,62 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common_setup.sh"
 
 BASE_REF="${BASE_REF:-origin/main}"
+DOCS_CONTEXT_PROOF_PATHS=(
+  "docs/context/README.md"
+  "docs/context/INDEX.md"
+  "docs/context/catalog.yaml"
+)
 
-uv run --active python scripts/validation/check_docs_proof_consistency.py --base "$BASE_REF"
+path_selected() {
+  local needle="$1"
+  shift
+  local selected
+  for selected in "$@"; do
+    if [ "$selected" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+changed_files="$(git diff --name-only "${BASE_REF}...HEAD")"
+docs_context_only=1
+
+if [ -z "$changed_files" ]; then
+  docs_context_only=0
+else
+  while IFS= read -r file; do
+    if [[ "$file" != docs/context/* ]]; then
+      docs_context_only=0
+      break
+    fi
+  done <<<"$changed_files"
+fi
+
+if [ "$docs_context_only" -eq 1 ]; then
+  paths=()
+  while IFS= read -r file; do
+    if [ -z "$file" ]; then
+      continue
+    fi
+    if ! path_selected "$file" "${paths[@]}"; then
+      paths+=("$file")
+    fi
+  done <<<"$changed_files"
+
+  for required_path in "${DOCS_CONTEXT_PROOF_PATHS[@]}"; do
+    if ! path_selected "$required_path" "${paths[@]}"; then
+      paths+=("$required_path")
+    fi
+  done
+
+  path_args=()
+  for selected in "${paths[@]}"; do
+    path_args+=(--path "$selected")
+  done
+
+  uv run --active python scripts/validation/check_docs_proof_consistency.py \
+    --base "$BASE_REF" "${path_args[@]}"
+else
+  uv run --active python scripts/validation/check_docs_proof_consistency.py --base "$BASE_REF"
+fi

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
 _CONTEXT_README = Path("docs/context/README.md")
+_CONTEXT_INDEX = Path("docs/context/INDEX.md")
 _CONTEXT_CATALOG = Path("docs/context/catalog.yaml")
 _TOP_LEVEL_CONTEXT_DIR = Path("docs/context")
 _EVIDENCE_DIR = Path("docs/context/evidence")
@@ -199,6 +200,15 @@ def _contains_link_target(targets: Iterable[str], expected: str) -> bool:
     return False
 
 
+def _context_note_is_added(changed: ChangedFile) -> bool:
+    """Return whether a changed file is a new top-level context note."""
+    return (
+        _is_added_status(changed.status)
+        and changed.path.parent == _TOP_LEVEL_CONTEXT_DIR
+        and changed.path.suffix == ".md"
+    )
+
+
 def _context_readme_link_diagnostics(
     changed_files: Iterable[ChangedFile],
     *,
@@ -208,11 +218,9 @@ def _context_readme_link_diagnostics(
     diagnostics: list[Diagnostic] = []
     targets = _markdown_targets(context_readme_text)
     for changed in changed_files:
-        if not _is_added_status(changed.status):
+        if not _context_note_is_added(changed):
             continue
-        if changed.path.parent != _TOP_LEVEL_CONTEXT_DIR:
-            continue
-        if changed.path.suffix != ".md" or changed.path.name == "README.md":
+        if changed.path.name == _CONTEXT_README.name:
             continue
         if _contains_link_target(targets, changed.path.name):
             continue
@@ -220,6 +228,30 @@ def _context_readme_link_diagnostics(
             Diagnostic(
                 path=changed.path,
                 message="added context note is not linked from docs/context/README.md",
+            )
+        )
+    return diagnostics
+
+
+def _context_index_link_diagnostics(
+    changed_files: Iterable[ChangedFile],
+    *,
+    context_index_text: str,
+) -> list[Diagnostic]:
+    """Flag added top-level docs/context notes missing from the context index."""
+    diagnostics: list[Diagnostic] = []
+    targets = _markdown_targets(context_index_text)
+    for changed in changed_files:
+        if not _context_note_is_added(changed):
+            continue
+        if changed.path.name in {_CONTEXT_README.name, _CONTEXT_INDEX.name}:
+            continue
+        if _contains_link_target(targets, changed.path.name):
+            continue
+        diagnostics.append(
+            Diagnostic(
+                path=changed.path,
+                message="added context note is not linked from docs/context/INDEX.md",
             )
         )
     return diagnostics
@@ -565,6 +597,14 @@ def _collect_diagnostics(
             _context_readme_link_diagnostics(
                 changed_list,
                 context_readme_text=_read_text(context_readme),
+            )
+        )
+    context_index = repo_root / _CONTEXT_INDEX
+    if context_index.exists():
+        diagnostics.extend(
+            _context_index_link_diagnostics(
+                changed_list,
+                context_index_text=_read_text(context_index),
             )
         )
     diagnostics.extend(_context_catalog_diagnostics(_CONTEXT_CATALOG, repo_root=repo_root))

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -12,6 +12,7 @@ from scripts.validation.check_docs_proof_consistency import (
     ChangedFile,
     _collect_diagnostics,
     _context_catalog_diagnostics,
+    _context_index_link_diagnostics,
     _context_readme_link_diagnostics,
     _parse_name_status,
     _selected_files,
@@ -38,6 +39,34 @@ def test_context_note_anchor_link_counts_as_index_link() -> None:
     diagnostics = _context_readme_link_diagnostics(
         [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
         context_readme_text="- [Issue 999 Example](issue_999_example.md#validation)\n",
+    )
+
+    assert diagnostics == []
+
+
+def test_context_note_requires_context_index_link() -> None:
+    """New top-level context notes should be linked from the context index."""
+    diagnostics = _context_index_link_diagnostics(
+        [ChangedFile(status="A", path=Path("docs/context/issue_999_example.md"))],
+        context_index_text="# Context Retrieval Index\n",
+    )
+
+    assert diagnostics == [
+        type(diagnostics[0])(
+            path=Path("docs/context/issue_999_example.md"),
+            message="added context note is not linked from docs/context/INDEX.md",
+        )
+    ]
+
+
+def test_context_index_link_check_skips_context_entrypoints() -> None:
+    """README and INDEX are the context entrypoints, not notes requiring index links."""
+    diagnostics = _context_index_link_diagnostics(
+        [
+            ChangedFile(status="A", path=Path("docs/context/README.md")),
+            ChangedFile(status="A", path=Path("docs/context/INDEX.md")),
+        ],
+        context_index_text="# Context Retrieval Index\n",
     )
 
     assert diagnostics == []


### PR DESCRIPTION
## Summary

- Make the lightweight docs proof wrapper detect docs/context-only diffs and include the context README, INDEX, and catalog in the default check set.
- Require newly changed top-level `docs/context/*.md` notes to be discoverable from `docs/context/INDEX.md` as well as the README, while skipping the context entrypoint files themselves.
- Cover the new diff selection and INDEX-link diagnostics with focused validation tests, and document the default docs-only gate in `docs/dev_guide.md`.

Closes #2491.

## Validation

- `rtk bash -n scripts/dev/check_docs_proof_consistency_diff.sh`
- `rtk uv run pytest tests/validation/test_check_docs_proof_consistency.py` -> 27 passed
- `rtk uv run ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`
- `rtk uv run ruff format --check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`
- `rtk bash scripts/dev/check_docs_proof_consistency_diff.sh`
- `rtk env PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> 5591 passed, 9 skipped at implementation commit `18e116e14fdbb8108d32d3cac3a2dd7b09418ae4`
- Review-fix head `347f2ba9000658a3f49f5fd511c33297edca8ef6`: `rtk bash -n scripts/dev/check_docs_proof_consistency_diff.sh`, `rtk bash scripts/dev/check_docs_proof_consistency_diff.sh`, and `rtk uv run pytest tests/validation/test_check_docs_proof_consistency.py` -> 27 passed

## Artifact Decision

Ignored local `output/coverage/` and `output/validation/pr_ready/` files are disposable validation artifacts and are not promoted.

## Research Result Guidance

- Target claim / blocker: NA - support workflow/docs-only validation gate.
- Comparator / baseline: Existing wrapper only selected changed docs/proof/catalog files and did not automatically add context entrypoints for docs/context-only diffs.
- Evidence tier: Targeted unit tests plus full PR readiness for the implementation commit, followed by focused review-fix validation at the current head.
- Result classification: Workflow hardening.
- Decision / stop rule: The wrapper selects the docs/context gate by default for context-only diffs, diagnostics enforce discoverability, and the repository readiness gate passes.
- Synthesis surface / update target: `docs/dev_guide.md` documents the default gate.

## Downstream Propagation

- Parent issue: #2491.
- Claim map / benchmark report / leaderboard / artifact catalog: NA - no benchmark or research artifact.
- Registry / config index: NA.
- Context index / memory note: NA - implementation updates the docs gate and dev guide, not a context-note result.
