### PR TITLE
feat: add compact CI monitor evidence

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -165,10 +165,11 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
    ledger. The default budget is `ceil(920s * 1.3) = 1196s`, unless a newer committed skill/doc
    baseline has replaced it.
 2. Start one read-only `ci_wait_monitor` route or Codex app/Spark sidecar for that PR. In non-TTY
-   agent sessions, use bounded one-shot polling rather than `gh pr checks --watch`:
+   agent sessions, use bounded polling rather than `gh pr checks --watch`:
 
    ```bash
    uv run python scripts/dev/check_pr_ci_status.py <pr-number> \
+     --expected-head-sha <head-sha> \
      --poll-attempts 40 \
      --poll-interval 30 \
      --json
@@ -180,7 +181,10 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
 4. When the monitor returns, the main agent must review the result against the current PR head SHA
    before applying `merge-ready`, merging, or reporting completion.
 
-The polling helper prints queued, in-progress, failed, and passed check summaries. Use
+The polling helper prints queued, in-progress, failed, and passed check summaries. With `--json`,
+each poll payload includes compact `monitor` metadata: expected head SHA, SHA-match result, attempt
+count, poll interval, wait budget, deadline, and `route_evidence_only: true`. Review that compact
+payload before considering raw CI logs or full command output. Use
 `gh run view <run-id> --json status,conclusion,jobs` when a job URL needs deeper state, and fetch
 logs only after the relevant job has completed. Do not change committed polling budgets after one
 ordinary slow run; update them only after repeated over-budget evidence or an obvious CI workflow

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -269,6 +269,22 @@ Use `uv run python scripts/dev/ci_timing_summary.py --run-id <github-actions-run
 when GitHub CI wall time drifts from local readiness and you need queue, job, and slowest-step
 timings from `gh run view` data.
 
+For routine autopilot CI waits, prefer the compact monitor helper instead of leaving the parent
+thread idle on raw GitHub output:
+
+```bash
+uv run python scripts/dev/check_pr_ci_status.py <pr-number> \
+  --expected-head-sha <head-sha> \
+  --poll-attempts 40 \
+  --poll-interval 30 \
+  --json
+```
+
+Each JSON payload includes `monitor` metadata for the active delegation ledger: expected head SHA,
+SHA-match result, poll attempt, wait budget, deadline, and `route_evidence_only: true`. Monitor
+success is route evidence only; reassess the current PR head SHA and normal readiness proof before
+labeling or merging.
+
 Use `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` before PR handoff when a
 branch adds or edits context notes, evidence bundles, or other proof-heavy docs surfaces. The
 checker is intentionally conservative: it only flags high-confidence issues such as missing

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -195,6 +195,35 @@ def _fetch_ci_status(
     }
 
 
+def _add_monitor_metadata(
+    data: dict[str, Any],
+    *,
+    expected_head_sha: str,
+    attempt: int,
+    attempts: int,
+    poll_interval: float,
+    wait_budget_seconds: float,
+    deadline_epoch_seconds: int | None,
+) -> None:
+    """Attach compact CI monitor resume metadata to a status payload."""
+    head_sha = str(data.get("head_sha") or "")
+    if expected_head_sha:
+        head_sha_matches_expected: bool | None = bool(head_sha) and head_sha == expected_head_sha
+    else:
+        head_sha_matches_expected = None
+    data["monitor"] = {
+        "route": "ci_wait_monitor",
+        "expected_head_sha": expected_head_sha,
+        "head_sha_matches_expected": head_sha_matches_expected,
+        "poll_attempt": attempt,
+        "poll_attempts": attempts,
+        "poll_interval_seconds": poll_interval,
+        "wait_budget_seconds": wait_budget_seconds,
+        "deadline_epoch_seconds": deadline_epoch_seconds,
+        "route_evidence_only": True,
+    }
+
+
 def _format_human(data: dict[str, Any]) -> str:
     """Format CI status data for human-readable compact output."""
     if data.get("status") == "error":
