### PR TITLE
feat: add compact autopilot state snapshots

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -55,6 +55,9 @@ In token-efficient mode:
   execution.
 - Prefer compact parent-thread snapshots before broad repository, GitHub,
   worktree, CI, or validation output.
+- For routine orientation, start with `scripts/dev/autopilot_state_snapshot.py`
+  instead of repeated broad `gh issue list`, `gh pr view`, `git worktree list`,
+  or claim-state calls.
 - Require compact worker artifacts before reading raw logs.
 - Offload routine CI waits to read-only monitors when safe work remains.
 - Keep final GitHub mutation, publication, merge-readiness, benchmark, paper,
@@ -197,6 +200,28 @@ Treat monitor exit states as follows:
 - `pending timeout` / exit code `2`: keep the PR in `awaiting_ci`, record the pending checks, and
   continue other work.
 - `error`: record stale head, auth, API, or parsing failure; do not trust the waiter for readiness.
+
+### Snapshot-First Parent Orientation
+
+Before broad queue, worktree, claim, PR, or CI reads in the parent thread, prefer the compact
+snapshot helper:
+
+```bash
+uv run python scripts/dev/autopilot_state_snapshot.py \
+  --include-worktrees \
+  --claim-issue <issue-number> \
+  --issue-search "is:issue is:open <queue-filter>" \
+  --pr <pr-number>
+```
+
+The helper emits `autopilot_state_snapshot.v1` JSON with source commands, branch/head SHA,
+`origin/main` SHA, worktree rows, issue queue rows, claim refs, explicit PR headline state, and
+freshness metadata. Treat it as route evidence only: use it to decide the next safe read or worker
+prompt, then run fresh local/GitHub checks before claiming an issue, pushing, labeling, merging, or
+publishing a benchmark-facing conclusion. Read raw command output only when the snapshot reports
+`ok: false`, stale claim refs, missing state, or a field that is insufficient for the next decision.
+The helper caps worktree rows by default and reports `worktree_count` plus `worktrees_truncated`;
+raise `--worktree-limit` only when the compact rows are insufficient.
 
 ### Active Delegation Ledger
 

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -121,6 +121,20 @@ reimplement. If the issue is a follow-up that depends on an unmerged source PR, 
 blocked/unavailable for clean-main work with the unblock condition "source PR merged to
 `origin/main`", unless the user explicitly chooses a stacked-PR route.
 
