### PR TITLE
feat: predeclare static deadlock activation gate (#2653)

### DIFF
--- a/configs/policy_search/transfer/issue_2653_static_deadlock_activation_capable_h500.yaml
+++ b/configs/policy_search/transfer/issue_2653_static_deadlock_activation_capable_h500.yaml
@@ -1,0 +1,37 @@
+stage_order:
+  - full_matrix
+
+stages:
+  full_matrix:
+    scenario_matrix: configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml
+    seed_list: [111, 112, 113]
+    benchmark_profile: experimental
+    horizon: 500
+    dt: 0.1
+    workers: 1
+    requires_slurm: false
+    paper_facing: false
+    mechanism_transfer:
+      issue: 2653
+      mechanism: static_deadlock_recovery
+      transfer_axis: activation_capable_h500_static_recenter_slice
+      candidate_pairs:
+        - baseline_candidate: hybrid_rule_v3_fast_progress
+          intervention_candidate: issue_2170_static_recenter_only
+        - baseline_candidate: issue_2170_static_escape_only
+          intervention_candidate: issue_2170_static_escape_recenter_no_transit
+      activation_capable_gate:
+        active_row_denominator_definition: >
+          completed comparator-unsolved matched rows where the intervention row
+          has recenter_activation_count > 0.
+        min_active_row_denominator: 2
+        min_terminal_outcome_delta_count: 1
+        claim_boundary: >
+          Diagnostic static-deadlock activation accounting only unless this gate
+          passes with native or declared adapter rows and no fallback, degraded,
+          failed, missing, or unavailable rows counted as success evidence.
+        stop_rule: >
+          No planner-promotion, benchmark-candidate, mechanism-transfer, or
+          paper-facing claim unless active_row_denominator >= 2 and
+          terminal_outcome_delta_count >= 1.
+      claim_boundary: predeclared_activation_capable_h500_diagnostic_only

--- a/configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml
+++ b/configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml
@@ -1,0 +1,38 @@
+## Issue #2653 activation-capable h500 static-deadlock expansion
+#
+# Purpose:
+#   Predeclare a static-deadlock h500 expansion that can only support a stronger
+#   mechanism-transfer interpretation when enough comparator-unsolved rows activate
+#   and at least one active row changes terminal outcome. This is not planner
+#   ranking, promotion, or paper-facing evidence by itself.
+
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - ../archetypes/classic_bottleneck.yaml
+  - ../archetypes/classic_head_on_corridor.yaml
+  - ../archetypes/issue_596_static_obstacles.yaml
+
+select_scenarios:
+  - classic_bottleneck_low
+  - classic_head_on_corridor_low
+  - narrow_passage
+
+scenario_overrides:
+  seeds: [111, 112, 113]
+  metadata:
+    mechanism_aware_suite_id: static_deadlock_recovery
+    issue: 2653
+    evidence_tier: predeclared_activation_capable_h500
+    active_row_denominator_definition: >
+      completed comparator-unsolved matched rows where the intervention row has
+      recenter_activation_count > 0.
+    claim_boundary: >
+      Predeclared h500 static-deadlock activation-capable slice for mechanism
+      accounting only. It does not establish planner ranking, planner promotion,
+      mechanism transfer, benchmark-candidate evidence, or paper-facing proof
+      unless the transfer-funnel gate passes on native or declared adapter rows
+      without fallback, degraded, failed, missing, or unavailable rows counted as
+      success evidence.
+
+map_search_paths:
+  - ../../../maps/svg_maps

--- a/scripts/validation/run_static_recenter_activation_trace.py
+++ b/scripts/validation/run_static_recenter_activation_trace.py
@@ -291,7 +291,7 @@ def _active_row_denominator(rows: list[dict[str, Any]]) -> int:
         for row in rows
         if row.get("paired_row_status") == "completed"
         and int(row.get("activation_count", 0) or 0) > 0
-        and not bool(row.get("baseline", {}).get("success", False))
+        and not bool((row.get("baseline") or {}).get("success", False))
     )
 
 

