### PR TITLE
feat: define signal-state promotion contract

### DIFF
--- a/configs/benchmarks/signalized_pedestrian_crossing_issue_2474.yaml
+++ b/configs/benchmarks/signalized_pedestrian_crossing_issue_2474.yaml
@@ -81,6 +81,49 @@ signal_phase_semantics:
     hidden, or only encoded through pedestrian motion. Mixed visibility modes must not be
     aggregated without an explicit observation-track caveat.
 
+signal_state_promotion_contract:
+  states:
+    proxy_diagnostic:
+      planner_consumed_fields: []
+      recorded_only_fields:
+        - schema_version
+        - status
+        - signal_id
+        - conflict_zone_id
+        - phase
+        - intent_phase
+        - robot_right_of_way
+        - pedestrian_right_of_way
+        - legality_state
+        - planner_observable
+        - observation_mode
+        - benchmark_evidence
+        - claim_boundary
+      fail_closed_reason: >
+        Proxy or synthetic signal-state metadata is trace/report metadata only and must not be
+        interpreted as planner-observable traffic-light semantics or benchmark evidence.
+    planner_observable:
+      required_schema_version: signal-state-observable.v1
+      required_status: planner_observable_signal_state
+      required_observation_mode: planner_observable
+      required_benchmark_evidence: true
+      planner_consumed_fields:
+        - signal_id
+        - conflict_zone_id
+        - phase
+        - phase_elapsed_s
+        - phase_remaining_s
+        - robot_right_of_way
+        - pedestrian_right_of_way
+        - legality_state
+    unavailable:
+      planner_consumed_fields: []
+      fail_closed_reason: signal_state_metadata_absent
+  denominator_policy: >
+    Only planner_observable rows with explicit schema/status/observation-mode fields may enter
+    signalized-crossing benchmark denominators. Proxy_diagnostic and unavailable rows are excluded
+    or reported as not_available under the fallback policy.
+
 required_metrics:
   existing_metrics:
     - success

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -77,6 +77,11 @@ records the predeclared broader 3x3 slice after the selected active-row Issue #2
 supports `broader_delayed_rescue_supported` for the only unsolved active row, not benchmark-candidate
 or paper-facing proof.
 
+Recent signal-state promotion contract: [issue_2662_signal_state_promotion_contract.md](issue_2662_signal_state_promotion_contract.md)
+records the fail-closed distinction between `proxy_diagnostic`, `planner_observable`, and
+`unavailable` signal-state rows for future signalized-crossing benchmarks; it is schema/trace
+contract work only, not benchmark evidence.
+
 ## Context-Pack Manifests
 
 Generated packs are temporary artifacts and should stay under ignored paths such as

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -248,6 +248,8 @@ knowledge, not every transient iteration detail.
   [issue_2527_waiting_crossing_fixture.md](issue_2527_waiting_crossing_fixture.md)
 * Issue #2564 Signal-State Proxy Smoke:
   [issue_2564_signal_state_proxy_smoke.md](issue_2564_signal_state_proxy_smoke.md)
+* Issue #2662 Signal-State Promotion Contract:
+  [issue_2662_signal_state_promotion_contract.md](issue_2662_signal_state_promotion_contract.md)
 * Issue #2473 Cyclist Interaction Benchmark Scope:
   [issue_2473_cyclist_interaction_benchmark.md](issue_2473_cyclist_interaction_benchmark.md)
 * Issue #2459 SocNavBench / HuNavSim Mapping:
@@ -681,6 +683,8 @@ knowledge, not every transient iteration detail.
   [artifact](evidence/issue_2523_scenario_prior_smoke/scenario_prior.v1.json))
 * Issue #2474 Signalized Pedestrian Crossing Benchmark Scope (2026-06-06):
   [issue_2474_signalized_crossing_benchmark.md](issue_2474_signalized_crossing_benchmark.md)
+* Issue #2662 Signal-State Promotion Contract (2026-06-12):
+  [issue_2662_signal_state_promotion_contract.md](issue_2662_signal_state_promotion_contract.md)
 * Issue #2475 Probabilistic Prediction Interface (2026-06-06):
   [issue_2475_probabilistic_prediction_interface.md](issue_2475_probabilistic_prediction_interface.md)
 * Issue #1638 local model path preflight:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -717,6 +717,10 @@ entries:
     status: proposal
     freshness: maintained
     area: benchmark_evidence
