### PR TITLE
docs: put benchmark claim boundaries before results

### DIFF
--- a/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
+++ b/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
@@ -47,6 +47,8 @@ consistency, reproducibility, and fallback-mode visibility before claiming bench
      - fallback preflight planners
 
 4. Summarize runtime + quality
+   - Start the report with claim boundary, evidence status, fallback/degraded exclusions, and major
+     caveats before planner rankings or success interpretation when evidence is mixed or limited.
    - Highlight slowest planners by `runtime_sec`.
    - Highlight weakest planners by success/collision/SNQI from derived episode means.
    - Note experimental planners running with fallback mode.
@@ -75,6 +77,8 @@ uv run python scripts/tools/analyze_camera_ready_campaign.py \
 
 - Classify each run mode as `native`, `adapter`, `fallback`, or `degraded`.
 - Fail-closed rule: do not treat fallback/degraded as successful benchmark evidence.
+- Fallback/degraded rows must appear as caveats or exclusions before comparative rankings,
+  aggregate success language, or recommendations.
 - Require the produced JSON + markdown reports as proof artifacts before summarizing results.
 - Only report planner ranking where metrics and episode counts are internally consistent.
 

--- a/.agents/skills/evidence-synthesis/SKILL.md
+++ b/.agents/skills/evidence-synthesis/SKILL.md
@@ -28,6 +28,8 @@ Use this skill when multiple issues, campaigns, configs, seeds, metrics, and art
 3. Classify artifacts with `artifact-provenance`.
 4. Build the required synthesis table.
 5. Separate observed evidence from hypothesis and state caveats before conclusions.
+6. For mixed or limited benchmark evidence, open the synthesis with the claim boundary: evidence
+   tier, fallback/degraded exclusions, major caveats, and uncertainty before result interpretation.
 
 ## Required table
 
@@ -38,6 +40,8 @@ Use this skill when multiple issues, campaigns, configs, seeds, metrics, and art
 
 - Do not upgrade exploratory evidence into paper-facing claims.
 - Do not average away blocked, fallback, or degraded rows.
+- Do not put rankings, success language, or mechanism conclusions before the claim boundary when
+  evidence is diagnostic-only, smoke-level, mixed, fallback-tainted, or below high confidence.
 - Use `paper-facing-docs` before manuscript-support language is published.
 
 ## Output

--- a/.agents/skills/paper-facing-docs/SKILL.md
+++ b/.agents/skills/paper-facing-docs/SKILL.md
@@ -34,12 +34,19 @@ public-facing provenance statements.
 3. Mark caveats with plain-language risk language.
 4. Review wording for unsupported causality or overclaim.
 5. Add explicit provenance pointers before handoff.
+6. For mixed or limited evidence, make the opening order: claim boundary, evidence status, major
+   caveats and exclusions, uncertainty, then result interpretation.
 
 ## Proof and Guardrails
 
 - Preserve fail-closed semantics: do not present fallback/degraded runs as success.
 - Any claim must point to concrete reproducible artifacts.
 - Prefer tracked canonical documents and execution notes for evidence.
+- Use consistent evidence-tier wording: `diagnostic-only`, `smoke evidence`,
+  `nominal benchmark evidence`, and `paper-grade`.
+- Put fallback/degraded rows in caveats or exclusions before any ranking or success language.
+- Place sub-95% confidence estimates, caveats, or conditions near the claim boundary, not after the
+  conclusion.
 
 ## Output
 
@@ -47,7 +54,8 @@ Paper-facing docs should:
 
 - cite canonical benchmark/config surfaces,
 - avoid overstating planner support,
-- name remaining caveats in plain language.
+- name remaining caveats in plain language,
+- put claim boundaries before interpretation when evidence is mixed or limited.
 ## Guardrails
 
 - Stay within the skill scope declared in `.agents/skills/skills.yaml`.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -28,6 +28,8 @@ For benchmark-facing changes, explicitly verify:
 - Are fallback, skip, and fail-fast paths still explicit and testable?
 - Are benchmark categories (`diagnostic`, `classical`, `learning`) still accurate?
 - Does any report wording overstate what the benchmark actually measures?
+- For mixed or limited evidence, does the report start with claim boundary, evidence status,
+  fallback/degraded exclusions, major caveats, and uncertainty before ranking or success language?
 
 ### Observation normalization
 - Are observation keys, bounds, clipping, and dtype contracts preserved or versioned?
@@ -103,6 +105,8 @@ or path-filtered in a way that may skip small durable evidence files such as CSV
   classification: benchmark evidence, smoke evidence, diagnostic-only, blocked, or proposal.
 - Check claim-boundary language explicitly separates observed evidence from hypotheses, future
   work, fallback/degraded execution, and paper-facing claims.
