### PR TITLE
benchmark: add occluded emergence variants

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1204,6 +1204,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2780_occluded_emergence_variants/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -111,6 +111,10 @@ Policy caveats:
   deterministic occluded-emergence trace fixture. The fixture separates ground-truth and observed
   pedestrian state, records first visibility and conflict timing, and feeds observation-noise plus
   constant-velocity forecast diagnostics.
+- `issue_2780_occluded_emergence_variants/`: smoke/diagnostic/stress evidence for five simulated
+  occluded-emergence variant fixtures varying emergence side, pedestrian speed, first-visible
+  distance, conflict timing, and robot approach speed. Four variants are safety-relevant under
+  live replay; none replace #2777 live replay evidence.
 - `issue_2757_cv_forecast_eval_2026-06-13/`: diagnostic-only constant-velocity
   pedestrian forecast baseline evaluation on bounded durable trace fixtures. The corridor traces
   produce short-horizon metrics; crossing, bottleneck, signalized, occluded, and dense-interaction

--- a/docs/context/evidence/issue_2780_occluded_emergence_variants/README.md
+++ b/docs/context/evidence/issue_2780_occluded_emergence_variants/README.md
@@ -1,4 +1,4 @@
-# Issue 2780 Occluded Emergence Variants
+# Issue #2780 Occluded Emergence Variants 2026-06-13
 
 This evidence note records five simulated occluded-emergence variant fixtures generated for
 issue #2780.  The variants explore different emergence configurations beyond the single

--- a/docs/context/evidence/issue_2780_occluded_emergence_variants/README.md
+++ b/docs/context/evidence/issue_2780_occluded_emergence_variants/README.md
@@ -1,0 +1,65 @@
+# Issue 2780 Occluded Emergence Variants
+
+This evidence note records five simulated occluded-emergence variant fixtures generated for
+issue #2780.  The variants explore different emergence configurations beyond the single
+hand-authored issue #2756 fixture.
+
+## Claim Boundary
+
+Smoke/diagnostic/stress only.  The fixtures prove that the repository can generate and validate
+multiple occluded-emergence configurations varying emergence side, pedestrian speed, first-visible
+distance, conflict timing, and robot approach speed.  They do not establish real-world occlusion
+representativeness, paper-facing benchmark coverage, or live-replay safety sufficiency.  The
+fixtures do not replace the #2777 live replay.
+
+## Variant Summary
+
+| Variant | Side | Ped Speed | First Visible | Robot Speed | Expected Failure Mode | Safety-Relevant |
+|---------|------|-----------|---------------|-------------|-----------------------|-----------------|
+| `left_close` | left | 1.2 m/s | step 4 | 1.0 m/s | late_detection | yes |
+| `right_close` | right | 1.2 m/s | step 4 | 1.0 m/s | wrong_source_selection | yes |
+| `late_visibility` | center | 1.0 m/s | step 8 | 1.0 m/s | insufficient_braking_distance | yes |
+| `slow_pedestrian` | center | 0.4 m/s | step 5 | 0.8 m/s | unnecessary_stop | no |
+| `fast_pedestrian` | center | 2.0 m/s | step 3 | 1.2 m/s | forecast_miss | yes |
+
+## Variation Dimensions
+
+- **Emergence side**: left, right, center (different occluder x-bounds)
+- **Pedestrian speed**: 0.4 to 2.0 m/s
+- **First-visible step**: 3 to 8 (reaction time pressure)
+- **Robot approach speed**: 0.8 to 1.2 m/s
+- **Conflict timing**: varies with speed and initial position
+
+## Failure Modes
+
+- `late_detection`: pedestrian detected too close to conflict for comfortable response
+- `wrong_source_selection`: right-side emergence may confuse source attribution
+- `insufficient_braking_distance`: very late visibility leaves no braking room
+- `unnecessary_stop`: slow pedestrian does not actually require a stop
+- `forecast_miss`: fast pedestrian exceeds forecast horizon coverage
+
+## Safety Relevance Boundary
+
+Four variants (`left_close`, `right_close`, `late_visibility`, `fast_pedestrian`) are
+safety-relevant under live replay because they exercise detection latency, source selection,
+or braking distance under stress.  The `slow_pedestrian` variant is non-safety-relevant
+because the low speed gives ample reaction time.  No variant replaces the #2777 live replay
+evidence.
+
+## Durable Inputs
+
+- Summary: `docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json`
+- Generator: `scripts/tools/generate_occluded_emergence_variants.py`
+- Test file: `tests/benchmark/test_occluded_emergence_variants.py`
+- Trace fixtures: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_*_episode_0000.json`
+- Source metadata: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_*.meta.json`
+
+## Validation
+
+```bash
+uv run pytest tests/benchmark/test_occluded_emergence_variants.py -q
+uv run pytest tests/benchmark/test_occluded_emergence_fixture.py tests/benchmark/test_occluded_emergence_variants.py -q
+uv run ruff check scripts/tools/generate_occluded_emergence_variants.py tests/benchmark/test_occluded_emergence_variants.py
+uv run ruff format --check scripts/tools/generate_occluded_emergence_variants.py tests/benchmark/test_occluded_emergence_variants.py
+uv run python scripts/tools/generate_occluded_emergence_variants.py
+```

--- a/docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json
+++ b/docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "occluded_emergence_variants_summary.v1",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "claim_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "variant_count": 5,
+  "variants": [
+    {
+      "name": "occluded_emergence_left_close",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json",
+      "metadata_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_left_close_fixture_111_ep0000.meta.json",
+      "scenario_id": "issue_2780_occluded_emergence_left_close",
+      "seed": 111,
+      "episode_id": "issue_2780_occluded_emergence_left_close_ep0000",
+      "expected_failure_mode": "late_detection",
+      "variation_dimensions": ["emergence_side:left", "first_visible_step:4", "ped_speed:1.2"],
+      "safety_relevant_under_live_replay": true
+    },
+    {
+      "name": "occluded_emergence_right_close",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json",
+      "metadata_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_right_close_fixture_111_ep0000.meta.json",
+      "scenario_id": "issue_2780_occluded_emergence_right_close",
+      "seed": 111,
+      "episode_id": "issue_2780_occluded_emergence_right_close_ep0000",
+      "expected_failure_mode": "wrong_source_selection",
+      "variation_dimensions": ["emergence_side:right", "first_visible_step:4", "ped_speed:1.2"],
+      "safety_relevant_under_live_replay": true
+    },
+    {
+      "name": "occluded_emergence_late_visibility",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json",
+      "metadata_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_late_visibility_fixture_111_ep0000.meta.json",
+      "scenario_id": "issue_2780_occluded_emergence_late_visibility",
+      "seed": 111,
+      "episode_id": "issue_2780_occluded_emergence_late_visibility_ep0000",
+      "expected_failure_mode": "insufficient_braking_distance",
+      "variation_dimensions": ["first_visible_step:8", "ped_speed:1.0", "robot_v0:1.0"],
+      "safety_relevant_under_live_replay": true
+    },
+    {
+      "name": "occluded_emergence_slow_pedestrian",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json",
+      "metadata_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_slow_pedestrian_fixture_111_ep0000.meta.json",
+      "scenario_id": "issue_2780_occluded_emergence_slow_pedestrian",
+      "seed": 111,
+      "episode_id": "issue_2780_occluded_emergence_slow_pedestrian_ep0000",
+      "expected_failure_mode": "unnecessary_stop",
+      "variation_dimensions": ["ped_speed:0.4", "robot_v0:0.8", "first_visible_step:5"],
+      "safety_relevant_under_live_replay": false
+    },
+    {
+      "name": "occluded_emergence_fast_pedestrian",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json",
+      "metadata_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_fast_pedestrian_fixture_111_ep0000.meta.json",
+      "scenario_id": "issue_2780_occluded_emergence_fast_pedestrian",
+      "seed": 111,
+      "episode_id": "issue_2780_occluded_emergence_fast_pedestrian_ep0000",
+      "expected_failure_mode": "forecast_miss",
+      "variation_dimensions": ["ped_speed:2.0", "robot_v0:1.2", "first_visible_step:3"],
+      "safety_relevant_under_live_replay": true
+    }
+  ],
+  "safety_relevance": {
+    "at_least_one_safety_relevant": true,
+    "safety_relevant_variants": [
+      "occluded_emergence_left_close",
+      "occluded_emergence_right_close",
+      "occluded_emergence_late_visibility",
+      "occluded_emergence_fast_pedestrian"
+    ],
+    "non_safety_relevant_variants": [
+      "occluded_emergence_slow_pedestrian"
+    ],
+    "explanation": "Four of five variants exercise detection latency, source selection, or braking distance under stress. The slow-pedestrian variant is non-safety-relevant because the low speed gives ample reaction time. None replace #2777 live replay evidence."
+  },
+  "variation_coverage": {
+    "emergence_side": ["left", "right", "center"],
+    "first_visible_step": [3, 4, 5, 8],
+    "pedestrian_speed_m_s": [0.4, 1.0, 1.2, 2.0],
+    "robot_approach_speed_m_s": [0.8, 1.0, 1.2],
+    "failure_modes": [
+      "late_detection",
+      "wrong_source_selection",
+      "insufficient_braking_distance",
+      "unnecessary_stop",
+      "forecast_miss"
+    ]
+  },
+  "diagnostic_support": {
+    "trace_schema": "simulation_trace_export.v1",
+    "all_variants_forecast_evaluable": true,
+    "distinct_failure_modes": true
+  },
+  "validation": {
+    "targeted_tests": "uv run pytest tests/benchmark/test_occluded_emergence_variants.py -q",
+    "related_tests": "uv run pytest tests/benchmark/test_occluded_emergence_fixture.py tests/benchmark/test_occluded_emergence_variants.py -q",
+    "generator": "uv run python scripts/tools/generate_occluded_emergence_variants.py"
+  }
+}

