### PR TITLE
docs: keep optional research paths open at lower priority

### DIFF
--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -147,6 +147,12 @@ remove a concrete blocker. If the remaining queue is mostly docs cleanup or anot
 extension under an already-expanded research parent, propose a synthesis issue or synthesis pass
 before adding more exploratory children.
 
+When re-ranking research backlog issues, do not close an interesting optional path simply because it
+is not the best next issue. Leave it open at lower priority with a short reason and revival
+condition. Close only duplicate, invalid, or fully superseded issues, or issues that no longer
+preserve useful research optionality. Splitting or synthesis is preferred when a broad issue still
+contains one implementable child or a reusable research question.
+
 ## Queue Exhaustion Audit
 
 Before declaring the implementation queue exhausted, first run the closed-issue state-label hygiene
@@ -204,6 +210,8 @@ Allowed classifications:
 - `parent_or_epic`: parent, epic, decision, or umbrella issue that should produce a child issue,
 - `analysis_only`: synthesis, interpretation, or research-only work that is not an implementation
   PR unless the run explicitly targets synthesis,
+- `lower_priority_research`: interesting research path that should remain open with a recorded
+  deprioritization reason and revival condition,
 - `blocked_external`: requires unavailable datasets, private artifacts, external services, CARLA,
   or non-local credentials,
 - `blocked_slurm`: requires SLURM/Auxme or another unavailable execution environment,
@@ -278,6 +286,11 @@ queue_audit:
       implementable_now: false
       recommended_action: wait_for_pr
       rationale: open PR #1238 covers the scope
+    - issue: "#1238"
+      classification: lower_priority_research
+      implementable_now: false
+      recommended_action: keep_open_lower_priority
+      rationale: interesting optional path, but current evidence makes synthesis or another issue a better next step
     - issue: "#1239"
       classification: ready_local
       implementable_now: true

--- a/.agents/skills/issue-audit/SKILL.md
+++ b/.agents/skills/issue-audit/SKILL.md
@@ -59,6 +59,8 @@ After the answer:
 
 - add a short issue comment or `Maintainer priority note` body entry on the issue whose ordering
   changed,
+- for research issues that remain interesting but are not the best next path, keep them open at
+  lower priority by default and record both the deprioritization reason and revival condition,
 - cite the answer source when editing an issue body,
 - update Project #5 priority/status fields only when the answer changes those fields,
 - leave Project #5 score inputs advisory and quota-aware,
@@ -73,6 +75,8 @@ After the answer:
 - Do not ask the user to approve every next issue; clear cases should keep moving through the
   normal autonomous implementation loop.
 - Do not preserve stale issue statements once a decision invalidates them.
+- Do not close optional research paths merely because they are not next. Close only duplicate,
+  invalid, or fully superseded issues, or issues that no longer preserve useful research optionality.
 
 ## Output
 

--- a/.agents/skills/issue-contract-maintainer/SKILL.md
+++ b/.agents/skills/issue-contract-maintainer/SKILL.md
@@ -30,6 +30,10 @@ Use this skill when an issue needs contract maintenance before implementation: t
 - `audit-template-compliance`: compare issue bodies with `.github/ISSUE_TEMPLATE/` and repair clear gaps without changing intent.
 - `clarify-ambiguity`: identify problem, scope, solution, or validation ambiguity and post concise options with pros/cons.
 - `apply-user-decision`: update issue text, labels, and Project #5 state after the user resolves a readiness question.
+  For research backlog revision, keep interesting-but-not-next paths open at lower priority by
+  default. Record the reason for deprioritizing and the revival condition that would make the issue
+  relevant again. Close only duplicate, invalid, fully superseded, or no-longer-useful research
+  options.
 - `split-parent-to-child`: hand a parent, epic, decision, or research issue to `issue-splitter`
   when one smallest independently implementable child can be extracted without changing intent.
   Controlled multi-child batches are allowed only when the maintainer explicitly requested a