+  - path: docs/context/issue_2662_signal_state_promotion_contract.md
+    status: current
+    freshness: maintained
+    area: benchmark_evidence
   - path: docs/context/issue_2475_probabilistic_prediction_interface.md
     status: current
     freshness: dated

--- a/docs/context/issue_2662_signal_state_promotion_contract.md
+++ b/docs/context/issue_2662_signal_state_promotion_contract.md
@@ -1,0 +1,62 @@
+# Issue #2662 Signal-State Promotion Contract
+
+Issue: #2662
+
+Status: current schema/trace promotion contract; not benchmark evidence.
+
+Related surfaces:
+
+- Signalized crossing scope: [issue_2474_signalized_crossing_benchmark.md](issue_2474_signalized_crossing_benchmark.md)
+- Signal-state proxy smoke: [issue_2564_signal_state_proxy_smoke.md](issue_2564_signal_state_proxy_smoke.md)
+- Waiting/crossing fixture: [issue_2527_waiting_crossing_fixture.md](issue_2527_waiting_crossing_fixture.md)
+- Benchmark manifest: `configs/benchmarks/signalized_pedestrian_crossing_issue_2474.yaml`
+- Trace implementation: `robot_sf/benchmark/map_runner.py`
+- Contract tests:
+  `tests/benchmark/test_signalized_crossing_benchmark_manifest.py` and
+  `tests/benchmark/test_issue_2527_waiting_crossing_fixture.py`
+
+## Contract States
+
+`proxy_diagnostic` means signal metadata is recorded for trace/report inspection only. These fields
+may include signal phase labels, right-of-way flags, intent phase, observation mode, and claim
+boundary, but `planner_consumed_fields` must remain empty. Proxy rows cannot enter
+signalized-crossing benchmark denominators and must not be described as traffic-light semantics.
+
+`planner_observable` is reserved for a future explicit runtime contract. A row must declare
+`signal-state-observable.v1`, `planner_observable_signal_state`, `planner_observable` observation
+mode, and `benchmark_evidence: true` before signal fields can be treated as consumed by a planner.
+
+`unavailable` means signal-state metadata is absent. It fails closed with
+`signal_state_metadata_absent` and contributes no planner-consumed or benchmark-evidence signal
+fields.
+
+## Promotion Requirements
+
+A future signalized-crossing benchmark row must provide explicit signal runtime fields for:
+
+- signal and conflict-zone identity;
+- phase, elapsed time, and remaining time;
+- robot and pedestrian right-of-way;
+- legality state;
+- planner observation mode;
+- denominator policy for observable, hidden, or motion-only signal tracks.
+
+Until those fields are present through the observable contract, the existing proxy smoke remains
+diagnostic-only evidence for scenario/trace plumbing.
+
+## Validation
+
+Targeted validation:
+
+```bash
+uv run pytest tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py -q
+uv run ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py
+uv run ruff format --check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py
+uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml
+git diff --check
+```
+
+## Boundary
+
+This contract is schema and reportability work only. It does not prove signal-legality behavior,
+planner forced-waiting reasoning, traffic-signal realism, or planner performance.

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3115,6 +3115,86 @@ _PROXY_TRACE_FIELDS_PRESENT = [
     "signal_state",
 ]
 
