### PR TITLE
research: add observation-noise envelope evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-06-12
+updated_at: 2026-06-13
 policy: context-catalog.v1
 description: >
   Machine-readable catalog for the current retrieval-first context index. This is not a full
@@ -1157,6 +1157,14 @@ entries:
     freshness: evidence
     area: benchmark_evidence
   - path: docs/context/evidence/issue_2762_negative_result_register/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json
     status: evidence
     freshness: evidence
     area: benchmark_evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,11 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2755_observation_noise_envelope_2026-06-13/`: diagnostic trace-derived
+  near-field observation-noise robustness envelope. Evaluates seven perturbation conditions
+  (noop, low/medium Gaussian noise, missed detection, occlusion, delay, combined) against
+  the occluded-emergence trace fixture. Delay-only is trace-derived robustness evidence;
+  other conditions are diagnostic_only or scenario_too_weak. Not paper-facing benchmark evidence.
 - `issue_2756_occluded_emergence_2026-06-13/`: smoke/diagnostic note for the
   deterministic occluded-emergence trace fixture. The fixture separates ground-truth and observed
   pedestrian state, records first visibility and conflict timing, and feeds observation-noise plus

--- a/docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/README.md
+++ b/docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/README.md
@@ -1,0 +1,114 @@
+# Observation-Noise Robustness Envelope
+
+## Claim Boundary
+
+**Diagnostic trace-derived evidence only. Not paper-facing benchmark proof.**
+This evaluates near-field observation-noise robustness on a single occluded-emergence trace fixture. Results are diagnostic, not statistically powered population claims.
+
+## Reproducibility
+
+- **Issue:** #2755
+- **Generated at (UTC):** 2026-06-13T11:14:14.038693+00:00
+- **Command:** `uv run python scripts/benchmark/run_observation_noise_envelope.py --output-dir docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13`
+- **Repo HEAD:** `2aa3c468`
+- **Fixture:** `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json`
+- **Scenario:** issue_2756_occluded_emergence
+- **First visible step:** 5
+
+## Conditions
+
+### noop
+
+- **Description:** No perturbation applied (baseline).
+- **Noise profile:** none
+- **First observed step:** 5
+- **Response delay:** 0 steps from first-visible
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** True
+- **Yield feasible (first observed):** True
+- **Classification:** `diagnostic_only`
+  - No-perturbation baseline. Provides reference robot-pedestrian trajectory and action selection without observation noise.
+
+### low_noise
+
+- **Description:** Bounded Gaussian position noise with std=0.10 m, bound=0.20 m.
+- **Noise profile:** bounded_gaussian
+- **First observed step:** 5
+- **Response delay:** 0 steps from first-visible
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** True
+- **Yield feasible (first observed):** True
+- **Classification:** `diagnostic_only`
+  - Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence.
+
+### medium_noise
+
+- **Description:** Bounded Gaussian position noise with std=0.30 m, bound=0.60 m.
+- **Noise profile:** bounded_gaussian
+- **First observed step:** 5
+- **Response delay:** 0 steps from first-visible
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** True
+- **Yield feasible (first observed):** True
+- **Classification:** `diagnostic_only`
+  - Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence.
+
+### missed_detection_only
+
+- **Description:** Single pedestrian fully missed (probability=1.0).
+- **Noise profile:** missed_detection
+- **First observed step:** None
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** None
+- **Yield feasible (first observed):** None
+- **Classification:** `scenario_too_weak`
+  - Pedestrian fully missed after fixture visibility begins; no observation signal reaches the policy. Cannot test policy robustness.
+
+### occlusion_only
+
+- **Description:** Single pedestrian position/velocity zeroed by occlusion mask.
+- **Noise profile:** occlusion_mask
+- **First observed step:** None
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** None
+- **Yield feasible (first observed):** None
+- **Classification:** `scenario_too_weak`
+  - Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy.
+
+### delay_only
+
+- **Description:** 2-step delayed observation for the single pedestrian.
+- **Noise profile:** delayed_observation
+- **First observed step:** 7
+- **Response delay:** 2 steps from first-visible
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** False
+- **Yield feasible (first observed):** True
+- **Classification:** `robustness_evidence`
+  - Pedestrian observed at step 7 (2 steps after first-visible). Perturbation delayed/masked the observation and may have affected policy response timing.
+
+### combined
+
+- **Description:** Medium Gaussian noise + occlusion mask on the pedestrian.
+- **Noise profile:** bounded_gaussian
+- **First observed step:** None
+- **Closest distance:** 0.5
+- **Stop feasible (first observed):** None
+- **Yield feasible (first observed):** None
+- **Classification:** `scenario_too_weak`
+  - Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy.
+
+## Classification Legend
+
+- **robustness_evidence**: perturbation affected observation and may impact policy.
+- **scenario_too_weak**: scenario too weak (pedestrian never observed or too distant).
+- **policy_insensitive**: perturbation did not change policy action sequence.
+- **diagnostic_only**: mixed effects; needs broader evidence.
+- **blocked**: not applicable for this trace-derived evaluation.
+
+## Caveats
+
+- Single deterministic fixture (seed=111), single scenario family.
+- No live planner replay; action proxies are from the stored trace, not re-executed.
+- Stop/yield feasibility is from fixture metadata, not re-derived.
+- Not paper-facing benchmark evidence.

--- a/docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json
+++ b/docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json
@@ -1,0 +1,517 @@
+{
+  "schema_version": "observation_noise_envelope.v1",
+  "issue": 2755,
+  "claim_boundary": "Diagnostic trace-derived evidence only. Not paper-facing benchmark proof. Evaluates near-field observation-noise robustness on a single occluded-emergence trace fixture.",
+  "reproducibility": {
+    "issue": 2755,
+    "generated_at_utc": "2026-06-13T11:14:14.038693+00:00",
+    "command": "uv run python scripts/benchmark/run_observation_noise_envelope.py --output-dir docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13",
+    "repo_head": "2aa3c468"
+  },
+  "fixture": {
+    "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",
+    "scenario_id": "issue_2756_occluded_emergence",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2756_occluded_emergence_ep0000",
+    "frame_count": 16,
+    "first_visible_step": 5,
+    "conflict_time_s": 1.0,
+    "stop_feasible_before_step": 7,
+    "yield_feasible_before_step": 9
+  },
+  "conditions": [
+    {
+      "condition": "noop",
+      "description": "No perturbation applied (baseline).",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "none",
+        "is_noop": true
+      },
+      "first_observed_step": 5,
+      "response_delay_steps": 0,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": true,
+        "yield_feasible_first_observed": true
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "diagnostic_only",
+        "rationale": "No-perturbation baseline. Provides reference robot-pedestrian trajectory and action selection without observation noise."
+      }
+    },
+    {
+      "condition": "low_noise",
+      "description": "Bounded Gaussian position noise with std=0.10 m, bound=0.20 m.",
+      "spec": {
+        "position_noise_std_m": 0.1,
+        "position_noise_bound_m": 0.2,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "first_observed_step": 5,
+      "response_delay_steps": 0,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": true,
+        "yield_feasible_first_observed": true
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "diagnostic_only",
+        "rationale": "Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence."
+      }
+    },
+    {
+      "condition": "medium_noise",
+      "description": "Bounded Gaussian position noise with std=0.30 m, bound=0.60 m.",
+      "spec": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "first_observed_step": 5,
+      "response_delay_steps": 0,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": true,
+        "yield_feasible_first_observed": true
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "diagnostic_only",
+        "rationale": "Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence."
+      }
+    },
+    {
+      "condition": "missed_detection_only",
+      "description": "Single pedestrian fully missed (probability=1.0).",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 1.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "missed_detection",
+        "is_noop": false
+      },
+      "first_observed_step": null,
+      "response_delay_steps": null,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [],
+      "missed_actor_observations_total": 11,
+      "occluded_actor_observations_total": 0,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": null,
+        "yield_feasible_first_observed": null
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian fully missed after fixture visibility begins; no observation signal reaches the policy. Cannot test policy robustness."
+      }
+    },
+    {
+      "condition": "occlusion_only",
+      "description": "Single pedestrian position/velocity zeroed by occlusion mask.",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": true,
+        "delay_steps": 0,
+        "noise_profile": "occlusion_mask",
+        "is_noop": false
+      },
+      "first_observed_step": null,
+      "response_delay_steps": null,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 11,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": null,
+        "yield_feasible_first_observed": null
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy."
+      }
+    },
+    {
+      "condition": "delay_only",
+      "description": "2-step delayed observation for the single pedestrian.",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 2,
+        "noise_profile": "delayed_observation",
+        "is_noop": false
+      },
+      "first_observed_step": 7,
+      "response_delay_steps": 2,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "delay_steps_configured": 2,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": false,
+        "yield_feasible_first_observed": true
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "robustness_evidence",
+        "rationale": "Pedestrian observed at step 7 (2 steps after first-visible). Perturbation delayed/masked the observation and may have affected policy response timing."
+      }
+    },
+    {
+      "condition": "combined",
+      "description": "Medium Gaussian noise + occlusion mask on the pedestrian.",
+      "spec": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": true,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "first_observed_step": null,
+      "response_delay_steps": null,
+      "first_visible_step_reference": 5,
+      "total_frames": 16,
+      "fixture_observed_steps": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "perturbed_observed_steps": [],
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 11,
+      "delay_steps_configured": 0,
+      "closest_distance_m": 0.5,
+      "stop_yield_feasibility": {
+        "stop_feasible_first_observed": null,
+        "yield_feasible_first_observed": null
+      },
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy."
+      }
+    }
+  ],
+  "summary": {
+    "total_conditions": 7,
+    "classifications": {
+      "noop": "diagnostic_only",
+      "low_noise": "diagnostic_only",
+      "medium_noise": "diagnostic_only",
+      "missed_detection_only": "scenario_too_weak",
+      "occlusion_only": "scenario_too_weak",
+      "delay_only": "robustness_evidence",
+      "combined": "scenario_too_weak"
+    }
+  }
+}

--- a/scripts/benchmark/run_observation_noise_envelope.py
+++ b/scripts/benchmark/run_observation_noise_envelope.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Near-field observation-noise robustness envelope from an occluded-emergence trace.
+
+Reads the durable occluded-emergence trace fixture and evaluates near-field
+observation-noise perturbation conditions against the robot-pedestrian pair.
+This is diagnostic trace-derived evidence only, not a full planner benchmark.
+
+Usage::
+
+    uv run python scripts/benchmark/run_observation_noise_envelope.py \\
+        --output-dir docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import subprocess
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.observation_perturbation import (
+    ObservationPerturbationSpec,
+    ObservationPerturbationState,
+    perturb_ground_truth,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE_PATH = (
+    REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+    "occluded_emergence_episode_0000.json"
+)
+
+CONDITIONS: dict[str, dict[str, Any]] = {
+    "noop": {"description": "No perturbation applied (baseline)."},
+    "low_noise": {
+        "description": "Bounded Gaussian position noise with std=0.10 m, bound=0.20 m.",
+        "spec_kw": {"position_noise_std_m": 0.10, "position_noise_bound_m": 0.20, "seed": 2755},
+    },
+    "medium_noise": {
+        "description": "Bounded Gaussian position noise with std=0.30 m, bound=0.60 m.",
+        "spec_kw": {"position_noise_std_m": 0.30, "position_noise_bound_m": 0.60, "seed": 2755},
+    },
+    "missed_detection_only": {
+        "description": "Single pedestrian fully missed (probability=1.0).",
+        "spec_kw": {"missed_detection_probability": 1.0, "seed": 2755},
+    },
+    "occlusion_only": {
+        "description": "Single pedestrian position/velocity zeroed by occlusion mask.",
+        "spec_kw": {"occlusion_mask": np.array([True])},
+    },
+    "delay_only": {
+        "description": "2-step delayed observation for the single pedestrian.",
+        "spec_kw": {"delay_steps": 2},
+    },
+    "combined": {
+        "description": "Medium Gaussian noise + occlusion mask on the pedestrian.",
+        "spec_kw": {
+            "position_noise_std_m": 0.30,
+            "position_noise_bound_m": 0.60,
+            "occlusion_mask": np.array([True]),
+            "seed": 2755,
+        },
+    },
+}
+
+
+def _load_fixture(path: pathlib.Path) -> dict[str, Any]:
+    """Load the occluded-emergence trace fixture."""
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _git_head() -> str:
+    """Return the short git HEAD, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _extract_frame_arrays(frame: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract ground-truth robot position and pedestrian arrays from a frame.
+
+    Returns:
+        (robot_pos, ped_pos, ped_ids)
+    """
+    robot_pos = np.array(frame["robot"]["position"], dtype=np.float64)
+    ped_positions = np.array([p["position"] for p in frame["pedestrians"]], dtype=np.float64)
+    ped_ids = [str(p["id"]) for p in frame["pedestrians"]]
+    return robot_pos, ped_positions, ped_ids
+
+
+def _extract_observed_arrays(frame: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract fixture-visible pedestrian observations from a frame."""
+    observed_peds = frame.get("observed_pedestrians", [])
+    if not observed_peds:
+        return (
+            np.empty((0, 2), dtype=np.float64),
+            np.empty((0, 2), dtype=np.float64),
+            [],
+        )
+    positions = np.array([p["position"] for p in observed_peds], dtype=np.float64)
+    velocities = np.array([p["velocity"] for p in observed_peds], dtype=np.float64)
+    ids = [str(p["id"]) for p in observed_peds]
+    return positions, velocities, ids
+
+
+def _closest_distance(robot_pos: np.ndarray, ped_pos: np.ndarray) -> float:
+    """Compute Euclidean distance from robot to the nearest pedestrian."""
+    if ped_pos.size == 0:
+        return float("inf")
+    diffs = ped_pos - robot_pos
+    dists = np.sqrt(np.sum(diffs**2, axis=1))
+    return float(np.min(dists))
+
+
+def _spec_for_actor_count(
+    spec: ObservationPerturbationSpec, actor_count: int
+) -> ObservationPerturbationSpec:
+    """Adapt fixed-size occlusion masks to frames before fixture visibility."""
+    if spec.occlusion_mask is None:
+        return spec
+    if np.asarray(spec.occlusion_mask).size == actor_count:
+        return spec
+    if actor_count == 0:
+        return ObservationPerturbationSpec(
+            position_noise_std_m=spec.position_noise_std_m,
+            position_noise_bound_m=spec.position_noise_bound_m,
+            missed_detection_probability=spec.missed_detection_probability,
+            occlusion_mask=np.zeros(0, dtype=bool),
+            delay_steps=spec.delay_steps,
+            seed=spec.seed,
+        )
+    return spec
+
+
+def _stop_yield_feasibility(frame: dict[str, Any]) -> dict[str, bool]:
+    """Extract stop and yield feasibility from frame conflict_timing."""
+    ct = frame.get("conflict_timing", {})
+    return {
+        "stop_feasible": bool(ct.get("stop_feasible", False)),
+        "yield_feasible": bool(ct.get("yield_feasible", False)),
+    }
+
+
+def _selected_action_proxy(frame: dict[str, Any]) -> dict[str, Any]:
+    """Extract selected action and event from frame planner payload."""
+    planner = frame.get("planner", {})
+    return {
+        "linear_velocity": planner.get("selected_action", {}).get("linear_velocity"),
+        "angular_velocity": planner.get("selected_action", {}).get("angular_velocity"),
+        "event": planner.get("event"),
+    }
+
+
+def evaluate_condition(
+    condition_name: str,
+    condition_cfg: dict[str, Any],
+    frames: list[dict[str, Any]],
+    first_visible_step: int,
+) -> dict[str, Any]:
+    """Evaluate one perturbation condition against the trace frames.
+
+    Returns a compact result dict with condition metadata and aggregated classification.
+    """
+    spec_kw = dict(condition_cfg.get("spec_kw", {}))
+    spec = ObservationPerturbationSpec(**spec_kw)
+    needs_state = spec.delay_steps > 0
+    state = ObservationPerturbationState(delay_steps=spec.delay_steps) if needs_state else None
+
+    first_observed_step: int | None = None
+    response_delay_steps: int | None = None
+    missed_counts: list[int] = []
+    occluded_counts: list[int] = []
+    closest_distances: list[float] = []
+    action_proxies: list[dict[str, Any]] = []
+    observed_steps: list[int] = []
+    perturbed_observed_steps: list[int] = []
+    feasibility_by_step: dict[int, dict[str, bool]] = {}
+
+    for frame in frames:
+        step = frame["step"]
+        robot_pos, ground_truth_ped_positions, _ped_ids = _extract_frame_arrays(frame)
+        observed_positions, observed_velocities, observed_ids = _extract_observed_arrays(frame)
+        if observed_positions.size > 0:
+            observed_steps.append(step)
+        step_spec = _spec_for_actor_count(spec, len(observed_ids))
+
+        perturb_result = perturb_ground_truth(
+            observed_positions,
+            observed_velocities,
+            observed_ids,
+            spec=step_spec,
+            step=step,
+            state=state,
+        )
+
+        obs = perturb_result["observed"]
+        meta = perturb_result["metadata"]
+
+        # Determine if pedestrian is "observed" (non-zero position in observed state)
+        ped_observed = False
+        if obs["positions"].size > 0:
+            ped_observed = bool(np.any(obs["positions"] != 0.0))
+
+        if ped_observed and first_observed_step is None:
+            first_observed_step = step
+            if first_visible_step is not None:
+                response_delay_steps = step - first_visible_step
+        if ped_observed:
+            perturbed_observed_steps.append(step)
+
+        closest_dist = _closest_distance(robot_pos, ground_truth_ped_positions)
+        fy = _stop_yield_feasibility(frame)
+        action_proxy = _selected_action_proxy(frame)
+        feasibility_by_step[step] = fy
+
+        missed_counts.append(meta["missed_actor_count"])
+        occluded_counts.append(meta["occluded_actor_count"])
+        closest_distances.append(closest_dist)
+        action_proxies.append(action_proxy)
+
+    # Classification logic
+    classification = _classify_condition(
+        condition_name=condition_name,
+        first_observed_step=first_observed_step,
+        first_visible_step=first_visible_step,
+        response_delay_steps=response_delay_steps,
+        closest_distances=closest_distances,
+        missed_counts=missed_counts,
+        occluded_counts=occluded_counts,
+    )
+
+    return {
+        "condition": condition_name,
+        "description": condition_cfg["description"],
+        "spec": _spec_summary(spec),
+        "first_observed_step": first_observed_step,
+        "response_delay_steps": response_delay_steps,
+        "first_visible_step_reference": first_visible_step,
+        "total_frames": len(frames),
+        "fixture_observed_steps": observed_steps,
+        "perturbed_observed_steps": perturbed_observed_steps,
+        "missed_actor_observations_total": sum(missed_counts),
+        "occluded_actor_observations_total": sum(occluded_counts),
+        "delay_steps_configured": spec.delay_steps,
+        "closest_distance_m": round(min(closest_distances), 4) if closest_distances else None,
+        "stop_yield_feasibility": {
+            "stop_feasible_first_observed": (
+                feasibility_by_step[first_observed_step]["stop_feasible"]
+                if first_observed_step is not None
+                else None
+            ),
+            "yield_feasible_first_observed": (
+                feasibility_by_step[first_observed_step]["yield_feasible"]
+                if first_observed_step is not None
+                else None
+            ),
+        },
+        "action_proxy_changes": _action_proxy_summary(action_proxies),
+        "classification": classification,
+    }
+
+
+def _spec_summary(spec: ObservationPerturbationSpec) -> dict[str, Any]:
+    """Summarize a perturbation spec as a plain dict."""
+    return {
+        "position_noise_std_m": spec.position_noise_std_m,
+        "position_noise_bound_m": spec.position_noise_bound_m,
+        "missed_detection_probability": spec.missed_detection_probability,
+        "has_occlusion_mask": spec.occlusion_mask is not None,
+        "delay_steps": spec.delay_steps,
+        "noise_profile": spec.noise_profile,
+        "is_noop": spec.is_noop,
+    }
+
+
+def _classify_condition(
+    *,
+    condition_name: str,
+    first_observed_step: int | None,
+    first_visible_step: int,
+    response_delay_steps: int | None,
+    closest_distances: list[float],
+    missed_counts: list[int],
+    occluded_counts: list[int],
+) -> dict[str, str]:
+    """Classify the condition result into one of the allowed categories."""
+    # Noop is always diagnostic_only (it is the reference)
+    if condition_name == "noop":
+        return {
+            "label": "diagnostic_only",
+            "rationale": (
+                "No-perturbation baseline. Provides reference robot-pedestrian "
+                "trajectory and action selection without observation noise."
+            ),
+        }
+
+    never_observed = first_observed_step is None
+    has_missed_observations = any(c > 0 for c in missed_counts)
+    has_occluded_observations = any(c > 0 for c in occluded_counts)
+
+    # If pedestrian never observed (full occlusion or full miss)
+    if never_observed:
+        if has_missed_observations:
+            return {
+                "label": "scenario_too_weak",
+                "rationale": (
+                    "Pedestrian fully missed after fixture visibility begins; no observation "
+                    "signal reaches the policy. Cannot test policy robustness."
+                ),
+            }
+        if has_occluded_observations:
+            return {
+                "label": "scenario_too_weak",
+                "rationale": (
+                    "Pedestrian position/velocity zeroed by occlusion after fixture visibility "
+                    "begins; no observation signal reaches the policy."
+                ),
+            }
+
+    min_dist = min(closest_distances) if closest_distances else float("inf")
+
+    if first_observed_step is not None and min_dist > 2.0:
+        return {
+            "label": "scenario_too_weak",
+            "rationale": (
+                f"Closest robot-pedestrian distance ({min_dist:.2f} m) exceeds "
+                "near-field threshold (2.0 m). Scenario too weak for observation-noise "
+                "sensitivity test."
+            ),
+        }
+
+    # If perturbation caused observable differences, it is robustness evidence
+    if (
+        first_observed_step is not None
+        and response_delay_steps is not None
+        and response_delay_steps > 0
+    ):
+        return {
+            "label": "robustness_evidence",
+            "rationale": (
+                f"Pedestrian observed at step {first_observed_step} "
+                f"({response_delay_steps} steps after first-visible). "
+                "Perturbation delayed/masked the observation and may have affected "
+                "policy response timing."
+            ),
+        }
+
+    return {
+        "label": "diagnostic_only",
+        "rationale": (
+            "Perturbation produced mixed effects. Classified as diagnostic-only "
+            "pending broader seed/scenario evidence."
+        ),
+    }
+
+
+def _action_proxy_summary(action_proxies: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize stored-trace action proxies without embedding every action."""
+    if not action_proxies:
+        return {"linear_velocity_changed": False, "events": [], "velocity_range": None}
+    events = [ap.get("event") for ap in action_proxies]
+    unique_events = list(dict.fromkeys(events))  # preserve order, dedupe
+    velocities = [ap.get("linear_velocity") for ap in action_proxies]
+    changed = len(set(velocities)) > 1
+    return {
+        "linear_velocity_changed": changed,
+        "events": unique_events,
+        "velocity_range": [min(velocities), max(velocities)] if velocities else None,
+    }
+
+
+def _build_report(
+    results: list[dict[str, Any]],
+    fixture_meta: dict[str, Any],
+    repro: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the full JSON report."""
+    return {
+        "schema_version": "observation_noise_envelope.v1",
+        "issue": 2755,
+        "claim_boundary": (
+            "Diagnostic trace-derived evidence only. Not paper-facing benchmark proof. "
+            "Evaluates near-field observation-noise robustness on a single "
+            "occluded-emergence trace fixture."
+        ),
+        "reproducibility": repro,
+        "fixture": fixture_meta,
+        "conditions": results,
+        "summary": {
+            "total_conditions": len(results),
+            "classifications": {r["condition"]: r["classification"]["label"] for r in results},
+        },
+    }
+
+
+def _generate_markdown(
+    results: list[dict[str, Any]],
+    fixture_meta: dict[str, Any],
+    repro: dict[str, Any],
+) -> str:
+    """Generate the Markdown evidence report."""
+    lines: list[str] = [
+        "# Observation-Noise Robustness Envelope",
+        "",
+        "## Claim Boundary",
+        "",
+        "**Diagnostic trace-derived evidence only. Not paper-facing benchmark proof.**",
+        "This evaluates near-field observation-noise robustness on a single "
+        "occluded-emergence trace fixture. Results are diagnostic, not statistically "
+        "powered population claims.",
+        "",
+        "## Reproducibility",
+        "",
+        f"- **Issue:** #{repro['issue']}",
+        f"- **Generated at (UTC):** {repro['generated_at_utc']}",
+        f"- **Command:** `{repro['command']}`",
+        f"- **Repo HEAD:** `{repro['repo_head']}`",
+        f"- **Fixture:** `{fixture_meta['trace_path']}`",
+        f"- **Scenario:** {fixture_meta.get('scenario_id', '')}",
+        f"- **First visible step:** {fixture_meta.get('first_visible_step', '?')}",
+        "",
+        "## Conditions",
+        "",
+    ]
+
+    for r in results:
+        spec = r["spec"]
+        lines.append(f"### {r['condition']}")
+        lines.append("")
+        lines.append(f"- **Description:** {r['description']}")
+        lines.append(f"- **Noise profile:** {spec['noise_profile']}")
+        lines.append(f"- **First observed step:** {r['first_observed_step']}")
+        if r["response_delay_steps"] is not None:
+            lines.append(
+                f"- **Response delay:** {r['response_delay_steps']} steps from first-visible"
+            )
+        lines.append(
+            f"- **Closest distance:** {r['closest_distance_m']}"
+            if r["closest_distance_m"] is not None
+            else "- **Closest distance:** N/A"
+        )
+        fy = r["stop_yield_feasibility"]
+        lines.append(f"- **Stop feasible (first observed):** {fy['stop_feasible_first_observed']}")
+        lines.append(
+            f"- **Yield feasible (first observed):** {fy['yield_feasible_first_observed']}"
+        )
+        cl = r["classification"]
+        lines.append(f"- **Classification:** `{cl['label']}`")
+        lines.append(f"  - {cl['rationale']}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Classification Legend",
+            "",
+            "- **robustness_evidence**: perturbation affected observation and may impact policy.",
+            "- **scenario_too_weak**: scenario too weak (pedestrian never observed or too distant).",
+            "- **policy_insensitive**: perturbation did not change policy action sequence.",
+            "- **diagnostic_only**: mixed effects; needs broader evidence.",
+            "- **blocked**: not applicable for this trace-derived evaluation.",
+            "",
+            "## Caveats",
+            "",
+            "- Single deterministic fixture (seed=111), single scenario family.",
+            "- No live planner replay; action proxies are from the stored trace, not re-executed.",
+            "- Stop/yield feasibility is from fixture metadata, not re-derived.",
+            "- Not paper-facing benchmark evidence.",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run observation-noise envelope evaluation and write evidence."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate near-field observation-noise robustness envelope."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13",
+        help="Output directory for evidence artifacts.",
+    )
+    args = parser.parse_args()
+
+    output_dir = REPO_ROOT / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    trace = _load_fixture(FIXTURE_PATH)
+    frames = trace["frames"]
+    occlusion = trace["occlusion"]
+    first_visible_step = occlusion["first_visible_step"]
+
+    fixture_meta = {
+        "trace_path": str(FIXTURE_PATH.relative_to(REPO_ROOT)),
+        "scenario_id": trace["source"]["scenario_id"],
+        "seed": trace["source"]["seed"],
+        "planner_id": trace["source"]["planner_id"],
+        "episode_id": trace["source"]["episode_id"],
+        "frame_count": len(frames),
+        "first_visible_step": first_visible_step,
+        "conflict_time_s": occlusion.get("conflict_time_s"),
+        "stop_feasible_before_step": occlusion.get("stop_feasible_before_step"),
+        "yield_feasible_before_step": occlusion.get("yield_feasible_before_step"),
+    }
+
+    repo_head = _git_head()
+    generated_at = datetime.datetime.now(datetime.UTC).isoformat()
+    command = (
+        f"uv run python scripts/benchmark/run_observation_noise_envelope.py "
+        f"--output-dir {args.output_dir}"
+    )
+
+    repro = {
+        "issue": 2755,
+        "generated_at_utc": generated_at,
+        "command": command,
+        "repo_head": repo_head,
+    }
+
+    results: list[dict[str, Any]] = []
+    for name, cfg in CONDITIONS.items():
+        result = evaluate_condition(name, cfg, frames, first_visible_step)
+        results.append(result)
+
+    report = _build_report(results, fixture_meta, repro)
+
+    json_path = output_dir / "summary.json"
+    with open(json_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+
+    md_content = _generate_markdown(results, fixture_meta, repro)
+    md_path = output_dir / "README.md"
+    with open(md_path, "w") as fh:
+        fh.write(md_content)
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+
+    for r in results:
+        cl = r["classification"]
+        print(f"  [{cl['label']:>20s}] {r['condition']}: {r['description'][:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/run_observation_noise_envelope.py
+++ b/scripts/benchmark/run_observation_noise_envelope.py
@@ -70,7 +70,7 @@ CONDITIONS: dict[str, dict[str, Any]] = {
 
 def _load_fixture(path: pathlib.Path) -> dict[str, Any]:
     """Load the occluded-emergence trace fixture."""
-    with open(path) as fh:
+    with open(path, encoding="utf-8") as fh:
         return json.load(fh)
 
 
@@ -374,7 +374,7 @@ def _action_proxy_summary(action_proxies: list[dict[str, Any]]) -> dict[str, Any
         return {"linear_velocity_changed": False, "events": [], "velocity_range": None}
     events = [ap.get("event") for ap in action_proxies]
     unique_events = list(dict.fromkeys(events))  # preserve order, dedupe
-    velocities = [ap.get("linear_velocity") for ap in action_proxies]
+    velocities = [v for ap in action_proxies if (v := ap.get("linear_velocity")) is not None]
     changed = len(set(velocities)) > 1
     return {
         "linear_velocity_changed": changed,
@@ -541,12 +541,12 @@ def main() -> None:
     report = _build_report(results, fixture_meta, repro)
 
     json_path = output_dir / "summary.json"
-    with open(json_path, "w") as fh:
+    with open(json_path, "w", encoding="utf-8") as fh:
         json.dump(report, fh, indent=2)
 
     md_content = _generate_markdown(results, fixture_meta, repro)
     md_path = output_dir / "README.md"
-    with open(md_path, "w") as fh:
+    with open(md_path, "w", encoding="utf-8") as fh:
         fh.write(md_content)
 
     print(f"Wrote {json_path}")

--- a/tests/benchmark/test_observation_noise_envelope.py
+++ b/tests/benchmark/test_observation_noise_envelope.py
@@ -13,23 +13,22 @@ FIXTURE_PATH = (
     "occluded_emergence_episode_0000.json"
 )
 _SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_observation_noise_envelope.py"
+_LOADED_MOD = None
 
 
 def _load_script():
     """Load the observation noise envelope script as a module."""
+    global _LOADED_MOD
+    if _LOADED_MOD is not None:
+        return _LOADED_MOD
     spec = importlib.util.spec_from_file_location(
         "run_observation_noise_envelope_issue_2755", _SCRIPT_PATH
     )
     mod = importlib.util.module_from_spec(spec)
     sys.modules["run_observation_noise_envelope_issue_2755"] = mod
     spec.loader.exec_module(mod)
-    return mod
-
-
-def _load_trace() -> dict:
-    """Load the occluded-emergence fixture."""
-    with open(FIXTURE_PATH) as fh:
-        return json.load(fh)
+    _LOADED_MOD = mod
+    return _LOADED_MOD
 
 
 VALID_CLASSIFICATIONS = {
@@ -231,6 +230,21 @@ def test_action_proxy_has_required_fields() -> None:
     assert "last_action" not in ap
 
 
+def test_action_proxy_summary_ignores_missing_velocity() -> None:
+    """Action proxy summary handles frames without linear velocity."""
+    mod = _load_script()
+    summary = mod._action_proxy_summary(
+        [
+            {"linear_velocity": None, "event": "missing"},
+            {"linear_velocity": 0.0, "event": "stopped"},
+            {"linear_velocity": 1.0, "event": "moving"},
+        ]
+    )
+
+    assert summary["linear_velocity_changed"] is True
+    assert summary["velocity_range"] == [0.0, 1.0]
+
+
 def test_report_is_compact_condition_summary() -> None:
     """Condition report omits full frame dumps from durable evidence."""
     mod = _load_script()
@@ -292,5 +306,5 @@ def test_script_is_importable() -> None:
 
 def _load_fixture_for_test() -> dict:
     """Load the occluded-emergence fixture for test use."""
-    with open(FIXTURE_PATH) as fh:
+    with open(FIXTURE_PATH, encoding="utf-8") as fh:
         return json.load(fh)

--- a/tests/benchmark/test_observation_noise_envelope.py
+++ b/tests/benchmark/test_observation_noise_envelope.py
@@ -1,0 +1,296 @@
+"""Tests for the observation-noise robustness envelope script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE_PATH = (
+    REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+    "occluded_emergence_episode_0000.json"
+)
+_SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_observation_noise_envelope.py"
+
+
+def _load_script():
+    """Load the observation noise envelope script as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "run_observation_noise_envelope_issue_2755", _SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["run_observation_noise_envelope_issue_2755"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_trace() -> dict:
+    """Load the occluded-emergence fixture."""
+    with open(FIXTURE_PATH) as fh:
+        return json.load(fh)
+
+
+VALID_CLASSIFICATIONS = {
+    "robustness_evidence",
+    "scenario_too_weak",
+    "policy_insensitive",
+    "diagnostic_only",
+    "blocked",
+}
+
+EXPECTED_CONDITIONS = [
+    "noop",
+    "low_noise",
+    "medium_noise",
+    "missed_detection_only",
+    "occlusion_only",
+    "delay_only",
+    "combined",
+]
+
+
+def test_all_conditions_are_evaluated() -> None:
+    """Script evaluates exactly the seven required conditions."""
+    mod = _load_script()
+    assert list(mod.CONDITIONS.keys()) == EXPECTED_CONDITIONS
+
+
+def test_report_has_required_top_level_keys() -> None:
+    """JSON report contains schema_version, issue, claim_boundary, and conditions."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    results = []
+    for name, cfg in mod.CONDITIONS.items():
+        result = mod.evaluate_condition(name, cfg, frames, first_visible)
+        results.append(result)
+
+    fixture_meta = {"first_visible_step": first_visible, "frame_count": len(frames)}
+    repro = {"issue": 2755}
+    report = mod._build_report(results, fixture_meta, repro)
+
+    assert report["schema_version"] == "observation_noise_envelope.v1"
+    assert report["issue"] == 2755
+    assert "claim_boundary" in report
+    assert "conditions" in report
+    assert len(report["conditions"]) == 7
+    assert "summary" in report
+
+
+def test_condition_report_shape() -> None:
+    """Each condition result has all required fields."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    for name, cfg in mod.CONDITIONS.items():
+        result = mod.evaluate_condition(name, cfg, frames, first_visible)
+        assert result["condition"] == name
+        assert "description" in result
+        assert "spec" in result
+        assert "first_observed_step" in result
+        assert "response_delay_steps" in result
+        assert "fixture_observed_steps" in result
+        assert "perturbed_observed_steps" in result
+        assert "missed_actor_observations_total" in result
+        assert "occluded_actor_observations_total" in result
+        assert "delay_steps_configured" in result
+        assert "closest_distance_m" in result
+        assert "stop_yield_feasibility" in result
+        assert "action_proxy_changes" in result
+        assert "classification" in result
+
+
+def test_classifications_are_valid_labels() -> None:
+    """All classifications use allowed labels."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    for name, cfg in mod.CONDITIONS.items():
+        result = mod.evaluate_condition(name, cfg, frames, first_visible)
+        label = result["classification"]["label"]
+        assert label in VALID_CLASSIFICATIONS, f"Invalid classification '{label}' for {name}"
+
+
+def test_noop_is_diagnostic_only() -> None:
+    """Noop baseline is classified as diagnostic_only."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition("noop", mod.CONDITIONS["noop"], frames, first_visible)
+    assert result["classification"]["label"] == "diagnostic_only"
+
+
+def test_noop_first_observed_matches_fixture_visibility() -> None:
+    """Noop respects the fixture visibility boundary."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition("noop", mod.CONDITIONS["noop"], frames, first_visible)
+    assert result["first_observed_step"] == first_visible
+    assert result["response_delay_steps"] == 0
+    assert result["fixture_observed_steps"][0] == first_visible
+    assert result["perturbed_observed_steps"][0] == first_visible
+
+
+def test_missed_detection_never_observed() -> None:
+    """Full missed detection never observes the pedestrian."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition(
+        "missed_detection_only", mod.CONDITIONS["missed_detection_only"], frames, first_visible
+    )
+    assert result["first_observed_step"] is None
+    assert result["classification"]["label"] == "scenario_too_weak"
+
+
+def test_occlusion_only_never_observed() -> None:
+    """Full occlusion never observes the pedestrian."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition(
+        "occlusion_only", mod.CONDITIONS["occlusion_only"], frames, first_visible
+    )
+    assert result["first_observed_step"] is None
+    assert result["classification"]["label"] == "scenario_too_weak"
+
+
+def test_delay_only_observes_after_configured_lag() -> None:
+    """Delay-only condition observes after fixture visibility plus delay."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition(
+        "delay_only", mod.CONDITIONS["delay_only"], frames, first_visible
+    )
+    assert result["first_observed_step"] == first_visible + 2
+    assert result["response_delay_steps"] == 2
+    assert result["spec"]["delay_steps"] == 2
+    assert result["delay_steps_configured"] == 2
+    assert result["stop_yield_feasibility"]["stop_feasible_first_observed"] is False
+    assert result["stop_yield_feasibility"]["yield_feasible_first_observed"] is True
+
+
+def test_combined_never_observed() -> None:
+    """Combined noise + occlusion still never observes (occlusion zeros position)."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition("combined", mod.CONDITIONS["combined"], frames, first_visible)
+    assert result["first_observed_step"] is None
+    assert result["classification"]["label"] == "scenario_too_weak"
+
+
+def test_closest_distance_is_positive() -> None:
+    """Closest robot-pedestrian distance is always positive for all conditions."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    for name, cfg in mod.CONDITIONS.items():
+        result = mod.evaluate_condition(name, cfg, frames, first_visible)
+        if result["closest_distance_m"] is not None:
+            assert result["closest_distance_m"] > 0.0, f"Distance not positive for {name}"
+
+
+def test_action_proxy_has_required_fields() -> None:
+    """Action proxy summary stays compact but includes event and velocity signal."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition("noop", mod.CONDITIONS["noop"], frames, first_visible)
+    ap = result["action_proxy_changes"]
+    assert "linear_velocity_changed" in ap
+    assert "events" in ap
+    assert "velocity_range" in ap
+    assert "first_action" not in ap
+    assert "last_action" not in ap
+
+
+def test_report_is_compact_condition_summary() -> None:
+    """Condition report omits full frame dumps from durable evidence."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition("noop", mod.CONDITIONS["noop"], frames, first_visible)
+    assert "frames" not in result
+    assert result["total_frames"] == len(frames)
+    assert result["fixture_observed_steps"] == list(range(first_visible, len(frames)))
+
+
+def test_markdown_report_contains_caveats() -> None:
+    """Markdown report contains diagnostic-only caveats."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    results = []
+    for name, cfg in mod.CONDITIONS.items():
+        result = mod.evaluate_condition(name, cfg, frames, first_visible)
+        results.append(result)
+
+    fixture_meta = {
+        "first_visible_step": first_visible,
+        "frame_count": len(frames),
+        "trace_path": "x",
+        "scenario_id": "y",
+    }
+    repro = {"issue": 2755, "generated_at_utc": "2026-01-01", "command": "test", "repo_head": "abc"}
+    md = mod._generate_markdown(results, fixture_meta, repro)
+
+    assert "Not paper-facing benchmark proof" in md
+    assert "Diagnostic" in md
+
+
+def test_spec_summary_fields() -> None:
+    """Spec summary contains the expected keys."""
+    mod = _load_script()
+    from robot_sf.benchmark.observation_perturbation import ObservationPerturbationSpec
+
+    spec = ObservationPerturbationSpec(position_noise_std_m=0.5, seed=42)
+    summary = mod._spec_summary(spec)
+    assert "position_noise_std_m" in summary
+    assert "noise_profile" in summary
+    assert "is_noop" in summary
+    assert summary["position_noise_std_m"] == 0.5
+
+
+def test_script_is_importable() -> None:
+    """The script can be loaded as a module without errors."""
+    mod = _load_script()
+    assert hasattr(mod, "main")
+    assert hasattr(mod, "CONDITIONS")
+    assert hasattr(mod, "evaluate_condition")
+
+
+def _load_fixture_for_test() -> dict:
+    """Load the occluded-emergence fixture for test use."""
+    with open(FIXTURE_PATH) as fh:
+        return json.load(fh)


### PR DESCRIPTION
## Summary
Adds a trace-derived observation-noise robustness envelope for the occluded-emergence near-field fixture, with compact durable evidence and focused tests.

## Linked Issues
- Closes `#2755`
- Follow-up: `#2777`