--- a/scripts/validation/run_static_recenter_activation_trace.py
+++ b/scripts/validation/run_static_recenter_activation_trace.py
@@ -222,13 +222,11 @@ def _activation_summary(
     if baseline_terminal["success"] and mechanism_terminal["success"]:
         classification = "comparator_already_solved_case"
     elif not activated:
-        classification = "mechanism_inactive"
+        classification = "no_mechanism_activation"
     elif terminal_changed:
         classification = "mechanism_active_terminal_changed"
-    elif trace_changed:
-        classification = "mechanism_active_trace_changed"
     else:
-        classification = "mechanism_active_but_irrelevant"
+        classification = "mechanism_active_trace_only"
 
     return {
         "scenario_id": baseline_record.get("scenario_id"),
@@ -281,6 +279,73 @@ def _trace_run_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "activation_count_total": int(
             sum(int(row.get("activation_count", 0) or 0) for row in rows)
         ),
+        "active_row_denominator": _active_row_denominator(rows),
+        "terminal_outcome_delta_count": _terminal_outcome_delta_count(rows),
+    }
+
+
+def _active_row_denominator(rows: list[dict[str, Any]]) -> int:
+    """Count completed comparator-unsolved rows where the intervention mechanism activates."""
+    return sum(
+        1
+        for row in rows
+        if row.get("paired_row_status") == "completed"
+        and int(row.get("activation_count", 0) or 0) > 0
+        and not bool(row.get("baseline", {}).get("success", False))
+    )
+
+
+def _terminal_outcome_delta_count(rows: list[dict[str, Any]]) -> int:
+    """Count mechanism-active rows whose terminal outcome changed."""
+    return sum(
+        1 for row in rows if row.get("classification") == "mechanism_active_terminal_changed"
+    )
+
+
+def _activation_gate_summary(
+    rows: list[dict[str, Any]],
+    *,
+    gate_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Evaluate the predeclared static-deadlock activation gate.
+
+    Returns:
+        Gate summary that is safe to embed in compact evidence bundles.
+    """
+    gate_config = gate_config if isinstance(gate_config, dict) else {}
+    min_active_denominator = int(gate_config.get("min_active_row_denominator", 0) or 0)
+    min_terminal_changes = int(gate_config.get("min_terminal_outcome_delta_count", 0) or 0)
+    active_denominator = _active_row_denominator(rows)
+    terminal_changes = _terminal_outcome_delta_count(rows)
+    failures: list[str] = []
+    if active_denominator < min_active_denominator:
+        failures.append(
+            f"active_row_denominator_below_threshold:{active_denominator}<{min_active_denominator}"
+        )
+    if terminal_changes < min_terminal_changes:
+        failures.append(
+            f"terminal_outcome_delta_below_threshold:{terminal_changes}<{min_terminal_changes}"
+        )
+    return {
+        "status": "pass" if not failures else "fail",
+        "active_row_denominator_definition": gate_config.get(
+            "active_row_denominator_definition",
+            "completed comparator-unsolved matched rows with intervention activation_count > 0",
+        ),
+        "active_row_denominator": active_denominator,
+        "min_active_row_denominator": min_active_denominator,
+        "terminal_outcome_delta_count": terminal_changes,
+        "min_terminal_outcome_delta_count": min_terminal_changes,
+        "planner_promotion_claim_allowed": not failures,
+        "claim_boundary": gate_config.get(
+            "claim_boundary",
+            "diagnostic static-deadlock activation accounting only",
+        ),
+        "stop_rule": gate_config.get(
+            "stop_rule",
+            "No planner-promotion claim unless active denominator and terminal-change criteria pass.",
+        ),
+        "failures": failures,
     }
 
 
@@ -367,6 +432,12 @@ def main() -> None:
         )
         for key in sorted(baseline_records)
     ]
+    mechanism_transfer = stage.get("mechanism_transfer")
+    mechanism_transfer = mechanism_transfer if isinstance(mechanism_transfer, dict) else {}
+    gate = _activation_gate_summary(
+        rows,
+        gate_config=mechanism_transfer.get("activation_capable_gate"),
+    )
     payload = {
         "schema_version": "static-recenter-activation-trace.v1",
         "stage": args.stage,
@@ -378,6 +449,7 @@ def main() -> None:
         "mechanism_candidate": args.mechanism_candidate,
         "required_trace_fields": STATIC_DEADLOCK_REQUIRED_TRACE_FIELDS,
         "summary": _trace_run_summary(rows),
+        "activation_capable_gate": gate,
         "rows": rows,
     }
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
@@ -387,6 +459,8 @@ def main() -> None:
     print(
         json.dumps({"output_json": args.output_json.as_posix(), "rows": len(rows)}, sort_keys=True)
     )
+    if gate["status"] != "pass":
+        raise SystemExit(2)
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_issue_2452_mechanism_aware_suites.py
+++ b/tests/benchmark/test_issue_2452_mechanism_aware_suites.py
@@ -10,6 +10,12 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG_PATH = ROOT / "configs/benchmarks/issue_2452_mechanism_aware_local_nav_suites_v0.yaml"
 ISSUE_2544_SMOKE_MATRIX = ROOT / "configs/scenarios/sets/issue_2544_static_deadlock_smoke.yaml"
+ISSUE_2653_MATRIX = (
+    ROOT / "configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml"
+)
+ISSUE_2653_FUNNEL = (
+    ROOT / "configs/policy_search/transfer/issue_2653_static_deadlock_activation_capable_h500.yaml"
+)
 SCENARIO_ROOT = ROOT / "configs/scenarios"
 
 REQUIRED_SUITES: set[str] = {
@@ -156,3 +162,40 @@ def test_issue_2544_static_deadlock_smoke_matrix_binds_first_suite() -> None:
         assert metadata["issue"] == 2544
         assert metadata["evidence_tier"] == "diagnostic_smoke"
         assert "not planner ranking" in metadata["claim_boundary"]
+
+
+def test_issue_2653_static_deadlock_activation_capable_contract() -> None:
+    """Verify #2653 predeclares the denominator, stop rule, and fail-closed boundary."""
+    from robot_sf.training.scenario_loader import load_scenarios
+
+    scenarios = [dict(scenario) for scenario in load_scenarios(ISSUE_2653_MATRIX)]
+    assert [scenario["name"] for scenario in scenarios] == [
+        "classic_bottleneck_low",
+        "classic_head_on_corridor_low",
+        "narrow_passage",
+    ]
+    for scenario in scenarios:
+        assert scenario["seeds"] == [111, 112, 113]
+        metadata = scenario["metadata"]
+        assert metadata["mechanism_aware_suite_id"] == "static_deadlock_recovery"
+        assert metadata["issue"] == 2653
+        assert metadata["evidence_tier"] == "predeclared_activation_capable_h500"
+        claim_boundary = metadata["claim_boundary"].lower()
+        assert "recenter_activation_count > 0" in metadata["active_row_denominator_definition"]
+        assert "does not establish planner ranking" in claim_boundary
+        assert "fallback" in claim_boundary
+        assert "degraded" in claim_boundary
+
+    funnel = _load_yaml(ISSUE_2653_FUNNEL)
+    stage = funnel["stages"]["full_matrix"]
+    assert stage["scenario_matrix"] == (
+        "configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml"
+    )
+    assert stage["horizon"] == 500
+    transfer = stage["mechanism_transfer"]
+    assert transfer["issue"] == 2653
+    gate = transfer["activation_capable_gate"]
+    assert gate["min_active_row_denominator"] == 2
+    assert gate["min_terminal_outcome_delta_count"] == 1
+    assert "no planner-promotion" in gate["stop_rule"].lower()
+    assert "fallback" in gate["claim_boundary"].lower()

--- a/tests/validation/test_static_recenter_activation_trace.py
+++ b/tests/validation/test_static_recenter_activation_trace.py
@@ -138,6 +138,27 @@ def test_activation_gate_fails_closed_when_active_denominator_is_too_small() -> 
     assert "active_row_denominator_below_threshold:0<1" in gate["failures"]
 
 
+def test_activation_gate_treats_none_baseline_as_not_successful() -> None:
+    """Malformed baseline payloads should not crash active-denominator accounting."""
+    gate = _activation_gate_summary(
+        [
+            {
+                "paired_row_status": "completed",
+                "activation_count": 1,
+                "baseline": None,
+                "classification": "mechanism_active_trace_only",
+            }
+        ],
+        gate_config={
+            "min_active_row_denominator": 1,
+            "min_terminal_outcome_delta_count": 0,
+        },
+    )
+
+    assert gate["status"] == "pass"
+    assert gate["active_row_denominator"] == 1
+
+
 def test_activation_gate_passes_with_active_terminal_change() -> None:
     """Gate summaries expose the denominator and terminal-change stop rule."""
     rows = [

--- a/tests/validation/test_static_recenter_activation_trace.py
+++ b/tests/validation/test_static_recenter_activation_trace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from scripts.validation.run_static_recenter_activation_trace import (
+    _activation_gate_summary,
     _activation_summary,
     _episode_summary,
     _trace_run_summary,
@@ -82,7 +83,7 @@ def test_activation_summary_separates_trace_change_from_terminal_change() -> Non
         mechanism_record=_record(success=False, activation_values=[0.0, 1.0, 1.0]),
     )
 
-    assert row["classification"] == "mechanism_active_trace_changed"
+    assert row["classification"] == "mechanism_active_trace_only"
     assert row["trace_changed"] is True
     assert row["terminal_outcome_changed"] is False
 
@@ -104,7 +105,60 @@ def test_trace_run_summary_counts_missing_fields_and_pair_status() -> None:
 
     assert summary["rows"] == 2
     assert summary["paired_row_status_counts"] == {"completed": 1, "excluded": 1}
+    assert summary["active_row_denominator"] == 1
+    assert summary["terminal_outcome_delta_count"] == 0
     assert summary["all_required_trace_fields_present"] is False
     assert summary["missing_required_trace_fields"] == {
         "narrow_passage:111": {"baseline": ["row_status"], "mechanism": []}
     }
+
+
+def test_activation_gate_fails_closed_when_active_denominator_is_too_small() -> None:
+    """Predeclared gates should fail when active comparator-unsolved rows are insufficient."""
+    rows = [
+        _activation_summary(
+            baseline_record=_record(success=True, activation_values=[0.0, 0.0]),
+            mechanism_record=_record(success=True, activation_values=[0.0, 1.0]),
+        )
+    ]
+
+    gate = _activation_gate_summary(
+        rows,
+        gate_config={
+            "min_active_row_denominator": 1,
+            "min_terminal_outcome_delta_count": 1,
+            "claim_boundary": "diagnostic only",
+        },
+    )
+
+    assert gate["status"] == "fail"
+    assert gate["active_row_denominator"] == 0
+    assert gate["terminal_outcome_delta_count"] == 0
+    assert gate["planner_promotion_claim_allowed"] is False
+    assert "active_row_denominator_below_threshold:0<1" in gate["failures"]
+
+
+def test_activation_gate_passes_with_active_terminal_change() -> None:
+    """Gate summaries expose the denominator and terminal-change stop rule."""
+    rows = [
+        _activation_summary(
+            baseline_record=_record(success=False, activation_values=[0.0, 0.0, 0.0]),
+            mechanism_record=_record(success=True, activation_values=[0.0, 1.0, 1.0]),
+        )
+    ]
+
+    gate = _activation_gate_summary(
+        rows,
+        gate_config={
+            "min_active_row_denominator": 1,
+            "min_terminal_outcome_delta_count": 1,
+            "active_row_denominator_definition": "test denominator",
+            "stop_rule": "test stop rule",
+        },
+    )
+
+    assert gate["status"] == "pass"
+    assert gate["active_row_denominator"] == 1
+    assert gate["terminal_outcome_delta_count"] == 1
+    assert gate["active_row_denominator_definition"] == "test denominator"
+    assert gate["stop_rule"] == "test stop rule"


### PR DESCRIPTION
## Summary
Predeclares an activation-capable h500 static-deadlock expansion and teaches the static-recenter trace validator to fail closed when the active-row denominator or terminal-change gate is not met.

## Linked Issues
- Closes `#2653`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `configs/scenarios/sets/issue_2653_static_deadlock_activation_capable_h500.yaml`.
- Added `configs/policy_search/transfer/issue_2653_static_deadlock_activation_capable_h500.yaml`.
- Added validator gate output to `scripts/validation/run_static_recenter_activation_trace.py`.
- The gate defines active rows as completed comparator-unsolved matched rows where the intervention row has `recenter_activation_count > 0`.
- The predeclared stop rule requires `active_row_denominator >= 2` and `terminal_outcome_delta_count >= 1` before any stronger planner-promotion or mechanism-transfer interpretation.
- Added tests for gate pass/fail behavior and config contract metadata.

## Why It Matters
- Added value: prevents narrow one-row static-deadlock rescue evidence from being over-promoted.
- Expected impact: future runs can report row-status counts, active denominator, terminal-change count, and claim boundary in one compact evidence payload.
- Why this is worth merging now: it turns the next static-deadlock run into a predeclared decision point instead of another ambiguous diagnostic.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Static-deadlock mechanism-transfer promotion remains blocked until enough comparator-unsolved active rows and terminal changes are observed.
- Comparator or baseline, if applicable: matched baseline/intervention candidate pairs declared in the transfer config.
- Evidence tier: proposal / diagnostic infrastructure
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: no planner-promotion, benchmark-candidate, mechanism-transfer, or paper-facing claim unless the gate passes.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#2653`.
- New research/benchmark/metric/paper-facing analysis tool, if any: extends existing static-recenter validator; representative proof is unit/contract validation, not a benchmark run.

## Falsification / Non-Transfer Check
- Did the mechanism activate? unknown; this PR predeclares the gate and does not execute the matrix.
- Did the intervention change command source, selected command, trajectory, or route progress? unknown; future validator output will report this.
- Did the scenario actually contain the targeted failure mode? predeclared from existing static-deadlock suite rows; future run must prove active denominator.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: if the gate fails in execution, keep the result diagnostic-only and revise the slice.

## Next Empirical Action
- Rerun needed: yes, execute the new transfer config when ready.
- Extractor or analysis tool needed: no, validator gate added here.
- Artifact missing or unavailable: compact evidence bundle from actual run is intentionally not produced here.
- Stop / revise / continue decision: continue to execution only after this predeclaration lands.
- Proposed child issue or existing follow-up: none opened; #2653 covers the predeclaration scope.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/validation/test_static_recenter_activation_trace.py tests/benchmark/test_issue_2452_mechanism_aware_suites.py`
  - `rtk uv run ruff check scripts/validation/run_static_recenter_activation_trace.py tests/validation/test_static_recenter_activation_trace.py tests/benchmark/test_issue_2452_mechanism_aware_suites.py`
  - `rtk uv run ruff format --check scripts/validation/run_static_recenter_activation_trace.py tests/validation/test_static_recenter_activation_trace.py tests/benchmark/test_issue_2452_mechanism_aware_suites.py`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed with 16 tests; final readiness passed with 5598 passed, 9 skipped.
- Benchmarks or smoke tests, if applicable: no benchmark execution; this is predeclaration and validator gating only.

## Risks / Rollout
- Compatibility risks: low; existing validator output is extended with `activation_capable_gate`.
- Failure modes: future users may mistake a passing gate for a full planner-promotion result; config and payload wording explicitly prevent that.
- Rollback or fallback plan: remove the new config and ignore the optional gate payload; existing static trace summary remains available.

## Docs / Provenance
- Updated docs: config comments and claim-boundary fields in the new scenario and transfer configs.
- Relevant design or provenance notes: issue #2653; existing #2452 static-deadlock suite contract.
- Any assumptions that need to be preserved: active denominator excludes comparator-already-solved rows and any non-completed/fallback/degraded evidence from promotion accounting.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes `#2653`.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark result is produced.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): new config paths are self-contained under existing scenario/transfer config trees.
- Context index / memory note updated (yes/no/NA): NA; no durable evidence result.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR predeclares and validates a benchmark gate but does not produce empirical evidence.

## Follow-Up Issues
- Deferred work: execute the predeclared transfer config and preserve compact evidence if/when needed.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check the active-row denominator definition and the no-promotion stop rule carefully.
- Known limitation: the threshold values are conservative defaults in config (`2` active rows, `1` terminal change); empirical execution may show the slice still needs revision.
