### PR TITLE
Add live replay eligibility checker

### DIFF
--- a/scripts/validation/check_live_replay_eligibility.py
+++ b/scripts/validation/check_live_replay_eligibility.py
@@ -29,7 +29,7 @@ BOUNDARY_MARKERS = (
     "diagnostic",
     "not benchmark",
     "not paper",
-    "fail-closed",
+    "fail closed",
     "promotion",
     "live replay",
 )
@@ -74,8 +74,8 @@ def _safe_claim_boundary(record: dict[str, Any]) -> tuple[bool, str | None]:
     boundary = _text_value(record, "claim_boundary")
     if boundary is None:
         return False, "missing_claim_boundary"
-    lowered = boundary.lower()
-    if any(marker in lowered for marker in BOUNDARY_MARKERS):
+    normalized = boundary.lower().replace("_", " ").replace("-", " ")
+    if any(marker in normalized for marker in BOUNDARY_MARKERS):
         return True, None
     return False, "unsafe_claim_boundary"
 
@@ -119,6 +119,9 @@ def classify_record(record: Any, *, base_dir: Path | None = None, index: int = 0
             "missing_prerequisites": ["record_object"],
             "blocked_reasons": ["malformed_record"],
             "diagnostic_reasons": [],
+            "fixture_path": None,
+            "policy_candidate": None,
+            "claim_boundary": None,
         }
 
     blocked: list[str] = []

