### PR TITLE
feat: add pedestrian forecast baseline metrics

### DIFF
--- a/robot_sf/benchmark/pedestrian_forecast.py
+++ b/robot_sf/benchmark/pedestrian_forecast.py
@@ -1,0 +1,314 @@
+"""Deterministic pedestrian forecast baselines for benchmark step traces."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+DEFAULT_FORECAST_HORIZONS_S = (0.5, 1.0, 2.0)
+
+
+@dataclass(frozen=True)
+class PedestrianState:
+    """One trace-compatible pedestrian state at a single timestep."""
+
+    id: int
+    position: np.ndarray
+    velocity: np.ndarray
+    intent: str | None = None
+    signal: str | None = None
+    signal_available: bool = False
+
+    @classmethod
+    def from_trace(cls, payload: dict[str, Any]) -> PedestrianState:
+        """Build a state from ``simulation_step_trace.steps[].pedestrians[]``.
+
+        Returns:
+            Trace-compatible pedestrian state.
+        """
+
+        signal_state = payload.get("signal_state")
+        signal_available = False
+        signal: str | None = None
+        if isinstance(signal_state, dict):
+            signal_available = bool(
+                signal_state.get("available")
+                if "available" in signal_state
+                else signal_state.get("label") is not None
+            )
+            if signal_available and signal_state.get("label") is not None:
+                signal = str(signal_state["label"])
+        elif payload.get("signal_label") is not None:
+            signal_available = True
+            signal = str(payload["signal_label"])
+
+        return cls(
+            id=int(payload["id"]),
+            position=np.asarray(payload["position"], dtype=float),
+            velocity=np.asarray(payload["velocity"], dtype=float),
+            intent=str(payload["intent_label"])
+            if payload.get("intent_label") is not None
+            else None,
+            signal=signal,
+            signal_available=signal_available,
+        )
+
+
+@dataclass(frozen=True)
+class ForecastDistribution:
+    """Gaussian occupancy ellipse for one pedestrian and horizon."""
+
+    horizon_s: float
+    mean: np.ndarray
+    covariance: np.ndarray
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PedestrianForecast:
+    """Predicted distributions for one pedestrian."""
+
+    id: int
+    predictions: list[ForecastDistribution]
+
+
+def constant_velocity_gaussian_baseline(
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    base_std_m: float = 0.3,
+    velocity_std_rate: float = 0.4,
+    unavailable_context_multiplier: float = 1.5,
+) -> PedestrianForecast:
+    """Forecast future pedestrian occupancy with a deterministic Gaussian baseline.
+
+    The mean follows constant velocity. Uncertainty grows with horizon and is
+    widened when intent or signal context is unavailable, so unknown signal
+    state is represented as uncertainty rather than an assumed phase.
+
+    Returns:
+        Forecast distributions for the requested horizons.
+    """
+
+    context_available = state.intent is not None and state.signal_available
+    multiplier = 1.0 if context_available else unavailable_context_multiplier
+    predictions: list[ForecastDistribution] = []
+
+    for horizon_s in horizons_s:
+        horizon = float(horizon_s)
+        std_m = (base_std_m + velocity_std_rate * horizon) * multiplier
+        if std_m <= 0.0:
+            raise ValueError("forecast standard deviation must be positive")
+        predictions.append(
+            ForecastDistribution(
+                horizon_s=horizon,
+                mean=state.position + state.velocity * horizon,
+                covariance=np.eye(2, dtype=float) * (std_m**2),
+                metadata={
+                    "model": "constant_velocity_gaussian",
+                    "std_m": float(std_m),
+                    "is_intent_aware": state.intent is not None,
+                    "is_signal_aware": state.signal_available,
+                    "signal_state": state.signal if state.signal_available else "unknown",
+                    "context_status": "available" if context_available else "uncertain",
+                },
+            )
+        )
+
+    return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+def evaluate_forecast(
+    forecast: PedestrianForecast,
+    ground_truth: dict[float, np.ndarray],
+    *,
+    confidence_level: float = 0.95,
+    robot_positions: dict[float, np.ndarray] | None = None,
+    collision_distance_m: float = 0.8,
+) -> dict[str, float]:
+    """Evaluate likelihood, calibration, miss rate, and collision relevance.
+
+    Returns:
+        Flat metric dictionary keyed by metric name and horizon suffix.
+    """
+
+    metrics: dict[str, float] = {}
+    confidence_threshold = chi_square_2d_threshold(confidence_level)
+    for prediction in forecast.predictions:
+        horizon = prediction.horizon_s
+        if horizon not in ground_truth:
+            continue
+
+        actual_position = np.asarray(ground_truth[horizon], dtype=float)
+        offset = actual_position - prediction.mean
+        inverse_covariance = np.linalg.inv(prediction.covariance)
+        determinant = float(np.linalg.det(prediction.covariance))
+        mahalanobis_sq = float(offset.T @ inverse_covariance @ offset)
+        log_likelihood = -0.5 * (
+            mahalanobis_sq + math.log(determinant) + 2.0 * math.log(2.0 * math.pi)
+        )
+        within_confidence = mahalanobis_sq <= confidence_threshold
+        suffix = f"{horizon:g}s"
+
+        metrics[f"ade_{suffix}"] = float(np.linalg.norm(offset))
+        metrics[f"log_likelihood_{suffix}"] = float(log_likelihood)
+        metrics[f"negative_log_likelihood_{suffix}"] = float(-log_likelihood)
+        metrics[f"mahalanobis_dist_{suffix}"] = float(math.sqrt(mahalanobis_sq))
+        metrics[f"within_{int(confidence_level * 100)}ci_{suffix}"] = (
+            1.0 if within_confidence else 0.0
+        )
+        metrics[f"miss_rate_{suffix}"] = 0.0 if within_confidence else 1.0
+        metrics[f"calibration_error_{suffix}"] = abs(
+            (1.0 if within_confidence else 0.0) - confidence_level
+        )
+
+        if robot_positions is not None and horizon in robot_positions:
+            robot_position = np.asarray(robot_positions[horizon], dtype=float)
+            actual_relevant = float(
+                np.linalg.norm(actual_position - robot_position) <= collision_distance_m
+            )
+            predicted_relevant = float(
+                ellipse_overlaps_point(
+                    mean=prediction.mean,
+                    covariance=prediction.covariance,
+                    point=robot_position,
+                    confidence_threshold=confidence_threshold,
+                    radius_m=collision_distance_m,
+                )
+            )
+            metrics[f"collision_relevance_error_{suffix}"] = abs(
+                predicted_relevant - actual_relevant
+            )
+
+    return metrics
+
+
+def chi_square_2d_threshold(confidence_level: float) -> float:
+    """Return the chi-square threshold for a 2D Gaussian confidence ellipse."""
+
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be between 0 and 1")
+    return float(-2.0 * math.log(1.0 - confidence_level))
+
+
+def ellipse_overlaps_point(
+    *,
+    mean: np.ndarray,
+    covariance: np.ndarray,
+    point: np.ndarray,
+    confidence_threshold: float,
+    radius_m: float,
+) -> bool:
+    """Approximate whether an ellipse overlaps a circular relevance region.
+
+    The first baseline emits isotropic covariance, but this helper uses the
+    maximum covariance eigenvalue as a conservative bounding radius so later
+    non-isotropic forecasts can still be scored deterministically.
+
+    Returns:
+        True when the confidence ellipse overlaps the circular relevance region.
+    """
+
+    max_variance = float(np.max(np.linalg.eigvalsh(covariance)))
+    ellipse_radius = math.sqrt(max(0.0, confidence_threshold * max_variance))
+    return bool(np.linalg.norm(np.asarray(mean) - np.asarray(point)) <= ellipse_radius + radius_m)
+
+
+def compute_batch_forecast_metrics(
+    trace_steps: list[dict[str, Any]],
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    dt_s: float = 0.1,
+    confidence_level: float = 0.95,
+    collision_distance_m: float = 0.8,
+) -> dict[str, float]:
+    """Compute aggregate forecast metrics over benchmark trace steps.
+
+    Returns:
+        Mean metrics plus per-metric denominator counts.
+    """
+
+    if dt_s <= 0.0:
+        raise ValueError("dt_s must be positive")
+
+    sample_metrics: list[dict[str, float]] = []
+    for step_index, step in enumerate(trace_steps):
+        for pedestrian_payload in step.get("pedestrians", []):
+            state = PedestrianState.from_trace(pedestrian_payload)
+            ground_truth = _future_pedestrian_positions(
+                state.id,
+                step_index,
+                trace_steps,
+                horizons_s,
+                dt_s,
+            )
+            if not ground_truth:
+                continue
+            sample_metrics.append(
+                evaluate_forecast(
+                    constant_velocity_gaussian_baseline(state, horizons_s),
+                    ground_truth,
+                    confidence_level=confidence_level,
+                    robot_positions=_future_robot_positions(
+                        step_index,
+                        trace_steps,
+                        horizons_s,
+                        dt_s,
+                    ),
+                    collision_distance_m=collision_distance_m,
+                )
+            )
+
+    if not sample_metrics:
+        return {"forecast_evaluable_samples": 0.0}
+
+    values_by_key: dict[str, list[float]] = defaultdict(list)
+    for sample in sample_metrics:
+        for key, value in sample.items():
+            values_by_key[key].append(float(value))
+
+    summary = {"forecast_evaluable_samples": float(len(sample_metrics))}
+    for key, values in sorted(values_by_key.items()):
+        summary[f"mean_{key}"] = float(np.mean(values))
+        summary[f"count_{key}"] = float(len(values))
+    return summary
+
+
+def _future_pedestrian_positions(
+    pedestrian_id: int,
+    start_index: int,
+    trace_steps: list[dict[str, Any]],
+    horizons_s: list[float] | tuple[float, ...],
+    dt_s: float,
+) -> dict[float, np.ndarray]:
+    positions: dict[float, np.ndarray] = {}
+    for horizon_s in horizons_s:
+        future_step = start_index + round(float(horizon_s) / dt_s)
+        if future_step >= len(trace_steps):
+            continue
+        for pedestrian in trace_steps[future_step].get("pedestrians", []):
+            if int(pedestrian["id"]) == pedestrian_id:
+                positions[float(horizon_s)] = np.asarray(pedestrian["position"], dtype=float)
+                break
+    return positions
+
+
+def _future_robot_positions(
+    start_index: int,
+    trace_steps: list[dict[str, Any]],
+    horizons_s: list[float] | tuple[float, ...],
+    dt_s: float,
+) -> dict[float, np.ndarray]:
+    positions: dict[float, np.ndarray] = {}
+    for horizon_s in horizons_s:
+        future_step = start_index + round(float(horizon_s) / dt_s)
+        if future_step >= len(trace_steps):
+            continue
+        robot = trace_steps[future_step].get("robot")
+        if isinstance(robot, dict) and robot.get("position") is not None:
+            positions[float(horizon_s)] = np.asarray(robot["position"], dtype=float)
+    return positions

--- a/tests/benchmark/test_pedestrian_forecast.py
+++ b/tests/benchmark/test_pedestrian_forecast.py
@@ -1,0 +1,202 @@
+"""Tests for deterministic pedestrian forecast baselines."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.pedestrian_forecast import (
+    PedestrianState,
+    chi_square_2d_threshold,
+    compute_batch_forecast_metrics,
+    constant_velocity_gaussian_baseline,
+    evaluate_forecast,
+)
+
+
+def test_constant_velocity_forecast_is_deterministic() -> None:
+    """Forecast means and covariance are stable for fixed trace inputs."""
+
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 1.0]),
+        velocity=np.array([1.0, -0.5]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+
+    first = constant_velocity_gaussian_baseline(state, horizons_s=(0.5, 1.0))
+    second = constant_velocity_gaussian_baseline(state, horizons_s=(0.5, 1.0))
+
+    assert first.id == 1
+    assert [prediction.horizon_s for prediction in first.predictions] == [0.5, 1.0]
+    for left, right in zip(first.predictions, second.predictions, strict=True):
+        np.testing.assert_allclose(left.mean, right.mean)
+        np.testing.assert_allclose(left.covariance, right.covariance)
+    np.testing.assert_allclose(first.predictions[0].mean, [0.5, 0.75])
+    assert first.predictions[0].metadata["context_status"] == "available"
+
+
+def test_unavailable_signal_widens_uncertainty_without_assuming_phase() -> None:
+    """Unavailable signal metadata is exposed as uncertainty, not a phase guess."""
+
+    aware = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    unknown_signal = PedestrianState.from_trace(
+        {
+            "id": 1,
+            "position": [0.0, 0.0],
+            "velocity": [1.0, 0.0],
+            "intent_label": "crossing",
+            "signal_state": {"available": False},
+        }
+    )
+
+    aware_forecast = constant_velocity_gaussian_baseline(aware, horizons_s=(1.0,))
+    unknown_forecast = constant_velocity_gaussian_baseline(unknown_signal, horizons_s=(1.0,))
+
+    assert unknown_signal.signal is None
+    assert unknown_forecast.predictions[0].metadata["signal_state"] == "unknown"
+    assert unknown_forecast.predictions[0].metadata["context_status"] == "uncertain"
+    assert unknown_forecast.predictions[0].metadata["std_m"] == pytest.approx(
+        aware_forecast.predictions[0].metadata["std_m"] * 1.5
+    )
+
+
+def test_flat_signal_label_trace_path_is_supported() -> None:
+    """Legacy flat signal labels are still represented as available signal context."""
+
+    state = PedestrianState.from_trace(
+        {
+            "id": 4,
+            "position": [1.0, 2.0],
+            "velocity": [0.0, 0.0],
+            "signal_label": "red",
+        }
+    )
+
+    assert state.signal_available is True
+    assert state.signal == "red"
+
+
+def test_evaluate_forecast_reports_likelihood_calibration_and_miss_rate() -> None:
+    """Single-sample forecast metrics include NLL, calibration, and miss rate."""
+
+    forecast = constant_velocity_gaussian_baseline(
+        PedestrianState(
+            id=1,
+            position=np.array([0.0, 0.0]),
+            velocity=np.array([1.0, 0.0]),
+            intent="crossing",
+            signal="green",
+            signal_available=True,
+        ),
+        horizons_s=(1.0,),
+    )
+
+    perfect = evaluate_forecast(forecast, {1.0: np.array([1.0, 0.0])})
+    assert perfect["negative_log_likelihood_1s"] == pytest.approx(-perfect["log_likelihood_1s"])
+    assert perfect["mahalanobis_dist_1s"] == 0.0
+    assert perfect["miss_rate_1s"] == 0.0
+    assert perfect["within_95ci_1s"] == 1.0
+    assert perfect["calibration_error_1s"] == pytest.approx(0.05)
+
+    missed = evaluate_forecast(forecast, {1.0: np.array([10.0, 0.0])})
+    assert missed["miss_rate_1s"] == 1.0
+    assert missed["within_95ci_1s"] == 0.0
+    assert missed["calibration_error_1s"] == pytest.approx(0.95)
+
+
+def test_evaluate_forecast_reports_collision_relevance_error() -> None:
+    """Collision relevance compares predicted overlap against future robot proximity."""
+
+    forecast = constant_velocity_gaussian_baseline(
+        PedestrianState(
+            id=7,
+            position=np.array([0.0, 0.0]),
+            velocity=np.array([1.0, 0.0]),
+            intent="crossing",
+            signal="green",
+            signal_available=True,
+        ),
+        horizons_s=(1.0,),
+    )
+
+    matching = evaluate_forecast(
+        forecast,
+        {1.0: np.array([1.0, 0.0])},
+        robot_positions={1.0: np.array([1.1, 0.0])},
+        collision_distance_m=0.3,
+    )
+    assert matching["collision_relevance_error_1s"] == 0.0
+
+    false_positive = evaluate_forecast(
+        forecast,
+        {1.0: np.array([5.0, 0.0])},
+        robot_positions={1.0: np.array([1.1, 0.0])},
+        collision_distance_m=0.3,
+    )
+    assert false_positive["collision_relevance_error_1s"] == 1.0
+
+
+def test_compute_batch_forecast_metrics_uses_trace_steps_and_denominators() -> None:
+    """Batch metrics consume trace steps and report denominator counts."""
+
+    dt_s = 0.5
+    trace_steps = []
+    for index in range(5):
+        x = index * dt_s
+        trace_steps.append(
+            {
+                "step": index,
+                "time_s": x,
+                "robot": {"position": [x + 0.1, 0.0]},
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [x, 0.0],
+                        "velocity": [1.0, 0.0],
+                        "intent_label": "crossing",
+                        "signal_state": {"available": True, "label": "green"},
+                    }
+                ],
+            }
+        )
+
+    summary = compute_batch_forecast_metrics(
+        trace_steps,
+        horizons_s=(0.5, 1.0),
+        dt_s=dt_s,
+        collision_distance_m=0.3,
+    )
+
+    assert summary["forecast_evaluable_samples"] == 4.0
+    assert summary["mean_ade_0.5s"] == pytest.approx(0.0)
+    assert summary["mean_ade_1s"] == pytest.approx(0.0)
+    assert summary["mean_miss_rate_1s"] == 0.0
+    assert summary["count_collision_relevance_error_0.5s"] == 4.0
+    assert summary["count_collision_relevance_error_1s"] == 3.0
+
+
+def test_batch_metrics_report_empty_and_invalid_dt_cases() -> None:
+    """Empty traces have an explicit denominator and invalid dt fails closed."""
+
+    assert compute_batch_forecast_metrics([]) == {"forecast_evaluable_samples": 0.0}
+    with pytest.raises(ValueError, match="dt_s must be positive"):
+        compute_batch_forecast_metrics([], dt_s=0.0)
+
+
+def test_confidence_threshold_rejects_invalid_probability() -> None:
+    """Confidence ellipse threshold rejects impossible probabilities."""
+
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        chi_square_2d_threshold(0.0)
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        chi_square_2d_threshold(1.0)