## Stack / Dependency
- Base dependency: `origin/main` at `2aa3c4688b238817a49ebe17668c488ea2cd228e`
- Required prior PRs: none
- Stack follow-up issues: `#2777`
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/benchmark/run_observation_noise_envelope.py` to evaluate seven perturbation families against the committed occluded-emergence trace fixture.
- Added `tests/benchmark/test_observation_noise_envelope.py` for condition coverage, visibility-boundary semantics, compact evidence shape, and delay behavior.
- Added durable evidence under `docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/`.
- Registered the evidence in `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.

## Why It Matters
- Added value: gives a reproducible near-field stress diagnostic using a fixture where pedestrian visibility changes before conflict.
- Expected impact: narrows #2755 from “unrun robustness envelope” to a concrete diagnostic result with caveats and a live-replay follow-up.
- Why this is worth merging now: it creates a small, reviewable, reusable evidence surface for future live planner replay work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: observation perturbations near first visibility can change interpretable local-policy timing signals.
- Comparator or baseline, if applicable: no-op condition on the same occluded-emergence fixture.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only overall, with delay-only classified as trace-derived robustness evidence and full missed/occlusion/combined classified scenario-too-weak.
- Decision or stop rule, if applicable: stop at trace-derived evidence; promote to live replay before making benchmark-strength claims.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, and issue #2755.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use is tracked in `docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json`; live replay promotion is tracked in #2777.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes for delay-only; low/medium noise did not alter first observation timing in this trace.
- Did the intervention change command source, selected command, trajectory, or route progress? unknown for live behavior; this PR uses stored action proxies only.
- Did the scenario actually contain the targeted failure mode? yes, it has hidden pedestrian state until step 5 and near-field closest distance 0.5 m.
- Result route: continue via #2777 for live replay.
- Follow-up question or issue for weak, negative, or non-transfer results: #2777.

