### PR TITLE
feat: add compact PR loop snapshots

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -239,15 +239,45 @@ Treat monitor exit states as follows:
 ### Snapshot-First Parent Orientation
 
 Before broad queue, worktree, claim, PR, or CI reads in the parent thread, prefer the compact
-snapshot helper:
+snapshot helpers. Use the full-state `autopilot_state_snapshot.py` for initial orientation, then
+use targeted compact snapshots for specific needs:
 
 ```bash
+# Full orientation snapshot (worktrees, claims, issues, PRs)
 uv run python scripts/dev/autopilot_state_snapshot.py \
   --include-worktrees \
   --claim-issue <issue-number> \
   --issue-search "is:issue is:open <queue-filter>" \
   --pr <pr-number>
+
+# Compact worktree bootstrap-state snapshot (fresh worktrees, local.machine.md, .venv)
+uv run python scripts/dev/compact_worktree_snapshot.py --filter <issue-or-branch-slug> --json
+
+# Compact CI snapshot for PR queue (check rollup, optional drift sample)
+uv run python scripts/dev/compact_ci_snapshot.py <pr> [<pr> ...] \
+  --expected-head-sha <sha> --json [--include-drift]
+
+# Compact issue batch snapshot with context capsules
+uv run python scripts/dev/snapshot_issue_batch.py <first> <last> \
+  --json --capsule-dir <artifact-dir>
+
+# Compact PR queue snapshot (headline state, next action)
+uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json
 ```
+
+Use `compact_worktree_snapshot.py` before expensive commands to detect fresh worktrees that need
+bootstrap. Prefer `--filter <issue-or-branch-slug>` so large worktree fleets do not re-enter the
+parent thread. The `is_fresh` and `bootstrap_required` fields indicate whether `local.machine.md`
+symlink and `uv sync` steps are needed.
+
+Use `compact_ci_snapshot.py` for token-efficient PR CI monitoring. The optional `--include-drift`
+flag adds recent successful run timings to recommend an updated wait budget after timeout. Pass
+`--expected-head-sha` whenever the parent has a known PR head so stale snapshots fail closed before
+CI or merge-readiness decisions.
+
+Treat all snapshot output as **route evidence only**. Run fresh local checks before issue claim,
+push, PR publication, label/project mutation, merge-ready application, merge, or benchmark/paper-facing
+publication decisions.
 
 The helper emits `autopilot_state_snapshot.v1` JSON with source commands, branch/head SHA,
 `origin/main` SHA, worktree rows, issue queue rows, claim refs, explicit PR headline state, and

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -97,6 +97,8 @@ GOAL_AUTOPILOT_LEDGER_REQUIRED_PHRASES = (
     "pr publication",
     "label/project mutation",
     "merge-ready",
+    "compact_worktree_snapshot.py",
+    "compact_ci_snapshot.py",
 )
 
 

