### PR TITLE
[codex] Add compact autopilot snapshots

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -142,6 +142,11 @@ Before each phase, run a delegation checkpoint:
 - Choose the routed helper role for the phase when `ai-delegation-routing` is active:
   queue scout, PR blocker reviewer, bounded editor, validation verifier, CI wait monitor, or
   discovery scout.
+- Before broad issue or PR queue review, prefer compact parent-thread snapshots:
+  `uv run python scripts/dev/snapshot_issue_batch.py <first> <last> --json` for issue batches and
+  `uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json` for PR headline
+  state. Use `--capsule-dir <private-artifact-dir>` when an implementation worker should receive a
+  bounded issue context capsule instead of rediscovering files with broad search.
 - For optional discovery scouts, default to a short hard timeout (120-180s) and require periodic
   evidence in the ledger. If a bounded scout emits no heartbeat within one timeout slice, treat it as
   incomplete and retry with an explicit local timeout + heartbeat plan.
@@ -173,6 +178,18 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
      --poll-interval 30 \
      --json
    ```
+
+   For a non-blocking current-state snapshot, prefer:
+
+   ```bash
+   uv run python scripts/dev/watch_pr_ci_status.py <pr-number> \
+     --expected-head-sha <head-sha> \
+     --json \
+     --once
+   ```
+
+   For longer delegated monitor waits, add `--emit-progress-json-every <seconds>` so the worker
+   returns compact progress evidence instead of silent polling.
 
 3. Continue with non-conflicting work on the main thread: review other PRs, merge already-green
    `merge-ready` PRs, or run bounded discovery. Do not mutate the waiting PR branch or resolve its

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -305,6 +305,22 @@ For GitHub issue batches and Project #5 updates, follow the batch-first workflow
 
 ### REST-first publication snippets for low-GraphQL autopilot
 
+For token-efficient autopilot runs, collect compact local snapshots before broad
+GitHub or repository reads:
+
+```bash
+uv run python scripts/dev/snapshot_issue_batch.py 2665 2675 --json
+uv run python scripts/dev/snapshot_issue_batch.py 2665 2675 --json \
+  --capsule-dir "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
+uv run python scripts/dev/snapshot_pr_queue.py --prs 2677 2678 2679 --json
+uv run python scripts/dev/watch_pr_ci_status.py 2679 --expected-head-sha "$SHA" --json --once
+```
+
+Use the snapshot JSON to seed worker prompts and active ledgers. Redirect broad
+search output or raw GitHub bodies to private agent-run artifacts; return only
+the compact snapshot, context capsule path, validation command, exit status, and
+short evidence excerpt to the parent Codex thread.
+
 Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
 
 ```bash

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -151,7 +151,7 @@ def _write_capsules(issues: list[dict[str, Any]], capsule_dir: pathlib.Path) -> 
         if issue.get("status") != "ok":
             continue
         path = capsule_dir / f"issue_{issue['number']}_context_capsule.json"
