### PR TITLE
Benchmark CV pedestrian forecast evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1160,6 +1160,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,10 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2757_cv_forecast_eval_2026-06-13/`: diagnostic-only constant-velocity
+  pedestrian forecast baseline evaluation on bounded durable trace fixtures. The corridor traces
+  produce short-horizon metrics; crossing, bottleneck, signalized, occluded, and dense-interaction
+  coverage remains limited or unavailable.
 - `issue_2749_observation_noise_diagnostics/`: diagnostic-only paired no-op vs
   perception-limited observation-noise step diagnostics for `hybrid_rule_v0_minimal` on a
   pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant

--- a/docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.json
+++ b/docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.json
@@ -1,0 +1,171 @@
+{
+  "issue": 2757,
+  "claim_boundary": "Diagnostic-only, not paper-facing evidence. Limited to bounded repository trace fixtures.",
+  "reproducibility": {
+    "issue": 2757,
+    "generated_at_utc": "2026-06-13T09:40:45.509121+00:00",
+    "command": "uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13",
+    "repo_head": "2a87f526",
+    "horizons_s": [
+      0.5,
+      1.0,
+      2.0
+    ]
+  },
+  "trace_family_gaps": {
+    "evaluated": [
+      "corridor_interaction"
+    ],
+    "limited": [
+      "bottleneck",
+      "crossing_proxy"
+    ],
+    "missing": [
+      "signalized_crossing",
+      "occluded_emergence",
+      "dense_pedestrian_interaction",
+      "bottleneck_with_motion"
+    ]
+  },
+  "results_by_trace": [
+    {
+      "label": "default_social_force",
+      "family": "corridor_interaction",
+      "trace_path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/default_social_force_trace_export.json",
+      "scenario_id": "classic_head_on_corridor_low",
+      "planner_id": "default_social_force",
+      "seed": 111,
+      "status": "evaluated",
+      "frame_count": 20,
+      "pedestrians_per_frame": 2,
+      "has_motion": true,
+      "dt_s": 0.1,
+      "horizons_s": [
+        0.5,
+        1.0,
+        2.0
+      ],
+      "metrics": {
+        "forecast_evaluable_samples": 30.0,
+        "mean_ade_0.5s": 0.024280292893659475,
+        "count_ade_0.5s": 30.0,
+        "mean_ade_1s": 0.07693663848497238,
+        "count_ade_1s": 20.0,
+        "mean_calibration_error_0.5s": 0.050000000000000044,
+        "count_calibration_error_0.5s": 30.0,
+        "mean_calibration_error_1s": 0.050000000000000044,
+        "count_calibration_error_1s": 20.0,
+        "mean_collision_relevance_error_0.5s": 0.0,
+        "count_collision_relevance_error_0.5s": 30.0,
+        "mean_collision_relevance_error_1s": 0.0,
+        "count_collision_relevance_error_1s": 20.0,
+        "mean_log_likelihood_0.5s": -1.2676793071505172,
+        "count_log_likelihood_0.5s": 30.0,
+        "mean_log_likelihood_1s": -1.952169154331188,
+        "count_log_likelihood_1s": 20.0,
+        "mean_mahalanobis_dist_0.5s": 0.032373723858212626,
+        "count_mahalanobis_dist_0.5s": 30.0,
+        "mean_mahalanobis_dist_1s": 0.07327298903330705,
+        "count_mahalanobis_dist_1s": 20.0,
+        "mean_miss_rate_0.5s": 0.0,
+        "count_miss_rate_0.5s": 30.0,
+        "mean_miss_rate_1s": 0.0,
+        "count_miss_rate_1s": 20.0,
+        "mean_negative_log_likelihood_0.5s": 1.2676793071505172,
+        "count_negative_log_likelihood_0.5s": 30.0,
+        "mean_negative_log_likelihood_1s": 1.952169154331188,
+        "count_negative_log_likelihood_1s": 20.0,
+        "mean_within_95ci_0.5s": 1.0,
+        "count_within_95ci_0.5s": 30.0,
+        "mean_within_95ci_1s": 1.0,
+        "count_within_95ci_1s": 20.0
+      }
+    },
+    {
+      "label": "ammv_social_force",
+      "family": "corridor_interaction",
+      "trace_path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/ammv_social_force_trace_export.json",
+      "scenario_id": "classic_head_on_corridor_low",
+      "planner_id": "ammv_social_force",
+      "seed": 111,
+      "status": "evaluated",
+      "frame_count": 20,
+      "pedestrians_per_frame": 2,
+      "has_motion": true,
+      "dt_s": 0.1,
+      "horizons_s": [
+        0.5,
+        1.0,
+        2.0
+      ],
+      "metrics": {
+        "forecast_evaluable_samples": 30.0,
+        "mean_ade_0.5s": 0.024280292893659475,
+        "count_ade_0.5s": 30.0,
+        "mean_ade_1s": 0.07693663848497238,
+        "count_ade_1s": 20.0,
+        "mean_calibration_error_0.5s": 0.050000000000000044,
+        "count_calibration_error_0.5s": 30.0,
+        "mean_calibration_error_1s": 0.050000000000000044,
+        "count_calibration_error_1s": 20.0,
+        "mean_collision_relevance_error_0.5s": 0.0,
+        "count_collision_relevance_error_0.5s": 30.0,
+        "mean_collision_relevance_error_1s": 0.0,
+        "count_collision_relevance_error_1s": 20.0,
+        "mean_log_likelihood_0.5s": -1.2676793071505172,
+        "count_log_likelihood_0.5s": 30.0,
+        "mean_log_likelihood_1s": -1.952169154331188,
+        "count_log_likelihood_1s": 20.0,
+        "mean_mahalanobis_dist_0.5s": 0.032373723858212626,
+        "count_mahalanobis_dist_0.5s": 30.0,
+        "mean_mahalanobis_dist_1s": 0.07327298903330705,
+        "count_mahalanobis_dist_1s": 20.0,
+        "mean_miss_rate_0.5s": 0.0,
+        "count_miss_rate_0.5s": 30.0,
+        "mean_miss_rate_1s": 0.0,
+        "count_miss_rate_1s": 20.0,
+        "mean_negative_log_likelihood_0.5s": 1.2676793071505172,
+        "count_negative_log_likelihood_0.5s": 30.0,
+        "mean_negative_log_likelihood_1s": 1.952169154331188,
+        "count_negative_log_likelihood_1s": 20.0,
+        "mean_within_95ci_0.5s": 1.0,
+        "count_within_95ci_0.5s": 30.0,
+        "mean_within_95ci_1s": 1.0,
+        "count_within_95ci_1s": 20.0
+      }
+    },
+    {
+      "label": "synthetic_crossing_proxy_orca",
+      "family": "crossing_proxy",
+      "trace_path": "docs/context/evidence/issue_2667_trace_failure_predicate_tables_2026-06-12/inputs/synthetic_crossing_proxy_orca_111_trace_export.json",
+      "scenario_id": "crossing_proxy",
+      "planner_id": "orca",
+      "seed": 111,
+      "status": "limited_no_pedestrian_motion",
+      "frame_count": 5,
+      "pedestrians_per_frame": 1,
+      "has_motion": false,
+      "metrics": {
+        "forecast_evaluable_samples": 0.0
+      },
+      "limitation": "All pedestrian velocities are zero; constant-velocity forecast produces degenerate predictions with no motion to evaluate against."
+    },
+    {
+      "label": "minimal_fixture",
+      "family": "bottleneck",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json",
+      "scenario_id": "classic_bottleneck_medium",
+      "planner_id": "hybrid_rule_v0_minimal",
+      "seed": 111,
+      "status": "limited_no_pedestrian_motion",
+      "frame_count": 2,
+      "pedestrians_per_frame": 1,
+      "has_motion": false,
+      "metrics": {
+        "forecast_evaluable_samples": 0.0
+      },
+      "limitation": "All pedestrian velocities are zero; constant-velocity forecast produces degenerate predictions with no motion to evaluate against."
+    }
+  ],
+  "failure_cases": []
+}

--- a/docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md
+++ b/docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md
@@ -1,0 +1,78 @@
+# CV Forecast Baseline Evaluation
+
+## Claim Boundary
+
+**Diagnostic-only, not paper-facing evidence.** This evaluates the constant-velocity Gaussian forecast baseline on a bounded set of existing repository trace fixtures. Results are per-family rollups, not statistically powered population claims.
+
+## Reproducibility
+
+- **Issue:** #2757
+- **Generated at (UTC):** 2026-06-13T09:40:45.509121+00:00
+- **Command:** `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13`
+- **Repo HEAD:** `2a87f526`
+- **Forecast horizons:** [0.5, 1.0, 2.0]
+
+## Selected Trace Families
+
+| Family | Label | Scenario | Frames | Peds | Motion | dt (s) | Status |
+|--------|-------|----------|--------|------|--------|--------|--------|
+| corridor_interaction | default_social_force | classic_head_on_corridor_low | 20 | 2 | yes | 0.1 | evaluated |
+| corridor_interaction | ammv_social_force | classic_head_on_corridor_low | 20 | 2 | yes | 0.1 | evaluated |
+| crossing_proxy | synthetic_crossing_proxy_orca | crossing_proxy | 5 | 1 | no | - | limited_no_pedestrian_motion |
+| bottleneck | minimal_fixture | classic_bottleneck_medium | 2 | 1 | no | - | limited_no_pedestrian_motion |
+
+## Missing Trace Families
+
+These scenario families have no durable trace fixtures in the repository and were not evaluated:
+
+- **signalized_crossing**: no durable trace fixture available
+- **occluded_emergence**: no durable trace fixture available
+- **dense_pedestrian_interaction**: no durable trace fixture available
+- **bottleneck_with_motion**: existing bottleneck fixture has zero pedestrian velocity
+
+## Aggregate Metrics by Trace Family
+
+### corridor_interaction / default_social_force
+
+- Evaluable samples: 30
+- **Horizon 0.5s:**
+  - ADE: 0.0243 m
+  - NLL: 1.2677
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 1s:**
+  - ADE: 0.0769 m
+  - NLL: 1.9522
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 2s:**
+  - Not available for this trace length.
+
+### corridor_interaction / ammv_social_force
+
+- Evaluable samples: 30
+- **Horizon 0.5s:**
+  - ADE: 0.0243 m
+  - NLL: 1.2677
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 1s:**
+  - ADE: 0.0769 m
+  - NLL: 1.9522
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 2s:**
+  - Not available for this trace length.
+
+
+## Interpretation
+
+The constant-velocity Gaussian baseline is adequate for short horizons (0.5s) on traces with relatively smooth, low-acceleration pedestrian motion (such as the corridor_interaction family). In this bounded evidence set, 1s metrics remain available and low-error, while 2s metrics are unavailable because the durable traces are too short for that forecast horizon.
+
+The available crossing_proxy and bottleneck fixtures are limitation records, not forecast-quality evidence: they contain zero pedestrian motion, so they do not test whether constant velocity handles crossing, bottleneck, occluded, or dense interaction dynamics.
+
+All traces in this evaluation lack intent and signal context metadata, so the forecast operates in 'uncertain' mode with 1.5x widened standard deviation. This is a systematic limitation of the available trace fixtures.

--- a/scripts/benchmark/run_cv_forecast_eval.py
+++ b/scripts/benchmark/run_cv_forecast_eval.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Evaluate constant-velocity pedestrian forecast baseline on bounded repository traces.
+
+Reads durable trace fixtures from the repository, runs
+``compute_batch_forecast_metrics`` from ``robot_sf.benchmark.pedestrian_forecast``,
+and writes JSON + Markdown evidence to the requested output directory.
+
+Usage::
+
+    uv run python scripts/benchmark/run_cv_forecast_eval.py \\
+        --output-dir docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13
+
+This is diagnostic-only evidence, not paper-facing benchmark proof.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import pathlib
+import subprocess
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.pedestrian_forecast import (
+    DEFAULT_FORECAST_HORIZONS_S,
+    compute_batch_forecast_metrics,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+TRACE_CANDIDATES: list[dict[str, Any]] = [
+    {
+        "family": "corridor_interaction",
+        "label": "default_social_force",
+        "path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/default_social_force_trace_export.json",
+        "scenario_id": "classic_head_on_corridor_low",
+        "planner_id": "default_social_force",
+        "seed": 111,
+    },
+    {
+        "family": "corridor_interaction",
+        "label": "ammv_social_force",
+        "path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/ammv_social_force_trace_export.json",
+        "scenario_id": "classic_head_on_corridor_low",
+        "planner_id": "ammv_social_force",
+        "seed": 111,
+    },
+    {
+        "family": "crossing_proxy",
+        "label": "synthetic_crossing_proxy_orca",
+        "path": "docs/context/evidence/issue_2667_trace_failure_predicate_tables_2026-06-12/inputs/synthetic_crossing_proxy_orca_111_trace_export.json",
+        "scenario_id": "crossing_proxy",
+        "planner_id": "orca",
+        "seed": 111,
+    },
+    {
+        "family": "bottleneck",
+        "label": "minimal_fixture",
+        "path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json",
+        "scenario_id": "classic_bottleneck_medium",
+        "planner_id": "hybrid_rule_v0_minimal",
+        "seed": 111,
+    },
+]
+
+MISSING_FAMILIES: list[dict[str, str]] = [
+    {"family": "signalized_crossing", "reason": "no durable trace fixture available"},
+    {"family": "occluded_emergence", "reason": "no durable trace fixture available"},
+    {"family": "dense_pedestrian_interaction", "reason": "no durable trace fixture available"},
+    {
+        "family": "bottleneck_with_motion",
+        "reason": "existing bottleneck fixture has zero pedestrian velocity",
+    },
+]
+
+
+def _load_trace(path: pathlib.Path) -> dict[str, Any]:
+    """Load a simulation_trace_export.v1 JSON file."""
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _extract_trace_steps(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert trace export frames to the step list expected by compute_batch_forecast_metrics.
+
+    Handles both ``frames`` (simulation_trace_export.v1) and ``steps`` keys.
+    Converts string pedestrian IDs to integers.
+    """
+    raw_frames = trace.get("frames") or trace.get("steps") or []
+    steps: list[dict[str, Any]] = []
+    for frame in raw_frames:
+        pedestrians = []
+        for ped in frame.get("pedestrians", []):
+            ped_copy = dict(ped)
+            ped_id = ped_copy.get("id")
+            if isinstance(ped_id, str):
+                try:
+                    ped_copy["id"] = int(ped_id)
+                except ValueError:
+                    digest = hashlib.sha256(ped_id.encode("utf-8")).hexdigest()
+                    ped_copy["id"] = int(digest[:16], 16) % (2**31)
+            pedestrians.append(ped_copy)
+        steps.append(
+            {
+                "step": frame.get("step", len(steps)),
+                "time_s": frame.get("time_s", len(steps) * 0.1),
+                "robot": frame.get("robot"),
+                "pedestrians": pedestrians,
+            }
+        )
+    return steps
+
+
+def _compute_dt_s(trace: dict[str, Any]) -> float:
+    """Infer dt_s from the first two frames of the trace."""
+    frames = trace.get("frames") or trace.get("steps") or []
+    if len(frames) < 2:
+        return 0.1
+    t0 = float(frames[0].get("time_s", 0.0))
+    t1 = float(frames[1].get("time_s", 0.1))
+    dt = t1 - t0
+    return dt if dt > 0 else 0.1
+
+
+def _trace_has_motion(trace: dict[str, Any]) -> bool:
+    """Check whether any pedestrian has non-zero velocity in any frame."""
+    frames = trace.get("frames") or trace.get("steps") or []
+    for frame in frames:
+        for ped in frame.get("pedestrians", []):
+            vel = ped.get("velocity", [0.0, 0.0])
+            if any(abs(float(v)) > 1e-6 for v in vel):
+                return True
+    return False
+
+
+def _pedestrian_count(trace: dict[str, Any]) -> int:
+    """Return the max number of pedestrians in any single frame."""
+    frames = trace.get("frames") or trace.get("steps") or []
+    max_peds = 0
+    for frame in frames:
+        max_peds = max(max_peds, len(frame.get("pedestrians", [])))
+    return max_peds
+
+
+def _git_head() -> str:
+    """Return the short git HEAD, or '' on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def evaluate_single_trace(
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    """Run CV forecast eval on one trace candidate and return a result dict."""
+    rel_path = candidate["path"]
+    abs_path = REPO_ROOT / rel_path
+    label = candidate["label"]
+    family = candidate["family"]
+
+    result: dict[str, Any] = {
+        "label": label,
+        "family": family,
+        "trace_path": rel_path,
+        "scenario_id": candidate.get("scenario_id", ""),
+        "planner_id": candidate.get("planner_id", ""),
+        "seed": candidate.get("seed"),
+        "status": "evaluated",
+    }
+
+    if not abs_path.exists():
+        result["status"] = "trace_file_missing"
+        result["metrics"] = {"forecast_evaluable_samples": 0.0}
+        return result
+
+    trace = _load_trace(abs_path)
+    frames = trace.get("frames") or trace.get("steps") or []
+    result["frame_count"] = len(frames)
+    result["pedestrians_per_frame"] = _pedestrian_count(trace)
+    result["has_motion"] = _trace_has_motion(trace)
+
+    if not _trace_has_motion(trace):
+        result["status"] = "limited_no_pedestrian_motion"
+        result["metrics"] = {"forecast_evaluable_samples": 0.0}
+        result["limitation"] = (
+            "All pedestrian velocities are zero; constant-velocity forecast "
+            "produces degenerate predictions with no motion to evaluate against."
+        )
+        return result
+
+    if len(frames) < 3:
+        result["status"] = "insufficient_frames"
+        result["metrics"] = {"forecast_evaluable_samples": 0.0}
+        result["limitation"] = (
+            f"Only {len(frames)} frames available; need at least 3 for any horizon."
+        )
+        return result
+
+    trace_steps = _extract_trace_steps(trace)
+    dt_s = _compute_dt_s(trace)
+
+    try:
+        metrics = compute_batch_forecast_metrics(
+            trace_steps,
+            horizons_s=list(DEFAULT_FORECAST_HORIZONS_S),
+            dt_s=dt_s,
+        )
+    except Exception as exc:
+        result["status"] = "evaluation_error"
+        result["error"] = str(exc)
+        result["metrics"] = {"forecast_evaluable_samples": 0.0}
+        return result
+
+    result["dt_s"] = dt_s
+    result["horizons_s"] = list(DEFAULT_FORECAST_HORIZONS_S)
+    result["metrics"] = _sanitize_metrics(metrics)
+
+    evaluable = metrics.get("forecast_evaluable_samples", 0.0)
+    if evaluable == 0.0:
+        result["status"] = "no_evaluable_samples"
+    else:
+        result["status"] = "evaluated"
+
+    return result
+
+
+def _sanitize_metrics(metrics: dict[str, float]) -> dict[str, float]:
+    """Convert numpy types to plain floats for JSON serialization."""
+    sanitized: dict[str, float] = {}
+    for key, value in metrics.items():
+        if isinstance(value, (np.floating, np.integer)):
+            sanitized[key] = float(value)
+        else:
+            sanitized[key] = float(value)
+    return sanitized
+
+
+def _build_failure_cases(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract representative failure cases from per-trace results."""
+    failure_cases: list[dict[str, Any]] = []
+    for r in results:
+        metrics = r.get("metrics", {})
+        samples = metrics.get("forecast_evaluable_samples", 0.0)
+        if samples == 0.0:
+            continue
+
+        miss_2s = metrics.get("mean_miss_rate_2s")
+        ade_2s = metrics.get("mean_ade_2s")
+        nll_2s = metrics.get("mean_negative_log_likelihood_2s")
+
+        if miss_2s is not None and miss_2s > 0.3:
+            failure_cases.append(
+                {
+                    "trace": r["label"],
+                    "family": r["family"],
+                    "trace_path": r["trace_path"],
+                    "metric": "mean_miss_rate_2s",
+                    "value": miss_2s,
+                    "interpretation": (
+                        "High miss rate at 2s horizon indicates constant-velocity "
+                        "forecast frequently fails to capture actual pedestrian position "
+                        "within the 95% confidence ellipse."
+                    ),
+                }
+            )
+        if ade_2s is not None and ade_2s > 0.5:
+            failure_cases.append(
+                {
+                    "trace": r["label"],
+                    "family": r["family"],
+                    "trace_path": r["trace_path"],
+                    "metric": "mean_ade_2s",
+                    "value": ade_2s,
+                    "interpretation": (
+                        "Large average displacement error at 2s horizon suggests "
+                        "pedestrian motion deviates substantially from constant velocity."
+                    ),
+                }
+            )
+        if nll_2s is not None and nll_2s > 5.0:
+            failure_cases.append(
+                {
+                    "trace": r["label"],
+                    "family": r["family"],
+                    "trace_path": r["trace_path"],
+                    "metric": "mean_negative_log_likelihood_2s",
+                    "value": nll_2s,
+                    "interpretation": (
+                        "High negative log-likelihood at 2s horizon indicates poor "
+                        "calibration of the constant-velocity Gaussian forecast."
+                    ),
+                }
+            )
+    return failure_cases
+
+
+def _md_header() -> list[str]:
+    """Return the report header section."""
+    return [
+        "# CV Forecast Baseline Evaluation",
+        "",
+        "## Claim Boundary",
+        "",
+        "**Diagnostic-only, not paper-facing evidence.** This evaluates the "
+        "constant-velocity Gaussian forecast baseline on a bounded set of existing "
+        "repository trace fixtures. Results are per-family rollups, not statistically "
+        "powered population claims.",
+    ]
+
+
+def _md_repro(repro: dict[str, Any]) -> list[str]:
+    """Return the reproducibility section."""
+    return [
+        "",
+        "## Reproducibility",
+        "",
+        f"- **Issue:** #{repro['issue']}",
+        f"- **Generated at (UTC):** {repro['generated_at_utc']}",
+        f"- **Command:** `{repro['command']}`",
+        f"- **Repo HEAD:** `{repro['repo_head']}`",
+        f"- **Forecast horizons:** {repro['horizons_s']}",
+    ]
+
+
+def _md_trace_table(results: list[dict[str, Any]]) -> list[str]:
+    """Return the trace families table."""
+    lines = [
+        "",
+        "## Selected Trace Families",
+        "",
+        "| Family | Label | Scenario | Frames | Peds | Motion | dt (s) | Status |",
+        "|--------|-------|----------|--------|------|--------|--------|--------|",
+    ]
+    for r in results:
+        motion_str = "yes" if r.get("has_motion") else "no"
+        frames_str = str(r.get("frame_count", "?"))
+        peds_str = str(r.get("pedestrians_per_frame", "?"))
+        dt_str = f"{r['dt_s']:.1f}" if "dt_s" in r else "-"
+        lines.append(
+            f"| {r['family']} | {r['label']} | {r.get('scenario_id', '')} "
+            f"| {frames_str} | {peds_str} | {motion_str} | {dt_str} | {r['status']} |"
+        )
+    return lines
+
+
+def _md_missing_families() -> list[str]:
+    """Return the missing families section."""
+    lines = [
+        "",
+        "## Missing Trace Families",
+        "",
+        "These scenario families have no durable trace fixtures in the repository "
+        "and were not evaluated:",
+        "",
+    ]
+    for mf in MISSING_FAMILIES:
+        lines.append(f"- **{mf['family']}**: {mf['reason']}")
+    return lines
+
+
+def _md_horizon_metrics(r: dict[str, Any], metrics: dict[str, float], horizon: float) -> list[str]:
+    """Return metric lines for one horizon."""
+    suffix = f"{horizon:g}s"
+    lines = [f"- **Horizon {suffix}:**"]
+    metric_lines = 0
+    for key, fmt in [
+        ("mean_ade", "  - ADE: {val:.4f} m"),
+        ("mean_negative_log_likelihood", "  - NLL: {val:.4f}"),
+        ("mean_miss_rate", "  - Miss rate: {val:.2%}"),
+        ("mean_within_95ci", "  - Within 95% CI: {val:.2%}"),
+        ("mean_calibration_error", "  - Calibration error: {val:.4f}"),
+    ]:
+        val = metrics.get(f"{key}_{suffix}")
+        if val is not None:
+            lines.append(fmt.format(val=val))
+            metric_lines += 1
+    if metric_lines == 0:
+        lines.append("  - Not available for this trace length.")
+    return lines
+
+
+def _md_metrics_section(results: list[dict[str, Any]]) -> list[str]:
+    """Return the metrics section."""
+    evaluated = [r for r in results if r["status"] == "evaluated"]
+    if not evaluated:
+        return ["", "## Metrics", "", "No traces had evaluable samples."]
+    lines = ["", "## Aggregate Metrics by Trace Family", ""]
+    for r in evaluated:
+        metrics = r["metrics"]
+        lines.append(f"### {r['family']} / {r['label']}")
+        lines.append("")
+        lines.append(f"- Evaluable samples: {metrics.get('forecast_evaluable_samples', 0):.0f}")
+        for horizon in r.get("horizons_s", []):
+            lines.extend(_md_horizon_metrics(r, metrics, horizon))
+        lines.append("")
+    return lines
+
+
+def _md_failure_cases(failure_cases: list[dict[str, Any]]) -> list[str]:
+    """Return the failure cases section."""
+    if not failure_cases:
+        return []
+    lines = [
+        "",
+        "## Representative Failure Cases",
+        "",
+        "These cases show where the constant-velocity baseline produces "
+        "degraded forecast quality. Each case links to the durable trace source.",
+        "",
+    ]
+    for fc in failure_cases:
+        lines.append(f"- **{fc['trace']}** ({fc['family']}): `{fc['metric']}` = {fc['value']:.4f}")
+        lines.append(f"  - {fc['interpretation']}")
+        lines.append(f"  - Trace: `{fc['trace_path']}`")
+    return lines
+
+
+def _md_interpretation() -> list[str]:
+    """Return the interpretation section."""
+    return [
+        "",
+        "## Interpretation",
+        "",
+        "The constant-velocity Gaussian baseline is adequate for short horizons "
+        "(0.5s) on traces with relatively smooth, low-acceleration pedestrian motion "
+        "(such as the corridor_interaction family). In this bounded evidence set, "
+        "1s metrics remain available and low-error, while 2s metrics are unavailable "
+        "because the durable traces are too short for that forecast horizon.",
+        "",
+        "The available crossing_proxy and bottleneck fixtures are limitation records, "
+        "not forecast-quality evidence: they contain zero pedestrian motion, so they "
+        "do not test whether constant velocity handles crossing, bottleneck, occluded, "
+        "or dense interaction dynamics.",
+        "",
+        "All traces in this evaluation lack intent and signal context metadata, "
+        "so the forecast operates in 'uncertain' mode with 1.5x widened standard "
+        "deviation. This is a systematic limitation of the available trace fixtures.",
+    ]
+
+
+def _generate_markdown(
+    results: list[dict[str, Any]],
+    failure_cases: list[dict[str, Any]],
+    repro: dict[str, Any],
+) -> str:
+    """Generate the Markdown evidence report."""
+    lines: list[str] = []
+    lines.extend(_md_header())
+    lines.extend(_md_repro(repro))
+    lines.extend(_md_trace_table(results))
+    lines.extend(_md_missing_families())
+    lines.extend(_md_metrics_section(results))
+    lines.extend(_md_failure_cases(failure_cases))
+    lines.extend(_md_interpretation())
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run CV forecast evaluation and write evidence artifacts."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate CV forecast baseline on bounded repository traces."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13",
+        help="Output directory for evidence artifacts.",
+    )
+    args = parser.parse_args()
+
+    output_dir = REPO_ROOT / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_head = _git_head()
+    generated_at = datetime.datetime.now(datetime.UTC).isoformat()
+    command = (
+        f"uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir {args.output_dir}"
+    )
+
+    repro = {
+        "issue": 2757,
+        "generated_at_utc": generated_at,
+        "command": command,
+        "repo_head": repo_head,
+        "horizons_s": list(DEFAULT_FORECAST_HORIZONS_S),
+    }
+
+    results: list[dict[str, Any]] = []
+    for candidate in TRACE_CANDIDATES:
+        result = evaluate_single_trace(candidate)
+        results.append(result)
+
+    failure_cases = _build_failure_cases(results)
+    evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
+    limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
+
+    report_json: dict[str, Any] = {
+        "issue": 2757,
+        "claim_boundary": (
+            "Diagnostic-only, not paper-facing evidence. "
+            "Limited to bounded repository trace fixtures."
+        ),
+        "reproducibility": repro,
+        "trace_family_gaps": {
+            "evaluated": evaluated_families,
+            "limited": limited_families,
+            "missing": [mf["family"] for mf in MISSING_FAMILIES],
+        },
+        "results_by_trace": results,
+        "failure_cases": failure_cases,
+    }
+
+    json_path = output_dir / "report.json"
+    with open(json_path, "w") as fh:
+        json.dump(report_json, fh, indent=2)
+
+    md_content = _generate_markdown(results, failure_cases, repro)
+    md_path = output_dir / "report.md"
+    with open(md_path, "w") as fh:
+        fh.write(md_content)
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+
+    for r in results:
+        status_icon = "+" if r["status"] == "evaluated" else "~"
+        samples = r.get("metrics", {}).get("forecast_evaluable_samples", 0)
+        print(
+            f"  [{status_icon}] {r['family']}/{r['label']}: {r['status']} ({samples:.0f} samples)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/test_pedestrian_forecast_cv_eval.py
+++ b/tests/benchmark/test_pedestrian_forecast_cv_eval.py
@@ -1,0 +1,318 @@
+"""Tests for the CV forecast evaluation script."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_cv_forecast_eval.py"
+
+
+def _load_script_module():
+    """Load the script as a module for testing."""
+    spec = importlib.util.spec_from_file_location("run_cv_forecast_eval", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["run_cv_forecast_eval"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script_module()
+
+MISSING_FAMILIES = _mod.MISSING_FAMILIES
+TRACE_CANDIDATES = _mod.TRACE_CANDIDATES
+_build_failure_cases = _mod._build_failure_cases
+_compute_dt_s = _mod._compute_dt_s
+_extract_trace_steps = _mod._extract_trace_steps
+_generate_markdown = _mod._generate_markdown
+_pedestrian_count = _mod._pedestrian_count
+_trace_has_motion = _mod._trace_has_motion
+evaluate_single_trace = _mod.evaluate_single_trace
+
+
+def test_extract_trace_steps_converts_frames_key() -> None:
+    """Extraction renames 'frames' to a step list with integer pedestrian IDs."""
+    trace = {
+        "frames": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "robot": {"position": [0.0, 0.0]},
+                "pedestrians": [{"id": "ped_1", "position": [1.0, 0.5], "velocity": [0.0, 0.0]}],
+            },
+            {
+                "step": 1,
+                "time_s": 0.1,
+                "robot": {"position": [0.01, 0.0]},
+                "pedestrians": [{"id": "ped_1", "position": [1.0, 0.5], "velocity": [0.0, 0.0]}],
+            },
+        ]
+    }
+    steps = _extract_trace_steps(trace)
+    assert len(steps) == 2
+    assert steps[0]["pedestrians"][0]["id"] == "ped_1" or isinstance(
+        steps[0]["pedestrians"][0]["id"], int
+    )
+    assert "robot" in steps[0]
+
+
+def test_extract_trace_steps_converts_string_ids_to_int() -> None:
+    """Numeric string IDs are converted to integers."""
+    trace = {
+        "frames": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "pedestrians": [{"id": "42", "position": [0, 0], "velocity": [1, 0]}],
+            }
+        ]
+    }
+    steps = _extract_trace_steps(trace)
+    assert steps[0]["pedestrians"][0]["id"] == 42
+
+
+def test_extract_trace_steps_hashes_non_numeric_string_ids() -> None:
+    """Non-numeric string IDs are deterministically hashed to integers."""
+    trace = {
+        "frames": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "pedestrians": [{"id": "ped-abc", "position": [0, 0], "velocity": [0, 0]}],
+            }
+        ]
+    }
+    steps = _extract_trace_steps(trace)
+    assert isinstance(steps[0]["pedestrians"][0]["id"], int)
+    assert (
+        steps[0]["pedestrians"][0]["id"] == _extract_trace_steps(trace)[0]["pedestrians"][0]["id"]
+    )
+
+
+def test_compute_dt_s_infers_from_timestamps() -> None:
+    """dt_s is inferred from the first two frames' time_s values."""
+    trace = {
+        "frames": [
+            {"time_s": 0.0},
+            {"time_s": 0.5},
+            {"time_s": 1.0},
+        ]
+    }
+    assert _compute_dt_s(trace) == pytest.approx(0.5)
+
+
+def test_compute_dt_s_defaults_for_single_frame() -> None:
+    """Single-frame traces default to 0.1s dt."""
+    trace = {"frames": [{"time_s": 0.0}]}
+    assert _compute_dt_s(trace) == 0.1
+
+
+def test_trace_has_motion_detects_velocity() -> None:
+    """Motion detection finds non-zero pedestrian velocity."""
+    moving = {
+        "frames": [
+            {"pedestrians": [{"velocity": [0.1, 0.0]}]},
+        ]
+    }
+    assert _trace_has_motion(moving) is True
+
+    still = {
+        "frames": [
+            {"pedestrians": [{"velocity": [0.0, 0.0]}]},
+        ]
+    }
+    assert _trace_has_motion(still) is False
+
+
+def test_pedestrian_count_returns_max() -> None:
+    """Pedestrian count returns the maximum across frames."""
+    trace = {
+        "frames": [
+            {"pedestrians": [{"id": 1}]},
+            {"pedestrians": [{"id": 1}, {"id": 2}, {"id": 3}]},
+            {"pedestrians": [{"id": 1}, {"id": 2}]},
+        ]
+    }
+    assert _pedestrian_count(trace) == 3
+
+
+def test_evaluate_single_trace_missing_file() -> None:
+    """Missing trace file produces trace_file_missing status."""
+    result = evaluate_single_trace(
+        {
+            "family": "test",
+            "label": "missing",
+            "path": "nonexistent/path.json",
+            "scenario_id": "test",
+            "planner_id": "test",
+            "seed": 0,
+        }
+    )
+    assert result["status"] == "trace_file_missing"
+    assert result["metrics"]["forecast_evaluable_samples"] == 0.0
+
+
+def test_evaluate_single_trace_with_motion() -> None:
+    """Trace with motion produces evaluated status."""
+    result = evaluate_single_trace(
+        {
+            "family": "corridor_interaction",
+            "label": "test_default_sf",
+            "path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/default_social_force_trace_export.json",
+            "scenario_id": "classic_head_on_corridor_low",
+            "planner_id": "default_social_force",
+            "seed": 111,
+        }
+    )
+    assert result["status"] in ("evaluated", "limited_no_pedestrian_motion")
+    assert "metrics" in result
+
+
+def test_evaluate_all_candidate_traces() -> None:
+    """All defined trace candidates can be evaluated without crashing."""
+    for candidate in TRACE_CANDIDATES:
+        result = evaluate_single_trace(candidate)
+        assert "status" in result
+        assert "metrics" in result
+        assert result["status"] != "evaluation_error", (
+            f"Trace {candidate['label']} failed: {result.get('error', 'unknown')}"
+        )
+
+
+def test_build_failure_cases_extracts_high_miss_rate() -> None:
+    """Failure cases are extracted for traces with high miss rate."""
+    results = [
+        {
+            "label": "test_trace",
+            "family": "test_family",
+            "trace_path": "test/path.json",
+            "status": "evaluated",
+            "metrics": {
+                "forecast_evaluable_samples": 10.0,
+                "mean_miss_rate_2s": 0.8,
+                "mean_ade_2s": 0.2,
+                "mean_negative_log_likelihood_2s": 2.0,
+            },
+        }
+    ]
+    cases = _build_failure_cases(results)
+    assert len(cases) >= 1
+    assert any(c["metric"] == "mean_miss_rate_2s" for c in cases)
+
+
+def test_build_failure_cases_empty_for_good_results() -> None:
+    """No failure cases for traces with low miss rate and ADE."""
+    results = [
+        {
+            "label": "good_trace",
+            "family": "test",
+            "trace_path": "test/path.json",
+            "status": "evaluated",
+            "metrics": {
+                "forecast_evaluable_samples": 10.0,
+                "mean_miss_rate_2s": 0.05,
+                "mean_ade_2s": 0.1,
+                "mean_negative_log_likelihood_2s": 1.0,
+            },
+        }
+    ]
+    cases = _build_failure_cases(results)
+    assert len(cases) == 0
+
+
+def test_generate_markdown_includes_claim_boundary() -> None:
+    """Markdown report includes the diagnostic-only claim boundary."""
+    md = _generate_markdown(
+        [],
+        [],
+        {
+            "issue": 2757,
+            "generated_at_utc": "test",
+            "command": "test",
+            "repo_head": "abc123",
+            "horizons_s": [0.5, 1.0, 2.0],
+        },
+    )
+    assert "Diagnostic-only" in md
+    assert "2757" in md
+
+
+def test_generate_markdown_lists_missing_families() -> None:
+    """Markdown report lists missing trace families."""
+    md = _generate_markdown(
+        [],
+        [],
+        {
+            "issue": 2757,
+            "generated_at_utc": "test",
+            "command": "test",
+            "repo_head": "abc",
+            "horizons_s": [0.5, 1.0, 2.0],
+        },
+    )
+    for mf in MISSING_FAMILIES:
+        assert mf["family"] in md
+
+
+def test_generate_markdown_lists_evaluated_traces() -> None:
+    """Markdown report includes evaluated traces in the table."""
+    results = [
+        {
+            "family": "corridor_interaction",
+            "label": "test",
+            "status": "evaluated",
+            "has_motion": True,
+            "frame_count": 20,
+            "pedestrians_per_frame": 2,
+            "dt_s": 0.1,
+            "scenario_id": "test_scenario",
+            "metrics": {"forecast_evaluable_samples": 5.0},
+            "horizons_s": [0.5, 1.0, 2.0],
+        }
+    ]
+    md = _generate_markdown(
+        results,
+        [],
+        {
+            "issue": 2757,
+            "generated_at_utc": "test",
+            "command": "test",
+            "repo_head": "abc",
+            "horizons_s": [0.5, 1.0, 2.0],
+        },
+    )
+    assert "corridor_interaction" in md
+    assert "test" in md
+    assert "Not available for this trace length" in md
+
+
+def test_generate_markdown_includes_failure_cases() -> None:
+    """Markdown report includes failure case details."""
+    failure_cases = [
+        {
+            "trace": "test_trace",
+            "family": "test_family",
+            "trace_path": "test/path.json",
+            "metric": "mean_miss_rate_2s",
+            "value": 0.8,
+            "interpretation": "High miss rate.",
+        }
+    ]
+    md = _generate_markdown(
+        [],
+        failure_cases,
+        {
+            "issue": 2757,
+            "generated_at_utc": "test",
+            "command": "test",
+            "repo_head": "abc",
+            "horizons_s": [0.5, 1.0, 2.0],
+        },
+    )
+    assert "Failure Cases" in md
+    assert "test_trace" in md
+    assert "test/path.json" in md


### PR DESCRIPTION
## Summary
Adds a deterministic constant-velocity pedestrian forecast evaluation script and promotes compact
JSON/Markdown evidence for the bounded durable traces available today.

## Linked Issues
- Closes `#2757`
- Follow-up `#2774`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#2774`
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/benchmark/run_cv_forecast_eval.py` to evaluate
  `compute_batch_forecast_metrics` on curated durable trace fixtures.
- Added targeted tests in `tests/benchmark/test_pedestrian_forecast_cv_eval.py`.
- Added durable evidence under
  `docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/`.
- Added discoverability entries in `docs/context/evidence/README.md` and
  `docs/context/catalog.yaml`.

## Why It Matters
- Added value: establishes the deterministic CV forecast baseline before learned-prediction work.
- Expected impact: future forecast experiments can compare against a reproducible diagnostic
  baseline and see which trace families remain unsupported.
- Why this is worth merging now: it turns the currently available trace fixtures into durable,
  reviewable evidence and records missing coverage instead of letting it disappear in local output.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: CV forecast baseline adequacy on bounded
  durable pedestrian traces; blocker is missing non-corridor motion-rich fixtures.
- Comparator or baseline, if applicable: deterministic constant-velocity Gaussian forecast.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: corridor traces are evaluable; crossing/bottleneck are
  limited by zero pedestrian motion; signalized, occluded, dense, and motion-rich bottleneck traces
  need follow-up before stronger claims.
- Parent issue, claim map, registry, context note, or synthesis surface to update:
  `docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md` and
  `docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.json`.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use included in
  this PR on tracked durable trace fixtures; follow-up `#2774` covers broader fixture coverage.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes for corridor traces; no usable motion signal for crossing_proxy
  and bottleneck fixtures.
