### PR TITLE
feat: add topology diagnostic report snapshot

### DIFF
--- a/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.json
+++ b/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.json
@@ -1,0 +1,119 @@
+{
+  "report_kind": "topology_diagnostic_report_snapshot",
+  "label": "issue-2661-smoke",
+  "claim_boundary": "diagnostic_only_not_benchmark_success",
+  "source_trace_count": 2,
+  "source_trace_paths": [
+    "docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_1.json",
+    "docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_2.json"
+  ],
+  "trace_count": 2,
+  "total_steps": 6,
+  "diagnostic_status_counts": {
+    "diagnostic_complete": 2
+  },
+  "selected_hypothesis_counts": {
+    "divert_left": 1,
+    "primary_route": 3
+  },
+  "near_parity_gate_reason_counts": {
+    "eligible_near_parity_alternative": 2,
+    "route_distance_exceeds_slack": 1,
+    "static_clearance_below_floor": 1
+  },
+  "reuse_penalty": {
+    "applied_steps": 2,
+    "eligible_near_parity_alternative_steps": 3,
+    "reason_counts": {
+      "cooldown_eligible": 2
+    }
+  },
+  "route_progress_deltas": [
+    {
+      "trace_scenario": "double_bottleneck_high",
+      "trace_seed": 42,
+      "rank": "0",
+      "samples": 3,
+      "first_corridor": "north_lane",
+      "last_corridor": "north_lane",
+      "first_remaining_m": 8.5,
+      "last_remaining_m": 3.2,
+      "progress_delta_m": 5.3,
+      "min_static_clearance_m": 0.4,
+      "min_dynamic_clearance_m": 0.3
+    },
+    {
+      "trace_scenario": "double_bottleneck_high",
+      "trace_seed": 42,
+      "rank": "1",
+      "samples": 3,
+      "first_corridor": "south_lane",
+      "last_corridor": "south_lane",
+      "first_remaining_m": 9.1,
+      "last_remaining_m": 7.8,
+      "progress_delta_m": 1.3,
+      "min_static_clearance_m": 0.35,
+      "min_dynamic_clearance_m": 0.28
+    },
+    {
+      "trace_scenario": "narrow_corridor",
+      "trace_seed": 99,
+      "rank": "0",
+      "samples": 3,
+      "first_corridor": "main_corridor",
+      "last_corridor": "main_corridor",
+      "first_remaining_m": 6.0,
+      "last_remaining_m": 6.0,
+      "progress_delta_m": 0.0,
+      "min_static_clearance_m": 0.25,
+      "min_dynamic_clearance_m": 0.2
+    },
+    {
+      "trace_scenario": "narrow_corridor",
+      "trace_seed": 99,
+      "rank": "1",
+      "samples": 3,
+      "first_corridor": "side_passage",
+      "last_corridor": "side_passage",
+      "first_remaining_m": 5.5,
+      "last_remaining_m": 7.2,
+      "progress_delta_m": -1.7,
+      "min_static_clearance_m": 0.22,
+      "min_dynamic_clearance_m": 0.18
+    }
+  ],
+  "top_regressions": [
+    {
+      "trace_scenario": "narrow_corridor",
+      "trace_seed": 99,
+      "rank": "1",
+      "samples": 3,
+      "first_corridor": "side_passage",
+      "last_corridor": "side_passage",
+      "first_remaining_m": 5.5,
+      "last_remaining_m": 7.2,
+      "progress_delta_m": -1.7,
+      "min_static_clearance_m": 0.22,
+      "min_dynamic_clearance_m": 0.18
+    }
+  ],
+  "top_unchanged": [
+    {
+      "trace_scenario": "narrow_corridor",
+      "trace_seed": 99,
+      "rank": "0",
+      "samples": 3,
+      "first_corridor": "main_corridor",
+      "last_corridor": "main_corridor",
+      "first_remaining_m": 6.0,
+      "last_remaining_m": 6.0,
+      "progress_delta_m": 0.0,
+      "min_static_clearance_m": 0.25,
+      "min_dynamic_clearance_m": 0.2
+    }
+  ],
+  "terminal_outcome_counts": {
+    "success": 1,
+    "truncated": 1
+  }
+}

--- a/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.md
+++ b/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.md
@@ -1,0 +1,47 @@
+# Topology Diagnostic Report Snapshot: issue-2661-smoke
+
+Diagnostic-only evidence; this is not planner-promotion or benchmark success evidence.
+
+- Claim boundary: `diagnostic_only_not_benchmark_success`
+- Trace count: 2
+- Total steps: 6
+- Diagnostic status counts: `{'diagnostic_complete': 2}`
+- Terminal outcome counts: `{'success': 1, 'truncated': 1}`
+
+## Selected Hypotheses
+
+- `divert_left`: 1
+- `primary_route`: 3
+
+## Near-Parity Gate Reasons
+
+- `eligible_near_parity_alternative`: 2
+- `route_distance_exceeds_slack`: 1
+- `static_clearance_below_floor`: 1
+
+## Reuse-Penalty Activations
+
+- Applied steps: 2
+- Eligible near-parity alternative steps: 3
+  - `cooldown_eligible`: 2
+
+## Route-Progress Deltas
+
+| Scenario | Seed | Rank | Samples | Progress delta (m) |
+|---|---:|---:|---:|---:|
+| double_bottleneck_high | 42 | 0 | 3 | 5.3 |
+| double_bottleneck_high | 42 | 1 | 3 | 1.3 |
+| narrow_corridor | 99 | 0 | 3 | 0.0 |
+| narrow_corridor | 99 | 1 | 3 | -1.7 |
+
+## Top Regressions
+
+| Scenario | Seed | Rank | Progress delta (m) | Last corridor |
+|---|---:|---:|---:|---|
+| narrow_corridor | 99 | 1 | -1.7 | side_passage |
+
+## Top Unchanged Cases
+
+| Scenario | Seed | Rank | Progress delta (m) | First corridor |
+|---|---:|---:|---:|---|
+| narrow_corridor | 99 | 0 | 0.0 | main_corridor |

