### PR TITLE
feat: add publication scout conformance linter

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -68,7 +68,9 @@ repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected 
 
 ## Workflow
 
-1. Refresh credentials and branch baseline (`gh auth status`, `git fetch origin`).
+1. Run preflight for required local tooling and the Scout publication linter:
+   `uv run python scripts/dev/check_skills.py --preflight gh-issue-autopilot`.
+   Then refresh credentials and branch baseline (`gh auth status`, `git fetch origin`).
 2. Resolve queue candidate and re-check issue state with local `gh issue view` or REST evidence
    before claim or branch, especially when a delegated scout proposed the issue.
 3. Check open PRs for duplicate coverage using the linked issue, head branch/scope, and title.

--- a/.agents/skills/skills.yaml
+++ b/.agents/skills/skills.yaml
@@ -454,6 +454,7 @@ skills:
       filesystem: true
     requires:
     - gh
+    - publication-scout-linter
     - git
     - project5
     delegates_to:

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -319,6 +319,7 @@ _REQUIREMENT_CHECKS: dict[str, tuple[str, str, str]] = {
     ),
 }
 
+PUBLICATION_SCOUT_LINTER_REQUIREMENT = "publication-scout-linter"
 _PROJECT5_EXTRA = "jq"
 
 
@@ -354,6 +355,23 @@ def _run_preflight_check(
     Returns one of (ok, version_string), (missing, error_string),
     or (unrecognized, message).
     """
+    if req == PUBLICATION_SCOUT_LINTER_REQUIREMENT:
+        script_path = REPO_ROOT / "scripts" / "dev" / "publication_scout_linter.py"
+        if script_path.is_file():
+            detail = f"{script_path.relative_to(REPO_ROOT)} present"
+            if json_output and results is not None:
+                results["checks"][req] = {"status": "ok", "detail": detail, "remedy": None}
+            return "ok", detail
+
+        detail = f"{script_path.relative_to(REPO_ROOT)} is required for publication-scout conformance checks"
+        if json_output and results is not None:
+            results["checks"][req] = {
+                "status": "missing",
+                "detail": detail,
+                "remedy": "Restore scripts/dev/publication_scout_linter.py or remove the requirement.",
+            }
+        return "missing", detail
+
     check = _REQUIREMENT_CHECKS.get(req)
     if check is None:
         detail = (

--- a/scripts/dev/publication_scout_linter.py
+++ b/scripts/dev/publication_scout_linter.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Conformance checks for publication-scout issue candidate readiness.
+
+The script is intentionally read-only and deterministic; all checks are driven from fixture or
+preloaded JSON payloads so tests can cover edge cases without contacting GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_RECENT_COMMENT_HOURS = 24
+SCHEMA = "publication_scout_linter.v1"
+COMMENT_WINDOW_FIELDS = ("createdAt", "created_at", "created")
+
+
+@dataclass(frozen=True)
+class LinterFinding:
+    """Single validation finding from issue candidate readiness checks."""
+
+    code: str
+    detail: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Serialize to a JSON-friendly payload."""
+        return {"code": self.code, "detail": self.detail}
+
+
+def parse_iso_datetime(raw: object) -> datetime | None:
+    """Parse common GitHub timestamp shapes into timezone-aware datetimes."""
+    if not isinstance(raw, str):
+        return None
+
+    candidate = raw.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _normalize_repo(value: object) -> str | None:
+    """Normalize a repository URL or owner/repo string to ``owner/repo``."""
+    if not isinstance(value, str):
+        return None
+
+    candidate = value.strip().rstrip("/")
+    if not candidate:
+        return None
+
+    lowered = candidate.lower()
+    if lowered.startswith("https://api.github.com/repos/"):
+        candidate = candidate[len("https://api.github.com/repos/") :]
+    elif lowered.startswith("https://github.com/"):
+        candidate = candidate[len("https://github.com/") :]
+
+    if "://" in candidate:
+        return None
+
+    parts = [part for part in candidate.split("/") if part]
+    if len(parts) < 2:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def extract_issue_repo(issue: dict[str, Any]) -> str | None:
+    """Extract repository owner/name from a typical GH issue payload."""
+    repository = issue.get("repository")
+    if isinstance(repository, dict):
+        owner = repository.get("owner")
+        if isinstance(owner, dict):
+            owner_value = owner.get("login")
+        else:
+            owner_value = owner
+        name = repository.get("name")
+        if isinstance(owner_value, str) and isinstance(name, str):
+            return f"{owner_value}/{name}"
+    for field in ("repository_url", "html_url", "url", "repo"):
+        normalized = _normalize_repo(issue.get(field))
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def _extract_comment_time(comment: dict[str, Any]) -> datetime | None:
+    """Return a parsed comment timestamp if available."""
+    for field in COMMENT_WINDOW_FIELDS:
+        value = comment.get(field)
+        parsed = parse_iso_datetime(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def has_recent_comment_evidence(
+    comments: object,
+    *,
+    recent_window_hours: int,
+    now: datetime | None = None,
+) -> bool:
+    """Return true when at least one comment is newer than the recency window."""
+    if not isinstance(recent_window_hours, int) or recent_window_hours < 0:
+        raise ValueError("recent_window_hours must be a non-negative integer")
+
+    if not isinstance(comments, list):
+        return False
+
+    now_dt = now or datetime.now(UTC)
+    if now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=UTC)
+
+    threshold = now_dt - timedelta(hours=recent_window_hours)
+
+    for raw_comment in comments:
+        if not isinstance(raw_comment, dict):
+            continue
+        created_at = _extract_comment_time(raw_comment)
+        if created_at is None:
+            continue
+        if created_at >= threshold:
+            return True
+    return False
+
+
+def validate_candidate(
+    issue: dict[str, Any],
+    comments: object,
+    *,
+    expected_repo: str = DEFAULT_REPO,
+    recent_comment_hours: int = DEFAULT_RECENT_COMMENT_HOURS,
+    now: datetime | None = None,
+) -> list[LinterFinding]:
+    """Validate a candidate issue for publication-scout handoff readiness."""
+    findings: list[LinterFinding] = []
+
+    if str(issue.get("state", "")).lower() != "open":
+        findings.append(
+            LinterFinding(
+                code="issue_not_open",
+                detail="candidate issue is not open; skip until the issue is open in source of truth",
+            )
+        )
+
+    actual_repo = extract_issue_repo(issue)
+    if actual_repo != expected_repo:
+        findings.append(
+            LinterFinding(
+                code="issue_repo_mismatch",
+                detail=(f"candidate repo {actual_repo or '<unknown>'} != expected {expected_repo}"),
+            )
+        )
+
+    if not has_recent_comment_evidence(
+        comments,
+        recent_window_hours=recent_comment_hours,
+        now=now,
+    ):
+        findings.append(
+            LinterFinding(
+                code="missing_recent_comments",
+                detail="no recent comments found within the configured recency window",
+            )
+        )
+
+    return findings
+
+
+def classify_comment_publication_result(raw_payload: object) -> dict[str, Any]:
+    """Classify GraphQL addComment result payloads for deterministic script checks."""
+    if not isinstance(raw_payload, dict):
+        return {
+            "ok": False,
+            "status": "invalid_payload",
+            "detail": "payload is not a JSON object",
+            "error_type": "invalid_payload",
+        }
+
+    errors = raw_payload.get("errors")
+    if not errors:
+        return {"ok": True, "status": "ok", "detail": "no GraphQL errors"}
+
+    if not isinstance(errors, list) or not errors or not isinstance(errors[0], dict):
+        return {
+            "ok": False,
+            "status": "invalid_payload",
+            "detail": "errors must be a non-empty list of objects",
+            "error_type": "invalid_payload",
+        }
+
+    first_error = errors[0]
+    error_type = str(
+        first_error.get("type", "") or first_error.get("extensions", {}).get("type", "")
+    )
+    message = str(first_error.get("message", "")).strip()
+    if not error_type:
+        error_type = "UNKNOWN"
+
+    normalized = error_type.upper()
+    status_map = {
+        "FORBIDDEN": "forbidden",
+        "UNAUTHENTICATED": "unauthenticated",
+        "NOT_FOUND": "target_not_found",
+        "UNPROCESSABLE": "unprocessable",
+        "RATE_LIMITED": "rate_limited",
+        "RATELIMITED": "rate_limited",
+        "BAD_REQUEST": "bad_request",
+    }
+
+    return {
+        "ok": False,
+        "status": status_map.get(normalized, "graphql_error"),
+        "detail": message or "GraphQL returned an error",
+        "error_type": normalized,
+        "raw_error": first_error,
+    }
+
+
+def _build_report(
+    *,
+    issue: dict[str, Any],
+    findings: list[LinterFinding],
+    expected_repo: str,
+    recent_comment_hours: int,
+    has_recent_comments: bool,
+) -> dict[str, Any]:
+    """Build the machine-readable CLI report."""
+    return {
+        "schema": SCHEMA,
+        "ok": not findings,
+        "read_only": True,
+        "project_writes": False,
+        "expected_repo": expected_repo,
+        "recent_comment_hours": recent_comment_hours,
+        "checks": [
+            {"name": "issue_state_open", "ok": str(issue.get("state", "")).lower() == "open"},
+            {
+                "name": "issue_repo_match",
+                "ok": extract_issue_repo(issue) == expected_repo,
+                "actual_repo": extract_issue_repo(issue),
+            },
+            {"name": "recent_comment_evidence", "ok": has_recent_comments},
+        ],
+        "issue_number": issue.get("number"),
+        "issue_url": issue.get("url"),
+        "findings": [finding.to_payload() for finding in findings],
+        "failure_summary": None
+        if not findings
+        else {
+            "count": len(findings),
+            "codes": [finding.code for finding in findings],
+        },
+    }
+
+
+def _load_json(payload_path: Path) -> Any:
+    """Load one JSON payload from disk."""
+    data = payload_path.read_text(encoding="utf-8")
+    return json.loads(data)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build a deterministic CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--issue-json", type=Path, required=True)
+    parser.add_argument("--comments-json", type=Path, required=True)
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help="Expected owner/repo (e.g. ll7/robot_sf_ll7)"
+    )
+    parser.add_argument(
+        "--recent-comment-hours",
+        type=int,
+        default=DEFAULT_RECENT_COMMENT_HOURS,
+        help="Window in hours for recency checks on comments.",
+    )
+    parser.add_argument(
+        "--publish-result-json",
+        type=Path,
+        default=None,
+        help="Optional GraphQL publication result payload for classify-only checks.",
+    )
+    return parser
+
+
+def _dump_json(payload: dict[str, Any]) -> None:
+    """Write sorted JSON for stable, machine-readable output."""
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = _build_parser().parse_args(argv)
+
+    try:
+        issue = _load_json(args.issue_json)
+        comments = _load_json(args.comments_json)
+    except (OSError, json.JSONDecodeError) as exc:
+        _dump_json(
+            {
+                "schema": SCHEMA,
+                "ok": False,
+                "read_only": True,
+                "project_writes": False,
+                "error": str(exc),
+            }
+        )
+        return 2
+
+    if not isinstance(issue, dict):
+        _dump_json(
+            {
+                "schema": SCHEMA,
+                "ok": False,
+                "read_only": True,
+                "project_writes": False,
+                "error": "issue-json payload must be an object",
+            }
+        )
+        return 2
+
+    findings = validate_candidate(
+        issue,
+        comments,
+        expected_repo=args.repo,
+        recent_comment_hours=args.recent_comment_hours,
+    )
+    report = _build_report(
+        issue=issue,
+        findings=findings,
+        expected_repo=args.repo,
+        recent_comment_hours=args.recent_comment_hours,
+        has_recent_comments=not any(f.code == "missing_recent_comments" for f in findings),
+    )
+
+    if args.publish_result_json is not None:
+        try:
+            publish_payload = _load_json(args.publish_result_json)
+        except (OSError, json.JSONDecodeError) as exc:
+            report["publish_classification"] = {
+                "ok": False,
+                "status": "invalid_payload",
+                "detail": str(exc),
+                "error_type": "invalid_payload",
+            }
+        else:
+            report["publish_classification"] = classify_comment_publication_result(publish_payload)
+
+    _dump_json(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dev/publication_scout_linter.py
+++ b/scripts/dev/publication_scout_linter.py
@@ -197,9 +197,9 @@ def classify_comment_publication_result(raw_payload: object) -> dict[str, Any]:
         }
 
     first_error = errors[0]
