### PR TITLE
feat: add trace failure predicate tables (#2654)

### DIFF
--- a/robot_sf/analysis_workbench/__init__.py
+++ b/robot_sf/analysis_workbench/__init__.py
@@ -17,7 +17,9 @@ from robot_sf.analysis_workbench.trace_annotation import (
 from robot_sf.analysis_workbench.trace_failure_predicates import (
     TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
     TraceFailurePredicate,
+    aggregate_trace_failure_predicate_tables,
     extract_trace_failure_predicates,
+    render_trace_failure_predicate_markdown,
 )
 
 __all__ = [
@@ -29,9 +31,11 @@ __all__ = [
     "TraceAnnotationSet",
     "TraceAnnotationSetValidationError",
     "TraceFailurePredicate",
+    "aggregate_trace_failure_predicate_tables",
     "extract_trace_failure_predicates",
     "load_simulation_trace_export",
     "load_trace_annotation_set",
+    "render_trace_failure_predicate_markdown",
     "simulation_trace_export_from_dict",
     "trace_annotation_set_from_dict",
 ]

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -174,6 +174,7 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
     rows = table_payload.get("rows")
     if not isinstance(rows, list):
         rows = []
+    table_rows = [row for row in rows if isinstance(row, Mapping)]
 
     lines = [
         "# Trace Failure Predicate Table",
@@ -189,7 +190,7 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
         "",
     ]
 
-    if not rows:
+    if not table_rows:
         lines.append("No predicate rows were observed in the provided traces.")
         return "\n".join(lines).rstrip() + "\n"
 
@@ -210,17 +211,17 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
             ),
             [
                 (
-                    str(row.get("scenario_family", "")),
-                    str(row.get("planner_id", "")),
-                    str(row.get("seed", "")),
-                    str(row.get("predicate_id", "")),
-                    str(row.get("validity_status", "")),
-                    str(row.get("severity", "")),
-                    int(row.get("predicate_count", 0)),
-                    int(row.get("trace_denominator", 0)),
-                    f"{float(row.get('predicate_rate_per_trace', 0.0)):.4f}",
+                    _markdown_value(row.get("scenario_family")),
+                    _markdown_value(row.get("planner_id")),
+                    _markdown_value(row.get("seed")),
+                    _markdown_value(row.get("predicate_id")),
+                    _markdown_value(row.get("validity_status")),
+                    _markdown_value(row.get("severity")),
+                    _markdown_int(row.get("predicate_count")),
+                    _markdown_int(row.get("trace_denominator")),
+                    f"{_markdown_float(row.get('predicate_rate_per_trace')):.4f}",
                 )
-                for row in rows
+                for row in table_rows
             ],
         )
     )
@@ -724,6 +725,21 @@ def _format_markdown_cell(value: str) -> str:
         Escaped cell text.
     """
     return value.replace("|", "\\|").replace("\n", " ")
+
+
+def _markdown_value(value: Any) -> str:
+    """Return a display value while preserving falsy non-None identifiers."""
+    return "" if value is None else str(value)
+
+
+def _markdown_int(value: Any) -> int:
+    """Return an integer cell value with None-only fallback."""
+    return 0 if value is None else int(value)
+
+
+def _markdown_float(value: Any) -> float:
+    """Return a float cell value with None-only fallback."""
+    return 0.0 if value is None else float(value)
 
 
 __all__ = [

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass
 from itertools import pairwise
 from typing import TYPE_CHECKING, Any
@@ -70,6 +71,207 @@ def extract_trace_failure_predicates(
     Returns:
         ``trace_failure_predicates.v1`` payload with predicate rows and summary counts.
     """
