### PR TITLE
docs: reuse active ledger snapshots

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -271,12 +271,20 @@ mkdir -p "$LEDGER_DIR"
 
 Use a short Markdown or YAML file such as
 `$LEDGER_DIR/issue-<number>-delegation-ledger.md` or `$LEDGER_DIR/pr-<number>-delegation-ledger.md`.
-This ledger is a handoff checklist, not a replacement for GitHub issues, PR bodies, issue-claim
-refs, worker artifacts, validation logs, or final summaries.
+When a phase produces compact snapshots, also record their paths in the ledger and pass the fresh
+ledger snapshot paths or context capsules to the next worker prompt instead of asking the worker to
+rediscover the same queue, PR, CI, or worktree state. This ledger is a handoff checklist, not a
+replacement for GitHub issues, PR bodies, issue-claim refs, worker artifacts, validation logs, or
+final summaries.
 
 Track only the fields needed to resume safely in under one minute:
 
 - route: provider/tool, model or agent role, run ID or artifact path, and route status;
+- loaded context: skill/doc summaries already read for the active phase, plus the freshness keys
+  that make them reusable or stale;
+- snapshots: issue, PR, worktree, claim, and CI snapshot paths with freshness keys such as issue
+  number, PR number, branch, origin/main SHA, head SHA, expected PR head SHA, captured-at time, and
+  source helper command;
 - delegation budget: for long delegated runs, record Gemini attempts, model variant,
   capacity/quota outcome, accepted evidence tier, and any user-defined stop threshold such as
   weekly usage remaining;
@@ -286,7 +294,20 @@ Track only the fields needed to resume safely in under one minute:
 - PR/CI: PR URL or number, head SHA, review state, CI state, and merge-ready state;
 - CI wait: baseline seconds, multiplier, budget seconds, poll interval, deadline, monitor
   route/run ID, expected head SHA, final status, and drift sample when collected;
-- cleanup: app-agent or worker close status, claim release status, worktree/artifact decision.
+- workers: current worker run IDs, worker artifact paths, artifact status, and accepted/rejected
+  evidence tier;
+- cleanup: app-agent or worker close status, claim release status, worktree/artifact decision;
+- stale-state triggers: missing or mismatched claim refs, issue/PR state changes, branch/head SHA
+  drift, expected PR head SHA drift, stale origin/main, CI rerun/retry, failed validation,
+  interrupted worker, missing compact artifacts, or elapsed freshness window.
+
+Consult the ledger before repeating broad state polling, full skill/doc reads, or worker
+rediscovery. Repeated broad `gh issue list`, `gh pr view`, `git worktree list --porcelain`, CI log
+fetches, full skill reads, or repository-wide search after a fresh ledger snapshot exists is an
+anti-pattern unless a stale-state trigger fired or the compact snapshot lacks the field needed for
+the next decision. Fresh live checks are still required before issue claim, push, PR publication,
+label/project mutation, merge-ready application, merge, claim release, or any benchmark/paper-facing
+publication decision.
 
 Distinguish route success from task success. A delegate command exiting zero or producing a report
 only proves `route_status: completed`; the parent phase is not complete until the main agent has

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -81,6 +81,23 @@ GOAL_PR_REVIEW_REQUIRED_PHRASES = (
     "full logs",
     "private artifacts",
 )
+GOAL_AUTOPILOT_LEDGER_REQUIRED_PHRASES = (
+    "loaded context",
+    "skill/doc summaries",
+    "snapshot paths",
+    "freshness keys",
+    "expected pr head sha",
+    "worker artifact paths",
+    "stale-state triggers",
+    "ledger snapshot paths",
+    "repeating broad state polling",
+    "fresh live checks",
+    "issue claim",
+    "push",
+    "pr publication",
+    "label/project mutation",
+    "merge-ready",
+)
 
 
 def _read_yaml(path: Path) -> Any:
@@ -290,6 +307,11 @@ def _validate_artifact_first_contract(path: Path, metadata: dict[str, Any], text
     for phrase in WORKER_OUTPUT_REQUIRED_PHRASES:
         if phrase not in lower:
             errors.append(f"{rel}: missing worker-output limit requirement {phrase!r}")
+
+    if metadata.get("name") == "goal-autopilot":
+        for phrase in GOAL_AUTOPILOT_LEDGER_REQUIRED_PHRASES:
+            if phrase not in lower:
+                errors.append(f"{rel}: missing active-ledger requirement {phrase!r}")
 
     if metadata.get("name") == "goal-pr-review":
         for phrase in GOAL_PR_REVIEW_REQUIRED_PHRASES:

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -85,6 +85,11 @@ or inconsistent.
 The parent must inspect route evidence and run targeted local checks.
 Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
 no broad rg -n ., and no full file reads.
+The active ledger records loaded context with skill/doc summaries, snapshot paths,
+freshness keys, expected PR head SHA, worker artifact paths, and stale-state triggers.
+Pass ledger snapshot paths to workers, avoid repeating broad state polling, and run
+fresh live checks before issue claim, push, PR publication, label/project mutation,
+or merge-ready decisions.
 """
     errors = check_skills._validate_artifact_first_contract(
         skill_path,
@@ -109,6 +114,7 @@ def test_artifact_first_contract_fails_when_missing_required_artifacts(tmp_path:
     assert any("result.json" in e for e in errors)
     assert any("artifact-first phrase requirement" in e for e in errors)
     assert any("worker-output limit requirement" in e for e in errors)
+    assert any("active-ledger requirement" in e for e in errors)
 
 
 def test_artifact_first_contract_requires_canonical_result_markdown_case(
@@ -134,6 +140,30 @@ no broad rg -n ., and no full file reads.
     )
 
     assert any("RESULT.md" in e for e in errors)
+
+
+def test_goal_autopilot_contract_requires_active_ledger_reuse_terms(tmp_path: Path) -> None:
+    """Goal autopilot should keep explicit ledger reuse and freshness-key guidance."""
+    check_skills = _load_check_skills_module()
+    check_skills.REPO_ROOT = tmp_path
+    skill_path = tmp_path / "goal-autopilot" / "SKILL.md"
+    skill_path.parent.mkdir()
+    body = """
+Artifact-first delegated review requires result.json, RESULT.md, diffstat.txt, and validation.json.
+Treat worker exit success as route evidence only. Read raw logs only if artifacts are missing
+or inconsistent.
+The parent must inspect route evidence and run targeted local checks.
+Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private artifacts,
+no broad rg -n ., and no full file reads.
+The active ledger records only issue number, next action, and cleanup.
+"""
+    errors = check_skills._validate_artifact_first_contract(
+        skill_path,
+        {"name": "goal-autopilot"},
+        body,
+    )
+
+    assert any("active-ledger requirement" in e for e in errors)
 
 
 def test_goal_pr_review_contract_requires_compact_ci_snapshot_terms(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Expand the goal-autopilot active ledger contract to reuse fresh compact snapshot paths/context capsules before repeating broad state polling or worker rediscovery.
- Add skill-checker coverage for required ledger fields, freshness keys, stale-state triggers, and fresh live-check boundaries.
- Extend focused checker tests so ledger reuse guidance cannot silently drift.

Closes #2695

## Validation

- `rtk uv run python scripts/dev/check_skills.py`
- `rtk uv run pytest tests/dev/test_check_skills.py -q`
- `rtk uv run ruff check scripts/dev/check_skills.py tests/dev/test_check_skills.py`
- `rtk uv run ruff format --check scripts/dev/check_skills.py tests/dev/test_check_skills.py`
- `rtk git diff --check`

## Downstream Propagation

- Parent issue #2695 is closed by this PR.
- No benchmark report, artifact catalog, registry, or model provenance update is needed; this is workflow documentation plus validator coverage for active goal ledgers.
- Private active ledger updated at `.git/codex-agent-runs/active/goal-autopilot-20260612-issue-2695.md` for this run.

## Research Result Guidance

- Target claim/hypothesis/blocker: NA; this is token-efficiency workflow support, not benchmark or research evidence.
- Comparator/baseline: NA.
- Evidence tier: Tier 0 workflow docs/tooling validation.
- Result classification: support/tooling.
- Decision/stop rule: focused checker/tests/lint/format pass for the changed surfaces.
- Synthesis surface/update target: `.agents/skills/goal-autopilot/SKILL.md` and skill checker tests.

## Risks

- The validator checks durable phrase anchors rather than full semantic parsing, so future wording can still drift if it preserves all required phrases while changing meaning.
