### PR TITLE
analysis: classify observation-noise mechanisms

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1180,6 +1180,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -103,6 +103,10 @@ Policy caveats:
   (noop, low/medium Gaussian noise, missed detection, occlusion, delay, combined) against
   the occluded-emergence trace fixture. Delay-only is trace-derived robustness evidence;
   other conditions are diagnostic_only or scenario_too_weak. Not paper-facing benchmark evidence.
+- `issue_2782_observation_noise_mechanisms/`: diagnostic mechanism-layer classification for the
+  Issue #2755 observation-noise envelope. Maps each perturbation condition to the pipeline layer
+  where the perturbation did, did not, or could not be shown to propagate. Not paper-facing
+  benchmark evidence.
 - `issue_2756_occluded_emergence_2026-06-13/`: smoke/diagnostic note for the
   deterministic occluded-emergence trace fixture. The fixture separates ground-truth and observed
   pedestrian state, records first visibility and conflict timing, and feeds observation-noise plus

--- a/docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
+++ b/docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
@@ -1,0 +1,112 @@
+# Observation-Noise Mechanism Classification
+
+## Claim Boundary
+
+**Diagnostic mechanism-layer classification only. Not paper-facing benchmark proof.**
+This classifies each perturbation condition from the observation-noise envelope by the pipeline layer at which it had (or did not have) an effect: observation source, command, trajectory, or timing.
+The label table is the valid vocabulary; the distribution section shows which labels were actually assigned for this evidence bundle.
+
+## Reproducibility
+
+- **Issue:** #2782
+- **Generated at (UTC):** 2026-06-13T15:23:51.094473+00:00
+- **Command:** `uv run python scripts/tools/classify_observation_noise_mechanisms.py --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms`
+- **Repo HEAD:** `165444d1`
+- **Source evidence:** `docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json`
+- **Fixture:** `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json`
+- **Scenario:** issue_2756_occluded_emergence
+- **First visible step:** 5
+
+## Mechanism Label Vocabulary
+
+| Label | Pipeline layer | Meaning |
+|---|---|---|
+| `noise_stayed_below_decision_threshold` | Decision | Noise present but did not cross the decision boundary |
+| `observation_affected_source_but_not_command` | Observation -> Command | Observation perturbed but command unchanged |
+| `observation_did_not_affect_selected_source` | Observation | Perturbation did not reach the policy input |
+| `command_changed_but_trajectory_did_not` | Command -> Trajectory | Command changed but trajectory unchanged |
+| `delay_shifted_stop_timing` | Timing | Delay shifted stop/yield decision timing |
+| `occlusion_changed_first_actionable_frame` | Observation timing | Occlusion changed when policy first saw the pedestrian |
+| `scenario_had_no_actionable_conflict` | Scenario | No actionable conflict for noise testing |
+| `stored_action_proxy_prevents_live_conclusion` | Proxy boundary | Action proxies from stored trace; live replay required |
+| `diagnostic_only` | Reference | Baseline or mixed-effects reference |
+| `inconclusive` | Fallback | Insufficient data for classification |
+
+## Conditions
+
+### noop
+
+- **Mechanism label:** `diagnostic_only`
+  - No-perturbation baseline; mechanism classification is not applicable to the reference trajectory.
+- **Prior classification:** `diagnostic_only`
+- **Noise profile:** none
+- **Response delay:** 0 steps
+- **Closest distance:** 0.5 m
+
+### low_noise
+
+- **Mechanism label:** `noise_stayed_below_decision_threshold`
+  - Gaussian noise (std=0.10 m) applied but policy command sequence matches baseline. Noise stayed below the decision threshold for this planner/scenario combination.
+- **Prior classification:** `diagnostic_only`
+- **Noise profile:** bounded_gaussian
+- **Response delay:** 0 steps
+- **Closest distance:** 0.5 m
+
+### medium_noise
+
+- **Mechanism label:** `observation_affected_source_but_not_command`
+  - Gaussian noise (std=0.30 m) perturbed the observation source but the policy command sequence matches baseline. The perturbation did not propagate to the command layer.
+- **Prior classification:** `diagnostic_only`
+- **Noise profile:** bounded_gaussian
+- **Response delay:** 0 steps
+- **Closest distance:** 0.5 m
+
+### missed_detection_only
+
+- **Mechanism label:** `occlusion_changed_first_actionable_frame`
+  - Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached.
+- **Prior classification:** `scenario_too_weak`
+- **Noise profile:** missed_detection
+- **Closest distance:** 0.5 m
+
+### occlusion_only
+
+- **Mechanism label:** `occlusion_changed_first_actionable_frame`
+  - Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached.
+- **Prior classification:** `scenario_too_weak`
+- **Noise profile:** occlusion_mask
+- **Closest distance:** 0.5 m
+
+### delay_only
+
+- **Mechanism label:** `delay_shifted_stop_timing`
+  - Observation arrived 2 step(s) after first-visible (step 7). Stop/yield feasibility at first observation differs from baseline, indicating the delay shifted decision timing.
+- **Prior classification:** `robustness_evidence`
+- **Noise profile:** delayed_observation
+- **Response delay:** 2 steps
+- **Closest distance:** 0.5 m
+
+### combined
+
+- **Mechanism label:** `occlusion_changed_first_actionable_frame`
+  - Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached.
+- **Prior classification:** `scenario_too_weak`
+- **Noise profile:** bounded_gaussian
+- **Closest distance:** 0.5 m
+
+## Mechanism Distribution
+
+| Mechanism label | Conditions | Count |
+|---|---|---|
+| `delay_shifted_stop_timing` | delay_only | 1 |
+| `diagnostic_only` | noop | 1 |
+| `noise_stayed_below_decision_threshold` | low_noise | 1 |
+| `observation_affected_source_but_not_command` | medium_noise | 1 |
+| `occlusion_changed_first_actionable_frame` | missed_detection_only, occlusion_only, combined | 3 |
+
+## Caveats
+
+- Single deterministic fixture (seed=111), single scenario family.
+- Action proxies are from the stored trace, not re-executed; command -> trajectory conclusions require live replay.
+- Mechanism labels are rule-based heuristics, not causal proof.
+- Not paper-facing benchmark evidence.