--- a/scripts/dev/compact_ci_snapshot.py
+++ b/scripts/dev/compact_ci_snapshot.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Emit a compact CI snapshot for PR queue monitoring.
+
+This helper provides token-efficient CI state summaries for autonomous PR loops.
+It avoids fetching full CI logs and instead reports compact check rollup state,
+with optional drift sampling after timeout.
+
+Use before delegating CI wait monitors or making merge-readiness decisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+SCHEMA_VERSION = "compact_ci_snapshot.v1"
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_WORKFLOW = "CI"
+DEFAULT_SAMPLE_LIMIT = 10
+FAILURE_CONCLUSIONS = {
+    "failure",
+    "error",
+    "cancelled",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+}
+PENDING_STATUSES = {"expected", "in_progress", "pending", "queued", "requested", "waiting"}
+
+
+@dataclass(frozen=True, slots=True)
+class CheckSummary:
+    """Compact check rollup."""
+
+    overall: str
+    total: int
+    by_conclusion: dict[str, int]
+    by_status: dict[str, int]
+    names: list[str]
+    failed_names: list[str]
+    pending_names: list[str]
+    success_names: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class DriftSample:
+    """CI drift sample after timeout."""
+
+    source: str
+    workflow: str
+    sample_count: int
+    median_seconds: int | None
+    recommended_budget_seconds: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class PRSnapshot:
+    """Compact PR CI snapshot."""
+
+    number: int
+    title: str
+    state: str
+    branch: str
+    head_sha: str
+    expected_head_sha: str | None
+    head_matches_expected: bool | None
+    mergeable: str
+    checks: CheckSummary | None
+    next_action: str
+    freshness_key: str
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotResult:
+    """Full CI snapshot result."""
+
+    schema: str
+    repo: str
+    prs: list[PRSnapshot]
+    drift_sample: DriftSample | None
+    generated_at_utc: str
+    errors: list[str]
+
+
+def _gh(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command."""
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["gh", *args],
+            returncode=124,
+            stdout="",
+            stderr=f"gh command timed out after {timeout} seconds",
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=["gh", *args],
+            returncode=127,
+            stdout="",
+            stderr="gh CLI not found",
+        )
+
+
+def _rollup_conclusion(check: dict[str, Any]) -> str:
+    """Normalize check conclusion."""
+    conclusion = check.get("conclusion")
+    if conclusion:
+        return str(conclusion).lower()
+    state = check.get("state")
+    if state:
+        return str(state).lower()
+    return "pending"
+
+
+def _rollup_status(check: dict[str, Any]) -> str:
+    """Normalize check status."""
+    status = check.get("status")
+    if status:
+        return str(status).lower()
+    state = check.get("state")
+    if not state:
+        return "completed"
+    state_str = str(state).lower()
+    if state_str in {"success", "failure", "error"}:
+        return "completed"
+    return state_str
+
+
+def _check_name(check: dict[str, Any]) -> str:
+    """Return compact check name."""
+    return str(check.get("name") or check.get("context") or "unknown")
+
+
+def _build_check_summary(rollup: list[dict[str, Any]]) -> CheckSummary:
+    """Build compact check summary from rollup."""
+    valid_checks = [c for c in rollup if isinstance(c, dict)]
+    conclusions: dict[str, int] = {}
+    statuses: dict[str, int] = {}
+    names: set[str] = set()
+    failed_names: set[str] = set()
+    pending_names: set[str] = set()
+    success_names: set[str] = set()
+
+    for check in valid_checks:
+        conclusion = _rollup_conclusion(check)
+        status = _rollup_status(check)
+        name = _check_name(check)
+        conclusions[conclusion] = conclusions.get(conclusion, 0) + 1
+        statuses[status] = statuses.get(status, 0) + 1
+        names.add(name)
+        if conclusion in FAILURE_CONCLUSIONS:
+            failed_names.add(name)
+        elif status in PENDING_STATUSES:
+            pending_names.add(name)
+        elif conclusion in {"success", "neutral", "skipped"}:
+            success_names.add(name)
+
+    failure_count = sum(conclusions.get(c, 0) for c in FAILURE_CONCLUSIONS)
+    pending_count = sum(statuses.get(s, 0) for s in PENDING_STATUSES)
+
+    if failure_count:
+        overall = "failure"
+    elif pending_count or not valid_checks:
+        overall = "pending"
+    else:
+        overall = "success"
+
+    return CheckSummary(
+        overall=overall,
+        total=len(valid_checks),
+        by_conclusion=dict(sorted(conclusions.items())),
+        by_status=dict(sorted(statuses.items())),
+        names=sorted(names),
+        failed_names=sorted(failed_names),
+        pending_names=sorted(pending_names),
+        success_names=sorted(success_names),
+    )
+
+
+def _next_action(checks: CheckSummary | None, head_matches_expected: bool | None) -> str:
+    """Return a compact next-action hint for the parent orchestrator."""
+    if head_matches_expected is False:
+        return "refresh_snapshot_expected_head_changed"
+    if checks is None:
+        return "wait_for_checks_or_verify_pr_head"
+    if checks.overall == "failure":
+        return "inspect_failed_check_excerpt"
+    if checks.overall == "pending":
+        return "await_ci_with_compact_monitor"
+    return "review_merge_readiness"
+
+
+def _fetch_pr_snapshot(
+    number: int,
+    repo: str,
+    *,
+    expected_head_sha: str | None = None,
+) -> PRSnapshot:
+    """Fetch compact PR CI snapshot."""
+    result = _gh(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,state,mergeable,headRefName,headRefOid,statusCheckRollup",
+        ]
+    )
+
+    if result.returncode != 0:
+        return PRSnapshot(
+            number=number,
+            title="",
+            state="",
+            branch="",
+            head_sha="",
+            expected_head_sha=expected_head_sha,
+            head_matches_expected=None,
+            mergeable="",
+            checks=None,
+            next_action="fix_pr_snapshot_fetch",
+            freshness_key=f"pr-{number}:unavailable",
+            error=result.stderr.strip() or f"gh returned exit code {result.returncode}",
+        )
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return PRSnapshot(
+            number=number,
+            title="",
+            state="",
+            branch="",
+            head_sha="",
+            expected_head_sha=expected_head_sha,
+            head_matches_expected=None,
+            mergeable="",
+            checks=None,
+            next_action="fix_pr_snapshot_parse",
+            freshness_key=f"pr-{number}:invalid-json",
+            error=f"invalid JSON: {exc}",
+        )
+
+    rollup = data.get("statusCheckRollup", []) or []
+    checks = _build_check_summary(rollup) if rollup else None
+    head_sha = str(data.get("headRefOid", ""))
+    head_matches_expected = expected_head_sha == head_sha if expected_head_sha else None
+
+    return PRSnapshot(
+        number=data.get("number", number),
+        title=data.get("title", ""),
+        state=data.get("state", ""),
+        branch=data.get("headRefName", ""),
+        head_sha=head_sha,
+        expected_head_sha=expected_head_sha,
+        head_matches_expected=head_matches_expected,
+        mergeable=data.get("mergeable", ""),
+        checks=checks,
+        next_action=_next_action(checks, head_matches_expected),
+        freshness_key=f"pr-{data.get('number', number)}:{head_sha}",
+        error=None,
+    )
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    """Parse GitHub timestamp."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _duration_seconds(start: Any, end: Any) -> int | None:
+    """Calculate elapsed seconds."""
+    started = _parse_timestamp(start)
+    completed = _parse_timestamp(end)
+    if started is None or completed is None:
+        return None
+    try:
+        return max(int((completed - started).total_seconds()), 0)
+    except TypeError:
+        return None
+
+
+def _fetch_drift_sample(
+    workflow: str,
+    sample_limit: int,
+    repo: str,
+) -> DriftSample:
+    """Fetch recent successful CI durations for drift analysis."""
+    result = _gh(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--repo",
+            repo,
+            "--status",
+            "success",
+            "--limit",
+            str(sample_limit),
+            "--json",
+            "databaseId,displayTitle,status,conclusion,createdAt,updatedAt",
+        ]
+    )
+
+    if result.returncode != 0:
+        return DriftSample(
+            source=f"error: {result.stderr.strip() or 'gh failed'}",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+
+    try:
+        runs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return DriftSample(
+            source="gh run list",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+
+    if not isinstance(runs, list):
+        return DriftSample(
+            source="gh run list",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+
+    durations: list[int] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("conclusion", "")).lower() != "success":
+            continue
+        duration = _duration_seconds(run.get("createdAt"), run.get("updatedAt"))
+        if duration is not None:
+            durations.append(duration)
+
+    if not durations:
+        return DriftSample(
+            source="gh run list",
+            workflow=workflow,
+            sample_count=0,
+            median_seconds=None,
+            recommended_budget_seconds=None,
+        )
+
+    median_seconds = math.ceil(statistics.median(durations))
+    return DriftSample(
+        source="gh run list",
+        workflow=workflow,
+        sample_count=len(durations),
+        median_seconds=median_seconds,
+        recommended_budget_seconds=math.ceil(median_seconds * 1.3),
+    )
+
+
+def _now_utc() -> str:
+    """Return ISO-8601 UTC timestamp."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_snapshot(
+    pr_numbers: list[int],
+    *,
+    repo: str = DEFAULT_REPO,
+    expected_head_sha: str | None = None,
+    include_drift: bool = False,
+    workflow: str = DEFAULT_WORKFLOW,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> SnapshotResult:
+    """Build compact CI snapshot."""
+    errors: list[str] = []
+    prs: list[PRSnapshot] = []
+
+    for number in pr_numbers:
+        pr = _fetch_pr_snapshot(number, repo=repo, expected_head_sha=expected_head_sha)
+        if pr.error:
+            errors.append(f"PR {number}: {pr.error}")
+        prs.append(pr)
+
+    drift_sample: DriftSample | None = None
+    if include_drift:
+        drift_sample = _fetch_drift_sample(
+            workflow=workflow,
+            sample_limit=sample_limit,
+            repo=repo,
+        )
+
+    return SnapshotResult(
+        schema=SCHEMA_VERSION,
+        repo=repo,
+        prs=prs,
+        drift_sample=drift_sample,
+        generated_at_utc=_now_utc(),
+        errors=errors,
+    )
+
+
+def format_human(result: SnapshotResult) -> str:
+    """Format as human-readable text."""
+    lines = [
+        f"CI Snapshot (schema: {result.schema})",
+        f"  Repo: {result.repo}",
+        f"  Generated: {result.generated_at_utc}",
+        f"  PRs: {len(result.prs)}",
+    ]
+
+    for pr in result.prs:
+        status = pr.checks.overall if pr.checks else "unknown"
+        lines.append(f"    - PR #{pr.number}: {pr.title[:50]}... [{status}]")
+        lines.append(f"        freshness: {pr.freshness_key}; next: {pr.next_action}")
+        if pr.checks:
+            lines.append(
+                f"        checks: {pr.checks.total} total, "
+                f"conclusions={pr.checks.by_conclusion}, "
+                f"status={pr.checks.by_status}"
+            )
+            if pr.checks.failed_names:
+                lines.append(f"        failed: {', '.join(pr.checks.failed_names)}")
+            if pr.checks.pending_names:
+                lines.append(f"        pending: {', '.join(pr.checks.pending_names)}")
+        if pr.error:
+            lines.append(f"        error: {pr.error}")
+
+    if result.drift_sample:
+        ds = result.drift_sample
+        lines.append(
+            f"  Drift sample: {ds.sample_count} runs, "
+            f"median={ds.median_seconds}s, "
+            f"recommended={ds.recommended_budget_seconds}s"
+        )
+
+    if result.errors:
+        lines.append("  Errors:")
+        for err in result.errors:
+            lines.append(f"    - {err}")
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "prs",
+        nargs="+",
+        type=int,
+        help="PR numbers to snapshot",
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help="GitHub repo",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    parser.add_argument(
+        "--expected-head-sha",
+        help="Expected PR head SHA freshness key. Mark stale if the live PR head differs.",
+    )
+    parser.add_argument(
+        "--include-drift",
+        action="store_true",
+        help="Include drift sample from recent runs",
+    )
+    parser.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        help="Workflow name for drift sampling",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=DEFAULT_SAMPLE_LIMIT,
+        help="Recent runs to sample for drift",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+
+    try:
+        result = build_snapshot(
+            pr_numbers=args.prs,
+            repo=args.repo,
+            expected_head_sha=args.expected_head_sha,
+            include_drift=args.include_drift,
+            workflow=args.workflow,
+            sample_limit=args.sample_limit,
+        )
+    except Exception as exc:
+        print(f"ERROR building CI snapshot: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        output = asdict(result)
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print(format_human(result))
+
+    return 0 if not result.errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/compact_worktree_snapshot.py
+++ b/scripts/dev/compact_worktree_snapshot.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Emit a compact worktree bootstrap-state snapshot.
+
+This helper detects fresh linked worktrees and reports bootstrap state for autonomous
+PR loops. It avoids broad git worktree output by reporting only essential fields.
+
+Use before running expensive commands in a linked worktree to determine whether
+bootstrap steps (uv sync, local.machine.md symlink) are required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SCHEMA_VERSION = "compact_worktree_snapshot.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeInfo:
+    """Compact worktree state."""
+
+    path: str
+    branch: str
+    head_sha: str
+    is_current: bool
+    is_linked: bool
+    is_fresh: bool
+    has_local_machine: bool
+    has_venv: bool
+    main_repo_root: str | None
+    bootstrap_required: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotResult:
+    """Full snapshot result."""
+
+    schema: str
+    current_worktree: str | None
+    current_branch: str
+    current_head_sha: str
+    is_linked_worktree: bool
+    filters: list[str]
+    worktrees: list[WorktreeInfo]
+    worktree_count: int
+    included_worktree_count: int
+    worktrees_truncated: bool
+    errors: list[str]
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    """Run a command and capture output."""
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=f"command timed out after {timeout} seconds",
+        )
+
+
+def _git_common_dir() -> Path | None:
+    """Return the common git dir path."""
+    result = _run_command(["git", "rev-parse", "--git-common-dir"])
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def _is_linked_worktree() -> bool:
+    """Check if current checkout is a linked worktree."""
+    git_dir = Path(".git")
+    if not git_dir.exists():
+        return False
+    if git_dir.is_file():
+        content = git_dir.read_text().strip()
+        return content.startswith("gitdir:")
+    return False
+
+
+def _get_main_repo_root() -> Path | None:
+    """Get the main repository root from common git dir."""
+    common_dir = _git_common_dir()
+    if not common_dir:
+        return None
+    parent = common_dir.parent
+    if parent.exists() and (parent / ".git").exists():
+        return parent
+    return None
+
+
+def _parse_worktree_porcelain(stdout: str) -> list[dict[str, str]]:  # noqa: C901
+    """Parse git worktree list --porcelain output."""
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+
+        parts = line.split(" ", 1)
+        if len(parts) != 2:
+            continue
+
+        key, value = parts
+        if key == "worktree":
+            if current:
+                worktrees.append(current)
+            current = {"path": value}
+        elif key == "HEAD":
+            current["head"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key in {"bare", "detached"}:
+            current[key] = "true"
+
+    if current:
+        worktrees.append(current)
+
+    return worktrees
+
+
+def _is_fresh_worktree(worktree_path: Path) -> bool:
+    """Check if a worktree needs bootstrap."""
+    has_local_machine = (worktree_path / "local.machine.md").exists()
+    has_venv = (worktree_path / ".venv").exists()
+    return not has_local_machine and not has_venv
+
+
+def _matches_filters(row: dict[str, str], filters: list[str]) -> bool:
+    """Return whether a worktree row matches any issue/branch/slug filter."""
+    if not filters:
+        return True
+    haystack = " ".join((row.get("path", ""), row.get("branch", ""))).lower()
+    return any(filter_text.lower() in haystack for filter_text in filters)
+
+
+def _detect_worktrees(
+    *,
+    current_path: Path,
+    main_repo_root: Path | None,
+    filters: list[str],
+    limit: int | None = 20,
+) -> tuple[list[WorktreeInfo], int, bool]:
+    """Detect all worktrees with bootstrap state."""
+    result = _run_command(["git", "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        return [], 0, False
+
+    parsed = _parse_worktree_porcelain(result.stdout)
+    filtered = [row for row in parsed if _matches_filters(row, filters)]
+    selected = filtered if limit is None else filtered[:limit]
+    worktrees = []
+
+    for wt in selected:
+        wt_path = Path(wt.get("path", ""))
+        is_current = wt_path.resolve() == current_path.resolve()
+        is_linked = _is_linked_worktree() if is_current else wt_path.joinpath(".git").is_file()
+        has_local_machine = wt_path.joinpath("local.machine.md").exists()
+        has_venv = wt_path.joinpath(".venv").exists()
+        is_fresh = _is_fresh_worktree(wt_path)
+
+        worktrees.append(
+            WorktreeInfo(
+                path=str(wt_path),
+                branch=wt.get("branch", ""),
+                head_sha=wt.get("head", ""),
+                is_current=is_current,
+                is_linked=is_linked,
+                is_fresh=is_fresh,
+                has_local_machine=has_local_machine,
+                has_venv=has_venv,
+                main_repo_root=str(main_repo_root) if main_repo_root else None,
+                bootstrap_required=is_fresh and main_repo_root is not None,
+            )
+        )
+
+    return worktrees, len(parsed), len(filtered) > len(selected)
+
+
+def build_snapshot(
+    *,
+    include_all_worktrees: bool = False,
+    worktree_limit: int = 20,
+    filters: list[str] | None = None,
+) -> SnapshotResult:
+    """Build the compact worktree snapshot."""
+    errors: list[str] = []
+    filter_values = filters or []
+    current_path = Path.cwd().resolve()
+
+    result = _run_command(["git", "branch", "--show-current"])
+    if result.returncode != 0:
+        errors.append("failed to get current branch")
+        current_branch = ""
+    else:
+        current_branch = result.stdout.strip()
+
+    result = _run_command(["git", "rev-parse", "HEAD"])
+    if result.returncode != 0:
+        errors.append("failed to get HEAD SHA")
+        current_head_sha = ""
+    else:
+        current_head_sha = result.stdout.strip()
+
+    is_linked = _is_linked_worktree()
+    main_root = _get_main_repo_root()
+
+    worktrees, total_worktree_count, worktrees_truncated = _detect_worktrees(
+        current_path=current_path,
+        main_repo_root=main_root,
+        filters=filter_values,
+        limit=None if include_all_worktrees else worktree_limit,
+    )
+
+    current_worktree = None
+    for wt in worktrees:
+        if wt.is_current:
+            current_worktree = wt.path
+            break
+
+    return SnapshotResult(
+        schema=SCHEMA_VERSION,
+        current_worktree=current_worktree,
+        current_branch=current_branch,
+        current_head_sha=current_head_sha,
+        is_linked_worktree=is_linked,
+        filters=filter_values,
+        worktrees=worktrees,
+        worktree_count=total_worktree_count,
+        included_worktree_count=len(worktrees),
+        worktrees_truncated=worktrees_truncated,
+        errors=errors,
+    )
+
+
+def format_human(result: SnapshotResult) -> str:
+    """Format snapshot as human-readable text."""
+    lines = [
+        f"Worktree Snapshot (schema: {result.schema})",
+        f"  Current: {result.current_worktree or 'N/A'}",
+        f"  Branch: {result.current_branch or 'N/A'}",
+        f"  HEAD: {result.current_head_sha or 'N/A'}",
+        f"  Linked worktree: {result.is_linked_worktree}",
+        f"  Total worktrees: {result.worktree_count}",
+        f"  Included worktrees: {result.included_worktree_count}",
+        f"  Truncated: {result.worktrees_truncated}",
+    ]
+    if result.filters:
+        lines.append(f"  Filters: {', '.join(result.filters)}")
+
+    if result.worktrees:
+        lines.append("  Worktrees:")
+        for wt in result.worktrees:
+            status = []
+            if wt.is_current:
+                status.append("current")
+            if wt.is_fresh:
+                status.append("fresh")
+            if wt.bootstrap_required:
+                status.append("bootstrap-required")
+            status_str = f" ({', '.join(status)})" if status else ""
+            lines.append(f"    - {wt.branch}: {wt.path}{status_str}")
+
+    if result.errors:
+        lines.append("  Errors:")
+        for err in result.errors:
+            lines.append(f"    - {err}")
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    parser.add_argument(
+        "--include-all-worktrees",
+        action="store_true",
+        help="Include all worktrees without limit",
+    )
+    parser.add_argument(
+        "--worktree-limit",
+        type=int,
+        default=20,
+        help="Maximum worktrees to include",
+    )
+    parser.add_argument(
+        "--filter",
+        dest="filters",
+        action="append",
+        default=[],
+        help="Issue number, branch substring, or slug to match against branch/path. May repeat.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+
+    try:
+        result = build_snapshot(
+            include_all_worktrees=args.include_all_worktrees,
+            worktree_limit=args.worktree_limit,
+            filters=args.filters,
+        )
+    except Exception as exc:
+        print(f"ERROR building worktree snapshot: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        output = asdict(result)
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print(format_human(result))
+
+    return 0 if not result.errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -87,6 +87,7 @@ Worker output uses rg -l, rg --files, bounded sed -n, a 200 lines cap, private a
 no broad rg -n ., and no full file reads.
 The active ledger records loaded context with skill/doc summaries, snapshot paths,
 freshness keys, expected PR head SHA, worker artifact paths, and stale-state triggers.
+Use compact_worktree_snapshot.py and compact_ci_snapshot.py before broad worktree or CI polling.
 Pass ledger snapshot paths to workers, avoid repeating broad state polling, and run
 fresh live checks before issue claim, push, PR publication, label/project mutation,
 or merge-ready decisions.

--- a/tests/dev/test_compact_ci_snapshot.py
+++ b/tests/dev/test_compact_ci_snapshot.py
@@ -1,0 +1,78 @@
+"""Tests for compact CI snapshots."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from scripts.dev import compact_ci_snapshot as snapshot
+
+
+def test_build_check_summary_exposes_bounded_job_name_sets() -> None:
+    """CI summaries should expose targeted names without raw logs."""
+    summary = snapshot._build_check_summary(
+        [
+            {"name": "fast-feedback", "status": "completed", "conclusion": "success"},
+            {"name": "examples-smoke", "status": "in_progress", "conclusion": ""},
+            {"name": "lint", "status": "completed", "conclusion": "failure"},
+        ]
+    )
+
+    assert summary.overall == "failure"
+    assert summary.failed_names == ["lint"]
+    assert summary.pending_names == ["examples-smoke"]
+    assert summary.success_names == ["fast-feedback"]
+    assert summary.by_conclusion == {"failure": 1, "pending": 1, "success": 1}
+
+
+def test_fetch_pr_snapshot_reports_freshness_and_next_action() -> None:
+    """PR snapshots should carry expected-head freshness and next useful action."""
+    pr_payload = {
+        "number": 2712,
+        "title": "compact CI state",
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "headRefName": "issue-2712",
+        "headRefOid": "abc123",
+        "statusCheckRollup": [
+            {"name": "ci", "status": "completed", "conclusion": "success"},
+        ],
+    }
+    with patch("scripts.dev.compact_ci_snapshot._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        result = snapshot._fetch_pr_snapshot(
+            2712,
+            repo="ll7/robot_sf_ll7",
+            expected_head_sha="abc123",
+        )
+
+    assert result.freshness_key == "pr-2712:abc123"
+    assert result.head_matches_expected is True
+    assert result.next_action == "review_merge_readiness"
+    assert result.checks is not None
+    assert result.checks.success_names == ["ci"]
+
+
+def test_fetch_pr_snapshot_marks_stale_expected_head() -> None:
+    """A changed PR head should route the parent to refresh instead of waiting."""
+    pr_payload = {
+        "number": 2712,
+        "title": "compact CI state",
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "headRefName": "issue-2712",
+        "headRefOid": "new-sha",
+        "statusCheckRollup": [
+            {"name": "ci", "status": "in_progress", "conclusion": ""},
+        ],
+    }
+    with patch("scripts.dev.compact_ci_snapshot._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        result = snapshot._fetch_pr_snapshot(
+            2712,
+            repo="ll7/robot_sf_ll7",
+            expected_head_sha="old-sha",
+        )
+
+    assert result.head_matches_expected is False
+    assert result.next_action == "refresh_snapshot_expected_head_changed"

--- a/tests/dev/test_compact_worktree_snapshot.py
+++ b/tests/dev/test_compact_worktree_snapshot.py
@@ -1,0 +1,135 @@
+"""Tests for compact worktree bootstrap snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.dev import compact_worktree_snapshot as snapshot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return snapshot.subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_parse_worktree_porcelain_extracts_compact_rows() -> None:
+    """Porcelain worktree output should become branch/path/head rows."""
+    rows = snapshot._parse_worktree_porcelain(
+        "\n".join(
+            [
+                "worktree /repo/main",
+                "HEAD abc123",
+                "branch refs/heads/main",
+                "",
+                "worktree /repo/issue-2715",
+                "HEAD def456",
+                "branch refs/heads/issue-2715-compact-ci-worktree-snapshots",
+                "",
+            ]
+        )
+    )
+
+    assert rows == [
+        {"path": "/repo/main", "head": "abc123", "branch": "main"},
+        {
+            "path": "/repo/issue-2715",
+            "head": "def456",
+            "branch": "issue-2715-compact-ci-worktree-snapshots",
+        },
+    ]
+
+
+def test_detect_worktrees_filters_by_issue_slug_and_reports_total(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Filtering should avoid dumping every linked worktree into parent context."""
+    main = tmp_path / "main"
+    issue = tmp_path / "issue-2715-compact-ci-worktree-snapshots"
+    other = tmp_path / "other"
+    main.mkdir()
+    issue.mkdir()
+    other.mkdir()
+    (issue / ".git").write_text("gitdir: /repo/.git/worktrees/issue-2715\n", encoding="utf-8")
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del cwd, timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                "\n".join(
+                    [
+                        f"worktree {main}",
+                        "HEAD aaa",
+                        "branch refs/heads/main",
+                        "",
+                        f"worktree {issue}",
+                        "HEAD bbb",
+                        "branch refs/heads/issue-2715-compact-ci-worktree-snapshots",
+                        "",
+                        f"worktree {other}",
+                        "HEAD ccc",
+                        "branch refs/heads/other-work",
+                        "",
+                    ]
+                )
+            )
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    worktrees, total, truncated = snapshot._detect_worktrees(
+        current_path=issue,
+        main_repo_root=main,
+        filters=["2715"],
+        limit=20,
+    )
+
+    assert total == 3
+    assert truncated is False
+    assert [row.branch for row in worktrees] == ["issue-2715-compact-ci-worktree-snapshots"]
+    assert worktrees[0].is_current is True
+    assert worktrees[0].is_fresh is True
+    assert worktrees[0].bootstrap_required is True
+
+
+def test_include_all_worktrees_does_not_slice_to_zero(monkeypatch, tmp_path: Path) -> None:
+    """The include-all path should include rows instead of applying a zero limit."""
+    worktree = tmp_path / "issue-1"
+    worktree.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del cwd, timeout
+        if args == ["git", "branch", "--show-current"]:
+            return _result("issue-1\n")
+        if args == ["git", "rev-parse", "HEAD"]:
+            return _result("abc123\n")
+        if args == ["git", "rev-parse", "--git-common-dir"]:
+            return _result(str(tmp_path / ".git") + "\n")
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                "\n".join(
+                    [
+                        f"worktree {worktree}",
+                        "HEAD abc123",
+                        "branch refs/heads/issue-1",
+                        "",
+                    ]
+                )
+            )
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.chdir(worktree)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot(include_all_worktrees=True)
+
+    assert result.worktree_count == 1
+    assert result.included_worktree_count == 1
+    assert result.worktrees_truncated is False