### PR DESCRIPTION
## Summary
Adds a deterministic constant-velocity Gaussian pedestrian forecast baseline for benchmark step traces, plus trace-compatible evaluation metrics for likelihood, calibration, miss rate, and collision relevance.

## Linked Issues
- Closes `#2729`

## Stack / Dependency
- Base dependency: `origin/main` after PR #2740 merge
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf/benchmark/pedestrian_forecast.py` with trace-compatible pedestrian state parsing, default horizons `(0.5, 1.0, 2.0)`, deterministic Gaussian occupancy forecasts, and aggregate metric helpers.
- Represented unavailable signal state as `unknown` / `uncertain` metadata with widened covariance instead of assuming a traffic phase.
- Added tests for deterministic output, unknown-signal uncertainty, flat signal-label compatibility, NLL/calibration/miss metrics, collision relevance, empty/invalid denominator cases, and confidence-threshold validation.

## Why It Matters
- Added value: creates a simple non-deep probabilistic baseline for later learned pedestrian predictors.
- Expected impact: future trace comparisons can report calibrated probability metrics instead of only point-error distances.
- Why this is worth merging now: the baseline is small, deterministic, and covered by committed fixture-style tests.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: provides a reproducible baseline contract for short-horizon pedestrian forecast comparisons; it does not claim learned predictor performance.
- Comparator or baseline, if applicable: constant-velocity Gaussian baseline.
- Evidence tier: targeted smoke / committed unit fixture.
- Result classification: blocker-resolution for the baseline API and metric definitions.
- Decision or stop rule, if applicable: stop when trace-compatible deterministic forecasts and the requested metric families are covered by tests and smoke output.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2729.
- New research/benchmark/metric/paper-facing analysis tool, if any: yes, module-level forecast metric helper; representative use is covered by `tests/benchmark/test_pedestrian_forecast.py` and the local smoke report generated from a synthetic trace.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; deterministic fixture forecasts produce zero ADE/miss on constant-velocity traces and finite NLL/calibration values.
- Did the intervention change command source, selected command, trajectory, or route progress? NA; analysis helper only.
- Did the scenario actually contain the targeted failure mode? NA; this PR establishes a baseline and metric contract, not a failure-mode benchmark result.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA for this scoped baseline PR.

## Next Empirical Action
- Rerun needed: no for this baseline contract.
- Extractor or analysis tool needed: no for the module-level API; later report wiring can be proposed separately if desired.
- Artifact missing or unavailable: no required durable artifact; committed tests provide the representative durable input.
- Stop / revise / continue decision: continue with this baseline as the first comparison surface.
- Proposed child issue or existing follow-up: none opened.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run pytest tests/benchmark/test_pedestrian_forecast.py -q`
  - `uv run ruff check robot_sf/benchmark/pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast.py`
  - `uv run ruff format --check robot_sf/benchmark/pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast.py`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted tests: `8 passed`.
  - Full readiness: `5754 passed, 9 skipped, 9 warnings`; readiness stamp `output/validation/pr_ready/issue-2729-ped-forecast-baseline.json`, `tree_state=clean`.
  - Changed-file coverage warning only: `robot_sf/benchmark/pedestrian_forecast.py` at `99.2%`.