- Did the intervention change command source, selected command, trajectory, or route progress? NA;
  analysis-only forecast baseline evaluation.
- Did the scenario actually contain the targeted failure mode? only partially; corridor traces have
  pedestrian motion, but missing/limited families do not yet test crossing, bottleneck, occluded, or
  dense interaction dynamics.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: `#2774`.

## Next Empirical Action
- Rerun needed: yes, after motion-rich non-corridor fixtures are promoted.
- Extractor or analysis tool needed: no for the current evaluator; fixture generation/promotion is
  needed.
- Artifact missing or unavailable: signalized crossing, occluded emergence, dense pedestrian
  interaction, and motion-rich bottleneck/crossing fixtures.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: `#2774`.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_pedestrian_forecast_cv_eval.py -q`
  - `uv run pytest tests/benchmark/test_pedestrian_forecast.py -q`
  - `uv run ruff check scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run ruff format --check scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/evidence/README.md --path docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md`
  - `git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed on committed HEAD
  `1adc9d5ac6a8d9f0e19df7423537d1824d760108` with 5994 passed, 9 skipped.
- Benchmarks or smoke tests, if applicable: evaluator smoke wrote tracked JSON/Markdown evidence.

## Risks / Rollout
- Compatibility risks: low; new script and tests are additive.
- Failure modes: future trace schema changes could need converter updates; current evidence remains
  limited to available durable fixtures.
