### PR TITLE
feat: add dissertation why-first report mode

### DIFF
--- a/scripts/tools/generate_why_first_report.py
+++ b/scripts/tools/generate_why_first_report.py
@@ -23,6 +23,7 @@ REQUIRED_SECTIONS = (
 )
 CLAIM_BOUNDARY = "Report strength is limited to the compact input evidence."
 _NON_SUCCESS_STATUSES = {"fallback", "degraded", "failed", "not_available", "skipped"}
+_REPORT_MODES = ("why-first", "dissertation")
 
 
 class WhyFirstReportError(ValueError):
@@ -34,6 +35,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, required=True, help="Compact JSON evidence input.")
     parser.add_argument("--output", type=Path, required=True, help="Markdown report output path.")
+    parser.add_argument(
+        "--mode",
+        choices=_REPORT_MODES,
+        default="why-first",
+        help="Report mode to render. The default preserves the original why-first report.",
+    )
     return parser
 
 
@@ -49,12 +56,14 @@ def load_evidence(path: Path) -> dict[str, Any]:
     return payload
 
 
-def generate_report(evidence: Mapping[str, Any]) -> str:
+def generate_report(evidence: Mapping[str, Any], *, mode: str = "why-first") -> str:
     """Generate the why-first report Markdown.
 
     Returns:
         str: Markdown report with the required why-first sections.
     """
+    if mode not in _REPORT_MODES:
+        raise WhyFirstReportError(f"unsupported report mode: {mode}")
     title = _text(evidence.get("title"), default="Why-First Benchmark Report")
     lines = [f"# {title}", ""]
     lines.extend(_section("Outcome Summary", _outcome_summary(evidence)))
@@ -69,6 +78,8 @@ def generate_report(evidence: Mapping[str, Any]) -> str:
     lines.extend(_section("Trace Evidence", _trace_evidence(evidence)))
     lines.extend(_section("Alternative Explanations", _alternative_explanations(evidence)))
     lines.extend(_section("Continue / Revise / Stop Decision", _decision(evidence)))
+    if mode == "dissertation":
+        lines.extend(_section("Dissertation-Facing Handoff", _dissertation_handoff(evidence)))
     lines.extend(["## Claim Boundary", "", CLAIM_BOUNDARY, ""])
     return "\n".join(lines)
 
