### PR TITLE
docs: require routine worktree cleanup

### DIFF
--- a/.agents/skills/clean-up/SKILL.md
+++ b/.agents/skills/clean-up/SKILL.md
@@ -39,9 +39,10 @@ parallel tests, and diff-based quality gates.
    - `BASE_REF=origin/main scripts/dev/check_docstring_todos_diff.sh`
 6. Report:
    - Summarize passed/failed commands and any residual risk blocks (flaky or deferred tests).
-7. Optional worktree hygiene:
-   - If asked to tidy stale worktrees, follow `AGENTS.md` "Worktree Teardown And Preservation"
-     before removing or pruning anything.
+7. Worktree hygiene:
+   - Treat removal of no-longer-needed worktrees as part of normal closeout after PR review, issue
+     implementation, publishing, or abandoned exploration.
+   - Follow `AGENTS.md` "Worktree Teardown And Preservation" before removing or pruning anything.
    - Inspect `output/` and other ignored local artifacts before cleanup; classify them as
      disposable, ignored-cache, tracked-manifest, durable-required, or handoff-needed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,10 @@ When working in a linked Git worktree, detect bootstrap state before running exp
 
 ## Worktree Teardown And Preservation
 
+Treat worktree cleanup as a normal closeout step after PR review, issue implementation, publishing,
+or abandoned exploration. Once a worktree is no longer needed for active validation, CI follow-up,
+artifact recovery, or handoff, either remove it safely or record why it must be preserved.
+
 Before removing or pruning worktrees, enumerate them with `git worktree list --porcelain` from the
 main checkout. For each candidate, inspect `git -C <path> status --short --branch`; when generated
 outputs may matter, also inspect ignored output paths such as
@@ -139,6 +143,9 @@ outputs may matter, also inspect ignored output paths such as
   explicit handoff.
 - Do not remove a dirty worktree or a worktree with unpushed commits unless the preservation record
   says exactly what was kept or why nothing needed preservation.
+- Inspect large ignored directories such as `output/` before removal. Classify them as disposable,
+  ignored cache, tracked manifest/evidence, durable-required, or handoff-needed; never treat
+  worktree-local `output/` contents as durable artifact storage.
 - Prefer `git worktree remove <path>` for clean worktrees and `git worktree prune` only after
   verifying stale administrative entries no longer point at useful local state.
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -102,6 +102,10 @@ git merge origin/main
 
 ### Worktree teardown and preservation
 
+Make worktree cleanup part of normal closeout after PR review, issue implementation, publishing, or
+abandoned exploration. If a worktree is no longer needed for active validation, CI follow-up,
+artifact recovery, or handoff, remove it safely or record why it is intentionally preserved.
+
 Before deleting old worktrees, run `git worktree list --porcelain` from the main checkout and inspect
 each candidate with `git -C <path> status --short --branch`. If the worktree may contain generated
 evidence or local experiment outputs, also inspect relevant ignored paths, for example
@@ -110,8 +114,11 @@ evidence or local experiment outputs, also inspect relevant ignored paths, for e
 Only remove a worktree after preserving relevant tracked, untracked, and ignored-but-important
 changes through a commit, stash, patch, durable artifact promotion, or explicit handoff note. Do not
 delete dirty or unpushed worktrees unless the cleanup record states what was preserved or why nothing
-needed preservation. Use `git worktree remove <path>` for clean worktrees; reserve
-`git worktree prune` for stale administrative entries after local state is checked.
+needed preservation. Classify large ignored directories such as `output/` before removal as
+disposable, ignored cache, tracked manifest/evidence, durable-required, or handoff-needed; do not let
+worktree-local `output/` become durable artifact storage. Use `git worktree remove <path>` for clean
+worktrees; reserve `git worktree prune` for stale administrative entries after local state is
+checked.
 
 ### Targeted shared-venv worktree validation
 


### PR DESCRIPTION
## Summary
Tightens routine worktree cleanup guidance so stale worktrees are removed as part of normal closeout after PR review, issue implementation, publishing, or abandoned exploration.

## Linked Issues
- Closes `#2644`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Updated `AGENTS.md` and `docs/dev_guide.md` to make worktree teardown a normal closeout step.
- Reinforced preservation requirements for dirty, untracked, ignored-important, and unpushed state.
- Clarified that large ignored directories such as `output/` must be inspected and classified before deletion, and are not durable artifact storage.
- Aligned `.agents/skills/clean-up/SKILL.md` with the same cleanup default.

## Why It Matters
- Added value: reduces stale-worktree disk pressure without encouraging unsafe deletion.
- Expected impact: future autonomous and human closeout runs have one clear cleanup contract.
- Why this is worth merging now: it documents the cleanup behavior already needed by recent goal-autopilot work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow/docs-only cleanup guidance.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs-only.
- Result classification: NA.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support guidance only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: stop for #2644 scope.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk bash scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py --preflight clean-up`
  - `rtk git diff --check`
- Evidence that the change works here: changed docs contain each #2644 acceptance point and the cleanup skill preflight passes.
- Benchmarks or smoke tests, if applicable: not run; docs/skill-guidance only.

## Risks / Rollout
- Compatibility risks: low; guidance-only.
- Failure modes: agents could still skip cleanup if they do not read closeout docs; the cleanup skill now mirrors the rule.
- Rollback or fallback plan: revert the docs changes.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/dev_guide.md`, `.agents/skills/clean-up/SKILL.md`.
- Relevant design or provenance notes: #2644 was opened after local disk pressure from stale worktrees.
- Any assumptions that need to be preserved: inspect and preserve local state before removal.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR will close `#2644`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: workflow/docs-only cleanup guidance.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: wording preserves state before deletion and does not encourage removing dirty worktrees.
- Any known limitations: this PR does not remove any existing stale worktrees.
