### PR TITLE
feat: add observation perturbation diagnostics

### DIFF
--- a/robot_sf/benchmark/observation_perturbation.py
+++ b/robot_sf/benchmark/observation_perturbation.py
@@ -1,0 +1,384 @@
+"""Bounded observation-perturbation helper for local policy inputs.
+
+Provides a pure, stateless-per-step function that separates ground-truth
+actor state from a noisy/occluded/delayed observed state.  Designed for
+diagnostic trace and report payloads that must keep ``ideal_state`` and
+``perception_limited`` rows distinct.
+
+This module is a *benchmark diagnostic tool*, not a sensor model or
+hardware abstraction.  Evidence class labels are metadata only and
+carry no sensor-certification semantics.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+NOISE_PROFILE_NONE = "none"
+NOISE_PROFILE_GAUSSIAN = "bounded_gaussian"
+NOISE_PROFILE_MISSED_DETECTION = "missed_detection"
+NOISE_PROFILE_OCCLUSION_MASK = "occlusion_mask"
+NOISE_PROFILE_DELAYED_OBSERVATION = "delayed_observation"
+EVIDENCE_IDEAL = "ideal_state"
+EVIDENCE_PERCEPTION_LIMITED = "perception_limited"
+
+
+@dataclass(frozen=True)
+class ObservationPerturbationSpec:
+    """Configuration for observation perturbation applied to ground-truth actor state."""
+
+    position_noise_std_m: float = 0.0
+    position_noise_bound_m: float = 0.0
+    missed_detection_probability: float = 0.0
+    occlusion_mask: np.ndarray | None = None
+    delay_steps: int = 0
+    seed: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate parameter ranges."""
+        if self.position_noise_std_m < 0.0:
+            raise ValueError("position_noise_std_m must be >= 0")
+        if self.position_noise_bound_m < 0.0:
+            raise ValueError("position_noise_bound_m must be >= 0")
+        if not 0.0 <= self.missed_detection_probability <= 1.0:
+            raise ValueError("missed_detection_probability must be between 0 and 1")
+        if self.delay_steps < 0:
+            raise ValueError("delay_steps must be >= 0")
+
+    @property
+    def is_noop(self) -> bool:
+        """Return True when the spec produces ground-truth output deterministically."""
+        return (
+            self.position_noise_std_m <= 0.0
+            and self.missed_detection_probability <= 0.0
+            and self.occlusion_mask is None
+            and self.delay_steps <= 0
+        )
+
+    @property
+    def noise_profile(self) -> str:
+        """Return a short label for the active noise profile."""
+        if self.is_noop:
+            return NOISE_PROFILE_NONE
+        if self.position_noise_std_m > 0.0:
+            return NOISE_PROFILE_GAUSSIAN
+        if self.missed_detection_probability > 0.0:
+            return NOISE_PROFILE_MISSED_DETECTION
+        if self.occlusion_mask is not None:
+            return NOISE_PROFILE_OCCLUSION_MASK
+        if self.delay_steps > 0:
+            return NOISE_PROFILE_DELAYED_OBSERVATION
+        return NOISE_PROFILE_NONE
+
+
+@dataclass
+class ObservationPerturbationState:
+    """Mutable state for delay-buffer management across steps.
+
+    The caller owns this object and passes it to ``perturb_ground_truth``.
+    For specs with ``delay_steps > 0``, the buffer stores recent observed
+    snapshots and the observed state lags behind the latest ground truth.
+    """
+
+    delay_steps: int = 0
+    _delay_buffer: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=1))
+
+    def __post_init__(self) -> None:
+        """Ensure the buffer capacity matches the configured delay."""
+        if self.delay_steps < 0:
+            raise ValueError("delay_steps must be >= 0")
+        capacity = max(1, self.delay_steps + 1)
+        if getattr(self._delay_buffer, "maxlen", 1) != capacity:
+            existing = list(self._delay_buffer)
+            self._delay_buffer = deque(existing, maxlen=capacity)
+
+    def reset(self, initial_obs: dict[str, Any] | None = None) -> None:
+        """Reset the delay buffer, optionally seeding with an initial observation."""
+        capacity = max(1, self.delay_steps + 1)
+        self._delay_buffer = deque(maxlen=capacity)
+        if initial_obs is not None:
+            self._delay_buffer.append(initial_obs)
+
+
+def _make_rng(spec: ObservationPerturbationSpec, step: int) -> np.random.Generator | None:
+    """Create a deterministic RNG for one perturbation step.
+
+    Returns:
+        NumPy generator or None for no-op specs.
+    """
+    if spec.is_noop:
+        return None
+    if spec.seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng(np.random.SeedSequence([spec.seed, step]))
+
+
+def _apply_bounded_gaussian(
+    positions: np.ndarray,
+    *,
+    std: float,
+    bound: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Return positions with bounded additive Gaussian noise.
+
+    Each axis is perturbed independently.  The displacement is clipped
+    to ``[-bound, bound]`` per axis.
+    """
+    if std <= 0.0 or positions.size == 0:
+        return positions
+    noise = rng.normal(0.0, std, size=positions.shape)
+    if bound > 0.0:
+        noise = np.clip(noise, -bound, bound)
+    return positions + noise
+
+
+@dataclass(frozen=True)
+class _DelayedResultContext:
+    """Internal bundle for delay-buffer result construction."""
+
+    gt_pos: np.ndarray
+    gt_vel: np.ndarray
+    actor_ids: list[str]
+    observed_snapshot: dict[str, Any]
+    state: ObservationPerturbationState
+    delay: int
+    step: int
+    missed_mask: np.ndarray
+    occluded_mask: np.ndarray
+    n_actors: int
+    spec: ObservationPerturbationSpec
+
+
+def _build_delayed_result(ctx: _DelayedResultContext) -> dict[str, Any]:
+    """Build the perturbation result with delay-buffer bookkeeping.
+
+    Returns:
+        Complete perturbation result dictionary with delayed observed state.
+    """
+    ctx.state._delay_buffer.append(ctx.observed_snapshot)
+    if len(ctx.state._delay_buffer) > ctx.delay:
+        delayed_snapshot = ctx.state._delay_buffer[0]
+    else:
+        delayed_snapshot = {
+            "positions": ctx.gt_pos.copy(),
+            "velocities": ctx.gt_vel.copy(),
+            "ids": list(ctx.actor_ids),
+        }
+    observed_out = delayed_snapshot
+    observed_actor_count = observed_out["positions"].shape[0]
+    missing_ids = [aid for aid in ctx.actor_ids if aid not in observed_out["ids"]]
+    return {
+        "ground_truth": {
+            "positions": ctx.gt_pos,
+            "velocities": ctx.gt_vel,
+            "ids": list(ctx.actor_ids),
+        },
+        "observed": observed_out,
+        "missing_ids": missing_ids,
+        "metadata": {
+            "noise_profile": ctx.spec.noise_profile,
+            "evidence_class": EVIDENCE_PERCEPTION_LIMITED,
+            "position_noise_std_m": ctx.spec.position_noise_std_m,
+            "position_noise_bound_m": ctx.spec.position_noise_bound_m,
+            "missed_detection_probability": ctx.spec.missed_detection_probability,
+            "missed_actor_count": int(ctx.missed_mask.sum()),
+            "occluded_actor_count": int(ctx.occluded_mask.sum()),
+            "delay_steps": ctx.delay,
+            "step": ctx.step,
+            "actor_count": ctx.n_actors,
+            "observed_actor_count": observed_actor_count,
+        },
+    }
+
+
+def _compute_observed_state(
+    *,
+    gt_pos: np.ndarray,
+    gt_vel: np.ndarray,
+    actor_ids: list[str],
+    n_actors: int,
+    spec: ObservationPerturbationSpec,
+    rng: np.random.Generator,
+) -> tuple[np.ndarray, np.ndarray, list[str], np.ndarray, np.ndarray]:
+    """Compute the observed state after missed detections, noise, and occlusion.
+
+    Returns:
+        Tuple of (obs_positions, obs_velocities, obs_ids, missed_mask, occluded_mask).
+    """
+    missed_mask = np.zeros(n_actors, dtype=bool)
+    occluded_mask = np.zeros(n_actors, dtype=bool)
+
+    # --- missed detections ---
+    ids_out = list(actor_ids)
+    if spec.missed_detection_probability > 0.0 and n_actors > 0:
+        keep = rng.random(n_actors) >= spec.missed_detection_probability
+        missed_mask = ~keep
+
+    # --- bounded gaussian noise ---
+    obs_pos_full = gt_pos.copy()
+    if spec.position_noise_std_m > 0.0 and n_actors > 0:
+        obs_pos_full = _apply_bounded_gaussian(
+            gt_pos,
+            std=spec.position_noise_std_m,
+            bound=spec.position_noise_bound_m,
+            rng=rng,
+        )
+
+    # --- occlusion mask ---
+    if spec.occlusion_mask is not None:
+        ext_mask = np.asarray(spec.occlusion_mask, dtype=bool).reshape(-1)
+        if ext_mask.shape[0] != n_actors:
+            raise ValueError(f"occlusion_mask length {ext_mask.shape[0]} != actor count {n_actors}")
+        occluded_mask = ext_mask & ~missed_mask
+
+    # Build observed array: drop missed, zero occluded positions
+    if missed_mask.any():
+        obs_pos = obs_pos_full[~missed_mask]
+        obs_vel_out = gt_vel[~missed_mask]
+        ids_out = [aid for aid, m in zip(actor_ids, ~missed_mask, strict=True) if m]
+    else:
+        obs_pos = obs_pos_full
+        obs_vel_out = gt_vel.copy()
+        ids_out = list(actor_ids)
+
+    # Zero out occluded actor positions in the observed view
+    for i, aid in enumerate(ids_out):
+        orig_idx = actor_ids.index(aid)
+        if occluded_mask[orig_idx]:
+            obs_pos[i] = 0.0
+            obs_vel_out[i] = 0.0
+
+    return obs_pos, obs_vel_out, ids_out, missed_mask, occluded_mask
+
+
+def perturb_ground_truth(
+    ground_truth_positions: np.ndarray | list,
+    ground_truth_velocities: np.ndarray | list,
+    actor_ids: list[str],
+    *,
+    spec: ObservationPerturbationSpec,
+    step: int = 0,
+    state: ObservationPerturbationState | None = None,
+) -> dict[str, Any]:
+    """Separate ground-truth actor state from a perturbed observed state.
+
+    Args:
+        ground_truth_positions: ``(N, 2)`` array of actor [x, y] positions.
+        ground_truth_velocities: ``(N, 2)`` array of actor [vx, vy] velocities.
+        actor_ids: List of ``N`` actor identifier strings.
+        spec: Perturbation configuration.
+        step: Current simulation step index (used for RNG seeding).
+        state: Mutable delay-buffer state.  Required when ``spec.delay_steps > 0``.
+
+    Returns:
+        Dictionary with keys:
+        - ``ground_truth``: dict of position/velocity/id arrays (always unmodified).
+        - ``observed``: dict of perturbed position/velocity/id arrays.
+        - ``missing_ids``: list of actor IDs not present in the observed state.
+        - ``metadata``: dict with noise profile, evidence class, and per-actor flags.
+
+    Raises:
+        ValueError: When actor count mismatches or delay state is missing.
+    """
+    gt_pos = np.asarray(ground_truth_positions, dtype=np.float64).reshape(-1, 2).copy()
+    gt_vel = np.asarray(ground_truth_velocities, dtype=np.float64).reshape(-1, 2).copy()
+    n_actors = gt_pos.shape[0]
+
+    if gt_vel.shape[0] != n_actors:
+        raise ValueError(
+            f"Actor count mismatch: {n_actors} positions vs {gt_vel.shape[0]} velocities"
+        )
+    if len(actor_ids) != n_actors:
+        raise ValueError(f"Actor count mismatch: {n_actors} positions vs {len(actor_ids)} ids")
+
+    gt_payload = {
+        "positions": gt_pos,
+        "velocities": gt_vel,
+        "ids": list(actor_ids),
+    }
+
+    if spec.is_noop:
+        return {
+            "ground_truth": gt_payload,
+            "observed": {
+                "positions": gt_pos.copy(),
+                "velocities": gt_vel.copy(),
+                "ids": list(actor_ids),
+            },
+            "missing_ids": [],
+            "metadata": {
+                "noise_profile": NOISE_PROFILE_NONE,
+                "evidence_class": EVIDENCE_IDEAL,
+                "position_noise_std_m": 0.0,
+                "position_noise_bound_m": 0.0,
+                "missed_detection_probability": 0.0,
+                "missed_actor_count": 0,
+                "occluded_actor_count": 0,
+                "delay_steps": 0,
+                "step": step,
+                "actor_count": n_actors,
+                "observed_actor_count": n_actors,
+            },
+        }
+
+    rng = _make_rng(spec, step)
+
+    obs_pos, obs_vel_out, ids_out, missed_mask, occluded_mask = _compute_observed_state(
+        gt_pos=gt_pos,
+        gt_vel=gt_vel,
+        actor_ids=actor_ids,
+        n_actors=n_actors,
+        spec=spec,
+        rng=rng,
+    )
+
+    observed_snapshot = {
+        "positions": obs_pos.copy(),
+        "velocities": obs_vel_out.copy(),
+        "ids": list(ids_out),
+    }
+
+    delay = spec.delay_steps
+    if delay > 0:
+        if state is None:
+            raise ValueError("ObservationPerturbationState required when delay_steps > 0")
+        return _build_delayed_result(
+            _DelayedResultContext(
+                gt_pos=gt_pos,
+                gt_vel=gt_vel,
+                actor_ids=actor_ids,
+                observed_snapshot=observed_snapshot,
+                state=state,
+                delay=delay,
+                step=step,
+                missed_mask=missed_mask,
+                occluded_mask=occluded_mask,
+                n_actors=n_actors,
+                spec=spec,
+            )
+        )
+
+    missing_ids = [aid for aid in actor_ids if aid not in ids_out]
+    return {
+        "ground_truth": gt_payload,
+        "observed": observed_snapshot,
+        "missing_ids": missing_ids,
+        "metadata": {
+            "noise_profile": spec.noise_profile,
+            "evidence_class": EVIDENCE_PERCEPTION_LIMITED,
+            "position_noise_std_m": spec.position_noise_std_m,
+            "position_noise_bound_m": spec.position_noise_bound_m,
+            "missed_detection_probability": spec.missed_detection_probability,
+            "missed_actor_count": int(missed_mask.sum()),
+            "occluded_actor_count": int(occluded_mask.sum()),
+            "delay_steps": 0,
+            "step": step,
+            "actor_count": n_actors,
+            "observed_actor_count": obs_pos.shape[0],
+        },
+    }

--- a/scripts/validation/run_policy_search_step_diagnostics.py
+++ b/scripts/validation/run_policy_search_step_diagnostics.py
@@ -17,6 +17,12 @@ from robot_sf.benchmark.map_runner import (
     _policy_command_to_env_action,
     _scenario_with_episode_seed_defaults,
 )
+from robot_sf.benchmark.observation_perturbation import (
+    EVIDENCE_IDEAL,
+    ObservationPerturbationSpec,
+    ObservationPerturbationState,
+    perturb_ground_truth,
+)
 from robot_sf.benchmark.termination_reason import route_complete_success
 from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.training.scenario_loader import load_scenarios
@@ -305,6 +311,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed-index", type=int, default=0)
     parser.add_argument("--horizon", type=int, default=None)
     parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--observation-noise-std-m", type=float, default=0.0)
+    parser.add_argument("--observation-noise-bound-m", type=float, default=0.0)
+    parser.add_argument("--missed-detection-probability", type=float, default=0.0)
+    parser.add_argument("--occlusion-distance-m", type=float, default=None)
+    parser.add_argument("--observation-delay-steps", type=int, default=0)
+    parser.add_argument("--observation-perturbation-seed", type=int, default=None)
     return parser.parse_args()
 
 
@@ -364,6 +376,110 @@ def _sim_min_robot_ped_distance(env: Any) -> float | None:
     if ped_pos.size == 0:
         return None
     return float(np.min(np.linalg.norm(ped_pos[:, :2] - robot_pos.reshape(1, 2), axis=1)))
+
+
+def _pedestrian_state_from_sim(env: Any) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Return current simulator pedestrian positions, velocities, and stable synthetic IDs."""
+    ped_pos = np.asarray(getattr(env.simulator, "ped_pos", []), dtype=float)
+    if ped_pos.ndim == 1:
+        ped_pos = ped_pos.reshape(-1, 2) if ped_pos.size % 2 == 0 else np.zeros((0, 2), dtype=float)
+    ped_pos = ped_pos[:, :2].copy() if ped_pos.size else np.zeros((0, 2), dtype=float)
+
+    ped_vel = np.asarray(getattr(env.simulator, "ped_vel", []), dtype=float)
+    if ped_vel.ndim == 1:
+        ped_vel = ped_vel.reshape(-1, 2) if ped_vel.size % 2 == 0 else np.zeros((0, 2), dtype=float)
+    if ped_vel.shape[0] != ped_pos.shape[0]:
+        ped_vel = np.zeros_like(ped_pos)
+    else:
+        ped_vel = ped_vel[:, :2].copy()
+
+    actor_ids = [f"ped_{idx}" for idx in range(ped_pos.shape[0])]
+    return ped_pos, ped_vel, actor_ids
+
+
+def _occlusion_mask_by_distance(
+    env: Any,
+    ped_pos: np.ndarray,
+    *,
+    occlusion_distance_m: float | None,
+) -> np.ndarray | None:
+    """Return a simple range-limited occlusion mask for diagnostic stress tests."""
+    if occlusion_distance_m is None:
+        return None
+    robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float).reshape(-1)[:2]
+    if ped_pos.size == 0:
+        return np.zeros((0,), dtype=bool)
+    distances = np.linalg.norm(ped_pos - robot_pos.reshape(1, 2), axis=1)
+    return distances > float(occlusion_distance_m)
+
+
+def _observation_perturbation_spec(
+    args: argparse.Namespace, env: Any
+) -> ObservationPerturbationSpec:
+    """Build a per-step observation perturbation spec from CLI flags."""
+    ped_pos, _ped_vel, _actor_ids = _pedestrian_state_from_sim(env)
+    return ObservationPerturbationSpec(
+        position_noise_std_m=float(args.observation_noise_std_m),
+        position_noise_bound_m=float(args.observation_noise_bound_m),
+        missed_detection_probability=float(args.missed_detection_probability),
+        occlusion_mask=_occlusion_mask_by_distance(
+            env,
+            ped_pos,
+            occlusion_distance_m=args.occlusion_distance_m,
+        ),
+        delay_steps=int(args.observation_delay_steps),
+        seed=args.observation_perturbation_seed,
+    )
+
+
+def _apply_observed_pedestrians_to_policy_obs(
+    obs: Any,
+    perturbation: dict[str, Any],
+) -> Any:
+    """Return an observation copy whose pedestrian payload uses perturbed state."""
+    if not isinstance(obs, dict):
+        return obs
+    policy_obs = dict(obs)
+    pedestrians = dict(policy_obs.get("pedestrians", {}))
+    observed = perturbation["observed"]
+    observed_positions = np.asarray(observed["positions"], dtype=np.float32)
+    observed_velocities = np.asarray(observed["velocities"], dtype=np.float32)
+    observed_count = np.asarray([observed_positions.shape[0]], dtype=np.float32)
+    pedestrians["positions"] = observed_positions
+    pedestrians["velocities"] = observed_velocities
+    pedestrians["count"] = observed_count
+    policy_obs["pedestrians"] = pedestrians
+    if "pedestrians_positions" in policy_obs:
+        policy_obs["pedestrians_positions"] = observed_positions
+    if "pedestrians_velocities" in policy_obs:
+        policy_obs["pedestrians_velocities"] = observed_velocities
+    if "pedestrians_count" in policy_obs:
+        policy_obs["pedestrians_count"] = observed_count
+    return policy_obs
+
+
+def _trace_observation_payload(perturbation: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact trace payload for ground-truth and observed pedestrians."""
+    metadata = perturbation["metadata"]
+    ground_truth = perturbation["ground_truth"]
+    observed = perturbation["observed"]
+    return {
+        "ground_truth_observation": {
+            "positions": _json_ready(ground_truth["positions"]),
+            "velocities": _json_ready(ground_truth["velocities"]),
+            "ids": _json_ready(ground_truth["ids"]),
+            "evidence_class": EVIDENCE_IDEAL,
+        },
+        "observed_observation": {
+            "positions": _json_ready(observed["positions"]),
+            "velocities": _json_ready(observed["velocities"]),
+            "ids": _json_ready(observed["ids"]),
+            "missing_ids": _json_ready(perturbation["missing_ids"]),
+            "evidence_class": metadata["evidence_class"],
+            "noise_profile": metadata["noise_profile"],
+        },
+        "observation_perturbation": _json_ready(metadata),
+    }
 
 
 def main() -> int:  # noqa: C901, PLR0912, PLR0915
@@ -436,6 +552,11 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
     env = make_robot_env(config=env_config, seed=seed, debug=False)
     trace_rows: list[dict[str, Any]] = []
     done_info: dict[str, Any] = {}
+    observation_state = (
+        ObservationPerturbationState(delay_steps=int(args.observation_delay_steps))
+        if int(args.observation_delay_steps) > 0
+        else None
+    )
     try:
         obs, _ = env.reset(seed=seed)
         if callable(planner_bind_env):
@@ -451,7 +572,18 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             if min_robot_ped_dist is None:
                 min_robot_ped_dist = _obs_min_robot_ped_distance(obs)
 
-            policy_command = policy_fn(obs)
+            ped_pos, ped_vel, actor_ids = _pedestrian_state_from_sim(env)
+            perturbation_spec = _observation_perturbation_spec(args, env)
+            perturbation = perturb_ground_truth(
+                ped_pos,
+                ped_vel,
+                actor_ids,
+                spec=perturbation_spec,
+                step=step_idx,
+                state=observation_state,
+            )
+            policy_obs = _apply_observed_pedestrians_to_policy_obs(obs, perturbation)
+            policy_command = policy_fn(policy_obs)
             step_is_native = getattr(policy_fn, "_last_step_native", planner_native_action)
             if step_is_native:
                 env_action = np.asarray(policy_command, dtype=np.float32)
@@ -496,6 +628,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                     "is_pedestrian_collision": bool(meta.get("is_pedestrian_collision", False)),
                     "is_obstacle_collision": bool(meta.get("is_obstacle_collision", False)),
                     "is_robot_collision": bool(meta.get("is_robot_collision", False)),
+                    **_trace_observation_payload(perturbation),
                 }
             )
             if terminated or truncated or is_success:
@@ -527,6 +660,14 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "algo": algo,
         "algo_config": _json_ready(effective_cfg),
         "algorithm_metadata": _json_ready(algo_meta),
+        "observation_perturbation_config": {
+            "position_noise_std_m": float(args.observation_noise_std_m),
+            "position_noise_bound_m": float(args.observation_noise_bound_m),
+            "missed_detection_probability": float(args.missed_detection_probability),
+            "occlusion_distance_m": args.occlusion_distance_m,
+            "delay_steps": int(args.observation_delay_steps),
+            "seed": args.observation_perturbation_seed,
+        },
         "planner_summary": _json_ready(planner_summary),
         "progress_summary": _json_ready(progress_summary),
         "done_info": _json_ready(done_info),
@@ -555,6 +696,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         f"- Trace JSON: `{trace_path}`",
         f"- Decision counts: `{dict(decision_counter)}`",
         f"- Selected heads: `{dict(selected_head_counter)}`",
+        f"- Observation perturbation: `{trace_payload['observation_perturbation_config']}`",
         "",
         "## Outcome",
         "",

--- a/scripts/validation/smoke_observation_perturbation_trace.py
+++ b/scripts/validation/smoke_observation_perturbation_trace.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Smoke test: prove trace/report payload shape from observation perturbation.
+
+Demonstrates that ground-truth and observed states are cleanly separated
+in a trace row, with no merging of ideal_state and perception_limited rows.
+
+Exit 0 = shape contract satisfied.  This is a diagnostic-only artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from robot_sf.benchmark.observation_perturbation import (
+    EVIDENCE_IDEAL,
+    EVIDENCE_PERCEPTION_LIMITED,
+    ObservationPerturbationSpec,
+    ObservationPerturbationState,
+    perturb_ground_truth,
+)
+
+
+def _simulate_5_steps() -> list[dict[str, object]]:
+    """Simulate 5 steps of a 3-actor episode with mixed perturbation profiles."""
+    actor_ids = ["ped_A", "ped_B", "ped_C"]
+    rows: list[dict[str, object]] = []
+
+    noop_spec = ObservationPerturbationSpec()
+    noisy_spec = ObservationPerturbationSpec(
+        position_noise_std_m=0.3,
+        position_noise_bound_m=0.5,
+        missed_detection_probability=0.2,
+        seed=42,
+    )
+
+    for step in range(5):
+        pos = np.array([[1.0 + step, 2.0], [5.0, 5.0 + step], [10.0, 0.0]])
+        vel = np.array([[0.1, 0.0], [-0.2, 0.3], [0.0, 0.5]])
+
+        gt_result = perturb_ground_truth(pos, vel, actor_ids, spec=noop_spec, step=step)
+        obs_result = perturb_ground_truth(pos, vel, actor_ids, spec=noisy_spec, step=step)
+
+        rows.append(
+            {
+                "step": step,
+                "ground_truth_observation": {
+                    "positions": gt_result["observed"]["positions"].tolist(),
+                    "ids": gt_result["observed"]["ids"],
+                    "evidence_class": gt_result["metadata"]["evidence_class"],
+                },
+                "observed_observation": {
+                    "positions": obs_result["observed"]["positions"].tolist(),
+                    "ids": obs_result["observed"]["ids"],
+                    "evidence_class": obs_result["metadata"]["evidence_class"],
+                    "missing_ids": obs_result["missing_ids"],
+                    "noise_profile": obs_result["metadata"]["noise_profile"],
+                },
+            }
+        )
+    return rows
+
+
+def _simulate_delayed_steps() -> dict[str, object]:
+    """Prove delay buffer produces distinct GT and lagged observed payloads."""
+    actor_ids = ["ped_A"]
+    spec = ObservationPerturbationSpec(delay_steps=2, seed=0)
+    state = ObservationPerturbationState(delay_steps=2)
+    results: list[dict[str, object]] = []
+
+    for step in range(4):
+        pos = np.array([[float(step), 0.0]])
+        vel = np.array([[0.0, 0.0]])
+        r = perturb_ground_truth(pos, vel, actor_ids, spec=spec, step=step, state=state)
+        results.append(
+            {
+                "step": step,
+                "gt_x": r["ground_truth"]["positions"][0][0],
+                "obs_x": r["observed"]["positions"][0][0],
+                "evidence_class": r["metadata"]["evidence_class"],
+                "delay_steps": r["metadata"]["delay_steps"],
+            }
+        )
+    return {"delay_trace": results}
+
+
+def main() -> int:
+    """Execute the smoke test and write trace/report artifacts."""
+    rows = _simulate_5_steps()
+    delay_info = _simulate_delayed_steps()
+
+    # Shape contract checks
+    for row in rows:
+        assert "ground_truth_observation" in row
+        assert "observed_observation" in row
+        gt = row["ground_truth_observation"]
+        obs = row["observed_observation"]
+        assert gt["evidence_class"] == EVIDENCE_IDEAL
+        assert obs["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+        assert isinstance(gt["positions"], list)
+        assert isinstance(obs["positions"], list)
+        assert isinstance(obs["missing_ids"], list)
+
+    # Delay contract: observed lags behind GT
+    for entry in delay_info["delay_trace"]:
+        assert entry["delay_steps"] == 2
+        assert entry["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+
+    # Write artifacts
+    output_dir = Path("output/agent/issue-2730-opencode")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    trace = {
+        "trace_rows": rows,
+        **delay_info,
+    }
+    trace_path = output_dir / "smoke_trace.json"
+    trace_path.write_text(json.dumps(trace, indent=2), encoding="utf-8")
+
+    report_lines = [
+        "# Observation Perturbation Smoke Report",
+        "",
+        "## Trace/Report Shape",
+        "",
+        "- Each step has separate `ground_truth_observation` and `observed_observation` fields.",
+        "- `ground_truth_observation.evidence_class` = `ideal_state` (always).",
+        "- `observed_observation.evidence_class` = `perception_limited` (always).",
+        "- Rows never merge ideal_state and perception_limited data.",
+        "",
+        "## Delay Behavior",
+        "",
+        "- Delay steps: 2",
+        "- Observed positions lag GT by 2 steps after buffer warmup.",
+        "",
+        "## Integration Status",
+        "",
+        "- Direct integration into `run_policy_search_step_diagnostics.py` deferred:",
+        "  requires modifying the step loop's observation flow, which is a broader refactor.",
+        "- This smoke script proves the helper produces the correct trace/report payload shape.",
+    ]
+    report_path = output_dir / "RESULT.md"
+    report_path.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+
+    print(json.dumps({"status": "ok", "trace_path": str(trace_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_observation_perturbation.py
+++ b/tests/benchmark/test_observation_perturbation.py
@@ -1,0 +1,446 @@
+"""Tests for bounded observation-perturbation helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.observation_perturbation import (
+    EVIDENCE_IDEAL,
+    EVIDENCE_PERCEPTION_LIMITED,
+    NOISE_PROFILE_DELAYED_OBSERVATION,
+    NOISE_PROFILE_GAUSSIAN,
+    NOISE_PROFILE_MISSED_DETECTION,
+    NOISE_PROFILE_NONE,
+    NOISE_PROFILE_OCCLUSION_MASK,
+    ObservationPerturbationSpec,
+    ObservationPerturbationState,
+    perturb_ground_truth,
+)
+
+
+def _simple_actors() -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Return a 3-actor fixture."""
+    positions = np.array([[1.0, 2.0], [5.0, 5.0], [10.0, 0.0]])
+    velocities = np.array([[0.1, 0.0], [-0.2, 0.3], [0.0, 0.5]])
+    ids = ["ped_A", "ped_B", "ped_C"]
+    return positions, velocities, ids
+
+
+class TestNoopSpec:
+    """No-noise config must reproduce ground truth deterministically."""
+
+    def test_noop_returns_ground_truth_identically(self) -> None:
+        """Zero-noise spec should output ground truth as observed state."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec()
+        assert spec.is_noop
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        np.testing.assert_array_equal(result["observed"]["positions"], pos)
+        np.testing.assert_array_equal(result["observed"]["velocities"], vel)
+        assert result["observed"]["ids"] == ids
+        assert result["missing_ids"] == []
+        assert result["metadata"]["evidence_class"] == EVIDENCE_IDEAL
+        assert result["metadata"]["noise_profile"] == NOISE_PROFILE_NONE
+        assert result["metadata"]["missed_actor_count"] == 0
+        assert result["metadata"]["occluded_actor_count"] == 0
+
+    def test_noop_ground_truth_dict_matches_input(self) -> None:
+        """Ground-truth payload should match input arrays."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec()
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec)
+
+        np.testing.assert_array_equal(result["ground_truth"]["positions"], pos)
+        np.testing.assert_array_equal(result["ground_truth"]["velocities"], vel)
+        assert result["ground_truth"]["ids"] == ids
+
+    def test_noop_is_deterministic_across_calls(self) -> None:
+        """Repeated calls with same input should produce identical output."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec()
+
+        first = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+        second = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        np.testing.assert_array_equal(
+            first["observed"]["positions"], second["observed"]["positions"]
+        )
+
+    def test_noop_metadata_shape(self) -> None:
+        """Metadata should contain the canonical set of keys."""
+        pos, vel, ids = _simple_actors()
+        result = perturb_ground_truth(pos, vel, ids, spec=ObservationPerturbationSpec())
+        meta = result["metadata"]
+        assert set(meta.keys()) == {
+            "noise_profile",
+            "evidence_class",
+            "position_noise_std_m",
+            "position_noise_bound_m",
+            "missed_detection_probability",
+            "missed_actor_count",
+            "occluded_actor_count",
+            "delay_steps",
+            "step",
+            "actor_count",
+            "observed_actor_count",
+        }
+
+
+class TestBoundedGaussianNoise:
+    """Bounded Gaussian position noise must respect std and bound."""
+
+    def test_noise_perturbs_positions(self) -> None:
+        """Non-zero noise should change positions but keep velocities/ids."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=0.5, position_noise_bound_m=1.0, seed=42
+        )
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+        assert result["metadata"]["noise_profile"] == NOISE_PROFILE_GAUSSIAN
+        assert result["metadata"]["missed_actor_count"] == 0
+        assert result["observed"]["positions"].shape == pos.shape
+        assert not np.allclose(result["observed"]["positions"], pos)
+        np.testing.assert_array_equal(result["observed"]["velocities"], vel)
+        assert result["observed"]["ids"] == ids
+
+    def test_noise_is_bounded(self) -> None:
+        """Per-axis displacement should not exceed the configured bound."""
+        pos, vel, ids = _simple_actors()
+        bound = 0.25
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=10.0, position_noise_bound_m=bound, seed=99
+        )
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+        diff = np.abs(result["observed"]["positions"] - pos)
+        assert np.all(diff <= bound + 1e-10)
+
+    def test_noise_is_deterministic_for_same_seed(self) -> None:
+        """Same seed and step should produce identical noise."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=0.3, position_noise_bound_m=0.5, seed=7
+        )
+
+        a = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+        b = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        np.testing.assert_array_equal(a["observed"]["positions"], b["observed"]["positions"])
+
+    def test_noise_differs_across_steps(self) -> None:
+        """Different step indices should produce different noise."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=0.3, position_noise_bound_m=0.5, seed=7
+        )
+
+        a = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+        b = perturb_ground_truth(pos, vel, ids, spec=spec, step=1)
+
+        assert not np.allclose(a["observed"]["positions"], b["observed"]["positions"])
+
+
+class TestMissedDetections:
+    """Missed detection probability should drop whole actors."""
+
+    def test_full_miss_drops_all(self) -> None:
+        """Probability=1.0 should remove all actors from observed state."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(missed_detection_probability=1.0, seed=0)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["missed_actor_count"] == 3
+        assert result["observed"]["positions"].shape[0] == 0
+        assert result["missing_ids"] == ids
+        assert result["metadata"]["observed_actor_count"] == 0
+        assert result["metadata"]["noise_profile"] == NOISE_PROFILE_MISSED_DETECTION
+
+    def test_zero_miss_keeps_all(self) -> None:
+        """Probability=0.0 should keep all actors."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(missed_detection_probability=0.0, seed=0)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["missed_actor_count"] == 0
+        assert result["observed"]["positions"].shape[0] == 3
+        assert result["missing_ids"] == []
+
+    def test_partial_miss(self) -> None:
+        """Non-trivial probability should drop at least one but not all actors."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(missed_detection_probability=0.5, seed=42)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        observed_count = result["observed"]["positions"].shape[0]
+        assert 0 <= observed_count <= 3
+        assert result["metadata"]["missed_actor_count"] == 3 - observed_count
+        assert len(result["missing_ids"]) == result["metadata"]["missed_actor_count"]
+        assert result["metadata"]["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+
+    def test_miss_with_zero_std_has_no_position_noise(self) -> None:
+        """Missed-only spec should not add position noise."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=0.0, missed_detection_probability=1.0, seed=0
+        )
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+        assert result["observed"]["positions"].shape[0] == 0
+
+
+class TestOcclusionMask:
+    """Occlusion mask should zero out positions/velocities of occluded actors."""
+
+    def test_occlusion_zeros_positions(self) -> None:
+        """Occluded actors should have zeroed positions in observed state."""
+        pos, vel, ids = _simple_actors()
+        mask = np.array([True, False, True])  # A and C occluded
+        spec = ObservationPerturbationSpec(occlusion_mask=mask, seed=0)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["occluded_actor_count"] == 2
+        assert result["metadata"]["noise_profile"] == NOISE_PROFILE_OCCLUSION_MASK
+        assert result["observed"]["positions"].shape[0] == 3
+        np.testing.assert_array_equal(result["observed"]["ids"], ids)
+        np.testing.assert_array_equal(result["observed"]["positions"][0], [0.0, 0.0])
+        np.testing.assert_array_equal(result["observed"]["positions"][2], [0.0, 0.0])
+        np.testing.assert_array_equal(result["observed"]["positions"][1], pos[1])
+
+    def test_occlusion_does_not_drop_actors(self) -> None:
+        """All-occluded mask should keep all actors in observed state."""
+        pos, vel, ids = _simple_actors()
+        mask = np.array([True, True, True])
+        spec = ObservationPerturbationSpec(occlusion_mask=mask, seed=0)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["occluded_actor_count"] == 3
+        assert result["observed"]["positions"].shape[0] == 3
+        assert result["missing_ids"] == []
+
+    def test_occlusion_with_noise_zeros_only_occluded(self) -> None:
+        """Noise applies to non-occluded; occluded stay zeroed."""
+        pos, vel, ids = _simple_actors()
+        mask = np.array([False, True, False])
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=0.5,
+            position_noise_bound_m=1.0,
+            occlusion_mask=mask,
+            seed=42,
+        )
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["metadata"]["occluded_actor_count"] == 1
+        np.testing.assert_array_equal(result["observed"]["positions"][1], [0.0, 0.0])
+        assert not np.allclose(result["observed"]["positions"][0], pos[0])
+        assert not np.allclose(result["observed"]["positions"][2], pos[2])
+
+    def test_occlusion_mask_length_mismatch_raises(self) -> None:
+        """Occlusion mask with wrong length should raise ValueError."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(occlusion_mask=np.array([True, False]), seed=0)
+
+        with pytest.raises(ValueError, match="occlusion_mask length"):
+            perturb_ground_truth(pos, vel, ids, spec=spec)
+
+
+class TestDelayBehavior:
+    """Delay buffer should lag observed state behind ground truth."""
+
+    def test_delay_requires_state_object(self) -> None:
+        """Missing state with delay_steps > 0 should raise ValueError."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(delay_steps=2, seed=0)
+
+        with pytest.raises(ValueError, match="ObservationPerturbationState required"):
+            perturb_ground_truth(pos, vel, ids, spec=spec)
+
+    def test_delay_1_returns_previous_step(self) -> None:
+        """With delay=1, step N should return step N-1 observed state."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(delay_steps=1, seed=0)
+        state = ObservationPerturbationState(delay_steps=1)
+
+        # Step 0: buffer fills, returns GT (buffer not yet full)
+        r0 = perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        np.testing.assert_array_equal(r0["observed"]["positions"], pos)
+        assert r0["metadata"]["delay_steps"] == 1
+
+        # Step 1: returns step 0 observed
+        pos2 = pos + 1.0
+        r1 = perturb_ground_truth(pos2, vel, ids, spec=spec, step=1, state=state)
+        np.testing.assert_array_equal(r1["observed"]["positions"], pos)
+
+    def test_delay_2_lags_by_two_steps(self) -> None:
+        """With delay=2, step N should return step N-2 observed state."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(delay_steps=2, seed=0)
+        state = ObservationPerturbationState(delay_steps=2)
+
+        r0 = perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        r1 = perturb_ground_truth(pos + 1, vel, ids, spec=spec, step=1, state=state)
+        r2 = perturb_ground_truth(pos + 2, vel, ids, spec=spec, step=2, state=state)
+
+        # Step 0: buffer not full, returns GT
+        np.testing.assert_array_equal(r0["observed"]["positions"], pos)
+        # Step 1: buffer not full, returns GT
+        np.testing.assert_array_equal(r1["observed"]["positions"], pos + 1)
+        # Step 2: buffer full, returns step 0
+        np.testing.assert_array_equal(r2["observed"]["positions"], pos)
+
+    def test_delay_preserves_metadata_fields(self) -> None:
+        """Delayed results should carry valid metadata."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(delay_steps=1, seed=0)
+        state = ObservationPerturbationState(delay_steps=1)
+
+        perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        r1 = perturb_ground_truth(pos + 1, vel, ids, spec=spec, step=1, state=state)
+
+        assert r1["metadata"]["delay_steps"] == 1
+        assert r1["metadata"]["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+        assert r1["metadata"]["noise_profile"] == NOISE_PROFILE_DELAYED_OBSERVATION
+
+    def test_delay_reports_missing_ids_from_delayed_snapshot(self) -> None:
+        """Delayed results should report missing IDs from the returned observed snapshot."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(missed_detection_probability=1.0, delay_steps=1, seed=0)
+        state = ObservationPerturbationState(delay_steps=1)
+
+        perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        r1 = perturb_ground_truth(pos + 1, vel, ids, spec=spec, step=1, state=state)
+
+        assert r1["observed"]["positions"].shape[0] == 0
+        assert r1["missing_ids"] == ids
+
+
+class TestSpecValidation:
+    """Spec constructor should reject invalid parameters."""
+
+    def test_negative_noise_std_raises(self) -> None:
+        """Negative position noise std should raise ValueError."""
+        with pytest.raises(ValueError, match="position_noise_std_m"):
+            ObservationPerturbationSpec(position_noise_std_m=-1.0)
+
+    def test_negative_bound_raises(self) -> None:
+        """Negative noise bound should raise ValueError."""
+        with pytest.raises(ValueError, match="position_noise_bound_m"):
+            ObservationPerturbationSpec(position_noise_bound_m=-0.5)
+
+    def test_bad_miss_prob_raises(self) -> None:
+        """Missed detection probability > 1 should raise ValueError."""
+        with pytest.raises(ValueError, match="missed_detection_probability"):
+            ObservationPerturbationSpec(missed_detection_probability=1.5)
+
+    def test_negative_delay_raises(self) -> None:
+        """Negative delay_steps should raise ValueError."""
+        with pytest.raises(ValueError, match="delay_steps"):
+            ObservationPerturbationSpec(delay_steps=-1)
+
+
+class TestInputValidation:
+    """perturb_ground_truth should reject count mismatches."""
+
+    def test_position_velocity_count_mismatch(self) -> None:
+        """Mismatched position/velocity arrays should raise ValueError."""
+        pos = np.array([[1.0, 2.0], [3.0, 4.0]])
+        vel = np.array([[0.1, 0.0]])
+        with pytest.raises(ValueError, match="Actor count mismatch"):
+            perturb_ground_truth(pos, vel, ["a", "b"], spec=ObservationPerturbationSpec())
+
+    def test_id_count_mismatch(self) -> None:
+        """Mismatched ID list length should raise ValueError."""
+        pos = np.array([[1.0, 2.0]])
+        vel = np.array([[0.0, 0.0]])
+        with pytest.raises(ValueError, match="Actor count mismatch"):
+            perturb_ground_truth(pos, vel, ["a", "b"], spec=ObservationPerturbationSpec())
+
+
+class TestTraceShapeSeparation:
+    """Ground truth and observed payloads must be distinct objects in trace output."""
+
+    def test_ground_truth_unmodified_by_noise(self) -> None:
+        """Ground truth should not be altered by noise application."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(
+            position_noise_std_m=1.0, position_noise_bound_m=2.0, seed=42
+        )
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        np.testing.assert_array_equal(result["ground_truth"]["positions"], pos)
+        np.testing.assert_array_equal(result["ground_truth"]["velocities"], vel)
+        assert result["ground_truth"]["ids"] == ids
+        assert not np.allclose(result["observed"]["positions"], pos)
+
+    def test_ground_truth_unmodified_by_missed_detections(self) -> None:
+        """Ground truth should retain all actors even when all are missed."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(missed_detection_probability=1.0, seed=0)
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        assert result["ground_truth"]["positions"].shape[0] == 3
+        assert result["ground_truth"]["ids"] == ids
+        assert result["observed"]["positions"].shape[0] == 0
+
+    def test_metadata_evidence_class_always_set(self) -> None:
+        """Evidence class should distinguish ideal vs perception-limited results."""
+        pos, vel, ids = _simple_actors()
+        noop = perturb_ground_truth(pos, vel, ids, spec=ObservationPerturbationSpec())
+        noisy = perturb_ground_truth(
+            pos,
+            vel,
+            ids,
+            spec=ObservationPerturbationSpec(position_noise_std_m=0.1, seed=0),
+        )
+
+        assert noop["metadata"]["evidence_class"] == EVIDENCE_IDEAL
+        assert noisy["metadata"]["evidence_class"] == EVIDENCE_PERCEPTION_LIMITED
+
+
+class TestStateReset:
+    """ObservationPerturbationState.reset should clear delay buffer."""
+
+    def test_reset_clears_buffer(self) -> None:
+        """Reset should empty the delay buffer so next call uses fresh GT."""
+        state = ObservationPerturbationState(delay_steps=2)
+        spec = ObservationPerturbationSpec(delay_steps=2, seed=0)
+        pos, vel, ids = _simple_actors()
+
+        perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        perturb_ground_truth(pos + 1, vel, ids, spec=spec, step=1, state=state)
+        perturb_ground_truth(pos + 2, vel, ids, spec=spec, step=2, state=state)
+
+        state.reset()
+        r = perturb_ground_truth(pos + 10, vel, ids, spec=spec, step=3, state=state)
+        np.testing.assert_array_equal(r["observed"]["positions"], pos + 10)
+
+    def test_reset_with_initial_obs(self) -> None:
+        """Reset with initial_obs should seed the buffer."""
+        state = ObservationPerturbationState(delay_steps=1)
+        spec = ObservationPerturbationSpec(delay_steps=1, seed=0)
+        pos, vel, ids = _simple_actors()
+
+        state.reset(
+            initial_obs={
+                "positions": pos + 99,
+                "velocities": vel,
+                "ids": ids,
+            }
+        )
+        r = perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
+        # Buffer has initial_obs, delay=1: should return the seeded observation
+        np.testing.assert_array_equal(r["observed"]["positions"], pos + 99)

--- a/tests/validation/test_run_policy_search_step_diagnostics.py
+++ b/tests/validation/test_run_policy_search_step_diagnostics.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import pytest
 
 from scripts.validation.run_policy_search_step_diagnostics import (
+    _apply_observed_pedestrians_to_policy_obs,
     _diagnostics_stdout_payload,
     _format_planner_summary_lines,
+    _occlusion_mask_by_distance,
+    _pedestrian_state_from_sim,
+    _trace_observation_payload,
     _trace_progress_summary,
 )
 
@@ -191,3 +195,97 @@ def test_stdout_payload_includes_planner_summary(tmp_path) -> None:
 
     assert payload["planner_summary"] == {"fallback_count": 1}
     assert payload["progress_summary"] == {"steps_observed": 1}
+
+
+class _DummySimulator:
+    def __init__(self) -> None:
+        self.robot_pos = [[0.0, 0.0]]
+        self.ped_pos = [[1.0, 0.0], [5.0, 0.0]]
+        self.ped_vel = [[0.1, 0.0], [0.0, 0.2]]
+
+
+class _DummyEnv:
+    def __init__(self) -> None:
+        self.simulator = _DummySimulator()
+
+
+def test_pedestrian_state_from_sim_uses_stable_synthetic_ids() -> None:
+    """Diagnostic traces should expose simulator pedestrian state with stable IDs."""
+    positions, velocities, actor_ids = _pedestrian_state_from_sim(_DummyEnv())
+
+    assert positions.tolist() == [[1.0, 0.0], [5.0, 0.0]]
+    assert velocities.tolist() == [[0.1, 0.0], [0.0, 0.2]]
+    assert actor_ids == ["ped_0", "ped_1"]
+
+
+def test_occlusion_mask_by_distance_marks_out_of_range_pedestrians() -> None:
+    """Range-limited occlusion should hide pedestrians beyond the diagnostic threshold."""
+    env = _DummyEnv()
+    positions, _velocities, _actor_ids = _pedestrian_state_from_sim(env)
+
+    mask = _occlusion_mask_by_distance(env, positions, occlusion_distance_m=2.0)
+
+    assert mask.tolist() == [False, True]
+
+
+def test_policy_obs_uses_observed_pedestrian_payload() -> None:
+    """Perturbed observations should be passed to policy input without mutating the source obs."""
+    original = {
+        "robot": {"position": [0.0, 0.0]},
+        "pedestrians": {
+            "positions": [[1.0, 0.0], [5.0, 0.0]],
+            "velocities": [[0.1, 0.0], [0.0, 0.2]],
+            "count": [2.0],
+        },
+        "pedestrians_positions": [[1.0, 0.0], [5.0, 0.0]],
+        "pedestrians_velocities": [[0.1, 0.0], [0.0, 0.2]],
+        "pedestrians_count": [2.0],
+    }
+    perturbation = {
+        "observed": {
+            "positions": [[9.0, 9.0]],
+            "velocities": [[0.0, 0.0]],
+            "ids": ["ped_0"],
+        }
+    }
+
+    policy_obs = _apply_observed_pedestrians_to_policy_obs(original, perturbation)
+
+    assert policy_obs["pedestrians"]["positions"].tolist() == [[9.0, 9.0]]
+    assert policy_obs["pedestrians"]["velocities"].tolist() == [[0.0, 0.0]]
+    assert policy_obs["pedestrians"]["count"].tolist() == [1.0]
+    assert policy_obs["pedestrians_positions"].tolist() == [[9.0, 9.0]]
+    assert policy_obs["pedestrians_velocities"].tolist() == [[0.0, 0.0]]
+    assert policy_obs["pedestrians_count"].tolist() == [1.0]
+    assert original["pedestrians"]["positions"] == [[1.0, 0.0], [5.0, 0.0]]
+
+
+def test_trace_observation_payload_separates_ground_truth_and_observed() -> None:
+    """Trace rows should keep ideal and perception-limited evidence separate."""
+    payload = _trace_observation_payload(
+        {
+            "ground_truth": {
+                "positions": [[1.0, 0.0], [5.0, 0.0]],
+                "velocities": [[0.1, 0.0], [0.0, 0.2]],
+                "ids": ["ped_0", "ped_1"],
+            },
+            "observed": {
+                "positions": [[1.0, 0.0]],
+                "velocities": [[0.1, 0.0]],
+                "ids": ["ped_0"],
+            },
+            "missing_ids": ["ped_1"],
+            "metadata": {
+                "evidence_class": "perception_limited",
+                "noise_profile": "missed_detection",
+                "actor_count": 2,
+                "observed_actor_count": 1,
+            },
+        }
+    )
+
+    assert payload["ground_truth_observation"]["ids"] == ["ped_0", "ped_1"]
+    assert payload["ground_truth_observation"]["evidence_class"] == "ideal_state"
+    assert payload["observed_observation"]["ids"] == ["ped_0"]
+    assert payload["observed_observation"]["missing_ids"] == ["ped_1"]
+    assert payload["observed_observation"]["evidence_class"] == "perception_limited"


### PR DESCRIPTION
## Summary
- Adds a pure observation perturbation helper for local policy inputs with no-op, bounded Gaussian noise, missed detections, occlusion masks, and delayed observations.
- Wires opt-in perturbation flags into policy-search step diagnostics so policy input can use observed pedestrian state while trace rows keep ground truth and observed observations separate.
- Adds unit and smoke coverage for deterministic no-noise behavior, bounded noise, missed detections, occlusion, delay, and evidence-class trace payloads.

Fixes #2730

## Validation
- `uv run pytest tests/benchmark/test_observation_perturbation.py tests/validation/test_run_policy_search_step_diagnostics.py -q` -> 42 passed.
- `uv run ruff check ...` and `uv run ruff format --check ...` -> passed.
- `uv run python scripts/validation/smoke_observation_perturbation_trace.py` -> status ok.
- `uv run python scripts/validation/run_policy_search_step_diagnostics.py --candidate hybrid_rule_v0_minimal --stage smoke --horizon 2 --output-dir output/validation/issue-2730-observation-perturbation-smoke --observation-noise-std-m 0.1 --observation-noise-bound-m 0.2 --missed-detection-probability 0.25 --occlusion-distance-m 3.0 --observation-delay-steps 1 --observation-perturbation-seed 2730` -> trace/report written; compact JSON assertion confirmed ground_truth_observation=ideal_state and observed_observation=perception_limited.
- `uv sync --all-extras && BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 5896 passed, 9 skipped; stamp `output/validation/pr_ready/issue-2730-observation-noise-wrapper.json`, head `f43077acda97dc9045d3fa7719eb62dce3a07e1d`.

## Research Result Guidance
- Target claim/blocker: unblock local policy stress diagnostics that distinguish ground-truth simulator state from perception-limited observed state.
- Comparator/baseline: default no-op perturbation preserves current step diagnostics behavior and records ideal-state observations.
- Evidence tier: diagnostic tooling proof, not benchmark-strength evidence.
- Result classification: implemented diagnostic capability; the 2-step smoke only proves execution and trace/report shape.
- Decision/stop rule: accept when no-op is deterministic, perturbations are bounded/configurable, policy input can consume observed state, and traces label ground truth vs observed evidence separately.
- Synthesis surface/update target: issue #2730 and future observation-noise policy degradation runs.

## Downstream Propagation
- Parent issue: #2730.
- Claim map/benchmark report/leaderboard: NA; this PR adds diagnostic tooling and does not publish benchmark conclusions.
- Registry/config index: NA; flags are CLI-only for controlled stress runs.
- Context/memory note: NA; behavior is covered by tests and PR validation.
- Follow-up: future campaigns can run paired no-op vs noisy diagnostics and publish durable summaries.