### PR TITLE
feat: record routed worker artifact presence

### DIFF
--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -197,7 +197,10 @@ Treat it as a reviewer-lens pass, not another full test suite:
 - delegated worker outputs: record useful sidecar answers as `route_evidence`, not benchmark or
   claim proof by themselves. Classify missing or sparse compact artifacts as route failure or T0
   evidence. If the worker produced no useful `result`, `status`, or `diffstat` summary, rely on
-  local validation or reroute instead of treating the silence as a negative finding.
+  local validation or reroute instead of treating the silence as a negative finding. Routed-worker
+  manifests should include per-attempt artifact presence for `result.json`, `RESULT.md`,
+  `diffstat.txt`, `status.txt`, and `validation.txt`; wrapper success, zero exit, and manifest
+  presence are still route evidence only, not task acceptance.
 
 ### 7. Open the PR
 

--- a/scripts/dev/routed_worker_manifest.py
+++ b/scripts/dev/routed_worker_manifest.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build compact routed-worker artifact manifests.
+
+The manifest records route evidence only. A zero exit code, successful wrapper
+run, or complete artifact set is not task acceptance; the parent orchestrator
+still needs local diff review and validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "routed_worker_manifest.v1"
+ROUTE_EVIDENCE_WARNING = (
+    "Wrapper success, zero exit, and manifest presence are route evidence only; "
+    "they are not task acceptance. The orchestrator must still inspect the diff "
+    "and run the required local validation."
+)
+REQUIRED_ARTIFACTS = {
+    "result_json": "result.json",
+    "result_md": "RESULT.md",
+    "diffstat": "diffstat.txt",
+    "status": "status.txt",
+    "validation": "validation.txt",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactPresence:
+    """Compact presence record for one expected worker artifact."""
+
+    present: bool
+    path: str
+    reason: str | None
+    size_bytes: int | None
+
+
+def _resolve_run_dir(run_dir: str | Path, *, target_repo: Path) -> Path:
+    """Resolve a run directory relative to the target repository."""
+    repo_resolved = target_repo.resolve(strict=False)
+    path = Path(run_dir)
+    if path.is_absolute():
+        unresolved_path = path
+    else:
+        unresolved_path = target_repo / path
+    if unresolved_path.is_symlink():
+        raise ValueError("run_dir must not be a symlink")
+    resolved = unresolved_path.resolve(strict=False)
+    if not resolved.is_relative_to(repo_resolved):
+        raise ValueError("run_dir must resolve inside target_repo")
+    return resolved
+
+
+def scan_artifact_presence(
+    run_dir: str | Path,
+    *,
+    target_repo: str | Path = ".",
+    artifact_filenames: dict[str, str] | None = None,
+) -> dict[str, ArtifactPresence]:
+    """Scan expected artifact files in a worker run directory.
+
+    Relative run directories are resolved against ``target_repo`` so wrappers
+    write manifests into the repository being operated on, not into the
+    orchestrator tooling checkout.
+    """
+    repo_root = Path(target_repo).resolve()
+    run_root = _resolve_run_dir(run_dir, target_repo=repo_root)
+    filenames = artifact_filenames or REQUIRED_ARTIFACTS
+    presence: dict[str, ArtifactPresence] = {}
+    for key, filename in filenames.items():
+        artifact_path = run_root / filename
+        relative_path = str(Path(run_dir) / filename)
+        if artifact_path.is_file():
+            presence[key] = ArtifactPresence(
+                present=True,
+                path=relative_path,
+                reason=None,
+                size_bytes=artifact_path.stat().st_size,
+            )
+        else:
+            presence[key] = ArtifactPresence(
+                present=False,
+                path=relative_path,
+                reason="missing",
+                size_bytes=None,
+            )
+    return presence
+
+
+def _jsonable_presence(presence: dict[str, ArtifactPresence]) -> dict[str, dict[str, Any]]:
+    """Return JSON-ready artifact presence entries."""
+    return {key: asdict(entry) for key, entry in presence.items()}
+
+
+def build_routing_manifest(
+    attempts: list[dict[str, Any]],
+    *,
+    chosen_index: int,
+    target_repo: str | Path = ".",
+    task_class: str | None = None,
+) -> dict[str, Any]:
+    """Build a routed-worker manifest for every attempt and the chosen route."""
+    if not attempts:
+        raise ValueError("at least one route attempt is required")
+    if chosen_index < 0 or chosen_index >= len(attempts):
+        raise IndexError("chosen_index is outside attempts")
+
+    repo_root = Path(target_repo).resolve()
+    manifest_attempts: list[dict[str, Any]] = []
+    for index, attempt in enumerate(attempts):
+        run_dir = attempt.get("run_dir")
+        if run_dir:
+            compact_artifacts = _jsonable_presence(
+                scan_artifact_presence(run_dir, target_repo=repo_root)
+            )
+        else:
+            compact_artifacts = _jsonable_presence(
+                {
+                    key: ArtifactPresence(
+                        present=False,
+                        path=filename,
+                        reason=attempt.get("missing_reason") or "not-run",
+                        size_bytes=None,
+                    )
+                    for key, filename in REQUIRED_ARTIFACTS.items()
+                }
+            )
+        manifest_attempts.append(
+            {
+                "attempt_index": index,
+                "route": attempt.get("route"),
+                "returncode": attempt.get("returncode"),
+                "failure_class": attempt.get("failure_class"),
+                "run_dir": run_dir,
+                "compact_artifacts": compact_artifacts,
+            }
+        )
+
+    chosen_attempt = manifest_attempts[chosen_index]
+    return {
+        "schema": SCHEMA_VERSION,
+        "task_class": task_class,
+        "route_evidence_only": True,
+        "warning": ROUTE_EVIDENCE_WARNING,
+        "attempted_routes": manifest_attempts,
+        "chosen_route": chosen_attempt["route"],
+        "chosen_run_dir": chosen_attempt["run_dir"],
+        "compact_artifacts": chosen_attempt["compact_artifacts"],
+    }
+
+
+def write_routing_manifest(
+    attempts: list[dict[str, Any]],
+    *,
+    chosen_index: int,
+    target_repo: str | Path = ".",
+    task_class: str | None = None,
+    filename: str = "routing_manifest.json",
+) -> Path:
+    """Write the routing manifest into the chosen attempt run directory."""
+    manifest = build_routing_manifest(
+        attempts,
+        chosen_index=chosen_index,
+        target_repo=target_repo,
+        task_class=task_class,
+    )
+    chosen_run_dir = manifest["chosen_run_dir"]
+    if not chosen_run_dir:
+        raise ValueError("chosen route has no run_dir; cannot write manifest")
+    run_root = _resolve_run_dir(chosen_run_dir, target_repo=Path(target_repo).resolve())
+    run_root.mkdir(parents=True, exist_ok=True)
+    output_path = run_root / filename
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output_path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--attempts-json", required=True, help="JSON file containing route attempts."
+    )
+    parser.add_argument("--chosen-index", type=int, required=True)
+    parser.add_argument("--target-repo", default=".")
+    parser.add_argument("--task-class")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = _parse_args()
+    attempts = json.loads(Path(args.attempts_json).read_text(encoding="utf-8"))
+    output_path = write_routing_manifest(
+        attempts,
+        chosen_index=args.chosen_index,
+        target_repo=args.target_repo,
+        task_class=args.task_class,
+    )
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_routed_worker_manifest.py
+++ b/tests/dev/test_routed_worker_manifest.py
@@ -1,0 +1,150 @@
+"""Tests for routed worker artifact manifests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.dev import routed_worker_manifest as manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_artifacts(run_dir: Path, filenames: list[str]) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for filename in filenames:
+        (run_dir / filename).write_text(f"{filename}\n", encoding="utf-8")
+
+
+def test_scan_artifact_presence_reports_success_and_missing(tmp_path: Path) -> None:
+    """Presence scan should include paths and missing reasons for all artifacts."""
+    run_dir = tmp_path / "repo" / ".git" / "codex-agent-runs" / "run-1"
+    _write_artifacts(run_dir, ["result.json", "RESULT.md", "status.txt"])
+
+    presence = manifest.scan_artifact_presence(
+        ".git/codex-agent-runs/run-1",
+        target_repo=tmp_path / "repo",
+    )
+
+    assert presence["result_json"].present is True
+    assert presence["result_json"].path == ".git/codex-agent-runs/run-1/result.json"
+    assert presence["result_json"].size_bytes is not None
+    assert presence["diffstat"].present is False
+    assert presence["diffstat"].path == ".git/codex-agent-runs/run-1/diffstat.txt"
+    assert presence["diffstat"].reason == "missing"
+    assert presence["validation"].reason == "missing"
+
+
+def test_build_manifest_includes_attempts_chosen_route_and_warning(tmp_path: Path) -> None:
+    """Manifest should distinguish route evidence from task acceptance."""
+    repo = tmp_path / "repo"
+    run_dir = repo / ".git" / "codex-agent-runs" / "run-2"
+    _write_artifacts(
+        run_dir,
+        ["result.json", "RESULT.md", "diffstat.txt", "status.txt", "validation.txt"],
+    )
+    attempts = [
+        {
+            "route": {"provider": "gemini"},
+            "returncode": 2,
+            "failure_class": "route-collapse",
+            "run_dir": None,
+        },
+        {
+            "route": {"provider": "qwen"},
+            "returncode": 0,
+            "failure_class": "none",
+            "run_dir": ".git/codex-agent-runs/run-2",
+        },
+    ]
+
+    data = manifest.build_routing_manifest(
+        attempts,
+        chosen_index=1,
+        target_repo=repo,
+        task_class="mechanical_code_edit",
+    )
+
+    assert data["schema"] == "routed_worker_manifest.v1"
+    assert data["route_evidence_only"] is True
+    assert "not task acceptance" in data["warning"]
+    assert len(data["attempted_routes"]) == 2
+    assert data["attempted_routes"][0]["compact_artifacts"]["validation"]["reason"] == "not-run"
+    assert data["chosen_route"] == {"provider": "qwen"}
+    assert data["compact_artifacts"]["validation"]["present"] is True
+
+
+def test_write_manifest_uses_target_repository_run_directory(tmp_path: Path) -> None:
+    """Relative run dirs must resolve under target_repo, not the caller cwd."""
+    target_repo = tmp_path / "target-repo"
+    orchestrator_repo = tmp_path / "orchestrator"
+    chosen_run_dir = ".git/codex-agent-runs/run-3"
+    _write_artifacts(
+        target_repo / chosen_run_dir,
+        ["result.json", "RESULT.md", "diffstat.txt", "status.txt"],
+    )
+    orchestrator_repo.mkdir()
+    attempts = [
+        {
+            "route": {"provider": "qwen"},
+            "returncode": 0,
+            "failure_class": "none",
+            "run_dir": chosen_run_dir,
+        }
+    ]
+
+    output_path = manifest.write_routing_manifest(
+        attempts,
+        chosen_index=0,
+        target_repo=target_repo,
+        task_class="mechanical_code_edit",
+    )
+
+    assert output_path == target_repo / chosen_run_dir / "routing_manifest.json"
+    assert not (orchestrator_repo / chosen_run_dir / "routing_manifest.json").exists()
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["compact_artifacts"]["validation"]["present"] is False
+    assert data["compact_artifacts"]["validation"]["reason"] == "missing"
+
+
+def test_write_manifest_rejects_run_dir_outside_target_repository(tmp_path: Path) -> None:
+    """Traversal-style run dirs should not write manifests outside target_repo."""
+    target_repo = tmp_path / "target-repo"
+    target_repo.mkdir()
+    attempts = [
+        {
+            "route": {"provider": "qwen"},
+            "returncode": 0,
+            "failure_class": "none",
+            "run_dir": "../outside-run",
+        }
+    ]
+
+    with pytest.raises(ValueError, match="inside target_repo"):
+        manifest.write_routing_manifest(attempts, chosen_index=0, target_repo=target_repo)
+
+    assert not (tmp_path / "outside-run" / "routing_manifest.json").exists()
+
+
+def test_scan_artifact_presence_rejects_symlink_run_directory(tmp_path: Path) -> None:
+    """Symlink-valued run dirs should fail closed before path resolution."""
+    target_repo = tmp_path / "target-repo"
+    outside_run = tmp_path / "outside-run"
+    target_repo.mkdir()
+    outside_run.mkdir()
+    (target_repo / "run-link").symlink_to(outside_run, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        manifest.scan_artifact_presence("run-link", target_repo=target_repo)
+
+
+def test_build_manifest_rejects_invalid_chosen_index() -> None:
+    """A malformed wrapper should fail before writing misleading route evidence."""
+    with pytest.raises(IndexError):
+        manifest.build_routing_manifest(
+            [{"route": {"provider": "qwen"}, "run_dir": "run"}],
+            chosen_index=3,
+        )


### PR DESCRIPTION
## Summary
Adds a repo-owned helper for routed-worker manifests that records compact artifact presence for every route attempt and the chosen route.

## Linked Issues
- Closes `#2714`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/routed_worker_manifest.py` to scan `result.json`, `RESULT.md`, `diffstat.txt`, `status.txt`, and `validation.txt` for each route attempt.
- Added tests covering present/missing artifacts, chosen-route manifest shape, invalid chosen indices, and target-repository run-directory writes.
- Updated `docs/ai/ai-workflow.md` to state that wrapper success, zero exit, and manifest presence are route evidence only.

## Why It Matters
- Added value: parent agents can review delegated route evidence without reading broad worker logs.
- Expected impact: lower Codex-token review cost and clearer route-success versus task-success separation.
- Why this is worth merging now: it directly supports the current token-efficiency issue batch.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support tooling only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA.
- Result classification: NA.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#2714`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it records worker artifact presence and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support tooling only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA - validation completed.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_routed_worker_manifest.py -q`
  - `uv run ruff check scripts/dev/routed_worker_manifest.py tests/dev/test_routed_worker_manifest.py`
  - `uv run ruff format --check scripts/dev/routed_worker_manifest.py tests/dev/test_routed_worker_manifest.py`
  - CLI smoke: `uv run python scripts/dev/routed_worker_manifest.py --attempts-json <tmp>/attempts.json --chosen-index 0 --target-repo <tmp>/repo --task-class mechanical_code_edit`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed; CLI smoke wrote `routing_manifest.json` under the target repo run directory; review feedback path-containment and symlink cases were added; full readiness passed with `5706 passed, 9 skipped, 8 warnings`.
- Benchmarks or smoke tests, if applicable: NA - support tooling.

## Risks / Rollout
- Compatibility risks: helper is additive and does not change existing worker wrappers until they opt in.
- Failure modes: callers can still over-trust route evidence; the manifest and docs explicitly warn against that. Traversal-style relative run directories and symlink-valued run directories are rejected.
- Rollback or fallback plan: remove the helper and tests; existing manual artifact review remains unchanged.

## Docs / Provenance
- Updated docs: `docs/ai/ai-workflow.md`.
- Relevant design or provenance notes: private delegate artifacts recorded under `.git/codex-agent-runs/`.
- Any assumptions that need to be preserved: route evidence is not task acceptance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): closes via this PR.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is token-efficiency support tooling with no benchmark or research-result claim.

## Follow-Up Issues
- Deferred work: wrappers that want this manifest should call the helper when emitting route attempts.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: target-repo path resolution in `write_routing_manifest`.
- Any known limitations: the helper does not automatically integrate into external `codex-routed-agent-worker`; it provides the repo-owned manifest contract and test coverage for wrappers to call.