+- Check fallback/degraded rows are introduced as caveats or exclusions before any comparative
+  ranking, aggregate success language, or recommendation.
 - Check generated evidence points back to a reproducible command, commit, config or scenario
   matrix, seed policy, and durable artifact/provenance decision.
 - If an evidence CSV or other small table is path-filtered out of automated review, state in the PR
@@ -116,6 +120,7 @@ Docs changes should be rejected if they:
 - blur the line between observed evidence and future intent,
 - describe experimental planners as baseline-ready,
 - omit caveats around optional dependencies or upstream source limits.
+- bury mixed-evidence claim boundaries or sub-95% confidence caveats after result interpretation.
 
 Prefer docs that point to canonical config files, scripts, and issue execution notes instead of freehand operational prose.
 

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -17,6 +17,13 @@ and what remains uncertain.
 Fallback or degraded benchmark execution is never success evidence. It may be useful diagnostic
 information only when labeled that way.
 
+Reports with mixed or limited benchmark evidence should put the claim boundary first: evidence
+status, major caveats, fallback/degraded exclusions, and uncertainty belong before result
+interpretation, rankings, or success language. Use the lightweight ladder consistently:
+`diagnostic-only` for debugging or contract probes, `smoke evidence` for narrow execution proof,
+`nominal benchmark evidence` for predeclared benchmark-matrix results, and `paper-grade` only for
+fully reproducible claims suitable for manuscript-facing use.
+
 When the intended proof fails or cannot be gathered, close the work as `blocked`, `diagnostic`, or
 `not benchmark evidence` as appropriate, and record the next smallest proof step. Do not relabel an
 unproven result as complete just to preserve momentum.
@@ -37,8 +44,8 @@ Use explicit status language:
 
 For substantive claims, recommendations, benchmark conclusions, and prioritization judgments below
 roughly 95 percent confidence, include a short numeric uncertainty estimate, caveat, or condition
-that would change the conclusion. Do not spend reasoning effort quantifying ordinary status updates
-or low-impact implementation narration.
+that would change the conclusion near the claim boundary. Do not spend reasoning effort
+quantifying ordinary status updates or low-impact implementation narration.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
Updates benchmark/reporting guidance so mixed or limited evidence leads with claim boundaries, evidence status, caveats, fallback/degraded exclusions, and uncertainty before result interpretation.

## Linked Issues
- Closes `#2666`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added claim-boundary-first reporting guidance to `docs/maintainer_values.md`.
- Updated `docs/code_review.md` so reviewers reject buried caveats and require fallback/degraded rows to be introduced as caveats or exclusions before rankings.
- Updated `evidence-synthesis`, `paper-facing-docs`, and `analyze-camera-ready-benchmark` skills with the same report-opening order and evidence-tier vocabulary.

## Why It Matters
- Added value: reduces overclaim risk in benchmark and research reports.
- Expected impact: future reports should make diagnostic/smoke/nominal/paper-grade status explicit before readers absorb results.
- Why this is worth merging now: it codifies a recurring maintainer decision as reusable guidance instead of relying on ad-hoc reviewer memory.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark/report language should surface claim boundary and caveats before interpretation when evidence is mixed or limited.
- Comparator or baseline, if applicable: existing guidance already required caveats but did not consistently require top-of-report ordering.
- Evidence tier: docs-only.
- Result classification: NA; guidance update, no new empirical result.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2666 and the updated docs/skills.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA; no new tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `scripts/validation/check_docs_proof_consistency.py --path docs/maintainer_values.md`
  - `scripts/validation/check_docs_proof_consistency.py --path docs/code_review.md`
  - `git diff --check`
- Evidence that the change works here: skill registry validation passed and changed docs proof checks passed.
- Benchmarks or smoke tests, if applicable: NA; docs/skill guidance only.

## Risks / Rollout
- Compatibility risks: low; guidance-only change.
- Failure modes: future reports may still ignore ordering unless reviewers apply the checklist.
- Rollback or fallback plan: revert this docs/skill guidance commit.

## Docs / Provenance
- Updated docs: `docs/maintainer_values.md`, `docs/code_review.md`.
- Relevant design or provenance notes: issue #2666.
- Any assumptions that need to be preserved: evidence tiers mean `diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`, and `paper-grade` in this guidance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark result moved.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; this updates canonical guidance files directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: guidance-only change with no empirical artifact propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that the new ordering rule is strict enough without forcing heavy report templates for small docs updates.
- Known limitations: this is process guidance, not automated report enforcement.
