### PR TITLE
feat: add stale artifact detector

### DIFF
--- a/scripts/tools/stale_artifact_detector.py
+++ b/scripts/tools/stale_artifact_detector.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Classify dissertation and release-bundle artifact freshness.
+
+This helper is intentionally conservative. It records whether an artifact is
+safe to cite as current evidence, historically valid evidence, stale evidence
+that needs refresh, or blocked for manuscript use. Local-only paths such as
+``output/`` are never treated as durable manuscript proof.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import posixpath
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, NamedTuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dependency is present in repo env
+    yaml = None
+
+SCHEMA_VERSION = "stale_artifact_detector.v1"
+CURRENT_ARTIFACT_SCHEMA = "artifact_catalog.v1"
+BLOCKING_MARKERS = {
+    "blocked",
+    "blocked-for-manuscript-use",
+    "diagnostic",
+    "future-work only",
+    "not benchmark evidence",
+}
+LOCAL_ONLY_PREFIXES = ("output", "results", ".git", ".venv")
+
+
+class ArtifactState(StrEnum):
+    """Freshness state for manuscript/release artifact reuse."""
+
+    CURRENT = "current"
+    HISTORICAL_VALID = "historical-valid"
+    STALE_NEEDS_REFRESH = "stale-needs-refresh"
+    BLOCKED_FOR_MANUSCRIPT_USE = "blocked-for-manuscript-use"
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactResult:
+    """Classification result for one manifest entry."""
+
+    artifact_id: str
+    state: ArtifactState
+    reasons: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    checksum_expected: str | None = None
+    checksum_actual: str | None = None
+    schema_version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactFreshnessReport:
+    """Machine-readable artifact freshness report."""
+
+    generated_at_utc: str
+    manifest_path: str
+    results: list[ArtifactResult]
+    schema: str = SCHEMA_VERSION
+
+    @property
+    def exit_code(self) -> int:
+        """Return non-zero when any artifact is not current or historical-valid."""
+        return int(
+            any(
+                result.state
+                in {
+                    ArtifactState.STALE_NEEDS_REFRESH,
+                    ArtifactState.BLOCKED_FOR_MANUSCRIPT_USE,
+                }
+                for result in self.results
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable report."""
+        return {
+            "schema": self.schema,
+            "generated_at_utc": self.generated_at_utc,
+            "manifest_path": self.manifest_path,
+            "summary": _summarize(self.results),
+            "results": [
+                {
+                    "artifact_id": result.artifact_id,
+                    "state": result.state.value,
+                    "reasons": result.reasons,
+                    "warnings": result.warnings,
+                    "checksum_expected": result.checksum_expected,
+                    "checksum_actual": result.checksum_actual,
+                    "schema_version": result.schema_version,
+                }
+                for result in self.results
+            ],
+        }
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 checksum for ``path``."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _summarize(results: list[ArtifactResult]) -> dict[str, int]:
+    """Count results by state."""
+    counts = {state.value: 0 for state in ArtifactState}
+    for result in results:
+        counts[result.state.value] += 1
+    return counts
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _artifact_id(entry: dict[str, Any]) -> str:
+    return _as_text(entry.get("artifact_id") or entry.get("id") or entry.get("name")) or "unnamed"
+
+
+class OutputSpec(NamedTuple):
+    """Normalized artifact output metadata."""
+
+    name: str
+    path: str | None
+    expected_checksum: str | None
+
+
+def _output_specs(entry: dict[str, Any]) -> list[OutputSpec]:
+    outputs = entry.get("outputs")
+    if isinstance(outputs, dict):
+        specs: list[OutputSpec] = []
+        for name, value in outputs.items():
+            if not isinstance(value, dict):
+                specs.append(OutputSpec(str(name), None, None))
+                continue
+            specs.append(
+                OutputSpec(
+                    str(name),
+                    _as_text(value.get("path")),
+                    _as_text(
+                        value.get("checksum")
+                        or value.get("sha256")
+                        or entry.get("checksum")
+                        or entry.get("sha256")
+                    ),
+                )
+            )
+        if specs:
+            return specs
+
+    return [
+        OutputSpec(
+            "artifact",
+            _as_text(entry.get("path")),
+            _as_text(entry.get("checksum") or entry.get("sha256")),
+        )
+    ]
+
+
+def _is_local_only(path_text: str, *, manifest_dir: Path | None = None) -> bool:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path.parts[:2] in {("/", "tmp"), ("/", "var")} or path.resolve(strict=False).parts[
+            :2
+        ] in {("/", "tmp"), ("/", "var")}
+
+    raw_parts = tuple(part for part in path.parts if part not in {"", "."})
+    if raw_parts and raw_parts[0] in LOCAL_ONLY_PREFIXES:
+        return True
+
+    normalized_parts = tuple(
+        part for part in Path(posixpath.normpath(path_text)).parts if part not in {"", "."}
+    )
+    if normalized_parts and normalized_parts[0] in LOCAL_ONLY_PREFIXES:
+        return True
+
+    if manifest_dir is None:
+        return False
+
+    candidate = _resolve_output_path(path_text, manifest_dir=manifest_dir)
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+        resolved_manifest = manifest_dir.resolve(strict=True)
+    except OSError:
+        return False
+    for prefix in LOCAL_ONLY_PREFIXES:
+        try:
+            resolved_candidate.relative_to((resolved_manifest / prefix).resolve(strict=False))
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _evaluate_outputs(
+    specs: list[OutputSpec],
+    *,
+    manifest_dir: Path | None,
+) -> tuple[list[str], list[str], list[str], list[str], bool, bool]:
+    reasons: list[str] = []
+    result_warnings: list[str] = []
+    expected_values: list[str] = []
+    actual_values: list[str] = []
+    has_failure = False
+    has_local_only = False
+
+    for spec in specs:
+        output_label = f"output {spec.name}"
+        if not spec.path:
+            reasons.append(f"{output_label} missing output path")
+            has_failure = True
+            continue
+        if _is_local_only(spec.path, manifest_dir=manifest_dir):
+            result_warnings.append(
+                f"{output_label} path is local-only and not durable: {spec.path}"
+            )
+            has_local_only = True
+
+        if not spec.expected_checksum:
+            reasons.append(f"{output_label} missing checksum")
+            has_failure = True
+            continue
+
+        expected_values.append(spec.expected_checksum)
+        candidate = _resolve_output_path(spec.path, manifest_dir=manifest_dir)
+        if candidate.is_file():
+            actual = sha256_file(candidate)
+            actual_values.append(actual)
+            if actual == spec.expected_checksum:
+                reasons.append(f"{output_label} checksum matches")
+            else:
+                reasons.append(f"{output_label} checksum mismatch")
+                has_failure = True
+        else:
+            reasons.append(f"{output_label} referenced artifact file is missing")
+            has_failure = True
+
+    return reasons, result_warnings, expected_values, actual_values, has_failure, has_local_only
+
+
+def _resolve_output_path(path_text: str, *, manifest_dir: Path | None) -> Path:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    if manifest_dir is None:
+        return path
+    return manifest_dir / path
+
+
+def _explicit_blocker(entry: dict[str, Any]) -> str | None:
+    for marker_field in ("readiness", "review_state", "status", "result_classification"):
+        marker = _as_text(entry.get(marker_field))
+        if marker and marker.lower() in BLOCKING_MARKERS:
+            return f"{marker_field}={marker}"
+    blocker = _as_text(entry.get("blocked_reason") or entry.get("provenance_blocker"))
+    if blocker:
+        return f"blocked_reason={blocker}"
+    return None
+
+
+def classify_artifact(
+    entry: dict[str, Any],
+    *,
+    manifest_dir: Path | None = None,
+    current_schema: str = CURRENT_ARTIFACT_SCHEMA,
+) -> ArtifactResult:
+    """Classify one artifact manifest entry without raising on malformed data."""
+    artifact_id = _artifact_id(entry)
+    schema_version = _as_text(entry.get("schema_version"))
+
+    blocker = _explicit_blocker(entry)
+    if blocker:
+        return ArtifactResult(
+            artifact_id=artifact_id,
+            state=ArtifactState.BLOCKED_FOR_MANUSCRIPT_USE,
+            reasons=[f"explicit manuscript blocker: {blocker}"],
+            schema_version=schema_version,
+        )
+
+    reasons, result_warnings, expected_values, actual_values, has_failure, has_local_only = (
+        _evaluate_outputs(_output_specs(entry), manifest_dir=manifest_dir)
+    )
+
+    if has_local_only:
+        return ArtifactResult(
+            artifact_id=artifact_id,
+            state=ArtifactState.STALE_NEEDS_REFRESH,
+            reasons=[*reasons, "artifact is only represented by disposable local output"],
+            warnings=result_warnings,
+            checksum_expected=", ".join(expected_values) or None,
+            checksum_actual=", ".join(actual_values) or None,
+            schema_version=schema_version,
+        )
+
+    if not has_failure and expected_values and len(actual_values) == len(expected_values):
+        if schema_version == current_schema:
+            state = ArtifactState.CURRENT
+        else:
+            state = ArtifactState.HISTORICAL_VALID
+            reasons.append(f"schema is not current: {schema_version or 'missing'}")
+    else:
+        state = ArtifactState.STALE_NEEDS_REFRESH
+
+    return ArtifactResult(
+        artifact_id=artifact_id,
+        state=state,
+        reasons=reasons,
+        warnings=result_warnings,
+        checksum_expected=", ".join(expected_values) or None,
+        checksum_actual=", ".join(actual_values) or None,
+        schema_version=schema_version,
+    )
+
+
+def load_manifest(path: Path) -> list[Any]:
+    """Load JSON or YAML manifest entries."""
+    text = path.read_text(encoding="utf-8")
+
+    if path.suffix.lower() == ".json":
+        payload = json.loads(text)
+    else:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required for YAML manifests")
+        payload = yaml.safe_load(text)
+
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return payload
+    raise ValueError(f"manifest {path} is not a mapping or list")
+
+
+def scan_manifest(
+    manifest_path: Path,
+    *,
+    current_schema: str = CURRENT_ARTIFACT_SCHEMA,
+) -> ArtifactFreshnessReport:
+    """Build a freshness report for every entry in ``manifest_path``."""
+    results: list[ArtifactResult] = []
+    try:
+        entries = load_manifest(manifest_path)
+    except Exception as exc:
+        entries = [
+            {
+                "artifact_id": manifest_path.name,
+                "scan_error": f"cannot load manifest: {exc}",
+            }
+        ]
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            results.append(
+                ArtifactResult(
+                    artifact_id="unnamed",
+                    state=ArtifactState.STALE_NEEDS_REFRESH,
+                    reasons=["manifest entry is not a mapping"],
+                )
+            )
+            continue
+        scan_error = _as_text(entry.get("scan_error"))
+        if scan_error:
+            results.append(
+                ArtifactResult(
+                    artifact_id=_artifact_id(entry),
+                    state=ArtifactState.STALE_NEEDS_REFRESH,
+                    reasons=[scan_error],
+                )
+            )
+            continue
+        results.append(
+            classify_artifact(
+                entry, manifest_dir=manifest_path.parent, current_schema=current_schema
+            )
+        )
+
+    return ArtifactFreshnessReport(
+        generated_at_utc=datetime.now(UTC).isoformat(),
+        manifest_path=str(manifest_path),
+        results=results,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify dissertation/release artifacts for manuscript freshness."
+    )
+    parser.add_argument("manifest", type=Path, help="Artifact manifest JSON/YAML file.")
+    parser.add_argument("--current-schema", default=CURRENT_ARTIFACT_SCHEMA)
+    parser.add_argument("--json-out", type=Path, help="Optional JSON report output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    report = scan_manifest(args.manifest, current_schema=args.current_schema)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_stale_artifact_detector.py
+++ b/tests/tools/test_stale_artifact_detector.py
@@ -1,0 +1,296 @@
+"""Tests for stale artifact freshness classification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools import stale_artifact_detector as detector
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_artifact(tmp_path: Path, name: str, content: bytes = b"artifact") -> tuple[Path, str]:
+    path = tmp_path / "durable" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path, hashlib.sha256(content).hexdigest()
+
+
+def test_classifies_current_artifact_with_matching_checksum(tmp_path: Path) -> None:
+    """Current artifacts need durable path, matching checksum, and current schema."""
+    artifact_path, checksum = _write_artifact(tmp_path, "current.md")
+    relative_artifact = artifact_path.relative_to(tmp_path)
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "current-report",
+            "schema_version": "artifact_catalog.v1",
+            "checksum": checksum,
+            "outputs": {"md": {"path": str(relative_artifact)}},
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.CURRENT
+    assert result.checksum_actual == checksum
+    assert result.reasons == ["output md checksum matches"]
+
+
+def test_classifies_historical_valid_when_checksum_matches_old_schema(tmp_path: Path) -> None:
+    """Older schema with matching durable artifact remains citable only historically."""
+    artifact_path, checksum = _write_artifact(tmp_path, "historical.csv", b"old")
+    relative_artifact = artifact_path.relative_to(tmp_path)
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "historical-table",
+            "schema_version": "artifact_catalog.v0",
+            "sha256": checksum,
+            "outputs": {"csv": {"path": str(relative_artifact)}},
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.HISTORICAL_VALID
+    assert "schema is not current" in result.reasons[-1]
+
+
+def test_classifies_stale_when_checksum_mismatches(tmp_path: Path) -> None:
+    """Checksum drift means the artifact must be refreshed before manuscript use."""
+    artifact_path, _checksum = _write_artifact(tmp_path, "stale.json", b"new")
+    relative_artifact = artifact_path.relative_to(tmp_path)
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "stale-json",
+            "schema_version": "artifact_catalog.v1",
+            "checksum": "0" * 64,
+            "outputs": {"json": {"path": str(relative_artifact)}},
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert "output json checksum mismatch" in result.reasons
+
+
+def test_classifies_blocked_for_manuscript_use_from_readiness_marker() -> None:
+    """Explicit diagnostic or blocked markers should dominate checksum freshness."""
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "diagnostic-only",
+            "schema_version": "artifact_catalog.v1",
+            "readiness": "diagnostic",
+        }
+    )
+
+    assert result.state == detector.ArtifactState.BLOCKED_FOR_MANUSCRIPT_USE
+    assert result.reasons == ["explicit manuscript blocker: readiness=diagnostic"]
+
+
+def test_classifies_blocked_for_manuscript_use_from_blocked_reason() -> None:
+    """A provenance blocker marks the artifact as blocked for manuscript use."""
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "missing-source",
+            "schema_version": "artifact_catalog.v1",
+            "blocked_reason": "missing source provenance",
+        }
+    )
+
+    assert result.state == detector.ArtifactState.BLOCKED_FOR_MANUSCRIPT_USE
+    assert "missing source provenance" in result.reasons[0]
+
+
+def test_local_only_output_paths_are_stale_even_with_matching_checksum(tmp_path: Path) -> None:
+    """Ignored local output paths are not durable manuscript proof."""
+    output_path = tmp_path / "output" / "local.md"
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text("local", encoding="utf-8")
+    checksum = hashlib.sha256(b"local").hexdigest()
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "local-output",
+            "schema_version": "artifact_catalog.v1",
+            "checksum": checksum,
+            "outputs": {"md": {"path": "output/local.md"}},
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert any("local-only" in warning for warning in result.warnings)
+    assert "artifact is only represented by disposable local output" in result.reasons
+
+
+def test_missing_metadata_is_stale_not_crashing() -> None:
+    """Malformed entries should fail closed instead of crashing."""
+    result = detector.classify_artifact({"artifact_id": ""})
+
+    assert result.artifact_id == "unnamed"
+    assert result.state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert result.reasons == ["output artifact missing output path"]
+
+
+def test_local_only_path_traversal_is_stale_even_when_checksum_matches(tmp_path: Path) -> None:
+    """Traversal through a disposable root should not evade local-only detection."""
+    artifact_path = tmp_path / "durable" / "escaped.md"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("escaped", encoding="utf-8")
+    checksum = hashlib.sha256(b"escaped").hexdigest()
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "escaped-output",
+            "schema_version": "artifact_catalog.v1",
+            "outputs": {"md": {"path": "output/../durable/escaped.md", "sha256": checksum}},
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert any("local-only" in warning for warning in result.warnings)
+
+
+def test_multi_output_requires_every_output_to_match(tmp_path: Path) -> None:
+    """A single stale output makes the whole artifact stale."""
+    current_path, current_checksum = _write_artifact(tmp_path, "multi-current.md", b"current")
+    stale_path, _stale_checksum = _write_artifact(tmp_path, "multi-stale.json", b"changed")
+
+    result = detector.classify_artifact(
+        {
+            "artifact_id": "multi-output",
+            "schema_version": "artifact_catalog.v1",
+            "outputs": {
+                "md": {
+                    "path": str(current_path.relative_to(tmp_path)),
+                    "sha256": current_checksum,
+                },
+                "json": {
+                    "path": str(stale_path.relative_to(tmp_path)),
+                    "sha256": "0" * 64,
+                },
+            },
+        },
+        manifest_dir=tmp_path,
+    )
+
+    assert result.state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert "output md checksum matches" in result.reasons
+    assert "output json checksum mismatch" in result.reasons
+
+
+def test_scan_manifest_handles_non_mapping_entries(tmp_path: Path) -> None:
+    """Non-mapping manifest rows become stale entries in the report."""
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(yaml.safe_dump(["not-a-mapping"]), encoding="utf-8")
+
+    report = detector.scan_manifest(manifest)
+
+    assert report.exit_code == 1
+    assert report.results[0].state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert report.results[0].reasons == ["manifest entry is not a mapping"]
+
+
+def test_scan_manifest_summarizes_all_four_states(tmp_path: Path) -> None:
+    """Reports expose compact counts by classification state."""
+    current_path, current_checksum = _write_artifact(tmp_path, "current.md", b"current")
+    historical_path, historical_checksum = _write_artifact(tmp_path, "historical.md", b"history")
+    stale_path, _stale_checksum = _write_artifact(tmp_path, "stale.md", b"changed")
+    current_relative = current_path.relative_to(tmp_path)
+    historical_relative = historical_path.relative_to(tmp_path)
+    stale_relative = stale_path.relative_to(tmp_path)
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "artifact_id": "current",
+                    "schema_version": "artifact_catalog.v1",
+                    "checksum": current_checksum,
+                    "outputs": {"md": {"path": str(current_relative)}},
+                },
+                {
+                    "artifact_id": "historical",
+                    "schema_version": "artifact_catalog.v0",
+                    "checksum": historical_checksum,
+                    "outputs": {"md": {"path": str(historical_relative)}},
+                },
+                {
+                    "artifact_id": "stale",
+                    "schema_version": "artifact_catalog.v1",
+                    "checksum": "0" * 64,
+                    "outputs": {"md": {"path": str(stale_relative)}},
+                },
+                {"artifact_id": "blocked", "readiness": "blocked"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = detector.scan_manifest(manifest)
+    data = report.to_dict()
+
+    assert report.exit_code == 1
+    assert data["summary"] == {
+        "blocked-for-manuscript-use": 1,
+        "current": 1,
+        "historical-valid": 1,
+        "stale-needs-refresh": 1,
+    }
+
+
+def test_load_manifest_supports_json_and_single_mapping(tmp_path: Path) -> None:
+    """JSON and single mapping manifests are normalized to entry lists."""
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"artifact_id": "one"}), encoding="utf-8")
+
+    entries = detector.load_manifest(manifest)
+
+    assert entries == [{"artifact_id": "one"}]
+
+
+def test_scan_manifest_reports_parse_failure_as_stale(tmp_path: Path) -> None:
+    """Manifest load failures produce a non-clean stale report."""
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{not-json", encoding="utf-8")
+
+    report = detector.scan_manifest(manifest)
+
+    assert report.exit_code == 1
+    assert report.results[0].artifact_id == "manifest.json"
+    assert report.results[0].state == detector.ArtifactState.STALE_NEEDS_REFRESH
+    assert "cannot load manifest" in report.results[0].reasons[0]
+
+
+def test_cli_writes_json_report(tmp_path: Path) -> None:
+    """CLI writes a machine-readable JSON report and returns report status."""
+    artifact_path, checksum = _write_artifact(tmp_path, "current.md", b"cli")
+    relative_artifact = artifact_path.relative_to(tmp_path)
+    manifest = tmp_path / "manifest.yaml"
+    report_path = tmp_path / "report.json"
+    manifest.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "artifact_id": "cli-current",
+                    "schema_version": "artifact_catalog.v1",
+                    "checksum": checksum,
+                    "outputs": {"md": {"path": str(relative_artifact)}},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = detector.main([str(manifest), "--json-out", str(report_path)])
+
+    assert exit_code == 0
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert data["summary"]["current"] == 1


### PR DESCRIPTION
## Summary
Adds a local stale-artifact detector for dissertation and release-bundle manifests so artifacts can be classified before manuscript or release reuse.

## Linked Issues
- Closes `#2721`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/tools/stale_artifact_detector.py` with JSON/YAML manifest loading and compact JSON report output.
- Added `tests/tools/test_stale_artifact_detector.py` covering current, historical-valid, stale-needs-refresh, blocked-for-manuscript-use, malformed entries, local-only paths, and CLI JSON output.

## Why It Matters
- Added value: gives release/dissertation workflows a fail-closed local check before treating artifacts as current manuscript evidence.
- Expected impact: reduces stale or local-only evidence leaking into publication/release bundles.
- Why this is worth merging now: it directly supports artifact-quality and reproducibility work in the current goal batch.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support tooling only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA.
- Result classification: NA.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#2721`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it classifies artifact freshness metadata and does not interpret benchmark outcomes.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support tooling only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA - validation completed.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/tools/test_stale_artifact_detector.py -q`
  - `uv run ruff check scripts/tools/stale_artifact_detector.py tests/tools/test_stale_artifact_detector.py`
  - `uv run ruff format --check scripts/tools/stale_artifact_detector.py tests/tools/test_stale_artifact_detector.py`
  - CLI smoke: `uv run python scripts/tools/stale_artifact_detector.py <tmp>/manifest.yaml --json-out <tmp>/report.json`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed; CLI smoke produced a JSON report with `summary.current == 1`; full readiness passed with `5717 passed, 9 skipped, 9 warnings`.
- Benchmarks or smoke tests, if applicable: NA - support tooling.

## Risks / Rollout
- Compatibility risks: additive script; no existing workflows are changed until they opt in.
- Failure modes: artifact schemas vary; the detector fails closed to stale/blocked when metadata is missing, local-only, or malformed.
- Rollback or fallback plan: remove the script and tests; release workflows retain existing manual artifact review.

## Docs / Provenance
- Updated docs: none; classification rules are documented in the script docstring and tests.
- Relevant design or provenance notes: private delegation artifacts recorded under `.git/codex-agent-runs/`.
- Any assumptions that need to be preserved: local `output/` artifacts are not durable manuscript proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): closes via this PR.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is support tooling with no research-result claim.

## Follow-Up Issues
- Deferred work: optional integration into release bundle generation once the detector has a canonical manifest source.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: fail-closed classification for local-only paths and malformed metadata.
- Any known limitations: this PR adds the detector and tests; it does not yet wire the detector into release publication commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added artifact freshness detection tool that classifies manuscript/release artifacts as current, historically valid, stale, or blocked for use based on manifest data.
  * Generates detailed JSON reports with artifact status, classification reasons, and summary counts.

* **Tests**
  * Added comprehensive test suite validating artifact classification logic, manifest parsing, and command-line interface functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->