+    predicates = _extract_trace_failure_predicate_records(
+        trace,
+        scenario_family=scenario_family,
+        clearance_threshold_m=clearance_threshold_m,
+        near_miss_threshold_m=near_miss_threshold_m,
+        stationary_displacement_threshold_m=stationary_displacement_threshold_m,
+        oscillation_min_sign_changes=oscillation_min_sign_changes,
+        evasive_angular_velocity_threshold=evasive_angular_velocity_threshold,
+        evasive_linear_drop_threshold_mps=evasive_linear_drop_threshold_mps,
+    )
+    return _predicates_payload(trace=trace, predicates=predicates)
+
+
+def aggregate_trace_failure_predicate_tables(
+    traces: Iterable[SimulationTraceExport],
+    *,
+    scenario_family: str | None = None,
+) -> dict[str, Any]:
+    """Build denominator-aware aggregate rows across one or more trace predicates.
+
+    Returns:
+        Aggregate rows grouped by scenario family, planner, seed, predicate ID,
+        validity status, and severity.
+    """
+    grouped_predicates: Counter[tuple[str, str, int, str, str, str]] = Counter()
+    trace_denominators: Counter[tuple[str, str, int]] = Counter()
+    included_trace_count = 0
+
+    for trace in traces:
+        group_family = scenario_family or trace.source.scenario_id
+        group_key = (group_family, trace.source.planner_id, int(trace.source.seed))
+        trace_denominators[group_key] += 1
+        included_trace_count += 1
+        for predicate in _extract_trace_failure_predicate_records(
+            trace,
+            scenario_family=group_family,
+            clearance_threshold_m=0.4,
+            near_miss_threshold_m=0.5,
+            stationary_displacement_threshold_m=0.05,
+            oscillation_min_sign_changes=3,
+            evasive_angular_velocity_threshold=1.0,
+            evasive_linear_drop_threshold_mps=0.3,
+        ):
+            grouped_predicates[
+                (
+                    group_family,
+                    predicate.planner_id,
+                    int(trace.source.seed),
+                    predicate.predicate_id,
+                    predicate.validity_status,
+                    predicate.severity,
+                )
+            ] += 1
+
+    rows = [
+        {
+            "scenario_family": family,
+            "planner_id": planner_id,
+            "seed": seed,
+            "predicate_id": predicate_id,
+            "validity_status": validity_status,
+            "severity": severity,
+            "predicate_count": count,
+            "trace_denominator": trace_denominators[(family, planner_id, seed)],
+            "predicate_rate_per_trace": (count / trace_denominators[(family, planner_id, seed)]),
+        }
+        for (
+            family,
+            planner_id,
+            seed,
+            predicate_id,
+            validity_status,
+            severity,
+        ), count in sorted(grouped_predicates.items())
+    ]
+
+    return {
+        "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
+        "table_kind": "aggregate_by_predicate_group",
+        "summary": {
+            "input_trace_count": included_trace_count,
+            "scenario_family_filter": scenario_family,
+            "row_count": len(rows),
+        },
+        "rows": rows,
+        "caveats": [
+            "Aggregate predicate rows are diagnostic summaries, not benchmark rates or claims.",
+            "Rows include `not_available` and other valid status values when evidence is partial.",
+            "Do not treat these as benchmark outcomes unless tied to a predeclared benchmark matrix.",
+        ],
+    }
+
+
+def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) -> str:
+    """Render aggregate failure predicate rows as a compact Markdown diagnostic table.
+
+    Returns:
+        Rendered markdown text.
+    """
+    summary = _read_mapping(table_payload.get("summary"), {})
+    rows = table_payload.get("rows")
+    if not isinstance(rows, list):
+        rows = []
+
+    lines = [
+        "# Trace Failure Predicate Table",
+        "",
+        (
+            "Aggregate predicate rows are diagnostic-only unless tied to a predeclared benchmark "
+            "matrix."
+        ),
+        "",
+        f"- input traces: {summary.get('input_trace_count', 0)}",
+        f"- table kind: {table_payload.get('table_kind', 'aggregate_by_predicate_group')}",
+        f"- schema version: {table_payload.get('schema_version', TRACE_FAILURE_PREDICATE_SCHEMA_VERSION)}",
+        "",
+    ]
+
+    if not rows:
+        lines.append("No predicate rows were observed in the provided traces.")
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.append("## Aggregate Rows")
+    lines.append("")
+    lines.append(
+        _markdown_table(
+            (
+                "scenario_family",
+                "planner_id",
+                "seed",
+                "predicate_id",
+                "validity_status",
+                "severity",
+                "predicate_count",
+                "trace_denominator",
+                "predicate_rate_per_trace",
+            ),
+            [
+                (
+                    str(row.get("scenario_family", "")),
+                    str(row.get("planner_id", "")),
+                    str(row.get("seed", "")),
+                    str(row.get("predicate_id", "")),
+                    str(row.get("validity_status", "")),
+                    str(row.get("severity", "")),
+                    int(row.get("predicate_count", 0)),
+                    int(row.get("trace_denominator", 0)),
+                    f"{float(row.get('predicate_rate_per_trace', 0.0)):.4f}",
+                )
+                for row in rows
+            ],
+        )
+    )
+    lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _predicates_payload(
+    trace: SimulationTraceExport,
+    predicates: list[TraceFailurePredicate],
+) -> dict[str, Any]:
+    """Build the trace predicate payload schema.
+
+    Returns:
+        Normalized single-trace payload.
+    """
+    return {
+        "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
+        "predicate_source": TRACE_FAILURE_PREDICATE_SOURCE,
+        "trace_id": trace.trace_id,
+        "source": {
+            "scenario_id": trace.source.scenario_id,
+            "seed": trace.source.seed,
+            "planner_id": trace.source.planner_id,
+            "episode_id": trace.source.episode_id,
+        },
+        "predicates": [predicate.to_dict() for predicate in predicates],
+        "summary": _summary(predicates),
+        "caveats": [
+            "Predicates are rule-based trace diagnostics, not benchmark rates or safety claims.",
+            "not_available rows mark partial evidence with missing required fields.",
+        ],
+    }
+
+
+def _extract_trace_failure_predicate_records(
+    trace: SimulationTraceExport,
+    *,
+    scenario_family: str | None,
+    clearance_threshold_m: float,
+    near_miss_threshold_m: float,
+    stationary_displacement_threshold_m: float,
+    oscillation_min_sign_changes: int,
+    evasive_angular_velocity_threshold: float,
+    evasive_linear_drop_threshold_mps: float,
+) -> list[TraceFailurePredicate]:
+    """Extract a typed list of predicates for one trace.
+
+    Returns:
+        Predicate records from one trace.
+    """
     family = scenario_family or trace.source.scenario_id
     predicates: list[TraceFailurePredicate] = []
     predicates.extend(
@@ -110,23 +312,7 @@ def extract_trace_failure_predicates(
     )
     if occlusion is not None:
         predicates.append(occlusion)
-    return {
-        "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
-        "predicate_source": TRACE_FAILURE_PREDICATE_SOURCE,
-        "trace_id": trace.trace_id,
-        "source": {
-            "scenario_id": trace.source.scenario_id,
-            "seed": trace.source.seed,
-            "planner_id": trace.source.planner_id,
-            "episode_id": trace.source.episode_id,
-        },
-        "predicates": [predicate.to_dict() for predicate in predicates],
-        "summary": _summary(predicates),
-        "caveats": [
-            "Predicates are rule-based trace diagnostics, not benchmark rates or safety claims.",
-            "not_available rows mark partial evidence with missing required fields.",
-        ],
-    }
+    return predicates
 
 
 def _clearance_critical_interactions(
@@ -507,10 +693,45 @@ def _sign(value: float) -> int:
     return 1 if value > 0.0 else -1
 
 
+def _read_mapping(value: Any, default: dict[str, Any]) -> dict[str, Any]:
+    """Read a mapping value from the payload or return a default.
+
+    Returns:
+        Mapping payload.
+    """
+    return dict(value) if isinstance(value, Mapping) else default
+
+
+def _markdown_table(headers: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> str:
+    """Render simple Markdown table rows.
+
+    Returns:
+        Rendered table body.
+    """
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_format_markdown_cell(str(cell)) for cell in row) + " |")
+    return "\n".join(lines)
+
+
+def _format_markdown_cell(value: str) -> str:
+    """Escape markdown table cell values.
+
+    Returns:
+        Escaped cell text.
+    """
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
 __all__ = [
     "TRACE_FAILURE_PREDICATE_IDS",
     "TRACE_FAILURE_PREDICATE_SCHEMA_VERSION",
     "TRACE_FAILURE_PREDICATE_SOURCE",
     "TraceFailurePredicate",
+    "aggregate_trace_failure_predicate_tables",
     "extract_trace_failure_predicates",
+    "render_trace_failure_predicate_markdown",
 ]

--- a/scripts/tools/build_trace_failure_predicate_tables.py
+++ b/scripts/tools/build_trace_failure_predicate_tables.py
@@ -1,0 +1,106 @@
+"""Build denominator-aware trace failure predicate tables from simulation traces.
+
+These artifacts are analysis diagnostics and must not be treated as benchmark outcomes
+unless the underlying workflow is tied to a predeclared benchmark matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.analysis_workbench.simulation_trace_export import load_simulation_trace_export
+from robot_sf.analysis_workbench.trace_failure_predicates import (
+    aggregate_trace_failure_predicate_tables,
+    render_trace_failure_predicate_markdown,
+)
+
+
+def build_trace_failure_predicate_tables(
+    *,
+    traces: list[Path],
+    scenario_family: str | None = None,
+) -> dict[str, Any]:
+    """Build aggregate predicate tables from one or more trace paths."""
+    loaded = [load_simulation_trace_export(trace_path) for trace_path in traces]
+    return aggregate_trace_failure_predicate_tables(
+        loaded,
+        scenario_family=scenario_family,
+    )
+
+
+def write_trace_failure_predicate_tables(
+    *,
+    traces: list[Path],
+    scenario_family: str | None = None,
+    output_json: Path,
+    output_markdown: Path,
+) -> tuple[Path, Path]:
+    """Load traces, build aggregate tables, and persist JSON/Markdown outputs."""
+    payload = build_trace_failure_predicate_tables(
+        traces=traces,
+        scenario_family=scenario_family,
+    )
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    output_markdown.write_text(
+        render_trace_failure_predicate_markdown(payload),
+        encoding="utf-8",
+    )
+    return output_json, output_markdown
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for trace-failure predicate table generation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trace",
+        type=Path,
+        required=True,
+        action="append",
+        help="Path to one or more simulation_trace_export.v1 JSON traces.",
+    )
+    parser.add_argument("--scenario-family", help="Optional aggregate scenario-family label.")
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("trace_failure_predicate_tables.json"),
+        help="JSON output path. Defaults to ./trace_failure_predicate_tables.json.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path("trace_failure_predicate_tables.md"),
+        help="Markdown output path. Defaults to ./trace_failure_predicate_tables.md.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI entrypoint."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        json_output, markdown_output = write_trace_failure_predicate_tables(
+            traces=args.trace,
+            scenario_family=args.scenario_family,
+            output_json=args.json_output,
+            output_markdown=args.markdown_output,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"{exc}", file=sys.stderr)
+        return 1
+    print(f"wrote table JSON to {json_output}")
+    print(f"wrote table markdown to {markdown_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -1,0 +1,331 @@
+"""Tests for trace failure predicate extraction and aggregate table rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    load_simulation_trace_export,
+    simulation_trace_export_from_dict,
+)
+from robot_sf.analysis_workbench.trace_failure_predicates import (
+    aggregate_trace_failure_predicate_tables,
+    extract_trace_failure_predicates,
+    render_trace_failure_predicate_markdown,
+)
+from scripts.tools.build_trace_failure_predicate_tables import write_trace_failure_predicate_tables
+
+TRACE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "minimal_trace.json"
+)
+
+
+def _frame(
+    step: int,
+    time_s: float,
+    *,
+    robot: dict[str, object] | None = None,
+    pedestrians: list[dict[str, object]] | None = None,
+    action: tuple[float, float] = (0.2, 0.0),
+    planner_extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Build one synthetic frame payload."""
+    robot_payload = robot or {
+        "position": [0.0, 0.0],
+        "heading": 0.0,
+        "velocity": [0.0, 0.0],
+    }
+    planner_payload = {
+        "selected_action": {
+            "linear_velocity": action[0],
+            "angular_velocity": action[1],
+        },
+        "event": "step",
+    }
+    if planner_extra:
+        planner_payload.update(planner_extra)
+    return {
+        "step": step,
+        "time_s": time_s,
+        "robot": robot_payload,
+        "pedestrians": pedestrians or [],
+        "planner": planner_payload,
+    }
+
+
+def _build_trace(
+    *,
+    trace_id: str,
+    scenario_id: str,
+    seed: int,
+    planner_id: str,
+    frames: list[dict[str, object]],
+):
+    payload = load_simulation_trace_export(TRACE_FIXTURE_PATH).to_dict()
+    payload["trace_id"] = trace_id
+    payload["source"]["scenario_id"] = scenario_id
+    payload["source"]["seed"] = seed
+    payload["source"]["planner_id"] = planner_id
+    payload["source"]["episode_id"] = f"{trace_id}-episode"
+    payload["frames"] = frames
+    return simulation_trace_export_from_dict(payload, source=TRACE_FIXTURE_PATH)
+
+
+def _aggregate_rows(payload: dict[str, object]) -> list[dict[str, object]]:
+    return list(payload.get("rows", []))
+
+
+def _find_row(
+    rows: list[dict[str, object]],
+    *,
+    predicate_id: str,
+) -> dict[str, object] | None:
+    return next((row for row in rows if row.get("predicate_id") == predicate_id), None)
+
+
+def test_aggregate_preserves_occlusion_not_available_row() -> None:
+    """Missing occlusion metadata should emit and preserve `not_available` rows."""
+    trace = _build_trace(
+        trace_id="trace-missing-occlusion",
+        scenario_id="scenario-occlusion",
+        seed=11,
+        planner_id="planner-a",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={"position": [0.0, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                action=(0.1, 0.0),
+                pedestrians=[{"id": "ped_1", "position": [0.45, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    payload = aggregate_trace_failure_predicate_tables([trace])
+    row = _find_row(
+        _aggregate_rows(payload),
+        predicate_id="occlusion_triggered_near_miss",
+    )
+
+    assert row is not None
+    assert row["validity_status"] == "not_available"
+    assert row["severity"] == "not_available"
+    assert row["predicate_count"] == 1
+    assert row["trace_denominator"] == 1
+    assert row["predicate_rate_per_trace"] == 1.0
+    assert payload["summary"]["input_trace_count"] == 1
+
+
+def test_aggregate_includes_zero_motion_timeout_predicate() -> None:
+    """A timeout frame plus stationary motion should emit zero-motion predicate."""
+    trace = _build_trace(
+        trace_id="trace-zero-motion",
+        scenario_id="scenario-zero-motion",
+        seed=12,
+        planner_id="planner-b",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={"position": [0.0, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                action=(0.0, 0.0),
+            ),
+            _frame(
+                1,
+                0.1,
+                robot={"position": [0.01, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                action=(0.0, 0.0),
+                planner_extra={"event": "timeout"},
+            ),
+        ],
+    )
+    row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([trace])),
+        predicate_id="zero_motion_timeout_behavior",
+    )
+
+    assert row is not None
+    assert row["validity_status"] == "valid"
+    assert row["predicate_count"] == 1
+
+
+def test_aggregate_includes_oscillatory_control_predicate() -> None:
+    """Alternating angular signs should emit oscillatory-local-control."""
+    trace = _build_trace(
+        trace_id="trace-oscillation",
+        scenario_id="scenario-oscillation",
+        seed=13,
+        planner_id="planner-c",
+        frames=[
+            _frame(0, 0.0, action=(0.2, 0.2)),
+            _frame(1, 0.1, action=(0.2, -0.2)),
+            _frame(2, 0.2, action=(0.2, 0.2)),
+            _frame(3, 0.3, action=(0.2, -0.2)),
+        ],
+    )
+    row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([trace])),
+        predicate_id="oscillatory_local_control",
+    )
+
+    assert row is not None
+    assert row["validity_status"] == "valid"
+    assert row["severity"] == "medium"
+
+
+def test_aggregate_includes_bottleneck_deadlock_predicate() -> None:
+    """Planner deadlock events should be preserved as aggregate predicate rows."""
+    trace = _build_trace(
+        trace_id="trace-bottleneck",
+        scenario_id="scenario-bottleneck",
+        seed=14,
+        planner_id="planner-d",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"event": "bottleneck_deadlock"},
+            )
+        ],
+    )
+    row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([trace])),
+        predicate_id="bottleneck_deadlock",
+    )
+
+    assert row is not None
+    assert row["predicate_count"] == 1
+    assert row["validity_status"] == "valid"
+
+
+def test_aggregate_includes_clearance_critical_interaction_predicate() -> None:
+    """Near-clearance observations should emit clearance-critical interaction predicates."""
+    trace = _build_trace(
+        trace_id="trace-clearance",
+        scenario_id="scenario-clearance",
+        seed=15,
+        planner_id="planner-e",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([trace])),
+        predicate_id="clearance_critical_interaction",
+    )
+
+    assert row is not None
+    assert row["validity_status"] == "valid"
+    assert row["severity"] == "high"
+
+
+def test_denominator_and_markdown_render_include_rate_fields() -> None:
+    """Aggregate payload and markdown output should expose denominator and rate columns."""
+    traces = [
+        _build_trace(
+            trace_id=f"trace-denom-{index}",
+            scenario_id="scenario-denom",
+            seed=16,
+            planner_id="planner-f",
+            frames=[
+                _frame(
+                    0,
+                    0.0,
+                    action=(0.1, 0.0),
+                    pedestrians=[{"id": "ped_1", "position": [0.45, 0.0], "velocity": [0.0, 0.0]}],
+                )
+            ],
+        )
+        for index in range(2)
+    ]
+    payload = aggregate_trace_failure_predicate_tables(traces)
+    row = _find_row(
+        _aggregate_rows(payload),
+        predicate_id="occlusion_triggered_near_miss",
+    )
+
+    assert row is not None
+    assert row["trace_denominator"] == 2
+    assert row["predicate_count"] == 2
+    assert row["predicate_rate_per_trace"] == 1.0
+
+    markdown = render_trace_failure_predicate_markdown(payload)
+    assert "trace_denominator" in markdown
+    assert "predicate_rate_per_trace" in markdown
+    assert "scenario-denom" in markdown
+
+
+def test_scenario_family_override_normalizes_group_without_rewriting_source() -> None:
+    """Scenario-family overrides should label groups without hiding the source scenario."""
+    trace = _build_trace(
+        trace_id="trace-family-override",
+        scenario_id="classic_bottleneck_medium",
+        seed=17,
+        planner_id="planner-g",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"event": "bottleneck_deadlock"},
+            )
+        ],
+    )
+
+    single_trace_payload = extract_trace_failure_predicates(
+        trace,
+        scenario_family="bottleneck",
+    )
+    aggregate_payload = aggregate_trace_failure_predicate_tables(
+        [trace],
+        scenario_family="bottleneck",
+    )
+
+    assert single_trace_payload["source"]["scenario_id"] == "classic_bottleneck_medium"
+    assert single_trace_payload["predicates"][0]["scenario_family"] == "bottleneck"
+    row = _find_row(
+        _aggregate_rows(aggregate_payload),
+        predicate_id="bottleneck_deadlock",
+    )
+    assert row is not None
+    assert row["scenario_family"] == "bottleneck"
+    assert aggregate_payload["summary"]["input_trace_count"] == 1
+
+
+def test_writer_persists_json_and_markdown_outputs(tmp_path: Path) -> None:
+    """The CLI writer should persist denominator-aware JSON and diagnostic Markdown."""
+    trace = _build_trace(
+        trace_id="trace-writer",
+        scenario_id="scenario-writer",
+        seed=18,
+        planner_id="planner-h",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"event": "bottleneck_deadlock"},
+            )
+        ],
+    )
+    trace_path = tmp_path / "trace.json"
+    json_output = tmp_path / "tables.json"
+    markdown_output = tmp_path / "tables.md"
+    trace_path.write_text(json.dumps(trace.to_dict(), indent=2), encoding="utf-8")
+
+    write_trace_failure_predicate_tables(
+        traces=[trace_path],
+        output_json=json_output,
+        output_markdown=markdown_output,
+    )
+
+    assert '"trace_denominator"' in json_output.read_text(encoding="utf-8")
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert "diagnostic-only" in markdown
+    assert "trace_denominator" in markdown

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -329,3 +329,32 @@ def test_writer_persists_json_and_markdown_outputs(tmp_path: Path) -> None:
     markdown = markdown_output.read_text(encoding="utf-8")
     assert "diagnostic-only" in markdown
     assert "trace_denominator" in markdown
+
+
+def test_markdown_renderer_skips_invalid_rows_and_preserves_falsy_values() -> None:
+    """Renderer should ignore malformed rows without replacing valid falsy identifiers."""
+    markdown = render_trace_failure_predicate_markdown(
+        {
+            "schema_version": "trace_failure_predicates.v1",
+            "table_kind": "aggregate_by_predicate_group",
+            "summary": {"input_trace_count": 1},
+            "rows": [
+                None,
+                "bad-row",
+                {
+                    "scenario_family": 0,
+                    "planner_id": "",
+                    "seed": 0,
+                    "predicate_id": "zero_like",
+                    "validity_status": "valid",
+                    "severity": "low",
+                    "predicate_count": 0,
+                    "trace_denominator": 1,
+                    "predicate_rate_per_trace": 0.0,
+                },
+            ],
+        }
+    )
+
+    assert "| 0 |  | 0 | zero_like | valid | low | 0 | 1 | 0.0000 |" in markdown
+    assert "bad-row" not in markdown


### PR DESCRIPTION
## Summary
Adds denominator-aware aggregate trace failure predicate tables for `simulation_trace_export.v1` traces, plus a CLI that writes JSON and Markdown diagnostics.

## Linked Issues
- Closes `#2654`
- Follow-up: `#2667`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#2667`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added aggregate predicate rows grouped by scenario family, planner, seed, predicate ID, validity status, and severity.
- Added denominator fields: `trace_denominator`, `predicate_count`, and `predicate_rate_per_trace`.
- Preserved `not_available` rows for partial evidence, including missing occlusion/visibility metadata.
- Added Markdown rendering and `scripts/tools/build_trace_failure_predicate_tables.py`.
- Added focused tests for missing occlusion evidence, zero-motion timeout, oscillatory control, bottleneck deadlock, clearance-critical interactions, scenario-family normalization, and JSON/Markdown output.

## Why It Matters
- Added value: makes trace-level failure predicates comparable across trace groups without hiding denominators.
- Expected impact: improves diagnostic review of planner failure mechanisms while keeping benchmark claims fail-closed.
- Why this is worth merging now: it gives the analysis workbench a concrete table output needed before applying predicates to a durable trace bundle.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocks denominator-aware failure-mode synthesis from trace exports.
- Comparator or baseline, if applicable: Previous single-trace predicate payloads had no aggregate denominator table.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision or stop rule, if applicable: Merge when fixture and full-suite validation pass; defer benchmark interpretation until a predeclared matrix exists.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#2654`, with durable application follow-up in `#2667`.
- New research/benchmark/metric/paper-facing analysis tool, if any: CLI smoke ran on committed fixture `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json`; `#2667` tracks first durable trace-bundle or matrix application.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, in focused synthetic trace tests and fixture CLI smoke.
- Did the intervention change command source, selected command, trajectory, or route progress? no, analysis-only tooling.
- Did the scenario actually contain the targeted failure mode? focused tests contain each targeted predicate; committed fixture smoke validates entrypoint/output on versioned input.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: `#2667`

## Next Empirical Action
- Rerun needed: no for this implementation PR.
- Extractor or analysis tool needed: no, added here.
- Artifact missing or unavailable: durable trace-bundle application is deferred to `#2667`.
- Stop / revise / continue decision: continue to durable application after merge.
- Proposed child issue or existing follow-up: `#2667`

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run pytest tests/analysis_workbench`
  - `rtk uv run ruff check robot_sf/analysis_workbench/trace_failure_predicates.py robot_sf/analysis_workbench/__init__.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run ruff format --check robot_sf/analysis_workbench/trace_failure_predicates.py robot_sf/analysis_workbench/__init__.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run python scripts/tools/build_trace_failure_predicate_tables.py --trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --json-output /tmp/trace_failure_predicate_tables_2654.json --markdown-output /tmp/trace_failure_predicate_tables_2654.md`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused predicate tests passed; analysis-workbench suite passed; CLI wrote JSON/Markdown from committed fixture input; final readiness passed with 5603 passed, 9 skipped.
- Benchmarks or smoke tests, if applicable: CLI smoke on committed analysis-workbench fixture; no benchmark claim.

## Risks / Rollout
- Compatibility risks: low; existing single-trace predicate extraction remains available.
- Failure modes: aggregate rates can be over-interpreted if callers ignore the diagnostic-only caveat.
- Rollback or fallback plan: remove the new CLI/helper usage; single-trace predicate extraction remains intact.

## Docs / Provenance
- Updated docs: CLI/module and Markdown output state aggregate predicates are diagnostic-only unless tied to a predeclared benchmark matrix.
- Relevant design or provenance notes: #2654 issue contract; #2667 for durable application.
- Any assumptions that need to be preserved: `trace_denominator` is traces per scenario/planner/seed group, not an episode success-rate denominator.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#2654`.
- Claim map / benchmark report updated (yes/no/NA): deferred to `#2667`.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): deferred to `#2667` if durable evidence is produced.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, `#2667`.
- Not applicable because: this PR adds analysis tooling and fixture validation; it does not publish benchmark evidence.

## Follow-Up Issues
- Deferred work: apply tool to durable trace bundle or predeclared matrix and update synthesis surface.
- Issues opened for follow-up: `#2667`

## Reviewer Notes
- Please verify the grouping contract and diagnostic-only language.
- Known limitation: predicate thresholds use the extractor defaults; configurable thresholds can be added later if a matrix needs them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added functionality to aggregate trace failure predicates across multiple simulation traces.
  * New command-line tool to generate predicate tables from simulation trace exports.
  * Predicate tables now support Markdown rendering for improved readability and reporting.

* **Tests**
  * Added comprehensive test suite for trace failure predicate extraction and aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->