--- a/docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
+++ b/docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
@@ -9,9 +9,9 @@ The label table is the valid vocabulary; the distribution section shows which la
 ## Reproducibility
 
 - **Issue:** #2782
-- **Generated at (UTC):** 2026-06-13T15:23:51.094473+00:00
+- **Generated at (UTC):** 2026-06-13T15:38:38.522073+00:00
 - **Command:** `uv run python scripts/tools/classify_observation_noise_mechanisms.py --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms`
-- **Repo HEAD:** `165444d1`
+- **Repo HEAD:** `d6078ca2`
 - **Source evidence:** `docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json`
 - **Fixture:** `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json`
 - **Scenario:** issue_2756_occluded_emergence

--- a/docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json
+++ b/docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json
@@ -5,9 +5,9 @@
   "source_evidence": "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json",
   "reproducibility": {
     "issue": 2782,
-    "generated_at_utc": "2026-06-13T15:23:51.094473+00:00",
+    "generated_at_utc": "2026-06-13T15:38:38.522073+00:00",
     "command": "uv run python scripts/tools/classify_observation_noise_mechanisms.py --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms",
-    "repo_head": "165444d1"
+    "repo_head": "d6078ca2"
   },
   "fixture": {
     "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",

--- a/docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json
+++ b/docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json
@@ -1,0 +1,354 @@
+{
+  "schema_version": "observation_noise_mechanism.v1",
+  "issue": 2782,
+  "claim_boundary": "Diagnostic mechanism-layer classification of observation-noise envelope evidence. Not paper-facing benchmark proof. Classifies each perturbation condition by the pipeline layer at which it had (or did not have) an effect.",
+  "source_evidence": "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json",
+  "reproducibility": {
+    "issue": 2782,
+    "generated_at_utc": "2026-06-13T15:23:51.094473+00:00",
+    "command": "uv run python scripts/tools/classify_observation_noise_mechanisms.py --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms",
+    "repo_head": "165444d1"
+  },
+  "fixture": {
+    "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",
+    "scenario_id": "issue_2756_occluded_emergence",
+    "first_visible_step": 5
+  },
+  "mechanism_labels_valid": [
+    "command_changed_but_trajectory_did_not",
+    "delay_shifted_stop_timing",
+    "diagnostic_only",
+    "inconclusive",
+    "noise_stayed_below_decision_threshold",
+    "observation_affected_source_but_not_command",
+    "observation_did_not_affect_selected_source",
+    "occlusion_changed_first_actionable_frame",
+    "scenario_had_no_actionable_conflict",
+    "stored_action_proxy_prevents_live_conclusion"
+  ],
+  "mechanism_labels_assigned": [
+    "delay_shifted_stop_timing",
+    "diagnostic_only",
+    "noise_stayed_below_decision_threshold",
+    "observation_affected_source_but_not_command",
+    "occlusion_changed_first_actionable_frame"
+  ],
+  "conditions": [
+    {
+      "condition": "noop",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "none",
+        "is_noop": true
+      },
+      "mechanism": {
+        "label": "diagnostic_only",
+        "rationale": "No-perturbation baseline; mechanism classification is not applicable to the reference trajectory."
+      },
+      "condition_classification": {
+        "label": "diagnostic_only",
+        "rationale": "No-perturbation baseline. Provides reference robot-pedestrian trajectory and action selection without observation noise."
+      },
+      "response_delay_steps": 0,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "low_noise",
+      "spec": {
+        "position_noise_std_m": 0.1,
+        "position_noise_bound_m": 0.2,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "noise_stayed_below_decision_threshold",
+        "rationale": "Gaussian noise (std=0.10 m) applied but policy command sequence matches baseline. Noise stayed below the decision threshold for this planner/scenario combination."
+      },
+      "condition_classification": {
+        "label": "diagnostic_only",
+        "rationale": "Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence."
+      },
+      "response_delay_steps": 0,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "medium_noise",
+      "spec": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "observation_affected_source_but_not_command",
+        "rationale": "Gaussian noise (std=0.30 m) perturbed the observation source but the policy command sequence matches baseline. The perturbation did not propagate to the command layer."
+      },
+      "condition_classification": {
+        "label": "diagnostic_only",
+        "rationale": "Perturbation produced mixed effects. Classified as diagnostic-only pending broader seed/scenario evidence."
+      },
+      "response_delay_steps": 0,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "missed_detection_only",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 1.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "missed_detection",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "occlusion_changed_first_actionable_frame",
+        "rationale": "Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached."
+      },
+      "condition_classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian fully missed after fixture visibility begins; no observation signal reaches the policy. Cannot test policy robustness."
+      },
+      "response_delay_steps": null,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "occlusion_only",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": true,
+        "delay_steps": 0,
+        "noise_profile": "occlusion_mask",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "occlusion_changed_first_actionable_frame",
+        "rationale": "Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached."
+      },
+      "condition_classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy."
+      },
+      "response_delay_steps": null,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "delay_only",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 2,
+        "noise_profile": "delayed_observation",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "delay_shifted_stop_timing",
+        "rationale": "Observation arrived 2 step(s) after first-visible (step 7). Stop/yield feasibility at first observation differs from baseline, indicating the delay shifted decision timing."
+      },
+      "condition_classification": {
+        "label": "robustness_evidence",
+        "rationale": "Pedestrian observed at step 7 (2 steps after first-visible). Perturbation delayed/masked the observation and may have affected policy response timing."
+      },
+      "response_delay_steps": 2,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    },
+    {
+      "condition": "combined",
+      "spec": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": true,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false
+      },
+      "mechanism": {
+        "label": "occlusion_changed_first_actionable_frame",
+        "rationale": "Perturbation completely suppressed the pedestrian observation (missed detections or occlusion mask). The first actionable frame was changed or never reached."
+      },
+      "condition_classification": {
+        "label": "scenario_too_weak",
+        "rationale": "Pedestrian position/velocity zeroed by occlusion after fixture visibility begins; no observation signal reaches the policy."
+      },
+      "response_delay_steps": null,
+      "closest_distance_m": 0.5,
+      "action_proxy_changes": {
+        "linear_velocity_changed": true,
+        "events": [
+          "approach_occluder",
+          "last_occluded_frame",
+          "first_visible",
+          "yield_start",
+          "yield",
+          "yield_complete",
+          "conflict_time",
+          "post_conflict",
+          "resume",
+          "clear"
+        ],
+        "velocity_range": [
+          0.0,
+          0.6
+        ]
+      }
+    }
+  ],
+  "summary": {
+    "total_conditions": 7,
+    "mechanism_distribution": {
+      "diagnostic_only": 1,
+      "noise_stayed_below_decision_threshold": 1,
+      "observation_affected_source_but_not_command": 1,
+      "occlusion_changed_first_actionable_frame": 3,
+      "delay_shifted_stop_timing": 1
+    },
+    "mechanism_to_conditions": {
+      "diagnostic_only": [
+        "noop"
+      ],
+      "noise_stayed_below_decision_threshold": [
+        "low_noise"
+      ],
+      "observation_affected_source_but_not_command": [
+        "medium_noise"
+      ],
+      "occlusion_changed_first_actionable_frame": [
+        "missed_detection_only",
+        "occlusion_only",
+        "combined"
+      ],
+      "delay_shifted_stop_timing": [
+        "delay_only"
+      ]
+    }
+  }
+}

