### PR TITLE
docs: cap delegated worker output

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -69,6 +69,11 @@ In token-efficient mode:
      rechecks) against the committed candidate state.
 - Only then, and only if needed, read raw logs, CI text, or verbose worker transcripts when artifacts are
   missing, inconsistent, failed, or suspicious.
+- Worker prompts must cap parent-thread raw output at about 200 lines. Use `rg -l`, `rg --files`,
+  and bounded `sed -n` ranges for discovery. Do not use broad `rg -n .` or full file reads unless
+  a context pack, snapshot, or targeted artifact is missing and the broad read is explicitly
+  justified. Redirect larger command output to private artifacts and return only a compact summary
+  with inspected files, command exit codes, and short evidence excerpts.
 - A successful worker command exit code, positive wrapper message, or candidate commit is route evidence
   only. The parent phase is not complete until this evidence is reviewed, diff status is verified locally,
   and required commands are rerun from the parent with parent-owned proof.

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -148,6 +148,10 @@ For delegated implementation review and execution workers, enforce artifact-firs
   3. Inspect `diffstat.txt`.
   4. Run targeted local verification and diff reads for the reported files/commits before opening logs.
 - Raw logs are read only when artifacts are missing, inconsistent, failed, or suspicious.
+- Worker prompts must cap parent-thread raw output at about 200 lines. Require `rg -l`, `rg --files`,
+  and bounded `sed -n` for search/read tasks; forbid broad `rg -n .` and full file reads unless a
+  context pack or compact snapshot failed. Larger output must go to private artifacts with only a
+  compact summary returned to the parent.
 - Treat worker wrapper completion, worker `route_status: complete`, or any candidate commit as route
   evidence only. Issue implementation is complete only after local revalidation passes and cleanup checks
   are updated.

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -97,6 +97,8 @@ Avoid loops:
    - require artifact-first delegated review and validate in order: `result.json`, `RESULT.md`,
      `diffstat.txt`, and `validation.json`, inspect route evidence first, then run targeted local checks
      before raw logs,
+   - cap parent-thread raw output at about 200 lines; use `rg -l`, `rg --files`, bounded `sed -n`,
+     and private artifacts instead of broad `rg -n .` or full file reads,
    - classify findings as fixable now, deferred, or blocker.
 4. Fix actionable items on writable branches; commit and push.
 5. Validate per required tier.

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -64,6 +64,15 @@ ARTIFACT_FIRST_REQUIRED_PHRASES = (
     "raw logs",
     "targeted local",
 )
+WORKER_OUTPUT_REQUIRED_PHRASES = (
+    "rg -l",
+    "rg --files",
+    "sed -n",
+    "200 lines",
+    "private artifacts",
+    "rg -n .",
+    "full file reads",
+)
 
 
 def _read_yaml(path: Path) -> Any:
@@ -269,6 +278,10 @@ def _validate_artifact_first_contract(path: Path, metadata: dict[str, Any], text
     for phrase in ARTIFACT_FIRST_REQUIRED_PHRASES:
         if phrase not in lower:
             errors.append(f"{rel}: missing artifact-first phrase requirement {phrase!r}")
+
+    for phrase in WORKER_OUTPUT_REQUIRED_PHRASES:
+        if phrase not in lower:
+            errors.append(f"{rel}: missing worker-output limit requirement {phrase!r}")
 
     return errors
 

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -83,6 +83,8 @@ Artifact-first delegated review requires result.json, RESULT.md, diffstat.txt, a
 Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing
 or inconsistent.
 The parent must inspect route evidence and run targeted local checks.
+Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
+no broad rg -n ., and no full file reads.
 """
     errors = check_skills._validate_artifact_first_contract(
         skill_path,
@@ -106,6 +108,7 @@ def test_artifact_first_contract_fails_when_missing_required_artifacts(tmp_path:
     )
     assert any("result.json" in e for e in errors)
     assert any("artifact-first phrase requirement" in e for e in errors)
+    assert any("worker-output limit requirement" in e for e in errors)
 
 
 def test_artifact_first_contract_requires_canonical_result_markdown_case(
@@ -121,6 +124,8 @@ Artifact-first delegated review requires result.json, result.md, diffstat.txt, a
 Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing
 or inconsistent.
 The parent must inspect route evidence and run targeted local checks.
+Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
+no broad rg -n ., and no full file reads.
 """
     errors = check_skills._validate_artifact_first_contract(
         skill_path,


### PR DESCRIPTION
## Summary

- Adds hard worker output/search limits to the goal autopilot, issue implementation, and PR review skills.
- Requires worker prompts to prefer `rg -l`, `rg --files`, bounded `sed -n`, private artifacts, and compact summaries.
- Extends `check_skills.py` so the three orchestrator skills must keep the output-limit contract alongside the artifact-first contract.

Closes #2693.

## Validation

- `rtk uv run python scripts/dev/check_skills.py`
- `rtk uv run pytest tests/dev/test_check_skills.py -q` (`24 passed in 13.49s`)
- `rtk uv run ruff check scripts/dev/check_skills.py tests/dev/test_check_skills.py`
- `rtk uv run ruff format --check scripts/dev/check_skills.py tests/dev/test_check_skills.py`

Full PR readiness was not run because this is a focused skill/checker contract change.

## Downstream Propagation

- Parent issue: #2693 will be closed by this PR.
- Claim map / benchmark report / leaderboard / registry: NA; no benchmark or research result changes.
- Context index or memory note: NA; the changed skills/checker are the durable workflow surface.
- Follow-up issue: #2694 and #2695 remain next token-efficiency follow-ups.

## Research Result Guidance

- Target claim/hypothesis/blocker: delegated workers should not leak broad raw search/read output into parent Codex context.
- Comparator/baseline: previous artifact-first contract did not enforce search/read/output limits.
- Evidence tier: workflow/tooling validation, not benchmark evidence.
- Result classification: support/tooling improvement for token efficiency.
- Decision/stop rule: accepted when orchestrator skills state the 200-line cap, safe search/read patterns, and private-artifact fallback, and `check_skills.py` fails if those phrases are removed.
- Synthesis surface/update target: #2693 PR/issue record.

## Risks

- The checker validates required wording, not runtime enforcement of every worker command.
- Future wording edits must preserve the required terms unless the checker is intentionally updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation for internal agent skills to refine operational constraints

* **Chores**
  * Enhanced validation checks for skill contract compliance and updated corresponding tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->