--- a/scripts/tools/generate_occluded_emergence_variants.py
+++ b/scripts/tools/generate_occluded_emergence_variants.py
@@ -68,8 +68,13 @@ def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
             occlusion_status = "visible"
             first_visible = step == first_visible_step
 
-        dist_to_conflict = abs(ped_y - conflict_y)
-        time_to_conflict = dist_to_conflict / ped_speed if ped_speed > 0 else 999.0
+        signed_dist_to_conflict = conflict_y - ped_y
+        time_to_conflict = signed_dist_to_conflict / ped_speed if ped_speed > 0 else 999.0
+        previous_time_to_conflict = 999.0
+        if ped_speed > 0 and step > 0:
+            previous_ped_y = ped_initial_y + ped_speed * ((step - 1) * DT_S)
+            previous_time_to_conflict = (conflict_y - previous_ped_y) / ped_speed
+        crosses_conflict = previous_time_to_conflict > 0.0 >= time_to_conflict
         # Simplified feasibility thresholds
         stop_feasible = time_to_conflict > cfg.get("stop_horizon_s", 0.2)
         yield_feasible = time_to_conflict > cfg.get("yield_horizon_s", 0.1)
@@ -77,15 +82,15 @@ def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
         if step < first_visible_step:
             event = "approach_occluder"
             v_lin = round(robot_v0 * 0.8, 2)
+        elif crosses_conflict:
+            event = "conflict_time"
+            v_lin = 0.0
         elif step == first_visible_step:
             event = "first_visible"
             v_lin = round(robot_v0 * 0.5, 2)
         elif stop_feasible:
             event = "yield_start"
             v_lin = round(robot_v0 * 0.3, 2)
-        elif time_to_conflict <= 0.0:
-            event = "conflict_time"
-            v_lin = 0.0
         elif step > cfg.get("yield_feasible_before_step", 12):
             event = "resume"
             v_lin = round(robot_v0 * 0.4, 2)
@@ -105,7 +110,7 @@ def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
                 "occlusion_status": {"emerging_ped": occlusion_status},
                 "first_visible": first_visible,
                 "conflict_timing": {
-                    "time_to_conflict_s": round(time_to_conflict, 4),
+                    "time_to_conflict_s": round(max(0.0, time_to_conflict), 4),
                     "stop_feasible": stop_feasible,
                     "yield_feasible": yield_feasible,
                 },

--- a/scripts/tools/generate_occluded_emergence_variants.py
+++ b/scripts/tools/generate_occluded_emergence_variants.py
@@ -124,6 +124,20 @@ def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
     conflict_time_s = (
         round(abs(cfg["ped_initial_y"] - conflict_y) / ped_speed, 4) if ped_speed > 0 else 999.0
     )