--- a/robot_sf/benchmark/observation_noise_mechanism_classifier.py
+++ b/robot_sf/benchmark/observation_noise_mechanism_classifier.py
@@ -1,0 +1,219 @@
+"""Mechanism-layer classifier for observation-noise envelope evidence.
+
+Turns per-condition evaluation results from the observation-noise envelope
+into mechanism-layer labels that describe *where* in the observation ->
+perception -> command -> trajectory pipeline the perturbation had (or did
+not have) an effect.
+
+This is diagnostic, rule-based evidence only. It does not infer causality
+from a single fixture and does not promote benchmark or paper-facing claims.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MECHANISM_LABELS: set[str] = {
+    "observation_did_not_affect_selected_source",
+    "observation_affected_source_but_not_command",
+    "command_changed_but_trajectory_did_not",
+    "delay_shifted_stop_timing",
+    "occlusion_changed_first_actionable_frame",
+    "noise_stayed_below_decision_threshold",
+    "scenario_had_no_actionable_conflict",
+    "stored_action_proxy_prevents_live_conclusion",
+    "diagnostic_only",
+    "inconclusive",
+}
+
+# Near-field threshold in metres; scenarios farther away lack actionable
+# conflict for observation-noise testing.
+_NEAR_FIELD_THRESHOLD_M: float = 2.0
+
+# Heuristic boundary for "small" Gaussian noise that is unlikely to cross
+# a decision boundary in the default hybrid_rule_v0 planner.
+_SMALL_NOISE_STD_M: float = 0.15
+
+
+def classify_mechanism(
+    condition_result: dict[str, Any],
+    fixture_meta: dict[str, Any],
+    noop_result: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Classify one perturbation condition by mechanism layer.
+
+    Args:
+        condition_result: Single condition dict from ``evaluate_condition``.
+        fixture_meta: Fixture metadata with at least ``first_visible_step``.
+        noop_result: Optional baseline (noop) condition result for command
+            comparison.  When *None*, command-comparison labels fall back to
+            ``stored_action_proxy_prevents_live_conclusion``.
+
+    Returns:
+        ``{"label": <mechanism_label>, "rationale": <str>}``
+    """
+    spec: dict[str, Any] = condition_result.get("spec", {})
+    first_observed: int | None = condition_result.get("first_observed_step")
+    response_delay: int | None = condition_result.get("response_delay_steps")
+    closest_dist: float | None = condition_result.get("closest_distance_m")
+    action_proxy: dict[str, Any] = condition_result.get("action_proxy_changes", {})
+    missed_total: int = condition_result.get("missed_actor_observations_total", 0)
+    occluded_total: int = condition_result.get("occluded_actor_observations_total", 0)
+    stop_yield: dict[str, Any] = condition_result.get("stop_yield_feasibility", {})
+
+    if spec.get("is_noop", False):
+        return {
+            "label": "diagnostic_only",
+            "rationale": (
+                "No-perturbation baseline; mechanism classification is not "
+                "applicable to the reference trajectory."
+            ),
+        }
+
+    if first_observed is None:
+        if missed_total > 0 or occluded_total > 0:
+            return {
+                "label": "occlusion_changed_first_actionable_frame",
+                "rationale": (
+                    "Perturbation completely suppressed the pedestrian "
+                    "observation (missed detections or occlusion mask). "
+                    "The first actionable frame was changed or never reached."
+                ),
+            }
+        return {
+            "label": "inconclusive",
+            "rationale": (
+                "Pedestrian never observed but no missed-detection or "
+                "occlusion signal recorded. Insufficient data for mechanism "
+                "classification."
+            ),
+        }
+
+    # Evaluate "no actionable conflict" after complete missed/occluded
+    # observations so the scenario fallback does not mask an observation
+    # mechanism when both signals are present.
+    if closest_dist is not None and closest_dist > _NEAR_FIELD_THRESHOLD_M:
+        return {
+            "label": "scenario_had_no_actionable_conflict",
+            "rationale": (
+                f"Closest robot-pedestrian distance ({closest_dist:.2f} m) "
+                f"exceeds near-field threshold ({_NEAR_FIELD_THRESHOLD_M} m). "
+                "No actionable conflict for observation-noise testing."
+            ),
+        }
+
+    if response_delay is not None and response_delay > 0:
+        stop_changed = _stop_yield_changed(stop_yield, noop_result)
+        rationale_parts = [
+            (
+                f"Observation arrived {response_delay} step(s) after "
+                f"first-visible (step {first_observed})."
+            ),
+        ]
+        if stop_changed:
+            rationale_parts.append(
+                "Stop/yield feasibility at first observation differs from "
+                "baseline, indicating the delay shifted decision timing."
+            )
+        return {
+            "label": "delay_shifted_stop_timing",
+            "rationale": " ".join(rationale_parts),
+        }
+
+    has_noise = spec.get("position_noise_std_m", 0.0) > 0.0
+    if has_noise:
+        command_same = _command_unchanged(action_proxy, noop_result)
+        if command_same:
+            noise_std = spec.get("position_noise_std_m", 0.0)
+            if noise_std <= _SMALL_NOISE_STD_M:
+                return {
+                    "label": "noise_stayed_below_decision_threshold",
+                    "rationale": (
+                        f"Gaussian noise (std={noise_std:.2f} m) applied but "
+                        "policy command sequence matches baseline. Noise "
+                        "stayed below the decision threshold for this "
+                        "planner/scenario combination."
+                    ),
+                }
+            return {
+                "label": "observation_affected_source_but_not_command",
+                "rationale": (
+                    f"Gaussian noise (std={noise_std:.2f} m) perturbed the "
+                    "observation source but the policy command sequence "
+                    "matches baseline. The perturbation did not propagate "
+                    "to the command layer."
+                ),
+            }
+        # Command changed, but trajectory comparison requires live replay.
+        return {
+            "label": "stored_action_proxy_prevents_live_conclusion",
+            "rationale": (
+                "Noise perturbed the observation and the stored-trace action "
+                "proxy differs from baseline, but live replay is required to "
+                "determine whether the trajectory actually changed."
+            ),
+        }
+
+    return {
+        "label": "inconclusive",
+        "rationale": (
+            "Condition has no active perturbation mechanism and is not the "
+            "baseline. Insufficient data for mechanism classification."
+        ),
+    }
+
+
+def _command_unchanged(
+    action_proxy: dict[str, Any],
+    noop_result: dict[str, Any] | None,
+) -> bool:
+    """Return True when the action proxy matches the noop baseline."""
+    if noop_result is None:
+        return False
+    noop_proxy = noop_result.get("action_proxy_changes", {})
+    return (
+        action_proxy.get("linear_velocity_changed") == noop_proxy.get("linear_velocity_changed")
+        and action_proxy.get("events") == noop_proxy.get("events")
+        and action_proxy.get("velocity_range") == noop_proxy.get("velocity_range")
+    )
+
+
+def _stop_yield_changed(
+    stop_yield: dict[str, Any],
+    noop_result: dict[str, Any] | None,
+) -> bool:
+    """Return True when stop/yield feasibility differs from noop."""
+    if noop_result is None:
+        return False
+    noop_sy = noop_result.get("stop_yield_feasibility", {})
+    return stop_yield.get("stop_feasible_first_observed") != noop_sy.get(
+        "stop_feasible_first_observed"
+    ) or stop_yield.get("yield_feasible_first_observed") != noop_sy.get(
+        "yield_feasible_first_observed"
+    )
+
+
+def classify_all_conditions(
+    condition_results: list[dict[str, Any]],
+    fixture_meta: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Classify every condition and attach mechanism labels in-place.
+
+    Args:
+        condition_results: List of dicts from ``evaluate_condition``.
+        fixture_meta: Fixture metadata.
+
+    Returns:
+        The same list with an added ``"mechanism"`` key on each entry.
+    """
+    noop_result: dict[str, Any] | None = None
+    for r in condition_results:
+        if r.get("spec", {}).get("is_noop", False):
+            noop_result = r
+            break
+
+    for r in condition_results:
+        mechanism = classify_mechanism(r, fixture_meta, noop_result)
+        r["mechanism"] = mechanism
+
+    return condition_results

--- a/robot_sf/benchmark/observation_noise_mechanism_classifier.py
+++ b/robot_sf/benchmark/observation_noise_mechanism_classifier.py
@@ -52,14 +52,14 @@ def classify_mechanism(
     Returns:
         ``{"label": <mechanism_label>, "rationale": <str>}``
     """
-    spec: dict[str, Any] = condition_result.get("spec", {})
+    spec: dict[str, Any] = condition_result.get("spec") or {}
     first_observed: int | None = condition_result.get("first_observed_step")
     response_delay: int | None = condition_result.get("response_delay_steps")
     closest_dist: float | None = condition_result.get("closest_distance_m")
-    action_proxy: dict[str, Any] = condition_result.get("action_proxy_changes", {})
+    action_proxy: dict[str, Any] = condition_result.get("action_proxy_changes") or {}
     missed_total: int = condition_result.get("missed_actor_observations_total", 0)
     occluded_total: int = condition_result.get("occluded_actor_observations_total", 0)
-    stop_yield: dict[str, Any] = condition_result.get("stop_yield_feasibility", {})
+    stop_yield: dict[str, Any] = condition_result.get("stop_yield_feasibility") or {}
 
     if spec.get("is_noop", False):
         return {
@@ -120,11 +120,10 @@ def classify_mechanism(
             "rationale": " ".join(rationale_parts),
         }
 
-    has_noise = spec.get("position_noise_std_m", 0.0) > 0.0
-    if has_noise:
+    noise_std = spec.get("position_noise_std_m") or 0.0
+    if noise_std > 0.0:
         command_same = _command_unchanged(action_proxy, noop_result)
         if command_same:
-            noise_std = spec.get("position_noise_std_m", 0.0)
             if noise_std <= _SMALL_NOISE_STD_M:
                 return {
                     "label": "noise_stayed_below_decision_threshold",
@@ -170,7 +169,7 @@ def _command_unchanged(
     """Return True when the action proxy matches the noop baseline."""
     if noop_result is None:
         return False
-    noop_proxy = noop_result.get("action_proxy_changes", {})
+    noop_proxy = noop_result.get("action_proxy_changes") or {}
     return (
         action_proxy.get("linear_velocity_changed") == noop_proxy.get("linear_velocity_changed")
         and action_proxy.get("events") == noop_proxy.get("events")
@@ -185,7 +184,7 @@ def _stop_yield_changed(
     """Return True when stop/yield feasibility differs from noop."""
     if noop_result is None:
         return False
-    noop_sy = noop_result.get("stop_yield_feasibility", {})
+    noop_sy = noop_result.get("stop_yield_feasibility") or {}
     return stop_yield.get("stop_feasible_first_observed") != noop_sy.get(
         "stop_feasible_first_observed"
     ) or stop_yield.get("yield_feasible_first_observed") != noop_sy.get(
@@ -208,7 +207,7 @@ def classify_all_conditions(
     """
     noop_result: dict[str, Any] | None = None
     for r in condition_results:
-        if r.get("spec", {}).get("is_noop", False):
+        if (r.get("spec") or {}).get("is_noop", False):
             noop_result = r
             break
 

--- a/scripts/tools/classify_observation_noise_mechanisms.py
+++ b/scripts/tools/classify_observation_noise_mechanisms.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Mechanism-classification report for observation-noise envelope evidence.
+
+Reads an existing observation-noise envelope ``summary.json`` and emits a
+mechanism-layer classification report as compact JSON and Markdown.
+
+Usage::
+
+    uv run python scripts/tools/classify_observation_noise_mechanisms.py \\
+        --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json \\
+        --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms
+
+When ``--evidence`` is omitted the script falls back to the default
+envelope evidence path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import subprocess
+from typing import Any
+
+from robot_sf.benchmark.observation_noise_mechanism_classifier import (
+    MECHANISM_LABELS,
+    classify_all_conditions,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_EVIDENCE = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
+    / "summary.json"
+)
+
+
+def _git_head() -> str:
+    """Return the short git HEAD, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _relative_to_repo(path: pathlib.Path) -> str:
+    """Return path relative to REPO_ROOT, or the original path string."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _load_evidence(path: pathlib.Path) -> dict[str, Any]:
+    """Load the envelope summary JSON."""
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _build_mechanism_report(
+    classified: list[dict[str, Any]],
+    envelope_meta: dict[str, Any],
+    repro: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the mechanism-classification JSON report."""
+    mechanism_summary: dict[str, list[str]] = {}
+    for r in classified:
+        label = r["mechanism"]["label"]
+        mechanism_summary.setdefault(label, []).append(r["condition"])
+    assigned_labels = sorted(mechanism_summary)
+
+    return {
+        "schema_version": "observation_noise_mechanism.v1",
+        "issue": 2782,
+        "claim_boundary": (
+            "Diagnostic mechanism-layer classification of observation-noise "
+            "envelope evidence. Not paper-facing benchmark proof. Classifies "
+            "each perturbation condition by the pipeline layer at which it "
+            "had (or did not have) an effect."
+        ),
+        "source_evidence": envelope_meta.get("source_path", ""),
+        "reproducibility": repro,
+        "fixture": {
+            "trace_path": envelope_meta.get("trace_path", ""),
+            "scenario_id": envelope_meta.get("scenario_id", ""),
+            "first_visible_step": envelope_meta.get("first_visible_step"),
+        },
+        "mechanism_labels_valid": sorted(MECHANISM_LABELS),
+        "mechanism_labels_assigned": assigned_labels,
+        "conditions": [
+            {
+                "condition": r["condition"],
+                "spec": r.get("spec", {}),
+                "mechanism": r["mechanism"],
+                "condition_classification": r.get("classification", {}),
+                "response_delay_steps": r.get("response_delay_steps"),
+                "closest_distance_m": r.get("closest_distance_m"),
+                "action_proxy_changes": r.get("action_proxy_changes", {}),
+            }
+            for r in classified
+        ],
+        "summary": {
+            "total_conditions": len(classified),
+            "mechanism_distribution": {k: len(v) for k, v in mechanism_summary.items()},
+            "mechanism_to_conditions": mechanism_summary,
+        },
+    }
+
+
+def _generate_markdown(
+    classified: list[dict[str, Any]],
+    envelope_meta: dict[str, Any],
+    repro: dict[str, Any],
+) -> str:
+    """Generate the Markdown mechanism report."""
+    lines: list[str] = [
+        "# Observation-Noise Mechanism Classification",
+        "",
+        "## Claim Boundary",
+        "",
+        "**Diagnostic mechanism-layer classification only. Not paper-facing benchmark proof.**",
+        "This classifies each perturbation condition from the observation-noise "
+        "envelope by the pipeline layer at which it had (or did not have) an "
+        "effect: observation source, command, trajectory, or timing.",
+        "The label table is the valid vocabulary; the distribution section shows "
+        "which labels were actually assigned for this evidence bundle.",
+        "",
+        "## Reproducibility",
+        "",
+        f"- **Issue:** #{repro['issue']}",
+        f"- **Generated at (UTC):** {repro['generated_at_utc']}",
+        f"- **Command:** `{repro['command']}`",
+        f"- **Repo HEAD:** `{repro['repo_head']}`",
+        f"- **Source evidence:** `{envelope_meta.get('source_path', '')}`",
+        f"- **Fixture:** `{envelope_meta.get('trace_path', '')}`",
+        f"- **Scenario:** {envelope_meta.get('scenario_id', '')}",
+        f"- **First visible step:** {envelope_meta.get('first_visible_step', '?')}",
+        "",
+        "## Mechanism Label Vocabulary",
+        "",
+        "| Label | Pipeline layer | Meaning |",
+        "|---|---|---|",
+        "| `noise_stayed_below_decision_threshold` | Decision | Noise present but did not cross the decision boundary |",
+        "| `observation_affected_source_but_not_command` | Observation -> Command | Observation perturbed but command unchanged |",
+        "| `observation_did_not_affect_selected_source` | Observation | Perturbation did not reach the policy input |",
+        "| `command_changed_but_trajectory_did_not` | Command -> Trajectory | Command changed but trajectory unchanged |",
+        "| `delay_shifted_stop_timing` | Timing | Delay shifted stop/yield decision timing |",
+        "| `occlusion_changed_first_actionable_frame` | Observation timing | Occlusion changed when policy first saw the pedestrian |",
+        "| `scenario_had_no_actionable_conflict` | Scenario | No actionable conflict for noise testing |",
+        "| `stored_action_proxy_prevents_live_conclusion` | Proxy boundary | Action proxies from stored trace; live replay required |",
+        "| `diagnostic_only` | Reference | Baseline or mixed-effects reference |",
+        "| `inconclusive` | Fallback | Insufficient data for classification |",
+        "",
+        "## Conditions",
+        "",
+    ]
+
+    for r in classified:
+        m = r["mechanism"]
+        spec = r.get("spec", {})
+        lines.append(f"### {r['condition']}")
+        lines.append("")
+        lines.append(f"- **Mechanism label:** `{m['label']}`")
+        lines.append(f"  - {m['rationale']}")
+        lines.append(
+            f"- **Prior classification:** `{r.get('classification', {}).get('label', '?')}`"
+        )
+        lines.append(f"- **Noise profile:** {spec.get('noise_profile', '?')}")
+        if r.get("response_delay_steps") is not None:
+            lines.append(f"- **Response delay:** {r['response_delay_steps']} steps")
+        lines.append(f"- **Closest distance:** {r.get('closest_distance_m', 'N/A')} m")
+        lines.append("")
+
+    # Distribution summary
+    mechanism_summary: dict[str, list[str]] = {}
+    for r in classified:
+        label = r["mechanism"]["label"]
+        mechanism_summary.setdefault(label, []).append(r["condition"])
+
+    lines.extend(
+        [
+            "## Mechanism Distribution",
+            "",
+            "| Mechanism label | Conditions | Count |",
+            "|---|---|---|",
+        ]
+    )
+    for label in sorted(mechanism_summary.keys()):
+        conditions = mechanism_summary[label]
+        lines.append(f"| `{label}` | {', '.join(conditions)} | {len(conditions)} |")
+
+    lines.extend(
+        [
+            "",
+            "## Caveats",
+            "",
+            "- Single deterministic fixture (seed=111), single scenario family.",
+            "- Action proxies are from the stored trace, not re-executed; "
+            "command -> trajectory conclusions require live replay.",
+            "- Mechanism labels are rule-based heuristics, not causal proof.",
+            "- Not paper-facing benchmark evidence.",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run mechanism classification and write reports."""
+    parser = argparse.ArgumentParser(
+        description="Classify observation-noise envelope by mechanism layer."
+    )
+    parser.add_argument(
+        "--evidence",
+        type=str,
+        default=str(DEFAULT_EVIDENCE),
+        help="Path to the envelope summary.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="docs/context/evidence/issue_2782_observation_noise_mechanisms",
+        help="Output directory for mechanism reports.",
+    )
+    args = parser.parse_args()
+
+    evidence_path = pathlib.Path(args.evidence)
+    if not evidence_path.exists():
+        raise SystemExit(f"Evidence file not found: {evidence_path}")
+
+    output_dir = REPO_ROOT / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    envelope = _load_evidence(evidence_path)
+
+    fixture_meta = {
+        "trace_path": envelope.get("fixture", {}).get("trace_path", ""),
+        "scenario_id": envelope.get("fixture", {}).get("scenario_id", ""),
+        "first_visible_step": envelope.get("fixture", {}).get("first_visible_step"),
+        "source_path": _relative_to_repo(evidence_path),
+    }
+
+    classified = classify_all_conditions(
+        envelope["conditions"],
+        fixture_meta,
+    )
+
+    repo_head = _git_head()
+    generated_at = datetime.datetime.now(datetime.UTC).isoformat()
+    command = (
+        f"uv run python scripts/tools/classify_observation_noise_mechanisms.py "
+        f"--evidence {args.evidence} --output-dir {args.output_dir}"
+    )
+
+    repro = {
+        "issue": 2782,
+        "generated_at_utc": generated_at,
+        "command": command,
+        "repo_head": repo_head,
+    }
+
+    report = _build_mechanism_report(classified, fixture_meta, repro)
+
+    json_path = output_dir / "mechanism_report.json"
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+
+    md_content = _generate_markdown(classified, fixture_meta, repro)
+    md_path = output_dir / "README.md"
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write(md_content)
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+
+    dist = report["summary"]["mechanism_distribution"]
+    for label in sorted(dist):
+        print(f"  [{label:>50s}]  {dist[label]} condition(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/classify_observation_noise_mechanisms.py
+++ b/scripts/tools/classify_observation_noise_mechanisms.py
@@ -242,15 +242,16 @@ def main() -> None:
 
     envelope = _load_evidence(evidence_path)
 
+    fixture_envelope = envelope.get("fixture") or {}
     fixture_meta = {
-        "trace_path": envelope.get("fixture", {}).get("trace_path", ""),
-        "scenario_id": envelope.get("fixture", {}).get("scenario_id", ""),
-        "first_visible_step": envelope.get("fixture", {}).get("first_visible_step"),
+        "trace_path": fixture_envelope.get("trace_path", ""),
+        "scenario_id": fixture_envelope.get("scenario_id", ""),
+        "first_visible_step": fixture_envelope.get("first_visible_step"),
         "source_path": _relative_to_repo(evidence_path),
     }
 
     classified = classify_all_conditions(
-        envelope["conditions"],
+        envelope.get("conditions") or [],
         fixture_meta,
     )
 

--- a/tests/benchmark/test_observation_noise_mechanism_classifier.py
+++ b/tests/benchmark/test_observation_noise_mechanism_classifier.py
@@ -347,6 +347,40 @@ class TestInconclusiveFallback:
         m = classify_mechanism(result, _fixture_meta())
         assert m["label"] == "inconclusive"
 
+    def test_null_nested_fields_are_safe(self) -> None:
+        """Explicit JSON null values fall back to empty containers."""
+        result = {
+            "spec": None,
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": None,
+            "stop_yield_feasibility": None,
+        }
+        noop = _noop_result()
+        noop["action_proxy_changes"] = None
+        noop["stop_yield_feasibility"] = None
+
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+
+        assert m["label"] == "inconclusive"
+
+    def test_null_spec_in_all_conditions_scan(self) -> None:
+        """Noop discovery tolerates rows with explicit null spec values."""
+        conditions = [
+            {"spec": None, "first_observed_step": 5, "closest_distance_m": 0.5},
+            _noop_result(),
+        ]
+
+        classified = classify_all_conditions(conditions, _fixture_meta())
+
+        assert [row["mechanism"]["label"] for row in classified] == [
+            "inconclusive",
+            "diagnostic_only",
+        ]
+
     def test_never_observed_no_signal(self) -> None:
         """Never observed with no signal gets inconclusive."""
         result = {

--- a/tests/benchmark/test_observation_noise_mechanism_classifier.py
+++ b/tests/benchmark/test_observation_noise_mechanism_classifier.py
@@ -1,0 +1,361 @@
+"""Tests for the observation-noise mechanism-layer classifier."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from robot_sf.benchmark.observation_noise_mechanism_classifier import (
+    MECHANISM_LABELS,
+    classify_all_conditions,
+    classify_mechanism,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+EVIDENCE_PATH = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
+    / "summary.json"
+)
+
+
+def _load_envelope() -> dict:
+    """Load the envelope evidence for test use."""
+    with open(EVIDENCE_PATH, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _noop_result() -> dict:
+    """Build a minimal noop result for comparison."""
+    return {
+        "spec": {"is_noop": True, "position_noise_std_m": 0.0},
+        "first_observed_step": 5,
+        "response_delay_steps": 0,
+        "closest_distance_m": 0.5,
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "stop_yield_feasibility": {
+            "stop_feasible_first_observed": True,
+            "yield_feasible_first_observed": True,
+        },
+        "action_proxy_changes": {
+            "linear_velocity_changed": True,
+            "events": ["a", "b"],
+            "velocity_range": [0.0, 0.6],
+        },
+    }
+
+
+def _fixture_meta() -> dict:
+    """Minimal fixture metadata."""
+    return {"first_visible_step": 5, "trace_path": "x", "scenario_id": "y"}
+
+
+class TestMechanismLabels:
+    """Verify the allowed label set is stable."""
+
+    def test_labels_are_strings(self) -> None:
+        """All mechanism labels are strings."""
+        assert all(isinstance(label, str) for label in MECHANISM_LABELS)
+
+    def test_expected_labels_present(self) -> None:
+        """Label set matches the expected mechanism vocabulary."""
+        expected = {
+            "observation_did_not_affect_selected_source",
+            "observation_affected_source_but_not_command",
+            "command_changed_but_trajectory_did_not",
+            "delay_shifted_stop_timing",
+            "occlusion_changed_first_actionable_frame",
+            "noise_stayed_below_decision_threshold",
+            "scenario_had_no_actionable_conflict",
+            "stored_action_proxy_prevents_live_conclusion",
+            "diagnostic_only",
+            "inconclusive",
+        }
+        assert expected == MECHANISM_LABELS
+
+
+class TestClassifyNoop:
+    """Noop baseline gets diagnostic_only."""
+
+    def test_noop_is_diagnostic_only(self) -> None:
+        """Noop baseline receives diagnostic_only mechanism label."""
+        result = {
+            "spec": {"is_noop": True, "position_noise_std_m": 0.0},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "diagnostic_only"
+        assert "Baseline" in m["rationale"] or "baseline" in m["rationale"].lower()
+
+
+class TestClassifyDelay:
+    """Delay conditions get delay_shifted_stop_timing."""
+
+    def test_delay_shifts_stop_timing(self) -> None:
+        """Two-step delay classifies as delay_shifted_stop_timing."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.0, "delay_steps": 2},
+            "first_observed_step": 7,
+            "response_delay_steps": 2,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "stop_yield_feasibility": {
+                "stop_feasible_first_observed": False,
+                "yield_feasible_first_observed": True,
+            },
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a"],
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        noop = _noop_result()
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+        assert m["label"] == "delay_shifted_stop_timing"
+        assert "2 step" in m["rationale"]
+
+    def test_delay_detects_stop_change(self) -> None:
+        """Delay rationale mentions stop/yield feasibility change."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.0, "delay_steps": 2},
+            "first_observed_step": 7,
+            "response_delay_steps": 2,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "stop_yield_feasibility": {
+                "stop_feasible_first_observed": False,
+                "yield_feasible_first_observed": True,
+            },
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a"],
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        noop = _noop_result()
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+        assert "Stop/yield feasibility" in m["rationale"]
+
+
+class TestClassifyOcclusion:
+    """Occlusion/missed-detection conditions get occlusion_changed_first_actionable_frame."""
+
+    def test_missed_detection(self) -> None:
+        """Full missed detection classifies as occlusion_changed_first_actionable_frame."""
+        result = {
+            "spec": {
+                "is_noop": False,
+                "position_noise_std_m": 0.0,
+                "missed_detection_probability": 1.0,
+            },
+            "first_observed_step": None,
+            "response_delay_steps": None,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 11,
+            "occluded_actor_observations_total": 0,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "occlusion_changed_first_actionable_frame"
+        assert "missed" in m["rationale"].lower()
+
+    def test_occlusion_mask(self) -> None:
+        """Full occlusion mask classifies as occlusion_changed_first_actionable_frame."""
+        result = {
+            "spec": {
+                "is_noop": False,
+                "position_noise_std_m": 0.0,
+                "has_occlusion_mask": True,
+            },
+            "first_observed_step": None,
+            "response_delay_steps": None,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 11,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "occlusion_changed_first_actionable_frame"
+        assert "occlusion" in m["rationale"].lower()
+
+    def test_occlusion_priority_over_far_distance(self) -> None:
+        """Complete occlusion remains the mechanism even when the closest distance is far."""
+        result = {
+            "spec": {
+                "is_noop": False,
+                "position_noise_std_m": 0.0,
+                "has_occlusion_mask": True,
+            },
+            "first_observed_step": None,
+            "response_delay_steps": None,
+            "closest_distance_m": 3.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 11,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "occlusion_changed_first_actionable_frame"
+
+
+class TestClassifyNoise:
+    """Gaussian noise conditions classify by command change."""
+
+    def test_small_noise_below_threshold(self) -> None:
+        """Small Gaussian noise (std<=0.15) with unchanged command stays below threshold."""
+        noop = _noop_result()
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.10},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a", "b"],
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+        assert m["label"] == "noise_stayed_below_decision_threshold"
+
+    def test_larger_noise_affects_source(self) -> None:
+        """Larger Gaussian noise (std>0.15) with unchanged command affects source."""
+        noop = _noop_result()
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.30},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a", "b"],
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+        assert m["label"] == "observation_affected_source_but_not_command"
+
+    def test_noise_command_changed_needs_live_replay(self) -> None:
+        """Noise with changed command requires live replay for conclusion."""
+        noop = _noop_result()
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.30},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a", "b", "c"],  # differs from noop
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        m = classify_mechanism(result, _fixture_meta(), noop_result=noop)
+        assert m["label"] == "stored_action_proxy_prevents_live_conclusion"
+
+    def test_noise_without_noop_needs_live_replay(self) -> None:
+        """Noise without a noop comparison cannot support command-layer conclusions."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.30},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": {
+                "linear_velocity_changed": True,
+                "events": ["a", "b"],
+                "velocity_range": [0.0, 0.6],
+            },
+        }
+        m = classify_mechanism(result, _fixture_meta(), noop_result=None)
+        assert m["label"] == "stored_action_proxy_prevents_live_conclusion"
+
+
+class TestClassifyFarScenario:
+    """Far-away scenarios get scenario_had_no_actionable_conflict."""
+
+    def test_far_scenario(self) -> None:
+        """Far-away scenario classifies as scenario_had_no_actionable_conflict."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.30},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 3.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "scenario_had_no_actionable_conflict"
+
+
+class TestClassifyAllConditions:
+    """classify_all_conditions attaches mechanism to every condition."""
+
+    def test_all_conditions_get_mechanism(self) -> None:
+        """Every condition receives a mechanism label from the allowed set."""
+        envelope = _load_envelope()
+        classified = classify_all_conditions(envelope["conditions"], _fixture_meta())
+        for r in classified:
+            assert "mechanism" in r
+            assert "label" in r["mechanism"]
+            assert r["mechanism"]["label"] in MECHANISM_LABELS
+
+    def test_envelope_mechanism_distribution(self) -> None:
+        """Run against the real envelope and verify expected labels."""
+        envelope = _load_envelope()
+        classified = classify_all_conditions(envelope["conditions"], _fixture_meta())
+        labels = {r["condition"]: r["mechanism"]["label"] for r in classified}
+
+        assert labels["noop"] == "diagnostic_only"
+        assert labels["delay_only"] == "delay_shifted_stop_timing"
+        assert labels["missed_detection_only"] == "occlusion_changed_first_actionable_frame"
+        assert labels["occlusion_only"] == "occlusion_changed_first_actionable_frame"
+        assert labels["combined"] == "occlusion_changed_first_actionable_frame"
+        # low_noise: std=0.10 <= 0.15 threshold
+        assert labels["low_noise"] == "noise_stayed_below_decision_threshold"
+        # medium_noise: std=0.30 > 0.15 threshold
+        assert labels["medium_noise"] == "observation_affected_source_but_not_command"
+
+
+class TestInconclusiveFallback:
+    """Conditions without active perturbation get inconclusive."""
+
+    def test_no_perturbation_non_noop(self) -> None:
+        """Non-noop condition with no active perturbation gets inconclusive."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.0},
+            "first_observed_step": 5,
+            "response_delay_steps": 0,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+            "action_proxy_changes": {
+                "linear_velocity_changed": False,
+                "events": [],
+                "velocity_range": None,
+            },
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "inconclusive"
+
+    def test_never_observed_no_signal(self) -> None:
+        """Never observed with no signal gets inconclusive."""
+        result = {
+            "spec": {"is_noop": False, "position_noise_std_m": 0.0},
+            "first_observed_step": None,
+            "response_delay_steps": None,
+            "closest_distance_m": 0.5,
+            "missed_actor_observations_total": 0,
+            "occluded_actor_observations_total": 0,
+        }
+        m = classify_mechanism(result, _fixture_meta())
+        assert m["label"] == "inconclusive"


### PR DESCRIPTION
## Summary

- Add `robot_sf.benchmark.observation_noise_mechanism_classifier` to classify existing observation-noise envelope rows by mechanism layer.
- Add `scripts/tools/classify_observation_noise_mechanisms.py` to regenerate compact JSON/Markdown mechanism reports from the Issue #2755 envelope summary.
- Publish the diagnostic-only Issue #2782 evidence bundle and index it in `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.

Closes #2782.

## Validation

- `uv run python scripts/tools/classify_observation_noise_mechanisms.py --evidence docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json --output-dir docs/context/evidence/issue_2782_observation_noise_mechanisms`
- `uv run pytest tests/benchmark/test_observation_noise_mechanism_classifier.py tests/benchmark/test_observation_noise_envelope.py -q` (`34 passed`)
- `uv run ruff format --check robot_sf/benchmark/observation_noise_mechanism_classifier.py scripts/tools/classify_observation_noise_mechanisms.py tests/benchmark/test_observation_noise_mechanism_classifier.py`
- `uv run ruff check robot_sf/benchmark/observation_noise_mechanism_classifier.py scripts/tools/classify_observation_noise_mechanisms.py tests/benchmark/test_observation_noise_mechanism_classifier.py`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/evidence/README.md --path docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md --path docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`6094 passed, 9 skipped, 8 warnings`; final stamp clean for `d6078ca2775443e337860b8692f601c09ee4f80d`; changed-file coverage warning only: classifier 98.3%, minimum 80%)

## Downstream Propagation

- Parent issue: closes #2782.
- Evidence/index surfaces updated: `docs/context/evidence/issue_2782_observation_noise_mechanisms/`, `docs/context/evidence/README.md`, and `docs/context/catalog.yaml`.
- Claim maps/leaderboards/model registries: not applicable; this is a diagnostic-only analysis artifact, not a benchmark or paper claim promotion.
- Follow-up issue: not opened; no deferred scope was identified beyond the existing live-replay boundary tracked by related observation-noise work.

## Research Result Guidance

- Target claim/hypothesis/blocker: classify why existing observation-noise perturbation outcomes did or did not propagate through observation, command, timing, or proxy layers.
- Comparator/baseline: existing Issue #2755 observation-noise envelope summary and noop baseline condition.
- Evidence tier: analysis-only diagnostic evidence from one deterministic occluded-emergence fixture.
- Result classification: diagnostic-only mechanism labeling; not benchmark-strength, not paper-facing proof.
- Decision/stop rule: every existing perturbation family receives a mechanism label or explicit inconclusive boundary, with stored-action proxy limitations preserved.
- Synthesis/update target: future observation-noise and mechanism-synthesis issues can cite `docs/context/evidence/issue_2782_observation_noise_mechanisms/mechanism_report.json`.

## Delegation

- OpenCode Go (`opencode-go/mimo-v2.5`) produced the initial implementation candidate; Zen skipped because the user explicitly requested Go usage.
- Command Code (`xiaomi/mimo-v2.5`) performed a read-only review and flagged the occlusion-vs-distance priority edge case plus unused-label wording risk.
- Local orchestrator accepted only after fixing those review findings and rerunning validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for observation noise mechanism classification, including condition definitions, mechanism vocabulary, and reproducibility metadata.

* **New Features**
  * Added an automated tool to classify observation noise perturbation conditions and generate detailed mechanism analysis reports.

* **Tests**
  * Added extensive test coverage for mechanism classification logic across different perturbation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->