### PR TITLE
fix: preserve zero trace predicate groups

### DIFF
--- a/docs/context/issue_2667_trace_failure_predicate_tables.md
+++ b/docs/context/issue_2667_trace_failure_predicate_tables.md
@@ -42,16 +42,27 @@ evasive reaction, oscillatory local control, and zero-motion timeout behavior.
 ## Denominators
 
 Each aggregate row reports `trace_denominator` for its
-`scenario_family` / `planner_id` / `seed` group. The predicate rows in this run are all from
-`crossing_proxy` / `orca` / seed `111`, so their row-level denominator is `1`. The two #2428 traces
-are included in `input_trace_count` as negative durable inputs, but they do not appear as row-level
-denominators because the current table only renders groups with observed predicates.
+`scenario_family` / `planner_id` / `seed` / trace-source group. The predicate rows in this run are
+all from `crossing_proxy` / `orca` / seed `111`, so their row-level denominator is `1`.
+
+Issue #2687 tightened future table generation so JSON and Markdown outputs also preserve
+`zero_predicate_groups` when a trace group has zero valid predicates. This separates:
+
+- a true zero valid-predicate group;
+- a `not_available` predicate row caused by missing evidence fields;
+- a trace absent from the input set;
+- excluded, fallback, or degraded runs that should not enter the denominator.
+
+The original #2667 evidence bundle remains diagnostic-only and was not regenerated as a new
+benchmark result.
 
 ## Interpretation
 
 This is diagnostic-only evidence. It proves the table-generation path can consume versioned
 `simulation_trace_export.v1` inputs, preserve denominator fields, and carry a fail-closed