+For token-efficient orientation, collect a compact snapshot before broad parent reads:
+
+```bash
+uv run python scripts/dev/autopilot_state_snapshot.py \
+  --include-worktrees \
+  --claim-issue <issue-number> \
+  --issue-search "is:issue is:open <issue-number>"
+```
+
+Use the snapshot to seed worker prompts with issue/claim/worktree freshness and candidate PR
+headline state, but do not treat it as authority for final branch, claim, publication, or merge
+decisions. If `ok: false`, a claim is stale against `origin/main`, or the needed field is missing,
+run the specific raw `gh`/`git` command named by the snapshot source metadata.
+
 ## Queue Policy
 
 Default order:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -285,6 +285,25 @@ SHA-match result, poll attempt, wait budget, deadline, and `route_evidence_only:
 success is route evidence only; reassess the current PR head SHA and normal readiness proof before
 labeling or merging.
 
+For routine goal-autopilot orientation, prefer the compact state snapshot helper before broad parent
+thread reads:
+
+```bash
+uv run python scripts/dev/autopilot_state_snapshot.py \
+  --include-worktrees \
+  --claim-issue <issue-number> \
+  --issue-search "is:issue is:open <queue-filter>" \
+  --pr <pr-number>
+```
+
+The JSON output includes source commands, branch/head SHA, `origin/main` SHA, linked worktrees,
+claim refs, issue queue rows, explicit PR headline state, and freshness metadata. Use it to seed
+worker prompts and active ledgers; run fresh focused `gh`/`git` checks before claim, push, PR,
+label, merge, or publication decisions. Raw logs and broad CLI output are appropriate when the
+snapshot reports `ok: false`, stale claims, missing state, or insufficient fields.
+Worktree rows are capped by default; use `worktree_count` and `worktrees_truncated` to decide
+whether a larger `--worktree-limit` is worth the parent-thread context cost.
+
 Use `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` before PR handoff when a
 branch adds or edits context notes, evidence bundles, or other proof-heavy docs surfaces. The
 checker is intentionally conservative: it only flags high-confidence issues such as missing

--- a/scripts/dev/autopilot_state_snapshot.py
+++ b/scripts/dev/autopilot_state_snapshot.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Emit compact goal-autopilot state snapshots.
+
+The snapshot is route evidence for orientation and handoff.  It is not a substitute for fresh
+local checks before publishing, labeling, merging, or making benchmark-facing claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+FAILURE_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "error",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+PENDING_STATUSES = {"expected", "in_progress", "pending", "queued", "requested", "waiting"}
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Captured command result for compact provenance."""
+
+    command: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _run(command: list[str], *, timeout: int = 30) -> CommandResult:
+    """Run a command and capture text output."""
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return CommandResult(
+            command=tuple(command),
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    except subprocess.TimeoutExpired:
+        return CommandResult(
+            command=tuple(command),
+            returncode=124,
+            stdout="",
+            stderr=f"command timed out after {timeout} seconds",
+        )
+
+
+def _now_utc() -> str:
+    """Return an ISO-8601 UTC timestamp."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _command_source(result: CommandResult, *, name: str) -> dict[str, Any]:
+    """Return compact command provenance."""
+    return {
+        "name": name,
+        "command": list(result.command),
+        "returncode": result.returncode,
+    }
+
+
+def _parse_json_result(result: CommandResult) -> tuple[Any | None, str | None]:
+    """Parse a JSON command result."""
+    if result.returncode != 0:
+        return None, (result.stderr or result.stdout).strip() or f"exit {result.returncode}"
+    try:
+        return json.loads(result.stdout), None
+    except json.JSONDecodeError as exc:
+        return None, f"json_parse_error: {exc}"
+
+
+def _git_text(command: list[str], *, name: str) -> tuple[str, dict[str, Any], str | None]:
+    """Run a git command that should return one line of text."""
+    result = _run(command)
+    source = _command_source(result, name=name)
+    if result.returncode != 0:
+        return "", source, (result.stderr or result.stdout).strip() or f"{name} failed"
+    return result.stdout.strip(), source, None
+
+
+def _append_worktree_row(rows: list[dict[str, Any]], row: dict[str, Any]) -> None:
+    """Append a parsed worktree row with stable default fields."""
+    if not row:
+        return
+    row.setdefault("branch", "")
+    row.setdefault("head_sha", "")
+    row.setdefault("bare", False)
+    row.setdefault("detached", False)
+    rows.append(row)
+
+
+def _parse_worktree_porcelain(stdout: str) -> list[dict[str, Any]]:
+    """Parse `git worktree list --porcelain` into compact worktree rows."""
+    rows: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current:
+                _append_worktree_row(rows, current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            if current:
+                _append_worktree_row(rows, current)
+            current = {"path": value}
+        elif key == "HEAD":
+            current["head_sha"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key in {"bare", "detached"}:
+            current[key] = True
+    if current:
+        _append_worktree_row(rows, current)
+    return rows
+
+
+def git_snapshot(
+    *, include_worktrees: bool, worktree_limit: int
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    """Return compact local git state."""
+    sources: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    branch, source, error = _git_text(["git", "branch", "--show-current"], name="git.branch")
+    sources.append(source)
+    if error:
+        errors.append(error)
+
+    head_sha, source, error = _git_text(["git", "rev-parse", "HEAD"], name="git.head")
+    sources.append(source)
+    if error:
+        errors.append(error)
+
+    origin_main_sha, source, error = _git_text(
+        ["git", "rev-parse", "--verify", "origin/main^{commit}"],
+        name="git.origin_main",
+    )
+    sources.append(source)
+    if error:
+        errors.append(error)
+
+    worktrees: list[dict[str, Any]] = []
+    if include_worktrees:
+        result = _run(["git", "worktree", "list", "--porcelain"])
+        sources.append(_command_source(result, name="git.worktrees"))
+        if result.returncode == 0:
+            worktrees = _parse_worktree_porcelain(result.stdout)
+            worktrees.sort(
+                key=lambda row: (
+                    row.get("branch") != branch,
+                    row.get("head_sha") != head_sha,
+                    row.get("path", ""),
+                )
+            )
+        else:
+            errors.append((result.stderr or result.stdout).strip() or "git worktree list failed")
+    worktree_count = len(worktrees)
+    worktree_limit = max(0, worktree_limit)
+    visible_worktrees = worktrees[:worktree_limit] if worktree_limit else []
+
+    return (
+        {
+            "branch": branch,
+            "head_sha": head_sha,
+            "origin_main_sha": origin_main_sha,
+            "head_matches_origin_main": bool(
+                head_sha and origin_main_sha and head_sha == origin_main_sha
+            ),
+            "worktree_count": worktree_count,
+            "worktrees_truncated": worktree_count > len(visible_worktrees),
+            "worktrees": visible_worktrees,
+        },
+        sources,
+        errors,
+    )
+
+
+def claim_snapshot(
+    issue_numbers: list[int], *, remote: str, origin_main_sha: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    """Return compact claim-ref state for issue numbers."""
+    rows: list[dict[str, Any]] = []
+    sources: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for issue in issue_numbers:
+        claim_ref = f"refs/heads/agent-claims/issue-{issue}"
+        result = _run(["git", "ls-remote", "--heads", remote, claim_ref])
+        sources.append(_command_source(result, name=f"claim.issue_{issue}"))
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout).strip() or "claim lookup failed"
+            rows.append(
+                {
+                    "issue": issue,
+                    "ok": False,
+                    "claimed": None,
+                    "claim_ref": claim_ref.removeprefix("refs/heads/"),
+                    "sha": None,
+                    "stale_against_origin_main": None,
+                    "error": error,
+                }
+            )
+            errors.append(f"issue {issue}: {error}")
+            continue
+        sha = None
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1] == claim_ref:
+                sha = parts[0]
+                break
+        rows.append(
+            {
+                "issue": issue,
+                "ok": True,
+                "claimed": sha is not None,
+                "claim_ref": claim_ref.removeprefix("refs/heads/"),
+                "sha": sha,
+                "stale_against_origin_main": bool(
+                    sha and origin_main_sha and sha != origin_main_sha
+                ),
+                "error": None,
+            }
+        )
+    return rows, sources, errors
+
+
+def issue_queue_snapshot(
+    searches: list[str], *, limit: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    """Return compact issue rows for one or more GitHub issue searches."""
+    rows: list[dict[str, Any]] = []
+    sources: list[dict[str, Any]] = []
+    errors: list[str] = []
+    seen: set[int] = set()
+    for search in searches:
+        command = [
+            "gh",
+            "issue",
+            "list",
+            "--search",
+            search,
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,state,labels,updatedAt,url",
+        ]
+        result = _run(command)
+        sources.append(_command_source(result, name=f"issues.search:{search}"))
+        data, error = _parse_json_result(result)
+        if error:
+            errors.append(f"issue search {search!r}: {error}")
+            continue
+        for issue in data if isinstance(data, list) else []:
+            number = issue.get("number")
+            if not isinstance(number, int) or number in seen:
+                continue
+            seen.add(number)
+            labels = issue.get("labels", []) or []
+            rows.append(
+                {
+                    "number": number,
+                    "title": issue.get("title", ""),
+                    "state": issue.get("state", ""),
+                    "labels": sorted(
+                        label.get("name", "")
+                        for label in labels
+                        if isinstance(label, dict) and label.get("name")
+                    ),
+                    "updated_at": issue.get("updatedAt", ""),
+                    "url": issue.get("url", ""),
+                }
+            )
+    return rows, sources, errors
+
+
+def _rollup_conclusion(check: dict[str, Any]) -> str:
+    """Return a normalized check conclusion."""
+    return str(check.get("conclusion") or check.get("state") or "pending").lower()
+
+
+def _rollup_status(check: dict[str, Any]) -> str:
+    """Return a normalized check status."""
+    status = check.get("status")
+    if status:
+        return str(status).lower()
+    state = str(check.get("state") or "").lower()
+    if state in {"success", "failure", "error"}:
+        return "completed"
+    return state or "completed"
+
+
+def _check_name(check: dict[str, Any]) -> str:
+    """Return a compact check name."""
+    return str(check.get("name") or check.get("context") or "unknown")
+
+
+def _checks_summary(rollup: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize a PR statusCheckRollup payload."""
+    valid_checks = [check for check in rollup if isinstance(check, dict)]
+    conclusions: dict[str, int] = {}
+    statuses: dict[str, int] = {}
+    for check in valid_checks:
+        conclusion = _rollup_conclusion(check)
+        status = _rollup_status(check)
+        conclusions[conclusion] = conclusions.get(conclusion, 0) + 1
+        statuses[status] = statuses.get(status, 0) + 1
+    failure_count = sum(conclusions.get(conclusion, 0) for conclusion in FAILURE_CONCLUSIONS)
+    pending_count = sum(statuses.get(status, 0) for status in PENDING_STATUSES)
+    if failure_count:
+        overall = "failure"
+    elif pending_count or not valid_checks:
+        overall = "pending"
+    else:
+        overall = "success"
+    return {
+        "overall": overall,
+        "total": len(valid_checks),
+        "by_conclusion": conclusions,
+        "by_status": statuses,
+        "names": sorted({_check_name(check) for check in valid_checks}),
+    }
+
+
+def pr_snapshot(
+    pr_numbers: list[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    """Return compact PR headline state for explicit PR numbers."""
+    rows: list[dict[str, Any]] = []
+    sources: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for pr in pr_numbers:
+        command = [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--json",
+            "number,title,state,mergeable,headRefName,headRefOid,statusCheckRollup,url",
+        ]
+        result = _run(command)
+        sources.append(_command_source(result, name=f"pr.{pr}"))
+        data, error = _parse_json_result(result)
+        if error or not isinstance(data, dict):
+            errors.append(f"pr {pr}: {error or 'not a JSON object'}")
+            continue
+        rollup = data.get("statusCheckRollup", []) or []
+        rows.append(
+            {
+                "number": data.get("number", pr),
+                "title": data.get("title", ""),
+                "state": data.get("state", ""),
+                "mergeable": data.get("mergeable", ""),
+                "branch": data.get("headRefName", ""),
+                "head_sha": data.get("headRefOid", ""),
+                "checks": _checks_summary(rollup if isinstance(rollup, list) else []),
+                "url": data.get("url", ""),
+            }
+        )
+    return rows, sources, errors
+
+
+def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
+    """Build the full snapshot payload."""
+    git, sources, errors = git_snapshot(
+        include_worktrees=args.include_worktrees,
+        worktree_limit=args.worktree_limit,
+    )
+
+    claims, claim_sources, claim_errors = claim_snapshot(
+        args.claim_issue,
+        remote=args.remote,
+        origin_main_sha=git.get("origin_main_sha", ""),
+    )
+    sources.extend(claim_sources)
+    errors.extend(claim_errors)
+
+    issues, issue_sources, issue_errors = issue_queue_snapshot(args.issue_search, limit=args.limit)
+    sources.extend(issue_sources)
+    errors.extend(issue_errors)
+
+    prs, pr_sources, pr_errors = pr_snapshot(args.pr)
+    sources.extend(pr_sources)
+    errors.extend(pr_errors)
+
+    return {
+        "schema": "autopilot_state_snapshot.v1",
+        "ok": not errors,
+        "generated_at_utc": _now_utc(),
+        "freshness": {
+            "route_evidence_only": True,
+            "requires_fresh_check_before_publication": True,
+            "branch": git.get("branch", ""),
+            "head_sha": git.get("head_sha", ""),
+            "origin_main_sha": git.get("origin_main_sha", ""),
+        },
+        "git": git,
+        "claims": claims,
+        "issues": issues,
+        "prs": prs,
+        "errors": errors,
+        "sources": sources,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--issue-search",
+        action="append",
+        default=[],
+        metavar="QUERY",
+        help="GitHub issue search query to summarize; may be repeated.",
+    )
+    parser.add_argument("--limit", type=int, default=20, help="maximum issues per search")
+    parser.add_argument(
+        "--pr", type=int, action="append", default=[], help="PR number to summarize"
+    )
+    parser.add_argument(
+        "--claim-issue",
+        type=int,
+        action="append",
+        default=[],
+        help="issue number whose agent-claim ref should be summarized",
+    )
+    parser.add_argument("--remote", default="origin", help="git remote used for claim refs")
+    parser.add_argument(
+        "--include-worktrees",
+        action="store_true",
+        help="include `git worktree list --porcelain` summary",
+    )
+    parser.add_argument(
+        "--worktree-limit",
+        type=int,
+        default=20,
+        help="maximum worktree rows to include; total count and truncation are always reported",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    payload = build_snapshot(args)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/dev/test_autopilot_state_snapshot.py
+++ b/tests/dev/test_autopilot_state_snapshot.py
@@ -1,0 +1,233 @@
+"""Tests for compact goal-autopilot state snapshots."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts.dev import autopilot_state_snapshot as snapshot
+
+
+def _result(command: list[str], *, stdout: str = "", stderr: str = "", returncode: int = 0):
+    return snapshot.CommandResult(
+        command=tuple(command),
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_parse_worktree_porcelain_summarizes_linked_worktrees() -> None:
+    """Worktree porcelain output should become compact branch/head rows."""
+    rows = snapshot._parse_worktree_porcelain(
+        "\n".join(
+            [
+                "worktree /repo/main",
+                "HEAD abc123",
+                "branch refs/heads/main",
+                "",
+                "worktree /repo/feature",
+                "HEAD def456",
+                "branch refs/heads/issue-1",
+                "",
+            ]
+        )
+    )
+
+    assert rows == [
+        {
+            "path": "/repo/main",
+            "head_sha": "abc123",
+            "branch": "main",
+            "bare": False,
+            "detached": False,
+        },
+        {
+            "path": "/repo/feature",
+            "head_sha": "def456",
+            "branch": "issue-1",
+            "bare": False,
+            "detached": False,
+        },
+    ]
+
+
+def test_build_snapshot_includes_queue_claim_pr_and_worktree_state(
+    monkeypatch,
+) -> None:
+    """A normal snapshot should include compact queue, claim, PR, and worktree state."""
+    origin_main_sha = "6e55ea36affa82ea1b3c870c27f0133464295fd0"
+
+    def fake_run(command: list[str], *, timeout: int = 30):
+        del timeout
+        if command == ["git", "branch", "--show-current"]:
+            return _result(command, stdout="issue-2671-compact-state-snapshots\n")
+        if command == ["git", "rev-parse", "HEAD"]:
+            return _result(command, stdout=f"{origin_main_sha}\n")
+        if command == ["git", "rev-parse", "--verify", "origin/main^{commit}"]:
+            return _result(command, stdout=f"{origin_main_sha}\n")
+        if command == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                command,
+                stdout=(
+                    "worktree /repo/main\n"
+                    f"HEAD {origin_main_sha}\n"
+                    "branch refs/heads/main\n\n"
+                    "worktree /repo/issue-2671\n"
+                    f"HEAD {origin_main_sha}\n"
+                    "branch refs/heads/issue-2671-compact-state-snapshots\n"
+                ),
+            )
+        if command[:3] == ["git", "ls-remote", "--heads"]:
+            return _result(
+                command,
+                stdout=f"{origin_main_sha}\trefs/heads/agent-claims/issue-2671\n",
+            )
+        if command[:3] == ["gh", "issue", "list"]:
+            return _result(
+                command,
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": 2671,
+                            "title": "Reduce token burn",
+                            "state": "OPEN",
+                            "labels": [{"name": "enhancement"}],
+                            "updatedAt": "2026-06-12T09:00:00Z",
+                            "url": "https://example.test/issues/2671",
+                        }
+                    ]
+                ),
+            )
+        if command[:3] == ["gh", "pr", "view"]:
+            return _result(
+                command,
+                stdout=json.dumps(
+                    {
+                        "number": 2683,
+                        "title": "compact CI monitor evidence",
+                        "state": "OPEN",
+                        "mergeable": "MERGEABLE",
+                        "headRefName": "issue-2672",
+                        "headRefOid": "abc123",
+                        "statusCheckRollup": [
+                            {"name": "ci", "status": "completed", "conclusion": "success"}
+                        ],
+                        "url": "https://example.test/pull/2683",
+                    }
+                ),
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(snapshot, "_run", fake_run)
+    args = snapshot._build_parser().parse_args(
+        [
+            "--include-worktrees",
+            "--claim-issue",
+            "2671",
+            "--issue-search",
+            "is:issue is:open 2671",
+            "--pr",
+            "2683",
+        ]
+    )
+
+    payload = snapshot.build_snapshot(args)
+
+    assert payload["schema"] == "autopilot_state_snapshot.v1"
+    assert payload["ok"] is True
+    assert payload["freshness"]["route_evidence_only"] is True
+    assert payload["git"]["branch"] == "issue-2671-compact-state-snapshots"
+    assert payload["git"]["worktree_count"] == 2
+    assert payload["git"]["worktrees_truncated"] is False
+    assert payload["git"]["worktrees"][0]["branch"] == "issue-2671-compact-state-snapshots"
+    assert payload["claims"] == [
+        {
+            "issue": 2671,
+            "ok": True,
+            "claimed": True,
+            "claim_ref": "agent-claims/issue-2671",
+            "sha": origin_main_sha,
+            "stale_against_origin_main": False,
+            "error": None,
+        }
+    ]
+    assert payload["issues"][0]["labels"] == ["enhancement"]
+    assert payload["prs"][0]["checks"]["overall"] == "success"
+    assert payload["sources"]
+
+
+def test_claim_snapshot_marks_stale_claim_against_origin_main(monkeypatch) -> None:
+    """Claim refs should expose when their source SHA is behind origin/main."""
+    old_sha = "1111111111111111111111111111111111111111"
+    new_sha = "2222222222222222222222222222222222222222"
+
+    def fake_run(command: list[str], *, timeout: int = 30):
+        del timeout
+        return _result(command, stdout=f"{old_sha}\trefs/heads/agent-claims/issue-2671\n")
+
+    monkeypatch.setattr(snapshot, "_run", fake_run)
+
+    rows, sources, errors = snapshot.claim_snapshot(
+        [2671], remote="origin", origin_main_sha=new_sha
+    )
+
+    assert errors == []
+    assert sources[0]["name"] == "claim.issue_2671"
+    assert rows[0]["claimed"] is True
+    assert rows[0]["stale_against_origin_main"] is True
+
+
+def test_claim_snapshot_reports_missing_state_errors(monkeypatch) -> None:
+    """A failed claim lookup should stay compact but make the snapshot not-ok."""
+
+    def fake_run(command: list[str], *, timeout: int = 30):
+        del timeout
+        return _result(command, stderr="network unavailable", returncode=1)
+
+    monkeypatch.setattr(snapshot, "_run", fake_run)
+
+    rows, _sources, errors = snapshot.claim_snapshot(
+        [2671],
+        remote="origin",
+        origin_main_sha="6e55ea36affa82ea1b3c870c27f0133464295fd0",
+    )
+
+    assert errors == ["issue 2671: network unavailable"]
+    assert rows[0]["ok"] is False
+    assert rows[0]["claimed"] is None
+    assert rows[0]["error"] == "network unavailable"
+
+
+def test_run_converts_timeouts_to_compact_command_result(monkeypatch) -> None:
+    """Hung git or gh commands should become compact snapshot errors, not tracebacks."""
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["gh"], timeout=5)
+
+    monkeypatch.setattr(snapshot.subprocess, "run", fake_subprocess_run)
+
+    result = snapshot._run(["gh", "issue", "list"], timeout=5)
+
+    assert result.returncode == 124
+    assert result.stdout == ""
+    assert result.stderr == "command timed out after 5 seconds"
+
+
+def test_checks_summary_ignores_malformed_rollup_entries() -> None:
+    """Unexpected PR rollup entries should not crash compact PR snapshots."""
+    summary = snapshot._checks_summary(
+        [
+            None,  # type: ignore[list-item]
+            "bad",  # type: ignore[list-item]
+            {"name": "ci", "status": "completed", "conclusion": "success"},
+        ]
+    )
+
+    assert summary == {
+        "overall": "success",
+        "total": 1,
+        "by_conclusion": {"success": 1},
+        "by_status": {"completed": 1},
+        "names": ["ci"],
+    }


### PR DESCRIPTION
## Summary
Adds a compact `autopilot_state_snapshot.py` helper for goal-autopilot orientation and documents snapshot-first parent-thread reads.

## Linked Issues
- Closes #2671

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/autopilot_state_snapshot.py` with `autopilot_state_snapshot.v1` JSON for git/head freshness, linked worktrees, issue searches, issue-claim refs, and explicit PR headline/check state.
- Added worktree truncation controls: default capped rows plus `worktree_count` and `worktrees_truncated`, with the active branch/head prioritized.
- Added tests for normal snapshot composition, worktree parsing, stale claim refs, and missing claim-state errors.
- Updated goal-autopilot, goal-issue-implementation, and dev-guide docs to prefer compact snapshots before broad parent-thread reads.

