### PR TITLE
docs: clarify caveat-first evidence reporting

### DIFF
--- a/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
+++ b/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
@@ -52,6 +52,8 @@ consistency, reproducibility, and fallback-mode visibility before claiming bench
    - Highlight slowest planners by `runtime_sec`.
    - Highlight weakest planners by success/collision/SNQI from derived episode means.
    - Note experimental planners running with fallback mode.
+   - Before ranking language, include claim boundary + evidence status + major caveats, including fallback/degraded
+     rows.
 
 5. Recommend actions
    - If inconsistencies are found, propose concrete follow-ups in issue-facing wording.
@@ -79,6 +81,8 @@ uv run python scripts/tools/analyze_camera_ready_campaign.py \
 - Fail-closed rule: do not treat fallback/degraded as successful benchmark evidence.
 - Fallback/degraded rows must appear as caveats or exclusions before comparative rankings,
   aggregate success language, or recommendations.
+- Mixed/limited evidence outputs must lead with claim boundary, evidence status, and caveats; only
+  then provide comparative interpretation.
 - Require the produced JSON + markdown reports as proof artifacts before summarizing results.
 - Only report planner ranking where metrics and episode counts are internally consistent.
 

--- a/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
+++ b/.agents/skills/analyze-camera-ready-benchmark/SKILL.md
@@ -51,9 +51,8 @@ consistency, reproducibility, and fallback-mode visibility before claiming bench
      caveats before planner rankings or success interpretation when evidence is mixed or limited.
    - Highlight slowest planners by `runtime_sec`.
    - Highlight weakest planners by success/collision/SNQI from derived episode means.
-   - Note experimental planners running with fallback mode.
-   - Before ranking language, include claim boundary + evidence status + major caveats, including fallback/degraded
-     rows.
+   - Note experimental planners running with fallback mode and make uncertainty visible before any
+     ranking language.
 
 5. Recommend actions
    - If inconsistencies are found, propose concrete follow-ups in issue-facing wording.

--- a/.agents/skills/evidence-synthesis/SKILL.md
+++ b/.agents/skills/evidence-synthesis/SKILL.md
@@ -30,6 +30,8 @@ Use this skill when multiple issues, campaigns, configs, seeds, metrics, and art
 5. Separate observed evidence from hypothesis and state caveats before conclusions.
 6. For mixed or limited benchmark evidence, open the synthesis with the claim boundary: evidence
    tier, fallback/degraded exclusions, major caveats, and uncertainty before result interpretation.
+   Use evidence status terms consistently: `diagnostic-only`, `smoke evidence`,
+   `nominal benchmark evidence`, or `paper-grade`.
 
 For ordinary exploratory runs, prefer per-experiment hypothesis notes over a central ledger. The
 minimum reusable fields are hypothesis, variant/config, expected signal, result classification,
@@ -51,6 +53,9 @@ now?" instead of "what should we run next?".
   synthesis.
 - Do not put rankings, success language, or mechanism conclusions before the claim boundary when
   evidence is diagnostic-only, smoke-level, mixed, fallback-tainted, or below high confidence.
+- Surface fallback/degraded rows as explicit caveats or exclusions before ranking claims.
+- For uncertain comparisons below high confidence (about 95%), place numeric uncertainty and change
+  conditions near the claim boundary.
 - Use `paper-facing-docs` before manuscript-support language is published.
 
 ## Output

--- a/.agents/skills/paper-facing-docs/SKILL.md
+++ b/.agents/skills/paper-facing-docs/SKILL.md
@@ -36,11 +36,16 @@ public-facing provenance statements.
 5. Add explicit provenance pointers before handoff.
 6. For mixed or limited evidence, make the opening order: claim boundary, evidence status, major
    caveats and exclusions, uncertainty, then result interpretation.
+7. State evidence status in one of: `diagnostic-only`, `smoke evidence`,
+   `nominal benchmark evidence`, or `paper-grade`.
 
 ## Proof and Guardrails
 
 - Preserve fail-closed semantics: do not present fallback/degraded runs as success.
+- For mixed, limited, or degraded evidence, require caveat-first ordering before any ranking/success language.
 - Any claim must point to concrete reproducible artifacts.
+- Use claim-boundary language early when confidence is below high confidence (approx 95%) and include numeric
+  uncertainty.
 - Prefer tracked canonical documents and execution notes for evidence.
 - Use consistent evidence-tier wording: `diagnostic-only`, `smoke evidence`,
   `nominal benchmark evidence`, and `paper-grade`.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -26,10 +26,12 @@ For benchmark-facing changes, explicitly verify:
 ### Evaluation semantics
 - Does the change alter success, collision, timeout, or metric semantics?
 - Are fallback, skip, and fail-fast paths still explicit and testable?
-- Are benchmark categories (`diagnostic`, `classical`, `learning`) still accurate?
+- Are benchmark categories (`diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`,
+  `paper-grade`) still accurate?
 - Does any report wording overstate what the benchmark actually measures?
