### PR TITLE
docs: add REST-first publication snippets (#2490)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -324,7 +324,7 @@ gh api repos/$OWNER/$REPO/pulls/$PR -X PATCH \
 
 ```bash
 RUN_ID=$(gh api repos/$OWNER/$REPO/actions/runs \
-  --method GET --paginate \
+  --method GET \
   -f branch=$BRANCH \
   -q '.workflow_runs | sort_by(.created_at) | reverse | .[0].id')
 while :; do

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -303,6 +303,63 @@ For GitHub issue batches and Project #5 updates, follow the batch-first workflow
   remote branch deletion reporting a missing ref after merge as a cleanup caveat to record, not as
   evidence that the merge failed; verify the merged PR or base branch SHA instead.
 
+### REST-first publication snippets for low-GraphQL autopilot
+
+Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
+
+```bash
+gh api repos/$OWNER/$REPO/pulls -X POST \
+  -f title="Issue #$ISSUE: short summary" \
+  -f head=$BRANCH -f base=$BASE \
+  -f body="Automated publication update from Issue #$ISSUE"
+```
+
+```bash
+PR=$(gh api repos/$OWNER/$REPO/pulls --method GET \
+  -f state=open -f head="$OWNER:$BRANCH" \
+  --jq '.[0].number')
+gh api repos/$OWNER/$REPO/pulls/$PR -X PATCH \
+  -f body="Updated summary $(date -Iseconds)"
+```
+
+```bash
+RUN_ID=$(gh api repos/$OWNER/$REPO/actions/runs \
+  --method GET --paginate \
+  -f branch=$BRANCH \
+  -q '.workflow_runs | sort_by(.created_at) | reverse | .[0].id')
+while :; do
+  STATUS=$(gh api repos/$OWNER/$REPO/actions/runs/$RUN_ID --jq '.status')
+  echo "run=$RUN_ID status=$STATUS"
+  [ "$STATUS" = "completed" ] && break
+  sleep 20
+done
+CONCLUSION=$(gh api repos/$OWNER/$REPO/actions/runs/$RUN_ID --jq '.conclusion')
+PR_SHA=$(gh api repos/$OWNER/$REPO/pulls/$PR --jq '.head.sha')
+gh api repos/$OWNER/$REPO/commits/$PR_SHA/check-runs \
+  --jq '.check_runs[] | [.name, .status, .conclusion] | @tsv'
+```
+
+```bash
+gh api repos/$OWNER/$REPO/issues/$ISSUE/comments -f body="CI=$CONCLUSION (run=$RUN_ID)"
+gh api repos/$OWNER/$REPO/issues/$ISSUE/labels -X POST -f labels[]="autopilot-reviewed"
+gh api repos/$OWNER/$REPO/issues/$ISSUE/labels/needs-publication -X DELETE --silent
+```
+
+```bash
+gh api repos/$OWNER/$REPO/pulls/$PR/merge -X PUT \
+  -f merge_method="squash" -f commit_title="Merge PR #$PR" -f sha="$PR_SHA"
+```
+
+```bash
+gh api repos/$OWNER/$REPO/git/refs/heads/$BRANCH -X DELETE \
+  || gh api repos/$OWNER/$REPO/git/refs/heads/$BRANCH --silent >/dev/null \
+  || echo "branch ref already absent; confirm merge by checking issue/merge commit before closing out"
+```
+
+- GraphQL is still appropriate for: Projects v2 objects, review-thread resolution, and nested
+  permission-dependent reads where REST needs multiple expanded requests and GraphQL is materially
+  cheaper.
+
 ### Context note workflow
 
 For non-trivial work, persist reusable insights, decisions, reasoning, validation notes, and


### PR DESCRIPTION
## Summary

- Add a compact REST-first publication snippet section to `docs/dev_guide.md`.
- Cover PR creation/update, workflow and commit check-run polling, issue comments, labels, merge, and remote branch cleanup caveats.
- Clarify when GraphQL is still the better tool: Projects v2, review-thread resolution, and nested reads that are materially cheaper than expanded REST calls.

Closes #2490.

## Validation

- `rtk env BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> `OK docs/proof consistency check passed for 1 changed file(s).`
- `rtk git diff --check`
- `rtk grep -n "gh pr list\\|issues/\\$ISSUE/labels -X DELETE" docs/dev_guide.md` -> 0 matches, confirming the snippets avoid the deprecated/non-REST helper path and the invalid label delete shape.
- Review-fix head `9b1f442fa830f52940cb73b12154a3184ce7327f`: `rtk env BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` passed for 1 changed file, and `rtk git diff --check` passed.

Full PR readiness was not run because this is a docs-only workflow-reference change; the lightweight docs proof gate is the intended validation path.

## Artifact Decision

No tracked or promoted artifacts are required for this docs-only change.

## Research Result Guidance

- Target claim / blocker: NA - support workflow documentation only.
- Comparator / baseline: Existing guidance named REST-first behavior but did not provide concrete publication snippets for low-GraphQL runs.
- Evidence tier: Docs-only validation.
- Result classification: Workflow hardening.
- Decision / stop rule: The dev guide now has compact REST-first snippets for the requested publication operations plus GraphQL carve-outs.
- Synthesis surface / update target: `docs/dev_guide.md`.

## Downstream Propagation

- Parent issue: #2490.
- Claim map / benchmark report / leaderboard / artifact catalog: NA.
- Registry / config index: NA.
- Context index / memory note: NA - no new context note.
