### PR TITLE
feat: add PR loop policy dry-run

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -166,7 +166,8 @@ Before each phase, run a delegation checkpoint:
 - Before broad issue or PR queue review, prefer compact parent-thread snapshots:
   `uv run python scripts/dev/snapshot_issue_batch.py <first> <last> --json` for issue batches and
   `uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json` for PR headline
-  state. Use `--capsule-dir <private-artifact-dir>` when an implementation worker should receive a
+  state. Apply `uv run python scripts/dev/pr_loop_policy.py --snapshot <queue.json> --json` for
+  machine-checkable state classification and next-action decisions under a loop budget. Use `--capsule-dir <private-artifact-dir>` when an implementation worker should receive a
   bounded issue context capsule instead of rediscovering files with broad search.
 - For optional discovery scouts, default to a short hard timeout (120-180s) and require periodic
   evidence in the ledger. If a bounded scout emits no heartbeat within one timeout slice, treat it as
@@ -263,6 +264,9 @@ uv run python scripts/dev/snapshot_issue_batch.py <first> <last> \
 
 # Compact PR queue snapshot (headline state, next action)
 uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json
+
+# Machine-checkable PR loop policy (state + next action under budget)
+uv run python scripts/dev/pr_loop_policy.py --snapshot <queue-snapshot.json> --json
 ```
 
 Use `compact_worktree_snapshot.py` before expensive commands to detect fresh worktrees that need

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -101,6 +101,18 @@ Avoid loops:
    - cap parent-thread raw output at about 200 lines; use `rg -l`, `rg --files`, bounded `sed -n`,
      and private artifacts instead of broad `rg -n .` or full file reads,
    - classify findings as fixable now, deferred, or blocker.
+
+Before choosing the next action for any PR, consult the compact snapshot and apply the
+machine-checkable state policy:
+
+```bash
+uv run python scripts/dev/pr_loop_policy.py --snapshot <queue-snapshot.json> --json
+```
+
+The policy classifies each PR into `pending_ci`, `failed_ci`, `missing_artifacts`,
+`stale_worktree`, `ready_to_merge`, or `no_action` and recommends one bounded action
+under the loop budget. Use the policy decision to avoid ad-hoc state inspection.
+
 4. Fix actionable items on writable branches; commit and push.
 5. Validate per required tier.
 6. Re-query unresolved review threads after push and verification before resolving anything, especially

--- a/scripts/dev/pr_loop_policy.py
+++ b/scripts/dev/pr_loop_policy.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Machine-checkable state policy for autonomous PR loops.
+
+Classifies PR state from compact snapshots and recommends one bounded action:
+stop, continue, reroute, escalate, wait_ci, inspect_failed_ci, verify_artifacts,
+refresh_snapshot, mark_ready_candidate, or no_action.
+
+Every PolicyDecision also emits a high-level ``flow_decision`` — one of exactly
+``stop``, ``continue``, ``reroute``, or ``escalate`` — for machine consumption.
+
+Review state (e.g. CHANGES_REQUESTED, APPROVED, COMMENTED) from the snapshot
+is incorporated: CHANGES_REQUESTED forces a non-continue flow decision.
+
+Accepts a compact PR queue snapshot JSON (as emitted by snapshot_pr_queue.py)
+or a single-PR mock, and emits JSON or concise text with the next action and
+stop reason. Dry-run mode never calls gh or mutates state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any
+
+DEFAULT_MAX_ACTIONS = 5
+
+VALID_ACTIONS = frozenset(
+    {
+        "stop",
+        "continue",
+        "reroute",
+        "escalate",
+        "wait_ci",
+        "inspect_failed_ci",
+        "verify_artifacts",
+        "refresh_snapshot",
+        "mark_ready_candidate",
+        "no_action",
+    }
+)
+
+VALID_FLOW_DECISIONS = frozenset({"stop", "continue", "reroute", "escalate"})
+
+VALID_STATES = frozenset(
+    {
+        "pending_ci",
+        "failed_ci",
+        "missing_artifacts",
+        "stale_worktree",
+        "ready_to_merge",
+        "no_action",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDecision:
+    """A deterministic policy recommendation for one PR."""
+
+    pr: int
+    action: str
+    state: str
+    flow_decision: str
+    reason: str
+    actions_remaining: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the decision as a plain dict."""
+        return asdict(self)
+
+
+def classify_pr_state(pr: dict[str, Any]) -> str:
+    """Classify a single PR into a machine-checkable loop state.
+
+    Pure function: no side effects, no GitHub calls.
+    """
+    if not isinstance(pr, dict):
+        return "no_action"
+    status = str(pr.get("status", ""))
+    if status == "error":
+        return "no_action"
+    checks = pr.get("checks") or {}
+    overall = str(checks.get("overall", ""))
+    labels = pr.get("labels") or []
+    if isinstance(labels, list):
+        label_names = [str(label) for label in labels]
+    else:
+        label_names = []
+    is_draft = bool(pr.get("draft", False))
+    head_sha = str(pr.get("head_sha", ""))
+    expected = str(pr.get("expected_head_sha", ""))
+    artifacts = pr.get("artifacts")
+    if is_draft:
+        return "no_action"
+    if overall == "failure":
+        return "failed_ci"
+    if overall == "pending":
+        return "pending_ci"
+    if expected and head_sha and head_sha != expected:
+        return "stale_worktree"
+    if artifacts is not None and not artifacts:
+        return "missing_artifacts"
+    if "merge-ready" in label_names and overall == "success":
+        return "ready_to_merge"
+    return "no_action"
+
+
+def _review_state(pr: dict[str, Any]) -> str:
+    """Extract review state string from a PR dict.
+
+    Supports two formats:
+      - scalar: ``review_state`` or ``review`` field with a single string value.
+      - dict: ``reviews`` field mapping review conclusions to counts, e.g.
+        ``{"CHANGES_REQUESTED": 1, "APPROVED": 1}``.
+
+    Returns the uppercased review state or empty string if absent.
+    Priority: CHANGES_REQUESTED > CHANGES_REQUESTED (via scalar) > any other dict
+    key with count > 0 > scalar value > empty.
+    """
+    raw = pr.get("review_state") or pr.get("review") or ""
+    reviews_dict = pr.get("reviews")
+    if isinstance(reviews_dict, dict):
+        if reviews_dict.get("CHANGES_REQUESTED", 0) > 0:
+            return "CHANGES_REQUESTED"
+        for key, count in reviews_dict.items():
+            if isinstance(count, (int, float)) and count > 0:
+                return str(key).upper()
+    return str(raw).upper() if raw else ""
+
+
+def _compute_flow_decision(
+    state: str,
+    *,
+    review_state: str,
+    budget_exhausted: bool,
+) -> str:
+    """Map classified state + review state to a high-level flow decision.
+
+    Exactly one of: stop, continue, reroute, escalate.
+
+    Deterministic rules:
+      - budget_exhausted -> stop
+      - CHANGES_REQUESTED -> escalate (review blocker overrides other routing)
+      - pending_ci -> continue
+      - ready_to_merge -> continue
+      - failed_ci, missing_artifacts, stale_worktree -> reroute
+      - no_action -> stop
+    """
+    if budget_exhausted:
+        return "stop"
+    if review_state == "CHANGES_REQUESTED":
+        return "escalate"
+    match state:
+        case "pending_ci" | "ready_to_merge":
+            return "continue"
+        case "failed_ci" | "missing_artifacts" | "stale_worktree":
+            return "reroute"
+        case _:
+            return "stop"
+
+
+def recommend_action(
+    state: str,
+    *,
+    pr_number: int,
+    actions_remaining: int,
+    has_merge_ready: bool = False,
+    ci_success: bool = False,
+    review_state: str = "",
+) -> PolicyDecision:
+    """Map a classified state to a deterministic next action.
+
+    Pure function: no side effects.
+    """
+    budget_exhausted = actions_remaining <= 0
+    flow_decision = _compute_flow_decision(
+        state,
+        review_state=review_state,
+        budget_exhausted=budget_exhausted,
+    )
+    if budget_exhausted:
+        return PolicyDecision(
+            pr=pr_number,
+            action="stop",
+            state=state,
+            flow_decision="stop",
+            reason="loop budget exhausted",
+            actions_remaining=0,
+        )
+    remaining = actions_remaining - 1
+    if review_state == "CHANGES_REQUESTED":
+        return PolicyDecision(
+            pr=pr_number,
+            action="escalate",
+            state=state,
+            flow_decision=flow_decision,
+            reason="review changes requested; escalate before continuing loop automation",
+            actions_remaining=remaining,
+        )
+    match state:
+        case "pending_ci":
+            return PolicyDecision(
+                pr=pr_number,
+                action="wait_ci",
+                state=state,
+                flow_decision=flow_decision,
+                reason="CI checks still pending",
+                actions_remaining=remaining,
+            )
+        case "failed_ci":
+            return PolicyDecision(
+                pr=pr_number,
+                action="inspect_failed_ci",
+                state=state,
+                flow_decision=flow_decision,
+                reason="CI checks failed; inspect failures before retry",
+                actions_remaining=remaining,
+            )
+        case "missing_artifacts":
+            return PolicyDecision(
+                pr=pr_number,
+                action="verify_artifacts",
+                state=state,
+                flow_decision=flow_decision,
+                reason="required artifacts not present",
+                actions_remaining=remaining,
+            )
+        case "stale_worktree":
+            return PolicyDecision(
+                pr=pr_number,
+                action="refresh_snapshot",
+                state=state,
+                flow_decision=flow_decision,
+                reason="PR head SHA does not match expected snapshot",
+                actions_remaining=remaining,
+            )
+        case "ready_to_merge":
+            return PolicyDecision(
+                pr=pr_number,
+                action="mark_ready_candidate",
+                state=state,
+                flow_decision=flow_decision,
+                reason="CI green and merge-ready label present",
+                actions_remaining=remaining,
+            )
+        case _:
+            return PolicyDecision(
+                pr=pr_number,
+                action="no_action",
+                state="no_action",
+                flow_decision=flow_decision,
+                reason="nothing actionable for this PR",
+                actions_remaining=remaining,
+            )
+
+
+def _pr_number(pr: dict[str, Any]) -> int:
+    """Extract PR number safely."""
+    try:
+        return int(pr.get("number", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def evaluate_queue(
+    prs: list[dict[str, Any]],
+    *,
+    max_actions: int = DEFAULT_MAX_ACTIONS,
+    expected_head_shas: dict[int, str] | None = None,
+    artifact_presence: dict[int, bool] | None = None,
+) -> dict[str, Any]:
+    """Evaluate a PR queue and emit per-PR decisions under a loop budget.
+
+    Pure function: reads snapshot dicts, never calls external APIs.
+    """
+    decisions: list[dict[str, Any]] = []
+    actions_used = 0
+    expected_shas = expected_head_shas or {}
+    artifacts = artifact_presence or {}
+    for pr in prs:
+        num = _pr_number(pr)
+        enriched: dict[str, Any] = dict(pr)
+        if num in expected_shas:
+            enriched["expected_head_sha"] = expected_shas[num]
+        if num in artifacts:
+            enriched["artifacts"] = artifacts[num]
+        state = classify_pr_state(enriched)
+        review = _review_state(enriched)
+        labels = enriched.get("labels") or []
+        label_names = [str(label) for label in labels] if isinstance(labels, list) else []
+        checks = enriched.get("checks") or {}
+        has_merge = "merge-ready" in label_names
+        ci_ok = str(checks.get("overall", "")) == "success"
+        remaining = max_actions - actions_used
+        if remaining <= 0:
+            decisions.append(
+                PolicyDecision(
+                    pr=num,
+                    action="stop",
+                    state="no_action",
+                    flow_decision="stop",
+                    reason="loop budget exhausted",
+                    actions_remaining=0,
+                ).to_dict()
+            )
+            break
+        decision = recommend_action(
+            state,
+            pr_number=num,
+            actions_remaining=remaining,
+            has_merge_ready=has_merge,
+            ci_success=ci_ok,
+            review_state=review,
+        )
+        decisions.append(decision.to_dict())
+        actions_used += 1
+    return {
+        "schema": "pr_loop_policy.v1",
+        "max_actions": max_actions,
+        "actions_used": actions_used,
+        "decisions": decisions,
+    }
+
+
+def format_text(result: dict[str, Any]) -> str:
+    """Format a compact human-readable policy summary."""
+    lines = [
+        f"max_actions: {result['max_actions']}  actions_used: {result['actions_used']}",
+    ]
+    for d in result["decisions"]:
+        lines.append(
+            f"PR #{d['pr']}: {d['action']} (state={d['state']}, flow={d['flow_decision']}) "
+            f"— {d['reason']} [remaining={d['actions_remaining']}]"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--snapshot",
+        help="Path to a compact PR queue snapshot JSON file.",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read snapshot JSON from stdin instead of a file.",
+    )
+    parser.add_argument(
+        "--max-actions",
+        type=int,
+        default=DEFAULT_MAX_ACTIONS,
+        help=f"Loop budget: maximum actions before stop (default {DEFAULT_MAX_ACTIONS}).",
+    )
+    parser.add_argument(
+        "--expected-sha",
+        nargs="*",
+        metavar="PR=SHA",
+        help="Expected head SHAs as PR=SHA pairs for staleness detection.",
+    )
+    parser.add_argument(
+        "--artifact-present",
+        nargs="*",
+        metavar="PR=true|false",
+        help="Artifact presence as PR=true|false pairs.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args(argv)
+
+
+def _parse_pairs(pairs: list[str] | None, *, as_bool: bool = False) -> dict[int, Any]:
+    """Parse PR=VALUE pairs into a dict."""
+    result: dict[int, Any] = {}
+    if not pairs:
+        return result
+    for pair in pairs:
+        if "=" not in pair:
+            continue
+        key_str, _, value = pair.partition("=")
+        try:
+            key = int(key_str)
+        except ValueError:
+            continue
+        if as_bool:
+            result[key] = value.lower() in ("true", "1", "yes")
+        else:
+            result[key] = value
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    raw: dict[str, Any] | list[dict[str, Any]] | None = None
+    if args.stdin:
+        try:
+            raw = json.load(sys.stdin)
+        except json.JSONDecodeError as exc:
+            print(f"invalid JSON on stdin: {exc}", file=sys.stderr)
+            return 1
+    elif args.snapshot:
+        try:
+            with open(args.snapshot) as fh:
+                raw = json.load(fh)
+        except FileNotFoundError:
+            print(f"file not found: {args.snapshot}", file=sys.stderr)
+            return 1
+        except json.JSONDecodeError as exc:
+            print(f"invalid JSON in {args.snapshot}: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("provide --snapshot or --stdin", file=sys.stderr)
+        return 1
+    if isinstance(raw, dict) and "prs" in raw:
+        prs: list[dict[str, Any]] = raw["prs"]
+    elif isinstance(raw, list):
+        prs = raw
+    else:
+        print("snapshot must contain a 'prs' array or be a JSON array of PR dicts", file=sys.stderr)
+        return 1
+    expected_shas = _parse_pairs(args.expected_sha)
+    artifact_presence = _parse_pairs(args.artifact_present, as_bool=True)
+    result = evaluate_queue(
+        prs,
+        max_actions=args.max_actions,
+        expected_head_shas=expected_shas,
+        artifact_presence=artifact_presence,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(format_text(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/fixtures/pr_loop_policy/comprehensive_queue.json
+++ b/tests/dev/fixtures/pr_loop_policy/comprehensive_queue.json
@@ -1,0 +1,78 @@
+{
+  "schema": "pr_queue_snapshot.v1",
+  "prs": [
+    {
+      "number": 2001,
+      "status": "ok",
+      "draft": false,
+      "head_sha": "sha-pending",
+      "labels": ["needs-review"],
+      "reviews": {"CHANGES_REQUESTED": 1, "COMMENTED": 2},
+      "checks": {
+        "overall": "pending",
+        "total": 1,
+        "by_conclusion": {},
+        "by_status": {"in_progress": 1},
+        "names": ["ci"]
+      }
+    },
+    {
+      "number": 2002,
+      "status": "ok",
+      "draft": false,
+      "head_sha": "sha-failed",
+      "labels": [],
+      "reviews": {"CHANGES_REQUESTED": 1, "APPROVED": 1},
+      "checks": {
+        "overall": "failure",
+        "total": 2,
+        "by_conclusion": {"failure": 2},
+        "by_status": {"completed": 2},
+        "names": ["ci", "lint"]
+      }
+    },
+    {
+      "number": 2003,
+      "status": "ok",
+      "draft": false,
+      "head_sha": "sha-stale",
+      "labels": [],
+      "checks": {
+        "overall": "success",
+        "total": 1,
+        "by_conclusion": {"success": 1},
+        "by_status": {"completed": 1},
+        "names": ["ci"]
+      }
+    },
+    {
+      "number": 2004,
+      "status": "ok",
+      "draft": false,
+      "head_sha": "sha-green",
+      "labels": ["merge-ready"],
+      "reviews": {"APPROVED": 2},
+      "checks": {
+        "overall": "success",
+        "total": 1,
+        "by_conclusion": {"success": 1},
+        "by_status": {"completed": 1},
+        "names": ["ci"]
+      }
+    },
+    {
+      "number": 2005,
+      "status": "ok",
+      "draft": true,
+      "head_sha": "sha-draft",
+      "labels": [],
+      "checks": {
+        "overall": "pending",
+        "total": 0,
+        "by_conclusion": {},
+        "by_status": {},
+        "names": []
+      }
+    }
+  ]
+}

--- a/tests/dev/test_pr_loop_policy.py
+++ b/tests/dev/test_pr_loop_policy.py
@@ -1,0 +1,675 @@
+"""Tests for machine-checkable PR loop policy."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.dev.pr_loop_policy import (
+    PolicyDecision,
+    _review_state,
+    classify_pr_state,
+    evaluate_queue,
+    format_text,
+    main,
+    recommend_action,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pr_loop_policy"
+
+
+def _pr(
+    number: int,
+    *,
+    overall: str = "success",
+    labels: list[str] | None = None,
+    draft: bool = False,
+    head_sha: str = "abc123",
+    expected_head_sha: str = "",
+    status: str = "ok",
+    artifacts: bool | None = None,
+) -> dict[str, object]:
+    """Build a compact PR snapshot dict for testing."""
+    result: dict[str, object] = {
+        "number": number,
+        "status": status,
+        "draft": draft,
+        "head_sha": head_sha,
+        "labels": labels or [],
+        "checks": {
+            "overall": overall,
+            "total": 1,
+            "by_conclusion": {overall: 1},
+            "by_status": {"completed": 1} if overall != "pending" else {"in_progress": 1},
+            "names": ["ci"],
+        },
+    }
+    if expected_head_sha:
+        result["expected_head_sha"] = expected_head_sha
+    if artifacts is not None:
+        result["artifacts"] = artifacts
+    return result
+
+
+def _snapshot(prs: list[dict[str, object]]) -> dict[str, object]:
+    """Build a snapshot dict wrapping multiple PRs."""
+    return {"schema": "pr_queue_snapshot.v1", "prs": prs}
+
+
+# ---------------------------------------------------------------------------
+# classify_pr_state
+# ---------------------------------------------------------------------------
+
+
+def test_classify_pending_ci() -> None:
+    """Pending CI should classify as pending_ci."""
+    pr = _pr(100, overall="pending")
+    assert classify_pr_state(pr) == "pending_ci"
+
+
+def test_classify_failed_ci() -> None:
+    """Failed CI should classify as failed_ci."""
+    pr = _pr(101, overall="failure")
+    assert classify_pr_state(pr) == "failed_ci"
+
+
+def test_classify_stale_worktree() -> None:
+    """Head SHA mismatch should classify as stale_worktree."""
+    pr = _pr(102, head_sha="new-sha", expected_head_sha="old-sha")
+    assert classify_pr_state(pr) == "stale_worktree"
+
+
+def test_classify_missing_artifacts() -> None:
+    """Artifacts present but empty should classify as missing_artifacts."""
+    pr = _pr(103, artifacts=False)
+    assert classify_pr_state(pr) == "missing_artifacts"
+
+
+def test_classify_ready_to_merge() -> None:
+    """CI green + merge-ready label should classify as ready_to_merge."""
+    pr = _pr(104, overall="success", labels=["merge-ready"])
+    assert classify_pr_state(pr) == "ready_to_merge"
+
+
+def test_classify_no_action_default() -> None:
+    """No special conditions should classify as no_action."""
+    pr = _pr(105)
+    assert classify_pr_state(pr) == "no_action"
+
+
+def test_classify_draft_is_no_action() -> None:
+    """Draft PRs should always be no_action."""
+    pr = _pr(106, draft=True, overall="pending")
+    assert classify_pr_state(pr) == "no_action"
+
+
+def test_classify_error_status_is_no_action() -> None:
+    """Error status PRs should classify as no_action."""
+    pr = {"number": 107, "status": "error", "error": "gh failed"}
+    assert classify_pr_state(pr) == "no_action"
+
+
+def test_classify_non_dict_input() -> None:
+    """Non-dict input should classify as no_action."""
+    assert classify_pr_state("not a dict") == "no_action"  # type: ignore[arg-type]
+    assert classify_pr_state(None) == "no_action"  # type: ignore[arg-type]
+
+
+def test_classify_success_without_merge_ready_is_no_action() -> None:
+    """CI green but no merge-ready label should be no_action."""
+    pr = _pr(108, overall="success", labels=["needs-review"])
+    assert classify_pr_state(pr) == "no_action"
+
+
+def test_classify_artifacts_true_not_missing() -> None:
+    """Artifacts present and True should not be missing_artifacts."""
+    pr = _pr(109, overall="success", artifacts=True)
+    assert classify_pr_state(pr) == "no_action"
+
+
+# ---------------------------------------------------------------------------
+# recommend_action
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_wait_ci_for_pending() -> None:
+    """Pending CI should recommend wait_ci."""
+    decision = recommend_action("pending_ci", pr_number=200, actions_remaining=3)
+    assert decision.action == "wait_ci"
+    assert decision.actions_remaining == 2
+
+
+def test_recommend_inspect_for_failed_ci() -> None:
+    """Failed CI should recommend inspect_failed_ci."""
+    decision = recommend_action("failed_ci", pr_number=201, actions_remaining=3)
+    assert decision.action == "inspect_failed_ci"
+
+
+def test_recommend_verify_for_missing_artifacts() -> None:
+    """Missing artifacts should recommend verify_artifacts."""
+    decision = recommend_action("missing_artifacts", pr_number=202, actions_remaining=3)
+    assert decision.action == "verify_artifacts"
+
+
+def test_recommend_refresh_for_stale() -> None:
+    """Stale worktree should recommend refresh_snapshot."""
+    decision = recommend_action("stale_worktree", pr_number=203, actions_remaining=3)
+    assert decision.action == "refresh_snapshot"
+
+
+def test_recommend_mark_ready_for_ready() -> None:
+    """Ready-to-merge should recommend mark_ready_candidate."""
+    decision = recommend_action("ready_to_merge", pr_number=204, actions_remaining=3)
+    assert decision.action == "mark_ready_candidate"
+
+
+def test_recommend_no_action_for_default() -> None:
+    """No-action state should recommend no_action."""
+    decision = recommend_action("no_action", pr_number=205, actions_remaining=3)
+    assert decision.action == "no_action"
+
+
+def test_recommend_stop_when_budget_exhausted() -> None:
+    """Zero remaining budget should recommend stop."""
+    decision = recommend_action("pending_ci", pr_number=206, actions_remaining=0)
+    assert decision.action == "stop"
+    assert decision.actions_remaining == 0
+
+
+def test_recommend_stop_negative_budget() -> None:
+    """Negative budget should also recommend stop."""
+    decision = recommend_action("pending_ci", pr_number=207, actions_remaining=-1)
+    assert decision.action == "stop"
+    assert decision.actions_remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# evaluate_queue
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_queue_single_pr() -> None:
+    """Single PR queue should produce one decision."""
+    prs = [_pr(300, overall="pending")]
+    result = evaluate_queue(prs, max_actions=3)
+    assert result["schema"] == "pr_loop_policy.v1"
+    assert result["max_actions"] == 3
+    assert len(result["decisions"]) == 1
+    assert result["decisions"][0]["action"] == "wait_ci"
+
+
+def test_evaluate_queue_budget_enforced() -> None:
+    """Budget should cap the number of actions produced before stop."""
+    prs = [_pr(400, overall="pending") for _ in range(10)]
+    result = evaluate_queue(prs, max_actions=2)
+    assert result["actions_used"] == 2
+    assert len(result["decisions"]) == 3
+    assert result["decisions"][0]["action"] == "wait_ci"
+    assert result["decisions"][1]["action"] == "wait_ci"
+    assert result["decisions"][2]["action"] == "stop"
+
+
+def test_evaluate_queue_stop_on_budget_exhaustion() -> None:
+    """Budget=1 should process one PR then stop before the second."""
+    prs = [_pr(500, overall="pending"), _pr(501, overall="failure")]
+    result = evaluate_queue(prs, max_actions=1)
+    assert result["actions_used"] == 1
+    assert result["decisions"][0]["action"] == "wait_ci"
+    assert result["decisions"][1]["action"] == "stop"
+
+
+def test_evaluate_queue_empty() -> None:
+    """Empty queue should produce zero decisions."""
+    result = evaluate_queue([], max_actions=5)
+    assert result["decisions"] == []
+    assert result["actions_used"] == 0
+
+
+def test_evaluate_queue_expected_sha_injection() -> None:
+    """Expected head SHAs should be injected for staleness detection."""
+    prs = [_pr(600, head_sha="new")]
+    result = evaluate_queue(
+        prs,
+        max_actions=3,
+        expected_head_shas={600: "old"},
+    )
+    assert result["decisions"][0]["state"] == "stale_worktree"
+    assert result["decisions"][0]["action"] == "refresh_snapshot"
+
+
+def test_evaluate_queue_artifact_presence_injection() -> None:
+    """Artifact presence should be injected for missing-artifact detection."""
+    prs = [_pr(700, overall="success", labels=["merge-ready"])]
+    result = evaluate_queue(
+        prs,
+        max_actions=3,
+        artifact_presence={700: False},
+    )
+    # Artifact check overrides ready_to_merge when artifacts are missing
+    assert result["decisions"][0]["state"] == "missing_artifacts"
+
+
+def test_evaluate_queue_mixed_states() -> None:
+    """Mixed queue should produce correct per-PR decisions."""
+    prs = [
+        _pr(800, overall="pending"),
+        _pr(801, overall="failure"),
+        _pr(802, overall="success", labels=["merge-ready"]),
+        _pr(803),
+    ]
+    result = evaluate_queue(prs, max_actions=10)
+    actions = [d["action"] for d in result["decisions"]]
+    assert actions == ["wait_ci", "inspect_failed_ci", "mark_ready_candidate", "no_action"]
+
+
+# ---------------------------------------------------------------------------
+# PolicyDecision
+# ---------------------------------------------------------------------------
+
+
+def test_policy_decision_to_dict() -> None:
+    """PolicyDecision should serialize deterministically."""
+    d = PolicyDecision(
+        pr=1,
+        action="stop",
+        state="pending_ci",
+        flow_decision="stop",
+        reason="budget",
+        actions_remaining=0,
+    )
+    out = d.to_dict()
+    assert out["pr"] == 1
+    assert out["action"] == "stop"
+    assert out["flow_decision"] == "stop"
+    assert set(out.keys()) == {
+        "pr",
+        "action",
+        "state",
+        "flow_decision",
+        "reason",
+        "actions_remaining",
+    }
+
+
+# ---------------------------------------------------------------------------
+# format_text
+# ---------------------------------------------------------------------------
+
+
+def test_format_text_contains_actions() -> None:
+    """Text output should list action, state, and flow for each decision."""
+    result = {
+        "max_actions": 5,
+        "actions_used": 1,
+        "decisions": [
+            {
+                "pr": 900,
+                "action": "wait_ci",
+                "state": "pending_ci",
+                "flow_decision": "continue",
+                "reason": "CI pending",
+                "actions_remaining": 4,
+            }
+        ],
+    }
+    text = format_text(result)
+    assert "PR #900" in text
+    assert "wait_ci" in text
+    assert "pending_ci" in text
+    assert "flow=continue" in text
+
+
+def test_format_text_empty_queue() -> None:
+    """Text output should handle empty queue."""
+    result = {"max_actions": 5, "actions_used": 0, "decisions": []}
+    text = format_text(result)
+    assert "actions_used: 0" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI (main)
+# ---------------------------------------------------------------------------
+
+
+def test_main_stdin_json(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI should read snapshot from stdin and emit JSON."""
+    snapshot = _snapshot([_pr(1000, overall="pending")])
+    stdin = StringIO(json.dumps(snapshot))
+    with patch("sys.stdin", stdin):
+        rc = main(["--stdin", "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["decisions"][0]["action"] == "wait_ci"
+
+
+def test_main_snapshot_file(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI should read snapshot from a file."""
+    snapshot = _snapshot([_pr(1100, overall="failure")])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    rc = main(["--snapshot", str(snap_file), "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["decisions"][0]["action"] == "inspect_failed_ci"
+
+
+def test_main_missing_file() -> None:
+    """CLI should fail on missing snapshot file."""
+    rc = main(["--snapshot", "/nonexistent/file.json"])
+    assert rc == 1
+
+
+def test_main_invalid_json(tmp_path: Path) -> None:
+    """CLI should fail on invalid JSON."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json {{{")
+    rc = main(["--snapshot", str(bad)])
+    assert rc == 1
+
+
+def test_main_no_snapshot_arg() -> None:
+    """CLI should fail when no snapshot source is provided."""
+    rc = main(["--json"])
+    assert rc == 1
+
+
+def test_main_text_output(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI should emit human-readable text without --json."""
+    snapshot = _snapshot([_pr(1200, overall="success", labels=["merge-ready"])])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    rc = main(["--snapshot", str(snap_file)])
+    assert rc == 0
+    text = capsys.readouterr().out
+    assert "PR #1200" in text
+    assert "mark_ready_candidate" in text
+
+
+def test_main_max_actions_flag(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI --max-actions should control the loop budget."""
+    snapshot = _snapshot([_pr(1300, overall="pending"), _pr(1301, overall="pending")])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    rc = main(["--snapshot", str(snap_file), "--max-actions", "1", "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["max_actions"] == 1
+    assert output["actions_used"] == 1
+    assert output["decisions"][0]["action"] == "wait_ci"
+    assert output["decisions"][1]["action"] == "stop"
+
+
+def test_main_expected_sha_pairs(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI --expected-sha should inject staleness detection."""
+    snapshot = _snapshot([_pr(1400, head_sha="new")])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    rc = main(["--snapshot", str(snap_file), "--expected-sha", "1400=old", "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["decisions"][0]["state"] == "stale_worktree"
+
+
+def test_main_artifact_present_pairs(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI --artifact-present should inject artifact detection."""
+    snapshot = _snapshot([_pr(1500, overall="success", labels=["merge-ready"])])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    rc = main(["--snapshot", str(snap_file), "--artifact-present", "1500=false", "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["decisions"][0]["state"] == "missing_artifacts"
+
+
+def test_main_cli_dry_run_no_gh(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI dry-run should never call gh, even with a realistic snapshot."""
+    snapshot = _snapshot(
+        [
+            _pr(1600, overall="pending"),
+            _pr(1601, overall="failure"),
+            _pr(1602, overall="success", labels=["merge-ready"]),
+        ]
+    )
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot))
+    with patch("subprocess.run") as mock_run:
+        rc = main(["--snapshot", str(snap_file), "--json"])
+    mock_run.assert_not_called()
+    assert rc == 0
+
+
+def test_main_stdin_invalid_json() -> None:
+    """CLI should fail on invalid stdin JSON."""
+    stdin = StringIO("not json")
+    with patch("sys.stdin", stdin):
+        rc = main(["--stdin"])
+    assert rc == 1
+
+
+def test_main_non_array_snapshot(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI should fail when snapshot is not an array or does not contain prs."""
+    snap_file = tmp_path / "bad.json"
+    snap_file.write_text(json.dumps({"not_prs": []}))
+    rc = main(["--snapshot", str(snap_file)])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# _review_state
+# ---------------------------------------------------------------------------
+
+
+def test_review_state_scalar() -> None:
+    """Scalar review_state field should be returned uppercased."""
+    pr = {"number": 9001, "review_state": "approved"}
+    assert _review_state(pr) == "APPROVED"
+
+
+def test_review_state_scalar_review_field() -> None:
+    """Fallback review field should be returned uppercased."""
+    pr = {"number": 9002, "review": "changes_requested"}
+    assert _review_state(pr) == "CHANGES_REQUESTED"
+
+
+def test_review_state_dict_changes_requested() -> None:
+    """reviews dict with CHANGES_REQUESTED > 0 should return CHANGES_REQUESTED."""
+    pr = {"number": 9003, "reviews": {"CHANGES_REQUESTED": 1, "APPROVED": 2}}
+    assert _review_state(pr) == "CHANGES_REQUESTED"
+
+
+def test_review_state_dict_no_changes_requested() -> None:
+    """reviews dict without CHANGES_REQUESTED should return first nonzero key."""
+    pr = {"number": 9004, "reviews": {"APPROVED": 1, "COMMENTED": 3}}
+    assert _review_state(pr) == "APPROVED"
+
+
+def test_review_state_dict_all_zero() -> None:
+    """reviews dict with all zero counts should fall through to scalar."""
+    pr = {"number": 9005, "reviews": {"APPROVED": 0, "COMMENTED": 0}, "review": "commented"}
+    assert _review_state(pr) == "COMMENTED"
+
+
+def test_review_state_empty() -> None:
+    """No review info should return empty string."""
+    pr = {"number": 9006}
+    assert _review_state(pr) == ""
+
+
+def test_review_state_dict_takes_priority_over_scalar() -> None:
+    """reviews dict should take priority over scalar review_state."""
+    pr = {
+        "number": 9007,
+        "review_state": "approved",
+        "reviews": {"CHANGES_REQUESTED": 1},
+    }
+    assert _review_state(pr) == "CHANGES_REQUESTED"
+
+
+# ---------------------------------------------------------------------------
+# flow_decision
+# ---------------------------------------------------------------------------
+
+
+def test_flow_decision_budget_exhausted() -> None:
+    """Budget exhausted should always yield stop."""
+    decision = recommend_action("pending_ci", pr_number=9100, actions_remaining=0)
+    assert decision.flow_decision == "stop"
+
+
+def test_flow_decision_pending_ci_continues() -> None:
+    """Pending CI with budget should yield continue."""
+    decision = recommend_action("pending_ci", pr_number=9101, actions_remaining=3)
+    assert decision.flow_decision == "continue"
+
+
+def test_flow_decision_ready_to_merge_continues() -> None:
+    """Ready-to-merge with budget should yield continue."""
+    decision = recommend_action("ready_to_merge", pr_number=9102, actions_remaining=3)
+    assert decision.flow_decision == "continue"
+
+
+def test_flow_decision_failed_ci_reroutes() -> None:
+    """Failed CI should yield reroute."""
+    decision = recommend_action("failed_ci", pr_number=9103, actions_remaining=3)
+    assert decision.flow_decision == "reroute"
+
+
+def test_flow_decision_missing_artifacts_reroutes() -> None:
+    """Missing artifacts should yield reroute."""
+    decision = recommend_action("missing_artifacts", pr_number=9104, actions_remaining=3)
+    assert decision.flow_decision == "reroute"
+
+
+def test_flow_decision_stale_worktree_reroutes() -> None:
+    """Stale worktree should yield reroute."""
+    decision = recommend_action("stale_worktree", pr_number=9105, actions_remaining=3)
+    assert decision.flow_decision == "reroute"
+
+
+def test_flow_decision_no_action_stops() -> None:
+    """No-action state should yield stop."""
+    decision = recommend_action("no_action", pr_number=9106, actions_remaining=3)
+    assert decision.flow_decision == "stop"
+
+
+def test_flow_decision_changes_requested_escalates_pending() -> None:
+    """CHANGES_REQUESTED review on pending_ci should escalate, not continue."""
+    decision = recommend_action(
+        "pending_ci",
+        pr_number=9107,
+        actions_remaining=3,
+        review_state="CHANGES_REQUESTED",
+    )
+    assert decision.flow_decision == "escalate"
+    assert decision.action == "escalate"
+
+
+def test_flow_decision_changes_requested_escalates_failed_ci() -> None:
+    """CHANGES_REQUESTED review on failed_ci should escalate instead of reroute."""
+    decision = recommend_action(
+        "failed_ci",
+        pr_number=9108,
+        actions_remaining=3,
+        review_state="CHANGES_REQUESTED",
+    )
+    assert decision.flow_decision == "escalate"
+    assert decision.action == "escalate"
+
+
+def test_flow_decision_changes_requested_escalates_missing_artifacts() -> None:
+    """CHANGES_REQUESTED review on missing_artifacts should escalate."""
+    decision = recommend_action(
+        "missing_artifacts",
+        pr_number=9109,
+        actions_remaining=3,
+        review_state="CHANGES_REQUESTED",
+    )
+    assert decision.flow_decision == "escalate"
+    assert decision.action == "escalate"
+
+
+def test_flow_decision_changes_requested_escalates_stale() -> None:
+    """CHANGES_REQUESTED review on stale_worktree should escalate."""
+    decision = recommend_action(
+        "stale_worktree",
+        pr_number=9110,
+        actions_remaining=3,
+        review_state="CHANGES_REQUESTED",
+    )
+    assert decision.flow_decision == "escalate"
+    assert decision.action == "escalate"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_queue with reviews
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_queue_reviews_dict_escalation() -> None:
+    """PR with CHANGES_REQUESTED in reviews dict should produce escalate flow."""
+    prs = [
+        {
+            "number": 9200,
+            "status": "ok",
+            "draft": False,
+            "head_sha": "sha",
+            "labels": [],
+            "reviews": {"CHANGES_REQUESTED": 1},
+            "checks": {"overall": "pending"},
+        }
+    ]
+    result = evaluate_queue(prs, max_actions=3)
+    d = result["decisions"][0]
+    assert d["flow_decision"] == "escalate"
+    assert d["action"] == "escalate"
+
+
+def test_evaluate_queue_reviews_dict_approved_continue() -> None:
+    """PR with only APPROVED in reviews dict should continue if state allows."""
+    prs = [
+        {
+            "number": 9201,
+            "status": "ok",
+            "draft": False,
+            "head_sha": "sha",
+            "labels": ["merge-ready"],
+            "reviews": {"APPROVED": 2},
+            "checks": {"overall": "success"},
+        }
+    ]
+    result = evaluate_queue(prs, max_actions=3)
+    d = result["decisions"][0]
+    assert d["flow_decision"] == "continue"
+    assert d["action"] == "mark_ready_candidate"
+
+
+# ---------------------------------------------------------------------------
+# Fixture file test
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_file_comprehensive_queue(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """A comprehensive fixture file should exercise all states under budget."""
+    fixture = FIXTURE_DIR / "comprehensive_queue.json"
+    if not fixture.exists():
+        pytest.skip("fixture file not present")
+    dest = tmp_path / "fixture_copy.json"
+    dest.write_text(fixture.read_text())
+    rc = main(["--snapshot", str(dest), "--json"])
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["schema"] == "pr_loop_policy.v1"
+    states_seen = {d["state"] for d in output["decisions"]}
+    assert len(states_seen) >= 2
+    flow_decisions = {d["flow_decision"] for d in output["decisions"]}
+    assert flow_decisions.issubset({"stop", "continue", "reroute", "escalate"})
+    pr2001 = next(d for d in output["decisions"] if d["pr"] == 2001)
+    assert pr2001["flow_decision"] == "escalate"
+    pr2002 = next(d for d in output["decisions"] if d["pr"] == 2002)
+    assert pr2002["flow_decision"] == "escalate"


### PR DESCRIPTION
## Summary
Adds a machine-checkable autonomous PR-loop dry-run policy that maps compact PR/CI/review/artifact snapshots to bounded `stop`, `continue`, `reroute`, or `escalate` decisions.

## Linked Issues
- Closes `#2731`
- Relates to `#2715`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/pr_loop_policy.py`, a dry-run-only PR queue policy helper with JSON/text output and no GitHub mutations.
- Added representative fixture coverage for pending CI, failed CI, missing artifacts, stale worktree, ready-to-merge, no-action, budget exhaustion, review escalation, expected SHA checks, and artifact-presence overrides.
- Updated `goal-autopilot` and `goal-pr-review` skills to route autonomous agents through compact snapshots plus this policy before acting.

## Why It Matters
- Added value: autonomous PR loops now have a reproducible stop/action policy instead of relying on ad-hoc rereads or broad CI polling.
- Expected impact: lower token use, fewer stale-state loops, and clearer handoff when a PR needs reroute or escalation.
- Why this is worth merging now: it directly supports the active delegation-first workflow and makes PR-loop decisions testable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper; no research, benchmark, metric, or paper-facing claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it classifies PR workflow state and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA - readiness and targeted tests passed for this support helper.
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: continue
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_pr_loop_policy.py -q`
  - `rtk uv run ruff check scripts/dev/pr_loop_policy.py tests/dev/test_pr_loop_policy.py`
  - `rtk uv run ruff format --check scripts/dev/pr_loop_policy.py tests/dev/test_pr_loop_policy.py`
  - `rtk uv run python scripts/dev/pr_loop_policy.py --snapshot tests/dev/fixtures/pr_loop_policy/comprehensive_queue.json --json`
  - `rtk grep "subprocess\\|gh \\|github\\|requests\\|urllib" scripts/dev/pr_loop_policy.py tests/dev/test_pr_loop_policy.py`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted policy suite: 62 passed.
  - Full readiness stamp: `output/validation/pr_ready/issue-2731-pr-loop-policy.json`, status `passed`, head `876de976caa253f2774bd1fb0e44e501c9a5fa6c`, tree state `clean`.
  - Full suite inside readiness: 5841 passed, 9 skipped.
  - Dry-run fixture output exercised the representative PR states, including review escalation and merge-ready continuation.
  - Runtime no-mutation check found no GitHub/network/subprocess mutation path in the policy helper; only documentation/test mock references matched.