--- a/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_1.json
+++ b/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_1.json
@@ -1,0 +1,87 @@
+{
+  "claim_boundary": "diagnostic_only_not_benchmark_success",
+  "diagnostic_kind": "topology_hypothesis_trace",
+  "diagnostic_status": "diagnostic_complete",
+  "scenario_id": "double_bottleneck_high",
+  "seed": 42,
+  "steps": [
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": true,
+          "reuse_penalty_applied": true,
+          "reuse_penalty_reason": "cooldown_eligible"
+        }
+      },
+      "step": 0,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": "eligible_near_parity_alternative",
+        "selected_hypothesis": "primary_route"
+      }
+    },
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": true,
+          "reuse_penalty_applied": true,
+          "reuse_penalty_reason": "cooldown_eligible"
+        }
+      },
+      "step": 1,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": "eligible_near_parity_alternative",
+        "selected_hypothesis": "primary_route"
+      }
+    },
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": false,
+          "reuse_penalty_applied": false,
+          "reuse_penalty_reason": null
+        }
+      },
+      "step": 2,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": "static_clearance_below_floor",
+        "selected_hypothesis": "primary_route"
+      }
+    }
+  ],
+  "summary": {
+    "corrective_behavior": {
+      "terminal_outcome": {
+        "outcome": "success"
+      }
+    },
+    "hypothesis_progress_by_rank": {
+      "0": {
+        "first_corridor_name": "north_lane",
+        "first_remaining_distance_m": 8.5,
+        "last_corridor_name": "north_lane",
+        "last_remaining_distance_m": 3.2,
+        "min_dynamic_clearance_m": 0.3,
+        "min_static_clearance_m": 0.4,
+        "progress_delta_m": 5.3,
+        "samples": 3
+      },
+      "1": {
+        "first_corridor_name": "south_lane",
+        "first_remaining_distance_m": 9.1,
+        "last_corridor_name": "south_lane",
+        "last_remaining_distance_m": 7.8,
+        "min_dynamic_clearance_m": 0.28,
+        "min_static_clearance_m": 0.35,
+        "progress_delta_m": 1.3,
+        "samples": 3
+      }
+    },
+    "route_selector_selected_hypothesis_counts": {
+      "primary_route": 3
+    },
+    "selected_row_near_parity_gate_reasons": {
+      "eligible_near_parity_alternative": 2,
+      "static_clearance_below_floor": 1
+    }
+  }
+}

--- a/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_2.json
+++ b/docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_2.json
@@ -1,0 +1,86 @@
+{
+  "claim_boundary": "diagnostic_only_not_benchmark_success",
+  "diagnostic_kind": "topology_hypothesis_trace",
+  "diagnostic_status": "diagnostic_complete",
+  "scenario_id": "narrow_corridor",
+  "seed": 99,
+  "steps": [
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": true,
+          "reuse_penalty_applied": false,
+          "reuse_penalty_reason": null
+        }
+      },
+      "step": 0,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": "route_distance_exceeds_slack",
+        "selected_hypothesis": "divert_left"
+      }
+    },
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": false,
+          "reuse_penalty_applied": false,
+          "reuse_penalty_reason": null
+        }
+      },
+      "step": 1,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": null,
+        "selected_hypothesis": null
+      }
+    },
+    {
+      "planner_route_corridor": {
+        "topology_reuse_penalty": {
+          "eligible_near_parity_alternative_exists": false,
+          "reuse_penalty_applied": false,
+          "reuse_penalty_reason": null
+        }
+      },
+      "step": 2,
+      "topology_instrumentation": {
+        "near_parity_gate_reason": null,
+        "selected_hypothesis": null
+      }
+    }
+  ],
+  "summary": {
+    "corrective_behavior": {
+      "terminal_outcome": {
+        "outcome": "truncated"
+      }
+    },
+    "hypothesis_progress_by_rank": {
+      "0": {
+        "first_corridor_name": "main_corridor",
+        "first_remaining_distance_m": 6.0,
+        "last_corridor_name": "main_corridor",
+        "last_remaining_distance_m": 6.0,
+        "min_dynamic_clearance_m": 0.2,
+        "min_static_clearance_m": 0.25,
+        "progress_delta_m": 0.0,
+        "samples": 3
+      },
+      "1": {
+        "first_corridor_name": "side_passage",
+        "first_remaining_distance_m": 5.5,
+        "last_corridor_name": "side_passage",
+        "last_remaining_distance_m": 7.2,
+        "min_dynamic_clearance_m": 0.18,
+        "min_static_clearance_m": 0.22,
+        "progress_delta_m": -1.7,
+        "samples": 3
+      }
+    },
+    "route_selector_selected_hypothesis_counts": {
+      "divert_left": 1
+    },
+    "selected_row_near_parity_gate_reasons": {
+      "route_distance_exceeds_slack": 1
+    }
+  }
+}