+    stop_feasible_before_step = (
+        max(
+            (frame["step"] for frame in frames if frame["conflict_timing"]["stop_feasible"]),
+            default=-1,
+        )
+        + 1
+    )
+    yield_feasible_before_step = (
+        max(
+            (frame["step"] for frame in frames if frame["conflict_timing"]["yield_feasible"]),
+            default=-1,
+        )
+        + 1
+    )
 
     return {
         "schema_version": "simulation_trace_export.v1",
@@ -144,8 +158,8 @@ def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
             "first_visible_step": first_visible_step,
             "conflict_zone_center": [cfg["ped_x"], conflict_y],
             "conflict_time_s": conflict_time_s,
-            "stop_feasible_before_step": cfg.get("stop_feasible_before_step", 10),
-            "yield_feasible_before_step": cfg.get("yield_feasible_before_step", 12),
+            "stop_feasible_before_step": stop_feasible_before_step,
+            "yield_feasible_before_step": yield_feasible_before_step,
         },
         "variant": {
             "name": name,

--- a/scripts/tools/generate_occluded_emergence_variants.py
+++ b/scripts/tools/generate_occluded_emergence_variants.py
@@ -1,0 +1,326 @@
+"""Generate simulated occluded-emergence variant trace fixtures.
+
+Produces five deterministic variant traces that explore different emergence
+configurations beyond the single hand-authored issue #2756 fixture.
+
+Variants:
+  - left_close: pedestrian emerges from left at close distance
+  - right_close: pedestrian emerges from right at close distance
+  - late_visibility: pedestrian becomes visible late with minimal reaction time
+  - slow_pedestrian: slow-moving pedestrian crossing path
+  - fast_pedestrian: fast-moving pedestrian crossing path
+
+All fixtures are diagnostic/stress evidence only.  They do not replace
+the #2756 hand-authored fixture or the #2777 live replay.
+
+Usage:
+  uv run python scripts/tools/generate_occluded_emergence_variants.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1"
+SOURCES_DIR = FIXTURE_DIR / "sources"
+
+DT_S = 0.1
+TOTAL_STEPS = 16
+
+
+def _occluder_bounds(side: str) -> dict[str, float]:
+    """Return occluder bounding box for the given emergence side."""
+    if side == "left":
+        return {"x_min": 0.8, "x_max": 1.05, "y_min": -0.8, "y_max": 0.8}
+    if side == "right":
+        return {"x_min": 1.5, "x_max": 1.75, "y_min": -0.8, "y_max": 0.8}
+    return {"x_min": 1.0, "x_max": 1.25, "y_min": -0.8, "y_max": 0.8}
+
+
+def _build_variant(name: str, cfg: dict[str, Any]) -> dict[str, Any]:
+    """Build a single variant trace dict."""
+    first_visible_step: int = cfg["first_visible_step"]
+    ped_speed: float = cfg["ped_speed"]
+    ped_initial_y: float = cfg["ped_initial_y"]
+    ped_x: float = cfg["ped_x"]
+    robot_v0: float = cfg["robot_v0"]
+    side: str = cfg.get("side", "center")
+    conflict_y: float = cfg.get("conflict_y", 0.0)
+
+    frames: list[dict[str, Any]] = []
+    for step in range(TOTAL_STEPS):
+        t = step * DT_S
+        robot_x = robot_v0 * t * 0.6
+        robot_pos = [round(robot_x, 4), 0.0]
+
+        ped_y = round(ped_initial_y + ped_speed * t, 4)
+        ped_pos = [ped_x, ped_y]
+        ped_vel = [0.0, ped_speed]
+
+        observed: list[dict[str, Any]] = []
+        occlusion_status = "occluded"
+        first_visible = False
+        if step >= first_visible_step:
+            observed = [{"id": cfg["ped_id"], "position": list(ped_pos), "velocity": list(ped_vel)}]
+            occlusion_status = "visible"
+            first_visible = step == first_visible_step
+
+        dist_to_conflict = abs(ped_y - conflict_y)
+        time_to_conflict = dist_to_conflict / ped_speed if ped_speed > 0 else 999.0
+        # Simplified feasibility thresholds
+        stop_feasible = time_to_conflict > cfg.get("stop_horizon_s", 0.2)
+        yield_feasible = time_to_conflict > cfg.get("yield_horizon_s", 0.1)
+
+        if step < first_visible_step:
+            event = "approach_occluder"
+            v_lin = round(robot_v0 * 0.8, 2)
+        elif step == first_visible_step:
+            event = "first_visible"
+            v_lin = round(robot_v0 * 0.5, 2)
+        elif stop_feasible:
+            event = "yield_start"
+            v_lin = round(robot_v0 * 0.3, 2)
+        elif time_to_conflict <= 0.0:
+            event = "conflict_time"
+            v_lin = 0.0
+        elif step > cfg.get("yield_feasible_before_step", 12):
+            event = "resume"
+            v_lin = round(robot_v0 * 0.4, 2)
+        else:
+            event = "yield"
+            v_lin = round(robot_v0 * 0.15, 2)
+
+        frames.append(
+            {
+                "step": step,
+                "time_s": round(t, 4),
+                "robot": {"position": robot_pos, "heading": 0.0, "velocity": [robot_v0, 0.0]},
+                "pedestrians": [
+                    {"id": cfg["ped_id"], "position": list(ped_pos), "velocity": list(ped_vel)}
+                ],
+                "observed_pedestrians": observed,
+                "occlusion_status": {"emerging_ped": occlusion_status},
+                "first_visible": first_visible,
+                "conflict_timing": {
+                    "time_to_conflict_s": round(time_to_conflict, 4),
+                    "stop_feasible": stop_feasible,
+                    "yield_feasible": yield_feasible,
+                },
+                "planner": {
+                    "selected_action": {"linear_velocity": v_lin, "angular_velocity": 0.0},
+                    "event": event,
+                },
+            }
+        )
+
+    conflict_time_s = (
+        round(abs(cfg["ped_initial_y"] - conflict_y) / ped_speed, 4) if ped_speed > 0 else 999.0
+    )
+
+    return {
+        "schema_version": "simulation_trace_export.v1",
+        "trace_id": cfg["trace_id"],
+        "source": {
+            "scenario_id": cfg["scenario_id"],
+            "seed": cfg["seed"],
+            "planner_id": "hybrid_rule_v0_minimal",
+            "episode_id": cfg["episode_id"],
+            "generated_by": f"deterministic variant generator for issue #2780 ({name})",
+        },
+        "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+        "coordinate_frame": "world",
+        "units": {"position": "m", "heading": "rad", "time": "s", "velocity": "m/s"},
+        "occlusion": {
+            "occluder_id": cfg.get("occluder_id", "static_wall_behind_corner"),
+            "occluder_bounds": _occluder_bounds(side),
+            "first_visible_step": first_visible_step,
+            "conflict_zone_center": [cfg["ped_x"], conflict_y],
+            "conflict_time_s": conflict_time_s,
+            "stop_feasible_before_step": cfg.get("stop_feasible_before_step", 10),
+            "yield_feasible_before_step": cfg.get("yield_feasible_before_step", 12),
+        },
+        "variant": {
+            "name": name,
+            "parent_issue": 2756,
+            "issue": 2780,
+            "expected_failure_mode": cfg["expected_failure_mode"],
+            "variation_dimensions": cfg["variation_dimensions"],
+            "safety_relevant_under_live_replay": cfg.get("safety_relevant", False),
+            "evidence_boundary_note": cfg.get(
+                "evidence_boundary_note",
+                "diagnostic_stress_only_not_benchmark_evidence",
+            ),
+        },
+        "frames": frames,
+    }
+
+
+VARIANT_CONFIGS: dict[str, dict[str, Any]] = {
+    "occluded_emergence_left_close": {
+        "trace_id": "issue_2780_occluded_emergence_left_close_seed111_ep0000",
+        "scenario_id": "issue_2780_occluded_emergence_left_close",
+        "episode_id": "issue_2780_occluded_emergence_left_close_ep0000",
+        "seed": 111,
+        "ped_id": 27801,
+        "ped_x": 0.9,
+        "ped_initial_y": -1.0,
+        "ped_speed": 1.2,
+        "robot_v0": 1.0,
+        "side": "left",
+        "conflict_y": 0.0,
+        "first_visible_step": 4,
+        "stop_feasible_before_step": 8,
+        "yield_feasible_before_step": 10,
+        "stop_horizon_s": 0.25,
+        "yield_horizon_s": 0.15,
+        "expected_failure_mode": "late_detection",
+        "variation_dimensions": ["emergence_side:left", "first_visible_step:4", "ped_speed:1.2"],
+        "safety_relevant": True,
+        "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence",
+    },
+    "occluded_emergence_right_close": {
+        "trace_id": "issue_2780_occluded_emergence_right_close_seed111_ep0000",
+        "scenario_id": "issue_2780_occluded_emergence_right_close",
+        "episode_id": "issue_2780_occluded_emergence_right_close_ep0000",
+        "seed": 111,
+        "ped_id": 27802,
+        "ped_x": 1.6,
+        "ped_initial_y": -1.0,
+        "ped_speed": 1.2,
+        "robot_v0": 1.0,
+        "side": "right",
+        "conflict_y": 0.0,
+        "first_visible_step": 4,
+        "stop_feasible_before_step": 8,
+        "yield_feasible_before_step": 10,
+        "stop_horizon_s": 0.25,
+        "yield_horizon_s": 0.15,
+        "expected_failure_mode": "wrong_source_selection",
+        "variation_dimensions": ["emergence_side:right", "first_visible_step:4", "ped_speed:1.2"],
+        "safety_relevant": True,
+        "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence",
+    },
+    "occluded_emergence_late_visibility": {
+        "trace_id": "issue_2780_occluded_emergence_late_visibility_seed111_ep0000",
+        "scenario_id": "issue_2780_occluded_emergence_late_visibility",
+        "episode_id": "issue_2780_occluded_emergence_late_visibility_ep0000",
+        "seed": 111,
+        "ped_id": 27803,
+        "ped_x": 1.2,
+        "ped_initial_y": -0.8,
+        "ped_speed": 1.0,
+        "robot_v0": 1.0,
+        "side": "center",
+        "conflict_y": 0.0,
+        "first_visible_step": 8,
+        "stop_feasible_before_step": 10,
+        "yield_feasible_before_step": 12,
+        "stop_horizon_s": 0.2,
+        "yield_horizon_s": 0.1,
+        "expected_failure_mode": "insufficient_braking_distance",
+        "variation_dimensions": ["first_visible_step:8", "ped_speed:1.0", "robot_v0:1.0"],
+        "safety_relevant": True,
+        "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence",
+    },
+    "occluded_emergence_slow_pedestrian": {
+        "trace_id": "issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000",
+        "scenario_id": "issue_2780_occluded_emergence_slow_pedestrian",
+        "episode_id": "issue_2780_occluded_emergence_slow_pedestrian_ep0000",
+        "seed": 111,
+        "ped_id": 27804,
+        "ped_x": 1.2,
+        "ped_initial_y": -0.6,
+        "ped_speed": 0.4,
+        "robot_v0": 0.8,
+        "side": "center",
+        "conflict_y": 0.0,
+        "first_visible_step": 5,
+        "stop_feasible_before_step": 7,
+        "yield_feasible_before_step": 9,
+        "stop_horizon_s": 0.3,
+        "yield_horizon_s": 0.2,
+        "expected_failure_mode": "unnecessary_stop",
+        "variation_dimensions": ["ped_speed:0.4", "robot_v0:0.8", "first_visible_step:5"],
+        "safety_relevant": False,
+        "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence",
+    },
+    "occluded_emergence_fast_pedestrian": {
+        "trace_id": "issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000",
+        "scenario_id": "issue_2780_occluded_emergence_fast_pedestrian",
+        "episode_id": "issue_2780_occluded_emergence_fast_pedestrian_ep0000",
+        "seed": 111,
+        "ped_id": 27805,
+        "ped_x": 1.2,
+        "ped_initial_y": -1.2,
+        "ped_speed": 2.0,
+        "robot_v0": 1.2,
+        "side": "center",
+        "conflict_y": 0.0,
+        "first_visible_step": 3,
+        "stop_feasible_before_step": 5,
+        "yield_feasible_before_step": 7,
+        "stop_horizon_s": 0.15,
+        "yield_horizon_s": 0.1,
+        "expected_failure_mode": "forecast_miss",
+        "variation_dimensions": ["ped_speed:2.0", "robot_v0:1.2", "first_visible_step:3"],
+        "safety_relevant": True,
+        "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence",
+    },
+}
+
+
+def generate_all() -> dict[str, dict[str, Any]]:
+    """Generate all variant traces and return them keyed by name."""
+    return {name: _build_variant(name, cfg) for name, cfg in VARIANT_CONFIGS.items()}
+
+
+def write_variants() -> list[pathlib.Path]:
+    """Write all variant traces and metadata to disk."""
+    variants = generate_all()
+    written: list[pathlib.Path] = []
+    for name, trace in variants.items():
+        trace_path = (
+            FIXTURE_DIR
+            / f"occluded_emergence_{name.replace('occluded_emergence_', '')}_episode_0000.json"
+        )
+        with open(trace_path, "w") as fh:
+            json.dump(trace, fh, indent=2)
+        written.append(trace_path)
+
+        meta = {
+            "algorithm": "hand_authored_deterministic_fixture",
+            "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+            "episode_id": trace["source"]["episode_id"],
+            "issue": 2780,
+            "parent_issue": 2756,
+            "scenario": trace["source"]["scenario_id"],
+            "seed": trace["source"]["seed"],
+            "source_kind": "simulation_trace_export.v1 fixture",
+            "variant_name": name,
+            "expected_failure_mode": trace["variant"]["expected_failure_mode"],
+            "variation_dimensions": trace["variant"]["variation_dimensions"],
+            "safety_relevant_under_live_replay": trace["variant"][
+                "safety_relevant_under_live_replay"
+            ],
+            "evidence_boundary": trace["variant"]["evidence_boundary_note"],
+            "notes": [
+                "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+                f"Expected failure mode: {trace['variant']['expected_failure_mode']}.",
+                f"Variation dimensions: {', '.join(trace['variant']['variation_dimensions'])}.",
+                "This fixture is not paper-facing benchmark evidence.",
+            ],
+        }
+        meta_path = SOURCES_DIR / f"issue_2780_{name}_fixture_111_ep0000.meta.json"
+        with open(meta_path, "w") as fh:
+            json.dump(meta, fh, indent=2)
+        written.append(meta_path)
+    return written
+
+
+if __name__ == "__main__":
+    paths = write_variants()
+    for p in paths:
+        print(p)

--- a/tests/benchmark/test_occluded_emergence_variants.py
+++ b/tests/benchmark/test_occluded_emergence_variants.py
@@ -257,6 +257,24 @@ def test_variant_frame_conflict_time_never_rebounds_after_crossing() -> None:
         assert times[-1] == 0.0
 
 
+def test_variant_feasibility_step_metadata_matches_frame_flags() -> None:
+    """Occlusion feasibility step metadata matches frame-level feasibility flags."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        frames = trace["frames"]
+        occlusion = trace["occlusion"]
+        stop_last_true = max(
+            (frame["step"] for frame in frames if frame["conflict_timing"]["stop_feasible"]),
+            default=-1,
+        )
+        yield_last_true = max(
+            (frame["step"] for frame in frames if frame["conflict_timing"]["yield_feasible"]),
+            default=-1,
+        )
+        assert occlusion["stop_feasible_before_step"] == stop_last_true + 1
+        assert occlusion["yield_feasible_before_step"] == yield_last_true + 1
+
+
 def test_variant_planner_event_does_not_restart_yield_after_conflict() -> None:
     """Planner events do not return to yield_start after the conflict-time frame."""
     for name in VARIANT_NAMES:

--- a/tests/benchmark/test_occluded_emergence_variants.py
+++ b/tests/benchmark/test_occluded_emergence_variants.py
@@ -1,0 +1,325 @@
+"""Tests for the issue #2780 simulated occluded-emergence variant fixtures."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+from robot_sf.benchmark.pedestrian_forecast import compute_batch_forecast_metrics
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1"
+SOURCES_DIR = FIXTURE_DIR / "sources"
+GENERATOR_PATH = REPO_ROOT / "scripts/tools/generate_occluded_emergence_variants.py"
+SUMMARY_PATH = (
+    REPO_ROOT / "docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json"
+)
+
+VARIANT_NAMES = [
+    "occluded_emergence_left_close",
+    "occluded_emergence_right_close",
+    "occluded_emergence_late_visibility",
+    "occluded_emergence_slow_pedestrian",
+    "occluded_emergence_fast_pedestrian",
+]
+
+EXPECTED_FAILURE_MODES = {
+    "occluded_emergence_left_close": "late_detection",
+    "occluded_emergence_right_close": "wrong_source_selection",
+    "occluded_emergence_late_visibility": "insufficient_braking_distance",
+    "occluded_emergence_slow_pedestrian": "unnecessary_stop",
+    "occluded_emergence_fast_pedestrian": "forecast_miss",
+}
+
+
+def _trace_path(name: str) -> pathlib.Path:
+    short = name.replace("occluded_emergence_", "")
+    return FIXTURE_DIR / f"occluded_emergence_{short}_episode_0000.json"
+
+
+def _meta_path(name: str) -> pathlib.Path:
+    return SOURCES_DIR / f"issue_2780_{name}_fixture_111_ep0000.meta.json"
+
+
+def _load_trace(name: str) -> dict:
+    with open(_trace_path(name)) as fh:
+        return json.load(fh)
+
+
+def _load_meta(name: str) -> dict:
+    with open(_meta_path(name)) as fh:
+        return json.load(fh)
+
+
+def _load_summary() -> dict:
+    with open(SUMMARY_PATH) as fh:
+        return json.load(fh)
+
+
+def _load_generator_module():
+    module_name = "generate_occluded_emergence_variants_issue_2780"
+    spec = importlib.util.spec_from_file_location(module_name, GENERATOR_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_all_variant_trace_files_exist() -> None:
+    """Every named variant has a trace JSON file."""
+    for name in VARIANT_NAMES:
+        path = _trace_path(name)
+        assert path.exists(), f"Missing trace fixture: {path}"
+
+
+def test_all_variant_metadata_files_exist() -> None:
+    """Every named variant has a metadata JSON file."""
+    for name in VARIANT_NAMES:
+        path = _meta_path(name)
+        assert path.exists(), f"Missing metadata: {path}"
+
+
+def test_variant_trace_schema_version() -> None:
+    """All variants use the correct schema version."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert trace["schema_version"] == "simulation_trace_export.v1"
+
+
+def test_variant_evidence_boundary() -> None:
+    """All variants carry the conservative evidence boundary."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert trace["evidence_boundary"] == "smoke_diagnostic_only_not_benchmark_evidence"
+
+
+def test_variant_metadata_boundaries() -> None:
+    """Metadata files record the same evidence boundary and variant name."""
+    for name in VARIANT_NAMES:
+        meta = _load_meta(name)
+        assert meta["boundary"] == "smoke_diagnostic_only_not_benchmark_evidence"
+        assert meta["variant_name"] == name
+        assert meta["issue"] == 2780
+        assert meta["parent_issue"] == 2756
+
+
+def test_variant_expected_failure_modes() -> None:
+    """Each variant records its expected failure mode."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert "variant" in trace
+        assert trace["variant"]["expected_failure_mode"] == EXPECTED_FAILURE_MODES[name]
+        assert trace["variant"]["issue"] == 2780
+
+
+def test_variant_metadata_failure_modes_match() -> None:
+    """Metadata failure modes match the trace variant field."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        meta = _load_meta(name)
+        assert meta["expected_failure_mode"] == trace["variant"]["expected_failure_mode"]
+
+
+def test_variant_variation_dimensions_nonempty() -> None:
+    """Each variant specifies at least two variation dimensions."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        dims = trace["variant"]["variation_dimensions"]
+        assert isinstance(dims, list)
+        assert len(dims) >= 2, f"{name} has too few variation dimensions: {dims}"
+
+
+def test_variant_evidence_boundary_note_present() -> None:
+    """Each variant records an evidence boundary note."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert "evidence_boundary_note" in trace["variant"]
+        assert trace["variant"]["evidence_boundary_note"].startswith("diagnostic")
+
+
+def test_variant_safety_relevant_field_present() -> None:
+    """Each variant explicitly declares safety relevance."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert "safety_relevant_under_live_replay" in trace["variant"]
+
+
+def test_variant_safety_relevant_set_matches_reported_boundary() -> None:
+    """Safety-relevant variants match the issue #2780 diagnostic boundary."""
+    expected_safety_relevant = {
+        "occluded_emergence_left_close",
+        "occluded_emergence_right_close",
+        "occluded_emergence_late_visibility",
+        "occluded_emergence_fast_pedestrian",
+    }
+    actual_safety_relevant = {
+        name
+        for name in VARIANT_NAMES
+        if _load_trace(name)["variant"]["safety_relevant_under_live_replay"]
+    }
+    assert actual_safety_relevant == expected_safety_relevant
+
+
+def test_variant_safety_relevant_slow_pedestrian_false() -> None:
+    """Slow-pedestrian variant is not safety-relevant."""
+    trace = _load_trace("occluded_emergence_slow_pedestrian")
+    assert trace["variant"]["safety_relevant_under_live_replay"] is False
+
+
+def test_variant_files_match_generator_output() -> None:
+    """Checked-in traces are exactly the deterministic generator output."""
+    generator = _load_generator_module()
+    generated = generator.generate_all()
+    assert set(generated) == set(VARIANT_NAMES)
+    for name in VARIANT_NAMES:
+        assert generated[name] == _load_trace(name)
+
+
+def test_variant_summary_matches_trace_and_metadata_files() -> None:
+    """Summary artifact paths and fields stay synchronized with fixture files."""
+    summary = _load_summary()
+    summary_variants = {row["name"]: row for row in summary["variants"]}
+    assert summary["variant_count"] == len(VARIANT_NAMES)
+    assert set(summary_variants) == set(VARIANT_NAMES)
+
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        meta = _load_meta(name)
+        row = summary_variants[name]
+
+        assert row["trace_path"] == str(_trace_path(name).relative_to(REPO_ROOT))
+        assert row["metadata_path"] == str(_meta_path(name).relative_to(REPO_ROOT))
+        assert row["scenario_id"] == trace["source"]["scenario_id"] == meta["scenario"]
+        assert row["seed"] == trace["source"]["seed"] == meta["seed"]
+        assert row["episode_id"] == trace["source"]["episode_id"] == meta["episode_id"]
+        assert (
+            row["expected_failure_mode"]
+            == trace["variant"]["expected_failure_mode"]
+            == meta["expected_failure_mode"]
+        )
+        assert (
+            row["variation_dimensions"]
+            == trace["variant"]["variation_dimensions"]
+            == meta["variation_dimensions"]
+        )
+        assert (
+            row["safety_relevant_under_live_replay"]
+            == trace["variant"]["safety_relevant_under_live_replay"]
+            == meta["safety_relevant_under_live_replay"]
+        )
+
+
+def test_variant_first_visible_step_present() -> None:
+    """All variants have an occlusion metadata block with first_visible_step."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert "first_visible_step" in trace["occlusion"]
+        assert isinstance(trace["occlusion"]["first_visible_step"], int)
+
+
+def test_variant_first_visible_frame_matches_occlusion_transition() -> None:
+    """Frame visibility flags transition at the variant first-visible step."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        first_visible_step = trace["occlusion"]["first_visible_step"]
+        first_visible_frames = [frame for frame in trace["frames"] if frame["first_visible"]]
+        assert [frame["step"] for frame in first_visible_frames] == [first_visible_step]
+
+        for frame in trace["frames"]:
+            expected_status = "occluded" if frame["step"] < first_visible_step else "visible"
+            assert frame["occlusion_status"] == {"emerging_ped": expected_status}
+
+
+def test_variant_conflict_time_matches_geometry() -> None:
+    """Conflict timing metadata is derived from the initial pedestrian geometry."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        occlusion = trace["occlusion"]
+        first_frame = trace["frames"][0]
+        pedestrian = first_frame["pedestrians"][0]
+        initial_y = pedestrian["position"][1]
+        speed_y = abs(pedestrian["velocity"][1])
+        conflict_y = occlusion["conflict_zone_center"][1]
+        expected_conflict_time = abs(initial_y - conflict_y) / speed_y
+        assert occlusion["conflict_time_s"] == round(expected_conflict_time, 4)
+
+
+def test_variant_emergence_sides_vary() -> None:
+    """Left and right variants have different occluder x-bounds."""
+    left = _load_trace("occluded_emergence_left_close")
+    right = _load_trace("occluded_emergence_right_close")
+    assert (
+        left["occlusion"]["occluder_bounds"]["x_max"]
+        < right["occlusion"]["occluder_bounds"]["x_min"]
+    )
+
+
+def test_variant_pedestrian_speeds_vary() -> None:
+    """Slow and fast variants have different pedestrian speeds."""
+    slow = _load_trace("occluded_emergence_slow_pedestrian")
+    fast = _load_trace("occluded_emergence_fast_pedestrian")
+    slow_speed = slow["frames"][0]["pedestrians"][0]["velocity"][1]
+    fast_speed = fast["frames"][0]["pedestrians"][0]["velocity"][1]
+    assert slow_speed < fast_speed
+
+
+def test_variant_frame_count() -> None:
+    """All variants have exactly 16 frames."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        assert len(trace["frames"]) == 16
+
+
+def test_variant_frames_have_required_fields() -> None:
+    """Every frame in every variant has the standard trace fields."""
+    required = [
+        "step",
+        "time_s",
+        "robot",
+        "pedestrians",
+        "observed_pedestrians",
+        "occlusion_status",
+        "first_visible",
+        "conflict_timing",
+        "planner",
+    ]
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        for frame in trace["frames"]:
+            for field in required:
+                assert field in frame, f"{name} step {frame['step']} missing {field}"
+
+
+def test_variant_forecast_metrics_computable() -> None:
+    """All variants produce valid forecast metrics."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        steps = [
+            {
+                "step": frame["step"],
+                "time_s": frame["time_s"],
+                "robot": frame["robot"],
+                "pedestrians": frame["pedestrians"],
+            }
+            for frame in trace["frames"]
+        ]
+        metrics = compute_batch_forecast_metrics(steps, horizons_s=[0.5, 1.0], dt_s=0.1)
+        assert metrics["forecast_evaluable_samples"] > 0, f"{name} has no evaluable samples"
+
+
+def test_distinct_failure_modes_across_variants() -> None:
+    """Each variant has a distinct expected failure mode."""
+    modes = [EXPECTED_FAILURE_MODES[name] for name in VARIANT_NAMES]
+    assert len(set(modes)) == len(VARIANT_NAMES), f"Duplicate failure modes: {modes}"
+
+
+def test_at_least_one_safety_relevant_variant() -> None:
+    """At least one variant declares itself safety-relevant under live replay."""
+    has_safety = any(
+        _load_trace(name)["variant"]["safety_relevant_under_live_replay"] for name in VARIANT_NAMES
+    )
+    assert has_safety, "No variant is safety-relevant under live replay"

--- a/tests/benchmark/test_occluded_emergence_variants.py
+++ b/tests/benchmark/test_occluded_emergence_variants.py
@@ -248,6 +248,25 @@ def test_variant_conflict_time_matches_geometry() -> None:
         assert occlusion["conflict_time_s"] == round(expected_conflict_time, 4)
 
 
+def test_variant_frame_conflict_time_never_rebounds_after_crossing() -> None:
+    """Frame time-to-conflict decreases to zero instead of rebounding after crossing."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        times = [frame["conflict_timing"]["time_to_conflict_s"] for frame in trace["frames"]]
+        assert times == sorted(times, reverse=True)
+        assert times[-1] == 0.0
+
+
+def test_variant_planner_event_does_not_restart_yield_after_conflict() -> None:
+    """Planner events do not return to yield_start after the conflict-time frame."""
+    for name in VARIANT_NAMES:
+        trace = _load_trace(name)
+        events = [frame["planner"]["event"] for frame in trace["frames"]]
+        assert events.count("conflict_time") == 1
+        conflict_index = events.index("conflict_time")
+        assert "yield_start" not in events[conflict_index + 1 :]
+
+
 def test_variant_emergence_sides_vary() -> None:
     """Left and right variants have different occluder x-bounds."""
     left = _load_trace("occluded_emergence_left_close")

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
@@ -1,0 +1,927 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000",
+  "source": {
+    "scenario_id": "issue_2780_occluded_emergence_fast_pedestrian",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2780_occluded_emergence_fast_pedestrian_ep0000",
+    "generated_by": "deterministic variant generator for issue #2780 (occluded_emergence_fast_pedestrian)"
+  },
+  "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "occlusion": {
+    "occluder_id": "static_wall_behind_corner",
+    "occluder_bounds": {
+      "x_min": 1.0,
+      "x_max": 1.25,
+      "y_min": -0.8,
+      "y_max": 0.8
+    },
+    "first_visible_step": 3,
+    "conflict_zone_center": [
+      1.2,
+      0.0
+    ],
+    "conflict_time_s": 0.6,
+    "stop_feasible_before_step": 5,
+    "yield_feasible_before_step": 7
+  },
+  "variant": {
+    "name": "occluded_emergence_fast_pedestrian",
+    "parent_issue": 2756,
+    "issue": 2780,
+    "expected_failure_mode": "forecast_miss",
+    "variation_dimensions": [
+      "ped_speed:2.0",
+      "robot_v0:1.2",
+      "first_visible_step:3"
+    ],
+    "safety_relevant_under_live_replay": true,
+    "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [
+          0.0,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -1.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.96,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [
+          0.072,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -1.0
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.96,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 2,
+      "time_s": 0.2,
+      "robot": {
+        "position": [
+          0.144,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.8
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.96,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 3,
+      "time_s": 0.3,
+      "robot": {
+        "position": [
+          0.216,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": true,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.6,
+          "angular_velocity": 0.0
+        },
+        "event": "first_visible"
+      }
+    },
+    {
+      "step": 4,
+      "time_s": 0.4,
+      "robot": {
+        "position": [
+          0.288,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 5,
+      "time_s": 0.5,
+      "robot": {
+        "position": [
+          0.36,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            -0.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.18,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 6,
+      "time_s": 0.6,
+      "robot": {
+        "position": [
+          0.432,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.0,
+          "angular_velocity": 0.0
+        },
+        "event": "conflict_time"
+      }
+    },
+    {
+      "step": 7,
+      "time_s": 0.7,
+      "robot": {
+        "position": [
+          0.504,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.18,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 8,
+      "time_s": 0.8,
+      "robot": {
+        "position": [
+          0.576,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 9,
+      "time_s": 0.9,
+      "robot": {
+        "position": [
+          0.648,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 10,
+      "time_s": 1.0,
+      "robot": {
+        "position": [
+          0.72,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 11,
+      "time_s": 1.1,
+      "robot": {
+        "position": [
+          0.792,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.0
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.0
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 12,
+      "time_s": 1.2,
+      "robot": {
+        "position": [
+          0.864,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.2
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 13,
+      "time_s": 1.3,
+      "robot": {
+        "position": [
+          0.936,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.4
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 14,
+      "time_s": 1.4,
+      "robot": {
+        "position": [
+          1.008,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.6
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.8,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 15,
+      "time_s": 1.5,
+      "robot": {
+        "position": [
+          1.08,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.2,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.8
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27805,
+          "position": [
+            1.2,
+            1.8
+          ],
+          "velocity": [
+            0.0,
+            2.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.9,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.36,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
@@ -455,7 +455,7 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.1,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
         "yield_feasible": false
       },
@@ -512,16 +512,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.2,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -569,16 +569,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.3,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -626,16 +626,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.4,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -683,16 +683,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.5,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -740,16 +740,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.6,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -797,16 +797,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.7,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -854,16 +854,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.8,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -911,16 +911,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.9,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.36,
+          "linear_velocity": 0.48,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     }
   ]

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
@@ -31,7 +31,7 @@
     ],
     "conflict_time_s": 0.6,
     "stop_feasible_before_step": 5,
-    "yield_feasible_before_step": 7
+    "yield_feasible_before_step": 5
   },
   "variant": {
     "name": "occluded_emergence_fast_pedestrian",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
@@ -458,10 +458,10 @@
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.5,
+          "linear_velocity": 0.0,
           "angular_velocity": 0.0
         },
-        "event": "first_visible"
+        "event": "conflict_time"
       }
     },
     {
@@ -509,7 +509,7 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.1,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
         "yield_feasible": false
       },
@@ -566,9 +566,9 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.2,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
-        "yield_feasible": true
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
@@ -623,16 +623,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.3,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.15,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "yield"
       }
     },
     {
@@ -680,16 +680,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.4,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.15,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "yield"
       }
     },
     {
@@ -737,16 +737,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.5,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -794,16 +794,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.6,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -851,16 +851,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.7,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     }
   ]

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
@@ -30,8 +30,8 @@
       0.0
     ],
     "conflict_time_s": 0.8,
-    "stop_feasible_before_step": 10,
-    "yield_feasible_before_step": 12
+    "stop_feasible_before_step": 6,
+    "yield_feasible_before_step": 7
   },
   "variant": {
     "name": "occluded_emergence_late_visibility",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
@@ -1,0 +1,867 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "issue_2780_occluded_emergence_late_visibility_seed111_ep0000",
+  "source": {
+    "scenario_id": "issue_2780_occluded_emergence_late_visibility",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2780_occluded_emergence_late_visibility_ep0000",
+    "generated_by": "deterministic variant generator for issue #2780 (occluded_emergence_late_visibility)"
+  },
+  "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "occlusion": {
+    "occluder_id": "static_wall_behind_corner",
+    "occluder_bounds": {
+      "x_min": 1.0,
+      "x_max": 1.25,
+      "y_min": -0.8,
+      "y_max": 0.8
+    },
+    "first_visible_step": 8,
+    "conflict_zone_center": [
+      1.2,
+      0.0
+    ],
+    "conflict_time_s": 0.8,
+    "stop_feasible_before_step": 10,
+    "yield_feasible_before_step": 12
+  },
+  "variant": {
+    "name": "occluded_emergence_late_visibility",
+    "parent_issue": 2756,
+    "issue": 2780,
+    "expected_failure_mode": "insufficient_braking_distance",
+    "variation_dimensions": [
+      "first_visible_step:8",
+      "ped_speed:1.0",
+      "robot_v0:1.0"
+    ],
+    "safety_relevant_under_live_replay": true,
+    "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [
+          0.0,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.8
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.8,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [
+          0.06,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.7
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 2,
+      "time_s": 0.2,
+      "robot": {
+        "position": [
+          0.12,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.6
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 3,
+      "time_s": 0.3,
+      "robot": {
+        "position": [
+          0.18,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.5
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 4,
+      "time_s": 0.4,
+      "robot": {
+        "position": [
+          0.24,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 5,
+      "time_s": 0.5,
+      "robot": {
+        "position": [
+          0.3,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.3
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 6,
+      "time_s": 0.6,
+      "robot": {
+        "position": [
+          0.36,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.2
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 7,
+      "time_s": 0.7,
+      "robot": {
+        "position": [
+          0.42,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            -0.1
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 8,
+      "time_s": 0.8,
+      "robot": {
+        "position": [
+          0.48,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": true,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.5,
+          "angular_velocity": 0.0
+        },
+        "event": "first_visible"
+      }
+    },
+    {
+      "step": 9,
+      "time_s": 0.9,
+      "robot": {
+        "position": [
+          0.54,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.1
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.1
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 10,
+      "time_s": 1.0,
+      "robot": {
+        "position": [
+          0.6,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 11,
+      "time_s": 1.1,
+      "robot": {
+        "position": [
+          0.66,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.3
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.3
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 12,
+      "time_s": 1.2,
+      "robot": {
+        "position": [
+          0.72,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.4
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.4
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 13,
+      "time_s": 1.3,
+      "robot": {
+        "position": [
+          0.78,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.5
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.5
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 14,
+      "time_s": 1.4,
+      "robot": {
+        "position": [
+          0.84,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.6
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.6
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 15,
+      "time_s": 1.5,
+      "robot": {
+        "position": [
+          0.9,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.7
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27803,
+          "position": [
+            1.2,
+            0.7
+          ],
+          "velocity": [
+            0.0,
+            1.0
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
@@ -557,16 +557,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.0667,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
         "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.15,
+          "linear_velocity": 0.0,
           "angular_velocity": 0.0
         },
-        "event": "yield"
+        "event": "conflict_time"
       }
     },
     {
@@ -614,9 +614,9 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.1667,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
-        "yield_feasible": true
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
@@ -671,16 +671,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.2667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -728,16 +728,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.3667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -785,16 +785,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.4667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -842,16 +842,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.5667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -899,16 +899,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.6667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     }
   ]

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
@@ -30,8 +30,8 @@
       0.0
     ],
     "conflict_time_s": 0.8333,
-    "stop_feasible_before_step": 8,
-    "yield_feasible_before_step": 10
+    "stop_feasible_before_step": 6,
+    "yield_feasible_before_step": 7
   },
   "variant": {
     "name": "occluded_emergence_left_close",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
@@ -1,0 +1,915 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "issue_2780_occluded_emergence_left_close_seed111_ep0000",
+  "source": {
+    "scenario_id": "issue_2780_occluded_emergence_left_close",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2780_occluded_emergence_left_close_ep0000",
+    "generated_by": "deterministic variant generator for issue #2780 (occluded_emergence_left_close)"
+  },
+  "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "occlusion": {
+    "occluder_id": "static_wall_behind_corner",
+    "occluder_bounds": {
+      "x_min": 0.8,
+      "x_max": 1.05,
+      "y_min": -0.8,
+      "y_max": 0.8
+    },
+    "first_visible_step": 4,
+    "conflict_zone_center": [
+      0.9,
+      0.0
+    ],
+    "conflict_time_s": 0.8333,
+    "stop_feasible_before_step": 8,
+    "yield_feasible_before_step": 10
+  },
+  "variant": {
+    "name": "occluded_emergence_left_close",
+    "parent_issue": 2756,
+    "issue": 2780,
+    "expected_failure_mode": "late_detection",
+    "variation_dimensions": [
+      "emergence_side:left",
+      "first_visible_step:4",
+      "ped_speed:1.2"
+    ],
+    "safety_relevant_under_live_replay": true,
+    "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [
+          0.0,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -1.0
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.8333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [
+          0.06,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.88
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 2,
+      "time_s": 0.2,
+      "robot": {
+        "position": [
+          0.12,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.76
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 3,
+      "time_s": 0.3,
+      "robot": {
+        "position": [
+          0.18,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.64
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 4,
+      "time_s": 0.4,
+      "robot": {
+        "position": [
+          0.24,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.52
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.52
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": true,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.5,
+          "angular_velocity": 0.0
+        },
+        "event": "first_visible"
+      }
+    },
+    {
+      "step": 5,
+      "time_s": 0.5,
+      "robot": {
+        "position": [
+          0.3,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 6,
+      "time_s": 0.6,
+      "robot": {
+        "position": [
+          0.36,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2333,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 7,
+      "time_s": 0.7,
+      "robot": {
+        "position": [
+          0.42,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1333,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 8,
+      "time_s": 0.8,
+      "robot": {
+        "position": [
+          0.48,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0333,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 9,
+      "time_s": 0.9,
+      "robot": {
+        "position": [
+          0.54,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.08
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.08
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0667,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 10,
+      "time_s": 1.0,
+      "robot": {
+        "position": [
+          0.6,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1667,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 11,
+      "time_s": 1.1,
+      "robot": {
+        "position": [
+          0.66,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.32
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.32
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 12,
+      "time_s": 1.2,
+      "robot": {
+        "position": [
+          0.72,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.44
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.44
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 13,
+      "time_s": 1.3,
+      "robot": {
+        "position": [
+          0.78,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.56
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.56
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 14,
+      "time_s": 1.4,
+      "robot": {
+        "position": [
+          0.84,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.68
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.68
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 15,
+      "time_s": 1.5,
+      "robot": {
+        "position": [
+          0.9,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27801,
+          "position": [
+            0.9,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
@@ -557,16 +557,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.0667,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
         "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.15,
+          "linear_velocity": 0.0,
           "angular_velocity": 0.0
         },
-        "event": "yield"
+        "event": "conflict_time"
       }
     },
     {
@@ -614,9 +614,9 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.1667,
+        "time_to_conflict_s": 0.0,
         "stop_feasible": false,
-        "yield_feasible": true
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
@@ -671,16 +671,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.2667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -728,16 +728,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.3667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -785,16 +785,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.4667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -842,16 +842,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.5667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     },
     {
@@ -899,16 +899,16 @@
       },
       "first_visible": false,
       "conflict_timing": {
-        "time_to_conflict_s": 0.6667,
-        "stop_feasible": true,
-        "yield_feasible": true
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
       },
       "planner": {
         "selected_action": {
-          "linear_velocity": 0.3,
+          "linear_velocity": 0.4,
           "angular_velocity": 0.0
         },
-        "event": "yield_start"
+        "event": "resume"
       }
     }
   ]

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
@@ -30,8 +30,8 @@
       0.0
     ],
     "conflict_time_s": 0.8333,
-    "stop_feasible_before_step": 8,
-    "yield_feasible_before_step": 10
+    "stop_feasible_before_step": 6,
+    "yield_feasible_before_step": 7
   },
   "variant": {
     "name": "occluded_emergence_right_close",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
@@ -1,0 +1,915 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "issue_2780_occluded_emergence_right_close_seed111_ep0000",
+  "source": {
+    "scenario_id": "issue_2780_occluded_emergence_right_close",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2780_occluded_emergence_right_close_ep0000",
+    "generated_by": "deterministic variant generator for issue #2780 (occluded_emergence_right_close)"
+  },
+  "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "occlusion": {
+    "occluder_id": "static_wall_behind_corner",
+    "occluder_bounds": {
+      "x_min": 1.5,
+      "x_max": 1.75,
+      "y_min": -0.8,
+      "y_max": 0.8
+    },
+    "first_visible_step": 4,
+    "conflict_zone_center": [
+      1.6,
+      0.0
+    ],
+    "conflict_time_s": 0.8333,
+    "stop_feasible_before_step": 8,
+    "yield_feasible_before_step": 10
+  },
+  "variant": {
+    "name": "occluded_emergence_right_close",
+    "parent_issue": 2756,
+    "issue": 2780,
+    "expected_failure_mode": "wrong_source_selection",
+    "variation_dimensions": [
+      "emergence_side:right",
+      "first_visible_step:4",
+      "ped_speed:1.2"
+    ],
+    "safety_relevant_under_live_replay": true,
+    "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [
+          0.0,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -1.0
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.8333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [
+          0.06,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.88
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 2,
+      "time_s": 0.2,
+      "robot": {
+        "position": [
+          0.12,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.76
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 3,
+      "time_s": 0.3,
+      "robot": {
+        "position": [
+          0.18,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.64
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.8,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 4,
+      "time_s": 0.4,
+      "robot": {
+        "position": [
+          0.24,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.52
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.52
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": true,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.5,
+          "angular_velocity": 0.0
+        },
+        "event": "first_visible"
+      }
+    },
+    {
+      "step": 5,
+      "time_s": 0.5,
+      "robot": {
+        "position": [
+          0.3,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3333,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 6,
+      "time_s": 0.6,
+      "robot": {
+        "position": [
+          0.36,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2333,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 7,
+      "time_s": 0.7,
+      "robot": {
+        "position": [
+          0.42,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1333,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 8,
+      "time_s": 0.8,
+      "robot": {
+        "position": [
+          0.48,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0333,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 9,
+      "time_s": 0.9,
+      "robot": {
+        "position": [
+          0.54,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.08
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.08
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0667,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 10,
+      "time_s": 1.0,
+      "robot": {
+        "position": [
+          0.6,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.2
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1667,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.15,
+          "angular_velocity": 0.0
+        },
+        "event": "yield"
+      }
+    },
+    {
+      "step": 11,
+      "time_s": 1.1,
+      "robot": {
+        "position": [
+          0.66,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.32
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.32
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 12,
+      "time_s": 1.2,
+      "robot": {
+        "position": [
+          0.72,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.44
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.44
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 13,
+      "time_s": 1.3,
+      "robot": {
+        "position": [
+          0.78,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.56
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.56
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 14,
+      "time_s": 1.4,
+      "robot": {
+        "position": [
+          0.84,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.68
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.68
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 15,
+      "time_s": 1.5,
+      "robot": {
+        "position": [
+          0.9,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          1.0,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27802,
+          "position": [
+            1.6,
+            0.8
+          ],
+          "velocity": [
+            0.0,
+            1.2
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6667,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.3,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json
@@ -30,8 +30,8 @@
       0.0
     ],
     "conflict_time_s": 1.5,
-    "stop_feasible_before_step": 7,
-    "yield_feasible_before_step": 9
+    "stop_feasible_before_step": 12,
+    "yield_feasible_before_step": 13
   },
   "variant": {
     "name": "occluded_emergence_slow_pedestrian",

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json
@@ -1,0 +1,903 @@
+{
+  "schema_version": "simulation_trace_export.v1",
+  "trace_id": "issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000",
+  "source": {
+    "scenario_id": "issue_2780_occluded_emergence_slow_pedestrian",
+    "seed": 111,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "issue_2780_occluded_emergence_slow_pedestrian_ep0000",
+    "generated_by": "deterministic variant generator for issue #2780 (occluded_emergence_slow_pedestrian)"
+  },
+  "evidence_boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "coordinate_frame": "world",
+  "units": {
+    "position": "m",
+    "heading": "rad",
+    "time": "s",
+    "velocity": "m/s"
+  },
+  "occlusion": {
+    "occluder_id": "static_wall_behind_corner",
+    "occluder_bounds": {
+      "x_min": 1.0,
+      "x_max": 1.25,
+      "y_min": -0.8,
+      "y_max": 0.8
+    },
+    "first_visible_step": 5,
+    "conflict_zone_center": [
+      1.2,
+      0.0
+    ],
+    "conflict_time_s": 1.5,
+    "stop_feasible_before_step": 7,
+    "yield_feasible_before_step": 9
+  },
+  "variant": {
+    "name": "occluded_emergence_slow_pedestrian",
+    "parent_issue": 2756,
+    "issue": 2780,
+    "expected_failure_mode": "unnecessary_stop",
+    "variation_dimensions": [
+      "ped_speed:0.4",
+      "robot_v0:0.8",
+      "first_visible_step:5"
+    ],
+    "safety_relevant_under_live_replay": false,
+    "evidence_boundary_note": "diagnostic_stress_only_not_benchmark_evidence"
+  },
+  "frames": [
+    {
+      "step": 0,
+      "time_s": 0.0,
+      "robot": {
+        "position": [
+          0.0,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.6
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.64,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 1,
+      "time_s": 0.1,
+      "robot": {
+        "position": [
+          0.048,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.56
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.64,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 2,
+      "time_s": 0.2,
+      "robot": {
+        "position": [
+          0.096,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.52
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.3,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.64,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 3,
+      "time_s": 0.3,
+      "robot": {
+        "position": [
+          0.144,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.48
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.2,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.64,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 4,
+      "time_s": 0.4,
+      "robot": {
+        "position": [
+          0.192,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.44
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [],
+      "occlusion_status": {
+        "emerging_ped": "occluded"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.1,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.64,
+          "angular_velocity": 0.0
+        },
+        "event": "approach_occluder"
+      }
+    },
+    {
+      "step": 5,
+      "time_s": 0.5,
+      "robot": {
+        "position": [
+          0.24,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.4
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": true,
+      "conflict_timing": {
+        "time_to_conflict_s": 1.0,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.4,
+          "angular_velocity": 0.0
+        },
+        "event": "first_visible"
+      }
+    },
+    {
+      "step": 6,
+      "time_s": 0.6,
+      "robot": {
+        "position": [
+          0.288,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.36
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.36
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.9,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 7,
+      "time_s": 0.7,
+      "robot": {
+        "position": [
+          0.336,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.32
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.32
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.8,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 8,
+      "time_s": 0.8,
+      "robot": {
+        "position": [
+          0.384,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.28
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.7,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 9,
+      "time_s": 0.9,
+      "robot": {
+        "position": [
+          0.432,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.24
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.24
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.6,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 10,
+      "time_s": 1.0,
+      "robot": {
+        "position": [
+          0.48,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.2
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.2
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.5,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 11,
+      "time_s": 1.1,
+      "robot": {
+        "position": [
+          0.528,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.16
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.4,
+        "stop_feasible": true,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.24,
+          "angular_velocity": 0.0
+        },
+        "event": "yield_start"
+      }
+    },
+    {
+      "step": 12,
+      "time_s": 1.2,
+      "robot": {
+        "position": [
+          0.576,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.12
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.12
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.3,
+        "stop_feasible": false,
+        "yield_feasible": true
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.32,
+          "angular_velocity": 0.0
+        },
+        "event": "resume"
+      }
+    },
+    {
+      "step": 13,
+      "time_s": 1.3,
+      "robot": {
+        "position": [
+          0.624,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.08
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.08
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.2,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.32,
+          "angular_velocity": 0.0
+        },
+        "event": "resume"
+      }
+    },
+    {
+      "step": 14,
+      "time_s": 1.4,
+      "robot": {
+        "position": [
+          0.672,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            -0.04
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.1,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.32,
+          "angular_velocity": 0.0
+        },
+        "event": "resume"
+      }
+    },
+    {
+      "step": 15,
+      "time_s": 1.5,
+      "robot": {
+        "position": [
+          0.72,
+          0.0
+        ],
+        "heading": 0.0,
+        "velocity": [
+          0.8,
+          0.0
+        ]
+      },
+      "pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "observed_pedestrians": [
+        {
+          "id": 27804,
+          "position": [
+            1.2,
+            0.0
+          ],
+          "velocity": [
+            0.0,
+            0.4
+          ]
+        }
+      ],
+      "occlusion_status": {
+        "emerging_ped": "visible"
+      },
+      "first_visible": false,
+      "conflict_timing": {
+        "time_to_conflict_s": 0.0,
+        "stop_feasible": false,
+        "yield_feasible": false
+      },
+      "planner": {
+        "selected_action": {
+          "linear_velocity": 0.0,
+          "angular_velocity": 0.0
+        },
+        "event": "conflict_time"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_fast_pedestrian_fixture_111_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_fast_pedestrian_fixture_111_ep0000.meta.json
@@ -1,0 +1,25 @@
+{
+  "algorithm": "hand_authored_deterministic_fixture",
+  "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "episode_id": "issue_2780_occluded_emergence_fast_pedestrian_ep0000",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "scenario": "issue_2780_occluded_emergence_fast_pedestrian",
+  "seed": 111,
+  "source_kind": "simulation_trace_export.v1 fixture",
+  "variant_name": "occluded_emergence_fast_pedestrian",
+  "expected_failure_mode": "forecast_miss",
+  "variation_dimensions": [
+    "ped_speed:2.0",
+    "robot_v0:1.2",
+    "first_visible_step:3"
+  ],
+  "safety_relevant_under_live_replay": true,
+  "evidence_boundary": "diagnostic_stress_only_not_benchmark_evidence",
+  "notes": [
+    "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+    "Expected failure mode: forecast_miss.",
+    "Variation dimensions: ped_speed:2.0, robot_v0:1.2, first_visible_step:3.",
+    "This fixture is not paper-facing benchmark evidence."
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_late_visibility_fixture_111_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_late_visibility_fixture_111_ep0000.meta.json
@@ -1,0 +1,25 @@
+{
+  "algorithm": "hand_authored_deterministic_fixture",
+  "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "episode_id": "issue_2780_occluded_emergence_late_visibility_ep0000",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "scenario": "issue_2780_occluded_emergence_late_visibility",
+  "seed": 111,
+  "source_kind": "simulation_trace_export.v1 fixture",
+  "variant_name": "occluded_emergence_late_visibility",
+  "expected_failure_mode": "insufficient_braking_distance",
+  "variation_dimensions": [
+    "first_visible_step:8",
+    "ped_speed:1.0",
+    "robot_v0:1.0"
+  ],
+  "safety_relevant_under_live_replay": true,
+  "evidence_boundary": "diagnostic_stress_only_not_benchmark_evidence",
+  "notes": [
+    "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+    "Expected failure mode: insufficient_braking_distance.",
+    "Variation dimensions: first_visible_step:8, ped_speed:1.0, robot_v0:1.0.",
+    "This fixture is not paper-facing benchmark evidence."
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_left_close_fixture_111_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_left_close_fixture_111_ep0000.meta.json
@@ -1,0 +1,25 @@
+{
+  "algorithm": "hand_authored_deterministic_fixture",
+  "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "episode_id": "issue_2780_occluded_emergence_left_close_ep0000",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "scenario": "issue_2780_occluded_emergence_left_close",
+  "seed": 111,
+  "source_kind": "simulation_trace_export.v1 fixture",
+  "variant_name": "occluded_emergence_left_close",
+  "expected_failure_mode": "late_detection",
+  "variation_dimensions": [
+    "emergence_side:left",
+    "first_visible_step:4",
+    "ped_speed:1.2"
+  ],
+  "safety_relevant_under_live_replay": true,
+  "evidence_boundary": "diagnostic_stress_only_not_benchmark_evidence",
+  "notes": [
+    "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+    "Expected failure mode: late_detection.",
+    "Variation dimensions: emergence_side:left, first_visible_step:4, ped_speed:1.2.",
+    "This fixture is not paper-facing benchmark evidence."
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_right_close_fixture_111_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_right_close_fixture_111_ep0000.meta.json
@@ -1,0 +1,25 @@
+{
+  "algorithm": "hand_authored_deterministic_fixture",
+  "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "episode_id": "issue_2780_occluded_emergence_right_close_ep0000",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "scenario": "issue_2780_occluded_emergence_right_close",
+  "seed": 111,
+  "source_kind": "simulation_trace_export.v1 fixture",
+  "variant_name": "occluded_emergence_right_close",
+  "expected_failure_mode": "wrong_source_selection",
+  "variation_dimensions": [
+    "emergence_side:right",
+    "first_visible_step:4",
+    "ped_speed:1.2"
+  ],
+  "safety_relevant_under_live_replay": true,
+  "evidence_boundary": "diagnostic_stress_only_not_benchmark_evidence",
+  "notes": [
+    "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+    "Expected failure mode: wrong_source_selection.",
+    "Variation dimensions: emergence_side:right, first_visible_step:4, ped_speed:1.2.",
+    "This fixture is not paper-facing benchmark evidence."
+  ]
+}

--- a/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_slow_pedestrian_fixture_111_ep0000.meta.json
+++ b/tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2780_occluded_emergence_slow_pedestrian_fixture_111_ep0000.meta.json
@@ -1,0 +1,25 @@
+{
+  "algorithm": "hand_authored_deterministic_fixture",
+  "boundary": "smoke_diagnostic_only_not_benchmark_evidence",
+  "episode_id": "issue_2780_occluded_emergence_slow_pedestrian_ep0000",
+  "issue": 2780,
+  "parent_issue": 2756,
+  "scenario": "issue_2780_occluded_emergence_slow_pedestrian",
+  "seed": 111,
+  "source_kind": "simulation_trace_export.v1 fixture",
+  "variant_name": "occluded_emergence_slow_pedestrian",
+  "expected_failure_mode": "unnecessary_stop",
+  "variation_dimensions": [
+    "ped_speed:0.4",
+    "robot_v0:0.8",
+    "first_visible_step:5"
+  ],
+  "safety_relevant_under_live_replay": false,
+  "evidence_boundary": "diagnostic_stress_only_not_benchmark_evidence",
+  "notes": [
+    "Variant of the issue #2756 occluded-emergence fixture for issue #2780.",
+    "Expected failure mode: unnecessary_stop.",
+    "Variation dimensions: ped_speed:0.4, robot_v0:0.8, first_visible_step:5.",
+    "This fixture is not paper-facing benchmark evidence."
+  ]
+}


### PR DESCRIPTION
## Summary
Adds five deterministic simulated occluded-emergence trace variants beyond the original hand-authored fixture, with metadata, tests, and an indexed evidence bundle.

## Linked Issues
- Closes `#2780`
- Relates to `#2756`
- Relates to `#2777`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `scripts/tools/generate_occluded_emergence_variants.py` to deterministically generate five issue #2780 variant traces and metadata.
- Added five committed `simulation_trace_export.v1` fixtures plus source metadata for left-close, right-close, late-visibility, slow-pedestrian, and fast-pedestrian occluded-emergence cases.
- Added `tests/benchmark/test_occluded_emergence_variants.py` covering schema, generator determinism, summary/metadata synchronization, safety-relevance boundary, variation coverage, visibility transition structure, conflict timing, and forecast metric computability.
- Added `docs/context/evidence/issue_2780_occluded_emergence_variants/` and indexed it in the evidence README and context catalog.

## Why It Matters
- Added value: expands the occluded-emergence stress surface from one hand-authored fixture into five reproducible variants.
- Expected impact: gives future planner/replay work durable inputs for late detection, source selection, braking-distance, unnecessary-stop, and forecast-miss diagnostics.
- Why this is worth merging now: it unblocks #2780 with trace-generating fixtures while keeping the evidence boundary conservative and explicit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #2780 needs reproducible occluded-emergence variants beyond the single #2756 fixture.
- Comparator or baseline, if applicable: the existing issue #2756 hand-authored occluded-emergence fixture.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop when the five named variants are trace-generating, metadata-backed, tested, indexed, and explicitly bounded as non-benchmark evidence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2780 and `docs/context/evidence/issue_2780_occluded_emergence_variants/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `scripts/tools/generate_occluded_emergence_variants.py` is exercised on committed fixture inputs/outputs in this PR; it does not interpret benchmark results.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, as deterministic trace-generation and forecast-metric smoke coverage.
- Did the intervention change command source, selected command, trajectory, or route progress? no live planner/replay trajectory claim is made.
- Did the scenario actually contain the targeted failure mode? the fixtures encode the targeted expected failure modes diagnostically; live replay remains follow-up evidence.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #2777 remains the live replay boundary for safety sufficiency.

## Next Empirical Action
- Rerun needed: no for this fixture-generation scope; yes for live replay/safety claims.
- Extractor or analysis tool needed: no for this PR.
- Artifact missing or unavailable: live replay evidence is intentionally out of scope.
- Stop / revise / continue decision: stop this fixture scope; continue via #2777/successor live replay work.
- Proposed child issue or existing follow-up: #2777.

## Validation / Proof
- Commands run:
  - `uv run python scripts/tools/generate_occluded_emergence_variants.py`
  - `uv run pytest tests/benchmark/test_occluded_emergence_variants.py tests/benchmark/test_occluded_emergence_fixture.py -q`
  - `uv run ruff check scripts/tools/generate_occluded_emergence_variants.py tests/benchmark/test_occluded_emergence_variants.py`
  - `uv run ruff format --check scripts/tools/generate_occluded_emergence_variants.py tests/benchmark/test_occluded_emergence_variants.py`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/evidence/README.md --path docs/context/evidence/issue_2780_occluded_emergence_variants/README.md --path docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json`
  - `BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed with `29 passed`; final PR readiness passed from clean head `9ffbcd94b30b031f59d8e88578cc41a36da95020` with `6120 passed, 9 skipped, 9 warnings`.
- Benchmarks or smoke tests, if applicable: forecast-metric smoke tests on all five committed trace fixtures.

## Risks / Rollout
- Compatibility risks: low; this adds fixtures, a generator script, tests, and evidence docs.
- Failure modes: downstream users could overinterpret diagnostic fixtures as live replay or paper-facing evidence; docs and metadata explicitly prohibit that.
- Rollback or fallback plan: revert the fixture/generator/test/evidence bundle.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, and `docs/context/evidence/issue_2780_occluded_emergence_variants/README.md`.
- Relevant design or provenance notes: `docs/context/evidence/issue_2780_occluded_emergence_variants/summary.json`.
- Any assumptions that need to be preserved: fixtures are diagnostic/stress-only and do not replace #2777 live replay evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR closes #2780.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark-strength claim is promoted.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, context catalog updated.
- Context index / memory note updated (yes/no/NA): yes, evidence README and catalog updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, existing #2777 covers live replay follow-up.
- Not applicable because: this PR creates diagnostic fixtures only and does not publish benchmark results.

## Follow-Up Issues
- Deferred work: live replay and safety-sufficiency evidence remain outside this PR.
- Issues opened for follow-up: none; #2777 already tracks the live replay boundary.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the evidence boundary language stays diagnostic-only and that `summary.json` matches the generated fixture metadata.
- Any known limitations: these traces are simulated/hand-authored deterministic fixtures, not real-world representativeness or live replay evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing five occluded emergence variant test scenarios with simulation parameters, failure modes, and safety relevance boundaries.

* **Tests**
  * Added comprehensive test suite for occluded emergence variant fixtures, including validation of fixture generation, schema compliance, determinism, behavioral properties, and safety-relevant scenario classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->