### PR TITLE
Add delegated route efficiency report

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -363,6 +363,19 @@ search output or raw GitHub bodies to private agent-run artifacts; return only
 the compact snapshot, context capsule path, validation command, exit status, and
 short evidence excerpt to the parent Codex thread.
 
+After delegated worker runs, summarize route efficiency from one or more
+`scripts/dev/routed_worker_manifest.py` outputs without reading raw worker logs:
+
+```bash
+uv run python scripts/dev/route_efficiency_report.py output/issue-2764/worker/routing_manifest.json \
+  --format markdown
+```
+
+The report counts delegated attempts, complete artifact sets, reroutes,
+validation presence, and optional final acceptance metadata. It is route
+evidence only; local diff review and validation still decide whether the task is
+accepted.
+
 Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
 
 ```bash

--- a/scripts/dev/route_efficiency_report.py
+++ b/scripts/dev/route_efficiency_report.py
@@ -89,13 +89,19 @@ class _Accumulator:
         self.failure_class_incomplete: Counter[str] = Counter()
 
     def process_attempt(self, idx: int, attempt: dict[str, Any]) -> None:
-        compact = attempt.get("compact_artifacts") or {}
+        if not isinstance(attempt, dict):
+            compact: dict[str, Any] = {}
+            provider = "unknown"
+            fc = "malformed"
+        else:
+            compact = attempt.get("compact_artifacts") or {}
+            provider = _provider_name(attempt.get("route"))
+            fc = attempt.get("failure_class") or "unknown"
+
         if _is_complete_artifact_set(compact):
             self.complete_count += 1
         else:
-            provider = _provider_name(attempt.get("route"))
             self.provider_incomplete[provider] += 1
-            fc = attempt.get("failure_class") or "unknown"
             self.failure_class_incomplete[str(fc)] += 1
 
         if _validate_present(compact):
@@ -113,8 +119,10 @@ def _extract_snapshot_outcome(
     """Pull accepted and outcome from optional snapshot metadata."""
     if not isinstance(snapshot, dict):
         return None, None
-    accepted = bool(snapshot["accepted"]) if "accepted" in snapshot else None
-    note = str(snapshot["outcome"]) if "outcome" in snapshot else None
+    accepted_raw = snapshot.get("accepted")
+    accepted = None if accepted_raw is None else bool(accepted_raw)
+    note_raw = snapshot.get("outcome")
+    note = None if note_raw is None else str(note_raw)
     return accepted, note
 
 
@@ -127,7 +135,11 @@ def analyze_manifests(
     acc = _Accumulator()
 
     for manifest in manifests:
+        if not isinstance(manifest, dict):
+            continue
         attempts = manifest.get("attempted_routes") or []
+        if not isinstance(attempts, list):
+            continue
         acc.total_attempts += len(attempts)
         for idx, attempt in enumerate(attempts):
             acc.process_attempt(idx, attempt)
@@ -149,7 +161,11 @@ def analyze_manifests(
         "incomplete_by_failure_class": dict(acc.failure_class_incomplete),
         "final_outcome": {
             "accepted": accepted,
-            "note": acceptance_note or "route evidence only; not task acceptance",
+            "note": (
+                acceptance_note
+                if acceptance_note is not None
+                else "route evidence only; not task acceptance"
+            ),
         },
         "estimated_inspections_avoided": acc.complete_count,
         "warning": ROUTE_EVIDENCE_WARNING,
@@ -217,16 +233,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _load_manifest_file(path: Path) -> list[dict[str, Any]]:
+    """Load one manifest file, accepting either one object or a list of objects."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, dict):
+        return [raw]
+    if isinstance(raw, list):
+        if not all(isinstance(item, dict) for item in raw):
+            raise ValueError(f"{path}: manifest list entries must be JSON objects")
+        return raw
+    raise ValueError(f"{path}: manifest input must be a JSON object or list of objects")
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = _parse_args(argv)
     manifests: list[dict[str, Any]] = []
     for path_str in args.manifests:
-        raw = json.loads(Path(path_str).read_text(encoding="utf-8"))
-        if isinstance(raw, list):
-            manifests.extend(raw)
-        else:
-            manifests.append(raw)
+        manifests.extend(_load_manifest_file(Path(path_str)))
 
     snapshot: dict[str, Any] | None = None
     if args.snapshot:

--- a/scripts/dev/route_efficiency_report.py
+++ b/scripts/dev/route_efficiency_report.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Local route-efficiency report for routed-worker manifests.
+
+Reads one or more routed-worker manifest JSON files and optionally a simple
+PR-loop/snapshot JSON file.  Emits a compact efficiency summary that measures
+whether delegated agent work is saving review effort.
+
+Route success is **not** task success.  The report surfaces this boundary
+explicitly in the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "route_efficiency_report.v1"
+ROUTE_EVIDENCE_WARNING = (
+    "Route success and complete artifact presence are route evidence only; "
+    "they are not task acceptance. The orchestrator must still inspect the "
+    "diff and run the required local validation."
+)
+_EXPECTED_ARTIFACT_KEYS = frozenset(
+    {"result_json", "result_md", "diffstat", "status", "validation"}
+)
+
+
+def _is_complete_artifact_set(compact: dict[str, Any]) -> bool:
+    """Return True when every expected artifact key is present."""
+    if not isinstance(compact, dict):
+        return False
+    return all(
+        isinstance(compact.get(k), dict) and compact[k].get("present") is True
+        for k in _EXPECTED_ARTIFACT_KEYS
+    )
+
+
+def _has_validation_success(compact: dict[str, Any]) -> bool | None:
+    """Return True/False when the validation artifact signals outcome, else None."""
+    val = compact.get("validation") if isinstance(compact, dict) else None
+    if not isinstance(val, dict) or not val.get("present"):
+        return None
+    result_text = val.get("result") or ""
+    if isinstance(result_text, str):
+        lowered = result_text.lower()
+        neutralized = re.sub(r"\b0\s+(?:failed|failures?|errors?)\b", "", lowered)
+        if (
+            "unsuccessful" in neutralized
+            or re.search(r"\b(?:failed|failure|errors?)\b", neutralized)
+            or re.search(r"\b[1-9]\d*\s+(?:failed|failures?|errors?)\b", neutralized)
+        ):
+            return False
+        if re.search(r"\b0\s+passed\b", neutralized):
+            return False
+        if re.search(r"\b(?:pass|passed|success|successful|succeeded|ok)\b", neutralized):
+            return True
+    return None
+
+
+def _provider_name(route: Any) -> str:
+    """Extract a provider label from a route dict, or 'unknown'."""
+    if isinstance(route, dict):
+        return route.get("provider") or route.get("name") or "unknown"
+    return "unknown"
+
+
+def _validate_present(compact: dict[str, Any]) -> bool:
+    """Return True if the validation artifact is present."""
+    if not isinstance(compact, dict):
+        return False
+    val = compact.get("validation")
+    return isinstance(val, dict) and val.get("present") is True
+
+
+class _Accumulator:
+    """Mutable counters for the manifest scan loop."""
+
+    def __init__(self) -> None:
+        self.total_attempts = 0
+        self.complete_count = 0
+        self.validation_present = 0
+        self.validation_success = 0
+        self.reroutes = 0
+        self.provider_incomplete: Counter[str] = Counter()
+        self.failure_class_incomplete: Counter[str] = Counter()
+
+    def process_attempt(self, idx: int, attempt: dict[str, Any]) -> None:
+        compact = attempt.get("compact_artifacts") or {}
+        if _is_complete_artifact_set(compact):
+            self.complete_count += 1
+        else:
+            provider = _provider_name(attempt.get("route"))
+            self.provider_incomplete[provider] += 1
+            fc = attempt.get("failure_class") or "unknown"
+            self.failure_class_incomplete[str(fc)] += 1
+
+        if _validate_present(compact):
+            self.validation_present += 1
+            if _has_validation_success(compact) is True:
+                self.validation_success += 1
+
+        if idx > 0:
+            self.reroutes += 1
+
+
+def _extract_snapshot_outcome(
+    snapshot: dict[str, Any] | None,
+) -> tuple[bool | None, str | None]:
+    """Pull accepted and outcome from optional snapshot metadata."""
+    if not isinstance(snapshot, dict):
+        return None, None
+    accepted = bool(snapshot["accepted"]) if "accepted" in snapshot else None
+    note = str(snapshot["outcome"]) if "outcome" in snapshot else None
+    return accepted, note
+
+
+def analyze_manifests(
+    manifests: list[dict[str, Any]],
+    *,
+    snapshot: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an efficiency report from one or more routed-worker manifests."""
+    acc = _Accumulator()
+
+    for manifest in manifests:
+        attempts = manifest.get("attempted_routes") or []
+        acc.total_attempts += len(attempts)
+        for idx, attempt in enumerate(attempts):
+            acc.process_attempt(idx, attempt)
+
+    accepted, acceptance_note = _extract_snapshot_outcome(snapshot)
+
+    rate = round(acc.complete_count / acc.total_attempts, 4) if acc.total_attempts else 0.0
+    return {
+        "schema": SCHEMA_VERSION,
+        "manifests_analyzed": len(manifests),
+        "delegated_attempts": acc.total_attempts,
+        "complete_artifacts": {"count": acc.complete_count, "rate": rate},
+        "validation_presence": {
+            "present": acc.validation_present,
+            "success_inferable": acc.validation_success,
+        },
+        "reroutes": acc.reroutes,
+        "incomplete_by_provider": dict(acc.provider_incomplete),
+        "incomplete_by_failure_class": dict(acc.failure_class_incomplete),
+        "final_outcome": {
+            "accepted": accepted,
+            "note": acceptance_note or "route evidence only; not task acceptance",
+        },
+        "estimated_inspections_avoided": acc.complete_count,
+        "warning": ROUTE_EVIDENCE_WARNING,
+    }
+
+
+def _format_markdown(report: dict[str, Any]) -> str:
+    """Render the report as a compact Markdown summary."""
+    lines: list[str] = []
+    lines.append("# Route Efficiency Report\n")
+    lines.append(f"- **Manifests analyzed:** {report['manifests_analyzed']}")
+    lines.append(f"- **Delegated attempts:** {report['delegated_attempts']}")
+
+    ca = report["complete_artifacts"]
+    lines.append(
+        f"- **Complete artifacts:** {ca['count']}/{report['delegated_attempts']} ({ca['rate']:.0%})"
+    )
+
+    vp = report["validation_presence"]
+    lines.append(
+        f"- **Validation present:** {vp['present']}"
+        f" | **success inferable:** {vp['success_inferable']}"
+    )
+    lines.append(f"- **Reroutes:** {report['reroutes']}")
+
+    ibp = report["incomplete_by_provider"]
+    if ibp:
+        parts = [f"{k}: {v}" for k, v in sorted(ibp.items())]
+        lines.append(f"- **Incomplete by provider:** {', '.join(parts)}")
+
+    ibf = report["incomplete_by_failure_class"]
+    if ibf:
+        parts = [f"{k}: {v}" for k, v in sorted(ibf.items())]
+        lines.append(f"- **Incomplete by failure class:** {', '.join(parts)}")
+
+    fo = report["final_outcome"]
+    lines.append(f"- **Final accepted:** {fo['accepted']} - {fo['note']}")
+    lines.append(f"- **Estimated inspections avoided:** {report['estimated_inspections_avoided']}")
+    lines.append(f"\n> {report['warning']}\n")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "manifests",
+        nargs="+",
+        help="Routed-worker manifest JSON files.",
+    )
+    parser.add_argument(
+        "--snapshot",
+        help="Optional PR-loop or snapshot JSON with accepted/outcome metadata.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        dest="output_format",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--output",
+        help="Write report to this file instead of stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    manifests: list[dict[str, Any]] = []
+    for path_str in args.manifests:
+        raw = json.loads(Path(path_str).read_text(encoding="utf-8"))
+        if isinstance(raw, list):
+            manifests.extend(raw)
+        else:
+            manifests.append(raw)
+
+    snapshot: dict[str, Any] | None = None
+    if args.snapshot:
+        snapshot = json.loads(Path(args.snapshot).read_text(encoding="utf-8"))
+
+    report = analyze_manifests(manifests, snapshot=snapshot)
+
+    if args.output_format == "markdown":
+        text = _format_markdown(report)
+    else:
+        text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/route_efficiency_report.py
+++ b/scripts/dev/route_efficiency_report.py
@@ -137,7 +137,7 @@ def analyze_manifests(
     for manifest in manifests:
         if not isinstance(manifest, dict):
             continue
-        attempts = manifest.get("attempted_routes") or []
+        attempts = manifest.get("attempted_routes")
         if not isinstance(attempts, list):
             continue
         acc.total_attempts += len(attempts)

--- a/tests/dev/test_route_efficiency_report.py
+++ b/tests/dev/test_route_efficiency_report.py
@@ -1,0 +1,456 @@
+"""Tests for local route-efficiency report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.dev import route_efficiency_report as rer
+
+
+def _compact_artifacts(*, present: bool = True) -> dict[str, dict]:
+    """Build a minimal compact_artifacts block for one attempt."""
+    return {
+        key: {
+            "present": present,
+            "path": f"run/{key}.txt",
+            "reason": None if present else "missing",
+        }
+        for key in rer._EXPECTED_ARTIFACT_KEYS
+    }
+
+
+def _manifest(
+    attempts: list[dict],
+    chosen_index: int = 0,
+    *,
+    chosen_route: dict | None = None,
+) -> dict:
+    """Build a minimal routed-worker manifest."""
+    chosen = chosen_route or attempts[chosen_index].get("route", {})
+    return {
+        "schema": "routed_worker_manifest.v1",
+        "attempted_routes": attempts,
+        "chosen_route": chosen,
+        "route_evidence_only": True,
+        "warning": "route evidence only",
+    }
+
+
+def test_analyze_single_complete_attempt(tmp_path: Path) -> None:
+    """A single complete attempt should yield full artifact rate and zero reroutes."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["manifests_analyzed"] == 1
+    assert report["delegated_attempts"] == 1
+    assert report["complete_artifacts"]["count"] == 1
+    assert report["complete_artifacts"]["rate"] == 1.0
+    assert report["reroutes"] == 0
+    assert report["estimated_inspections_avoided"] == 1
+    assert report["incomplete_by_provider"] == {}
+    assert report["incomplete_by_failure_class"] == {}
+
+
+def test_analyze_tracked_fixture_manifest() -> None:
+    """A tracked fixture should exercise the report's documented manifest input."""
+    manifest_path = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "route_efficiency"
+        / "routing_manifest_complete.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["manifests_analyzed"] == 1
+    assert report["delegated_attempts"] == 1
+    assert report["complete_artifacts"] == {"count": 1, "rate": 1.0}
+    assert report["validation_presence"] == {"present": 1, "success_inferable": 1}
+
+
+def test_analyze_missing_artifacts_counted_as_incomplete() -> None:
+    """Attempts with missing artifacts should feed incomplete breakdowns."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 2,
+                "failure_class": "route-collapse",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 2
+    assert report["complete_artifacts"]["count"] == 1
+    assert report["complete_artifacts"]["rate"] == 0.5
+    assert report["reroutes"] == 1  # second attempt is a reroute
+    assert report["incomplete_by_provider"]["gemini"] == 1
+    assert report["incomplete_by_failure_class"]["route-collapse"] == 1
+
+
+def test_route_success_vs_task_acceptance_distinction() -> None:
+    """A successful route should not imply task acceptance without snapshot."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["final_outcome"]["accepted"] is None
+    assert "not task acceptance" in report["final_outcome"]["note"]
+    assert "not task acceptance" in report["warning"]
+
+
+def test_snapshot_provides_acceptance_metadata() -> None:
+    """When a snapshot provides accepted=True, the report surfaces it."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    snapshot = {"accepted": True, "outcome": "merged"}
+
+    report = rer.analyze_manifests([manifest], snapshot=snapshot)
+
+    assert report["final_outcome"]["accepted"] is True
+    assert report["final_outcome"]["note"] == "merged"
+
+
+def test_multiple_manifests_aggregate() -> None:
+    """Multiple manifests should sum attempts, reroutes, and incomplete counts."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+        ]
+    )
+
+    report = rer.analyze_manifests([m1, m2])
+
+    assert report["manifests_analyzed"] == 2
+    assert report["delegated_attempts"] == 3
+    assert report["complete_artifacts"]["count"] == 2
+    assert report["reroutes"] == 1
+    assert report["incomplete_by_provider"]["gemini"] == 1
+    assert report["incomplete_by_failure_class"]["timeout"] == 1
+
+
+def test_empty_manifest_list() -> None:
+    """An empty manifest list should produce a zeroed-out report."""
+    report = rer.analyze_manifests([])
+
+    assert report["manifests_analyzed"] == 0
+    assert report["delegated_attempts"] == 0
+    assert report["complete_artifacts"]["rate"] == 0.0
+    assert report["estimated_inspections_avoided"] == 0
+
+
+def test_markdown_output_compactness(tmp_path: Path) -> None:
+    """Markdown output should be shorter than JSON and contain key sections."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+    md = rer._format_markdown(report)
+    js = json.dumps(report, indent=2, sort_keys=True)
+
+    assert "# Route Efficiency Report" in md
+    assert "Delegated attempts" in md
+    assert "Complete artifacts" in md
+    assert "Reroutes" in md
+    assert "not task acceptance" in md
+    assert len(md) <= len(js)
+
+
+def test_json_output_includes_schema_and_warning() -> None:
+    """JSON output should always include the schema version and evidence warning."""
+    report = rer.analyze_manifests([])
+    text = json.dumps(report, indent=2, sort_keys=True)
+
+    assert report["schema"] == "route_efficiency_report.v1"
+    assert "route evidence only" in report["warning"]
+    assert "route_efficiency_report.v1" in text
+
+
+def test_validation_success_detection() -> None:
+    """Validation success should be detected from artifact result text."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": {
+                    **_compact_artifacts(present=True),
+                    "validation": {
+                        "present": True,
+                        "path": "run/validation.txt",
+                        "reason": None,
+                        "result": "all tests passed",
+                    },
+                },
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 1
+
+
+def test_validation_success_detection_ignores_zero_failed() -> None:
+    """Common pytest summaries with zero failures should still infer success."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": {
+                    **_compact_artifacts(present=True),
+                    "validation": {
+                        "present": True,
+                        "path": "run/validation.txt",
+                        "reason": None,
+                        "result": "21 passed, 0 failed",
+                    },
+                },
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 1
+
+
+def test_validation_failure_detection() -> None:
+    """Validation failure should be detected but not counted as success."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": {
+                    **_compact_artifacts(present=True),
+                    "validation": {
+                        "present": True,
+                        "path": "run/validation.txt",
+                        "reason": None,
+                        "result": "2 errors found",
+                    },
+                },
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 0
+
+
+def test_validation_failure_detection_avoids_false_positive_substrings() -> None:
+    """Unsuccessful or zero-passed summaries should not infer validation success."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 1,
+                "failure_class": "validation",
+                "compact_artifacts": {
+                    **_compact_artifacts(present=True),
+                    "validation": {
+                        "present": True,
+                        "path": "run/validation.txt",
+                        "reason": None,
+                        "result": "unsuccessful run: 0 passed",
+                    },
+                },
+            }
+        ]
+    )
+
+    report = rer.analyze_manifests([manifest])
+
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 0
+
+
+def test_defensive_handling_of_missing_fields() -> None:
+    """Manifests with missing or malformed fields should not crash the report."""
+    # Completely empty manifest dict.
+    report = rer.analyze_manifests([{}])
+    assert report["delegated_attempts"] == 0
+
+    # Attempt with no compact_artifacts key.
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+            }
+        ]
+    )
+    report = rer.analyze_manifests([manifest])
+    assert report["delegated_attempts"] == 1
+    assert report["complete_artifacts"]["count"] == 0
+
+    # Attempt with non-dict compact_artifacts.
+    manifest2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "compact_artifacts": "not-a-dict",
+            }
+        ]
+    )
+    report2 = rer.analyze_manifests([manifest2])
+    assert report2["complete_artifacts"]["count"] == 0
+
+
+def test_cli_json_output(tmp_path: Path) -> None:
+    """CLI should produce valid JSON to stdout."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    exit_code = rer.main([str(manifest_path)])
+    assert exit_code == 0
+
+
+def test_cli_writes_output_file(tmp_path: Path) -> None:
+    """CLI --output should write the report to a file."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    out_path = tmp_path / "report.json"
+
+    exit_code = rer.main([str(manifest_path), "--output", str(out_path)])
+    assert exit_code == 0
+    assert out_path.exists()
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert data["schema"] == "route_efficiency_report.v1"
+
+
+def test_cli_markdown_output(tmp_path: Path) -> None:
+    """CLI --format markdown should produce Markdown text."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    out_path = tmp_path / "report.md"
+
+    exit_code = rer.main([str(manifest_path), "--format", "markdown", "--output", str(out_path)])
+    assert exit_code == 0
+    text = out_path.read_text(encoding="utf-8")
+    assert "# Route Efficiency Report" in text

--- a/tests/dev/test_route_efficiency_report.py
+++ b/tests/dev/test_route_efficiency_report.py
@@ -154,6 +154,27 @@ def test_snapshot_provides_acceptance_metadata() -> None:
     assert report["final_outcome"]["note"] == "merged"
 
 
+def test_snapshot_preserves_explicit_falsy_metadata() -> None:
+    """Explicit falsy snapshot values should not be replaced by defaults."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    snapshot = {"accepted": 0, "outcome": ""}
+
+    report = rer.analyze_manifests([manifest], snapshot=snapshot)
+
+    assert report["final_outcome"]["accepted"] is False
+    assert report["final_outcome"]["note"] == ""
+
+
 def test_multiple_manifests_aggregate() -> None:
     """Multiple manifests should sum attempts, reroutes, and incomplete counts."""
     m1 = _manifest(
@@ -360,6 +381,10 @@ def test_defensive_handling_of_missing_fields() -> None:
     report = rer.analyze_manifests([{}])
     assert report["delegated_attempts"] == 0
 
+    # Non-dict manifests and malformed attempted_routes are ignored defensively.
+    report = rer.analyze_manifests([[], {"attempted_routes": "not-a-list"}])  # type: ignore[list-item]
+    assert report["delegated_attempts"] == 0
+
     # Attempt with no compact_artifacts key.
     manifest = _manifest(
         [
@@ -387,6 +412,12 @@ def test_defensive_handling_of_missing_fields() -> None:
     )
     report2 = rer.analyze_manifests([manifest2])
     assert report2["complete_artifacts"]["count"] == 0
+
+    # Non-dict attempts are counted as malformed incomplete attempts.
+    manifest3 = {"attempted_routes": ["not-a-dict"]}
+    report3 = rer.analyze_manifests([manifest3])  # type: ignore[list-item]
+    assert report3["delegated_attempts"] == 1
+    assert report3["incomplete_by_failure_class"]["malformed"] == 1
 
 
 def test_cli_json_output(tmp_path: Path) -> None:
@@ -431,6 +462,19 @@ def test_cli_writes_output_file(tmp_path: Path) -> None:
     assert out_path.exists()
     data = json.loads(out_path.read_text(encoding="utf-8"))
     assert data["schema"] == "route_efficiency_report.v1"
+
+
+def test_cli_rejects_malformed_manifest_json(tmp_path: Path) -> None:
+    """CLI loading should reject non-object manifest payloads."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(["not-a-dict"]), encoding="utf-8")
+
+    try:
+        rer.main([str(manifest_path)])
+    except ValueError as exc:
+        assert "manifest list entries" in str(exc)
+    else:  # pragma: no cover - keeps the failure message clear.
+        raise AssertionError("expected malformed manifest list to raise ValueError")
 
 
 def test_cli_markdown_output(tmp_path: Path) -> None:

--- a/tests/fixtures/route_efficiency/routing_manifest_complete.json
+++ b/tests/fixtures/route_efficiency/routing_manifest_complete.json
@@ -1,0 +1,55 @@
+{
+  "chosen_route": {
+    "model": "mimo-v2.5",
+    "provider": "opencode-go"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/issue-2764/worker/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/issue-2764/worker/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/issue-2764/worker/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/issue-2764/worker/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/issue-2764/worker/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "mimo-v2.5",
+        "provider": "opencode-go"
+      },
+      "run_dir": "output/issue-2764/worker"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a local route-efficiency report for routed-worker manifests so delegated worker attempts can be reviewed from compact artifacts instead of raw logs.

## Linked Issues
- Closes #2764

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/route_efficiency_report.py` to summarize delegated attempts, complete artifact sets, reroutes, validation presence, and optional acceptance metadata from routed-worker manifests.
- Added focused unit tests plus a tracked representative fixture under `tests/fixtures/route_efficiency/`.
- Documented the compact report in `docs/dev_guide.md` beside the existing autopilot snapshot helpers.