--- a/robot_sf/analysis/__init__.py
+++ b/robot_sf/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis helpers for compact research and diagnostic reports."""

--- a/robot_sf/analysis/topology_diagnostic_report.py
+++ b/robot_sf/analysis/topology_diagnostic_report.py
@@ -1,0 +1,488 @@
+"""Topology diagnostic report snapshot.
+
+Aggregates topology-hypothesis JSONL traces into a compact Markdown/JSON summary
+covering selected hypotheses, near-parity gate reasons, reuse-penalty activations,
+route-progress deltas, top regressions, and top unchanged cases.
+
+This report is diagnostic/reviewability support, not planner-promotion evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path  # noqa: TC003
+from typing import Any
+
+CLAIM_BOUNDARY = "diagnostic_only_not_benchmark_success"
+
+
+def _load_traces(trace_paths: list[Path]) -> list[dict[str, Any]]:
+    """Load topology diagnostic traces from JSON or JSONL files.
+
+    Returns:
+        List of parsed trace dictionaries.
+    """
+    traces: list[dict[str, Any]] = []
+    for p in trace_paths:
+        if not p.is_file():
+            continue
+        traces.extend(_load_single_trace(p))
+    return traces
+
+
+def _load_single_trace(p: Path) -> list[dict[str, Any]]:
+    """Load trace dicts from a single JSON or JSONL file.
+
+    Returns:
+        List of parsed trace dictionaries from the file.
+    """
+    text = p.read_text(encoding="utf-8")
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        return _parse_json_trace(text)
+    if suffix == ".jsonl":
+        return _parse_jsonl_trace(text, source_path=p)
+    return []
+
+
+def _parse_json_trace(text: str) -> list[dict[str, Any]]:
+    """Parse a JSON trace file content.
+
+    Returns:
+        List of trace dicts (single dict or list of dicts).
+    """
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _parse_jsonl_trace(text: str, *, source_path: Path | None = None) -> list[dict[str, Any]]:
+    """Parse a JSONL trace file content.
+
+    Returns:
+        List of trace dicts parsed from non-empty lines.
+    """
+    traces: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            row = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            source = str(source_path) if source_path is not None else "<jsonl>"
+            raise ValueError(f"{source}: invalid JSONL at line {line_number}") from exc
+        if isinstance(row, dict):
+            traces.append(row)
+    return traces
+
+
+def _int_count(value: Any) -> int:
+    """Return integer count values while treating null/missing counters as zero."""
+    return int(value) if isinstance(value, int | float) else 0
+
+
+def _extract_step_topology(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return per-step topology rows from one trace payload."""
+    steps = trace.get("steps")
+    if isinstance(steps, list):
+        return [s for s in steps if isinstance(s, dict)]
+    return []
+
+
+def _topology_payload(row: dict[str, Any]) -> dict[str, Any]:
+    """Return the topology instrumentation payload from a step row."""
+    for key in ("topology", "topology_instrumentation"):
+        payload = row.get(key)
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _reuse_penalty_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the reuse-penalty payload from a step row."""
+    corridor = row.get("planner_route_corridor")
+    if not isinstance(corridor, dict):
+        return None
+    payload = corridor.get("topology_reuse_penalty")
+    return payload if isinstance(payload, dict) else None
+
+
+def _accumulate_summary_reuse_penalty(
+    summary: dict[str, Any],
+    applied: int,
+    eligible: int,
+    reason_counts: Counter[str],
+) -> tuple[int, int]:
+    """Accumulate reuse-penalty counters from a trace summary dict.
+
+    Returns:
+        Tuple of (updated_applied, updated_eligible).
+    """
+    reuse_diag = summary.get("topology_reuse_penalty", {})
+    if not isinstance(reuse_diag, dict):
+        return applied, eligible
+    applied += _int_count(reuse_diag.get("applied_steps", 0))
+    eligible += _int_count(reuse_diag.get("eligible_near_parity_alternative_steps", 0))
+    for k, v in reuse_diag.get("reason_counts", {}).items():
+        reason_counts[str(k)] += _int_count(v)
+    return applied, eligible
+
+
+def _accumulate_step_reuse_penalty(
+    steps: list[dict[str, Any]],
+    applied: int,
+    eligible: int,
+    reason_counts: Counter[str],
+) -> tuple[int, int]:
+    """Accumulate reuse-penalty counters from per-step data.
+
+    Returns:
+        Tuple of (updated_applied, updated_eligible).
+    """
+    for step_row in steps:
+        reuse = _reuse_penalty_payload(step_row)
+        if reuse is None:
+            continue
+        if bool(reuse.get("reuse_penalty_applied", False)):
+            applied += 1
+            reason = str(reuse.get("reuse_penalty_reason") or "unknown")
+            reason_counts[reason] += 1
+        if bool(reuse.get("eligible_near_parity_alternative_exists", False)):
+            eligible += 1
+    return applied, eligible
+
+
+def _accumulate_progress_deltas(
+    summary: dict[str, Any],
+    trace: dict[str, Any],
+    progress_deltas: list[dict[str, Any]],
+    regressions: list[dict[str, Any]],
+    unchanged: list[dict[str, Any]],
+) -> None:
+    """Extract and classify route-progress deltas from a trace summary."""
+    hypothesis_progress = summary.get("hypothesis_progress_by_rank", {})
+    if not isinstance(hypothesis_progress, dict):
+        return
+    for rank, row in hypothesis_progress.items():
+        if not isinstance(row, dict):
+            continue
+        delta = row.get("progress_delta_m")
+        entry = {
+            "trace_scenario": trace.get("scenario_id", "unknown"),
+            "trace_seed": trace.get("seed"),
+            "rank": rank,
+            "samples": row.get("samples", 0),
+            "first_corridor": row.get("first_corridor_name"),
+            "last_corridor": row.get("last_corridor_name"),
+            "first_remaining_m": row.get("first_remaining_distance_m"),
+            "last_remaining_m": row.get("last_remaining_distance_m"),
+            "progress_delta_m": delta,
+            "min_static_clearance_m": row.get("min_static_clearance_m"),
+            "min_dynamic_clearance_m": row.get("min_dynamic_clearance_m"),
+        }
+        if delta is None:
+            continue
+        progress_deltas.append(entry)
+        if isinstance(delta, int | float):
+            if delta < -1e-9:
+                regressions.append(entry)
+            elif abs(delta) < 1e-9:
+                unchanged.append(entry)
+
+
+def _accumulate_trace(  # noqa: C901, PLR0913
+    trace: dict[str, Any],
+    selected_hypothesis_counts: Counter[str],
+    near_parity_reason_counts: Counter[str],
+    reuse_penalty_applied: int,
+    reuse_penalty_eligible: int,
+    reuse_penalty_reason_counts: Counter[str],
+    progress_deltas: list[dict[str, Any]],
+    regressions: list[dict[str, Any]],
+    unchanged: list[dict[str, Any]],
+    terminal_outcomes: Counter[str],
+    diagnostic_status_counts: Counter[str],
+) -> tuple[int, int, int]:
+    """Accumulate diagnostic counters from one trace into shared accumulators.
+
+    Returns:
+        Tuple of (total_steps, reuse_penalty_applied, reuse_penalty_eligible).
+    """
+    diag_status = trace.get("diagnostic_status", "unknown")
+    diagnostic_status_counts[str(diag_status)] += 1
+
+    summary = trace.get("summary") if isinstance(trace.get("summary"), dict) else {}
+    corrective = summary.get("corrective_behavior", {})
+    if isinstance(corrective, dict):
+        outcome = corrective.get("terminal_outcome", {})
+        if isinstance(outcome, dict):
+            terminal_outcomes[str(outcome.get("outcome", "unknown"))] += 1
+
+    hypothesis_counts = summary.get("route_selector_selected_hypothesis_counts", {})
+    has_summary_hypothesis_counts = isinstance(hypothesis_counts, dict) and bool(hypothesis_counts)
+    if has_summary_hypothesis_counts:
+        for k, v in hypothesis_counts.items():
+            selected_hypothesis_counts[str(k)] += _int_count(v)
+
+    near_parity_reasons = summary.get("selected_row_near_parity_gate_reasons", {})
+    has_summary_gate_reasons = isinstance(near_parity_reasons, dict) and bool(near_parity_reasons)
+    if has_summary_gate_reasons:
+        for k, v in near_parity_reasons.items():
+            near_parity_reason_counts[str(k)] += _int_count(v)
+
+    steps = _extract_step_topology(trace)
+    total_steps = len(steps)
+
+    if steps:
+        reuse_penalty_applied, reuse_penalty_eligible = _accumulate_step_reuse_penalty(
+            steps,
+            reuse_penalty_applied,
+            reuse_penalty_eligible,
+            reuse_penalty_reason_counts,
+        )
+    else:
+        reuse_penalty_applied, reuse_penalty_eligible = _accumulate_summary_reuse_penalty(
+            summary,
+            reuse_penalty_applied,
+            reuse_penalty_eligible,
+            reuse_penalty_reason_counts,
+        )
+
+    _accumulate_progress_deltas(summary, trace, progress_deltas, regressions, unchanged)
+
+    for step_row in steps:
+        topo = _topology_payload(step_row)
+        selected_hyp = topo.get("selected_hypothesis")
+        if selected_hyp is not None and not has_summary_hypothesis_counts:
+            selected_hypothesis_counts[str(selected_hyp)] += 1
+        gate_reason = topo.get("near_parity_gate_reason")
+        if gate_reason is not None and not has_summary_gate_reasons:
+            near_parity_reason_counts[str(gate_reason)] += 1
+
+    return total_steps, reuse_penalty_applied, reuse_penalty_eligible
+
+
+def aggregate_traces(traces: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate topology diagnostic data across multiple trace payloads.
+
+    Returns:
+        Aggregated summary dictionary with all diagnostic fields.
+    """
+    selected_hypothesis_counts: Counter[str] = Counter()
+    near_parity_reason_counts: Counter[str] = Counter()
+    reuse_penalty_applied = 0
+    reuse_penalty_eligible = 0
+    reuse_penalty_reason_counts: Counter[str] = Counter()
+    total_steps = 0
+    progress_deltas: list[dict[str, Any]] = []
+    regressions: list[dict[str, Any]] = []
+    unchanged: list[dict[str, Any]] = []
+    terminal_outcomes: Counter[str] = Counter()
+    diagnostic_status_counts: Counter[str] = Counter()
+
+    for trace in traces:
+        steps_count, reuse_penalty_applied, reuse_penalty_eligible = _accumulate_trace(
+            trace,
+            selected_hypothesis_counts,
+            near_parity_reason_counts,
+            reuse_penalty_applied,
+            reuse_penalty_eligible,
+            reuse_penalty_reason_counts,
+            progress_deltas,
+            regressions,
+            unchanged,
+            terminal_outcomes,
+            diagnostic_status_counts,
+        )
+        total_steps += steps_count
+
+    regressions.sort(key=lambda r: r.get("progress_delta_m") or 0)
+    unchanged.sort(key=lambda r: abs(r.get("progress_delta_m") or 0))
+
+    return {
+        "claim_boundary": CLAIM_BOUNDARY,
+        "trace_count": len(traces),
+        "total_steps": total_steps,
+        "diagnostic_status_counts": dict(sorted(diagnostic_status_counts.items())),
+        "selected_hypothesis_counts": dict(sorted(selected_hypothesis_counts.items())),
+        "near_parity_gate_reason_counts": dict(sorted(near_parity_reason_counts.items())),
+        "reuse_penalty": {
+            "applied_steps": reuse_penalty_applied,
+            "eligible_near_parity_alternative_steps": reuse_penalty_eligible,
+            "reason_counts": dict(sorted(reuse_penalty_reason_counts.items())),
+        },
+        "route_progress_deltas": progress_deltas,
+        "top_regressions": regressions[:10],
+        "top_unchanged": unchanged[:10],
+        "terminal_outcome_counts": dict(sorted(terminal_outcomes.items())),
+    }
+
+
+def build_report_payload(
+    trace_paths: list[Path],
+    *,
+    label: str = "topology-diagnostic-snapshot",
+) -> dict[str, Any]:
+    """Build the full report payload from one or more trace files.
+
+    Returns:
+        Complete report payload dictionary.
+    """
+    traces = _load_traces(trace_paths)
+    agg = aggregate_traces(traces)
+    return {
+        "report_kind": "topology_diagnostic_report_snapshot",
+        "label": label,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source_trace_count": len(traces),
+        "source_trace_paths": [str(p) for p in trace_paths],
+        **agg,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    """Render the report payload as a Markdown string.
+
+    Returns:
+        Markdown-formatted report string.
+    """
+    lines = [
+        f"# Topology Diagnostic Report Snapshot: {payload.get('label', '')}",
+        "",
+        "Diagnostic-only evidence; this is not planner-promotion or benchmark success evidence.",
+        "",
+        f"- Claim boundary: `{payload.get('claim_boundary', '')}`",
+        f"- Trace count: {payload.get('trace_count', 0)}",
+        f"- Total steps: {payload.get('total_steps', 0)}",
+        f"- Diagnostic status counts: `{payload.get('diagnostic_status_counts', {})}`",
+        f"- Terminal outcome counts: `{payload.get('terminal_outcome_counts', {})}`",
+        "",
+        "## Selected Hypotheses",
+        "",
+    ]
+    lines.extend(_render_count_dict(payload.get("selected_hypothesis_counts", {})))
+    lines.extend(["", "## Near-Parity Gate Reasons", ""])
+    lines.extend(_render_count_dict(payload.get("near_parity_gate_reason_counts", {})))
+    lines.extend(["", "## Reuse-Penalty Activations", ""])
+    lines.extend(_render_reuse_penalty_section(payload.get("reuse_penalty", {})))
+    lines.extend(["", "## Route-Progress Deltas", ""])
+    lines.extend(
+        _render_progress_table(payload.get("route_progress_deltas", []), "progress_delta_m")
+    )
+    lines.extend(["", "## Top Regressions", ""])
+    lines.extend(_render_regression_table(payload.get("top_regressions", [])))
+    lines.extend(["", "## Top Unchanged Cases", ""])
+    lines.extend(_render_unchanged_table(payload.get("top_unchanged", [])))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_count_dict(counts: dict[str, Any]) -> list[str]:
+    """Render a count dictionary as Markdown bullet items.
+
+    Returns:
+        List of Markdown bullet item strings.
+    """
+    if not counts:
+        return ["- (none)"]
+    return [f"- `{k}`: {v}" for k, v in counts.items()]
+
+
+def _render_reuse_penalty_section(rp: dict[str, Any]) -> list[str]:
+    """Render the reuse-penalty section as Markdown lines.
+
+    Returns:
+        List of Markdown strings for the reuse-penalty section.
+    """
+    if not isinstance(rp, dict):
+        return ["- (none)"]
+    lines = [
+        f"- Applied steps: {rp.get('applied_steps', 0)}",
+        f"- Eligible near-parity alternative steps: "
+        f"{rp.get('eligible_near_parity_alternative_steps', 0)}",
+    ]
+    rp_reasons = rp.get("reason_counts", {})
+    if rp_reasons:
+        for reason, count in rp_reasons.items():
+            lines.append(f"  - `{reason}`: {count}")
+    return lines
+
+
+def _render_progress_table(
+    deltas: list[dict[str, Any]],
+    delta_key: str,
+) -> list[str]:
+    """Render a progress-delta table as Markdown lines.
+
+    Returns:
+        List of Markdown table row strings.
+    """
+    if not deltas:
+        return ["- (none)"]
+    lines = [
+        "| Scenario | Seed | Rank | Samples | Progress delta (m) |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for d in deltas[:20]:
+        lines.append(
+            f"| {d.get('trace_scenario', '')} "
+            f"| {d.get('trace_seed', '')} "
+            f"| {d.get('rank', '')} "
+            f"| {d.get('samples', '')} "
+            f"| {d.get(delta_key, '')} |"
+        )
+    return lines
+
+
+def _render_regression_table(regs: list[dict[str, Any]]) -> list[str]:
+    """Render the top-regressions table as Markdown lines.
+
+    Returns:
+        List of Markdown table row strings.
+    """
+    if not regs:
+        return ["- (none)"]
+    lines = [
+        "| Scenario | Seed | Rank | Progress delta (m) | Last corridor |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for r in regs:
+        lines.append(
+            f"| {r.get('trace_scenario', '')} "
+            f"| {r.get('trace_seed', '')} "
+            f"| {r.get('rank', '')} "
+            f"| {r.get('progress_delta_m', '')} "
+            f"| {r.get('last_corridor', '')} |"
+        )
+    return lines
+
+
+def _render_unchanged_table(rows: list[dict[str, Any]]) -> list[str]:
+    """Render the top-unchanged table as Markdown lines.
+
+    Returns:
+        List of Markdown table row strings.
+    """
+    if not rows:
+        return ["- (none)"]
+    lines = [
+        "| Scenario | Seed | Rank | Progress delta (m) | First corridor |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for u in rows:
+        lines.append(
+            f"| {u.get('trace_scenario', '')} "
+            f"| {u.get('trace_seed', '')} "
+            f"| {u.get('rank', '')} "
+            f"| {u.get('progress_delta_m', '')} "
+            f"| {u.get('first_corridor', '')} |"
+        )
+    return lines

--- a/scripts/tools/build_topology_diagnostic_report.py
+++ b/scripts/tools/build_topology_diagnostic_report.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Build a topology diagnostic report snapshot from JSONL/JSON trace files.
+
+Reads one or more topology-hypothesis diagnostic traces and emits a compact
+Markdown/JSON summary covering selected hypotheses, near-parity gate reasons,
+reuse-penalty activations, route-progress deltas, top regressions, and top
+unchanged cases.
+
+This report is diagnostic/reviewability support, not planner-promotion evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.analysis.topology_diagnostic_report import (
+    build_report_payload,
+    render_markdown,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "traces",
+        nargs="*",
+        type=Path,
+        help="JSON or JSONL topology diagnostic trace files.",
+    )
+    parser.add_argument(
+        "--label",
+        default="topology-diagnostic-snapshot",
+        help="Label for the report header.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Path to write the JSON report payload.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=None,
+        help="Path to write the Markdown report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI."""
+    args = parse_args(argv)
+    if not args.traces:
+        print("No trace files provided.", file=sys.stderr)
+        return 1
+
+    missing = [p for p in args.traces if not p.is_file()]
+    if missing:
+        for p in missing:
+            print(f"File not found or not a regular file: {p}", file=sys.stderr)
+        return 2
+
+    payload = build_report_payload(args.traces, label=args.label)
+
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if args.output_md:
+        args.output_md.parent.mkdir(parents=True, exist_ok=True)
+        md_text = render_markdown(payload)
+        args.output_md.write_text(md_text, encoding="utf-8")
+
+    if args.output_json is None and args.output_md is None:
+        print(json.dumps(payload, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/analysis/__init__.py
+++ b/tests/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for analysis and diagnostic report helpers."""

--- a/tests/analysis/test_topology_diagnostic_report.py
+++ b/tests/analysis/test_topology_diagnostic_report.py
@@ -1,0 +1,294 @@
+"""Tests for topology diagnostic report snapshot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_sf.analysis.topology_diagnostic_report import (
+    aggregate_traces,
+    build_report_payload,
+    render_markdown,
+)
+from scripts.tools.build_topology_diagnostic_report import main as report_main
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+SUMMARY_KEYS = [
+    "claim_boundary",
+    "trace_count",
+    "total_steps",
+    "diagnostic_status_counts",
+    "selected_hypothesis_counts",
+    "near_parity_gate_reason_counts",
+    "reuse_penalty",
+    "route_progress_deltas",
+    "top_regressions",
+    "top_unchanged",
+    "terminal_outcome_counts",
+]
+
+REUSE_PENALTY_KEYS = [
+    "applied_steps",
+    "eligible_near_parity_alternative_steps",
+    "reason_counts",
+]
+
+PAYLOAD_KEYS = [
+    "report_kind",
+    "label",
+    "claim_boundary",
+    "source_trace_count",
+    "source_trace_paths",
+]
+
+MARKDOWN_SECTIONS = [
+    "## Selected Hypotheses",
+    "## Near-Parity Gate Reasons",
+    "## Reuse-Penalty Activations",
+    "## Route-Progress Deltas",
+    "## Top Regressions",
+    "## Top Unchanged Cases",
+]
+
+
+def _minimal_trace(
+    *,
+    selected_hypothesis: str | None = "primary_route",
+    near_parity_gate_reason: str | None = "eligible_near_parity_alternative",
+    progress_delta: float | None = 1.5,
+    reuse_penalty_applied: bool = False,
+    terminal_outcome: str = "success",
+    diagnostic_status: str = "diagnostic_complete",
+) -> dict:
+    """Build a minimal topology diagnostic trace payload for testing."""
+    step = {
+        "step": 0,
+        "topology_status": "ok",
+        "hypothesis_count": 2,
+        "topology_instrumentation": {
+            "per_frame_hypothesis_count": 2,
+            "alternative_hypothesis_count": 1,
+            "selected_hypothesis": selected_hypothesis,
+            "near_parity_gate_reason": near_parity_gate_reason,
+        },
+        "planner_route_corridor": {
+            "topology_reuse_penalty": {
+                "reuse_penalty_applied": reuse_penalty_applied,
+                "eligible_near_parity_alternative_exists": True,
+                "reuse_penalty_reason": ("cooldown_eligible" if reuse_penalty_applied else None),
+            },
+        },
+    }
+    summary = {
+        "route_selector_selected_hypothesis_counts": (
+            {selected_hypothesis: 1} if selected_hypothesis else {}
+        ),
+        "selected_row_near_parity_gate_reasons": (
+            {near_parity_gate_reason: 1} if near_parity_gate_reason else {}
+        ),
+        "hypothesis_progress_by_rank": {
+            "0": {
+                "samples": 1,
+                "first_corridor_name": "alpha",
+                "last_corridor_name": "alpha",
+                "first_remaining_distance_m": 5.0,
+                "last_remaining_distance_m": 3.5,
+                "progress_delta_m": progress_delta,
+                "min_static_clearance_m": 0.4,
+                "min_dynamic_clearance_m": 0.3,
+            },
+        },
+        "corrective_behavior": {
+            "terminal_outcome": {"outcome": terminal_outcome},
+        },
+    }
+    return {
+        "diagnostic_kind": "topology_hypothesis_trace",
+        "diagnostic_status": diagnostic_status,
+        "claim_boundary": "diagnostic_only_not_benchmark_success",
+        "scenario_id": "test_scenario",
+        "seed": 42,
+        "summary": summary,
+        "steps": [step],
+    }
+
+
+def test_aggregate_summary_keys_present():
+    """All expected summary keys must be present and stable."""
+    trace = _minimal_trace()
+    result = aggregate_traces([trace])
+    for key in SUMMARY_KEYS:
+        assert key in result, f"Missing summary key: {key}"
+    assert result["claim_boundary"] == "diagnostic_only_not_benchmark_success"
+    assert result["trace_count"] == 1
+    assert result["total_steps"] == 1
+
+
+def test_aggregate_reuse_penalty_keys_present():
+    """Reuse-penalty sub-dict must contain expected keys."""
+    trace = _minimal_trace(reuse_penalty_applied=True)
+    result = aggregate_traces([trace])
+    rp = result["reuse_penalty"]
+    for key in REUSE_PENALTY_KEYS:
+        assert key in rp, f"Missing reuse_penalty key: {key}"
+    assert rp["applied_steps"] == 1
+    assert rp["eligible_near_parity_alternative_steps"] >= 1
+    assert "cooldown_eligible" in rp["reason_counts"]
+
+
+def test_aggregate_selected_hypothesis_counts():
+    """Selected hypotheses should be counted across traces."""
+    t1 = _minimal_trace(selected_hypothesis="primary_route")
+    t2 = _minimal_trace(selected_hypothesis="divert_left")
+    result = aggregate_traces([t1, t2])
+    counts = result["selected_hypothesis_counts"]
+    assert counts.get("primary_route") == 1
+    assert counts.get("divert_left") == 1
+
+
+def test_aggregate_near_parity_gate_reasons():
+    """Near-parity gate reasons should be counted."""
+    t1 = _minimal_trace(near_parity_gate_reason="eligible_near_parity_alternative")
+    t2 = _minimal_trace(near_parity_gate_reason="route_distance_exceeds_slack")
+    result = aggregate_traces([t1, t2])
+    reasons = result["near_parity_gate_reason_counts"]
+    assert reasons.get("eligible_near_parity_alternative") == 1
+    assert reasons.get("route_distance_exceeds_slack") == 1
+
+
+def test_aggregate_falls_back_to_step_counts_when_summary_omits_counts():
+    """Step-level selected and gate fields are used when summary counters are absent."""
+    trace = _minimal_trace(
+        selected_hypothesis="divert_left",
+        near_parity_gate_reason="static_clearance_below_floor",
+    )
+    trace["summary"].pop("route_selector_selected_hypothesis_counts")
+    trace["summary"].pop("selected_row_near_parity_gate_reasons")
+
+    result = aggregate_traces([trace])
+
+    assert result["selected_hypothesis_counts"] == {"divert_left": 1}
+    assert result["near_parity_gate_reason_counts"] == {"static_clearance_below_floor": 1}
+
+
+def test_aggregate_route_progress_deltas():
+    """Route-progress deltas should be extracted from hypothesis progress."""
+    t = _minimal_trace(progress_delta=2.0)
+    result = aggregate_traces([t])
+    assert len(result["route_progress_deltas"]) == 1
+    assert result["route_progress_deltas"][0]["progress_delta_m"] == 2.0
+
+
+def test_aggregate_top_regressions_sorted():
+    """Negative progress deltas should appear in top_regressions."""
+    t = _minimal_trace(progress_delta=-3.0)
+    result = aggregate_traces([t])
+    assert len(result["top_regressions"]) == 1
+    assert result["top_regressions"][0]["progress_delta_m"] == -3.0
+
+
+def test_aggregate_top_unchanged_cases():
+    """Zero progress deltas should appear in top_unchanged."""
+    t = _minimal_trace(progress_delta=0.0)
+    result = aggregate_traces([t])
+    assert len(result["top_unchanged"]) == 1
+    assert result["top_unchanged"][0]["progress_delta_m"] == 0.0
+
+
+def test_build_report_payload_keys():
+    """Report payload must contain top-level report keys."""
+    trace_path = FIXTURES / "topology_sample.jsonl"
+    payload = build_report_payload([trace_path], label="test-snapshot")
+    for key in PAYLOAD_KEYS:
+        assert key in payload, f"Missing payload key: {key}"
+    assert payload["report_kind"] == "topology_diagnostic_report_snapshot"
+    assert payload["label"] == "test-snapshot"
+    assert payload["source_trace_count"] == 1
+
+
+def test_render_markdown_contains_all_sections():
+    """Markdown output must contain all expected section headers."""
+    trace = _minimal_trace()
+    agg = aggregate_traces([trace])
+    payload = {"label": "test", **agg}
+    md = render_markdown(payload)
+    for section in MARKDOWN_SECTIONS:
+        assert section in md, f"Missing Markdown section: {section}"
+    assert "diagnostic_only_not_benchmark_success" in md
+
+
+def test_render_markdown_handles_empty_data():
+    """Markdown rendering should not crash with empty aggregation."""
+    agg = aggregate_traces([])
+    payload = {"label": "empty", **agg}
+    md = render_markdown(payload)
+    assert "(none)" in md
+    assert "## Selected Hypotheses" in md
+
+
+def test_build_report_payload_missing_file():
+    """Missing trace files should be handled gracefully."""
+    payload = build_report_payload([Path("/nonexistent/trace.jsonl")], label="missing")
+    assert payload["trace_count"] == 0
+    assert payload["total_steps"] == 0
+
+
+def test_build_report_payload_skips_directory_inputs(tmp_path: Path):
+    """Directory paths should not crash report aggregation."""
+    payload = build_report_payload([tmp_path], label="directory")
+    assert payload["trace_count"] == 0
+    assert payload["total_steps"] == 0
+
+
+def test_build_report_payload_accepts_uppercase_suffix(tmp_path: Path):
+    """Uppercase JSON suffixes should load like lowercase suffixes."""
+    trace_path = tmp_path / "trace.JSON"
+    trace_path.write_text(json_dumps(_minimal_trace()), encoding="utf-8")
+
+    payload = build_report_payload([trace_path], label="uppercase")
+
+    assert payload["trace_count"] == 1
+    assert payload["selected_hypothesis_counts"] == {"primary_route": 1}
+
+
+def test_jsonl_scalar_rows_are_ignored(tmp_path: Path):
+    """JSONL scalar rows should not be passed to trace aggregation."""
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text("42\n" + json_dumps(_minimal_trace()) + "\n", encoding="utf-8")
+
+    payload = build_report_payload([trace_path], label="jsonl")
+
+    assert payload["trace_count"] == 1
+    assert payload["total_steps"] == 1
+
+
+def test_null_summary_counters_are_treated_as_zero():
+    """Explicit null summary counters should not crash aggregation."""
+    trace = _minimal_trace()
+    trace["steps"] = []
+    trace["summary"]["topology_reuse_penalty"] = {
+        "applied_steps": None,
+        "eligible_near_parity_alternative_steps": None,
+        "reason_counts": {"missing": None},
+    }
+
+    result = aggregate_traces([trace])
+
+    assert result["reuse_penalty"]["applied_steps"] == 0
+    assert result["reuse_penalty"]["eligible_near_parity_alternative_steps"] == 0
+    assert result["reuse_penalty"]["reason_counts"] == {"missing": 0}
+
+
+def test_cli_rejects_directory_inputs(tmp_path: Path, capsys):
+    """CLI validation should reject directories before reading them."""
+    rc = report_main([str(tmp_path)])
+
+    assert rc == 2
+    assert "File not found" in capsys.readouterr().err
+
+
+def json_dumps(payload: dict) -> str:
+    """Serialize test payloads without importing json at module top level."""
+    import json
+
+    return json.dumps(payload)


### PR DESCRIPTION
## Summary

- Add `robot_sf.analysis.topology_diagnostic_report` to aggregate topology diagnostic traces into stable JSON/Markdown report payloads.
- Add `scripts/tools/build_topology_diagnostic_report.py` as the standalone report builder.
- Add focused tests plus a bounded, reproducible smoke report under `docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/`.

Closes #2661

## Validation

- `rtk uv run pytest tests/analysis/test_topology_diagnostic_report.py -q`
- `rtk uv run python scripts/tools/build_topology_diagnostic_report.py docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_1.json docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/smoke_trace_2.json --label issue-2661-smoke --output-json /tmp/issue2661-report-check.json --output-md /tmp/issue2661-report-check.md`
- `rtk cmp -s /tmp/issue2661-report-check.json docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.json`
- `rtk cmp -s /tmp/issue2661-report-check.md docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/report.md`
- `rtk uv run ruff check robot_sf/analysis/topology_diagnostic_report.py scripts/tools/build_topology_diagnostic_report.py tests/analysis/test_topology_diagnostic_report.py`
- `rtk uv run ruff format --check robot_sf/analysis/topology_diagnostic_report.py scripts/tools/build_topology_diagnostic_report.py tests/analysis/test_topology_diagnostic_report.py`
- `rtk git diff --check`

## Downstream Propagation

- Parent issue #2661 is closed by this PR.
- Evidence snapshot added under `docs/context/evidence/issue_2661_topology_diagnostic_report_snapshot/` with tracked smoke inputs and regenerated outputs.
- No leaderboard, benchmark report, model registry, or artifact catalog update is needed because this is a diagnostic reporting helper and bounded smoke artifact, not a benchmark-result publication.

## Research Result Guidance

- Target claim/hypothesis/blocker: make topology near-parity/reuse-penalty diagnostics reviewable without manual trace inspection.
- Comparator/baseline: previous state required ad hoc trace inspection; this PR adds a compact report surface over the same trace data.
- Evidence tier: smoke evidence from two tracked synthetic diagnostic traces.
- Result classification: diagnostic-only support artifact.
- Decision/stop rule: report payload includes stable summary keys for selected hypotheses, near-parity gate reasons, reuse-penalty activations, route-progress deltas, top regressions, and top unchanged cases; regenerated outputs match tracked report files.
- Synthesis surface/update target: future topology synthesis or promotion-gate work can consume the report, but this PR does not move a planner-promotion claim.

## Risks

- The report summarizes completed diagnostic trace files; it does not run simulations or prove planner performance.
- Sections are only as complete as the trace payloads provided by upstream diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added topology diagnostic report generation capability with CLI tool to build reports from trace files and output JSON/Markdown snapshots.

* **Documentation**
  * Added diagnostic snapshot reports with example traces and aggregated metrics for topology analysis.

* **Tests**
  * Added comprehensive test suite for topology diagnostic report aggregation and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->