-        path.write_text(json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n")
+        path.write_text(json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n", encoding="utf-8")
         issue["context_capsule_path"] = str(path)
 
 

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Emit a compact issue-batch snapshot for token-efficient goal orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+from scripts.dev.issue_claim import status_issue
+
+BODY_EXCERPT_CHARS = 300
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_REMOTE = "origin"
+
+
+def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def expand_issue_numbers(values: list[int], *, expand_range: bool) -> list[int]:
+    """Return issue numbers, expanding a two-number range when requested."""
+    if expand_range and len(values) == 2 and values[0] < values[1]:
+        return list(range(values[0], values[1] + 1))
+    return values
+
+
+def _labels(issue: dict[str, Any]) -> list[str]:
+    """Return compact label names from gh issue JSON."""
+    return sorted(
+        str(label.get("name", ""))
+        for label in issue.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    )
+
+
+def _assignees(issue: dict[str, Any]) -> list[str]:
+    """Return compact assignee logins from gh issue JSON."""
+    return sorted(
+        str(user.get("login", ""))
+        for user in issue.get("assignees", [])
+        if isinstance(user, dict) and user.get("login")
+    )
+
+
+def _body_excerpt(body: Any, *, limit: int) -> tuple[str, bool]:
+    """Return a whitespace-normalized body excerpt and truncation flag."""
+    text = " ".join(str(body or "").split())
+    return text[:limit], len(text) > limit
+
+
+def _recommended_context_pack(number: int, labels: list[str], title: str) -> str:
+    """Return a conservative context-pack hint for a worker prompt."""
+    label_text = " ".join(labels).lower()
+    title_text = title.lower()
+    if "docs" in label_text or "doc" in title_text:
+        return "docs/context/INDEX.md"
+    if "benchmark" in label_text or "benchmark" in title_text:
+        return "docs/benchmark_camera_ready.md"
+    if "workflow" in label_text or "workflow" in title_text:
+        return "docs/context/goal_driven_agent_loops_2026-05-13.md"
+    return f"docs/context/issue_{number}* if present, otherwise docs/context/INDEX.md"
+
+
+def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict[str, Any]:
+    """Fetch one issue and return a compact orchestration snapshot."""
+    result = _gh(
+        [
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,labels,url,assignees",
+        ]
+    )
+    if result.returncode != 0:
+        return {
+            "number": number,
+            "status": "error",
+            "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+        }
+    try:
+        issue = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"number": number, "status": "error", "error": f"invalid gh JSON: {exc}"}
+    labels = _labels(issue)
+    excerpt, truncated = _body_excerpt(issue.get("body"), limit=body_limit)
+    claim = status_issue(number, remote=remote)
+    return {
+        "number": issue.get("number", number),
+        "status": "ok",
+        "title": issue.get("title", ""),
+        "state": issue.get("state", ""),
+        "url": issue.get("url", ""),
+        "labels": labels,
+        "assignees": _assignees(issue),
+        "body_excerpt": excerpt,
+        "body_truncated": truncated,
+        "claim": {
+            "ok": claim.get("ok"),
+            "claimed": claim.get("claimed"),
+            "claim_ref": claim.get("claim_ref"),
+            "sha": claim.get("sha"),
+        },
+        "linked_prs": [],
+        "recommended_context_pack": _recommended_context_pack(
+            int(issue.get("number", number)), labels, str(issue.get("title", ""))
+        ),
+    }
+
+
+def _context_capsule(issue: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact worker-seeding capsule for one issue snapshot."""
+    return {
+        "schema": "issue_context_capsule.v1",
+        "issue": {
+            "number": issue.get("number"),
+            "title": issue.get("title", ""),
+            "url": issue.get("url", ""),
+            "labels": issue.get("labels", []),
+            "body_excerpt": issue.get("body_excerpt", ""),
+        },
+        "claim": issue.get("claim", {}),
+        "files_to_read": [issue.get("recommended_context_pack", "docs/context/INDEX.md")],
+        "tests_to_run": [],
+        "docs_to_update": [],
+        "known_risks": [],
+        "worker_prompt_seed": (
+            "Use this capsule as the first context source. Avoid broad repository search until "
+            "these files have been inspected and summarized."
+        ),
+    }
+
+
+def _write_capsules(issues: list[dict[str, Any]], capsule_dir: pathlib.Path) -> None:
+    """Write one optional context capsule per successfully fetched issue."""
+    capsule_dir.mkdir(parents=True, exist_ok=True)
+    for issue in issues:
+        if issue.get("status") != "ok":
+            continue
+        path = capsule_dir / f"issue_{issue['number']}_context_capsule.json"
+        path.write_text(json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n")
+        issue["context_capsule_path"] = str(path)
+
+
+def snapshot_issues(
+    numbers: list[int], *, repo: str, body_limit: int, remote: str, capsule_dir: str = ""
+) -> dict[str, Any]:
+    """Return a compact issue-batch snapshot."""
+    issues = [
+        fetch_issue(number, repo=repo, body_limit=body_limit, remote=remote) for number in numbers
+    ]
+    if capsule_dir:
+        _write_capsules(issues, pathlib.Path(capsule_dir))
+    return {
+        "schema": "issue_batch_snapshot.v1",
+        "repo": repo,
+        "body_excerpt_chars": body_limit,
+        "issues": issues,
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "issues", nargs="+", type=int, help="Issue numbers; two values form a range."
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--remote", default=DEFAULT_REMOTE)
+    parser.add_argument("--body-chars", type=int, default=BODY_EXCERPT_CHARS)
+    parser.add_argument(
+        "--capsule-dir",
+        default="",
+        help="Optional directory for per-issue context capsule JSON files.",
+    )
+    parser.add_argument(
+        "--no-expand-range",
+        action="store_true",
+        help="Treat two issue numbers as exactly two issues instead of an inclusive range.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    numbers = expand_issue_numbers(args.issues, expand_range=not args.no_expand_range)
+    try:
+        payload = snapshot_issues(
+            numbers,
+            repo=args.repo,
+            body_limit=max(args.body_chars, 0),
+            remote=args.remote,
+            capsule_dir=args.capsule_dir,
+        )
+    except FileNotFoundError:
+        print("gh or git command not found", file=sys.stderr)
+        return 1
+    except subprocess.TimeoutExpired as exc:
+        print(f"snapshot command timed out: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
+    return 1 if any(issue.get("status") == "error" for issue in payload["issues"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Emit compact PR queue state for token-efficient goal orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+from scripts.dev.check_pr_ci_status import (
+    FAILURE_CONCLUSIONS,
+    PENDING_STATUSES,
+    _rollup_conclusion,
+    _rollup_name,
+    _rollup_status,
+)
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+
+
+def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _labels(pr: dict[str, Any]) -> list[str]:
+    """Return compact label names from gh PR JSON."""
+    return sorted(
+        str(label.get("name", ""))
+        for label in pr.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    )
+
+
+def _reviews(pr: dict[str, Any]) -> dict[str, int]:
+    """Return review-state counts."""
+    states: dict[str, int] = {}
+    for review in pr.get("reviews", []) or []:
+        if not isinstance(review, dict):
+            continue
+        state = str(review.get("state", "UNKNOWN"))
+        states[state] = states.get(state, 0) + 1
+    return states
+
+
+def _checks(pr: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact CI check summary from statusCheckRollup."""
+    rollup = pr.get("statusCheckRollup", []) or []
+    conclusions: dict[str, int] = {}
+    statuses: dict[str, int] = {}
+    names: set[str] = set()
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        conclusion = _rollup_conclusion(check)
+        status = _rollup_status(check)
+        conclusions[conclusion] = conclusions.get(conclusion, 0) + 1
+        statuses[status] = statuses.get(status, 0) + 1
+        names.add(_rollup_name(check))
+    failure_count = sum(conclusions.get(conclusion, 0) for conclusion in FAILURE_CONCLUSIONS)
+    pending_count = sum(statuses.get(status, 0) for status in PENDING_STATUSES)
+    if failure_count:
+        overall = "failure"
+    elif pending_count or not rollup:
+        overall = "pending"
+    else:
+        overall = "success"
+    return {
+        "overall": overall,
+        "total": len(rollup),
+        "by_conclusion": conclusions,
+        "by_status": statuses,
+        "names": sorted(names),
+    }
+
+
+def _next_action(*, is_draft: bool, labels: list[str], checks: dict[str, Any]) -> str:
+    """Return a compact next-action hint for the parent orchestrator."""
+    if is_draft:
+        return "review_or_mark_ready_when_local_proof_passes"
+    if checks.get("overall") == "failure":
+        return "inspect_failing_checks"
+    if checks.get("overall") == "pending":
+        return "await_ci_or_start_read_only_monitor"
+    if "merge-ready" in labels:
+        return "merge_readiness_local_check"
+    return "review_for_merge_ready"
+
+
+def fetch_pr(number: int, *, repo: str) -> dict[str, Any]:
+    """Fetch one PR and return a compact queue snapshot."""
+    result = _gh(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,state,isDraft,labels,url,headRefName,headRefOid,mergeable,statusCheckRollup,reviews",
+        ]
+    )
+    if result.returncode != 0:
+        return {
+            "number": number,
+            "status": "error",
+            "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+        }
+    try:
+        pr = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"number": number, "status": "error", "error": f"invalid gh JSON: {exc}"}
+    labels = _labels(pr)
+    checks = _checks(pr)
+    is_draft = bool(pr.get("isDraft"))
+    return {
+        "number": pr.get("number", number),
+        "status": "ok",
+        "title": pr.get("title", ""),
+        "state": pr.get("state", ""),
+        "draft": is_draft,
+        "url": pr.get("url", ""),
+        "labels": labels,
+        "head_branch": pr.get("headRefName", ""),
+        "head_sha": pr.get("headRefOid", ""),
+        "mergeable": pr.get("mergeable", "unknown"),
+        "checks": checks,
+        "reviews": _reviews(pr),
+        "next_action": _next_action(is_draft=is_draft, labels=labels, checks=checks),
+    }
+
+
+def snapshot_prs(numbers: list[int], *, repo: str) -> dict[str, Any]:
+    """Return a compact PR queue snapshot."""
+    return {
+        "schema": "pr_queue_snapshot.v1",
+        "repo": repo,
+        "prs": [fetch_pr(number, repo=repo) for number in numbers],
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prs", nargs="*", type=int, help="PR numbers to snapshot.")
+    parser.add_argument("--prs", dest="prs_option", nargs="+", type=int, help="PR numbers.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    numbers = args.prs_option if args.prs_option is not None else args.prs
+    if not numbers:
+        print("at least one PR number is required", file=sys.stderr)
+        return 1
+    try:
+        payload = snapshot_prs(numbers, repo=args.repo)
+    except FileNotFoundError:
+        print("gh command not found", file=sys.stderr)
+        return 1
+    except subprocess.TimeoutExpired as exc:
+        print(f"snapshot command timed out: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
+    return 1 if any(pr.get("status") == "error" for pr in payload["prs"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/watch_pr_ci_status.py
+++ b/scripts/dev/watch_pr_ci_status.py
@@ -193,14 +193,20 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
     fetch_durations: Callable[..., list[int]] = fetch_recent_successful_ci_durations,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
+    once: bool = False,
+    emit_progress_json_every: int = 0,
+    progress_stream: Any = sys.stderr,
 ) -> WatchResult:
     """Poll PR CI status until success, failure, stale head, or budget timeout."""
     budget_seconds = wait_budget_seconds(baseline_seconds, multiplier)
     deadline = monotonic() + budget_seconds
     last_status: dict[str, Any] = {}
+    last_progress_at = 0.0
+    poll_count = 0
 
     while True:
         last_status = fetch_status(pr_number)
+        poll_count += 1
         head_sha = str(last_status.get("head_sha") or "")
         if last_status.get("status") == "error":
             return WatchResult(
@@ -262,8 +268,43 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 error="",
                 drift_sample=None,
             )
+        if once:
+            return WatchResult(
+                pr=last_status.get("pr", pr_number),
+                head_sha=head_sha,
+                expected_head_sha=expected_head_sha,
+                baseline_seconds=baseline_seconds,
+                multiplier=multiplier,
+                budget_seconds=budget_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                final_status=str(overall or "pending"),
+                checks=checks,
+                error="",
+                drift_sample=None,
+            )
 
         remaining = deadline - monotonic()
+        if emit_progress_json_every > 0:
+            now = monotonic()
+            if last_progress_at <= 0 or now - last_progress_at >= emit_progress_json_every:
+                print(
+                    json.dumps(
+                        {
+                            "schema": "pr_ci_watch_progress.v1",
+                            "pr": last_status.get("pr", pr_number),
+                            "head_sha": head_sha,
+                            "expected_head_sha": expected_head_sha,
+                            "poll_count": poll_count,
+                            "status": str(overall or "pending"),
+                            "remaining_seconds": max(int(remaining), 0),
+                            "checks": checks,
+                        },
+                        sort_keys=True,
+                    ),
+                    file=progress_stream,
+                    flush=True,
+                )
+                last_progress_at = now
         if remaining <= 0:
             drift_sample = _build_drift_sample(
                 workflow=workflow,
@@ -332,6 +373,17 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     parser.add_argument("--sample-limit", type=int, default=DEFAULT_SAMPLE_LIMIT)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Fetch one current CI status snapshot without waiting for checks to finish.",
+    )
+    parser.add_argument(
+        "--emit-progress-json-every",
+        type=int,
+        default=0,
+        help="Emit compact progress JSON to stderr at this interval while waiting.",
+    )
     return parser.parse_args(argv)
 
 
@@ -349,6 +401,8 @@ def main(argv: list[str] | None = None) -> int:
             sample_limit=args.sample_limit,
             fetch_status=_fetch_ci_status,
             fetch_durations=fetch_recent_successful_ci_durations,
+            once=args.once,
+            emit_progress_json_every=args.emit_progress_json_every,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         print(f"ERROR watching PR CI: {exc}", file=sys.stderr)
@@ -359,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
     print(result.to_json() if args.json else format_human(result))
     if result.final_status == "success":
         return 0
-    if result.final_status == "timeout":
+    if result.final_status in {"timeout", "pending"}:
         return 2
     return 1
 

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -1,0 +1,107 @@
+"""Tests for compact issue-batch snapshots."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.snapshot_issue_batch import expand_issue_numbers, main, snapshot_issues
+
+
+def test_expand_issue_numbers_treats_two_values_as_range() -> None:
+    """Two ascending values should support the concise batch command."""
+    assert expand_issue_numbers([2665, 2667], expand_range=True) == [2665, 2666, 2667]
+    assert expand_issue_numbers([2665, 2667], expand_range=False) == [2665, 2667]
+
+
+def test_snapshot_issues_emits_compact_fields() -> None:
+    """Snapshot output should include excerpts and claim state without raw bodies."""
+    body = " ".join(["detail"] * 100)
+    issue_payload = {
+        "number": 2665,
+        "title": "workflow: compact issue snapshot",
+        "body": body,
+        "state": "OPEN",
+        "url": "https://github.test/issues/2665",
+        "labels": [{"name": "workflow"}, {"name": "enhancement"}],
+        "assignees": [{"login": "alice"}],
+    }
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(issue_payload),
+            stderr="",
+        )
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue-2665",
+                "sha": None,
+            }
+            payload = snapshot_issues(
+                [2665], repo="ll7/robot_sf_ll7", body_limit=20, remote="origin"
+            )
+
+    issue = payload["issues"][0]
+    assert payload["schema"] == "issue_batch_snapshot.v1"
+    assert issue["number"] == 2665
+    assert issue["labels"] == ["enhancement", "workflow"]
+    assert issue["assignees"] == ["alice"]
+    assert issue["body_excerpt"] == "detail detail detail"
+    assert issue["body_truncated"] is True
+    assert issue["claim"]["claimed"] is False
+    assert issue["linked_prs"] == []
+    assert "goal_driven_agent_loops" in issue["recommended_context_pack"]
+
+
+def test_main_returns_error_when_any_issue_fails(capsys) -> None:  # type: ignore[no-untyped-def]
+    """CLI should keep a JSON payload even when one issue cannot be fetched."""
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        rc = main(["1", "--json"])
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["issues"][0]["status"] == "error"
+
+
+def test_snapshot_issues_can_write_context_capsules(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Optional capsules should seed workers without broad rediscovery."""
+    issue_payload = {
+        "number": 2666,
+        "title": "docs: claim boundary first",
+        "body": "short body",
+        "state": "OPEN",
+        "url": "https://github.test/issues/2666",
+        "labels": [{"name": "docs"}],
+        "assignees": [],
+    }
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(issue_payload),
+            stderr="",
+        )
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": True,
+                "claim_ref": "agent-claims/issue-2666",
+                "sha": "abc123",
+            }
+            payload = snapshot_issues(
+                [2666],
+                repo="ll7/robot_sf_ll7",
+                body_limit=300,
+                remote="origin",
+                capsule_dir=str(tmp_path),
+            )
+
+    path = tmp_path / "issue_2666_context_capsule.json"
+    assert payload["issues"][0]["context_capsule_path"] == str(path)
+    capsule = json.loads(path.read_text())
+    assert capsule["schema"] == "issue_context_capsule.v1"
+    assert capsule["issue"]["number"] == 2666
+    assert capsule["claim"]["claimed"] is True
+    assert capsule["files_to_read"] == ["docs/context/INDEX.md"]

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -1,0 +1,69 @@
+"""Tests for compact PR queue snapshots."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.snapshot_pr_queue import main, snapshot_prs
+
+
+def test_snapshot_prs_emits_headline_state() -> None:
+    """PR snapshots should summarize CI/review state without raw rollups."""
+    pr_payload = {
+        "number": 2679,
+        "title": "compact PR state",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2679",
+        "labels": [{"name": "merge-ready"}],
+        "headRefName": "feature",
+        "headRefOid": "abc123",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {"name": "ci", "status": "completed", "conclusion": "success"},
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+        ],
+        "reviews": [{"state": "APPROVED"}, {"state": "COMMENTED"}],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([2679], repo="ll7/robot_sf_ll7")
+
+    pr = payload["prs"][0]
+    assert payload["schema"] == "pr_queue_snapshot.v1"
+    assert pr["number"] == 2679
+    assert pr["head_sha"] == "abc123"
+    assert pr["checks"]["overall"] == "success"
+    assert pr["checks"]["names"] == ["ci", "lint"]
+    assert pr["reviews"] == {"APPROVED": 1, "COMMENTED": 1}
+    assert pr["next_action"] == "merge_readiness_local_check"
+
+
+def test_snapshot_prs_pending_next_action() -> None:
+    """Pending checks should route the parent toward a monitor instead of polling."""
+    pr_payload = {
+        "number": 2680,
+        "title": "pending PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "def456",
+        "mergeable": "UNKNOWN",
+        "statusCheckRollup": [{"name": "ci", "status": "in_progress", "conclusion": ""}],
+        "reviews": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([2680], repo="ll7/robot_sf_ll7")
+
+    assert payload["prs"][0]["checks"]["overall"] == "pending"
+    assert payload["prs"][0]["next_action"] == "await_ci_or_start_read_only_monitor"
+
+
+def test_main_requires_pr_number(capsys) -> None:  # type: ignore[no-untyped-def]
+    """CLI should fail compactly when no PRs are provided."""
+    rc = main(["--json"])
+    assert rc == 1
+    assert "at least one PR" in capsys.readouterr().err

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -103,6 +103,48 @@ def test_pending_after_budget_collects_drift_sample() -> None:
     fetch_durations.assert_called_once()
 
 
+def test_once_returns_pending_without_sleep_or_drift_sampling() -> None:
+    """One-shot mode should snapshot current status without waiting silently."""
+    fetch_durations = MagicMock(return_value=[1000])
+    sleep = MagicMock()
+
+    result = watch_pr_ci_status(
+        pr_number="42",
+        fetch_status=MagicMock(return_value=_status("pending")),
+        fetch_durations=fetch_durations,
+        sleep=sleep,
+        once=True,
+    )
+
+    assert result.final_status == "pending"
+    assert result.drift_sample is None
+    fetch_durations.assert_not_called()
+    sleep.assert_not_called()
+
+
+def test_progress_json_is_emitted_to_stream() -> None:
+    """Long waits can emit compact progress evidence without poll-only silence."""
+    now = iter([0.0, 0.0, 1.0, 1.0])
+    stream = MagicMock()
+
+    result = watch_pr_ci_status(
+        pr_number="42",
+        baseline_seconds=0,
+        fetch_status=MagicMock(return_value=_status("pending")),
+        fetch_durations=MagicMock(return_value=[]),
+        monotonic=lambda: next(now),
+        sleep=MagicMock(),
+        emit_progress_json_every=1,
+        progress_stream=stream,
+    )
+
+    assert result.final_status == "timeout"
+    assert stream.write.call_count > 0
+    written = "".join(str(call.args[0]) for call in stream.write.call_args_list)
+    assert "pr_ci_watch_progress.v1" in written
+    assert '"status": "pending"' in written
+
+
 def test_fetch_recent_successful_ci_durations_parses_gh_run_list() -> None:
     """The drift sampler should use run-list timestamps without inspecting every run."""
     payload = json.dumps(
@@ -146,6 +188,17 @@ def test_main_returns_timeout_exit_code(capsys: pytest.CaptureFixture[str]) -> N
     assert rc == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["final_status"] == "timeout"
+
+
+def test_main_once_pending_returns_timeout_exit_code(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI one-shot pending status should return exit 2 with parseable JSON."""
+    with patch("scripts.dev.watch_pr_ci_status._fetch_ci_status") as fetch_status:
+        fetch_status.return_value = _status("pending")
+        rc = main(["42", "--once", "--json"])
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["final_status"] == "pending"
 
 
 def test_parse_timestamp_accepts_any_and_returns_none_for_invalid() -> None:


### PR DESCRIPTION
## Summary

- Adds `scripts/dev/snapshot_issue_batch.py` for compact issue-batch snapshots with body excerpts, claim state, context-pack hints, and optional per-issue context capsule JSON files.
- Adds `scripts/dev/snapshot_pr_queue.py` for compact PR headline state: head SHA, labels, draft state, review counts, CI summary, and next-action hints.
- Extends `scripts/dev/watch_pr_ci_status.py` with `--once` for non-blocking current-state snapshots and `--emit-progress-json-every` for compact progress evidence during longer waits.
- Documents the snapshot-first flow in `goal-autopilot` and `docs/dev_guide.md` so parent Codex threads can avoid broad issue bodies, repeated PR polling, and silent CI monitor loops.

## Why

This implements the token-saving follow-up from the thread-cost audit: delegate work without delegating token noise back into the parent Codex thread.

## Validation

Passed:

- `uv run ruff check scripts/dev/snapshot_issue_batch.py scripts/dev/snapshot_pr_queue.py scripts/dev/watch_pr_ci_status.py tests/dev/test_snapshot_issue_batch.py tests/dev/test_snapshot_pr_queue.py tests/dev/test_watch_pr_ci_status.py`
- `uv run pytest tests/dev/test_snapshot_issue_batch.py tests/dev/test_snapshot_pr_queue.py tests/dev/test_watch_pr_ci_status.py` (`21 passed`)
- `bash scripts/dev/check_docs_proof_consistency_diff.sh`
- `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
- `uv run python -m py_compile scripts/dev/snapshot_issue_batch.py scripts/dev/snapshot_pr_queue.py scripts/dev/watch_pr_ci_status.py`

Full readiness attempted:

- `BASE_REF=origin/main bash scripts/dev/pr_ready_check.sh`
- First run needed declared `analytics` extra (`duckdb`, `pyarrow`).
- Second run needed declared `socnav` extra (`scikit-fmm`).
- Final run after `uv sync --extra analytics --extra socnav` reached `5523 passed, 12 skipped`, then failed on an existing slow example timeout: `tests/examples/test_examples_run.py::test_example_runs_without_error[benchmarks/demo_social_nav_scenarios.py]` exceeded its 60s timeout. This appears unrelated to the compact snapshot helpers.