@@ -243,12 +272,33 @@ def _poll_ci_status(
     poll_interval: float,
     backoff: float,
     json_output: bool,
+    expected_head_sha: str = "",
 ) -> dict[str, Any]:
     """Fetch CI status once or poll until checks settle or the budget expires."""
     data: dict[str, Any] = {}
+    wait_budget_seconds = max(0.0, float(attempts - 1) * max(0.0, poll_interval))
+    deadline_epoch_seconds = int(time.time() + wait_budget_seconds) if attempts > 1 else None
     for attempt in range(1, attempts + 1):
         data = _fetch_ci_status(pr, backoff=backoff if attempt == 1 else 0.0)
+        _add_monitor_metadata(
+            data,
+            expected_head_sha=expected_head_sha,
+            attempt=attempt,
+            attempts=attempts,
+            poll_interval=poll_interval,
+            wait_budget_seconds=wait_budget_seconds,
+            deadline_epoch_seconds=deadline_epoch_seconds,
+        )
         if data.get("status") == "error":
+            break
+        head_sha = str(data.get("head_sha") or "")
+        if expected_head_sha and not head_sha:
+            data["status"] = "error"
+            data["error"] = "PR head SHA missing while monitoring CI"
+            break
+        if expected_head_sha and head_sha != expected_head_sha:
+            data["status"] = "error"
+            data["error"] = "PR head SHA changed while monitoring CI"
             break
         overall = data.get("checks", {}).get("overall")
         if attempts > 1:
@@ -295,6 +345,11 @@ def main(argv: list[str] | None = None) -> int:
         default=30.0,
         help="seconds between bounded polling attempts",
     )
+    parser.add_argument(
+        "--expected-head-sha",
+        default="",
+        help="optional PR head SHA guard; stale heads return error without claiming readiness",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -306,6 +361,7 @@ def main(argv: list[str] | None = None) -> int:
             poll_interval=args.poll_interval,
             backoff=args.backoff,
             json_output=args.json,
+            expected_head_sha=args.expected_head_sha,
         )
     except FileNotFoundError:
         print("gh CLI not found. Install GitHub CLI: https://cli.github.com/", file=sys.stderr)