### PR DESCRIPTION
Closes #2715.

## Summary
- Add `scripts/dev/compact_worktree_snapshot.py` for filtered, bootstrap-aware worktree snapshots that avoid dumping all linked worktrees into the parent thread.
- Add `scripts/dev/compact_ci_snapshot.py` for bounded PR CI summaries with expected-head freshness, next-action hints, check counts, and failed/pending/success job-name sets without raw logs.
- Update goal-autopilot skill guidance and skill-contract checks so agents use compact snapshots before broad worktree/PR/CI polling.
- Add focused tests for filtered worktree snapshots, include-all behavior, CI freshness, next actions, and artifact-contract fixture integration.

## Validation
- `rtk uv run pytest tests/dev/test_check_skills.py::test_artifact_first_contract_passes_for_goal_autopilot tests/dev/test_compact_worktree_snapshot.py tests/dev/test_compact_ci_snapshot.py -q` => 7 passed
- `rtk uv run ruff check tests/dev/test_check_skills.py scripts/dev/compact_worktree_snapshot.py scripts/dev/compact_ci_snapshot.py tests/dev/test_compact_worktree_snapshot.py tests/dev/test_compact_ci_snapshot.py scripts/dev/check_skills.py` => passed
- `rtk uv run ruff format --check tests/dev/test_check_skills.py scripts/dev/compact_worktree_snapshot.py scripts/dev/compact_ci_snapshot.py tests/dev/test_compact_worktree_snapshot.py tests/dev/test_compact_ci_snapshot.py scripts/dev/check_skills.py` => passed
- `rtk uv run python scripts/dev/check_skills.py --preflight goal-autopilot` => PASS
- CLI smoke: `compact_worktree_snapshot.py --filter 2715 --json` => `included_worktree_count=1` from `worktree_count=581`
- CLI smoke: `compact_ci_snapshot.py 2712 --expected-head-sha fc07c142... --json` => `overall=success`, `head_matches_expected=true`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh` => 5700 passed, 9 skipped, 9 warnings in 243.20s

## Delegate Outcomes
- Gemini scout selected #2715 from compact issue metadata with high confidence but missed required `RESULT.md`; accepted only `result.json` and classified route as partially compliant.
- Qwen implementation produced candidate artifacts and most of the patch, but timed out and missed `validation.txt`; accepted after local controller repair, tests, and validation.
- OpenCode review route rejected after two setup/model failures (`--prompt` unsupported, then unavailable model / server error); no OpenCode diff accepted.

## Downstream Propagation
No benchmark result, metric value, model artifact, or claim-map update is introduced. This is workflow/tooling support. Generated local coverage, predictive-smoke, viewer, model-cache, and PR-ready output files were inspected as disposable ignored validation byproducts and removed before publication.

## Research Result Guidance
- Target claim/hypothesis/blocker: reduce parent Codex token leakage in autonomous PR loops caused by broad worktree and CI polling.
- Comparator/baseline: existing `git worktree list --porcelain`, broad PR status rollups, and repeated CI polling.
- Evidence tier: workflow/tooling validation, not benchmark evidence.
- Result classification: support/tooling improvement.
- Decision/stop rule: accept when compact helpers cover worktree filtering/bootstrap state and PR CI freshness/check summaries with tests and full readiness passing.
- Synthesis surface/update target: issue #2715 / goal-autopilot skill guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact CI snapshot utility to generate PR status summaries with check rollups and actionability hints.
  * Added compact worktree bootstrap snapshot utility to detect linked worktree states and freshness indicators.

* **Documentation**
  * Expanded goal-autopilot skill guidance with snapshot-first approach standardization, compact snapshot helper templates, and stale-state failure-closed behavior rules.

* **Tests**
  * Added unit tests for new CI snapshot and worktree snapshot utilities.

* **Chores**
  * Enhanced artifact-first contract validation to require new snapshot utility references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->