### PR TITLE
feat: report trace predicate denominator health

### DIFF
--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
 
 TRACE_FAILURE_PREDICATE_SCHEMA_VERSION = "trace_failure_predicates.v1"
 TRACE_FAILURE_PREDICATE_SOURCE = "trace_failure_predicates.rule_based.v1"
+TRACE_PREDICATE_DENOMINATOR_HEALTH_SCHEMA_VERSION = "trace_predicate_denominator_health.v1"
+
+VALIDITY_STATUS_VALID = "valid"
+VALIDITY_STATUS_UNAVAILABLE_DATA = "not_available"
+VALIDITY_STATUS_NO_PREDICATE_OBSERVED = "no_predicate_observed"
+VALIDITY_STATUS_PIPELINE_FAILURE = "pipeline_failure"
+DENOMINATOR_HEALTH_STATUSES = (
+    VALIDITY_STATUS_VALID,
+    VALIDITY_STATUS_UNAVAILABLE_DATA,
+    VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
+    VALIDITY_STATUS_PIPELINE_FAILURE,
+)
 
 TRACE_FAILURE_PREDICATE_IDS = (
     "late_evasive_reaction",
@@ -88,6 +100,7 @@ def aggregate_trace_failure_predicate_tables(
     traces: Iterable[SimulationTraceExport],
     *,
     scenario_family: str | None = None,
+    failed_trace_ids: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """Build denominator-aware aggregate rows across one or more trace predicates.
 
@@ -100,6 +113,13 @@ def aggregate_trace_failure_predicate_tables(
     trace_sources_by_group: dict[tuple[str, str, int], set[str]] = defaultdict(set)
     trace_status_counts: dict[tuple[str, str, int, str], Counter[str]] = defaultdict(Counter)
     included_trace_count = 0
+    predicate_status_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    failed_trace_id_list = list(failed_trace_ids or [])
+
+    if failed_trace_id_list:
+        for _failed_id in failed_trace_id_list:
+            for pred_id in TRACE_FAILURE_PREDICATE_IDS:
+                predicate_status_counts[pred_id][VALIDITY_STATUS_PIPELINE_FAILURE] += 1
 
     for trace in traces:
         group_family = scenario_family or trace.source.scenario_id
@@ -109,7 +129,7 @@ def aggregate_trace_failure_predicate_tables(
         trace_denominators[group_key] += 1
         trace_sources_by_group[group_key].add(trace_source_id)
         included_trace_count += 1
-        for predicate in _extract_trace_failure_predicate_records(
+        extracted_predicates = _extract_trace_failure_predicate_records(
             trace,
             scenario_family=group_family,
             clearance_threshold_m=0.4,
@@ -118,7 +138,9 @@ def aggregate_trace_failure_predicate_tables(
             oscillation_min_sign_changes=3,
             evasive_angular_velocity_threshold=1.0,
             evasive_linear_drop_threshold_mps=0.3,
-        ):
+        )
+        predicate_statuses_in_trace: dict[str, set[str]] = defaultdict(set)
+        for predicate in extracted_predicates:
             grouped_predicates[
                 (
                     group_family,
@@ -130,6 +152,12 @@ def aggregate_trace_failure_predicate_tables(
                 )
             ] += 1
             trace_status_counts[trace_key][predicate.validity_status] += 1
+            predicate_statuses_in_trace[predicate.predicate_id].add(predicate.validity_status)
+
+        _record_predicate_denominator_statuses(
+            predicate_status_counts,
+            predicate_statuses_in_trace,
+        )
 
     rows = [
         {
@@ -175,9 +203,9 @@ def aggregate_trace_failure_predicate_tables(
                 "planner_id": planner_id,
                 "seed": seed,
                 "trace_source_ids": sorted(trace_sources_by_group[group_key]),
-                "predicate_id": "no_predicate_observed",
-                "validity_status": "no_predicate_observed",
-                "severity": "no_predicate_observed",
+                "predicate_id": VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
+                "validity_status": VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
+                "severity": VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
                 "predicate_count": 0,
                 "trace_denominator": trace_denominators[group_key],
                 "predicate_rate_per_trace": 0.0,
@@ -191,12 +219,14 @@ def aggregate_trace_failure_predicate_tables(
             "seed": seed,
             "trace_source_id": trace_source_id,
             "trace_denominator": trace_denominators[group_key],
-            "valid_predicate_count": int(trace_status_counts[trace_key].get("valid", 0)),
+            "valid_predicate_count": int(
+                trace_status_counts[trace_key].get(VALIDITY_STATUS_VALID, 0)
+            ),
             "not_available_predicate_count": int(
-                trace_status_counts[trace_key].get("not_available", 0)
+                trace_status_counts[trace_key].get(VALIDITY_STATUS_UNAVAILABLE_DATA, 0)
             ),
             "zero_group_reason": (
-                "no_predicate_observed"
+                VALIDITY_STATUS_NO_PREDICATE_OBSERVED
                 if not trace_status_counts[trace_key]
                 else "valid_predicate_count_zero"
             ),
@@ -205,30 +235,59 @@ def aggregate_trace_failure_predicate_tables(
         for family, planner_id, seed in (group_key,)
         for trace_source_id in sorted(trace_sources)
         for trace_key in ((*group_key, trace_source_id),)
-        if trace_status_counts[trace_key].get("valid", 0) == 0
+        if trace_status_counts[trace_key].get(VALIDITY_STATUS_VALID, 0) == 0
     ]
 
     return {
         "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
         "table_kind": "aggregate_by_predicate_group",
         "summary": {
-            "input_trace_count": included_trace_count,
+            "input_trace_count": included_trace_count + len(failed_trace_id_list),
+            "failed_trace_count": len(failed_trace_id_list),
             "scenario_family_filter": scenario_family,
             "row_count": len(rows),
         },
         "rows": rows,
         "zero_predicate_groups": zero_predicate_groups,
+        "predicate_denominator_health": {
+            pred_id: {
+                status: int(predicate_status_counts[pred_id].get(status, 0))
+                for status in DENOMINATOR_HEALTH_STATUSES
+            }
+            for pred_id in TRACE_FAILURE_PREDICATE_IDS
+        },
         "caveats": [
             "Aggregate predicate rows are diagnostic summaries, not benchmark rates or claims.",
-            "Rows include `not_available` and other valid status values when evidence is partial.",
+            f"Rows include `{VALIDITY_STATUS_UNAVAILABLE_DATA}` and other valid status values when evidence is partial.",
             "`zero_predicate_groups` preserves trace groups with valid predicate count equal to zero.",
-            "Rows with `no_predicate_observed` mark trace groups that had no predicate rows at all.",
+            f"Rows with `{VALIDITY_STATUS_NO_PREDICATE_OBSERVED}` mark trace groups that had no predicate rows at all.",
+            f"Rows with `{VALIDITY_STATUS_PIPELINE_FAILURE}` mark traces that failed to load.",
             "Rate claims require a predeclared benchmark matrix; do not infer rates from these diagnostic rows.",
         ],
     }
 
 
-def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) -> str:
+def _record_predicate_denominator_statuses(
+    predicate_status_counts: dict[str, Counter[str]],
+    predicate_statuses_in_trace: Mapping[str, set[str]],
+) -> None:
+    """Record one denominator status per predicate family for a trace."""
+    for pred_id in TRACE_FAILURE_PREDICATE_IDS:
+        statuses = predicate_statuses_in_trace.get(pred_id, set())
+        if VALIDITY_STATUS_VALID in statuses:
+            predicate_status_counts[pred_id][VALIDITY_STATUS_VALID] += 1
+        elif VALIDITY_STATUS_UNAVAILABLE_DATA in statuses:
+            predicate_status_counts[pred_id][VALIDITY_STATUS_UNAVAILABLE_DATA] += 1
+        elif statuses:
+            for status in sorted(statuses):
+                predicate_status_counts[pred_id][status] += 1
+        else:
+            predicate_status_counts[pred_id][VALIDITY_STATUS_NO_PREDICATE_OBSERVED] += 1
+
+
+def render_trace_failure_predicate_markdown(
+    table_payload: Mapping[str, Any], denominator_health_report: Mapping[str, Any] | None = None
+) -> str:
     """Render aggregate failure predicate rows as a compact Markdown diagnostic table.
 
     Returns:
@@ -239,6 +298,11 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
     if not isinstance(rows, list):
         rows = []
     table_rows = [row for row in rows if isinstance(row, Mapping)]
+    health_report = (
+        denominator_health_report
+        if denominator_health_report is not None
+        else build_trace_predicate_denominator_health_report(table_payload)
+    )
 
     lines = [
         "# Trace Failure Predicate Table",
@@ -256,6 +320,9 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
 
     if not table_rows:
         lines.append("No predicate rows were observed in the provided traces.")
+        # Add denominator health report even if no predicate rows
+        lines.append("")
+        lines.extend(_render_denominator_health_section(health_report))
         return "\n".join(lines).rstrip() + "\n"
 
     zero_groups = table_payload.get("zero_predicate_groups")
@@ -263,7 +330,9 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
         zero_groups = []
     zero_group_rows = [row for row in zero_groups if isinstance(row, Mapping)]
     observed_rows = [
-        row for row in table_rows if row.get("predicate_id") != "no_predicate_observed"
+        row
+        for row in table_rows
+        if row.get("predicate_id") != VALIDITY_STATUS_NO_PREDICATE_OBSERVED
     ]
 
     lines.append("## Aggregate Rows")
@@ -332,7 +401,179 @@ def render_trace_failure_predicate_markdown(table_payload: Mapping[str, Any]) ->
             )
         )
     lines.append("")
+    lines.extend(_render_denominator_health_section(health_report))
     return "\n".join(lines).rstrip() + "\n"
+
+
+def build_trace_predicate_denominator_health_report(
+    table_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build compact denominator-health and claim-eligibility diagnostics.
+
+    Returns:
+        JSON-safe report grouped by predicate family.
+    """
+    summary = _read_mapping(table_payload.get("summary"), {})
+    input_trace_count = int(summary.get("input_trace_count", 0) or 0)
+    failed_trace_count = int(summary.get("failed_trace_count", 0) or 0)
+    raw_health = table_payload.get("predicate_denominator_health")
+    health_by_predicate = raw_health if isinstance(raw_health, Mapping) else {}
+    predicate_reports: dict[str, dict[str, Any]] = {}
+
+    for pred_id in TRACE_FAILURE_PREDICATE_IDS:
+        raw_counts = health_by_predicate.get(pred_id)
+        counts = raw_counts if isinstance(raw_counts, Mapping) else {}
+        valid_count = int(counts.get(VALIDITY_STATUS_VALID, 0) or 0)
+        unavailable_count = int(counts.get(VALIDITY_STATUS_UNAVAILABLE_DATA, 0) or 0)
+        no_predicate_count = int(counts.get(VALIDITY_STATUS_NO_PREDICATE_OBSERVED, 0) or 0)
+        pipeline_failure_count = int(counts.get(VALIDITY_STATUS_PIPELINE_FAILURE, 0) or 0)
+        total_count = valid_count + unavailable_count + no_predicate_count + pipeline_failure_count
+        if total_count == 0 and input_trace_count > 0:
+            no_predicate_count = max(input_trace_count - failed_trace_count, 0)
+            pipeline_failure_count = failed_trace_count
+            total_count = input_trace_count
+        claim_eligibility, allowed_wording = _predicate_claim_status(
+            valid_count=valid_count,
+            unavailable_count=unavailable_count,
+            no_predicate_count=no_predicate_count,
+            pipeline_failure_count=pipeline_failure_count,
+        )
+        predicate_reports[pred_id] = {
+            "total_denominator_count": total_count,
+            "valid_count": valid_count,
+            "unavailable_data_count": unavailable_count,
+            "no_predicate_observed_count": no_predicate_count,
+            "pipeline_failure_count": pipeline_failure_count,
+            "valid_ratio": _ratio(valid_count, total_count),
+            "unavailable_data_ratio": _ratio(unavailable_count, total_count),
+            "no_predicate_observed_ratio": _ratio(no_predicate_count, total_count),
+            "pipeline_failure_ratio": _ratio(pipeline_failure_count, total_count),
+            "claim_eligibility": claim_eligibility,
+            "allowed_wording": allowed_wording,
+        }
+
+    return {
+        "schema_version": TRACE_PREDICATE_DENOMINATOR_HEALTH_SCHEMA_VERSION,
+        "report_kind": "trace_predicate_denominator_health",
+        "summary": {
+            "total_traces_processed": input_trace_count,
+            "failed_trace_count": failed_trace_count,
+            "predicate_family_count": len(TRACE_FAILURE_PREDICATE_IDS),
+        },
+        "predicates": predicate_reports,
+        "caveats": [
+            "This report is diagnostic-only and does not convert missing predicate evidence into negative findings.",
+            "`no_predicate_observed` can be expected missingness; it is not evidence that a failure did not occur.",
+            "`not_available` and `pipeline_failure` weaken or block downstream figure/table claims.",
+        ],
+    }
+
+
+def _render_denominator_health_section(denominator_health_report: Mapping[str, Any]) -> list[str]:
+    """Render the predicate denominator health section for the Markdown report.
+
+    Returns:
+        Markdown lines for denominator health.
+    """
+    lines = ["## Predicate Denominator Health Report", ""]
+    overall_summary = denominator_health_report.get("summary", {})
+    lines.append(f"- Total Traces Processed: {overall_summary.get('total_traces_processed', 0)}")
+    lines.append(f"- Traces with Pipeline Failures: {overall_summary.get('failed_trace_count', 0)}")
+    lines.append("")
+    lines.append("### Missingness Categories")
+    lines.append(f"- `{VALIDITY_STATUS_VALID}`: predicate evaluated and emitted valid evidence.")
+    lines.append(
+        f"- `{VALIDITY_STATUS_UNAVAILABLE_DATA}`: required trace fields were missing; dependent "
+        "figures/tables are claim-ineligible or wording-weakened."
+    )
+    lines.append(
+        f"- `{VALIDITY_STATUS_NO_PREDICATE_OBSERVED}`: predicate was not emitted for the trace; "
+        "this can be expected missingness and is not a negative finding."
+    )
+    lines.append(
+        f"- `{VALIDITY_STATUS_PIPELINE_FAILURE}`: the trace could not be loaded or processed; "
+        "dependent outputs are claim-ineligible."
+    )
+    lines.append("")
+
+    predicate_data = denominator_health_report.get("predicates", {})
+    if not predicate_data:
+        lines.append("No predicate denominator health data available.")
+        return lines
+
+    health_rows = []
+    for pred_id in TRACE_FAILURE_PREDICATE_IDS:
+        data = predicate_data.get(pred_id, {})
+        if not data:
+            continue
+        health_rows.append(
+            (
+                pred_id,
+                _markdown_int(data.get("total_denominator_count")),
+                _markdown_int(data.get("valid_count")),
+                _markdown_int(data.get("unavailable_data_count")),
+                f"{_markdown_float(data.get('unavailable_data_ratio')):.2%}",
+                _markdown_int(data.get("no_predicate_observed_count")),
+                f"{_markdown_float(data.get('no_predicate_observed_ratio')):.2%}",
+                _markdown_int(data.get("pipeline_failure_count")),
+                f"{_markdown_float(data.get('pipeline_failure_ratio')):.2%}",
+                _markdown_value(data.get("claim_eligibility")),
+                _markdown_value(data.get("allowed_wording")),
+            )
+        )
+
+    if health_rows:
+        lines.append("### Predicate-specific Denominator Health")
+        lines.append("")
+        lines.append(
+            _markdown_table(
+                (
+                    "Predicate ID",
+                    "Total Traces",
+                    "Valid",
+                    "Unavailable Data",
+                    "% Unavailable",
+                    "Not Observed",
+                    "% Not Observed",
+                    "Pipeline Failure",
+                    "% Pipeline Fail",
+                    "Claim Eligibility",
+                    "Allowed Wording",
+                ),
+                health_rows,
+            )
+        )
+    return lines
+
+
+def _predicate_claim_status(
+    *,
+    valid_count: int,
+    unavailable_count: int,
+    no_predicate_count: int,
+    pipeline_failure_count: int,
+) -> tuple[str, str]:
+    """Classify predicate-family claim eligibility from denominator health.
+
+    Returns:
+        Claim eligibility status and allowed wording guidance.
+    """
+    if pipeline_failure_count > 0:
+        return "claim-ineligible", "pipeline failed; do not make predicate-family claims"
+    if valid_count == 0 and unavailable_count > 0:
+        return "claim-ineligible", "required predicate evidence is unavailable"
+    if valid_count == 0 and no_predicate_count > 0:
+        return "wording-weakened", "only report no observed predicate rows, not absence of failure"
+    if unavailable_count > 0:
+        return "wording-weakened", "qualify figure/table wording due to missing predicate evidence"
+    if no_predicate_count > 0:
+        return "wording-weakened", "state that some traces emitted no predicate rows"
+    return "claim-eligible", "diagnostic wording may cite observed predicate rows"
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    """Return a stable ratio for report payloads."""
+    return 0.0 if denominator <= 0 else numerator / denominator
 
 
 def _predicates_payload(
@@ -358,7 +599,7 @@ def _predicates_payload(
         "summary": _summary(predicates),
         "caveats": [
             "Predicates are rule-based trace diagnostics, not benchmark rates or safety claims.",
-            "not_available rows mark partial evidence with missing required fields.",
+            f"`{VALIDITY_STATUS_UNAVAILABLE_DATA}` rows mark partial evidence with missing required fields.",
         ],
     }
 
@@ -449,7 +690,7 @@ def _clearance_critical_interactions(
                         "clearance_threshold_m": clearance_threshold_m,
                     },
                     severity="high" if distance_m <= clearance_threshold_m * 0.75 else "medium",
-                    validity_status="valid",
+                    validity_status=VALIDITY_STATUS_VALID,
                 )
             )
     return predicates
@@ -514,7 +755,7 @@ def _late_evasive_reaction(
                 severity="high"
                 if pressure_distance_m <= near_miss_threshold_m * 0.75
                 else "medium",
-                validity_status="valid",
+                validity_status=VALIDITY_STATUS_VALID,
             )
     return None
 
@@ -546,7 +787,7 @@ def _oscillatory_local_control(
             "min_sign_changes": min_sign_changes,
         },
         severity="medium",
-        validity_status="valid",
+        validity_status=VALIDITY_STATUS_VALID,
     )
 
 
@@ -585,7 +826,7 @@ def _zero_motion_timeout_behavior(
             "timeout_events": [frame.planner.get("event") for frame in timeout_frames],
         },
         severity="high",
-        validity_status="valid",
+        validity_status=VALIDITY_STATUS_VALID,
     )
 
 
@@ -614,7 +855,7 @@ def _bottleneck_deadlocks(
                 involved_actors=["robot"],
                 evidence_fields={"event": event},
                 severity="high",
-                validity_status="valid",
+                validity_status=VALIDITY_STATUS_VALID,
             )
         )
     return predicates
@@ -648,8 +889,8 @@ def _occlusion_triggered_near_miss(
                     "near_miss_threshold_m": near_miss_threshold_m,
                     "missing_fields": ["planner.occlusion_or_visibility"],
                 },
-                severity="not_available",
-                validity_status="not_available",
+                severity=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                validity_status=VALIDITY_STATUS_UNAVAILABLE_DATA,
             )
         if occlusion_value:
             return _predicate(
@@ -665,7 +906,7 @@ def _occlusion_triggered_near_miss(
                     "occlusion_or_visibility": occlusion_value,
                 },
                 severity="high",
-                validity_status="valid",
+                validity_status=VALIDITY_STATUS_VALID,
             )
     return None
 
@@ -852,8 +1093,13 @@ __all__ = [
     "TRACE_FAILURE_PREDICATE_IDS",
     "TRACE_FAILURE_PREDICATE_SCHEMA_VERSION",
     "TRACE_FAILURE_PREDICATE_SOURCE",
+    "VALIDITY_STATUS_NO_PREDICATE_OBSERVED",
+    "VALIDITY_STATUS_PIPELINE_FAILURE",
+    "VALIDITY_STATUS_UNAVAILABLE_DATA",
+    "VALIDITY_STATUS_VALID",
     "TraceFailurePredicate",
     "aggregate_trace_failure_predicate_tables",
+    "build_trace_predicate_denominator_health_report",
     "extract_trace_failure_predicates",
     "render_trace_failure_predicate_markdown",
 ]

--- a/scripts/tools/build_trace_failure_predicate_tables.py
+++ b/scripts/tools/build_trace_failure_predicate_tables.py
@@ -10,26 +10,34 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import robot_sf.analysis_workbench.trace_failure_predicates as tfp
 from robot_sf.analysis_workbench.simulation_trace_export import load_simulation_trace_export
-from robot_sf.analysis_workbench.trace_failure_predicates import (
-    aggregate_trace_failure_predicate_tables,
-    render_trace_failure_predicate_markdown,
-)
+
+if TYPE_CHECKING:
+    from robot_sf.analysis_workbench.simulation_trace_export import SimulationTraceExport
 
 
 def build_trace_failure_predicate_tables(
     *,
     traces: list[Path],
     scenario_family: str | None = None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[str]]:
     """Build aggregate predicate tables from one or more trace paths."""
-    loaded = [load_simulation_trace_export(trace_path) for trace_path in traces]
-    return aggregate_trace_failure_predicate_tables(
-        loaded,
+    loaded_traces: list[SimulationTraceExport] = []
+    failed_trace_ids: list[str] = []
+    for trace_path in traces:
+        try:
+            loaded_traces.append(load_simulation_trace_export(trace_path))
+        except (ValueError, json.JSONDecodeError):
+            failed_trace_ids.append(trace_path.name)
+    payload = tfp.aggregate_trace_failure_predicate_tables(
+        loaded_traces,
         scenario_family=scenario_family,
+        failed_trace_ids=failed_trace_ids,
     )
+    return payload, failed_trace_ids
 
 
 def write_trace_failure_predicate_tables(
@@ -38,23 +46,35 @@ def write_trace_failure_predicate_tables(
     scenario_family: str | None = None,
     output_json: Path,
     output_markdown: Path,
-) -> tuple[Path, Path]:
+    output_denominator_health_json: Path | None = None,
+) -> tuple[Path, Path] | tuple[Path, Path, Path]:
     """Load traces, build aggregate tables, and persist JSON/Markdown outputs."""
-    payload = build_trace_failure_predicate_tables(
+    payload, _failed_trace_ids = build_trace_failure_predicate_tables(
         traces=traces,
         scenario_family=scenario_family,
     )
+    denominator_health_report = tfp.build_trace_predicate_denominator_health_report(payload)
+
     output_json.parent.mkdir(parents=True, exist_ok=True)
     output_markdown.parent.mkdir(parents=True, exist_ok=True)
+
     output_json.write_text(
         json.dumps(payload, indent=2, sort_keys=True),
         encoding="utf-8",
     )
     output_markdown.write_text(
-        render_trace_failure_predicate_markdown(payload),
+        tfp.render_trace_failure_predicate_markdown(payload, denominator_health_report),
         encoding="utf-8",
     )
-    return output_json, output_markdown
+    if output_denominator_health_json is None:
+        return output_json, output_markdown
+
+    output_denominator_health_json.parent.mkdir(parents=True, exist_ok=True)
+    output_denominator_health_json.write_text(
+        json.dumps(denominator_health_report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return output_json, output_markdown, output_denominator_health_json
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -80,6 +100,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("trace_failure_predicate_tables.md"),
         help="Markdown output path. Defaults to ./trace_failure_predicate_tables.md.",
     )
+    parser.add_argument(
+        "--denominator-health-json-output",
+        type=Path,
+        help="Optional JSON output path for the denominator health report.",
+    )
     return parser
 
 
@@ -88,17 +113,21 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     try:
-        json_output, markdown_output = write_trace_failure_predicate_tables(
+        output_paths = write_trace_failure_predicate_tables(
             traces=args.trace,
             scenario_family=args.scenario_family,
             output_json=args.json_output,
             output_markdown=args.markdown_output,
+            output_denominator_health_json=args.denominator_health_json_output,
         )
     except (OSError, ValueError) as exc:
         print(f"{exc}", file=sys.stderr)
         return 1
+    json_output, markdown_output = output_paths[:2]
     print(f"wrote table JSON to {json_output}")
     print(f"wrote table markdown to {markdown_output}")
+    if len(output_paths) == 3:
+        print(f"wrote denominator health JSON to {output_paths[2]}")
     return 0
 
 

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -11,6 +11,7 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
 )
 from robot_sf.analysis_workbench.trace_failure_predicates import (
     aggregate_trace_failure_predicate_tables,
+    build_trace_predicate_denominator_health_report,
     extract_trace_failure_predicates,
     render_trace_failure_predicate_markdown,
 )
@@ -359,3 +360,367 @@ def test_markdown_renderer_skips_invalid_rows_and_preserves_falsy_values() -> No
 
     assert "| 0 |  | 0 |  | zero_like | valid | low | 0 | 1 | 0.0000 |" in markdown
     assert "bad-row" not in markdown
+
+
+def _build_malformed_trace_file(tmp_path: Path, filename: str) -> Path:
+    """Build a malformed trace file for testing pipeline failures."""
+    malformed_trace_path = tmp_path / filename
+    malformed_trace_path.write_text("this is not valid json {", encoding="utf-8")
+    return malformed_trace_path
+
+
+def test_pipeline_failure_handling(tmp_path: Path) -> None:
+    """Pipeline failures should be captured in denominator health reports."""
+    from robot_sf.analysis_workbench.trace_failure_predicates import (
+        TRACE_FAILURE_PREDICATE_IDS,
+        VALIDITY_STATUS_PIPELINE_FAILURE,
+    )
+
+    valid_trace = _build_trace(
+        trace_id="trace-valid",
+        scenario_id="scenario-valid",
+        seed=1,
+        planner_id="planner-A",
+        frames=[_frame(0, 0.0)],
+    )
+    valid_trace_path = tmp_path / "valid_trace.json"
+    valid_trace_path.write_text(json.dumps(valid_trace.to_dict()), encoding="utf-8")
+
+    malformed_trace_path = _build_malformed_trace_file(tmp_path, "malformed_trace.json")
+
+    json_output = tmp_path / "tables.json"
+    markdown_output = tmp_path / "tables.md"
+    denominator_health_json_output = tmp_path / "denominator_health.json"
+
+    json_path, md_path, dh_json_path = write_trace_failure_predicate_tables(
+        traces=[valid_trace_path, malformed_trace_path],
+        output_json=json_output,
+        output_markdown=markdown_output,
+        output_denominator_health_json=denominator_health_json_output,
+    )
+
+    assert json_path == json_output
+    assert md_path == markdown_output
+    assert dh_json_path == denominator_health_json_output
+
+    dh_report = json.loads(dh_json_path.read_text(encoding="utf-8"))
+    assert dh_report["summary"]["total_traces_processed"] == 2
+    assert dh_report["summary"]["failed_trace_count"] == 1
+
+    for pred_id in TRACE_FAILURE_PREDICATE_IDS:
+        pred_summary = dh_report["predicates"][pred_id]
+        assert pred_summary["total_denominator_count"] == 2
+        assert pred_summary["pipeline_failure_count"] == 1
+        assert pred_summary["pipeline_failure_ratio"] == 0.5
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "Traces with Pipeline Failures: 1" in markdown
+    assert f"`{VALIDITY_STATUS_PIPELINE_FAILURE}`" in markdown
+    assert "claim-ineligible" in markdown
+
+
+def test_predicate_denominator_health_in_payload() -> None:
+    """The aggregate payload should include correct predicate denominator health."""
+    from robot_sf.analysis_workbench.trace_failure_predicates import (
+        VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
+        VALIDITY_STATUS_PIPELINE_FAILURE,
+        VALIDITY_STATUS_UNAVAILABLE_DATA,
+        VALIDITY_STATUS_VALID,
+    )
+
+    trace1 = _build_trace(
+        trace_id="t1",
+        scenario_id="s1",
+        seed=1,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"visibility": {"line_of_sight": True}},
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace2 = _build_trace(
+        trace_id="t2",
+        scenario_id="s1",
+        seed=2,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.45, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace3 = _build_trace(
+        trace_id="t3",
+        scenario_id="s1",
+        seed=3,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [5.0, 5.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables([trace1, trace2, trace3])
+
+    dh = payload["predicate_denominator_health"]
+
+    cci_counts = dh["clearance_critical_interaction"]
+    assert cci_counts[VALIDITY_STATUS_VALID] == 1
+    assert cci_counts[VALIDITY_STATUS_UNAVAILABLE_DATA] == 0
+    assert cci_counts[VALIDITY_STATUS_NO_PREDICATE_OBSERVED] == 2
+
+    otnm_counts = dh["occlusion_triggered_near_miss"]
+    assert otnm_counts[VALIDITY_STATUS_VALID] == 0
+    assert otnm_counts[VALIDITY_STATUS_UNAVAILABLE_DATA] == 1
+    assert otnm_counts[VALIDITY_STATUS_NO_PREDICATE_OBSERVED] == 2
+
+    zmtb_counts = dh["zero_motion_timeout_behavior"]
+    assert zmtb_counts[VALIDITY_STATUS_VALID] == 0
+    assert zmtb_counts[VALIDITY_STATUS_UNAVAILABLE_DATA] == 0
+    assert zmtb_counts[VALIDITY_STATUS_NO_PREDICATE_OBSERVED] == 3
+
+    for pred_id in dh:
+        assert VALIDITY_STATUS_PIPELINE_FAILURE in dh[pred_id]
+
+
+def test_denominator_health_counts_trace_groups_not_predicate_rows() -> None:
+    """Multiple rows for one predicate family should not inflate denominator health."""
+    from robot_sf.analysis_workbench.trace_failure_predicates import VALIDITY_STATUS_VALID
+
+    trace = _build_trace(
+        trace_id="trace-repeated-clearance",
+        scenario_id="scenario-repeated-clearance",
+        seed=20,
+        planner_id="planner-j",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"visibility": {"line_of_sight": True}},
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            ),
+            _frame(
+                1,
+                0.1,
+                planner_extra={"visibility": {"line_of_sight": True}},
+                pedestrians=[{"id": "ped_1", "position": [0.2, 0.1], "velocity": [0.0, 0.0]}],
+            ),
+        ],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables([trace])
+    row = _find_row(
+        _aggregate_rows(payload),
+        predicate_id="clearance_critical_interaction",
+    )
+    assert row is not None
+    assert row["predicate_count"] == 2
+    assert (
+        payload["predicate_denominator_health"]["clearance_critical_interaction"][
+            VALIDITY_STATUS_VALID
+        ]
+        == 1
+    )
+
+
+def test_denominator_health_json_report() -> None:
+    """The denominator health JSON report should be correctly structured and populated."""
+    trace1 = _build_trace(
+        trace_id="t1",
+        scenario_id="s1",
+        seed=1,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                planner_extra={"visibility": {"line_of_sight": True}},
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace2 = _build_trace(
+        trace_id="t2",
+        scenario_id="s1",
+        seed=2,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.45, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace3 = _build_trace(
+        trace_id="t3",
+        scenario_id="s1",
+        seed=3,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [5.0, 5.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables([trace1, trace2, trace3])
+    dh_report = build_trace_predicate_denominator_health_report(payload)
+
+    assert dh_report["schema_version"] == "trace_predicate_denominator_health.v1"
+    assert dh_report["summary"]["total_traces_processed"] == 3
+    assert dh_report["summary"]["failed_trace_count"] == 0
+
+    cci_summary = dh_report["predicates"]["clearance_critical_interaction"]
+    assert cci_summary["valid_count"] == 1
+    assert cci_summary["unavailable_data_count"] == 0
+    assert cci_summary["no_predicate_observed_count"] == 2
+    assert cci_summary["total_denominator_count"] == 3
+    assert cci_summary["unavailable_data_ratio"] == 0.0
+    assert cci_summary["pipeline_failure_count"] == 0
+
+    otnm_summary = dh_report["predicates"]["occlusion_triggered_near_miss"]
+    assert otnm_summary["valid_count"] == 0
+    assert otnm_summary["unavailable_data_count"] == 1
+    assert otnm_summary["no_predicate_observed_count"] == 2
+    assert otnm_summary["total_denominator_count"] == 3
+    assert otnm_summary["unavailable_data_ratio"] == 1 / 3
+    assert otnm_summary["pipeline_failure_count"] == 0
+    assert otnm_summary["claim_eligibility"] == "claim-ineligible"
+
+
+def test_writer_persists_denominator_health_json_when_requested(tmp_path: Path) -> None:
+    """The writer should persist compact denominator health JSON when requested."""
+    trace = _build_trace(
+        trace_id="trace-health-writer",
+        scenario_id="scenario-health-writer",
+        seed=19,
+        planner_id="planner-i",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace_path = tmp_path / "trace.json"
+    json_output = tmp_path / "tables.json"
+    markdown_output = tmp_path / "tables.md"
+    health_output = tmp_path / "denominator_health.json"
+    trace_path.write_text(json.dumps(trace.to_dict(), indent=2), encoding="utf-8")
+
+    paths = write_trace_failure_predicate_tables(
+        traces=[trace_path],
+        output_json=json_output,
+        output_markdown=markdown_output,
+        output_denominator_health_json=health_output,
+    )
+
+    assert paths == (json_output, markdown_output, health_output)
+    health = json.loads(health_output.read_text(encoding="utf-8"))
+    assert health["schema_version"] == "trace_predicate_denominator_health.v1"
+    assert health["summary"]["predicate_family_count"] == 6
+
+
+def test_markdown_report_with_denominator_health(tmp_path: Path) -> None:
+    """Markdown report should include denominator health section and caveats."""
+    from robot_sf.analysis_workbench.trace_failure_predicates import (
+        VALIDITY_STATUS_NO_PREDICATE_OBSERVED,
+        VALIDITY_STATUS_PIPELINE_FAILURE,
+        VALIDITY_STATUS_UNAVAILABLE_DATA,
+        VALIDITY_STATUS_VALID,
+    )
+
+    trace1 = _build_trace(
+        trace_id="t1",
+        scenario_id="s1",
+        seed=1,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.1], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace2 = _build_trace(
+        trace_id="t2",
+        scenario_id="s1",
+        seed=2,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.45, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    trace3 = _build_trace(
+        trace_id="t3",
+        scenario_id="s1",
+        seed=3,
+        planner_id="p1",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [5.0, 5.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+    malformed_trace_path = _build_malformed_trace_file(tmp_path, "malformed_trace_t4.json")
+
+    valid_trace_path1 = tmp_path / "valid_trace_t1.json"
+    valid_trace_path1.write_text(json.dumps(trace1.to_dict()), encoding="utf-8")
+    valid_trace_path2 = tmp_path / "valid_trace_t2.json"
+    valid_trace_path2.write_text(json.dumps(trace2.to_dict()), encoding="utf-8")
+    valid_trace_path3 = tmp_path / "valid_trace_t3.json"
+    valid_trace_path3.write_text(json.dumps(trace3.to_dict()), encoding="utf-8")
+    json_output = tmp_path / "tables.json"
+    markdown_output = tmp_path / "tables.md"
+    denominator_health_json_output = tmp_path / "denominator_health.json"
+
+    write_trace_failure_predicate_tables(
+        traces=[valid_trace_path1, valid_trace_path2, valid_trace_path3, malformed_trace_path],
+        output_json=json_output,
+        output_markdown=markdown_output,
+        output_denominator_health_json=denominator_health_json_output,
+    )
+
+    markdown_content = markdown_output.read_text(encoding="utf-8")
+
+    assert "## Predicate Denominator Health Report" in markdown_content
+    assert "### Missingness Categories" in markdown_content
+    assert f"- `{VALIDITY_STATUS_VALID}`: predicate evaluated" in markdown_content
+    assert (
+        f"- `{VALIDITY_STATUS_UNAVAILABLE_DATA}`: required trace fields were missing"
+        in markdown_content
+    )
+    assert (
+        f"- `{VALIDITY_STATUS_NO_PREDICATE_OBSERVED}`: predicate was not emitted"
+        in markdown_content
+    )
+    assert (
+        f"- `{VALIDITY_STATUS_PIPELINE_FAILURE}`: the trace could not be loaded" in markdown_content
+    )
+    assert "### Predicate-specific Denominator Health" in markdown_content
+
+    assert "clearance_critical_interaction" in markdown_content
+    assert "occlusion_triggered_near_miss" in markdown_content
+    assert "zero_motion_timeout_behavior" in markdown_content
+    assert "claim-ineligible" in markdown_content
+    assert "pipeline failed; do not make predicate-family claims" in markdown_content


### PR DESCRIPTION
## Summary
Adds denominator-health reporting for trace failure predicate tables, including compact JSON and Markdown claim-eligibility guidance for missing predicate evidence.

## Linked Issues
- Closes `#2719`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `predicate_denominator_health` to aggregate trace failure predicate payloads with one denominator status per predicate family per trace group.
- Added `trace_predicate_denominator_health.v1` JSON report generation and Markdown sections explaining `valid`, `not_available`, `no_predicate_observed`, and `pipeline_failure`.
- Extended the CLI writer with optional `--denominator-health-json-output` while preserving existing JSON/Markdown writer calls.
- Added tests for valid, zero-observed, not-available, pipeline-failure, Markdown, writer, and row-count-vs-denominator-count behavior.

## Why It Matters
- Added value: makes predicate missingness visible instead of burying denominator gaps in aggregate rows.
- Expected impact: dissertation/appendix artifacts can distinguish observed predicate evidence from unavailable traces or expected no-observed rows.
- Why this is worth merging now: it reduces risk of overstating trace-predicate findings from partial diagnostic data.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: trace predicate artifacts need denominator and missingness health before being used in figure/table wording.
- Comparator or baseline, if applicable: previous predicate aggregate table output without per-family denominator health.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision or stop rule, if applicable: downstream claims remain ineligible or wording-weakened when denominator health reports `not_available` or `pipeline_failure`.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#2719`
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use on committed fixture `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json` via the CLI command listed below.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - diagnostic analysis helper, not a planner mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA - fixture smoke verifies reporting path, not benchmark mechanism presence.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: none

## Next Empirical Action
- Rerun needed: no for this helper PR
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for the representative fixture smoke
- Stop / revise / continue decision: continue using denominator-health outputs in downstream trace artifact audits
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `rtk uv run ruff format robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py && rtk uv run ruff check robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py`
  - `rtk uv run pytest tests/analysis_workbench/test_trace_failure_predicates.py -q`
  - `rtk uv run python scripts/tools/build_trace_failure_predicate_tables.py --trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --json-output /tmp/issue2719_tables.json --markdown-output /tmp/issue2719_tables.md --denominator-health-json-output /tmp/issue2719_denominator_health.json`
  - `rtk env PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests passed (`15 passed`) and final PR readiness passed from committed head `2991beac1e2e087996a678511f039e43827cb565` with `5732 passed, 9 skipped`.
- Benchmarks or smoke tests, if applicable: CLI smoke on committed trace fixture wrote JSON, Markdown, and denominator-health JSON.

## Risks / Rollout
- Compatibility risks: low; status vocabulary remains `not_available`, schema stays `trace_failure_predicates.v1`, and denominator-health JSON output is opt-in for the CLI writer.
- Failure modes: malformed trace files are counted as `pipeline_failure` across predicate families rather than silently omitted.
- Rollback or fallback plan: revert this commit to restore previous aggregate-only trace predicate output.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: issue `#2719`; representative fixture smoke outputs were local `/tmp` validation artifacts only.
- Any assumptions that need to be preserved: `no_predicate_observed` is expected/diagnostic missingness, not evidence that a failure did not occur.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing `#2719`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this PR adds diagnostic helper output and fixture-level proof, but does not publish a new benchmark result, claim map row, leaderboard entry, or durable artifact bundle.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: denominator health counts predicate-family trace groups, not raw predicate rows; see the repeated-clearance regression test.
- Any known limitations: the Markdown report is diagnostic-only and intentionally does not reinterpret missing predicate rows as negative findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added denominator health reporting to trace failure predicate analysis for assessing data validity and predicate observability
  * Tracks and reports pipeline failures alongside predicate analysis results

* **Improvements**
  * Enhanced trace analysis with improved error handling and failure diagnostics
  * More comprehensive markdown output displaying data availability and validity information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->