@@ -318,7 +374,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if data.get("status") == "error":
-        print(_format_human(data))
+        if args.json:
+            print(json.dumps(data))
+        else:
+            print(_format_human(data))
         return 1
 
     if attempts == 1:

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -531,6 +531,108 @@ def test_main_bounded_polling_stops_on_success(
     assert "checks: success" in captured.out
 
 
+def test_main_bounded_polling_json_includes_monitor_metadata(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """JSON polling should emit compact monitor metadata suitable for a delegation ledger."""
+    pending_data = json.dumps(
+        {
+            "number": 9,
+            "title": "metadata poll",
+            "state": "OPEN",
+            "mergeable": "UNKNOWN",
+            "headRefName": "metadata-poll",
+            "headRefOid": "abc123",
+            "statusCheckRollup": [{"name": "ci", "status": "queued", "conclusion": ""}],
+            "reviews": [],
+        }
+    )
+    success_data = json.dumps(
+        {
+            "number": 9,
+            "title": "metadata poll",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "metadata-poll",
+            "headRefOid": "abc123",
+            "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+            "reviews": [],
+        }
+    )
+
+    with (
+        patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run,
+        patch("scripts.dev.check_pr_ci_status.time.sleep") as mock_sleep,
+        patch("scripts.dev.check_pr_ci_status.time.time", return_value=1000.0),
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=pending_data, stderr=""),
+            MagicMock(returncode=0, stdout=success_data, stderr=""),
+        ]
+        rc = main(
+            [
+                "9",
+                "--json",
+                "--expected-head-sha",
+                "abc123",
+                "--poll-attempts",
+                "5",
+                "--poll-interval",
+                "2.0",
+            ]
+        )
+
+    assert rc == 0
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once_with(2.0)
+    payloads = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+    assert len(payloads) == 2
+    assert payloads[0]["monitor"] == {
+        "route": "ci_wait_monitor",
+        "expected_head_sha": "abc123",
+        "head_sha_matches_expected": True,
+        "poll_attempt": 1,
+        "poll_attempts": 5,
+        "poll_interval_seconds": 2.0,
+        "wait_budget_seconds": 8.0,
+        "deadline_epoch_seconds": 1008,
+        "route_evidence_only": True,
+    }
+    assert payloads[1]["monitor"]["poll_attempt"] == 2
+    assert payloads[1]["checks"]["overall"] == "success"
+
+
+def test_main_expected_head_sha_mismatch_returns_json_error(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A stale PR head should fail closed before monitor output is trusted."""
+    mock_data = json.dumps(
+        {
+            "number": 10,
+            "title": "stale monitor",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "stale-monitor",
+            "headRefOid": "actual",
+            "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+            "reviews": [],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["10", "--json", "--expected-head-sha", "expected"])
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert payload["error"] == "PR head SHA changed while monitoring CI"
+    assert payload["head_sha"] == "actual"
+    assert payload["monitor"]["expected_head_sha"] == "expected"
+    assert payload["monitor"]["head_sha_matches_expected"] is False
+    assert payload["monitor"]["route_evidence_only"] is True
+
+
 def test_main_gh_not_installed() -> None:
     """main() should exit non-zero when gh is not on PATH."""
     with patch(


### PR DESCRIPTION
## Summary
Adds SHA-guarded compact CI monitor evidence to `scripts/dev/check_pr_ci_status.py` and aligns goal-autopilot/dev docs with the monitor workflow.

## Linked Issues
- Closes #2672

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `--expected-head-sha` to the compact PR CI checker, including fail-closed stale/missing head handling.
- Added per-poll `monitor` JSON metadata: route, expected SHA, SHA-match result, attempt count, poll interval, wait budget, deadline, and `route_evidence_only`.
- Kept `--json` error output machine-readable for monitor failures.
- Updated goal-autopilot and dev-guide text to require compact monitor review before raw logs and to treat monitor success as route evidence only.
- Added deterministic tests for compact monitor metadata and stale-head failure.

## Why It Matters
- Added value: autopilot can hand routine CI waits to read-only monitors while preserving a compact resumption trail.
- Expected impact: lower parent-thread token burn during PR waits without weakening final readiness gates.
- Why this is worth merging now: issues #2665-#2675 work exposed CI waits and verbose route evidence as a concrete autopilot throughput drain.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling helper for agent workflow, no research claim.
- Comparator or baseline, if applicable: existing `check_pr_ci_status.py` polling without SHA guard or monitor metadata.
- Evidence tier: targeted smoke plus full PR readiness.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: helper emits compact route evidence and fails closed on stale head.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2672.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/tooling PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop; issue contract covered.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `rtk test uv run pytest tests/dev/test_check_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py -q` (43 passed)
  - `rtk test uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
  - `rtk test uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
  - `rtk test BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (5619 passed, 9 skipped on amended head)
- Evidence that the change works here: final readiness stamp passed for clean committed head `839443b1544d4cded2ad49ee9565267a147b3d60`.
- Benchmarks or smoke tests, if applicable: targeted CI-helper tests plus full repo readiness; no benchmark claim.

## Risks / Rollout
- Compatibility risks: additive CLI option and additive JSON metadata; existing no-argument behavior remains.
- Failure modes: downstream monitor consumers must still check current PR head before merge-ready/merge.
- Rollback or fallback plan: omit `--expected-head-sha` or use existing human output; final readiness remains local.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-autopilot/SKILL.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: private active ledger recorded validation and ignored local output inspection.
- Any assumptions that need to be preserved: monitor output is route evidence, not final task readiness.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via `Closes #2672`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: support/tooling workflow change with no research artifact or benchmark propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: stale-head behavior in JSON mode and that monitor metadata remains compact enough for ledgers.
- Any known limitations: the RTK wrapper hung around one final readiness run, so final readiness was rerun raw with `timeout 900` for debugging. One full rerun hit an unrelated example timeout that passed on targeted rerun; the subsequent full readiness rerun passed on the amended head.
