### PR TITLE
docs: require artifact-first delegated review

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -58,7 +58,20 @@ In token-efficient mode:
 - For routine orientation, start with `scripts/dev/autopilot_state_snapshot.py`
   instead of repeated broad `gh issue list`, `gh pr view`, `git worktree list`,
   or claim-state calls.
-- Require compact worker artifacts before reading raw logs.
+- Require artifact-first compact worker artifacts before reading raw logs.
+- For every delegated implementation/review/queue task, the worker **must** write compact artifacts in
+  `<run_artifact_dir>` as: `result.json`, `RESULT.md`, `diffstat.txt`, and `validation.json`.
+  Parent review order is mandatory:
+  1. Read `result.json`.
+  2. Read `RESULT.md` for narrative and risk summary.
+  3. Read `diffstat.txt`.
+  4. Run only targeted local read/validation (e.g., `git diff <file>`, `git show <commit>`, quick
+     rechecks) against the committed candidate state.
+- Only then, and only if needed, read raw logs, CI text, or verbose worker transcripts when artifacts are
+  missing, inconsistent, failed, or suspicious.
+- A successful worker command exit code, positive wrapper message, or candidate commit is route evidence
+  only. The parent phase is not complete until this evidence is reviewed, diff status is verified locally,
+  and required commands are rerun from the parent with parent-owned proof.
 - Offload routine CI waits to read-only monitors when safe work remains.
 - Keep final GitHub mutation, publication, merge-readiness, benchmark, paper,
   and safety decisions local.

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -135,6 +135,23 @@ headline state, but do not treat it as authority for final branch, claim, public
 decisions. If `ok: false`, a claim is stale against `origin/main`, or the needed field is missing,
 run the specific raw `gh`/`git` command named by the snapshot source metadata.
 
+### Delegated Implementation Artifacts
+
+For delegated implementation review and execution workers, enforce artifact-first evidence:
+
+- Workers must write, at minimum, `result.json`, `RESULT.md`, `diffstat.txt`, and `validation.json`
+  under a compact artifact directory.
+- The parent must read these artifacts first, in that order.
+- Parent review flow after delegation:
+  1. Inspect `result.json` (status, failures, command list, suspicious signals).
+  2. Inspect `RESULT.md` (decision and rationale summary).
+  3. Inspect `diffstat.txt`.
+  4. Run targeted local verification and diff reads for the reported files/commits before opening logs.
+- Raw logs are read only when artifacts are missing, inconsistent, failed, or suspicious.
+- Treat worker wrapper completion, worker `route_status: complete`, or any candidate commit as route
+  evidence only. Issue implementation is complete only after local revalidation passes and cleanup checks
+  are updated.
+
 ## Queue Policy
 
 Default order:

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -94,6 +94,9 @@ Avoid loops:
      `.agents/skills/goal-autopilot/SKILL.md` with the PR, head SHA, route/run IDs, validation
      plan/status, review/CI state, cleanup status, and next action,
    - run `implementation-verification` for contract alignment,
+   - require artifact-first delegated review and validate in order: `result.json`, `RESULT.md`,
+     `diffstat.txt`, and `validation.json`, inspect route evidence first, then run targeted local checks
+     before raw logs,
    - classify findings as fixable now, deferred, or blocker.
 4. Fix actionable items on writable branches; commit and push.
 5. Validate per required tier.

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -56,6 +56,14 @@ CRITICAL_DUPLICATE_PATTERNS = (
     "fallback/degraded should be treated as a caveat",
 )
 BACKTICK_TOKEN_PATTERN = re.compile(r"`([a-z][a-z0-9-]+)`")
+ARTIFACT_FIRST_SKILLS = {"goal-autopilot", "goal-issue-implementation", "goal-pr-review"}
+ARTIFACT_FIRST_REQUIRED_FILES = ("result.json", "RESULT.md", "diffstat.txt", "validation.json")
+ARTIFACT_FIRST_REQUIRED_PHRASES = (
+    "artifact-first",
+    "route evidence",
+    "raw logs",
+    "targeted local",
+)
 
 
 def _read_yaml(path: Path) -> Any:
@@ -209,6 +217,7 @@ def _validate_skill_file(
     for section in REQUIRED_SECTIONS:
         if section not in body:
             errors.append(f"{rel}: missing required section {section!r}")
+    errors.extend(_validate_artifact_first_contract(path, metadata, body))
     if registry_metadata[name].get("requires_benchmark_artifacts"):
         policy_refs = (
             "fail-closed" in body.lower()
@@ -242,6 +251,26 @@ def _validate_generated_readme(registry: dict[str, Any], readme_text: str) -> li
             "`uv run python scripts/dev/generate_skills_readme.py`"
         ]
     return []
+
+
+def _validate_artifact_first_contract(path: Path, metadata: dict[str, Any], text: str) -> list[str]:
+    """Validate artifact-first delegated route contract text for selected skills."""
+    if metadata.get("name") not in ARTIFACT_FIRST_SKILLS:
+        return []
+
+    rel = path.relative_to(REPO_ROOT)
+    errors: list[str] = []
+
+    for filename in ARTIFACT_FIRST_REQUIRED_FILES:
+        if filename not in text:
+            errors.append(f"{rel}: missing artifact-first requirement {filename!r}")
+
+    lower = text.lower()
+    for phrase in ARTIFACT_FIRST_REQUIRED_PHRASES:
+        if phrase not in lower:
+            errors.append(f"{rel}: missing artifact-first phrase requirement {phrase!r}")
+
+    return errors
 
 
 def _validate_backticked_skill_tokens(

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -71,6 +71,66 @@ def test_frontmatter_fails_closed_for_non_mapping_yaml(tmp_path: Path) -> None:
         check_skills._frontmatter(skill_path)
 
 
+def test_artifact_first_contract_passes_for_goal_autopilot(tmp_path: Path) -> None:
+    """Artifact-first phrase and file requirements should pass for goal-autopilot style skills."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-autopilot" / "SKILL.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text("---\nname: goal-autopilot\n---\n", encoding="utf-8")
+    body = """
+Artifact-first delegated review requires result.json, RESULT.md, diffstat.txt, and validation.json.
+Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing
+or inconsistent.
+The parent must inspect route evidence and run targeted local checks.
+"""
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-autopilot"},
+        body,
+    )
+    assert errors == []
+
+
+def test_artifact_first_contract_fails_when_missing_required_artifacts(tmp_path: Path) -> None:
+    """Contracts should fail when required artifact filenames or evidence phrases are missing."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-autopilot" / "SKILL.md"
+    skill_path.parent.mkdir()
+    body = "Delegated workers should run and report summary."
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-autopilot"},
+        body,
+    )
+    assert any("result.json" in e for e in errors)
+    assert any("artifact-first phrase requirement" in e for e in errors)
+
+
+def test_artifact_first_contract_requires_canonical_result_markdown_case(
+    tmp_path: Path,
+) -> None:
+    """The compact artifact contract should preserve RESULT.md casing exactly."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-autopilot" / "SKILL.md"
+    skill_path.parent.mkdir()
+    body = """
+Artifact-first delegated review requires result.json, result.md, diffstat.txt, and validation.json.
+Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing
+or inconsistent.
+The parent must inspect route evidence and run targeted local checks.
+"""
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-autopilot"},
+        body,
+    )
+
+    assert any("RESULT.md" in e for e in errors)
+
+
 # -- preflight tests ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Adds an artifact-first delegated review contract to the goal autopilot, issue implementation, and PR review skills.
- Requires delegated workers to provide `result.json`, `RESULT.md`, `diffstat.txt`, and `validation.json` before parent raw-log reads.
- Adds `check_skills.py` validation plus regression tests so the orchestrator skills keep the compact artifact contract.

Closes #2692.

## Validation

- `rtk uv run python scripts/dev/check_skills.py`
- `rtk uv run pytest tests/dev/test_check_skills.py -q` (`24 passed in 13.36s`)
- `rtk uv run ruff check scripts/dev/check_skills.py tests/dev/test_check_skills.py`
- `rtk uv run ruff format --check scripts/dev/check_skills.py tests/dev/test_check_skills.py`

Full PR readiness was not run because this is a focused skill/checker contract change; the touched checker, tests, and generated skill registry validation were run directly.

## Downstream Propagation

- Parent issue: #2692 will be closed by this PR.
- Claim map / benchmark report / leaderboard / registry: NA; no benchmark or research result changes.
- Context index or memory note: NA; the changed skills and checker are the durable workflow surface.
- Follow-up issue: #2693, #2694, and #2695 remain the next token-efficiency follow-ups.

## Research Result Guidance

- Target claim/hypothesis/blocker: delegated implementation should reduce parent Codex context by using compact artifacts first.
- Comparator/baseline: previous goal skills encouraged compact evidence but did not require the specific artifact-first contract or checker.
- Evidence tier: workflow/tooling validation, not benchmark evidence.
- Result classification: support/tooling improvement for reproducibility and token efficiency.
- Decision/stop rule: accepted when orchestrator skills state the artifact-first review order and `check_skills.py` fails if required contract wording/artifacts are removed.
- Synthesis surface/update target: #2692 PR/issue record.

## Delegate Outcomes

- First worker route was rejected after interruption; it left no worktree changes or artifacts.
- Second worker route produced compact artifacts and a scoped diff; controller reran validation locally and fixed one missing exact phrase required by the checker before commit.

## Risks

- The checker intentionally validates explicit contract words and filenames, not the quality of every future worker artifact.
- Future wording edits to the three orchestrator skills must preserve the artifact filenames and phrases.