-- For mixed or limited evidence, does the report start with claim boundary, evidence status,
-  fallback/degraded exclusions, major caveats, and uncertainty before ranking or success language?
+- For mixed, partial, or fallback-tainted evidence, does the report start with claim boundary,
+  evidence status, fallback/degraded exclusions, major caveats, and uncertainty before ranking or
+  success language?
 
 ### Observation normalization
 - Are observation keys, bounds, clipping, and dtype contracts preserved or versioned?

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -26,7 +26,7 @@ For benchmark-facing changes, explicitly verify:
 ### Evaluation semantics
 - Does the change alter success, collision, timeout, or metric semantics?
 - Are fallback, skip, and fail-fast paths still explicit and testable?
-- Are benchmark categories (`diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`,
+- Are evidence statuses (`diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`,
   `paper-grade`) still accurate?
 - Does any report wording overstate what the benchmark actually measures?
 - For mixed, partial, or fallback-tainted evidence, does the report start with claim boundary,

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -18,7 +18,8 @@ When evidence is mixed, limited, or partly degraded, every report must open with
 1. claim boundary,
 2. evidence status (`diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`,
    `paper-grade`),
-3. major caveats (including fallback/degraded rows and confidence below ~95%).
+3. major caveats (including fallback/degraded rows),
+4. uncertainty or confidence below ~95%.
 Only after this ordering can result interpretation and recommendation appear.
 
 Fallback or degraded benchmark execution is never success evidence. It may be useful diagnostic

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -14,6 +14,13 @@ implemented in the repository. Benchmark, metric, schema, artifact-provenance, a
 claims require enough evidence for another contributor to understand what ran, what did not run,
 and what remains uncertain.
 
+When evidence is mixed, limited, or partly degraded, every report must open with:
+1. claim boundary,
+2. evidence status (`diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`,
+   `paper-grade`),
+3. major caveats (including fallback/degraded rows and confidence below ~95%).
+Only after this ordering can result interpretation and recommendation appear.
+
 Fallback or degraded benchmark execution is never success evidence. It may be useful diagnostic
 information only when labeled that way.
 

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -151,7 +151,9 @@ def _write_capsules(issues: list[dict[str, Any]], capsule_dir: pathlib.Path) -> 
         if issue.get("status") != "ok":
             continue
         path = capsule_dir / f"issue_{issue['number']}_context_capsule.json"
-        path.write_text(json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        path.write_text(
+            json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         issue["context_capsule_path"] = str(path)
 
 


### PR DESCRIPTION
## Summary
Clarifies caveat-first reporting guidance for mixed, limited, fallback, or degraded evidence across maintainer docs, review guidance, and benchmark-facing agent skills.

## Linked Issues
- None

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added explicit claim-boundary, evidence-status, caveat, and uncertainty ordering to benchmark evidence guidance.
- Aligned skill and review docs around `diagnostic-only`, `smoke evidence`, `nominal benchmark evidence`, and `paper-grade` wording.
- Reinforced that fallback/degraded rows should appear as caveats or exclusions before ranking or success language.

## Why It Matters
- Added value: reduces overclaim risk when reports synthesize partial or mixed benchmark evidence.
- Expected impact: reviewers and agents get a clearer checklist for evidence status and caveat placement.
- Why this is worth merging now: this preserves useful local guidance as shared repo policy.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - docs-only guidance, no new research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - docs-only guidance.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `git diff --cached --check`
  - `grep '^<<<<<<<|^=======$|^>>>>>>> ' .agents/skills docs`
  - referenced-path existence check for the changed docs and skill references
- Evidence that the change works here: staged diff inspected after resolving against current `origin/main`; no conflict markers or whitespace errors remained.
- Benchmarks or smoke tests, if applicable: NA - docs/skill guidance only.

## Risks / Rollout
- Compatibility risks: low; no runtime code changed.
- Failure modes: reviewers may prefer different evidence-tier naming.
- Rollback or fallback plan: revert the docs-only commit.

## Docs / Provenance
- Updated docs:
  - `docs/maintainer_values.md`
  - `docs/code_review.md`
  - `.agents/skills/analyze-camera-ready-benchmark/SKILL.md`
  - `.agents/skills/evidence-synthesis/SKILL.md`
  - `.agents/skills/paper-facing-docs/SKILL.md`
- Relevant design or provenance notes: updates were rebased onto current `origin/main` and duplicate upstream guidance was consolidated.
- Any assumptions that need to be preserved: fallback/degraded evidence is diagnostic or caveat material, not success evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is guidance-only and does not add a research result, benchmark artifact, metric, config, or evidence-producing tool.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether the evidence-tier labels are the preferred canonical wording.
- Any known limitations: full PR readiness gate was not run because this is a low-risk docs/skill update.

## Artifact Classification
- Existing ignored `output/wandb/...` files were observed locally and intentionally left untracked; they are disposable local run output and not part of this PR.