+_SIGNAL_STATE_OBSERVABLE_SCHEMA = "signal-state-observable.v1"
+_SIGNAL_STATE_OBSERVABLE_STATUS = "planner_observable_signal_state"
+_SIGNAL_STATE_OBSERVABLE_MODE = "planner_observable"
+_SIGNAL_STATE_OBSERVABLE_FIELDS = [
+    "signal_id",
+    "conflict_zone_id",
+    "phase",
+    "phase_elapsed_s",
+    "phase_remaining_s",
+    "robot_right_of_way",
+    "pedestrian_right_of_way",
+    "legality_state",
+]
+_SIGNAL_STATE_RECORDED_ONLY_FIELDS = [
+    "schema_version",
+    "status",
+    "signal_id",
+    "conflict_zone_id",
+    "phase",
+    "intent_phase",
+    "robot_right_of_way",
+    "pedestrian_right_of_way",
+    "legality_state",
+    "planner_observable",
+    "observation_mode",
+    "benchmark_evidence",
+    "claim_boundary",
+]
+
+
+def _signal_state_promotion_contract(signal_state: Any) -> dict[str, Any]:
+    """Classify signal-state metadata for benchmark promotion decisions.
+
+    Returns:
+        dict[str, Any]: Contract state plus planner-consumed and recorded-only fields.
+    """
+    if not isinstance(signal_state, dict):
+        return {
+            "contract_state": "unavailable",
+            "planner_consumed_fields": [],
+            "recorded_only_fields": [],
+            "promotion_required_fields": list(_SIGNAL_STATE_OBSERVABLE_FIELDS),
+            "fail_closed_reason": "signal_state_metadata_absent",
+            "benchmark_evidence": False,
+        }
+
+    schema_version = str(signal_state.get("schema_version") or "")
+    status = str(signal_state.get("status") or "")
+    observation_mode = str(signal_state.get("observation_mode") or "")
+    planner_observable = bool(signal_state.get("planner_observable", False))
+    benchmark_evidence = bool(signal_state.get("benchmark_evidence", False))
+    is_observable = (
+        schema_version == _SIGNAL_STATE_OBSERVABLE_SCHEMA
+        and status == _SIGNAL_STATE_OBSERVABLE_STATUS
+        and observation_mode == _SIGNAL_STATE_OBSERVABLE_MODE
+        and planner_observable
+        and benchmark_evidence
+    )
+    if is_observable:
+        return {
+            "contract_state": "planner_observable",
+            "planner_consumed_fields": list(_SIGNAL_STATE_OBSERVABLE_FIELDS),
+            "recorded_only_fields": [],
+            "promotion_required_fields": [],
+            "fail_closed_reason": "",
+            "benchmark_evidence": True,
+        }
+
+    return {
+        "contract_state": "proxy_diagnostic",
+        "planner_consumed_fields": [],
+        "recorded_only_fields": list(_SIGNAL_STATE_RECORDED_ONLY_FIELDS),
+        "promotion_required_fields": list(_SIGNAL_STATE_OBSERVABLE_FIELDS),
+        "fail_closed_reason": (
+            "signal_state_proxy_or_synthetic_not_planner_observable; "
+            "do_not_count_as_signalized_benchmark_evidence"
+        ),
+        "benchmark_evidence": False,
+    }
+
 
 def _synth_robot_stop_or_yield_expectation(
     robot_right_of_way: bool,
@@ -3168,6 +3248,7 @@ def _signal_state_proxy_wrapper(
     )
     return {
         **base,
+        **_signal_state_promotion_contract(signal_state),
         "signal_phase": base["phase"],
         "pedestrian_intent": pedestrian_intent,
         "robot_stop_or_yield_expectation": robot_stop_or_yield_expectation,

--- a/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
@@ -9,6 +9,7 @@ import yaml
 
 from robot_sf.benchmark.map_runner import (
     _intent_conditioned_behavior_summary,
+    _signal_state_promotion_contract,
     _signal_state_proxy_wrapper,
     _single_pedestrian_intent_metadata,
     _trace_pedestrians,
@@ -166,6 +167,12 @@ def test_signal_state_proxy_wrapper_exposes_bounded_diagnostic_fields() -> None:
         assert "robot_stop_or_yield_expectation" in proxy
         assert "trace_fields_present" in proxy
         assert proxy["claim_boundary"] == "proxy_diagnostic"
+        assert proxy["contract_state"] == "proxy_diagnostic"
+        assert proxy["planner_consumed_fields"] == []
+        assert "phase" in proxy["recorded_only_fields"]
+        assert "phase_remaining_s" in proxy["promotion_required_fields"]
+        assert proxy["benchmark_evidence"] is False
+        assert "do_not_count_as_signalized_benchmark_evidence" in proxy["fail_closed_reason"]
         assert "intent_label" in proxy["pedestrian_intent"]
         assert "intent_phase" in proxy["pedestrian_intent"]
         assert "intent_source" in proxy["pedestrian_intent"]
@@ -180,6 +187,55 @@ def test_signal_state_proxy_wrapper_exposes_bounded_diagnostic_fields() -> None:
 
     assert "signal_state" in waiting_proxy["trace_fields_present"]
     assert "pedestrian_intent" in waiting_proxy["trace_fields_present"]
+
+
+def test_signal_state_contract_fails_closed_when_unavailable() -> None:
+    """Absent signal semantics are unavailable and cannot enter benchmark denominators."""
+    contract = _signal_state_promotion_contract(None)
+
+    assert contract["contract_state"] == "unavailable"
+    assert contract["planner_consumed_fields"] == []
+    assert contract["recorded_only_fields"] == []
+    assert "phase_remaining_s" in contract["promotion_required_fields"]
+    assert contract["fail_closed_reason"] == "signal_state_metadata_absent"
+    assert contract["benchmark_evidence"] is False
+
+
+def test_proxy_signal_state_cannot_be_interpreted_as_planner_observable() -> None:
+    """Proxy fields remain recorded-only even if a fixture accidentally sets visibility flags."""
+    scenario = _scenario_payload()
+    spoofed_proxy = dict(scenario["metadata"]["signal_state"])
+    spoofed_proxy["planner_observable"] = True
+    spoofed_proxy["benchmark_evidence"] = True
+    spoofed_proxy["observation_mode"] = "planner_observable"
+
+    contract = _signal_state_promotion_contract(spoofed_proxy)
+
+    assert contract["contract_state"] == "proxy_diagnostic"
+    assert contract["planner_consumed_fields"] == []
+    assert "phase" in contract["recorded_only_fields"]
+    assert "phase_remaining_s" in contract["promotion_required_fields"]
+    assert contract["benchmark_evidence"] is False
+
+
+def test_explicit_observable_signal_state_names_planner_consumed_fields() -> None:
+    """Only the explicit observable schema/status can promote signal fields to planner inputs."""
+    contract = _signal_state_promotion_contract(
+        {
+            "schema_version": "signal-state-observable.v1",
+            "status": "planner_observable_signal_state",
+            "observation_mode": "planner_observable",
+            "planner_observable": True,
+            "benchmark_evidence": True,
+        }
+    )
+
+    assert contract["contract_state"] == "planner_observable"
+    assert "phase_remaining_s" in contract["planner_consumed_fields"]
+    assert contract["recorded_only_fields"] == []
+    assert contract["promotion_required_fields"] == []
+    assert contract["fail_closed_reason"] == ""
+    assert contract["benchmark_evidence"] is True
 
 
 def test_intent_summary_handles_missing_or_empty_intent_phases() -> None:

--- a/tests/benchmark/test_signalized_crossing_benchmark_manifest.py
+++ b/tests/benchmark/test_signalized_crossing_benchmark_manifest.py
@@ -59,6 +59,33 @@ def test_signal_phase_contract_lists_future_fields_and_current_proxy_fields() ->
     assert "planner-observable" in phase["planner_observable_policy"]
 
 
+def test_signal_state_promotion_contract_separates_proxy_observable_and_unavailable() -> None:
+    """Signal-state rows need explicit promotion before entering benchmark evidence."""
+    manifest = _manifest()
+    contract = manifest["signal_state_promotion_contract"]
+    assert isinstance(contract, dict)
+    states = contract["states"]
+    assert isinstance(states, dict)
+
+    proxy = states["proxy_diagnostic"]
+    observable = states["planner_observable"]
+    unavailable = states["unavailable"]
+
+    assert proxy["planner_consumed_fields"] == []
+    assert "phase" in proxy["recorded_only_fields"]
+    assert "traffic-light semantics" in proxy["fail_closed_reason"]
+
+    assert observable["required_schema_version"] == "signal-state-observable.v1"
+    assert observable["required_status"] == "planner_observable_signal_state"
+    assert observable["required_observation_mode"] == "planner_observable"
+    assert observable["required_benchmark_evidence"] is True
+    assert "phase_remaining_s" in observable["planner_consumed_fields"]
+
+    assert unavailable["planner_consumed_fields"] == []
+    assert unavailable["fail_closed_reason"] == "signal_state_metadata_absent"
+    assert "Proxy_diagnostic and unavailable rows are excluded" in contract["denominator_policy"]
+
+
 def test_required_metrics_and_trace_fields_cover_signal_specific_contract() -> None:
     """The benchmark direction should specify existing and signal-specific evidence fields."""
     manifest = _manifest()


### PR DESCRIPTION
## Summary
Defines an explicit signal-state promotion contract so proxy diagnostics, planner-observable signal state, and unavailable signal semantics are represented separately in benchmark traces and config/docs.

This closes the evidence-boundary gap from #2662: proxy waiting/crossing diagnostics remain recorded-only and cannot be counted as observable traffic-light benchmark evidence.

## Linked Issues
- Closes `#2662`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `_signal_state_promotion_contract` in `robot_sf/benchmark/map_runner.py`.
- Extended the signalized pedestrian crossing benchmark config with proxy, observable, and unavailable signal-state semantics.
- Added targeted tests proving proxy fields are recorded-only and cannot be interpreted as planner-observable traffic-light state.
- Added a context note and indexed it in `docs/context/`.

## Why It Matters
- Added value: makes the signalized-crossing evidence boundary explicit and testable.
- Expected impact: future signalized benchmark work has a clear promotion gate instead of reusing proxy diagnostics as if they were observable signal semantics.
- Why this is worth merging now: it prevents metric/report confusion before the next signalized-crossing benchmark promotion step.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker that proxy signal diagnostics could be mistaken for planner-observable signalized-crossing evidence.
- Comparator or baseline, if applicable: prior traces/config recorded signal-related proxy fields without an explicit proxy/observable/unavailable contract.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: proxy or unavailable signal state has `benchmark_evidence: false` and empty `planner_consumed_fields`; only the explicit observable schema/status/mode can set `benchmark_evidence: true`.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2662_signal_state_promotion_contract.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this adds contract wiring and tests, not a new analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? no, this is schema/config/test/docs contract work.
- Did the scenario actually contain the targeted failure mode? yes, the existing proxy wrapper emits waiting/crossing diagnostics that could otherwise be over-interpreted.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: future observable signalized-crossing benchmark work must provide native signal semantics before rows count as benchmark evidence.

## Next Empirical Action
- Rerun needed: no for this contract PR.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: real planner-observable traffic-light/signal-state source remains future work.
- Stop / revise / continue decision: continue only after a benchmark can emit explicit observable signal-state metadata.
- Proposed child issue or existing follow-up: none opened from this PR; #2662 captures this contract boundary.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py -q`
  - `rtk uv run ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py`
  - `rtk uv run ruff format --check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py`
  - `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
  - `rtk git diff --check`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted benchmark tests passed with `14 passed`; full PR readiness passed with `5680 passed, 9 skipped` at `f740e274c5d50c17294922277242176c2b1be652`.
- Benchmarks or smoke tests, if applicable: targeted benchmark smoke tests for the signal-state promotion contract.

## Risks / Rollout
- Compatibility risks: low; existing proxy payload fields are preserved and augmented with explicit contract metadata.
- Failure modes: future code must not set the observable schema/status/mode unless planner-observable signal semantics are truly available.
- Rollback or fallback plan: revert the contract helper/config/docs/tests and return to the previous recorded-only proxy wrapper behavior.

## Docs / Provenance
- Updated docs: `docs/context/issue_2662_signal_state_promotion_contract.md`, `docs/context/INDEX.md`, `docs/context/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: the context note records promotion requirements and the evidence boundary.
- Any assumptions that need to be preserved: proxy diagnostics are useful diagnostics, not signalized-crossing benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2662.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result claim changed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA, no leaderboard or durable benchmark artifact changed.
- Registry or config index updated (yes/no/NA): yes, benchmark config updated in place.
- Context index / memory note updated (yes/no/NA): yes, context catalog/index/README updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR defines the prerequisite contract; it does not produce observable signalized-crossing benchmark evidence.

## Follow-Up Issues
- Deferred work: implement a real planner-observable signal-state source before counting signalized-crossing evidence.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify closely that `proxy_diagnostic` and `unavailable` states both fail closed with `benchmark_evidence: false`.
- Known limitation: the observable schema path is intentionally strict and is not exercised by a live signalized-crossing environment yet.