## Why It Matters
- Added value: makes delegation quality measurable without pulling raw worker logs into the parent thread.
- Expected impact: supports cheaper Codex-controller workflows by exposing route completeness and reroute pressure from compact JSON/Markdown.
- Why this is worth merging now: recent goal-loop work is using more delegated CLIs, so this gives the workflow an immediate review-quality feedback surface.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support helper for agent workflow review, not a research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA - support helper
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2764
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it summarizes delegation route artifacts and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/tooling PR with no research mechanism claim.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; issue contract satisfied for local workflow reporting.
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_route_efficiency_report.py tests/dev/test_routed_worker_manifest.py -q`
  - `uv run ruff check scripts/dev/route_efficiency_report.py tests/dev/test_route_efficiency_report.py`
  - `uv run ruff format --check scripts/dev/route_efficiency_report.py tests/dev/test_route_efficiency_report.py`
  - `git diff --check`
  - `uv run python scripts/dev/route_efficiency_report.py tests/fixtures/route_efficiency/routing_manifest_complete.json --format markdown`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: fixture CLI emitted a compact Markdown report with 1/1 complete artifacts, validation present/success inferable, zero reroutes, and the route-evidence-only warning.
- Benchmarks or smoke tests, if applicable: full PR readiness passed with `6033 passed, 9 skipped, 10 warnings`; stamp `output/validation/pr_ready/issue-2764-route-efficiency-report.json`.

## Risks / Rollout
- Compatibility risks: low; new standalone CLI consumes existing `routed_worker_manifest.v1` fields and leaves existing tooling unchanged.
- Failure modes: validation success inference is heuristic when a manifest includes result text; manifests without result text still report validation presence without overclaiming success.
- Rollback or fallback plan: remove the new script/tests/docs pointer; no runtime behavior depends on it.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`
- Relevant design or provenance notes: active delegation ledger recorded partial OpenCode/Command Code routes and local validation.
- Any assumptions that need to be preserved: route success and artifact completeness remain route evidence only, not task acceptance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #2764
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is workflow support tooling, not benchmark/research evidence.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: route success is intentionally separated from task acceptance in both JSON and Markdown output.
- Any known limitations: `success_inferable` only increments when validation result text is present in the compact manifest; plain artifact-presence manifests report validation presence without claiming success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a route efficiency reporting tool that analyzes worker routing manifests and generates reports showing delegation attempt counts, artifact completeness, validation results, and reroute tracking.

* **Documentation**
  * Updated developer guide with instructions for running and interpreting route efficiency reports.

* **Tests**
  * Added comprehensive test coverage for the reporting tool, including CLI behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->