## Next Empirical Action
- Rerun needed: yes, live planner replay for benchmark-strength evidence.
- Extractor or analysis tool needed: no for this diagnostic; live replay path may need integration.
- Artifact missing or unavailable: live planner replay artifacts are deferred.
- Stop / revise / continue decision: continue via #2777.
- Proposed child issue or existing follow-up: #2777.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_observation_noise_envelope.py -q`
  - `uv run pytest tests/benchmark/test_observation_perturbation.py tests/benchmark/test_occluded_emergence_fixture.py tests/benchmark/test_observation_noise_envelope.py -q`
  - `uv run ruff check scripts/benchmark/run_observation_noise_envelope.py tests/benchmark/test_observation_noise_envelope.py`
  - `uv run ruff format --check scripts/benchmark/run_observation_noise_envelope.py tests/benchmark/test_observation_noise_envelope.py`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed at `3dd40232e683d00aa8f8592d515e326606a3eeda` with `6015 passed, 9 skipped`.
- Benchmarks or smoke tests, if applicable: diagnostic script generated tracked `summary.json` and `README.md` from the committed occluded-emergence fixture.

## Risks / Rollout
- Compatibility risks: low; this adds a standalone diagnostic script, tests, and docs/evidence.
- Failure modes: trace-derived action proxies must not be interpreted as live planner response; PR text and evidence call this out.
- Rollback or fallback plan: revert the standalone script/evidence/test additions.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: evidence report includes command, fixture path, repo HEAD, and claim boundary.
- Any assumptions that need to be preserved: first visible fixture step is 5; delay-only uses two-step lag and first observes at step 7.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR linkage.
- Claim map / benchmark report updated (yes/no/NA): NA; diagnostic-only, not paper-facing benchmark proof.
- Leaderboard / artifact catalog updated (yes/no/NA): artifact catalog updated.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): context catalog/evidence README updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #2777.
- Not applicable because: benchmark-strength propagation is deferred until live replay.

## Follow-Up Issues
- Deferred work: live planner observation-noise replay proof.
- Issues opened for follow-up: #2777.

## Reviewer Notes
- Please verify that the claim boundary stays diagnostic-only and that no reviewer reads stored action proxies as live replay evidence.
- OpenCode implementation and review were delegated; Codex repaired the visibility-boundary bug before validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observation-noise robustness evaluation capability with support for multiple perturbation conditions (baseline, noise variants, occlusion, delay, and combined scenarios).

* **Documentation**
  * Added comprehensive evidence documentation and reproducibility metadata for observation-noise robustness evaluation results.

* **Tests**
  * Added comprehensive test suite for observation-noise robustness evaluation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->