- Rollback or fallback plan: revert the additive script/tests/evidence entries.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes:
  `docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md`.
- Any assumptions that need to be preserved: diagnostic-only, not paper-facing; local `output/`
  is not durable proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR closes `#2757`.
- Claim map / benchmark report updated (yes/no/NA): NA; diagnostic-only evidence bundle.
- Leaderboard / artifact catalog updated (yes/no/NA): NA; no leaderboard claim.
- Registry or config index updated (yes/no/NA): yes, `docs/context/catalog.yaml`.
- Context index / memory note updated (yes/no/NA): yes, `docs/context/evidence/README.md`.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, `#2774`.
- Not applicable because: stronger forecast-family coverage is deferred until motion-rich fixtures
  exist.

## Follow-Up Issues
- Deferred work: add motion-rich non-corridor trace fixtures and rerun the evaluator.
- Issues opened for follow-up: `#2774`.

## Reviewer Notes
- Anything a reviewer should verify closely: claim boundary and limited/missing trace-family
  wording.
- Any known limitations: corridor-only evaluated metrics; crossing/bottleneck are limitation rows,
  not forecast-quality proof.

Delegated review:
- OpenCode implementation worker produced compact artifacts and passed targeted validation.
- Command Code review route hit a turn cap without required artifacts, classified uneconomic.
- OpenCode review worker accepted the final diff with no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic script to evaluate constant-velocity pedestrian forecast baseline against repository trace fixtures.

* **Documentation**
  * Added evidence reports documenting constant-velocity forecast baseline evaluation results, including metrics across trace families and identified evaluation gaps.

* **Tests**
  * Added comprehensive test coverage for the pedestrian forecast evaluation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->