-    error_type = str(
-        first_error.get("type", "") or first_error.get("extensions", {}).get("type", "")
-    )
+    extensions = first_error.get("extensions")
+    extension_type = extensions.get("type", "") if isinstance(extensions, dict) else ""
+    error_type = str(first_error.get("type", "") or extension_type)
     message = str(first_error.get("message", "")).strip()
     if not error_type:
         error_type = "UNKNOWN"

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -151,7 +151,9 @@ def _write_capsules(issues: list[dict[str, Any]], capsule_dir: pathlib.Path) -> 
         if issue.get("status") != "ok":
             continue
         path = capsule_dir / f"issue_{issue['number']}_context_capsule.json"
-        path.write_text(json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        path.write_text(
+            json.dumps(_context_capsule(issue), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         issue["context_capsule_path"] = str(path)
 
 

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -258,6 +258,48 @@ def test_preflight_json_failure_sets_status(tmp_path: Path, capsys: pytest.Captu
     assert payload["summary"]["unrecognized"] == 1
 
 
+def test_preflight_publication_scout_linter_requirement_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A declared publication linter requirement should fail if its script is missing."""
+    check_skills = _load_check_skills_module()
+    registry_yaml = tmp_path / "skills.yaml"
+    registry_yaml.write_text(
+        "version: 1\nskills:\n  scout-skill:\n    requires:\n      - publication-scout-linter\n",
+        encoding="utf-8",
+    )
+    check_skills.REPO_ROOT = tmp_path
+    check_skills.REGISTRY = registry_yaml
+    rc = check_skills._preflight("scout-skill")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "publication_scout_linter.py" in captured.out
+
+
+def test_preflight_publication_scout_linter_requirement_present(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A declared publication-linter requirement should pass when the script exists."""
+    check_skills = _load_check_skills_module()
+    registry_yaml = tmp_path / "skills.yaml"
+    registry_yaml.write_text(
+        "version: 1\nskills:\n  scout-skill:\n    requires:\n      - publication-scout-linter\n",
+        encoding="utf-8",
+    )
+    script_path = tmp_path / "scripts" / "dev" / "publication_scout_linter.py"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text("#!/usr/bin/env python3\nprint('ok')\n", encoding="utf-8")
+    check_skills.REPO_ROOT = tmp_path
+    check_skills.REGISTRY = registry_yaml
+    rc = check_skills._preflight("scout-skill")
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "publication-scout-linter" in captured.out
+    assert "PASS" in captured.out
+
+
 def test_parse_args_preflight() -> None:
     """--preflight flag should be parsed correctly."""
     check_skills = _load_check_skills_module()

--- a/tests/dev/test_publication_scout_linter.py
+++ b/tests/dev/test_publication_scout_linter.py
@@ -80,6 +80,16 @@ def test_classify_graphql_publish_payload_flags_forbidden() -> None:
     assert classified["status"] == "forbidden"
 
 
+def test_classify_graphql_publish_payload_handles_null_extensions() -> None:
+    """GraphQL error payloads may include null extensions and should not crash."""
+    payload = _fixture("comment_graphql_null_extensions.json")
+    classified = linter.classify_comment_publication_result(payload)
+
+    assert classified["ok"] is False
+    assert classified["status"] == "graphql_error"
+    assert classified["error_type"] == "UNKNOWN"
+
+
 def test_main_reports_failures_for_stale_issue(
     capsys,
 ) -> None:

--- a/tests/dev/test_publication_scout_linter.py
+++ b/tests/dev/test_publication_scout_linter.py
@@ -1,0 +1,106 @@
+"""Tests for publication scout linter helpers and fixture-backed classifications."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.dev import publication_scout_linter as linter
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "tests/fixtures/publication_scout_linter"
+
+
+def _fixture(name: str) -> object:
+    """Load one JSON fixture from test resources."""
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _fixed_now() -> datetime:
+    """Deterministic timestamp used by recency tests."""
+    return datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+
+
+def test_validate_candidate_flags_stale_issue_state() -> None:
+    """Closed issue state should create a conformance failure."""
+    issue = _fixture("issue_closed.json")
+    assert isinstance(issue, dict)
+    comments = _fixture("comments_recent.json")
+
+    findings = linter.validate_candidate(
+        issue,
+        comments,
+        expected_repo="ll7/robot_sf_ll7",
+        recent_comment_hours=24,
+        now=_fixed_now(),
+    )
+
+    assert findings and findings[0].code == "issue_not_open"
+
+
+def test_validate_candidate_flags_wrong_repo_owner() -> None:
+    """Wrong repository owner/repo should be a hard failure."""
+    issue = _fixture("issue_wrong_repo.json")
+    assert isinstance(issue, dict)
+    comments = _fixture("comments_recent.json")
+
+    findings = linter.validate_candidate(
+        issue,
+        comments,
+        expected_repo="ll7/robot_sf_ll7",
+        recent_comment_hours=24,
+        now=_fixed_now(),
+    )
+    assert any(finding.code == "issue_repo_mismatch" for finding in findings)
+
+
+def test_validate_candidate_flags_missing_recent_comments() -> None:
+    """Missing recency-window comments should fail readiness checks."""
+    issue = _fixture("issue_open.json")
+    assert isinstance(issue, dict)
+    comments = _fixture("comments_stale.json")
+
+    findings = linter.validate_candidate(
+        issue,
+        comments,
+        expected_repo="ll7/robot_sf_ll7",
+        recent_comment_hours=24,
+        now=_fixed_now(),
+    )
+
+    assert any(finding.code == "missing_recent_comments" for finding in findings)
+
+
+def test_classify_graphql_publish_payload_flags_forbidden() -> None:
+    """GraphQL errors should be classified into non-ok publication status."""
+    payload = _fixture("comment_graphql_error.json")
+    classified = linter.classify_comment_publication_result(payload)
+
+    assert classified["ok"] is False
+    assert classified["status"] == "forbidden"
+
+
+def test_main_reports_failures_for_stale_issue(
+    capsys,
+) -> None:
+    """CLI should report deterministic failures for a stale issue payload."""
+    issue_path = FIXTURE_DIR / "issue_closed.json"
+    comments_path = FIXTURE_DIR / "comments_recent.json"
+    exit_code = linter.main(
+        [
+            "--issue-json",
+            str(issue_path),
+            "--comments-json",
+            str(comments_path),
+            "--recent-comment-hours",
+            "24",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["schema"] == "publication_scout_linter.v1"
+    assert payload["ok"] is False
+    assert any(
+        check["name"] == "issue_state_open" and check["ok"] is False for check in payload["checks"]
+    )

--- a/tests/fixtures/publication_scout_linter/comment_graphql_error.json
+++ b/tests/fixtures/publication_scout_linter/comment_graphql_error.json
@@ -1,0 +1,14 @@
+{
+  "errors": [
+    {
+      "message": "Resource not accessible by integration",
+      "type": "FORBIDDEN",
+      "path": [
+        "addComment"
+      ]
+    }
+  ],
+  "data": {
+    "addComment": null
+  }
+}

--- a/tests/fixtures/publication_scout_linter/comment_graphql_null_extensions.json
+++ b/tests/fixtures/publication_scout_linter/comment_graphql_null_extensions.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "message": "Comment target is unavailable",
+      "extensions": null
+    }
+  ]
+}

--- a/tests/fixtures/publication_scout_linter/comments_recent.json
+++ b/tests/fixtures/publication_scout_linter/comments_recent.json
@@ -1,0 +1,10 @@
+[
+  {
+    "createdAt": "2026-06-12T10:00:00Z",
+    "body": "Scout confirmed source PR: #321"
+  },
+  {
+    "createdAt": "2026-06-10T10:00:00Z",
+    "body": "Old comment"
+  }
+]

--- a/tests/fixtures/publication_scout_linter/comments_stale.json
+++ b/tests/fixtures/publication_scout_linter/comments_stale.json
@@ -1,0 +1,6 @@
+[
+  {
+    "createdAt": "2026-06-10T10:00:00Z",
+    "body": "Stale note"
+  }
+]

--- a/tests/fixtures/publication_scout_linter/issue_closed.json
+++ b/tests/fixtures/publication_scout_linter/issue_closed.json
@@ -1,0 +1,7 @@
+{
+  "number": 2663,
+  "title": "publication scout conformance",
+  "state": "closed",
+  "url": "https://github.com/ll7/robot_sf_ll7/issues/2663",
+  "repository_url": "https://api.github.com/repos/ll7/robot_sf_ll7"
+}

--- a/tests/fixtures/publication_scout_linter/issue_open.json
+++ b/tests/fixtures/publication_scout_linter/issue_open.json
@@ -1,0 +1,7 @@
+{
+  "number": 2663,
+  "title": "publication scout conformance",
+  "state": "open",
+  "url": "https://github.com/ll7/robot_sf_ll7/issues/2663",
+  "repository_url": "https://api.github.com/repos/ll7/robot_sf_ll7"
+}

--- a/tests/fixtures/publication_scout_linter/issue_wrong_repo.json
+++ b/tests/fixtures/publication_scout_linter/issue_wrong_repo.json
@@ -1,0 +1,7 @@
+{
+  "number": 2663,
+  "title": "publication scout conformance",
+  "state": "open",
+  "url": "https://github.com/other-org/other-repo/issues/2663",
+  "repository_url": "https://api.github.com/repos/other-org/other-repo"
+}


### PR DESCRIPTION
## Summary
Adds a read-only publication/scout conformance linter for issue-candidate readiness and wires it into `gh-issue-autopilot` preflight requirements.

## Linked Issues
- Closes `#2663`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `scripts/dev/publication_scout_linter.py` with deterministic JSON-driven checks for issue state, repo ownership, recent-comment evidence, and GraphQL comment publication failure classification.
- Added fixture-backed tests plus `check_skills.py` preflight support for the new `publication-scout-linter` requirement.
- Documented the preflight in `gh-issue-autopilot` and registered the requirement in `.agents/skills/skills.yaml`.

## Why It Matters
- Added value: makes delegated scout/publication handoff checks locally testable before branch selection.
- Expected impact: reduces stale issue selection and publication failure surprises in future autonomous issue loops.
- Why this is worth merging now: it strengthens the workflow that chooses and publishes follow-on research/tooling work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA; support/tooling guardrail only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke / tooling tests.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: pass fixture-backed tests and `gh-issue-autopilot` preflight.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2663.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA; this is workflow conformance tooling, not research interpretation.

## Validation / Proof
- Commands run:
  - `uv run ruff check scripts/dev/publication_scout_linter.py tests/dev/test_publication_scout_linter.py scripts/dev/check_skills.py tests/dev/test_check_skills.py`
  - `uv run ruff format --check scripts/dev/publication_scout_linter.py tests/dev/test_publication_scout_linter.py scripts/dev/check_skills.py tests/dev/test_check_skills.py`
  - `./scripts/dev/run_worktree_shared_venv.sh -- pytest tests/dev/test_publication_scout_linter.py tests/dev/test_check_skills.py -q`
  - `uv run python scripts/dev/check_skills.py`
  - `uv run python scripts/dev/check_skills.py --preflight gh-issue-autopilot`
  - `uv run python scripts/dev/publication_scout_linter.py --issue-json tests/fixtures/publication_scout_linter/issue_open.json --comments-json tests/fixtures/publication_scout_linter/comments_recent.json --recent-comment-hours 24`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (failed once on unrelated `tests/test_robot_with_ped_obstacle_force.py::test_can_create_env`; see caveat)
  - `./scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_robot_with_ped_obstacle_force.py::test_can_create_env -q` (passed on rerun)
- Evidence that the change works here: targeted tests passed (`26 passed`), full skill registry check passed, and `gh-issue-autopilot` preflight now reports `publication-scout-linter` as present.
- Benchmarks or smoke tests, if applicable: NA.

## Risks / Rollout
- Compatibility risks: low; new linter is opt-in/read-only and fixture-driven.
- Failure modes: recency check confirms recent comments exist, not semantic content inside those comments.
- Rollback or fallback plan: remove the `publication-scout-linter` requirement and script if it proves too strict.

## Docs / Provenance
- Updated docs: `.agents/skills/gh-issue-autopilot/SKILL.md`.
- Relevant design or provenance notes: issue #2663.
- Any assumptions that need to be preserved: this guardrail supplements, not replaces, final Codex/human review of remote-visible GitHub mutations.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2663.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: support/tooling change with no benchmark/research claim.

## Follow-Up Issues
- Deferred work: none required.
- Issues opened for follow-up: none.

## Reviewer Notes
- The final readiness gate failed once on `tests/test_robot_with_ped_obstacle_force.py::test_can_create_env` due a route sampling RuntimeError in untouched simulation code. That test passed on direct rerun, so I am treating it as unrelated stochastic suite behavior.
- Generated coverage/model/viewer outputs from validation were discarded and not committed.