- Benchmarks or smoke tests, if applicable: NA - workflow support helper.

## Risks / Rollout
- Compatibility risks: compact snapshot schemas may evolve; the parser accepts multiple common aliases and fails closed into no-action/unknown handling where appropriate.
- Failure modes: incomplete snapshots can trigger conservative `missing_artifacts`, `stale_worktree`, or `no_action` decisions rather than mutating GitHub.
- Rollback or fallback plan: remove the skill references and stop invoking `scripts/dev/pr_loop_policy.py`; no persistent state migration is involved.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-autopilot/SKILL.md`, `.agents/skills/goal-pr-review/SKILL.md`
- Relevant design or provenance notes: issue `#2731`
- Any assumptions that need to be preserved: policy input should come from compact snapshots first; dry-run mode must remain mutation-free.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#2731`.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a workflow support helper with no benchmark, registry, claim-map, or paper-facing result.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: review-state escalation intentionally overrides otherwise actionable states so requested changes are surfaced to the controller instead of hidden behind CI/artifact status.
- Any known limitations: the helper is intentionally dry-run only and does not fetch live PR state by itself.

## Delegate Outcomes
- OpenCode Zen implementation worker produced the initial policy, fixture, tests, and skill updates; artifact status was partial, so Codex performed integration review.
- A malformed follow-up prompt was killed and rejected because shell interpolation stripped code literals; the corrected follow-up used a prompt file.
- OpenCode Zen follow-up added `flow_decision`; Codex review caught and fixed one action/flow inconsistency for `CHANGES_REQUESTED`.
- Gemini queue scout timed out with empty result and was classified uneconomic; a later Gemini diff review returned pass/no findings, with local validation authoritative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR queue state classification and action recommendation engine that evaluates PRs against machine-checkable policies.
  * Classifies PR states including pending CI, failed CI, missing artifacts, stale worktree, and ready-to-merge conditions.
  * Generates bounded action recommendations with budget tracking to manage PR loop workflows.

* **Tests**
  * Added comprehensive test suite for PR queue policy evaluation with fixture-based scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->