### PR TITLE
docs: add observation-noise diagnostic evidence

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,10 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2749_observation_noise_diagnostics/`: diagnostic-only paired no-op vs
+  perception-limited observation-noise step diagnostics for `hybrid_rule_v0_minimal` on a
+  pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant
+  pedestrian produced no measurable planner degradation.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/issue_2749_observation_noise_diagnostics/RESULT.md
+++ b/docs/context/evidence/issue_2749_observation_noise_diagnostics/RESULT.md
@@ -1,0 +1,110 @@
+# Issue #2749 - Observation Noise Diagnostics: Paired Step-Diagnostics Comparison (stress_slice rerun)
+
+**Result classification:** `diagnostic_only`
+**Not benchmark-strength evidence.**
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Candidate | `hybrid_rule_v0_minimal` |
+| Stage | `stress_slice` |
+| Scenario | `classic_bottleneck_medium` |
+| Scenario index | 0 |
+| Seed | 111 |
+| Horizon | 40 steps |
+| Algorithm | `hybrid_rule_local_planner` |
+| Pedestrians in scenario | 1 (map single_ped marker) |
+
+## Perturbation Config
+
+| Parameter | Baseline | Perception-limited |
+|---|---|---|
+| position_noise_std_m | 0.0 | 0.1 |
+| position_noise_bound_m | 0.0 | 0.2 |
+| missed_detection_probability | 0.0 | 0.25 |
+| occlusion_distance_m | null | 3.0 |
+| delay_steps | 0 | 1 |
+| seed | null | 2749 |
+| Evidence class | `ideal_state` | `perception_limited` |
+| Noise profile | `none` | `bounded_gaussian` |
+
+## Progress Comparison
+
+| Metric | Baseline | Perception-limited | Delta |
+|---|---|---|---|
+| Net goal progress | -10.646 | -10.646 | 0.0 |
+| Best goal progress | 0.0 | 0.0 | 0.0 |
+| Progress steps | 38 | 38 | 0 |
+| Regression steps | 2 | 2 | 0 |
+| Stagnant steps | 0 | 0 | 0 |
+| Closest robot-ped distance | 14.913m | 14.913m | 0.0 |
+| Pedestrian collisions | 0 | 0 | 0 |
+| Obstacle collisions | 0 | 0 | 0 |
+| Robot collisions | 0 | 0 | 0 |
+
+## Planner Comparison
+
+| Metric | Baseline | Perception-limited | Delta |
+|---|---|---|---|
+| Selected sources | dw:36, pf:4 | dw:36, pf:4 | identical |
+| Fallback count | 0 | 0 | 0 |
+| Rejection counts | sc:778 | sc:778 | identical |
+| Unavailable counts | cs:40 | cs:40 | identical |
+
+## Observation Perturbation Evidence
+
+| Metric | Baseline | Perception-limited |
+|---|---|---|
+| Actor count (per step) | 1 | 1 |
+| Observed actor count range | [1, 1] | [0, 1] |
+| Missed actor count range | [0, 0] | [0, 1] |
+| Occluded actor count range | [0, 0] | [0, 1] |
+| Evidence class | ideal_state | perception_limited |
+| Noise profile | none | bounded_gaussian |
+
+The perception-limited variant shows active occlusion masking on most steps (observed=0 at steps 5 and 39) and 1 missed detection at step 15. Despite this, planner decisions and trajectory outcomes are identical to baseline.
+
+## Key Finding
+
+The scenario contains 1 pedestrian (position [20.0, 6.0] at step 0, closest approach ~14.9m). The perturbation infrastructure is working correctly: occlusion masking and missed detections are active. However, because the pedestrian is far from the robot and the planner's decisions are dominated by **static obstacle clearance** (778 static_clearance rejections, nearest obstacle ~1.84m), the observation noise has **no measurable effect** on planner behavior, progress, or risk outcomes.
+
+This confirms the perturbation plumbing works on a pedestrian-present scenario but does **not** measure behavioral degradation, because the scenario's single distant pedestrian does not influence the planner's decisions.
+
+## Commands
+
+```bash
+# Baseline
+uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v0_minimal --stage stress_slice \
+  --scenario-index 0 --horizon 40 \
+  --output-dir output/validation/issue-2749-observation-noise-diagnostics/baseline
+
+# Perception-limited
+uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v0_minimal --stage stress_slice \
+  --scenario-index 0 --horizon 40 \
+  --observation-noise-std-m 0.1 --observation-noise-bound-m 0.2 \
+  --missed-detection-probability 0.25 --occlusion-distance-m 3.0 \
+  --observation-delay-steps 1 --observation-perturbation-seed 2749 \
+  --output-dir output/validation/issue-2749-observation-noise-diagnostics/perception_limited
+```
+
+## Trace/Report Paths
+
+- `output/validation/issue-2749-observation-noise-diagnostics/baseline/trace.json`
+- `output/validation/issue-2749-observation-noise-diagnostics/baseline/report.md`
+- `output/validation/issue-2749-observation-noise-diagnostics/perception_limited/trace.json`
+- `output/validation/issue-2749-observation-noise-diagnostics/perception_limited/report.md`
+
+## Limitations
+
+1. **Single scenario, single seed** - not statistically meaningful; only classic_bottleneck_medium at seed 111
+2. **Pedestrian too far to influence planner** - closest approach ~14.9m; planner decisions dominated by static obstacle clearance (~1.84m)
+3. **Short horizon (40 steps)** - limited trajectory diversity; robot regressed (net -10.646) in both variants
+4. **Only 1 pedestrian** - limited actor diversity for testing multi-agent perception degradation
+5. **diagnostic_only** - confirms infrastructure works with a pedestrian-present scenario; does not measure degradation
+
+## Summary JSON
+
+See `summary.json` in the same directory.

--- a/docs/context/evidence/issue_2749_observation_noise_diagnostics/summary.json
+++ b/docs/context/evidence/issue_2749_observation_noise_diagnostics/summary.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "observation_noise_diagnostics.v1",
+  "issue": 2749,
+  "result_classification": "diagnostic_only",
+  "result_summary": "Paired observation-noise step diagnostics for hybrid_rule_v0_minimal on classic_bottleneck_medium (stress_slice, scenario index 0, horizon 40, seed 111). The perception-limited variant applied bounded Gaussian noise (std=0.1m, bound=0.2m), missed detection (p=0.25), occlusion (distance=3.0m), and 1-step delay. The scenario contains 1 pedestrian (map single_ped marker). Evidence class correctly shifted from ideal_state to perception_limited with bounded_gaussian noise profile. Occlusion masking was active on most steps (observed=0 on steps 5 and 39); 1 missed detection occurred at step 15. Despite active perturbation, progress/risk outcomes were identical between baseline and perception-limited because the pedestrian is far from the robot (~14.9m closest) and planner decisions are dominated by static obstacle clearance, not pedestrian avoidance.",
+  "commands_run": [
+    {
+      "label": "baseline",
+      "command": "uv run python scripts/validation/run_policy_search_step_diagnostics.py --candidate hybrid_rule_v0_minimal --stage stress_slice --scenario-index 0 --horizon 40 --output-dir output/validation/issue-2749-observation-noise-diagnostics/baseline",
+      "exit_code": 0
+    },
+    {
+      "label": "perception_limited",
+      "command": "uv run python scripts/validation/run_policy_search_step_diagnostics.py --candidate hybrid_rule_v0_minimal --stage stress_slice --scenario-index 0 --horizon 40 --observation-noise-std-m 0.1 --observation-noise-bound-m 0.2 --missed-detection-probability 0.25 --occlusion-distance-m 3.0 --observation-delay-steps 1 --observation-perturbation-seed 2749 --output-dir output/validation/issue-2749-observation-noise-diagnostics/perception_limited",
+      "exit_code": 0
+    }
+  ],
+  "candidate": "hybrid_rule_v0_minimal",
+  "stage": "stress_slice",
+  "scenario_id": "classic_bottleneck_medium",
+  "family": "classic",
+  "seed": 111,
+  "horizon": 40,
+  "perturbation_config": {
+    "baseline": {
+      "position_noise_std_m": 0.0,
+      "position_noise_bound_m": 0.0,
+      "missed_detection_probability": 0.0,
+      "occlusion_distance_m": null,
+      "delay_steps": 0,
+      "seed": null
+    },
+    "perception_limited": {
+      "position_noise_std_m": 0.1,
+      "position_noise_bound_m": 0.2,
+      "missed_detection_probability": 0.25,
+      "occlusion_distance_m": 3.0,
+      "delay_steps": 1,
+      "seed": 2749
+    }
+  },
+  "comparison": {
+    "progress_summary": {
+      "net_goal_progress": {"baseline": -10.646, "perception_limited": -10.646, "delta": 0.0},
+      "best_goal_progress": {"baseline": 0.0, "perception_limited": 0.0, "delta": 0.0},
+      "progress_step_count": {"baseline": 38, "perception_limited": 38, "delta": 0},
+      "regression_step_count": {"baseline": 2, "perception_limited": 2, "delta": 0},
+      "stagnant_step_count": {"baseline": 0, "perception_limited": 0, "delta": 0},
+      "closest_robot_ped_distance": {"baseline": 14.913, "perception_limited": 14.913, "delta": 0.0},
+      "collision_flag_counts": {
+        "baseline": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+        "perception_limited": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+        "delta": "identical"
+      }
+    },
+    "planner_summary": {
+      "selected_source_counts": {
+        "baseline": {"dynamic_window": 36, "path_follow_0.5m": 4},
+        "perception_limited": {"dynamic_window": 36, "path_follow_0.5m": 4},
+        "delta": "identical"
+      },
+      "fallback_count": {"baseline": 0, "perception_limited": 0, "delta": 0},
+      "rejection_counts": {
+        "baseline": {"static_clearance": 778},
+        "perception_limited": {"static_clearance": 778},
+        "delta": "identical"
+      },
+      "unavailable_counts": {
+        "baseline": {"corridor_subgoal": 40},
+        "perception_limited": {"corridor_subgoal": 40},
+        "delta": "identical"
+      }
+    },
+    "evidence_classes": {
+      "baseline": "ideal_state",
+      "perception_limited": "perception_limited"
+    },
+    "noise_profiles": {
+      "baseline": "none",
+      "perception_limited": "bounded_gaussian"
+    },
+    "observation_perturbation_active": {
+      "baseline": {"actor_count": 1, "observed_actor_count": 1, "missed_actor_count": 0, "occluded_actor_count": 0},
+      "perception_limited": {
+        "actor_count": 1,
+        "observed_actor_count_range": [0, 1],
+        "missed_actor_count_range": [0, 1],
+        "occluded_actor_count_range": [0, 1],
+        "note": "Occlusion active on most steps; 1 missed detection at step 15; steps 5 and 39 show observed=0"
+      }
+    }
+  },
+  "trace_report_paths": {
+    "baseline_trace": "output/validation/issue-2749-observation-noise-diagnostics/baseline/trace.json",
+    "baseline_report": "output/validation/issue-2749-observation-noise-diagnostics/baseline/report.md",
+    "perception_limited_trace": "output/validation/issue-2749-observation-noise-diagnostics/perception_limited/trace.json",
+    "perception_limited_report": "output/validation/issue-2749-observation-noise-diagnostics/perception_limited/report.md"
+  },
+  "limitations": [
+    "Single scenario (classic_bottleneck_medium), single seed (111), short horizon (40 steps) - not benchmark-strength evidence",
+    "Pedestrian is far from robot (~14.9m closest) so planner decisions are dominated by static obstacle clearance, not pedestrian avoidance - noise perturbation has no measurable behavioral effect",
+    "Net goal progress is negative (-10.646) for both variants, indicating the robot moved away from goal - likely scenario geometry or initial heading issue, not noise-induced",
+    "Only 1 pedestrian in scenario - limited actor diversity for testing multi-agent perception degradation",
+    "diagnostic_only: confirms perturbation plumbing works with a pedestrian-present scenario but does not measure behavioral degradation under perception noise"
+  ],
+  "limitations_evidence_boundary": "This is diagnostic-only evidence confirming observation perturbation infrastructure works on a pedestrian-present scenario (stress_slice, classic_bottleneck_medium). It does not constitute benchmark-strength evidence of planner robustness or degradation under perception noise, because the single distant pedestrian does not influence planner decisions."
+}


### PR DESCRIPTION
## Summary
- Adds compact durable evidence for paired no-op vs perception-limited observation-noise diagnostics from issue #2749.
- Uses `hybrid_rule_v0_minimal` on `stress_slice` scenario index 0 (`classic_bottleneck_medium`), horizon 40, seed 111.
- Records a diagnostic-only negative result: perturbation activated on a pedestrian-present scenario, but the distant pedestrian produced no measurable planner degradation.
- Indexes the evidence bundle in `docs/context/evidence/README.md`.

Fixes #2749

## Validation
- `uv run python - <<'PY' ...` summary JSON shape/classification check -> `summary-json-ok`.
- `uv run pytest tests/validation/test_check_docs_proof_consistency.py tests/validation/test_check_active_doc_examples.py -q` -> 34 passed.
- `git diff --check HEAD~1 HEAD` -> passed.

## Research Result Guidance
- Target claim/blocker: test whether #2730 observation-perturbation diagnostics can produce paired no-op vs perception-limited evidence on a pedestrian-present slice.
- Comparator/baseline: no-op observation perturbation vs bounded Gaussian + missed detection + occlusion distance + one-step delay.
- Evidence tier: diagnostic-only compact evidence, not benchmark-strength evidence.
- Result classification: negative/diagnostic; perturbation plumbing activated, but planner progress/risk and selected sources were unchanged.
- Decision/stop rule: stop after one pedestrian-present paired run with compact trace-derived comparison and explicit limitations.
- Synthesis surface/update target: `docs/context/evidence/issue_2749_observation_noise_diagnostics/`.

## Downstream Propagation
- Parent issue: #2749.
- Claim map/benchmark report/leaderboard: NA; this is not benchmark-strength evidence.
- Registry/config index: NA; no persistent config changed.
- Context/evidence index: updated `docs/context/evidence/README.md`.
- Follow-up: choose a closer pedestrian or multi-ped scenario before interpreting observation-noise degradation as behavioral robustness evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added diagnostic evidence documentation for observation noise diagnostics, including detailed paired comparison results between baseline and perception-limited configurations. Results demonstrate no measurable degradation in planner performance during stress-testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->