## Why It Matters
- Added value: parent Codex threads can orient from compact, schema-stable JSON instead of repeated broad `gh`/`git` output.
- Expected impact: lower orchestration token burn and clearer handoff/ledger state.
- Why this is worth merging now: #2671 was the remaining target-range workflow gap after CI wait monitors landed in #2683.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling workflow helper, no research claim.
- Comparator or baseline, if applicable: existing broad parent-thread `gh issue list`, `gh pr view`, `git worktree list`, and claim checks.
- Evidence tier: targeted smoke plus full PR readiness.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: helper emits compact route evidence with freshness metadata and stale/missing-state indicators.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2671.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/tooling PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop; issue contract covered.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees --worktree-limit 3 --claim-issue 2671 --issue-search "is:issue is:open 2671" --limit 5`
  - `rtk test uv run pytest tests/dev/test_autopilot_state_snapshot.py -q` (6 passed)
  - `rtk test uv run ruff check scripts/dev/autopilot_state_snapshot.py tests/dev/test_autopilot_state_snapshot.py`
  - `rtk test uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
  - `rtk test uv run python scripts/dev/check_skills.py --preflight goal-issue-implementation`
  - `rtk test BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (5625 passed, 9 skipped)
- Evidence that the change works here: live snapshot stayed compact with `worktree_count: 580`, `worktrees_truncated: true`, active worktree first, issue #2671 row present, and claim fresh against `origin/main`.
- Benchmarks or smoke tests, if applicable: support helper smoke and full repo readiness; no benchmark claim.

## Risks / Rollout
- Compatibility risks: additive helper and docs only.
- Failure modes: snapshots may be stale; docs and JSON mark them as route evidence requiring fresh checks before publication/mutation.
- Rollback or fallback plan: continue using focused raw `gh`/`git` commands for final decisions.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-autopilot/SKILL.md`, `.agents/skills/goal-issue-implementation/SKILL.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: private active ledger recorded live snapshot and validation.
- Any assumptions that need to be preserved: snapshot output is advisory route evidence, not final readiness.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via `Closes #2671`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: support/tooling workflow change with no research artifact or benchmark propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the helper caps worktree output by default and reports truncation rather than dumping all linked worktrees.
- Any known limitations: PR readiness was run raw with `timeout 900` because RTK previously hung around long-running readiness wrappers; the final run passed on clean committed head `62b7d33f816ce4e8dc055d01e1f0bb9a2aead033`.
