### PR TITLE
docs: require compact PR CI review

### DIFF
--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -86,7 +86,8 @@ Avoid loops:
 
 ## Review Workflow
 
-1. Build queue snapshot (labels, draft status, checks, last update time).
+1. Build queue snapshot with `scripts/dev/snapshot_pr_queue.py` (labels, draft status, checks,
+   head SHA, last update time) before broad `gh pr view` fields.
 2. Sort/prioritize queue (or follow explicit user order).
 3. For each PR:
    - capture issue link and head SHA,
@@ -107,14 +108,15 @@ Avoid loops:
 7. Resolve review threads only after the post-push thread snapshot confirms the fixes still cover all
    actionable comments.
 8. Update `merge-ready` only after full proof bar closes.
-9. When CI is the only remaining external gate, put the PR in `awaiting_ci` and use bounded
-   one-shot polling in non-TTY agent sessions instead of `gh pr checks --watch`:
-   `uv run python scripts/dev/check_pr_ci_status.py <number> --poll-attempts 20 --poll-interval 30`.
-   The helper prints queued, in-progress, failed, and passed check summaries; exit code `2` means
-   the polling budget expired with checks still pending. Use
-   `gh run view <run-id> --json status,conclusion,jobs` for job state and fetch logs only after the
-   relevant job has completed. Use `.agents/skills/goal-autopilot/SKILL.md` "Async CI Wait Policy"
-   instead of idling the review loop when other safe PR or cycle work remains.
+9. When CI is the only remaining external gate, put the PR in `awaiting_ci` and use compact,
+   bounded one-shot polling in non-TTY agent sessions instead of `gh pr checks --watch`:
+   `uv run python scripts/dev/watch_pr_ci_status.py <number> --once --json --expected-head-sha <sha>`.
+   Inspect JSON/job state first with `gh run view <run-id> --json status,conclusion,jobs` or the
+   repo CI helpers. Fetch raw logs only for the relevant failed or completed job, return bounded
+   excerpts second with grep/tail, and explicitly label those snippets as bounded excerpts. Keep full logs in private artifacts. Avoid fetching
+   `body,comments,reviews,files,statusCheckRollup` together unless the review task explicitly needs
+   that full surface. Use `.agents/skills/goal-autopilot/SKILL.md` "Async CI Wait Policy" instead of
+   idling the review loop when other safe PR or cycle work remains.
 10. Update the active ledger before any CI wait or final handoff. Route completion is not task
    completion until the main agent has verified proof, GitHub state, and cleanup.
 

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -73,6 +73,14 @@ WORKER_OUTPUT_REQUIRED_PHRASES = (
     "rg -n .",
     "full file reads",
 )
+GOAL_PR_REVIEW_REQUIRED_PHRASES = (
+    "snapshot_pr_queue.py",
+    "watch_pr_ci_status.py",
+    "status,conclusion,jobs",
+    "bounded excerpts",
+    "full logs",
+    "private artifacts",
+)
 
 
 def _read_yaml(path: Path) -> Any:
@@ -282,6 +290,11 @@ def _validate_artifact_first_contract(path: Path, metadata: dict[str, Any], text
     for phrase in WORKER_OUTPUT_REQUIRED_PHRASES:
         if phrase not in lower:
             errors.append(f"{rel}: missing worker-output limit requirement {phrase!r}")
+
+    if metadata.get("name") == "goal-pr-review":
+        for phrase in GOAL_PR_REVIEW_REQUIRED_PHRASES:
+            if phrase not in lower:
+                errors.append(f"{rel}: missing PR-review compact CI requirement {phrase!r}")
 
     return errors
 

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -136,6 +136,54 @@ no broad rg -n ., and no full file reads.
     assert any("RESULT.md" in e for e in errors)
 
 
+def test_goal_pr_review_contract_requires_compact_ci_snapshot_terms(tmp_path: Path) -> None:
+    """Goal PR review should preserve compact PR/CI entry-point guidance."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-pr-review" / "SKILL.md"
+    skill_path.parent.mkdir()
+    body = """
+Artifact-first delegated review requires result.json, RESULT.md, diffstat.txt, and validation.json.
+Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing.
+The parent must inspect route evidence and run targeted local checks.
+Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
+no broad rg -n ., and no full file reads.
+Start with snapshot_pr_queue.py, poll with watch_pr_ci_status.py, inspect status,conclusion,jobs,
+return bounded excerpts, and keep full logs in private artifacts.
+"""
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-pr-review"},
+        body,
+    )
+
+    assert errors == []
+
+
+def test_goal_pr_review_compact_ci_terms_are_case_insensitive(tmp_path: Path) -> None:
+    """PR-review prose checks should tolerate sentence capitalization."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-pr-review" / "SKILL.md"
+    skill_path.parent.mkdir()
+    body = """
+Artifact-first delegated review requires result.json, RESULT.md, diffstat.txt, and validation.json.
+Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing.
+The parent must inspect route evidence and run targeted local checks.
+Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
+no broad rg -n ., and no full file reads.
+Start with snapshot_pr_queue.py, poll with watch_pr_ci_status.py, inspect status,conclusion,jobs.
+Return bounded excerpts, and keep full logs in private artifacts.
+"""
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-pr-review"},
+        body,
+    )
+
+    assert errors == []
+
+
 # -- preflight tests ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Makes `scripts/dev/snapshot_pr_queue.py` the explicit default entry point for goal PR review queue state.
- Requires CI review to inspect JSON/job metadata first, use bounded excerpts second, and keep full logs in private artifacts.
- Extends `check_skills.py` and tests so `goal-pr-review` keeps the compact PR/CI review contract.

Closes #2694.

## Validation

- `rtk uv run python scripts/dev/check_skills.py`
- `rtk uv run pytest tests/dev/test_check_skills.py -q` (`26 passed in 13.39s`)
- `rtk uv run ruff check scripts/dev/check_skills.py tests/dev/test_check_skills.py`
- `rtk uv run ruff format --check scripts/dev/check_skills.py tests/dev/test_check_skills.py`

Full PR readiness was not run because this is a focused skill/checker contract change.

## Downstream Propagation

- Parent issue: #2694 will be closed by this PR.
- Claim map / benchmark report / leaderboard / registry: NA; no benchmark or research result changes.
- Context index or memory note: NA; the changed skill/checker are the durable workflow surface.
- Follow-up issue: #2695 remains the next token-efficiency follow-up.

## Research Result Guidance

- Target claim/hypothesis/blocker: PR/CI review should avoid broad PR objects and raw CI logs unless compact evidence is insufficient.
- Comparator/baseline: previous goal PR review had bounded CI guidance but did not enforce compact PR snapshots and bounded log excerpt wording.
- Evidence tier: workflow/tooling validation, not benchmark evidence.
- Result classification: support/tooling improvement for token efficiency and review reproducibility.
- Decision/stop rule: accepted when the PR review skill states compact snapshot/job-metadata/log-excerpt order and `check_skills.py` fails if the contract is removed.
- Synthesis surface/update target: #2694 PR/issue record.

## Risks

- The checker validates required terms, not every future CI-log command invocation.
- Future wording edits to `goal-pr-review` must preserve the compact PR/CI contract or intentionally update the checker.