-`not_available` predicate row into JSON/Markdown outputs.
+`not_available` predicate row into JSON/Markdown outputs. After #2687, future table outputs also
+make zero valid-predicate groups explicit, but rate claims still require a predeclared benchmark
+matrix.
 
 It does not establish predicate rates, planner rankings, AMMV benefit, benchmark outcomes,
 paper-facing mechanism frequencies, or safety claims. A future predeclared benchmark matrix should

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -97,12 +97,17 @@ def aggregate_trace_failure_predicate_tables(
     """
     grouped_predicates: Counter[tuple[str, str, int, str, str, str]] = Counter()
     trace_denominators: Counter[tuple[str, str, int]] = Counter()
+    trace_sources_by_group: dict[tuple[str, str, int], set[str]] = defaultdict(set)
+    trace_status_counts: dict[tuple[str, str, int, str], Counter[str]] = defaultdict(Counter)
     included_trace_count = 0
 
     for trace in traces:
         group_family = scenario_family or trace.source.scenario_id
+        trace_source_id = trace.trace_id
         group_key = (group_family, trace.source.planner_id, int(trace.source.seed))
+        trace_key = (*group_key, trace_source_id)
         trace_denominators[group_key] += 1
+        trace_sources_by_group[group_key].add(trace_source_id)
         included_trace_count += 1
         for predicate in _extract_trace_failure_predicate_records(
             trace,
@@ -124,12 +129,14 @@ def aggregate_trace_failure_predicate_tables(
                     predicate.severity,
                 )
             ] += 1
+            trace_status_counts[trace_key][predicate.validity_status] += 1
 
     rows = [
         {
             "scenario_family": family,
             "planner_id": planner_id,
             "seed": seed,
+            "trace_source_ids": sorted(trace_sources_by_group[(family, planner_id, seed)]),
             "predicate_id": predicate_id,
             "validity_status": validity_status,
             "severity": severity,
@@ -147,6 +154,60 @@ def aggregate_trace_failure_predicate_tables(
         ), count in sorted(grouped_predicates.items())
     ]
 
+    observed_group_keys = {
+        (family, planner_id, seed)
+        for (
+            family,
+            planner_id,
+            seed,
+            _predicate_id,
+            _validity_status,
+            _severity,
+        ) in grouped_predicates
+    }
+    for group_key in sorted(trace_denominators):
+        if group_key in observed_group_keys:
+            continue
+        family, planner_id, seed = group_key
+        rows.append(
+            {
+                "scenario_family": family,
+                "planner_id": planner_id,
+                "seed": seed,
+                "trace_source_ids": sorted(trace_sources_by_group[group_key]),
+                "predicate_id": "no_predicate_observed",
+                "validity_status": "no_predicate_observed",
+                "severity": "no_predicate_observed",
+                "predicate_count": 0,
+                "trace_denominator": trace_denominators[group_key],
+                "predicate_rate_per_trace": 0.0,
+            }
+        )
+
+    zero_predicate_groups = [
+        {
+            "scenario_family": family,
+            "planner_id": planner_id,
+            "seed": seed,
+            "trace_source_id": trace_source_id,
+            "trace_denominator": trace_denominators[group_key],
+            "valid_predicate_count": int(trace_status_counts[trace_key].get("valid", 0)),
+            "not_available_predicate_count": int(
+                trace_status_counts[trace_key].get("not_available", 0)
+            ),
+            "zero_group_reason": (
+                "no_predicate_observed"
+                if not trace_status_counts[trace_key]
+                else "valid_predicate_count_zero"
+            ),
+        }
+        for group_key, trace_sources in sorted(trace_sources_by_group.items())
+        for family, planner_id, seed in (group_key,)
+        for trace_source_id in sorted(trace_sources)
+        for trace_key in ((*group_key, trace_source_id),)
+        if trace_status_counts[trace_key].get("valid", 0) == 0
+    ]
+
     return {
         "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
         "table_kind": "aggregate_by_predicate_group",
@@ -156,10 +217,13 @@ def aggregate_trace_failure_predicate_tables(
             "row_count": len(rows),
         },
         "rows": rows,
+        "zero_predicate_groups": zero_predicate_groups,
         "caveats": [
             "Aggregate predicate rows are diagnostic summaries, not benchmark rates or claims.",
             "Rows include `not_available` and other valid status values when evidence is partial.",
-            "Do not treat these as benchmark outcomes unless tied to a predeclared benchmark matrix.",
+            "`zero_predicate_groups` preserves trace groups with valid predicate count equal to zero.",
+            "Rows with `no_predicate_observed` mark trace groups that had no predicate rows at all.",
+            "Rate claims require a predeclared benchmark matrix; do not infer rates from these diagnostic rows.",
         ],
     }
 
@@ -194,37 +258,79 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
         lines.append("No predicate rows were observed in the provided traces.")
         return "\n".join(lines).rstrip() + "\n"
 
+    zero_groups = table_payload.get("zero_predicate_groups")
+    if not isinstance(zero_groups, list):
+        zero_groups = []
+    zero_group_rows = [row for row in zero_groups if isinstance(row, Mapping)]
+    observed_rows = [
+        row for row in table_rows if row.get("predicate_id") != "no_predicate_observed"
+    ]
+
     lines.append("## Aggregate Rows")
     lines.append("")
-    lines.append(
-        _markdown_table(
-            (
-                "scenario_family",
-                "planner_id",
-                "seed",
-                "predicate_id",
-                "validity_status",
-                "severity",
-                "predicate_count",
-                "trace_denominator",
-                "predicate_rate_per_trace",
-            ),
-            [
+    if observed_rows:
+        lines.append(
+            _markdown_table(
                 (
-                    _markdown_value(row.get("scenario_family")),
-                    _markdown_value(row.get("planner_id")),
-                    _markdown_value(row.get("seed")),
-                    _markdown_value(row.get("predicate_id")),
-                    _markdown_value(row.get("validity_status")),
-                    _markdown_value(row.get("severity")),
-                    _markdown_int(row.get("predicate_count")),
-                    _markdown_int(row.get("trace_denominator")),
-                    f"{_markdown_float(row.get('predicate_rate_per_trace')):.4f}",
-                )
-                for row in table_rows
-            ],
+                    "scenario_family",
+                    "planner_id",
+                    "seed",
+                    "trace_source_ids",
+                    "predicate_id",
+                    "validity_status",
+                    "severity",
+                    "predicate_count",
+                    "trace_denominator",
+                    "predicate_rate_per_trace",
+                ),
+                [
+                    (
+                        _markdown_value(row.get("scenario_family")),
+                        _markdown_value(row.get("planner_id")),
+                        _markdown_value(row.get("seed")),
+                        _markdown_value(row.get("trace_source_ids")),
+                        _markdown_value(row.get("predicate_id")),
+                        _markdown_value(row.get("validity_status")),
+                        _markdown_value(row.get("severity")),
+                        _markdown_int(row.get("predicate_count")),
+                        _markdown_int(row.get("trace_denominator")),
+                        f"{_markdown_float(row.get('predicate_rate_per_trace')):.4f}",
+                    )
+                    for row in observed_rows
+                ],
+            )
         )
-    )
+    if zero_group_rows:
+        lines.append("")
+        lines.append("### Trace Groups With Zero Valid Predicates")
+        lines.append("")
+        lines.append(
+            _markdown_table(
+                (
+                    "scenario_family",
+                    "planner_id",
+                    "seed",
+                    "trace_source_id",
+                    "trace_denominator",
+                    "valid_predicate_count",
+                    "not_available_predicate_count",
+                    "zero_group_reason",
+                ),
+                [
+                    (
+                        _markdown_value(row.get("scenario_family")),
+                        _markdown_value(row.get("planner_id")),
+                        _markdown_value(row.get("seed")),
+                        _markdown_value(row.get("trace_source_id")),
+                        _markdown_int(row.get("trace_denominator")),
+                        _markdown_int(row.get("valid_predicate_count")),
+                        _markdown_int(row.get("not_available_predicate_count")),
+                        _markdown_value(row.get("zero_group_reason")),
+                    )
+                    for row in zero_group_rows
+                ],
+            )
+        )
     lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -253,6 +253,7 @@ def test_denominator_and_markdown_render_include_rate_fields() -> None:
     )
 
     assert row is not None
+    assert row["trace_source_ids"] == ["trace-denom-0", "trace-denom-1"]
     assert row["trace_denominator"] == 2
     assert row["predicate_count"] == 2
     assert row["predicate_rate_per_trace"] == 1.0
@@ -356,5 +357,5 @@ def test_markdown_renderer_skips_invalid_rows_and_preserves_falsy_values() -> No
         }
     )
 
-    assert "| 0 |  | 0 | zero_like | valid | low | 0 | 1 | 0.0000 |" in markdown
+    assert "| 0 |  | 0 |  | zero_like | valid | low | 0 | 1 | 0.0000 |" in markdown
     assert "bad-row" not in markdown

--- a/tests/validation/test_trace_failure_predicates.py
+++ b/tests/validation/test_trace_failure_predicates.py
@@ -10,7 +10,9 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
 )
 from robot_sf.analysis_workbench.trace_failure_predicates import (
     TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
+    aggregate_trace_failure_predicate_tables,
     extract_trace_failure_predicates,
+    render_trace_failure_predicate_markdown,
 )
 
 
@@ -169,3 +171,152 @@ def test_event_and_action_predicates_cover_remaining_contract_ids() -> None:
     assert predicates["late_evasive_reaction"]["evidence_fields"]["reaction_delay_steps"] == 1
     assert predicates["bottleneck_deadlock"]["validity_status"] == "valid"
     assert predicates["bottleneck_deadlock"]["evidence_fields"]["event"] == "bottleneck_deadlock"
+
+
+def _clean_trace(
+    planner: dict[str, Any] | None = None,
+    *,
+    scenario_id: str = "open_field",
+    seed: int = 999,
+    planner_id: str = "dwa",
+) -> SimulationTraceExport:
+    """Build a trace with no close pedestrians, producing zero predicates."""
+    default_planner: dict[str, Any] = {
+        "selected_action": {"linear_velocity": 0.5, "angular_velocity": 0.0}
+    }
+    default_planner.update(planner or {})
+    return simulation_trace_export_from_dict(
+        {
+            "schema_version": "simulation_trace_export.v1",
+            "trace_id": f"clean-{scenario_id}-{planner_id}-{seed}",
+            "source": {
+                "scenario_id": scenario_id,
+                "seed": seed,
+                "planner_id": planner_id,
+                "episode_id": "episode-clean",
+                "generated_by": "test",
+            },
+            "evidence_boundary": "analysis_workbench_only",
+            "coordinate_frame": "world",
+            "units": {
+                "position": "m",
+                "heading": "rad",
+                "time": "s",
+                "velocity": "m/s",
+            },
+            "frames": [
+                {
+                    "step": 0,
+                    "time_s": 0.0,
+                    "robot": {"position": [0.0, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                    "pedestrians": [
+                        {"id": "ped-distant", "position": [10.0, 10.0], "velocity": [0.0, 0.0]}
+                    ],
+                    "planner": default_planner,
+                },
+                {
+                    "step": 1,
+                    "time_s": 1.0,
+                    "robot": {"position": [0.5, 0.0], "heading": 0.0, "velocity": [0.5, 0.0]},
+                    "pedestrians": [
+                        {"id": "ped-distant", "position": [10.5, 10.0], "velocity": [0.0, 0.0]}
+                    ],
+                    "planner": default_planner,
+                },
+            ],
+        }
+    )
+
+
+def test_zero_predicate_group_preserved_in_aggregate() -> None:
+    """A trace with no observed predicates should emit a no_predicate_observed row."""
+    clean = _clean_trace()
+    payload = aggregate_trace_failure_predicate_tables([clean], scenario_family="open_field")
+    zero_rows = [r for r in payload["rows"] if r["predicate_id"] == "no_predicate_observed"]
+    assert len(zero_rows) == 1
+    row = zero_rows[0]
+    assert row["scenario_family"] == "open_field"
+    assert row["planner_id"] == "dwa"
+    assert row["seed"] == 999
+    assert row["trace_source_ids"] == ["clean-open_field-dwa-999"]
+    assert row["predicate_count"] == 0
+    assert row["trace_denominator"] == 1
+    assert row["predicate_rate_per_trace"] == 0.0
+    assert payload["zero_predicate_groups"] == [
+        {
+            "scenario_family": "open_field",
+            "planner_id": "dwa",
+            "seed": 999,
+            "trace_source_id": "clean-open_field-dwa-999",
+            "trace_denominator": 1,
+            "valid_predicate_count": 0,
+            "not_available_predicate_count": 0,
+            "zero_group_reason": "no_predicate_observed",
+        }
+    ]
+
+
+def test_zero_predicate_group_rendered_in_markdown() -> None:
+    """Markdown output should expose zero-predicate trace groups separately."""
+    clean = _clean_trace()
+    payload = aggregate_trace_failure_predicate_tables([clean], scenario_family="open_field")
+    md = render_trace_failure_predicate_markdown(payload)
+    assert "Trace Groups With Zero Valid Predicates" in md
+    assert "open_field" in md
+    assert "dwa" in md
+    assert "clean-open_field-dwa-999" in md
+
+
+def test_mixed_observed_and_zero_groups() -> None:
+    """Observed and zero-predicate groups should coexist in the same aggregate table."""
+    crossing = _trace(
+        [
+            _frame(0, robot_x=0.0, angular_velocity=0.7),
+            _frame(1, robot_x=0.01, angular_velocity=-0.7, pedestrian_x=0.3),
+        ]
+    )
+    clean = _clean_trace(seed=555)
+    payload = aggregate_trace_failure_predicate_tables([crossing, clean], scenario_family=None)
+    observed = [r for r in payload["rows"] if r["predicate_id"] != "no_predicate_observed"]
+    zeros = [r for r in payload["rows"] if r["predicate_id"] == "no_predicate_observed"]
+    assert len(observed) > 0
+    assert len(zeros) == 1
+    assert zeros[0]["seed"] == 555
+    assert zeros[0]["trace_denominator"] == 1
+    zero_groups = payload["zero_predicate_groups"]
+    assert [row["seed"] for row in zero_groups] == [555]
+
+
+def test_absent_evidence_fields_not_available() -> None:
+    """A trace with near-miss geometry but no planner evidence should yield not_available."""
+    trace = _trace([_frame(0, robot_x=0.0, angular_velocity=0.0, pedestrian_x=0.25)])
+    payload = extract_trace_failure_predicates(trace, scenario_family="crossing")
+    occlusion = next(
+        r for r in payload["predicates"] if r["predicate_id"] == "occlusion_triggered_near_miss"
+    )
+    assert occlusion["validity_status"] == "not_available"
+    assert "missing_fields" in occlusion["evidence_fields"]
+    assert occlusion["evidence_fields"]["missing_fields"] == ["planner.occlusion_or_visibility"]
+
+
+def test_not_available_row_preserved_separately_from_true_zero() -> None:
+    """not_available rows must not be conflated with true zero observed predicate groups."""
+    trace = _trace([_frame(0, robot_x=0.0, angular_velocity=0.0, pedestrian_x=0.45)])
+    payload = aggregate_trace_failure_predicate_tables([trace], scenario_family="crossing")
+    not_avail = [r for r in payload["rows"] if r["validity_status"] == "not_available"]
+    true_zero = [r for r in payload["rows"] if r["predicate_id"] == "no_predicate_observed"]
+    assert len(not_avail) >= 1
+    assert all(r["predicate_count"] >= 1 for r in not_avail)
+    assert all(r["predicate_count"] == 0 for r in true_zero)
+    assert payload["zero_predicate_groups"] == [
+        {
+            "scenario_family": "crossing",
+            "planner_id": "orca",
+            "seed": 111,
+            "trace_source_id": "crossing-proxy-orca-111",
+            "trace_denominator": 1,
+            "valid_predicate_count": 0,
+            "not_available_predicate_count": 1,
+            "zero_group_reason": "valid_predicate_count_zero",
+        }
+    ]


### PR DESCRIPTION
## Summary
Preserves zero-valid-predicate trace groups in trace failure predicate table outputs while keeping the aggregate denominator contract compatible with existing analysis workbench callers.

## Linked Issues
- Closes `#2687`
- Relates to `#2667`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#2688`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a `zero_predicate_groups` payload section for trace sources with zero valid predicates.
- Kept aggregate predicate rows grouped by scenario family, planner, and seed, and added `trace_source_ids` for provenance.
- Rendered a Markdown section for zero-valid-predicate trace groups.
- Added validation coverage for no-predicate, mixed observed/zero, and `not_available` cases.
- Updated `docs/context/issue_2667_trace_failure_predicate_tables.md` to document the diagnostic boundary.

## Why It Matters
- Added value: clean traces and absent predicate evidence are no longer silently dropped from diagnostic summaries.
- Expected impact: downstream analysis can distinguish true zero-valid-predicate groups from partial evidence and unavailable predicate checks.
- Why this is worth merging now: it closes a reproducibility gap before any future rate or benchmark interpretation builds on these tables.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: diagnostic table completeness for trace predicate summaries.
- Comparator or baseline, if applicable: previous aggregate output omitted trace groups with zero valid predicates.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: preserve zero-valid-predicate groups without treating them as benchmark rates.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2667_trace_failure_predicate_tables.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: no new tool; this changes an existing diagnostic table generator and exercises it on tracked trace evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? no; analysis output only.
- Did the scenario actually contain the targeted failure mode? targeted tests cover true zero-valid-predicate and partial-evidence cases.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: `#2688` covers predeclared benchmark matrix/rate interpretation before claim use.

## Next Empirical Action
- Rerun needed: no for this diagnostic completeness fix.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for this PR scope.
- Stop / revise / continue decision: continue with matrix-level proof in `#2688`.
- Proposed child issue or existing follow-up: `#2688`.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/validation/test_trace_failure_predicates.py tests/analysis_workbench/test_trace_failure_predicates.py -q`
  - `rtk uv run ruff check robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/validation/test_trace_failure_predicates.py tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run ruff format --check robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/validation/test_trace_failure_predicates.py tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_2667_trace_failure_predicate_tables.md`
  - `rtk git diff --check`
  - `rtk uv run python scripts/tools/build_trace_failure_predicate_tables.py --trace docs/context/evidence/issue_2667_trace_failure_predicate_tables_2026-06-12/inputs/synthetic_crossing_proxy_orca_111_trace_export.json --trace docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/default_social_force_trace_export.json --trace docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/ammv_social_force_trace_export.json --json-output /tmp/issue2687_trace_failure_predicate_tables.json --markdown-output /tmp/issue2687_trace_failure_predicate_tables.md`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed, CLI smoke emitted `zero_predicate_groups`, `trace_source_ids`, `not_available`, and the Markdown zero-group section.
- Benchmarks or smoke tests, if applicable: full readiness passed with `5692 passed, 9 skipped`; changed-file coverage goal warning only for `trace_failure_predicates.py` at 91.9%.

## Risks / Rollout
- Compatibility risks: aggregate rows now expose `trace_source_ids` instead of the intermediate per-row `trace_source_id`; the aggregate denominator remains scenario/planner/seed compatible.
- Failure modes: callers assuming zero rows imply no eligible traces should switch to `zero_predicate_groups`.
- Rollback or fallback plan: revert this branch to the prior aggregate output shape if downstream consumers cannot accept the added payload fields.

## Docs / Provenance
- Updated docs: `docs/context/issue_2667_trace_failure_predicate_tables.md`.
- Relevant design or provenance notes: the updated note keeps #2667 evidence diagnostic-only and does not promote benchmark-rate claims.
- Any assumptions that need to be preserved: rate claims require a predeclared benchmark matrix.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR will close `#2687`.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no; existing context note updated directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, existing `#2688`.
- Not applicable because: this is diagnostic output completeness, not a benchmark result or claim-map update.

## Follow-Up Issues
- Deferred work: predeclared matrix/rate interpretation in `#2688`.
- Issues opened for follow-up: none in this branch.

## Reviewer Notes
- Anything a reviewer should verify closely: the aggregate denominator stays compatible for same scenario/planner/seed traces while `zero_predicate_groups` remains per trace source.
- Any known limitations: no benchmark claims are made; local `/tmp` smoke outputs were disposable and not promoted.
