### PR TITLE
feat: add stale worktree reaper dry-run

### DIFF
--- a/scripts/dev/stale_worktree_reaper.py
+++ b/scripts/dev/stale_worktree_reaper.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Dry-run stale-worktree reaper that classifies cleanup candidates.
+
+Emits a preservation-aware deletion plan without removing anything by default.
+Use --apply to actually remove safe candidates; risky candidates are refused
+unless explicit safeguards are satisfied.
+
+Default behavior is dry-run only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+SCHEMA_VERSION = "stale_worktree_reaper.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeCandidate:
+    """A single worktree cleanup candidate."""
+
+    path: str
+    branch: str
+    head_sha: str
+    is_current: bool
+    classification: str  # "current", "clean_stale", "risky"
+    risk_flags: list[str] = field(default_factory=list)
+    preservation_required: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ReaperPlan:
+    """Deletion plan output."""
+
+    schema: str
+    mode: str  # "dry_run" or "apply"
+    total_worktrees: int
+    current_worktree: str | None
+    candidates: list[WorktreeCandidate]
+    deletable: list[str]
+    refused: list[str]
+    errors: list[str]
+    audit_log: list[str]
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    """Run a command and capture output."""
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=f"command timed out after {timeout} seconds",
+        )
+
+
+def _parse_worktree_porcelain(stdout: str) -> list[dict[str, str]]:  # noqa: C901
+    """Parse git worktree list --porcelain output."""
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        parts = line.split(" ", 1)
+        if len(parts) != 2:
+            continue
+        key, value = parts
+        if key == "worktree":
+            if current:
+                worktrees.append(current)
+            current = {"path": value}
+        elif key == "HEAD":
+            current["head_sha"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key in {"bare", "detached"}:
+            current[key] = "true"
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def _is_worktree_dirty(path: str) -> bool:
+    """Check if a worktree has uncommitted changes."""
+    result = _run_command(["git", "status", "--porcelain"], cwd=path)
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _has_unpushed_commits(path: str, branch: str) -> bool:
+    """Check if a worktree has commits not pushed to its upstream branch."""
+    if not branch:
+        return True
+    upstream = _run_command(["git", "rev-parse", "--abbrev-ref", "@{upstream}"], cwd=path)
+    if upstream.returncode != 0 or not upstream.stdout.strip():
+        return True
+    result = _run_command(
+        ["git", "log", f"{upstream.stdout.strip()}..HEAD", "--oneline"],
+        cwd=path,
+    )
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
+def _has_open_pr(branch: str) -> bool:
+    """Check if the branch has an open PR on GitHub."""
+    if not branch:
+        return False
+    result = _run_command(
+        ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        data = json.loads(result.stdout)
+        return isinstance(data, list) and len(data) > 0
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
+def _has_ignored_output(path: str) -> bool:
+    """Check if a worktree has ignored files (e.g. output/ contents)."""
+    result = _run_command(
+        ["git", "status", "--ignored", "--short", "-uall"],
+        cwd=path,
+    )
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        if line.startswith("!! "):
+            return True
+    return False
+
+
+def classify_worktree(
+    *,
+    path: str,
+    branch: str,
+    head_sha: str,
+    current_path: str,
+    skip_pr_check: bool = False,
+) -> WorktreeCandidate:
+    """Classify a single worktree as current, clean_stale, or risky."""
+    is_current = Path(path).resolve() == Path(current_path).resolve()
+    if is_current:
+        return WorktreeCandidate(
+            path=path,
+            branch=branch,
+            head_sha=head_sha,
+            is_current=True,
+            classification="current",
+            preservation_required="current worktree",
+        )
+
+    risk_flags: list[str] = []
+
+    if _is_worktree_dirty(path):
+        risk_flags.append("dirty")
+
+    if _has_unpushed_commits(path, branch):
+        risk_flags.append("unpushed_commits")
+
+    if skip_pr_check and branch:
+        risk_flags.append("pr_check_skipped")
+    elif _has_open_pr(branch):
+        risk_flags.append("open_pr")
+
+    if _has_ignored_output(path):
+        risk_flags.append("ignored_output")
+
+    if risk_flags:
+        return WorktreeCandidate(
+            path=path,
+            branch=branch,
+            head_sha=head_sha,
+            is_current=False,
+            classification="risky",
+            risk_flags=risk_flags,
+            preservation_required=f"risky: {', '.join(risk_flags)}",
+        )
+
+    return WorktreeCandidate(
+        path=path,
+        branch=branch,
+        head_sha=head_sha,
+        is_current=False,
+        classification="clean_stale",
+    )
+
+
+def build_plan(
+    *,
+    current_path: str | None = None,
+    skip_pr_check: bool = False,
+    limit: int = 0,
+) -> ReaperPlan:
+    """Build a deletion plan from current repository worktrees."""
+    errors: list[str] = []
+    if current_path is None:
+        current_path = str(Path.cwd().resolve())
+
+    result = _run_command(["git", "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        errors.append("failed to list worktrees")
+        return ReaperPlan(
+            schema=SCHEMA_VERSION,
+            mode="dry_run",
+            total_worktrees=0,
+            current_worktree=None,
+            candidates=[],
+            deletable=[],
+            refused=[],
+            errors=errors,
+            audit_log=["failed to list worktrees"],
+        )
+
+    parsed = _parse_worktree_porcelain(result.stdout)
+    current_worktree = None
+    candidates: list[WorktreeCandidate] = []
+    audit_log: list[str] = []
+
+    worktrees_to_check = parsed[:limit] if limit > 0 else parsed
+    for wt in worktrees_to_check:
+        wt_path = wt.get("path", "")
+        branch = wt.get("branch", "")
+        head_sha = wt.get("head_sha", "")
+
+        candidate = classify_worktree(
+            path=wt_path,
+            branch=branch,
+            head_sha=head_sha,
+            current_path=current_path,
+            skip_pr_check=skip_pr_check,
+        )
+        if candidate.is_current:
+            current_worktree = wt_path
+        candidates.append(candidate)
+        audit_log.append(
+            f"classified {wt_path} as {candidate.classification}"
+            + (f" ({', '.join(candidate.risk_flags)})" if candidate.risk_flags else "")
+        )
+
+    deletable = [c.path for c in candidates if c.classification == "clean_stale"]
+    refused = [c.path for c in candidates if c.classification == "risky"]
+
+    return ReaperPlan(
+        schema=SCHEMA_VERSION,
+        mode="dry_run",
+        total_worktrees=len(parsed),
+        current_worktree=current_worktree,
+        candidates=candidates,
+        deletable=deletable,
+        refused=refused,
+        errors=errors,
+        audit_log=audit_log,
+    )
+
+
+def apply_deletions(plan: ReaperPlan, *, force: bool = False) -> ReaperPlan:
+    """Apply safe deletions from the plan. Refuses risky candidates."""
+    errors = list(plan.errors)
+
+    if plan.errors:
+        return plan
+
+    deletable = list(plan.deletable)
+    refused = list(plan.refused)
+    audit_log = list(plan.audit_log)
+
+    for candidate in plan.candidates:
+        if candidate.classification != "clean_stale":
+            if candidate.classification == "risky":
+                audit_log.append(f"refused risky candidate {candidate.path}")
+            continue
+        if candidate.is_current:
+            refused.append(candidate.path)
+            audit_log.append(f"refused current worktree {candidate.path}")
+            continue
+
+        result = _run_command(["git", "worktree", "remove", candidate.path])
+        if result.returncode != 0:
+            errors.append(f"failed to remove {candidate.path}: {result.stderr.strip()}")
+            refused.append(candidate.path)
+            audit_log.append(f"failed to remove {candidate.path}")
+        else:
+            deletable = [d for d in deletable if d != candidate.path]
+            audit_log.append(f"removed {candidate.path}")
+
+    return ReaperPlan(
+        schema=plan.schema,
+        mode="apply",
+        total_worktrees=plan.total_worktrees,
+        current_worktree=plan.current_worktree,
+        candidates=plan.candidates,
+        deletable=deletable,
+        refused=refused,
+        errors=errors,
+        audit_log=audit_log,
+    )
+
+
+def _append_candidate_lines(lines: list[str], candidates: list[WorktreeCandidate]) -> None:
+    """Append human-readable candidate rows."""
+    for c in candidates:
+        if c.classification == "current":
+            tag = "[CURRENT]"
+        elif c.classification == "clean_stale":
+            tag = "[DELETABLE]"
+        else:
+            tag = f"[RISKY: {', '.join(c.risk_flags)}]"
+        lines.append(f"  {tag} {c.branch or 'detached'}: {c.path}")
+
+
+def _append_path_section(lines: list[str], title: str, paths: list[str]) -> None:
+    """Append a titled path list when non-empty."""
+    if paths:
+        lines.append("")
+        lines.append(f"  {title} ({len(paths)}):")
+        for p in paths:
+            lines.append(f"    - {p}")
+
+
+def _append_text_section(lines: list[str], title: str, values: list[str]) -> None:
+    """Append a titled text list when non-empty."""
+    if values:
+        lines.append("")
+        lines.append(f"  {title}:")
+        for value in values:
+            lines.append(f"    - {value}")
+
+
+def format_human(plan: ReaperPlan) -> str:
+    """Format plan as human-readable text."""
+    lines = [
+        f"Stale Worktree Reaper (schema: {plan.schema})",
+        f"  Mode: {plan.mode}",
+        f"  Total worktrees: {plan.total_worktrees}",
+        f"  Current: {plan.current_worktree or 'N/A'}",
+        "",
+    ]
+
+    _append_candidate_lines(lines, plan.candidates)
+    _append_path_section(lines, "Deletable", plan.deletable)
+    _append_path_section(lines, "Refused", plan.refused)
+    _append_text_section(lines, "Errors", plan.errors)
+    _append_text_section(lines, "Audit log", plan.audit_log)
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually remove safe worktrees (risky candidates still refused)",
+    )
+    parser.add_argument(
+        "--skip-pr-check",
+        action="store_true",
+        help="Skip GitHub PR lookup (faster, offline-safe)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum worktrees to consider (0 = all)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+
+    try:
+        plan = build_plan(
+            skip_pr_check=args.skip_pr_check,
+            limit=args.limit,
+        )
+    except Exception as exc:
+        print(f"ERROR building reaper plan: {exc}", file=sys.stderr)
+        return 1
+
+    if args.apply:
+        plan = apply_deletions(plan)
+
+    if args.json:
+        output = asdict(plan)
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print(format_human(plan))
+
+    return 0 if not plan.errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_stale_worktree_reaper.py
+++ b/tests/dev/test_stale_worktree_reaper.py
@@ -1,0 +1,454 @@
+"""Tests for stale worktree reaper dry-run classification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from scripts.dev import stale_worktree_reaper as reaper
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return reaper.subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _worktree_porcelain(*entries: tuple[str, str, str]) -> str:
+    """Build porcelain output from (path, head, branch) tuples."""
+    blocks = []
+    for path, head, branch in entries:
+        blocks.append(f"worktree {path}")
+        blocks.append(f"HEAD {head}")
+        if branch:
+            blocks.append(f"branch refs/heads/{branch}")
+        blocks.append("")
+    return "\n".join(blocks)
+
+
+def test_parse_worktree_porcelain_extracts_rows() -> None:
+    """Porcelain output should yield path/head/branch dicts."""
+    stdout = _worktree_porcelain(
+        ("/repo/main", "aaa111", "main"),
+        ("/repo/issue-99", "bbb222", "issue-99-fix"),
+    )
+    rows = reaper._parse_worktree_porcelain(stdout)
+    assert len(rows) == 2
+    assert rows[0]["path"] == "/repo/main"
+    assert rows[0]["head_sha"] == "aaa111"
+    assert rows[0]["branch"] == "main"
+    assert rows[1]["branch"] == "issue-99-fix"
+
+
+def test_classify_current_worktree_is_protected(tmp_path: Path) -> None:
+    """The current worktree must never be classified as deletable."""
+    wt = tmp_path / "worktree-current"
+    wt.mkdir()
+    candidate = reaper.classify_worktree(
+        path=str(wt),
+        branch="main",
+        head_sha="abc",
+        current_path=str(wt),
+        skip_pr_check=True,
+    )
+    assert candidate.classification == "current"
+    assert candidate.preservation_required == "current worktree"
+
+
+def test_classify_clean_stale_candidate(tmp_path: Path) -> None:
+    """A worktree with no risks should be classified as clean_stale."""
+    main = tmp_path / "main"
+    stale = tmp_path / "stale-branch"
+    main.mkdir()
+    stale.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/stale-branch\n")
+        if args == ["git", "log", "origin/stale-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "stale-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(stale),
+            branch="stale-branch",
+            head_sha="def",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "clean_stale"
+    assert candidate.risk_flags == []
+
+
+def test_classify_dirty_worktree(tmp_path: Path) -> None:
+    """A worktree with uncommitted changes should be classified as risky."""
+    main = tmp_path / "main"
+    dirty = tmp_path / "dirty-wt"
+    main.mkdir()
+    dirty.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result(" M file.txt\n")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/dirty-branch\n")
+        if args == ["git", "log", "origin/dirty-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "dirty-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(dirty),
+            branch="dirty-branch",
+            head_sha="abc",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "risky"
+    assert "dirty" in candidate.risk_flags
+
+
+def test_classify_unpushed_commits(tmp_path: Path) -> None:
+    """Commits ahead of origin should be flagged as unpushed_commits."""
+    main = tmp_path / "main"
+    ahead = tmp_path / "ahead-wt"
+    main.mkdir()
+    ahead.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/ahead-branch\n")
+        if args == ["git", "log", "origin/ahead-branch..HEAD", "--oneline"]:
+            return _result("abc1234 add feature\n")
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "ahead-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(ahead),
+            branch="ahead-branch",
+            head_sha="def",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "risky"
+    assert "unpushed_commits" in candidate.risk_flags
+
+
+def test_classify_missing_upstream_as_unpushed_risk(tmp_path: Path) -> None:
+    """A branch without an upstream should not be considered safe to reap."""
+    main = tmp_path / "main"
+    local_only = tmp_path / "local-only-wt"
+    main.mkdir()
+    local_only.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("", "no upstream", 128)
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "local-only",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(local_only),
+            branch="local-only",
+            head_sha="def",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "risky"
+    assert "unpushed_commits" in candidate.risk_flags
+
+
+def test_classify_open_pr_risk(tmp_path: Path) -> None:
+    """An open PR should be flagged as open_pr."""
+    main = tmp_path / "main"
+    pr_wt = tmp_path / "pr-wt"
+    main.mkdir()
+    pr_wt.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/pr-branch\n")
+        if args == ["git", "log", "origin/pr-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "pr-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result('[{"number": 42}]')
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(pr_wt),
+            branch="pr-branch",
+            head_sha="abc",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "risky"
+    assert "open_pr" in candidate.risk_flags
+
+
+def test_skip_pr_check_is_conservative_risk(tmp_path: Path) -> None:
+    """Skipping PR lookup should prevent a branch worktree from becoming deletable."""
+    main = tmp_path / "main"
+    stale = tmp_path / "stale-wt"
+    main.mkdir()
+    stale.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/stale-branch\n")
+        if args == ["git", "log", "origin/stale-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(stale),
+            branch="stale-branch",
+            head_sha="abc",
+            current_path=str(main),
+            skip_pr_check=True,
+        )
+    assert candidate.classification == "risky"
+    assert "pr_check_skipped" in candidate.risk_flags
+
+
+def test_classify_ignored_output_risk(tmp_path: Path) -> None:
+    """Ignored output files should be flagged as ignored_output."""
+    main = tmp_path / "main"
+    out_wt = tmp_path / "output-wt"
+    main.mkdir()
+    out_wt.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/output-branch\n")
+        if args == ["git", "log", "origin/output-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "output-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("!! output/model_cache/\n!! output/videos/")
+        return _result("", returncode=1)
+
+    with patch.object(reaper, "_run_command", side_effect=fake_run):
+        candidate = reaper.classify_worktree(
+            path=str(out_wt),
+            branch="output-branch",
+            head_sha="abc",
+            current_path=str(main),
+            skip_pr_check=False,
+        )
+    assert candidate.classification == "risky"
+    assert "ignored_output" in candidate.risk_flags
+
+
+def test_apply_refuses_risky_candidates(tmp_path: Path) -> None:
+    """apply_deletions must not remove worktrees with risk flags."""
+    main = tmp_path / "main"
+    risky = tmp_path / "risky-wt"
+    main.mkdir()
+    risky.mkdir()
+
+    plan = reaper.ReaperPlan(
+        schema=reaper.SCHEMA_VERSION,
+        mode="dry_run",
+        total_worktrees=2,
+        current_worktree=str(main),
+        candidates=[
+            reaper.WorktreeCandidate(
+                path=str(main),
+                branch="main",
+                head_sha="a",
+                is_current=True,
+                classification="current",
+            ),
+            reaper.WorktreeCandidate(
+                path=str(risky),
+                branch="risky",
+                head_sha="b",
+                is_current=False,
+                classification="risky",
+                risk_flags=["dirty"],
+                preservation_required="risky: dirty",
+            ),
+        ],
+        deletable=[],
+        refused=[str(risky)],
+        errors=[],
+        audit_log=["classified risky"],
+    )
+
+    result = reaper.apply_deletions(plan)
+    assert result.mode == "apply"
+    assert str(risky) in result.refused
+    assert result.errors == []
+    assert any("refused risky candidate" in event for event in result.audit_log)
+
+
+def test_dry_run_produces_no_deletion_command(tmp_path: Path, monkeypatch) -> None:
+    """Dry-run mode must never invoke git worktree remove."""
+    main = tmp_path / "main"
+    stale = tmp_path / "stale-wt"
+    main.mkdir()
+    stale.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args[:4] == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                _worktree_porcelain(
+                    (str(main), "aaa", "main"),
+                    (str(stale), "bbb", "stale-branch"),
+                )
+            )
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/stale-branch\n")
+        if args[0:4] == ["git", "log", "origin/stale-branch..HEAD", "--oneline"]:
+            return _result("")
+        if args[:4] == [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            "stale-branch",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ]:
+            return _result("[]")
+        if args == ["git", "status", "--ignored", "--short", "-uall"]:
+            return _result("")
+        if args == ["git", "worktree", "remove", str(stale)]:
+            raise AssertionError("git worktree remove must NOT be called in dry-run mode")
+        return _result("", returncode=1)
+
+    monkeypatch.setattr(reaper, "_run_command", fake_run)
+    plan = reaper.build_plan(skip_pr_check=False)
+    assert plan.mode == "dry_run"
+    assert str(stale) in plan.deletable
+    assert plan.errors == []
+    assert any(str(stale) in event for event in plan.audit_log)
+
+
+def test_build_plan_dry_run_default(tmp_path: Path, monkeypatch) -> None:
+    """build_plan should default to dry_run mode."""
+    main = tmp_path / "main"
+    main.mkdir()
+
+    def fake_run(args, *, cwd=None, timeout=30):
+        if args[:4] == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                _worktree_porcelain(
+                    (str(main), "aaa", "main"),
+                )
+            )
+        return _result("", returncode=1)
+
+    monkeypatch.setattr(reaper, "_run_command", fake_run)
+    plan = reaper.build_plan(skip_pr_check=True, current_path=str(main))
+    assert plan.mode == "dry_run"
+    assert plan.total_worktrees == 1
+    assert len(plan.candidates) == 1
+    assert plan.candidates[0].classification == "current"
+    assert plan.audit_log == [f"classified {main} as current"]


### PR DESCRIPTION
## Summary
Adds a dry-run-first stale worktree reaper that classifies cleanup candidates, reports risk flags and preservation requirements, and only removes clean candidates when `--apply` is explicitly requested.

## Linked Issues
- Closes `#2732`
- Relates to `#2715`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/stale_worktree_reaper.py`.
- Added `tests/dev/test_stale_worktree_reaper.py`.
- The helper parses `git worktree list --porcelain`, classifies candidates as `current`, `clean_stale`, or `risky`, and emits JSON or text plans with `audit_log`, `risk_flags`, `deletable`, and `refused` lists.
- Risk flags include dirty state, unpushed/missing-upstream commits, open PRs, skipped PR checks, and ignored output.

## Why It Matters
- Added value: worktree cleanup now has a preservation-aware dry-run path instead of ad-hoc inspection.
- Expected impact: safer cleanup after delegated/autonomous work, with less broad parent-thread worktree output.
- Why this is worth merging now: the repo has many linked worktrees, and cleanup automation needs a fail-closed classifier before any deletion behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper; no research/benchmark/metric/paper-facing claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: smoke
- Result classification: blocker-resolution / workflow support
- Decision or stop rule, if applicable: risky candidates remain refused; only `clean_stale` candidates can be removed under `--apply`.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this support helper.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_stale_worktree_reaper.py -q`
  - `rtk uv run ruff check scripts/dev/stale_worktree_reaper.py tests/dev/test_stale_worktree_reaper.py`
  - `rtk uv run ruff format --check scripts/dev/stale_worktree_reaper.py tests/dev/test_stale_worktree_reaper.py`
  - `rtk uv run python scripts/dev/stale_worktree_reaper.py --json --limit 5 --skip-pr-check`
  - `rtk uv run python scripts/dev/stale_worktree_reaper.py --json --limit 2`
  - `BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Targeted tests: 12 passed.
  - Dry-run with skipped PR checks produced zero deletable candidates and conservative `pr_check_skipped` risk flags.
  - Normal dry-run with PR checks produced zero deletable candidates for the bounded sample.
  - Full readiness stamp: `output/validation/pr_ready/issue-2732-stale-worktree-reaper.json`, status `passed`, head `b706c1255b685bc9e776c06152277256b6730325`, tree state `clean`.
  - Full suite inside readiness: 5860 passed, 9 skipped.
- Benchmarks or smoke tests, if applicable: workflow smoke only.

## Risks / Rollout
- Compatibility risks: additive script only.
- Failure modes: GitHub PR lookup failures are conservative when explicitly skipped; missing upstream is treated as unpushed risk.
- Rollback or fallback plan: continue manual `git worktree list --porcelain` and `git status` inspection; no persistent state migration.

## Docs / Provenance
- Updated docs: NA.
- Relevant design or provenance notes: issue `#2732`.
- Any assumptions that need to be preserved: ignored output is a preservation risk, not disposable by default.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#2732`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: workflow support helper with no benchmark/result propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: `--skip-pr-check` intentionally adds `pr_check_skipped`, so offline mode cannot accidentally make a branch deletable.
- Any known limitations: `--apply` only removes `clean_stale` candidates; risky preservation workflows remain manual by design.

## Delegate Outcomes
- OpenCode Zen implemented the initial helper and tests through `codex-agent-worker`.
- Worker artifact status was partial, so Codex reviewed the diff directly, added missing-upstream and skipped-PR fail-closed safety checks, added explicit `audit_log`, and reran local validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Git worktree management tool that safely identifies and removes stale worktrees
  * Classifies worktrees as current, clean, or risky based on working tree status, unpushed commits, and open pull requests
  * Supports dry-run mode for preview and apply mode for execution
  * Outputs results in human-readable text or JSON format
  * Includes detailed audit logging and error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->