### PR TITLE
feat: unify manifest lineage fields

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -77,6 +77,11 @@ records the predeclared broader 3x3 slice after the selected active-row Issue #2
 supports `broader_delayed_rescue_supported` for the only unsolved active row, not benchmark-candidate
 or paper-facing proof.
 
+Recent manifest lineage schema: [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
+records the shared additive lineage/evidence-boundary fields for `scenario_prior.v1`,
+`adversarial_scenario_manifest.v1`, and `counterfactual_scenario_pair.v1`; it is schema
+reviewability work only, not benchmark or paper-facing evidence.
+
 ## Context-Pack Manifests
 
 Generated packs are temporary artifacts and should stay under ignored paths such as

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -351,6 +351,10 @@ knowledge, not every transient iteration detail.
 
   [issue_2547_counterfactual_mechanism_taxonomy.md](issue_2547_counterfactual_mechanism_taxonomy.md)
 
+* Issue #2659 Manifest Lineage Schema Unification (2026-06-12):
+
+  [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
+
 * Issue #2263 mechanism activation report fields:
 
   [issue_2263_mechanism_activation_report_fields.md](issue_2263_mechanism_activation_report_fields.md)
@@ -555,8 +559,6 @@ knowledge, not every transient iteration detail.
   [issue_2618_adversarial_manifest_smoke.md](issue_2618_adversarial_manifest_smoke.md)
 * Issue #2658 Validator-Runner Adversarial Manifest Smoke (2026-06-12):
   [issue_2658_adversarial_manifest_smoke.md](issue_2658_adversarial_manifest_smoke.md)
-* Issue #2659 Manifest Lineage Schema Unification (2026-06-12):
-  [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
 * Issue #1457 Adversarial Map And Start-State Generation Protocol (2026-05-23):
   [issue_1457_adversarial_generation_protocol.md](issue_1457_adversarial_generation_protocol.md)
 * Issue #1500 Adversarial Campaign Manifest Freeze (2026-05-26):
@@ -681,8 +683,6 @@ knowledge, not every transient iteration detail.
   [issue_2523_scenario_prior_smoke.md](issue_2523_scenario_prior_smoke.md)
   ([summary](evidence/issue_2523_scenario_prior_smoke/summary.json),
   [artifact](evidence/issue_2523_scenario_prior_smoke/scenario_prior.v1.json))
-* Issue #2659 Manifest Lineage Schema Unification (2026-06-12):
-  [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
 * Issue #2474 Signalized Pedestrian Crossing Benchmark Scope (2026-06-06):
   [issue_2474_signalized_crossing_benchmark.md](issue_2474_signalized_crossing_benchmark.md)
 * Issue #2475 Probabilistic Prediction Interface (2026-06-06):

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -555,6 +555,8 @@ knowledge, not every transient iteration detail.
   [issue_2618_adversarial_manifest_smoke.md](issue_2618_adversarial_manifest_smoke.md)
 * Issue #2658 Validator-Runner Adversarial Manifest Smoke (2026-06-12):
   [issue_2658_adversarial_manifest_smoke.md](issue_2658_adversarial_manifest_smoke.md)
+* Issue #2659 Manifest Lineage Schema Unification (2026-06-12):
+  [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
 * Issue #1457 Adversarial Map And Start-State Generation Protocol (2026-05-23):
   [issue_1457_adversarial_generation_protocol.md](issue_1457_adversarial_generation_protocol.md)
 * Issue #1500 Adversarial Campaign Manifest Freeze (2026-05-26):
@@ -679,6 +681,8 @@ knowledge, not every transient iteration detail.
   [issue_2523_scenario_prior_smoke.md](issue_2523_scenario_prior_smoke.md)
   ([summary](evidence/issue_2523_scenario_prior_smoke/summary.json),
   [artifact](evidence/issue_2523_scenario_prior_smoke/scenario_prior.v1.json))
+* Issue #2659 Manifest Lineage Schema Unification (2026-06-12):
+  [issue_2659_lineage_schema_unification.md](issue_2659_lineage_schema_unification.md)
 * Issue #2474 Signalized Pedestrian Crossing Benchmark Scope (2026-06-06):
   [issue_2474_signalized_crossing_benchmark.md](issue_2474_signalized_crossing_benchmark.md)
 * Issue #2475 Probabilistic Prediction Interface (2026-06-06):

--- a/docs/context/evidence/issue_2523_scenario_prior_smoke/scenario_prior.v1.json
+++ b/docs/context/evidence/issue_2523_scenario_prior_smoke/scenario_prior.v1.json
@@ -1,5 +1,10 @@
 {
   "schema_version": "scenario_prior.v1",
+  "generator_id": "issue_2523_proxy_scenario_prior_fixture",
+  "validator_version": "scenario_prior_proxy_fixture_validator.v1",
+  "evidence_tier": "smoke evidence",
+  "denominator_policy": "proxy_fixture_not_benchmark_denominator",
+  "execution_gate": "not_executable_until_real_data_staged",
   "issue": 2523,
   "parent_issue": 2521,
   "source": {

--- a/docs/context/issue_2659_lineage_schema_unification.md
+++ b/docs/context/issue_2659_lineage_schema_unification.md
@@ -1,4 +1,4 @@
-# Issue 2659 Lineage Schema Unification
+# Issue #2659 Manifest Lineage Schema Unification
 
 Issue: #2659
 

--- a/docs/context/issue_2659_lineage_schema_unification.md
+++ b/docs/context/issue_2659_lineage_schema_unification.md
@@ -1,0 +1,54 @@
+# Issue 2659 Lineage Schema Unification
+
+Issue: #2659
+
+## Purpose
+
+`scenario_prior.v1`, `adversarial_scenario_manifest.v1`, and
+`counterfactual_scenario_pair.v1` now expose a common lineage/evidence-boundary contract through
+`robot_sf.benchmark.manifest_lineage.ManifestLineageContract`.
+
+This is schema and reviewability work only. It does not convert any artifact into benchmark,
+planner-promotion, or paper-grade evidence.
+
+## Mandatory Fields Before Execution
+
+The shared contract requires these fields before a manifest-like artifact can be treated as ready
+for downstream execution or review:
+
+- `source`: input artifact/config provenance as a mapping.
+- `generator_id`: stable producer identifier.
+- `validator_version`: validator or fixture-validator contract version.
+- `schema_version`: manifest schema identifier.
+- `claim_boundary`: explicit claim or non-claim boundary.
+- `evidence_tier`: current evidence status, such as `diagnostic-only` or `smoke evidence`.
+- `denominator_policy`: whether rows may enter benchmark denominators.
+- `execution_gate`: the condition that must hold before execution or downstream use.
+
+## Family Mapping
+
+`scenario_prior.v1` remains a JSON-only proxy smoke artifact. Its tracked fixture declares:
+
+- `generator_id`: `issue_2523_proxy_scenario_prior_fixture`
+- `validator_version`: `scenario_prior_proxy_fixture_validator.v1`
+- `evidence_tier`: `smoke evidence`
+- `denominator_policy`: `proxy_fixture_not_benchmark_denominator`
+- `execution_gate`: `not_executable_until_real_data_staged`
+
+`adversarial_scenario_manifest.v1` now serializes the shared fields from its existing source,
+generator, execution status, and evidence boundary. Its denominator policy is
+`generated_candidates_not_benchmark_denominator`.
+
+`counterfactual_scenario_pair.v1` now serializes source provenance, generator/validator IDs,
+evidence tier, denominator policy, and preflight-based execution gate before returning the pair
+payload.
+
+## Compatibility Notes
+
+Existing family-specific fields remain in place. The shared contract is intentionally additive so
+older consumers can continue reading `source`, `generator`, `claim_boundary`, `evidence_boundary`,
+`perturbation_manifest`, and `preflight` fields where they already existed.
+
+The shared helper validates field presence and basic types; it does not prove a manifest is
+executable, benchmark-valid, or complete for paper-facing claims. Downstream benchmark claims still
+need executable evidence, denominator review, and fail-closed handling.

--- a/robot_sf/adversarial/scenario_manifest.py
+++ b/robot_sf/adversarial/scenario_manifest.py
@@ -139,21 +139,21 @@ class AdversarialScenarioManifest:
     def from_dict(cls, payload: dict[str, Any]) -> AdversarialScenarioManifest:
         """Build a manifest from a JSON/YAML dict."""
         return cls(
-            schema_version=str(payload.get("schema_version", MANIFEST_SCHEMA_VERSION)),
+            schema_version=_optional_string(payload.get("schema_version"), MANIFEST_SCHEMA_VERSION),
             source=SourceLineage(**payload["source"]) if "source" in payload else None,
             generator=GeneratorInfo(**payload["generator"]) if "generator" in payload else None,
             candidate_controls=payload.get("candidate_controls"),
             validation=_validation_from_dict(payload.get("validation")),
-            execution_status=str(payload.get("execution_status", "generated_only")),
-            validator_version=str(payload.get("validator_version", VALIDATOR_VERSION)),
-            evidence_tier=str(payload.get("evidence_tier", EVIDENCE_TIER)),
-            denominator_policy=str(payload.get("denominator_policy", DENOMINATOR_POLICY)),
-            evidence_boundary=str(
-                payload.get(
-                    "evidence_boundary",
-                    "diagnostic-only: no planner weakness, adversarial coverage, "
-                    "or benchmark-strength claim is made from this manifest.",
-                )
+            execution_status=_optional_string(payload.get("execution_status"), "generated_only"),
+            validator_version=_optional_string(payload.get("validator_version"), VALIDATOR_VERSION),
+            evidence_tier=_optional_string(payload.get("evidence_tier"), EVIDENCE_TIER),
+            denominator_policy=_optional_string(
+                payload.get("denominator_policy"), DENOMINATOR_POLICY
+            ),
+            evidence_boundary=_optional_string(
+                payload.get("evidence_boundary"),
+                "diagnostic-only: no planner weakness, adversarial coverage, "
+                "or benchmark-strength claim is made from this manifest.",
             ),
         )
 
@@ -164,6 +164,13 @@ class AdversarialScenarioManifest:
         if not isinstance(payload, dict):
             raise ValueError("manifest YAML must be a mapping")
         return cls.from_dict(payload)
+
+
+def _optional_string(value: Any, default: str) -> str:
+    """Return default for absent YAML fields without coercing None to a string."""
+    if value is None:
+        return default
+    return str(value)
 
 
 def _validation_from_dict(payload: Any) -> ValidationRecord | None:

--- a/robot_sf/adversarial/scenario_manifest.py
+++ b/robot_sf/adversarial/scenario_manifest.py
@@ -14,8 +14,12 @@ import yaml
 
 from robot_sf.adversarial.config import CandidateSpec, Pose2D, SearchSpaceConfig
 from robot_sf.adversarial.samplers import RandomCandidateSampler
+from robot_sf.benchmark.manifest_lineage import validate_lineage_contract
 
 MANIFEST_SCHEMA_VERSION = "adversarial_scenario_manifest.v1"
+VALIDATOR_VERSION = "adversarial_scenario_manifest_validator.v1"
+EVIDENCE_TIER = "diagnostic-only"
+DENOMINATOR_POLICY = "generated_candidates_not_benchmark_denominator"
 
 
 class ManifestCategory(Enum):
@@ -92,6 +96,9 @@ class AdversarialScenarioManifest:
     candidate_controls: dict[str, Any] | None = None
     validation: ValidationRecord | None = None
     execution_status: str = "generated_only"
+    validator_version: str = VALIDATOR_VERSION
+    evidence_tier: str = EVIDENCE_TIER
+    denominator_policy: str = DENOMINATOR_POLICY
     evidence_boundary: str = (
         "diagnostic-only: no planner weakness, adversarial coverage, "
         "or benchmark-strength claim is made from this manifest."
@@ -101,7 +108,17 @@ class AdversarialScenarioManifest:
         """Serialize the manifest to a JSON/YAML-safe dict."""
         result: dict[str, Any] = {
             "schema_version": self.schema_version,
+            "generator_id": (
+                self.generator.generator_id
+                if self.generator is not None
+                else GeneratorInfo().generator_id
+            ),
+            "validator_version": self.validator_version,
             "execution_status": self.execution_status,
+            "execution_gate": self.execution_status,
+            "evidence_tier": self.evidence_tier,
+            "denominator_policy": self.denominator_policy,
+            "claim_boundary": self.evidence_boundary,
             "evidence_boundary": self.evidence_boundary,
         }
         if self.source is not None:
@@ -128,6 +145,9 @@ class AdversarialScenarioManifest:
             candidate_controls=payload.get("candidate_controls"),
             validation=_validation_from_dict(payload.get("validation")),
             execution_status=str(payload.get("execution_status", "generated_only")),
+            validator_version=str(payload.get("validator_version", VALIDATOR_VERSION)),
+            evidence_tier=str(payload.get("evidence_tier", EVIDENCE_TIER)),
+            denominator_policy=str(payload.get("denominator_policy", DENOMINATOR_POLICY)),
             evidence_boundary=str(
                 payload.get(
                     "evidence_boundary",
@@ -304,6 +324,8 @@ def validate_manifest_payload(
         errors.append(f"schema_version must be {MANIFEST_SCHEMA_VERSION}")
     if not isinstance(payload.get("execution_status"), str):
         errors.append("execution_status must be a string")
+    lineage_errors = validate_lineage_contract(payload)
+    errors.extend(lineage_errors)
     if not isinstance(payload.get("evidence_boundary"), str):
         errors.append("evidence_boundary must be a string")
     errors.extend(

--- a/robot_sf/benchmark/manifest_lineage.py
+++ b/robot_sf/benchmark/manifest_lineage.py
@@ -1,0 +1,72 @@
+"""Shared lineage contract helpers for research manifest families."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+MANDATORY_LINEAGE_FIELDS = (
+    "source",
+    "generator_id",
+    "validator_version",
+    "schema_version",
+    "claim_boundary",
+    "evidence_tier",
+    "denominator_policy",
+    "execution_gate",
+)
+
+
+@dataclass(frozen=True)
+class ManifestLineageContract:
+    """Common provenance and evidence-boundary fields for manifest-like artifacts."""
+
+    source: dict[str, Any]
+    generator_id: str
+    validator_version: str
+    schema_version: str
+    claim_boundary: str | dict[str, Any]
+    evidence_tier: str
+    denominator_policy: str
+    execution_gate: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping.
+
+        Returns:
+            JSON-safe field mapping for embedding in manifest payloads.
+        """
+        return asdict(self)
+
+
+def validate_lineage_contract(payload: object) -> list[str]:
+    """Return validation errors for the shared lineage contract."""
+    if not isinstance(payload, dict):
+        return ["lineage payload must be a mapping"]
+    errors: list[str] = []
+    for field in MANDATORY_LINEAGE_FIELDS:
+        if field not in payload:
+            errors.append(f"{field} is required")
+    source = payload.get("source")
+    if "source" in payload and not isinstance(source, dict):
+        errors.append("source must be a mapping")
+    for field in (
+        "generator_id",
+        "validator_version",
+        "schema_version",
+        "evidence_tier",
+        "denominator_policy",
+        "execution_gate",
+    ):
+        if field in payload and not isinstance(payload.get(field), str):
+            errors.append(f"{field} must be a string")
+    if "claim_boundary" in payload and not isinstance(payload.get("claim_boundary"), str | dict):
+        errors.append("claim_boundary must be a string or mapping")
+    return errors
+
+
+def require_lineage_contract(payload: object) -> None:
+    """Raise ValueError when payload does not satisfy the shared lineage contract."""
+    errors = validate_lineage_contract(payload)
+    if errors:
+        raise ValueError("; ".join(errors))

--- a/robot_sf/benchmark/manifest_lineage.py
+++ b/robot_sf/benchmark/manifest_lineage.py
@@ -60,7 +60,7 @@ def validate_lineage_contract(payload: object) -> list[str]:
     ):
         if field in payload and not isinstance(payload.get(field), str):
             errors.append(f"{field} must be a string")
-    if "claim_boundary" in payload and not isinstance(payload.get("claim_boundary"), str | dict):
+    if "claim_boundary" in payload and not isinstance(payload.get("claim_boundary"), (str, dict)):
         errors.append("claim_boundary must be a string or mapping")
     return errors
 

--- a/scripts/tools/create_counterfactual_scenario_pair.py
+++ b/scripts/tools/create_counterfactual_scenario_pair.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from robot_sf.benchmark.manifest_lineage import require_lineage_contract
 from robot_sf.scenario_certification.perturbation_family_registry import (
     perturbation_family,
     validate_perturbation_family_parameters,
@@ -23,8 +24,12 @@ from robot_sf.scenario_certification.perturbation_preflight import (
 )
 
 COUNTERFACTUAL_PAIR_SCHEMA_VERSION = "counterfactual_scenario_pair.v1"
+COUNTERFACTUAL_PAIR_VALIDATOR_VERSION = "counterfactual_scenario_pair_validator.v1"
 MECHANISM_TAXONOMY_SCHEMA_VERSION = "counterfactual_mechanism_taxonomy.v1"
 CLAIM_BOUNDARY = "candidate mechanism-test inputs only; not benchmark evidence"
+EVIDENCE_TIER = "diagnostic-only"
+DENOMINATOR_POLICY = "counterfactual_pairs_not_benchmark_denominator"
+GENERATOR_ID = "create_counterfactual_scenario_pair"
 _SUCCESS_EVIDENCE_CANDIDATE = "eligible_success_evidence_candidate"
 _SUPPORTED_FEATURES = frozenset({"robot_route_offset"})
 MECHANISM_TAXONOMY_LABELS = (
@@ -153,8 +158,17 @@ def create_pair_manifest(
     preflight_payload = _preflight_embedded_manifest(perturbation_manifest)
     _require_pair_preflight_success(preflight_payload)
 
-    return {
+    payload = {
         "schema_version": COUNTERFACTUAL_PAIR_SCHEMA_VERSION,
+        "source": {
+            "scenario_config": scenario_config.as_posix(),
+            "source_scenario_id": source,
+        },
+        "generator_id": GENERATOR_ID,
+        "validator_version": COUNTERFACTUAL_PAIR_VALIDATOR_VERSION,
+        "evidence_tier": EVIDENCE_TIER,
+        "denominator_policy": DENOMINATOR_POLICY,
+        "execution_gate": "preflight_success_required_before_execution",
         "baseline": {
             "scenario_id": source,
             "variant_id": baseline_variant_id,
@@ -193,6 +207,8 @@ def create_pair_manifest(
         "perturbation_manifest": perturbation_manifest,
         "preflight": preflight_payload,
     }
+    require_lineage_contract(payload)
+    return payload
 
 
 def _supported_family(feature: str):

--- a/tests/adversarial/fixtures/issue_2529/accepted_manifest.yaml
+++ b/tests/adversarial/fixtures/issue_2529/accepted_manifest.yaml
@@ -1,5 +1,11 @@
 schema_version: adversarial_scenario_manifest.v1
+generator_id: structured_prompt_adapter_v1
+validator_version: adversarial_scenario_manifest_validator.v1
 execution_status: generated_only
+execution_gate: generated_only
+evidence_tier: diagnostic-only
+denominator_policy: generated_candidates_not_benchmark_denominator
+claim_boundary: diagnostic-only
 evidence_boundary: diagnostic-only
 source:
   scenario_template: crossing_ttc.yaml

--- a/tests/adversarial/test_adversarial_scenario_manifest.py
+++ b/tests/adversarial/test_adversarial_scenario_manifest.py
@@ -22,6 +22,7 @@ from robot_sf.adversarial.scenario_manifest import (
     validate_manifest_payload,
     write_manifest_yaml,
 )
+from robot_sf.benchmark.manifest_lineage import validate_lineage_contract
 from scripts.tools.generate_adversarial_scenario_manifests import (
     _load_template_info,
 )
@@ -295,9 +296,16 @@ def test_manifest_serializes_to_yaml(tmp_path: Path) -> None:
     assert isinstance(loaded, dict)
     assert loaded["schema_version"] == MANIFEST_SCHEMA_VERSION
     assert loaded["candidate_controls"]["spawn_time_s"] == 0.0
+    assert loaded["generator_id"] == "RandomCandidateSampler"
+    assert loaded["validator_version"] == "adversarial_scenario_manifest_validator.v1"
+    assert loaded["evidence_tier"] == "diagnostic-only"
+    assert loaded["denominator_policy"] == "generated_candidates_not_benchmark_denominator"
+    assert loaded["execution_gate"] == "generated_only"
+    assert loaded["claim_boundary"] == loaded["evidence_boundary"]
     assert loaded["execution_status"] == "generated_only"
     assert "diagnostic-only" in loaded["evidence_boundary"]
     assert loaded["source"]["map_id"] == "classic_cross_trap"
+    assert validate_lineage_contract(loaded) == []
 
 
 def test_manifest_round_trips_through_yaml(tmp_path: Path) -> None:
@@ -328,6 +336,16 @@ def test_validate_manifest_payload_accepts_valid_payload() -> None:
     assert record.status == ManifestCategory.VALID
     assert record.errors == ()
     assert record.normalized_control_hash == manifest.validation.normalized_control_hash
+
+
+def test_adversarial_manifest_payload_satisfies_shared_lineage_contract() -> None:
+    """Adversarial manifests expose the shared lineage/evidence-boundary fields."""
+    payload = _valid_manifest_payload()
+
+    assert validate_lineage_contract(payload) == []
+    assert payload["generator_id"] == "TestSampler"
+    assert payload["validator_version"] == "adversarial_scenario_manifest_validator.v1"
+    assert payload["claim_boundary"] == payload["evidence_boundary"]
 
 
 def test_validate_manifest_payload_rejects_bad_schema() -> None:

--- a/tests/research/test_issue_2523_scenario_prior_smoke.py
+++ b/tests/research/test_issue_2523_scenario_prior_smoke.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from robot_sf.benchmark.manifest_lineage import validate_lineage_contract
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE_DIR = REPO_ROOT / "docs/context/evidence/issue_2523_scenario_prior_smoke"
 ARTIFACT_PATH = EVIDENCE_DIR / "scenario_prior.v1.json"
@@ -29,6 +31,12 @@ def test_scenario_prior_proxy_artifact_preserves_claim_boundary() -> None:
     assert isinstance(adequacy, dict)
 
     assert artifact["schema_version"] == "scenario_prior.v1"
+    assert artifact["generator_id"] == "issue_2523_proxy_scenario_prior_fixture"
+    assert artifact["validator_version"] == "scenario_prior_proxy_fixture_validator.v1"
+    assert artifact["evidence_tier"] == "smoke evidence"
+    assert artifact["denominator_policy"] == "proxy_fixture_not_benchmark_denominator"
+    assert artifact["execution_gate"] == "not_executable_until_real_data_staged"
+    assert validate_lineage_contract(artifact) == []
     assert source["input_type"] == "proxy_synthetic"
     assert source["real_data_status"] == "missing"
     assert claim_boundary["benchmark_evidence"] is False

--- a/tests/tools/test_create_counterfactual_scenario_pair.py
+++ b/tests/tools/test_create_counterfactual_scenario_pair.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from robot_sf.benchmark.manifest_lineage import validate_lineage_contract
 from scripts.tools import create_counterfactual_scenario_pair
 
 if TYPE_CHECKING:
@@ -37,6 +38,16 @@ def test_create_supported_robot_route_offset_pair(tmp_path: Path) -> None:
     output_text = output_path.read_text(encoding="utf-8")
     payload = yaml.safe_load(output_text)
     assert payload["changed_feature"] == "robot_route_offset"
+    assert payload["source"] == {
+        "scenario_config": "configs/scenarios/single/planner_sanity_simple.yaml",
+        "source_scenario_id": "planner_sanity_simple",
+    }
+    assert payload["generator_id"] == "create_counterfactual_scenario_pair"
+    assert payload["validator_version"] == "counterfactual_scenario_pair_validator.v1"
+    assert payload["evidence_tier"] == "diagnostic-only"
+    assert payload["denominator_policy"] == "counterfactual_pairs_not_benchmark_denominator"
+    assert payload["execution_gate"] == "preflight_success_required_before_execution"
+    assert validate_lineage_contract(payload) == []
     assert payload["changed_factor"] == "robot_route_offset"
     assert (
         payload["claim_boundary"] == "candidate mechanism-test inputs only; not benchmark evidence"


### PR DESCRIPTION
## Summary
Adds a shared manifest lineage contract and wires its mandatory fields into `scenario_prior.v1`, `adversarial_scenario_manifest.v1`, and `counterfactual_scenario_pair.v1`.

This is schema/reviewability work only; it does not promote any artifact to benchmark or paper-facing evidence.

## Linked Issues
- Closes `#2659`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf.benchmark.manifest_lineage` with the shared required lineage/evidence-boundary fields and validation helpers.
- Updated adversarial manifests and counterfactual pair manifests to emit top-level `source`, `generator_id`, `validator_version`, `schema_version`, `claim_boundary`, `evidence_tier`, `denominator_policy`, and `execution_gate`.
- Updated the tracked scenario-prior smoke fixture and accepted LLM-manifest fixture with the shared lineage fields.
- Added fixture-backed coverage for all three affected manifest families.
- Added a context note plus context index/README links describing mandatory fields and compatibility boundaries.

## Why It Matters
- Added value: gives downstream reviewers and tools one common place to check provenance, evidence tier, denominator policy, and execution gates across these manifest families.
- Expected impact: reduces schema drift before execution or benchmark interpretation.
- Why this is worth merging now: it closes the lineage-field gap without changing benchmark claims or requiring new experiments.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker for consistent provenance/evidence-boundary review across scenario prior, adversarial, and counterfactual manifest families.
- Comparator or baseline, if applicable: prior manifests had family-specific or missing top-level lineage fields.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: stop when shared helper exists, all three families validate the required fields, and docs state the schema-only boundary.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2659_lineage_schema_unification.md`, `docs/context/INDEX.md`, `docs/context/README.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; the helper validates schema presence/types and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - schema/support PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA - no benchmark claim.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for this schema slice.
- Stop / revise / continue decision: stop for #2659 schema contract; future downstream claims still require executable evidence.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/adversarial/test_adversarial_scenario_manifest.py tests/tools/test_create_counterfactual_scenario_pair.py tests/research/test_issue_2523_scenario_prior_smoke.py -q`
  - `rtk uv run ruff check robot_sf/benchmark/manifest_lineage.py robot_sf/adversarial/scenario_manifest.py scripts/tools/create_counterfactual_scenario_pair.py tests/adversarial/test_adversarial_scenario_manifest.py tests/tools/test_create_counterfactual_scenario_pair.py tests/research/test_issue_2523_scenario_prior_smoke.py`
  - `rtk uv run ruff format --check robot_sf/benchmark/manifest_lineage.py robot_sf/adversarial/scenario_manifest.py scripts/tools/create_counterfactual_scenario_pair.py tests/adversarial/test_adversarial_scenario_manifest.py tests/tools/test_create_counterfactual_scenario_pair.py tests/research/test_issue_2523_scenario_prior_smoke.py`
  - `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
  - `rtk git diff --check`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted suite passed `52 passed`; full readiness passed with `5676 passed, 9 skipped`; readiness reported `ok: true` for head `9cce1cf52c7737210e8b3956bed1313975678f00`.
- Benchmarks or smoke tests, if applicable: fixture-backed schema smoke tests only; no benchmark run because this PR makes no benchmark result claim.

## Risks / Rollout
- Compatibility risks: `validate_manifest_payload` now treats missing shared lineage fields as invalid for adversarial manifest payload validation; serialization remains additive for consumers that read older family-specific fields.
- Failure modes: older hand-written manifests may need the new top-level fields before passing the validator.
- Rollback or fallback plan: revert the helper wiring and fixture updates, or relax validation if a legacy migration path is needed.

## Docs / Provenance
- Updated docs: `docs/context/issue_2659_lineage_schema_unification.md`, `docs/context/INDEX.md`, `docs/context/README.md`.
- Relevant design or provenance notes: the new note states mandatory fields before execution and preserves the schema-only boundary.
- Any assumptions that need to be preserved: downstream benchmark claims still require executable evidence, denominator review, and fail-closed handling.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR will close #2659.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context index and README updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is schema/reviewability support, not benchmark or paper-facing evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the new adversarial validator fail-closed behavior for missing lineage fields is the desired migration stance.
- Any known limitations: helper checks required fields and basic types only; it does not prove executability or evidence quality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing unified manifest lineage schema
  * Updated context index with new issue references

* **New Features**
  * Introduced shared lineage validation framework across scenario manifests
  * Extended scenario artifacts with standardized metadata for evidence tracking, validator versions, and execution gates

* **Tests**
  * Added validation tests for manifest lineage contract compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->