- Benchmarks or smoke tests, if applicable:
  - Local synthetic smoke report generated at `output/agent/issue-2729-local/smoke_report.json` with zero ADE/miss on constant-velocity trace and finite NLL/calibration metrics.

## Risks / Rollout
- Compatibility risks: new module only; no runner or config behavior changes.
- Failure modes: collision relevance uses a documented conservative ellipse-overlap approximation; future non-isotropic models may want richer overlap math.
- Rollback or fallback plan: remove the new module and tests; no existing call sites depend on it yet.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: PR body and tests document the baseline evidence boundary.
- Any assumptions that need to be preserved: unavailable signal state is uncertainty, not an assumed phase.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR reference.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark result claim is promoted.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA; no config/registry change.
- Context index / memory note updated (yes/no/NA): NA; scoped module addition.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR establishes a small reusable metric baseline but does not publish benchmark results or alter a reporting pipeline.

## Follow-Up Issues
- Deferred work: optional future CLI/report wiring for forecast comparisons.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that `signal_state.available=false` remains uncertainty-only and does not assume a phase.
- Known limitation: collision relevance is a deterministic conservative overlap proxy, appropriate for a baseline but not a full probabilistic collision integral.

## Delegation Notes
- Gemini implementation route produced a partial two-file diff but hit provider 429 and did not produce required compact artifacts; classified as uneconomic and locally repaired.
- Command Code read-only review returned `accept-with-small-fixes`; requested edge-case tests and approximation documentation, all applied before validation.