--- a/scripts/validation/check_live_replay_eligibility.py
+++ b/scripts/validation/check_live_replay_eligibility.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Classify diagnostic evidence records for live-replay promotion eligibility.
+
+This checker is a gatekeeping helper only. It does not run live replay and does
+not promote diagnostic evidence to benchmark, dissertation, or paper evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "live_replay_eligibility.v1"
+ELIGIBLE = "eligible"
+MISSING_FIELDS = "missing-fields"
+BLOCKED = "blocked"
+DIAGNOSTIC_ONLY = "diagnostic-only"
+
+REQUIRED_TEXT_PREREQUISITES = {
+    "scenario": ("scenario_id", "scenario_path", "executable_scenario"),
+    "policy_candidate": ("policy_candidate", "planner_id"),
+    "perturbation_config": ("perturbation_config",),
+    "output_report_path": ("output_report_path",),
+}
+BOUNDARY_MARKERS = (
+    "diagnostic",
+    "not benchmark",
+    "not paper",
+    "fail-closed",
+    "promotion",
+    "live replay",
+)
+
+
+def _text_value(record: dict[str, Any], *keys: str) -> str | None:
+    """Return the first non-empty string value among keys."""
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _truthy_bool(value: Any) -> bool:
+    """Return True only for an explicit boolean true value."""
+    return value is True
+
+
+def _evidence_class(record: dict[str, Any]) -> str:
+    """Return a normalized evidence class label."""
+    raw = (
+        record.get("evidence_class")
+        or record.get("classification")
+        or record.get("claim_scope")
+        or ""
+    )
+    return str(raw).strip().lower().replace("_", "-")
+
+
+def _has_live_replay_candidate(record: dict[str, Any]) -> bool:
+    """Return whether the record asks to be considered for live replay."""
+    if _truthy_bool(record.get("live_replay_candidate")):
+        return True
+    promotion_path = str(record.get("promotion_path") or "").lower()
+    normalized = promotion_path.replace("_", " ").replace("-", " ")
+    return normalized.strip() in {"live replay", "live replay promotion"}
+
+
+def _safe_claim_boundary(record: dict[str, Any]) -> tuple[bool, str | None]:
+    """Return whether claim boundary text is present and conservative."""
+    boundary = _text_value(record, "claim_boundary")
+    if boundary is None:
+        return False, "missing_claim_boundary"
+    lowered = boundary.lower()
+    if any(marker in lowered for marker in BOUNDARY_MARKERS):
+        return True, None
+    return False, "unsafe_claim_boundary"
+
+
+def _fixture_exists(record: dict[str, Any], *, base_dir: Path) -> tuple[bool, str | None]:
+    """Return whether the fixture path is declared and exists."""
+    fixture = _text_value(record, "fixture_path")
+    if fixture is None:
+        return False, "fixture_path"
+    path = Path(fixture)
+    if not path.is_absolute():
+        path = base_dir / path
+    if path.exists():
+        return True, None
+    return False, "fixture_path"
+
+
+def _missing_prerequisites(record: dict[str, Any], *, base_dir: Path) -> list[str]:
+    """Return missing live-replay promotion prerequisites."""
+    missing: list[str] = []
+    fixture_ok, fixture_missing = _fixture_exists(record, base_dir=base_dir)
+    if not fixture_ok and fixture_missing is not None:
+        missing.append(fixture_missing)
+
+    for requirement, keys in REQUIRED_TEXT_PREREQUISITES.items():
+        if _text_value(record, *keys) is None:
+            missing.append(requirement)
+
+    if not _truthy_bool(record.get("live_metrics_supported")):
+        missing.append("live_metrics_supported")
+    return missing
+
+
+def classify_record(record: Any, *, base_dir: Path | None = None, index: int = 0) -> dict[str, Any]:
+    """Classify one diagnostic evidence record."""
+    base = (base_dir or Path.cwd()).resolve()
+    if not isinstance(record, dict):
+        return {
+            "index": index,
+            "status": BLOCKED,
+            "missing_prerequisites": ["record_object"],
+            "blocked_reasons": ["malformed_record"],
+            "diagnostic_reasons": [],
+        }
+
+    blocked: list[str] = []
+    diagnostic: list[str] = []
+    missing = _missing_prerequisites(record, base_dir=base)
+
+    boundary_ok, boundary_reason = _safe_claim_boundary(record)
+    if not boundary_ok and boundary_reason is not None:
+        blocked.append(boundary_reason)
+
+    blocked_reason = _text_value(record, "blocked_reason")
+    if blocked_reason is not None:
+        blocked.append(blocked_reason)
+
+    evidence_class = _evidence_class(record)
+    if evidence_class in {"diagnostic-only", "diagnostic"} and not _has_live_replay_candidate(
+        record
+    ):
+        diagnostic.append("record_declares_diagnostic_only_without_live_replay_candidate")
+
+    if blocked:
+        status = BLOCKED
+    elif missing:
+        status = MISSING_FIELDS
+    elif diagnostic:
+        status = DIAGNOSTIC_ONLY
+    else:
+        status = ELIGIBLE
+
+    return {
+        "index": index,
+        "status": status,
+        "missing_prerequisites": sorted(set(missing)),
+        "blocked_reasons": blocked,
+        "diagnostic_reasons": diagnostic,
+        "fixture_path": record.get("fixture_path"),
+        "policy_candidate": record.get("policy_candidate") or record.get("planner_id"),
+        "claim_boundary": record.get("claim_boundary"),
+    }
+
+
+def load_records(path: Path) -> list[Any]:
+    """Load a JSON object, list, or object with an evidence_records list."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, dict) and isinstance(raw.get("evidence_records"), list):
+        return raw["evidence_records"]
+    if isinstance(raw, list):
+        return raw
+    return [raw]
+
+
+def evaluate_records(records: list[Any], *, base_dir: Path | None = None) -> dict[str, Any]:
+    """Evaluate records and return a machine-readable report."""
+    classifications = [
+        classify_record(record, base_dir=base_dir, index=index)
+        for index, record in enumerate(records)
+    ]
+    counts: dict[str, int] = {}
+    for row in classifications:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+    return {
+        "live_replay_eligibility": {
+            "schema_version": SCHEMA_VERSION,
+            "classifications": classifications,
+            "counts": counts,
+            "claim_boundary": (
+                "Eligibility means prerequisites for a future live-replay promotion check are "
+                "present. It is not benchmark evidence, paper evidence, or live-replay proof."
+            ),
+        }
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("records", type=Path, help="JSON record, list, or evidence_records object.")
+    parser.add_argument("--base-dir", type=Path, default=Path("."))
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the live-replay eligibility checker."""
+    args = build_parser().parse_args(argv)
+    report = evaluate_records(load_records(args.records), base_dir=args.base_dir)
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+    counts = report["live_replay_eligibility"]["counts"]
+    total = sum(counts.values())
+    return 0 if total > 0 and counts == {ELIGIBLE: total} else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/validation/test_check_live_replay_eligibility.py
+++ b/tests/validation/test_check_live_replay_eligibility.py
@@ -1,0 +1,208 @@
+"""Tests for live-replay promotion eligibility classification."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from scripts.validation import check_live_replay_eligibility as checker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _fixture(tmp_path: Path) -> Path:
+    path = tmp_path / "fixtures" / "trace.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"trace": true}\n', encoding="utf-8")
+    return path
+
+
+def _eligible_record(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "fixture_path": str(_fixture(tmp_path)),
+        "scenario_id": "issue_2756_occluded_emergence",
+        "policy_candidate": "hybrid_rule_v0_minimal",
+        "perturbation_config": "configs/perturbations/occluded_emergence.yaml",
+        "output_report_path": "output/live_replay/issue_2789/report.json",
+        "live_metrics_supported": True,
+        "claim_boundary": "diagnostic-only; live replay promotion required; not benchmark evidence",
+        "evidence_class": "diagnostic_only",
+        "live_replay_candidate": True,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_eligible_record_reports_eligible(tmp_path: Path) -> None:
+    """A complete promotion candidate should be eligible, not proof."""
+    report = checker.evaluate_records([_eligible_record(tmp_path)], base_dir=tmp_path)
+    payload = report["live_replay_eligibility"]
+
+    assert payload["schema_version"] == "live_replay_eligibility.v1"
+    assert payload["counts"] == {"eligible": 1}
+    assert payload["classifications"][0]["status"] == "eligible"
+    assert "not benchmark evidence" in payload["claim_boundary"]
+
+
+def test_missing_fixture_reports_missing_fields(tmp_path: Path) -> None:
+    """A missing fixture path should fail closed as missing prerequisites."""
+    record = _eligible_record(tmp_path, fixture_path="missing/trace.json")
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "missing-fields"
+    assert "fixture_path" in row["missing_prerequisites"]
+
+
+def test_missing_policy_reports_missing_fields(tmp_path: Path) -> None:
+    """Policy candidate or planner id is required."""
+    record = _eligible_record(tmp_path)
+    record.pop("policy_candidate")
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "missing-fields"
+    assert "policy_candidate" in row["missing_prerequisites"]
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_missing"),
+    [
+        ("scenario_id", "scenario"),
+        ("perturbation_config", "perturbation_config"),
+        ("output_report_path", "output_report_path"),
+    ],
+)
+def test_required_text_prerequisites_report_missing_fields(
+    tmp_path: Path,
+    field: str,
+    expected_missing: str,
+) -> None:
+    """Each required text prerequisite should have direct missing-field coverage."""
+    record = _eligible_record(tmp_path)
+    record.pop(field)
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "missing-fields"
+    assert expected_missing in row["missing_prerequisites"]
+
+
+def test_missing_metrics_reports_missing_fields(tmp_path: Path) -> None:
+    """Live metric support must be explicit true."""
+    record = _eligible_record(tmp_path, live_metrics_supported=False)
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "missing-fields"
+    assert "live_metrics_supported" in row["missing_prerequisites"]
+
+
+def test_blocked_claim_boundary_case(tmp_path: Path) -> None:
+    """Missing or unsafe claim boundary should block promotion eligibility."""
+    record = _eligible_record(tmp_path, claim_boundary="ready for paper table")
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "blocked"
+    assert row["blocked_reasons"] == ["unsafe_claim_boundary"]
+
+
+def test_missing_claim_boundary_blocks_promotion(tmp_path: Path) -> None:
+    """Absent claim boundary should fail closed as blocked."""
+    record = _eligible_record(tmp_path)
+    record.pop("claim_boundary")
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "blocked"
+    assert row["blocked_reasons"] == ["missing_claim_boundary"]
+
+
+def test_diagnostic_only_without_candidate_stays_diagnostic_only(tmp_path: Path) -> None:
+    """Diagnostic records that do not request promotion should stay diagnostic-only."""
+    record = _eligible_record(tmp_path, live_replay_candidate=False)
+    record.pop("promotion_path", None)
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "diagnostic-only"
+    assert row["diagnostic_reasons"] == [
+        "record_declares_diagnostic_only_without_live_replay_candidate"
+    ]
+
+
+def test_mixed_batch_exit_code_is_fail_closed(tmp_path: Path, capsys) -> None:
+    """Any non-eligible row should make the CLI return nonzero."""
+    records = tmp_path / "records.json"
+    payload = [
+        _eligible_record(tmp_path),
+        _eligible_record(tmp_path, live_metrics_supported=False),
+    ]
+    records.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = checker.main([str(records), "--base-dir", str(tmp_path)])
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out)["live_replay_eligibility"]["counts"] == {
+        "eligible": 1,
+        "missing-fields": 1,
+    }
+
+
+def test_malformed_record_blocks_fail_closed(tmp_path: Path) -> None:
+    """Malformed JSON list entries should fail closed as blocked."""
+    row = checker.evaluate_records(["not-a-record"], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "blocked"
+    assert row["missing_prerequisites"] == ["record_object"]
+    assert row["blocked_reasons"] == ["malformed_record"]
+
+
+def test_cli_writes_json_and_uses_blocked_exit_code(tmp_path: Path, capsys) -> None:
+    """CLI should write JSON and return nonzero when blocked rows exist."""
+    records = tmp_path / "records.json"
+    output = tmp_path / "report.json"
+    records.write_text(json.dumps(["bad-record"]), encoding="utf-8")
+
+    exit_code = checker.main(
+        [str(records), "--base-dir", str(tmp_path), "--output-json", str(output)]
+    )
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert stdout_payload == file_payload
+    assert file_payload["live_replay_eligibility"]["counts"] == {"blocked": 1}
+
+
+def test_cli_returns_success_for_all_eligible_records(tmp_path: Path, capsys) -> None:
+    """CLI should return zero only when every record is eligible."""
+    records = tmp_path / "records.json"
+    records.write_text(json.dumps([_eligible_record(tmp_path)]), encoding="utf-8")
+
+    exit_code = checker.main([str(records), "--base-dir", str(tmp_path)])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["live_replay_eligibility"]["counts"] == {
+        "eligible": 1
+    }

--- a/tests/validation/test_check_live_replay_eligibility.py
+++ b/tests/validation/test_check_live_replay_eligibility.py
@@ -121,6 +121,20 @@ def test_blocked_claim_boundary_case(tmp_path: Path) -> None:
     assert row["blocked_reasons"] == ["unsafe_claim_boundary"]
 
 
+def test_claim_boundary_accepts_hyphen_and_underscore_variants(tmp_path: Path) -> None:
+    """Boundary matching should normalize common separator variants."""
+    record = _eligible_record(
+        tmp_path,
+        claim_boundary="diagnostic_only; live_replay promotion required; fail_closed",
+    )
+
+    row = checker.evaluate_records([record], base_dir=tmp_path)["live_replay_eligibility"][
+        "classifications"
+    ][0]
+
+    assert row["status"] == "eligible"
+
+
 def test_missing_claim_boundary_blocks_promotion(tmp_path: Path) -> None:
     """Absent claim boundary should fail closed as blocked."""
     record = _eligible_record(tmp_path)
@@ -176,6 +190,9 @@ def test_malformed_record_blocks_fail_closed(tmp_path: Path) -> None:
     assert row["status"] == "blocked"
     assert row["missing_prerequisites"] == ["record_object"]
     assert row["blocked_reasons"] == ["malformed_record"]
+    assert row["fixture_path"] is None
+    assert row["policy_candidate"] is None
+    assert row["claim_boundary"] is None
 
 
 def test_cli_writes_json_and_uses_blocked_exit_code(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
Adds a fail-closed live-replay eligibility checker for diagnostic evidence records, plus fixture-style tests covering eligible, missing, blocked, diagnostic-only, and malformed cases.

## Linked Issues
- Closes #2789

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/validation/check_live_replay_eligibility.py`.
- Added `tests/validation/test_check_live_replay_eligibility.py`.
- The checker accepts JSON object/list/`evidence_records`, emits `eligible`, `missing-fields`, `blocked`, or `diagnostic-only`, and keeps the output boundary explicitly non-claim-grade.

## Why It Matters
- Added value: diagnostic artifacts can now state whether they have prerequisites for a future live-replay promotion check.
- Expected impact: improves reproducibility and ranking of diagnostic evidence without accidentally promoting it.
- Why this is worth merging now: follows #2778/#2777 evidence-boundary work and gives the repo a cheap fail-closed preflight.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: diagnostic evidence promotion readiness only.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke / support helper
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: diagnostic records with missing prerequisites stay non-eligible; no benchmark/paper claim is created.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2789
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper; representative dry-run used a tracked diagnostic fixture record and emitted `eligible` only for future live-replay promotion, not proof.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, checker classified complete and incomplete fixture records.
- Did the intervention change command source, selected command, trajectory, or route progress? NA - no live replay is run.
- Did the scenario actually contain the targeted failure mode? dry-run references the occluded-emergence diagnostic fixture from #2755/#2756.
- Result route: continue to live replay only when a downstream issue runs the actual promotion proof.
- Follow-up question or issue for weak, negative, or non-transfer results: #2777 remains the live-replay proof path.

## Next Empirical Action
- Rerun needed: no for this helper.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for helper validation.
- Stop / revise / continue decision: stop for #2789; continue with live replay in #2777 or successor work.
- Proposed child issue or existing follow-up: #2777

## Validation / Proof
- Commands run:
  - `uv run pytest tests/validation/test_check_live_replay_eligibility.py -q`
  - `uv run pytest tests/validation/test_check_live_replay_eligibility.py tests/validation/test_check_claim_readiness.py -q`
  - `uv run ruff check scripts/validation/check_live_replay_eligibility.py tests/validation/test_check_live_replay_eligibility.py`
  - `uv run ruff format --check scripts/validation/check_live_replay_eligibility.py tests/validation/test_check_live_replay_eligibility.py`
  - `git diff --check`
  - `uv run python scripts/validation/check_live_replay_eligibility.py output/issue-2789-dry-run-record.json --base-dir . --output-json output/issue-2789-live-replay-eligibility-report.json`
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: dry-run emitted `eligible: 1` for the tracked occluded-emergence diagnostic fixture record with an explicit not-benchmark/not-paper/not-live-proof boundary.
- Benchmarks or smoke tests, if applicable: full readiness passed with `6049 passed, 9 skipped, 9 warnings`; stamp `output/validation/pr_ready/issue-2789-live-replay-eligibility.json`.

## Risks / Rollout
- Compatibility risks: low; new standalone script and tests.
- Failure modes: input schemas may evolve; unknown/malformed records fail closed as `blocked`.
- Rollback or fallback plan: remove the new script/tests; no runtime path depends on it.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: active delegation ledger records scout/implementation/review routes and dry-run output.
- Any assumptions that need to be preserved: eligibility is only a future-promotion preflight, not live replay or benchmark proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #2789
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA, existing #2777 covers live replay proof.
- Not applicable because: this helper classifies promotion eligibility but does not promote evidence.

## Follow-Up Issues
- Deferred work: actual live-replay proof remains out of scope.
- Issues opened for follow-up: none; existing #2777 remains relevant.

## Reviewer Notes
- Anything a reviewer should verify closely: CLI exit code is fail-closed; it returns zero only when every record is eligible.
- Any known limitations: the checker validates declared prerequisites and local fixture existence, not scenario executability by running the simulator.