@@ -178,6 +189,38 @@ def _decision(evidence: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def _dissertation_handoff(evidence: Mapping[str, Any]) -> list[str]:
+    """Render conservative dissertation-facing handoff fields."""
+    dissertation = evidence.get("dissertation")
+    values = dissertation if isinstance(dissertation, Mapping) else evidence
+    status = _status(evidence)
+    caveat = (
+        "fallback/degraded/failed/not-available evidence must not be counted as benchmark success"
+        if _fallback_caveat(status)
+        else "no fallback/degraded status was declared in the compact evidence"
+    )
+    return [
+        "- `reader_takeaway`: "
+        + _text(values.get("reader_takeaway"), default="not specified")
+        + ".",
+        "- `allowed_wording`: "
+        + _list_or_text(values.get("allowed_wording"), default="not specified")
+        + ".",
+        "- `not_claimed`: "
+        + _list_or_text(values.get("not_claimed"), default="not specified")
+        + ".",
+        "- `figure_table_candidates`: "
+        + _list_or_text(
+            values.get("figure_table_candidates")
+            or values.get("artifact_ids")
+            or values.get("artifact_id"),
+            default="not specified",
+        )
+        + ".",
+        f"- `fallback_degraded_caveat`: {caveat}.",
+    ]
+
+
 def _status(evidence: Mapping[str, Any]) -> str:
     """Return the normalized execution status."""
     return _text(
@@ -213,11 +256,20 @@ def _text(value: Any, *, default: str) -> str:
     return text or default
 
 
+def _list_or_text(value: Any, *, default: str) -> str:
+    """Render a scalar or list value as compact report text."""
+    if isinstance(value, list):
+        rendered = [_text(item, default="").strip() for item in value]
+        rendered = [item for item in rendered if item]
+        return "; ".join(rendered) if rendered else default
+    return _text(value, default=default)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the report generator."""
     args = _build_parser().parse_args(argv)
     evidence = load_evidence(args.input)
-    report = generate_report(evidence)
+    report = generate_report(evidence, mode=args.mode)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(report, encoding="utf-8")
     return 0

--- a/tests/tools/test_generate_why_first_report.py
+++ b/tests/tools/test_generate_why_first_report.py
@@ -45,6 +45,18 @@ def _compact_evidence() -> dict[str, object]:
             "rationale": "fallback row cannot support benchmark-strength interpretation",
             "next_step": "rerun with native planner support",
         },
+        "dissertation": {
+            "reader_takeaway": "Fallback-active ORCA evidence is useful only as a limitation case.",
+            "allowed_wording": [
+                "The diagnostic report identifies fallback as a confound.",
+                "The row is not benchmark-strength planner evidence.",
+            ],
+            "not_claimed": [
+                "ORCA outperforms other planners.",
+                "Fallback execution is equivalent to native execution.",
+            ],
+            "figure_table_candidates": ["tab:robot_sf_release_planner_results"],
+        },
     }
 
 
@@ -58,6 +70,7 @@ def test_generate_report_includes_required_sections_and_fallback_caveat() -> Non
     assert "must not be counted as benchmark success" in report
     assert "fallback_adapter_confound" in report
     assert "## Claim Boundary" in report
+    assert "## Dissertation-Facing Handoff" not in report
 
 
 def test_cli_writes_markdown_report(tmp_path: Path) -> None:
@@ -80,3 +93,40 @@ def test_cli_writes_markdown_report(tmp_path: Path) -> None:
     assert report.startswith("# Fixture why report\n")
     assert "## Continue / Revise / Stop Decision" in report
     assert "rerun with native planner support" in report
+
+
+def test_dissertation_mode_emits_reader_takeaway_and_claim_boundaries() -> None:
+    """Dissertation mode should expose bounded wording without promoting claims."""
+    report = generate_why_first_report.generate_report(_compact_evidence(), mode="dissertation")
+
+    assert "## Dissertation-Facing Handoff" in report
+    assert "`reader_takeaway`: Fallback-active ORCA evidence" in report
+    assert "`allowed_wording`: The diagnostic report identifies fallback as a confound" in report
+    assert "`not_claimed`: ORCA outperforms other planners" in report
+    assert "`figure_table_candidates`: tab:robot_sf_release_planner_results" in report
+    assert "must not be counted as benchmark success" in report
+    assert "## Claim Boundary" in report
+
+
+def test_cli_dissertation_mode_writes_handoff_fields(tmp_path: Path) -> None:
+    """The CLI should expose dissertation-facing fields when explicitly requested."""
+    input_path = tmp_path / "evidence.json"
+    output_path = tmp_path / "why_report.md"
+    input_path.write_text(json.dumps(_compact_evidence()), encoding="utf-8")
+
+    result = generate_why_first_report.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--mode",
+            "dissertation",
+        ]
+    )
+
+    assert result == 0
+    report = output_path.read_text(encoding="utf-8")
+    assert "## Dissertation-Facing Handoff" in report
+    assert "`not_claimed`" in report
+    assert "`allowed_wording`" in report


### PR DESCRIPTION
Closes #2545.

## Summary
- Add an explicit `--mode dissertation` option to `scripts/tools/generate_why_first_report.py` while preserving the default why-first output.
- Render a conservative dissertation-facing handoff section with `reader_takeaway`, `allowed_wording`, `not_claimed`, `figure_table_candidates`, and fallback/degraded caveat fields.
- Add tests covering default compatibility plus CLI/API dissertation mode output.

## Validation
- `rtk uv run pytest tests/tools/test_generate_why_first_report.py -q` => 4 passed
- `rtk uv run ruff check scripts/tools/generate_why_first_report.py tests/tools/test_generate_why_first_report.py` => passed
- `rtk uv run ruff format --check scripts/tools/generate_why_first_report.py tests/tools/test_generate_why_first_report.py` => passed
- `rtk git diff --check` => passed
- CLI smoke: `generate_why_first_report.py --mode dissertation` on `docs/context/evidence/issue_2522_why_first_diagnostics/topology_near_parity_input.json` emitted all dissertation handoff fields
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` => 5694 passed, 9 skipped, 9 warnings in 258.26s

## Delegate Outcomes
- Rejected `command_code` / `command-code/default`: route collapsed because the model name was unavailable.
- Rejected `command_code` / `google/gemini-3.1-flash-lite`: route collapsed with `MODEL_NOT_IN_PLAN`.
- No delegate diff was accepted; implementation was completed locally after the bounded route failures. Self-review note: `.git/codex-agent-runs/notes/inbox/20260612-issue2545-command-code-route-collapse.md`.

## Downstream Propagation
No benchmark result, metric value, artifact registry, or claim-map update is introduced. This is report tooling only; generated local coverage output was removed, and the PR readiness stamp remains a local ignored validation artifact.

## Research Result Guidance
- Target claim/hypothesis/blocker: make why-first diagnostic reports easier to hand off into dissertation writing without turning diagnostics into stronger benchmark claims.
- Comparator/baseline: default `why-first` report mode before this change.
- Evidence tier: workflow/tooling validation, not benchmark evidence.
- Result classification: support/tooling improvement.
- Decision/stop rule: accept when default output remains backward compatible and dissertation mode exposes bounded wording/provenance/caveat fields through API and CLI tests.
- Synthesis surface/update target: issue #2545 / PR review; no broader research synthesis surface needs updating.
