### PR TITLE
feat: add signal compliance metrics

### DIFF
--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2606,7 +2606,22 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     try:
         values.update(calculate_signal_metrics(data))
     except Exception:
-        logger.exception("Failed to compute signal metrics; continuing without signal metrics.")
+        logger.exception("Failed to compute signal metrics; falling back to unavailable defaults.")
+        values.update(
+            {
+                "signal_red_phase_violations": 0,
+                "signal_stop_line_crossings_under_red": 0,
+                "signal_min_distance_to_stop_line_before_crossing_m": float("nan"),
+                "signal_delay_after_green_onset_s": float("nan"),
+                "signal_pedestrian_conflict_during_legal_crossing_count": 0,
+                "signal_unavailable_exclusion_count": 1,
+                "signal_metrics_denominator": 0,
+                "signal_metrics_evidence": {
+                    "state": "unavailable",
+                    "exclusion_reason": "signal_metrics_computation_failed",
+                },
+            }
+        )
     # Use collision-count-based success semantics for benchmark-facing outputs.
     values["success"] = 1.0 if episode_success else 0.0
     values["time_to_goal_norm"] = (

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -57,6 +57,7 @@ from robot_sf.benchmark.constants import (
 from robot_sf.benchmark.constants import (
     NEAR_MISS_DIST as D_NEAR,
 )
+from robot_sf.benchmark.signal_metrics import calculate_signal_metrics
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -110,6 +111,7 @@ class EpisodeData:
     other_agents_pos: np.ndarray | None = None
     robot_radius: float = 1.0
     ped_radius: float = 0.4
+    episode_metadata: dict[str, Any] | None = None
 
 
 def has_force_data(data: EpisodeData) -> bool:
@@ -2526,10 +2528,18 @@ METRIC_NAMES: list[str] = [
     "wall_collisions",
     "clearing_distance_min",
     "clearing_distance_avg",
+    "signal_red_phase_violations",
+    "signal_stop_line_crossings_under_red",
+    "signal_min_distance_to_stop_line_before_crossing_m",
+    "signal_delay_after_green_onset_s",
+    "signal_pedestrian_conflict_during_legal_crossing_count",
+    "signal_unavailable_exclusion_count",
+    "signal_metrics_denominator",
+    "signal_metrics_evidence",
 ]
 
 
-def compute_all_metrics(  # noqa: PLR0913
+def compute_all_metrics(  # noqa: PLR0913, PLR0915
     data: EpisodeData,
     *,
     horizon: int,
@@ -2541,7 +2551,7 @@ def compute_all_metrics(  # noqa: PLR0913
     ped_impact_window_steps: int = 5,
     social_proxemic_radius_m: float = 1.2,
     human_proxy_yield_speed_mps: float = 0.15,
-) -> dict[str, float]:
+) -> dict[str, Any]:
     """Compute all defined metrics for an episode and return them as a mapping.
 
     Calls each metric implementation on the provided ``EpisodeData`` instance and collects scalar
@@ -2567,7 +2577,7 @@ def compute_all_metrics(  # noqa: PLR0913
         human_proxy_yield_speed_mps: Robot speed threshold used to detect proxy yielding.
 
     Returns:
-        dict[str, float]: Mapping from metric name (e.g., ``success``, ``force_q50``,
+        dict[str, Any]: Mapping from metric name (e.g., ``success``, ``force_q50``,
         ``force_gradient_norm_mean``) to the computed scalar value. When
         ``experimental_ped_impact`` is enabled, additional ``ped_impact_*`` and
         exploratory ``social_proxemic_*`` keys are included.
@@ -2592,7 +2602,11 @@ def compute_all_metrics(  # noqa: PLR0913
         and total_collision_count == 0
     )
 
-    values: dict[str, float] = {}
+    values: dict[str, Any] = {}
+    try:
+        values.update(calculate_signal_metrics(data))
+    except Exception:
+        logger.exception("Failed to compute signal metrics; continuing without signal metrics.")
     # Use collision-count-based success semantics for benchmark-facing outputs.
     values["success"] = 1.0 if episode_success else 0.0
     values["time_to_goal_norm"] = (
@@ -2723,6 +2737,11 @@ def post_process_metrics(
         "shield_intervention_count",
         "shield_override_count",
         "shield_hard_constraint_violation_count",
+        "signal_red_phase_violations",
+        "signal_stop_line_crossings_under_red",
+        "signal_pedestrian_conflict_during_legal_crossing_count",
+        "signal_unavailable_exclusion_count",
+        "signal_metrics_denominator",
     ):
         if count_key in metrics and metrics[count_key] is not None:
             try:

--- a/robot_sf/benchmark/signal_metrics.py
+++ b/robot_sf/benchmark/signal_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Protocol
 
 import numpy as np
@@ -45,7 +46,7 @@ def _expand_timeline(timeline: list[dict[str, Any]], dt: float) -> list[dict[str
     expanded: list[dict[str, Any]] = []
     for phase_info in timeline:
         duration = float(phase_info.get("duration", 0.0))
-        steps = max(0, round(duration / dt))
+        steps = max(1, math.ceil(duration / dt)) if duration > 0.0 else 0
         expanded.extend([phase_info] * steps)
     return expanded
 
@@ -64,25 +65,19 @@ def _distance_to_segment(point: np.ndarray, segment: np.ndarray) -> float:
     return float(np.linalg.norm(point - closest_point))
 
 
-def _stop_line_side(
-    point: np.ndarray,
-    stop_line: np.ndarray,
-    crosswalk_polygon: list[list[float]] | None,
-) -> bool:
-    """Return whether a point is on the crosswalk side of the stop line."""
+def _signed_stop_line_side(point: np.ndarray, stop_line: np.ndarray) -> int:
+    """Return the signed side of a point relative to the stop line."""
     p1 = stop_line[0]
     p2 = stop_line[1]
     line_vec = p2 - p1
-    if crosswalk_polygon:
-        normal = np.array([-line_vec[1], line_vec[0]], dtype=float)
-        crosswalk_centroid = np.mean(np.asarray(crosswalk_polygon, dtype=float), axis=0)
-        side_crosswalk = float(np.dot(crosswalk_centroid - p1, normal))
-        if not np.isclose(side_crosswalk, 0.0):
-            return float(np.dot(point - p1, normal)) * side_crosswalk > 0.0
-    return bool(point[0] > stop_line[0][0])
+    normal = np.array([-line_vec[1], line_vec[0]], dtype=float)
+    signed = float(np.dot(point - p1, normal))
+    if np.isclose(signed, 0.0):
+        return 0
+    return 1 if signed > 0.0 else -1
 
 
-def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C901, PLR0912
+def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
     """Calculates all signal compliance and violation metrics for a given episode.
 
     Args:
@@ -118,7 +113,7 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
     stop_line = signal_state.get("stop_line")
     crosswalk_polygon = signal_state.get("crosswalk_polygon")
 
-    if not timeline or not stop_line:
+    if not timeline or not stop_line or not crosswalk_polygon:
         return _unavailable_metrics("planner_observable", "observable_signal_fields_incomplete")
 
     expanded_timeline = _expand_timeline(timeline, data.dt)
@@ -141,25 +136,30 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
             break
 
     crossed_stop_line = False
-    crossed_under_red = False
+    initial_side = _signed_stop_line_side(data.robot_pos[0], stop_line) if T > 0 else 0
+    previous_side = initial_side
 
     for t in range(T):
         pos = data.robot_pos[t]
         phase = expanded_timeline[min(t, len(expanded_timeline) - 1)]
 
         dist_to_line = _distance_to_segment(pos, stop_line)
-        is_past_line = _stop_line_side(pos, stop_line, crosswalk_polygon)
+        current_side = _signed_stop_line_side(pos, stop_line)
+        if previous_side == 0 and current_side != 0:
+            previous_side = current_side
+            if initial_side == 0:
+                initial_side = current_side
+        crossed_this_step = previous_side != 0 and current_side not in (0, previous_side)
+        is_past_line = current_side != 0 and initial_side not in (0, current_side)
 
-        if is_past_line and not crossed_stop_line:
+        if crossed_this_step and not crossed_stop_line:
             crossed_stop_line = True
             if phase.get("state") == "red":
-                crossed_under_red = True
+                red_phase_violations += 1
                 stop_line_crossings_under_red += 1
 
         if phase.get("state") == "red":
-            if is_past_line and crossed_under_red:
-                red_phase_violations += 1
-            elif not crossed_stop_line:
+            if not crossed_stop_line:
                 min_dist_to_stop_line = (
                     min(min_dist_to_stop_line, dist_to_line)
                     if not np.isnan(min_dist_to_stop_line)
@@ -169,6 +169,8 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
         if green_onset_step != -1 and t >= green_onset_step and np.isnan(delay_after_green):
             if is_past_line:
                 delay_after_green = (t - green_onset_step) * data.dt
+        if current_side != 0:
+            previous_side = current_side
 
     # Simplified pedestrian conflict
     if crosswalk_polygon and data.peds_pos.shape[1] > 0:

--- a/robot_sf/benchmark/signal_metrics.py
+++ b/robot_sf/benchmark/signal_metrics.py
@@ -1,0 +1,184 @@
+"""Signal compliance and violation metrics."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+from shapely.geometry import Point, Polygon
+
+
+class SignalEpisode(Protocol):
+    """Protocol for episode data needed by signal metrics."""
+
+    robot_pos: np.ndarray
+    peds_pos: np.ndarray
+    dt: float
+    episode_metadata: dict[str, Any] | None
+
+
+def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
+    """Calculates all signal compliance and violation metrics for a given episode.
+
+    Args:
+        data: An object conforming to the SignalEpisode protocol.
+
+    Returns:
+        A dictionary of calculated signal metrics.
+    """
+    if not data.episode_metadata:
+        return {
+            "signal_red_phase_violations": 0,
+            "signal_stop_line_crossings_under_red": 0,
+            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
+            "signal_delay_after_green_onset_s": np.nan,
+            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
+            "signal_unavailable_exclusion_count": 1,
+            "signal_metrics_denominator": 0,
+            "signal_metrics_evidence": {
+                "state": "unavailable",
+                "exclusion_reason": "signal_state_metadata_absent",
+            },
+        }
+
+    signal_state = data.episode_metadata.get("signal_state")
+    if (
+        not signal_state
+        or signal_state.get("contract_state") != "planner_observable"
+        or signal_state.get("benchmark_evidence") is not True
+    ):
+        evidence_state = (
+            str(signal_state.get("contract_state", "unavailable"))
+            if isinstance(signal_state, dict) and signal_state
+            else "unavailable"
+        )
+        exclusion_reason = (
+            "signal_state_metadata_absent"
+            if evidence_state == "unavailable"
+            else "signal_state_not_benchmark_evidence"
+            if isinstance(signal_state, dict) and signal_state.get("benchmark_evidence") is not True
+            else "signal_state_not_planner_observable"
+        )
+        return {
+            "signal_red_phase_violations": 0,
+            "signal_stop_line_crossings_under_red": 0,
+            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
+            "signal_delay_after_green_onset_s": np.nan,
+            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
+            "signal_unavailable_exclusion_count": 1,
+            "signal_metrics_denominator": 0,
+            "signal_metrics_evidence": {
+                "state": evidence_state,
+                "exclusion_reason": exclusion_reason,
+            },
+        }
+
+    timeline = signal_state.get("timeline", [])
+    stop_line = signal_state.get("stop_line")
+    crosswalk_polygon = signal_state.get("crosswalk_polygon")
+
+    if not timeline or not stop_line:
+        return {
+            "signal_red_phase_violations": 0,
+            "signal_stop_line_crossings_under_red": 0,
+            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
+            "signal_delay_after_green_onset_s": np.nan,
+            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
+            "signal_unavailable_exclusion_count": 1,
+            "signal_metrics_denominator": 0,
+            "signal_metrics_evidence": {
+                "state": "planner_observable",
+                "exclusion_reason": "observable_signal_fields_incomplete",
+            },
+        }
+
+    # Expand the timeline based on duration and dt
+    expanded_timeline = []
+    for phase_info in timeline:
+        steps = int(phase_info["duration"] / data.dt)
+        for _ in range(steps):
+            expanded_timeline.append(phase_info)
+
+    stop_line = np.array(stop_line)
+    red_phase_violations = 0
+    stop_line_crossings_under_red = 0
+    min_dist_to_stop_line = np.nan
+    delay_after_green = np.nan
+    ped_conflicts = 0
+
+    T = data.robot_pos.shape[0]
+
+    green_onset_step = -1
+    for i, phase in enumerate(expanded_timeline):
+        if phase.get("state") == "green" and green_onset_step == -1:
+            green_onset_step = i
+            break
+
+    crossed_stop_line = False
+
+    for t in range(T):
+        pos = data.robot_pos[t]
+        phase = expanded_timeline[min(t, len(expanded_timeline) - 1)]
+
+        # Distance to stop line (assuming stop line is a line segment)
+        p1 = stop_line[0]
+        p2 = stop_line[1]
+        line_vec = p2 - p1
+        p_vec = pos - p1
+        line_len_sq = np.dot(line_vec, line_vec)
+        if line_len_sq == 0:  # Should not happen with valid stop line
+            dist_to_line = np.linalg.norm(p_vec)
+        else:
+            t_val = np.dot(p_vec, line_vec) / line_len_sq
+            t_val = np.clip(t_val, 0, 1)
+            closest_point = p1 + t_val * line_vec
+            dist_to_line = np.linalg.norm(pos - closest_point)
+
+        # Check if robot is past the stop line
+        is_past_line = pos[0] > stop_line[0][0]
+
+        if phase.get("state") == "red":
+            if is_past_line:
+                red_phase_violations += 1
+                if not crossed_stop_line:
+                    stop_line_crossings_under_red += 1
+            elif not crossed_stop_line:
+                min_dist_to_stop_line = (
+                    min(min_dist_to_stop_line, dist_to_line)
+                    if not np.isnan(min_dist_to_stop_line)
+                    else dist_to_line
+                )
+
+        if green_onset_step != -1 and t >= green_onset_step and np.isnan(delay_after_green):
+            if is_past_line:
+                delay_after_green = (t - green_onset_step) * data.dt
+
+        if is_past_line:
+            crossed_stop_line = True
+
+    # Simplified pedestrian conflict
+    if crosswalk_polygon and data.peds_pos.shape[1] > 0:
+        crosswalk = Polygon(crosswalk_polygon)
+        for t in range(T):
+            if not expanded_timeline[min(t, len(expanded_timeline) - 1)].get("state") == "red":
+                robot_point = Point(data.robot_pos[t])
+                if crosswalk.contains(robot_point):
+                    for k in range(data.peds_pos.shape[1]):
+                        ped_point = Point(data.peds_pos[t, k])
+                        if crosswalk.contains(ped_point) and robot_point.distance(ped_point) < 2.0:
+                            ped_conflicts += 1
+                            break
+
+    return {
+        "signal_red_phase_violations": red_phase_violations,
+        "signal_stop_line_crossings_under_red": stop_line_crossings_under_red,
+        "signal_min_distance_to_stop_line_before_crossing_m": min_dist_to_stop_line,
+        "signal_delay_after_green_onset_s": delay_after_green,
+        "signal_pedestrian_conflict_during_legal_crossing_count": ped_conflicts,
+        "signal_unavailable_exclusion_count": 0,
+        "signal_metrics_denominator": 1,
+        "signal_metrics_evidence": {
+            "state": "planner_observable",
+            "exclusion_reason": "",
+        },
+    }

--- a/robot_sf/benchmark/signal_metrics.py
+++ b/robot_sf/benchmark/signal_metrics.py
@@ -17,7 +17,72 @@ class SignalEpisode(Protocol):
     episode_metadata: dict[str, Any] | None
 
 
-def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
+def _unavailable_metrics(state: str, exclusion_reason: str) -> dict[str, Any]:
+    """Return a schema-safe excluded signal-metric row."""
+    return {
+        "signal_red_phase_violations": 0,
+        "signal_stop_line_crossings_under_red": 0,
+        "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
+        "signal_delay_after_green_onset_s": np.nan,
+        "signal_pedestrian_conflict_during_legal_crossing_count": 0,
+        "signal_unavailable_exclusion_count": 1,
+        "signal_metrics_denominator": 0,
+        "signal_metrics_evidence": {
+            "state": state,
+            "exclusion_reason": exclusion_reason,
+        },
+    }
+
+
+def _expand_timeline(timeline: list[dict[str, Any]], dt: float) -> list[dict[str, Any]]:
+    """Expand phase durations into per-step phase records.
+
+    Returns:
+        Per-step signal phase records.
+    """
+    if dt <= 0.0 or not np.isfinite(dt):
+        return []
+    expanded: list[dict[str, Any]] = []
+    for phase_info in timeline:
+        duration = float(phase_info.get("duration", 0.0))
+        steps = max(0, round(duration / dt))
+        expanded.extend([phase_info] * steps)
+    return expanded
+
+
+def _distance_to_segment(point: np.ndarray, segment: np.ndarray) -> float:
+    """Return Euclidean distance from a point to a line segment."""
+    p1 = segment[0]
+    p2 = segment[1]
+    line_vec = p2 - p1
+    p_vec = point - p1
+    line_len_sq = float(np.dot(line_vec, line_vec))
+    if line_len_sq == 0.0:
+        return float(np.linalg.norm(p_vec))
+    t_val = float(np.dot(p_vec, line_vec) / line_len_sq)
+    closest_point = p1 + np.clip(t_val, 0.0, 1.0) * line_vec
+    return float(np.linalg.norm(point - closest_point))
+
+
+def _stop_line_side(
+    point: np.ndarray,
+    stop_line: np.ndarray,
+    crosswalk_polygon: list[list[float]] | None,
+) -> bool:
+    """Return whether a point is on the crosswalk side of the stop line."""
+    p1 = stop_line[0]
+    p2 = stop_line[1]
+    line_vec = p2 - p1
+    if crosswalk_polygon:
+        normal = np.array([-line_vec[1], line_vec[0]], dtype=float)
+        crosswalk_centroid = np.mean(np.asarray(crosswalk_polygon, dtype=float), axis=0)
+        side_crosswalk = float(np.dot(crosswalk_centroid - p1, normal))
+        if not np.isclose(side_crosswalk, 0.0):
+            return float(np.dot(point - p1, normal)) * side_crosswalk > 0.0
+    return bool(point[0] > stop_line[0][0])
+
+
+def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C901, PLR0912
     """Calculates all signal compliance and violation metrics for a given episode.
 
     Args:
@@ -27,19 +92,7 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
         A dictionary of calculated signal metrics.
     """
     if not data.episode_metadata:
-        return {
-            "signal_red_phase_violations": 0,
-            "signal_stop_line_crossings_under_red": 0,
-            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
-            "signal_delay_after_green_onset_s": np.nan,
-            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
-            "signal_unavailable_exclusion_count": 1,
-            "signal_metrics_denominator": 0,
-            "signal_metrics_evidence": {
-                "state": "unavailable",
-                "exclusion_reason": "signal_state_metadata_absent",
-            },
-        }
+        return _unavailable_metrics("unavailable", "signal_state_metadata_absent")
 
     signal_state = data.episode_metadata.get("signal_state")
     if (
@@ -59,47 +112,20 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
             if isinstance(signal_state, dict) and signal_state.get("benchmark_evidence") is not True
             else "signal_state_not_planner_observable"
         )
-        return {
-            "signal_red_phase_violations": 0,
-            "signal_stop_line_crossings_under_red": 0,
-            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
-            "signal_delay_after_green_onset_s": np.nan,
-            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
-            "signal_unavailable_exclusion_count": 1,
-            "signal_metrics_denominator": 0,
-            "signal_metrics_evidence": {
-                "state": evidence_state,
-                "exclusion_reason": exclusion_reason,
-            },
-        }
+        return _unavailable_metrics(evidence_state, exclusion_reason)
 
     timeline = signal_state.get("timeline", [])
     stop_line = signal_state.get("stop_line")
     crosswalk_polygon = signal_state.get("crosswalk_polygon")
 
     if not timeline or not stop_line:
-        return {
-            "signal_red_phase_violations": 0,
-            "signal_stop_line_crossings_under_red": 0,
-            "signal_min_distance_to_stop_line_before_crossing_m": np.nan,
-            "signal_delay_after_green_onset_s": np.nan,
-            "signal_pedestrian_conflict_during_legal_crossing_count": 0,
-            "signal_unavailable_exclusion_count": 1,
-            "signal_metrics_denominator": 0,
-            "signal_metrics_evidence": {
-                "state": "planner_observable",
-                "exclusion_reason": "observable_signal_fields_incomplete",
-            },
-        }
+        return _unavailable_metrics("planner_observable", "observable_signal_fields_incomplete")
 
-    # Expand the timeline based on duration and dt
-    expanded_timeline = []
-    for phase_info in timeline:
-        steps = int(phase_info["duration"] / data.dt)
-        for _ in range(steps):
-            expanded_timeline.append(phase_info)
+    expanded_timeline = _expand_timeline(timeline, data.dt)
+    if not expanded_timeline:
+        return _unavailable_metrics("planner_observable", "observable_signal_fields_incomplete")
 
-    stop_line = np.array(stop_line)
+    stop_line = np.asarray(stop_line, dtype=float)
     red_phase_violations = 0
     stop_line_crossings_under_red = 0
     min_dist_to_stop_line = np.nan
@@ -115,33 +141,24 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
             break
 
     crossed_stop_line = False
+    crossed_under_red = False
 
     for t in range(T):
         pos = data.robot_pos[t]
         phase = expanded_timeline[min(t, len(expanded_timeline) - 1)]
 
-        # Distance to stop line (assuming stop line is a line segment)
-        p1 = stop_line[0]
-        p2 = stop_line[1]
-        line_vec = p2 - p1
-        p_vec = pos - p1
-        line_len_sq = np.dot(line_vec, line_vec)
-        if line_len_sq == 0:  # Should not happen with valid stop line
-            dist_to_line = np.linalg.norm(p_vec)
-        else:
-            t_val = np.dot(p_vec, line_vec) / line_len_sq
-            t_val = np.clip(t_val, 0, 1)
-            closest_point = p1 + t_val * line_vec
-            dist_to_line = np.linalg.norm(pos - closest_point)
+        dist_to_line = _distance_to_segment(pos, stop_line)
+        is_past_line = _stop_line_side(pos, stop_line, crosswalk_polygon)
 
-        # Check if robot is past the stop line
-        is_past_line = pos[0] > stop_line[0][0]
+        if is_past_line and not crossed_stop_line:
+            crossed_stop_line = True
+            if phase.get("state") == "red":
+                crossed_under_red = True
+                stop_line_crossings_under_red += 1
 
         if phase.get("state") == "red":
-            if is_past_line:
+            if is_past_line and crossed_under_red:
                 red_phase_violations += 1
-                if not crossed_stop_line:
-                    stop_line_crossings_under_red += 1
             elif not crossed_stop_line:
                 min_dist_to_stop_line = (
                     min(min_dist_to_stop_line, dist_to_line)
@@ -153,19 +170,19 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
             if is_past_line:
                 delay_after_green = (t - green_onset_step) * data.dt
 
-        if is_past_line:
-            crossed_stop_line = True
-
     # Simplified pedestrian conflict
     if crosswalk_polygon and data.peds_pos.shape[1] > 0:
         crosswalk = Polygon(crosswalk_polygon)
         for t in range(T):
-            if not expanded_timeline[min(t, len(expanded_timeline) - 1)].get("state") == "red":
+            if expanded_timeline[min(t, len(expanded_timeline) - 1)].get("state") != "red":
                 robot_point = Point(data.robot_pos[t])
                 if crosswalk.contains(robot_point):
                     for k in range(data.peds_pos.shape[1]):
-                        ped_point = Point(data.peds_pos[t, k])
-                        if crosswalk.contains(ped_point) and robot_point.distance(ped_point) < 2.0:
+                        ped_pos = data.peds_pos[t, k]
+                        if np.linalg.norm(data.robot_pos[t] - ped_pos) >= 2.0:
+                            continue
+                        ped_point = Point(ped_pos)
+                        if crosswalk.contains(ped_point):
                             ped_conflicts += 1
                             break
 

--- a/tests/benchmark/test_signal_metrics.py
+++ b/tests/benchmark/test_signal_metrics.py
@@ -66,7 +66,7 @@ def test_calculate_signal_metrics_valid_observable():
     episode = MockSignalEpisode(robot_pos, peds_pos, dt, episode_metadata)
     metrics = calculate_signal_metrics(episode)
 
-    assert metrics["signal_red_phase_violations"] == 4
+    assert metrics["signal_red_phase_violations"] == 1
     assert metrics["signal_stop_line_crossings_under_red"] == 1
     assert np.isclose(metrics["signal_min_distance_to_stop_line_before_crossing_m"], 10.0)
     assert np.isclose(metrics["signal_delay_after_green_onset_s"], 0.0)
@@ -100,7 +100,7 @@ def test_calculate_signal_metrics_uses_crosswalk_side_for_stop_line():
     metrics = calculate_signal_metrics(episode)
 
     assert metrics["signal_stop_line_crossings_under_red"] == 1
-    assert metrics["signal_red_phase_violations"] == 2
+    assert metrics["signal_red_phase_violations"] == 1
 
 
 def test_calculate_signal_metrics_green_crossing_not_red_violation():
@@ -247,6 +247,31 @@ def test_calculate_signal_metrics_incomplete_observable_fields():
         "state": "planner_observable",
         "exclusion_reason": "observable_signal_fields_incomplete",
     }
+
+
+def test_calculate_signal_metrics_missing_crosswalk_is_incomplete():
+    """Pedestrian-conflict metrics need a conflict-zone polygon."""
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [{"state": "green", "duration": 1.0}],
+            "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+        }
+    }
+    episode = MockSignalEpisode(
+        np.zeros((2, 2)),
+        np.zeros((2, 0, 2)),
+        1.0,
+        episode_metadata,
+    )
+
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_metrics_denominator"] == 0
+    assert metrics["signal_metrics_evidence"]["exclusion_reason"] == (
+        "observable_signal_fields_incomplete"
+    )
 
 
 def test_calculate_signal_metrics_with_pedestrian_conflict():

--- a/tests/benchmark/test_signal_metrics.py
+++ b/tests/benchmark/test_signal_metrics.py
@@ -79,6 +79,58 @@ def test_calculate_signal_metrics_valid_observable():
     }
 
 
+def test_calculate_signal_metrics_uses_crosswalk_side_for_stop_line():
+    """Stop-line crossing should work for non-x-axis approaches."""
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [{"state": "red", "duration": 0.3}],
+            "stop_line": [[-1.0, 0.0], [1.0, 0.0]],
+            "crosswalk_polygon": [[-1.0, 1.0], [1.0, 1.0], [1.0, 3.0], [-1.0, 3.0]],
+        }
+    }
+    episode = MockSignalEpisode(
+        np.array([[0.0, -1.0], [0.0, 0.5], [0.0, 1.5]]),
+        np.zeros((3, 0, 2)),
+        0.1,
+        episode_metadata,
+    )
+
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_stop_line_crossings_under_red"] == 1
+    assert metrics["signal_red_phase_violations"] == 2
+
+
+def test_calculate_signal_metrics_green_crossing_not_red_violation():
+    """A robot already past the stop line after green onset should not be a red violation."""
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [
+                {"state": "red", "duration": 0.2},
+                {"state": "green", "duration": 0.2},
+            ],
+            "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+            "crosswalk_polygon": [[1.0, 1.0], [2.0, 1.0], [2.0, -1.0], [1.0, -1.0]],
+        }
+    }
+    episode = MockSignalEpisode(
+        np.array([[-1.0, 0.0], [-0.5, 0.0], [0.5, 0.0], [1.5, 0.0]]),
+        np.zeros((4, 0, 2)),
+        0.1,
+        episode_metadata,
+    )
+
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_stop_line_crossings_under_red"] == 0
+    assert metrics["signal_red_phase_violations"] == 0
+    assert np.isclose(metrics["signal_delay_after_green_onset_s"], 0.0)
+
+
 def test_calculate_signal_metrics_no_signal_data():
     """
     Tests that when no signal data is available in the metadata, the metrics reflect

--- a/tests/benchmark/test_signal_metrics.py
+++ b/tests/benchmark/test_signal_metrics.py
@@ -1,0 +1,237 @@
+"""Tests for the signal compliance metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.benchmark.signal_metrics import SignalEpisode, calculate_signal_metrics
+
+
+class MockSignalEpisode(SignalEpisode):
+    """A mock episode class for testing signal metrics."""
+
+    def __init__(
+        self,
+        robot_pos: np.ndarray,
+        peds_pos: np.ndarray,
+        dt: float,
+        episode_metadata: dict | None,
+    ):
+        """Initializes the mock episode."""
+        self.robot_pos = robot_pos
+        self.peds_pos = peds_pos
+        self.dt = dt
+        self.episode_metadata = episode_metadata
+
+
+def test_calculate_signal_metrics_valid_observable():
+    """
+    Tests the signal metrics calculation for a valid, observable scenario where the robot
+    violates a red light.
+    """
+    # Metadata for a signalized intersection
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [
+                {"state": "red", "duration": 5.0},
+                {"state": "green", "duration": 5.0},
+            ],
+            "stop_line": [[10.0, 10.0], [10.0, -10.0]],
+            "crosswalk_polygon": [
+                [11.0, 10.0],
+                [15.0, 10.0],
+                [15.0, -10.0],
+                [11.0, -10.0],
+            ],
+        }
+    }
+
+    # Robot trajectory: starts before the stop line, crosses it during red phase
+    robot_pos = np.array(
+        [
+            [0.0, 0.0],  # t=0, before stop line, red
+            [11.0, 0.0],  # t=1, crossed stop line, red
+            [12.0, 0.0],  # t=2, in crosswalk, red
+            [13.0, 0.0],  # t=3, in crosswalk, red
+            [14.0, 0.0],  # t=4, in crosswalk, red
+            [15.0, 0.0],  # t=5, start of green
+        ]
+    )
+
+    peds_pos = np.zeros((6, 0, 2))  # No pedestrians in this test
+    dt = 1.0
+
+    episode = MockSignalEpisode(robot_pos, peds_pos, dt, episode_metadata)
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_red_phase_violations"] == 4
+    assert metrics["signal_stop_line_crossings_under_red"] == 1
+    assert np.isclose(metrics["signal_min_distance_to_stop_line_before_crossing_m"], 10.0)
+    assert np.isclose(metrics["signal_delay_after_green_onset_s"], 0.0)
+    assert metrics["signal_pedestrian_conflict_during_legal_crossing_count"] == 0
+    assert metrics["signal_unavailable_exclusion_count"] == 0
+    assert metrics["signal_metrics_denominator"] == 1
+    assert metrics["signal_metrics_evidence"] == {
+        "state": "planner_observable",
+        "exclusion_reason": "",
+    }
+
+
+def test_calculate_signal_metrics_no_signal_data():
+    """
+    Tests that when no signal data is available in the metadata, the metrics reflect
+    an unavailable exclusion.
+    """
+    robot_pos = np.zeros((10, 2))
+    peds_pos = np.zeros((10, 0, 2))
+    dt = 0.1
+
+    # Test with None metadata
+    episode_none = MockSignalEpisode(robot_pos, peds_pos, dt, None)
+    metrics_none = calculate_signal_metrics(episode_none)
+    assert metrics_none["signal_unavailable_exclusion_count"] == 1
+    assert metrics_none["signal_metrics_denominator"] == 0
+    assert metrics_none["signal_metrics_evidence"] == {
+        "state": "unavailable",
+        "exclusion_reason": "signal_state_metadata_absent",
+    }
+
+    # Test with empty metadata
+    episode_empty = MockSignalEpisode(robot_pos, peds_pos, dt, {})
+    metrics_empty = calculate_signal_metrics(episode_empty)
+    assert metrics_empty["signal_unavailable_exclusion_count"] == 1
+    assert metrics_empty["signal_metrics_denominator"] == 0
+    assert metrics_empty["signal_metrics_evidence"] == {
+        "state": "unavailable",
+        "exclusion_reason": "signal_state_metadata_absent",
+    }
+
+    # Test with empty signal_state
+    episode_empty_signal_state = MockSignalEpisode(robot_pos, peds_pos, dt, {"signal_state": {}})
+    metrics_empty_signal_state = calculate_signal_metrics(episode_empty_signal_state)
+    assert metrics_empty_signal_state["signal_unavailable_exclusion_count"] == 1
+    assert metrics_empty_signal_state["signal_metrics_denominator"] == 0
+    assert metrics_empty_signal_state["signal_metrics_evidence"] == {
+        "state": "unavailable",
+        "exclusion_reason": "signal_state_metadata_absent",
+    }
+
+
+def test_calculate_signal_metrics_proxy_diagnostic():
+    """
+    Tests that for proxy/diagnostic planners, the metrics are marked as unavailable for
+    benchmark evidence.
+    """
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "proxy_diagnostic",
+            # other data doesn't matter for this test
+        }
+    }
+    robot_pos = np.zeros((10, 2))
+    peds_pos = np.zeros((10, 0, 2))
+    dt = 0.1
+    episode = MockSignalEpisode(robot_pos, peds_pos, dt, episode_metadata)
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_unavailable_exclusion_count"] == 1
+    assert metrics["signal_metrics_denominator"] == 0
+    assert metrics["signal_metrics_evidence"] == {
+        "state": "proxy_diagnostic",
+        "exclusion_reason": "signal_state_not_benchmark_evidence",
+    }
+
+
+def test_calculate_signal_metrics_degraded_observable_without_evidence():
+    """Planner-observable metadata without benchmark evidence remains excluded."""
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": False,
+            "timeline": [{"state": "green", "duration": 1.0}],
+            "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+        }
+    }
+    episode = MockSignalEpisode(
+        np.zeros((2, 2)),
+        np.zeros((2, 0, 2)),
+        1.0,
+        episode_metadata,
+    )
+
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_metrics_denominator"] == 0
+    assert metrics["signal_unavailable_exclusion_count"] == 1
+    assert metrics["signal_metrics_evidence"] == {
+        "state": "planner_observable",
+        "exclusion_reason": "signal_state_not_benchmark_evidence",
+    }
+
+
+def test_calculate_signal_metrics_incomplete_observable_fields():
+    """Observable evidence without required fields is preserved but excluded."""
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [{"state": "green", "duration": 1.0}],
+        }
+    }
+    episode = MockSignalEpisode(
+        np.zeros((2, 2)),
+        np.zeros((2, 0, 2)),
+        1.0,
+        episode_metadata,
+    )
+
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_metrics_denominator"] == 0
+    assert metrics["signal_unavailable_exclusion_count"] == 1
+    assert metrics["signal_metrics_evidence"] == {
+        "state": "planner_observable",
+        "exclusion_reason": "observable_signal_fields_incomplete",
+    }
+
+
+def test_calculate_signal_metrics_with_pedestrian_conflict():
+    """
+    Tests the pedestrian conflict metric during a legal crossing.
+    """
+    episode_metadata = {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [
+                {"state": "red", "duration": 2.0},
+                {"state": "green", "duration": 8.0},
+            ],
+            "stop_line": [[0.0, 5.0], [0.0, -5.0]],
+            "crosswalk_polygon": [[1.0, 5.0], [5.0, 5.0], [5.0, -5.0], [1.0, -5.0]],
+        }
+    }
+
+    robot_pos = np.array(
+        [
+            [-1.0, 0.0],  # t=0, red
+            [-0.5, 0.0],  # t=1, red
+            [1.5, 0.0],  # t=2, green, robot enters crosswalk
+            [2.5, 0.0],  # t=3, green, robot in crosswalk
+        ]
+    )
+
+    peds_pos = np.zeros((4, 1, 2))
+    peds_pos[3, 0] = [2.0, 0.0]  # Pedestrian appears close to robot at t=3
+
+    dt = 1.0
+
+    episode = MockSignalEpisode(robot_pos, peds_pos, dt, episode_metadata)
+    metrics = calculate_signal_metrics(episode)
+
+    assert metrics["signal_pedestrian_conflict_during_legal_crossing_count"] == 1
+    assert metrics["signal_unavailable_exclusion_count"] == 0
+    assert metrics["signal_metrics_denominator"] == 1
+    assert metrics["signal_metrics_evidence"]["state"] == "planner_observable"


### PR DESCRIPTION
## Summary

- Add deterministic signal-compliance metrics with explicit denominators and fail-closed evidence metadata.
- Wire signal metrics into `compute_all_metrics` while preserving backward-compatible `EpisodeData` callers and schema-safe metric values.
- Cover valid observable, no-signal/unavailable, proxy diagnostic, degraded/no-benchmark-evidence, incomplete-observable, orientation-aware stop-line, red violation, green crossing, delay, and pedestrian-conflict rows.

Closes #2718.

## Validation

- `uv run pytest tests/test_metrics.py tests/benchmark/test_signal_metrics.py -q` -> 86 passed
- `uv run pytest tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py -q` -> 14 passed
- `uv run ruff check robot_sf/benchmark/metrics.py robot_sf/benchmark/signal_metrics.py tests/test_metrics.py tests/benchmark/test_signal_metrics.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/metrics.py robot_sf/benchmark/signal_metrics.py tests/test_metrics.py tests/benchmark/test_signal_metrics.py` -> passed
- `git diff --check` -> passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5746 passed, 9 skipped; readiness stamp `output/validation/pr_ready/issue-2718-signal-compliance-metrics.json` for head `7a3258c9a8a2d31d909a1760e5bafd878298784f`

## Research Result Guidance

- Target claim/blocker: signalized-crossing rows can report observable signal-compliance metrics without promoting proxy/degraded evidence.
- Comparator/baseline: existing #2662 proxy-diagnostic signal wrapper and fail-closed promotion contract.
- Evidence tier: nominal local unit/schema/readiness proof; not benchmark outcome evidence.
- Result classification: support/metric plumbing. Valid rows require `planner_observable` plus `benchmark_evidence: true`; proxy, unavailable, degraded, and incomplete rows preserve denominator 0 with exclusion metadata.
- Decision/stop rule: metric output can be used by later report tables; planner traffic-light compliance remains unclaimed until observable runtime traces exist.
- Synthesis surface/update target: #2718 and future signalized-crossing benchmark/report work.

## Downstream Propagation

- Parent issue: #2718 closes with metric plumbing.
- Claim map/benchmark report/leaderboard: NA; this PR adds metric computation only, not benchmark results.
- Registry/config index: NA; no new benchmark config or artifact registry entry.
- Context/memory: Existing signal-state contract remains current; no durable generated artifact promoted.
- Follow-up: Future work can build report tables over real observable signal traces and use the new denominator/exclusion fields.

## Artifact Decision

Generated `output/coverage/*` and `output/validation/pr_ready/*` are local validation artifacts and remain ignored. No durable benchmark artifact is claimed.