@@ -54,6 +58,8 @@ flag malformed YAML or invalid values instead of inventing replacements.
 
 - Do not expand the issue beyond the original intent.
 - Do not implement the issue from this skill; hand ready work to `gh-issue-autopilot`.
+- Do not close useful optional research paths merely to reduce queue size; lower priority, split, or
+  synthesize them unless they are duplicate, invalid, or fully superseded.
 - Do not split a parent into more than one child in a single pass unless the maintainer explicitly
   requested `issue-splitter` controlled multi-child mode for a bounded reviewed plan.
 - Ask one readiness-blocking question at a time when user input is needed.

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -69,6 +69,12 @@ Use validation proportional to risk.
 GitHub issues are the central collection system for deferred work. Prefer better filtering,
 priority discussion, and issue splitting over creating separate backlog stores.
 
+Interesting research paths that are no longer the best next step should usually stay open at lower
+priority instead of being closed as parked or superseded. When deprioritizing one, record a short
+reason and a revival condition, such as the artifact, synthesis result, benchmark gap, or maintainer
+priority change that would make it relevant again. Close issues when they are duplicate, invalid,
+fully superseded by a merged/current issue, or no longer useful as a research option.
+
 Autonomous issue-to-PR loops may pick work themselves. When the ranking depends on a real tradeoff,
 use a priority-discussion workflow to ask one focused question, then record the answer in the issue
 or Project metadata. Priority discussion follow-up is tracked in issue #1729.


### PR DESCRIPTION
## Summary
Adds research-backlog revision guidance: interesting but not-best-next research issues should stay open at lower priority with a reason and revival condition, while duplicate/invalid/fully superseded issues can still be closed.

## Linked Issues
- Closes #2675

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated `docs/maintainer_values.md` with the open-at-lower-priority default and close criteria.
- Updated `issue-audit`, `goal-issue-implementation`, and `issue-contract-maintainer` skills so backlog revision records a reason and revival condition instead of closing useful optional research paths.
- Added `lower_priority_research` to queue-audit classifications for repeatable handoffs.

## Why It Matters
- Added value: keeps useful optional research ideas discoverable without letting them masquerade as next-best work.
- Expected impact: less stale queue noise and less accidental loss of future research paths.
- Why this is worth merging now: codifies the 2026-06-12 maintainer decision from #2675 in the issue workflows agents use.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: research backlog revision should preserve useful optionality while making priority status explicit.
- Comparator or baseline, if applicable: previous guidance favored priority discussion and splitting but did not say when interesting-but-not-next research issues should stay open.
- Evidence tier: docs-only.
- Result classification: NA; workflow guidance, no empirical result.
- Decision or stop rule, if applicable: keep interesting optional research paths open with lower priority/revival condition; close duplicate, invalid, fully superseded, or no-longer-useful issues.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2675 and the updated workflow docs/skills.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA; no new tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `scripts/validation/check_docs_proof_consistency.py --path docs/maintainer_values.md`
  - `git diff --check`
- Evidence that the change works here: skill validation and AI config link checks passed; maintainer values proof check passed.
- Benchmarks or smoke tests, if applicable: NA; docs/skill guidance only.

## Risks / Rollout
- Compatibility risks: low; guidance-only change.
- Failure modes: agents may still need discipline to avoid overusing `lower_priority_research` as a dumping ground.
- Rollback or fallback plan: revert this docs/skill guidance commit.

## Docs / Provenance
- Updated docs: `docs/maintainer_values.md`.
- Relevant design or provenance notes: issue #2675.
- Any assumptions that need to be preserved: Project #5 priority remains advisory; lower-priority open issues should include a revival condition.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark result moved.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; canonical workflow docs/skills updated directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: guidance-only change with no empirical artifact propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please check that `lower_priority_research` is clear enough for queue audits without encouraging broad parked backlogs.
- Known limitations: this is workflow guidance, not Project #5 automation.