### PR TITLE
benchmark: add signalized crossing metric report rows

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1212,6 +1212,18 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2753_signalized_crossing_metrics/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2753_signalized_crossing_metrics/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2753_signalized_crossing_metrics/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -313,3 +313,7 @@ Policy caveats:
 - `issue_2270_panel_candidate_manifest_2026-06-05/`: analysis-only panel candidate manifest for
   Issue #2270 / parent Issue #2227, recording static-recenter and topology panel candidates that
   remain blocked on durable `simulation_trace_export.v1` trace pairs.
+- `issue_2753_signalized_crossing_metrics/`: fixture/report-table evidence for the four canonical
+  signalized crossing metric row types (`red_required_stop`, `green_proceed`,
+  `unavailable_no_claim`, `proxy_only_denominator_excluded`).  No simulator or runtime traces;
+  fixture-only claim boundary.

--- a/docs/context/evidence/issue_2753_signalized_crossing_metrics/README.md
+++ b/docs/context/evidence/issue_2753_signalized_crossing_metrics/README.md
@@ -1,0 +1,36 @@
+# Issue #2753 Signalized Crossing Metrics Report-Row Fixture Evidence 2026-06-13
+
+**Date:** 2026-06-13
+**Commit:** (generated, see manifest)
+
+## Scope
+
+Fixture/report-table evidence for the four canonical signalized crossing
+metric row types defined in `robot_sf/benchmark/signal_metrics.py`:
+
+| Row type | planner_observable | benchmark_evidence | denominator | compliance_eligible |
+|---|---|---|---|---|
+| `red_required_stop` | true | true | 1 | true |
+| `green_proceed` | true | true | 1 | true |
+| `unavailable_no_claim` | false | false | 0 | false |
+| `proxy_only_denominator_excluded` | false | false | 0 | false |
+
+## Claim Boundary
+
+This is fixture/report-table evidence only.  The script constructs
+synthetic episodes and feeds them through `signal_metrics_report_rows`
+to verify the report-row contract.  No simulator or runtime traces were
+executed, so no compliance claim is established beyond the report-row
+structure. Simulator-backed runtime evidence is deferred to issue #2799.
+
+## Files
+
+- `summary.json`: machine-readable fixture summary
+- `report.md`: rendered Markdown report table
+- `README.md`: this file
+
+## Reproduction
+
+```bash
+uv run python scripts/tools/generate_signalized_crossing_metrics_report.py
+```

--- a/docs/context/evidence/issue_2753_signalized_crossing_metrics/report.md
+++ b/docs/context/evidence/issue_2753_signalized_crossing_metrics/report.md
@@ -1,0 +1,14 @@
+# Issue #2753 Signalized Crossing Metrics Report-Row Fixture 2026-06-13
+
+## Claim Boundary
+
+Fixture/report-table evidence only.  No simulator or runtime traces.
+
+## Report Table
+
+| episode_id | row_type | eligible | denominator | exclusion_reason | crossed_red | min_dist_m | ped_conflicts | delay_green_s |
+|---|---|---|---|---|---|---|---|---|
+| fixture_red_required_stop | red_required_stop | true | 1 | - | true | 10.00 | 0 | 0.00 |
+| fixture_green_proceed | green_proceed | true | 1 | - | false | 1.00 | 0 | 0.10 |
+| fixture_unavailable_no_claim | unavailable_no_claim | false | 0 | signal_state_metadata_absent | false | N/A | 0 | N/A |
+| fixture_proxy_only_denominator_excluded | proxy_only_denominator_excluded | false | 0 | signal_state_not_benchmark_evidence | false | N/A | 0 | N/A |

--- a/docs/context/evidence/issue_2753_signalized_crossing_metrics/summary.json
+++ b/docs/context/evidence/issue_2753_signalized_crossing_metrics/summary.json
@@ -1,0 +1,50 @@
+{
+  "issue": 2753,
+  "title": "Signalized crossing metrics report-row fixture evidence",
+  "claim_boundary": "Fixture/report-table evidence only. No simulator or runtime traces were executed. No compliance claim is established beyond the report-row contract.",
+  "total_rows": 4,
+  "row_types_present": [
+    "green_proceed",
+    "proxy_only_denominator_excluded",
+    "red_required_stop",
+    "unavailable_no_claim"
+  ],
+  "observable_count": 2,
+  "excluded_count": 2,
+  "eligible_rows": [
+    {
+      "episode_id": "fixture_red_required_stop",
+      "row_type": "red_required_stop",
+      "planner_observable": true,
+      "benchmark_evidence": true,
+      "signal_metrics_denominator": 1
+    },
+    {
+      "episode_id": "fixture_green_proceed",
+      "row_type": "green_proceed",
+      "planner_observable": true,
+      "benchmark_evidence": true,
+      "signal_metrics_denominator": 1
+    }
+  ],
+  "excluded_rows": [
+    {
+      "episode_id": "fixture_unavailable_no_claim",
+      "row_type": "unavailable_no_claim",
+      "planner_observable": false,
+      "benchmark_evidence": false,
+      "signal_metrics_denominator": 0,
+      "exclusion_reason": "signal_state_metadata_absent"
+    },
+    {
+      "episode_id": "fixture_proxy_only_denominator_excluded",
+      "row_type": "proxy_only_denominator_excluded",
+      "planner_observable": false,
+      "benchmark_evidence": false,
+      "signal_metrics_denominator": 0,
+      "exclusion_reason": "signal_state_not_benchmark_evidence"
+    }
+  ],
+  "excluded_denominator_zero": true,
+  "excluded_not_compliance_eligible": true
+}

--- a/robot_sf/benchmark/signal_metrics.py
+++ b/robot_sf/benchmark/signal_metrics.py
@@ -203,17 +203,12 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
     }
 
 
-def _classify_row_type(evidence: dict[str, Any], denominator: int) -> str:
-    """Classify a metrics row into one of the four canonical row types.
-
-    Row types:
-    - ``red_required_stop``: observable red-phase row (may include violations).
-    - ``green_proceed``: observable green-phase row.
-    - ``unavailable_no_claim``: signal state absent or fields incomplete.
-    - ``proxy_only_denominator_excluded``: proxy/diagnostic planner, excluded from denominator.
+def _classify_row_type(evidence: dict[str, Any]) -> str:
+    """Classify a metrics row into raw row types.
 
     Returns:
-        One of the four canonical row type strings.
+        One of ``observable``, ``unavailable_no_claim``, or
+        ``proxy_only_denominator_excluded``.
     """
     state = evidence.get("state", "unavailable")
     exclusion = evidence.get("exclusion_reason", "")
@@ -304,7 +299,7 @@ def signal_metrics_report_rows(
         planner_observable = state == "planner_observable" and not exclusion
         benchmark_evidence = planner_observable and denominator > 0
 
-        raw_row_type = _classify_row_type(evidence, denominator)
+        raw_row_type = _classify_row_type(evidence)
 
         # Determine the sub-type for observable rows (red vs green)
         if raw_row_type == "observable":

--- a/robot_sf/benchmark/signal_metrics.py
+++ b/robot_sf/benchmark/signal_metrics.py
@@ -201,3 +201,181 @@ def calculate_signal_metrics(data: SignalEpisode) -> dict[str, Any]:  # noqa: C9
             "exclusion_reason": "",
         },
     }
+
+
+def _classify_row_type(evidence: dict[str, Any], denominator: int) -> str:
+    """Classify a metrics row into one of the four canonical row types.
+
+    Row types:
+    - ``red_required_stop``: observable red-phase row (may include violations).
+    - ``green_proceed``: observable green-phase row.
+    - ``unavailable_no_claim``: signal state absent or fields incomplete.
+    - ``proxy_only_denominator_excluded``: proxy/diagnostic planner, excluded from denominator.
+
+    Returns:
+        One of the four canonical row type strings.
+    """
+    state = evidence.get("state", "unavailable")
+    exclusion = evidence.get("exclusion_reason", "")
+
+    if state == "planner_observable" and not exclusion:
+        return "observable"
+    if state == "planner_observable" and exclusion:
+        return "unavailable_no_claim"
+    if state == "unavailable":
+        return "unavailable_no_claim"
+    return "proxy_only_denominator_excluded"
+
+
+def _stop_line_behavior(metrics: dict[str, Any], row_type: str) -> dict[str, Any]:
+    """Summarize stop-line behaviour from raw metric values.
+
+    Returns:
+        Dict with ``crossed_under_red``, ``min_distance_m``, ``red_violation_count``.
+    """
+    if row_type != "observable":
+        return {
+            "crossed_under_red": False,
+            "min_distance_m": float("nan"),
+            "red_violation_count": 0,
+        }
+    return {
+        "crossed_under_red": metrics["signal_stop_line_crossings_under_red"] > 0,
+        "min_distance_m": metrics["signal_min_distance_to_stop_line_before_crossing_m"],
+        "red_violation_count": metrics["signal_red_phase_violations"],
+    }
+
+
+def _pedestrian_conflict_label(metrics: dict[str, Any], row_type: str) -> dict[str, Any]:
+    """Summarize pedestrian conflict information from raw metric values.
+
+    Returns:
+        Dict with ``count``, ``label``, and ``eligible`` keys.
+    """
+    count = metrics.get("signal_pedestrian_conflict_during_legal_crossing_count", 0)
+    if row_type != "observable":
+        return {"count": 0, "label": "not_applicable", "eligible": False}
+    return {
+        "count": count,
+        "label": "conflict_detected" if count > 0 else "no_conflict",
+        "eligible": True,
+    }
+
+
+def _compliance_eligible(planner_observable: bool, benchmark_evidence: bool) -> bool:
+    """Return True only when the row qualifies for traffic-light compliance claims.
+
+    A row may claim traffic-light compliance if and only if
+    ``planner_observable=true`` and ``benchmark_evidence=true``.
+    """
+    return planner_observable and benchmark_evidence
+
+
+def signal_metrics_report_rows(
+    episodes: list[tuple[str, SignalEpisode]],
+) -> list[dict[str, Any]]:
+    """Build structured report rows from a list of labelled signal episodes.
+
+    Each row includes:
+    - signal-compliance metrics
+    - denominator and exclusion reason
+    - stop-line behaviour summary
+    - pedestrian conflict label
+    - compliance eligibility flag
+
+    Rows are classified as one of four types:
+    ``red_required_stop``, ``green_proceed``, ``unavailable_no_claim``,
+    ``proxy_only_denominator_excluded``.
+
+    Args:
+        episodes: List of ``(episode_id, episode)`` pairs.
+
+    Returns:
+        List of structured row dicts suitable for report table rendering.
+    """
+    rows: list[dict[str, Any]] = []
+    for episode_id, episode in episodes:
+        metrics = calculate_signal_metrics(episode)
+        evidence = metrics.get("signal_metrics_evidence", {})
+        state = evidence.get("state", "unavailable")
+        exclusion = evidence.get("exclusion_reason", "")
+        denominator = metrics.get("signal_metrics_denominator", 0)
+
+        planner_observable = state == "planner_observable" and not exclusion
+        benchmark_evidence = planner_observable and denominator > 0
+
+        raw_row_type = _classify_row_type(evidence, denominator)
+
+        # Determine the sub-type for observable rows (red vs green)
+        if raw_row_type == "observable":
+            has_red_violation = metrics["signal_red_phase_violations"] > 0
+            has_stop_line_crossing = metrics["signal_stop_line_crossings_under_red"] > 0
+            if has_red_violation or has_stop_line_crossing:
+                row_type = "red_required_stop"
+            else:
+                row_type = "green_proceed"
+        else:
+            row_type = raw_row_type
+
+        stop_behaviour = _stop_line_behavior(metrics, raw_row_type)
+        ped_conflict = _pedestrian_conflict_label(metrics, raw_row_type)
+        eligible = _compliance_eligible(planner_observable, benchmark_evidence)
+
+        rows.append(
+            {
+                "episode_id": episode_id,
+                "row_type": row_type,
+                "planner_observable": planner_observable,
+                "benchmark_evidence": benchmark_evidence,
+                "signal_compliance_eligible": eligible,
+                "signal_unavailable_exclusion_count": metrics["signal_unavailable_exclusion_count"],
+                "signal_metrics_denominator": denominator,
+                "exclusion_reason": exclusion,
+                "stop_line_behaviour": stop_behaviour,
+                "pedestrian_conflict": ped_conflict,
+                "delay_after_green_onset_s": metrics["signal_delay_after_green_onset_s"],
+                "signal_metrics_evidence": evidence,
+            }
+        )
+    return rows
+
+
+def render_report_rows_markdown(rows: list[dict[str, Any]]) -> str:
+    """Render structured report rows as a Markdown table.
+
+    The table includes row type, compliance eligibility, denominator,
+    exclusion reason, stop-line crossing, min distance, pedestrian
+    conflicts, and delay after green onset.
+
+    Args:
+        rows: Output of ``signal_metrics_report_rows``.
+
+    Returns:
+        Markdown-formatted table string.
+    """
+    header = (
+        "| episode_id | row_type | eligible | denominator "
+        "| exclusion_reason | crossed_red | min_dist_m "
+        "| ped_conflicts | delay_green_s |"
+    )
+    separator = "|---|---|---|---|---|---|---|---|---|"
+    lines = [header, separator]
+    for r in rows:
+        stop = r["stop_line_behaviour"]
+        ped = r["pedestrian_conflict"]
+        delay = r["delay_after_green_onset_s"]
+        delay_str = f"{delay:.2f}" if np.isfinite(delay) else "N/A"
+        min_dist = stop["min_distance_m"]
+        min_dist_str = f"{min_dist:.2f}" if np.isfinite(min_dist) else "N/A"
+        lines.append(
+            f"| {r['episode_id']} "
+            f"| {r['row_type']} "
+            f"| {str(r['signal_compliance_eligible']).lower()} "
+            f"| {r['signal_metrics_denominator']} "
+            f"| {r['exclusion_reason'] or '-'} "
+            f"| {str(stop['crossed_under_red']).lower()} "
+            f"| {min_dist_str} "
+            f"| {ped['count']} "
+            f"| {delay_str} |"
+        )
+    return "\n".join(lines)

--- a/scripts/tools/generate_signalized_crossing_metrics_report.py
+++ b/scripts/tools/generate_signalized_crossing_metrics_report.py
@@ -1,0 +1,276 @@
+"""Generate fixture-based signalized crossing metrics report for issue #2753.
+
+Constructs four bounded fixture rows exercising the canonical row types
+defined in ``robot_sf.benchmark.signal_metrics``:
+
+- ``red_required_stop``: observable red-phase crossing, benchmark_evidence=true
+- ``green_proceed``: observable green-phase crossing, benchmark_evidence=true
+- ``unavailable_no_claim``: no signal metadata, denominator-excluded
+- ``proxy_only_denominator_excluded``: proxy diagnostic planner, denominator-excluded
+
+This is fixture/report-table evidence only.  It does **not** run simulator
+or runtime traces, therefore it does **not** establish compliance claims
+beyond the report-row contract.  No claim-matrix updates are produced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.signal_metrics import (
+    render_report_rows_markdown,
+    signal_metrics_report_rows,
+)
+
+_EVIDENCE_DIR = Path("docs/context/evidence/issue_2753_signalized_crossing_metrics")
+
+_ROWS_SPEC: list[dict[str, Any]] = [
+    {
+        "episode_id": "fixture_red_required_stop",
+        "robot_pos": np.array(
+            [
+                [0.0, 0.0],
+                [11.0, 0.0],
+                [12.0, 0.0],
+                [13.0, 0.0],
+                [14.0, 0.0],
+                [15.0, 0.0],
+            ]
+        ),
+        "peds_pos": np.zeros((6, 0, 2)),
+        "dt": 1.0,
+        "episode_metadata": {
+            "signal_state": {
+                "contract_state": "planner_observable",
+                "benchmark_evidence": True,
+                "timeline": [
+                    {"state": "red", "duration": 5.0},
+                    {"state": "green", "duration": 5.0},
+                ],
+                "stop_line": [[10.0, 10.0], [10.0, -10.0]],
+                "crosswalk_polygon": [
+                    [11.0, 10.0],
+                    [15.0, 10.0],
+                    [15.0, -10.0],
+                    [11.0, -10.0],
+                ],
+            }
+        },
+    },
+    {
+        "episode_id": "fixture_green_proceed",
+        "robot_pos": np.array(
+            [
+                [-1.0, 0.0],
+                [-0.5, 0.0],
+                [0.5, 0.0],
+                [1.5, 0.0],
+                [2.5, 0.0],
+            ]
+        ),
+        "peds_pos": np.zeros((5, 0, 2)),
+        "dt": 0.1,
+        "episode_metadata": {
+            "signal_state": {
+                "contract_state": "planner_observable",
+                "benchmark_evidence": True,
+                "timeline": [
+                    {"state": "red", "duration": 0.05},
+                    {"state": "green", "duration": 5.0},
+                ],
+                "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+                "crosswalk_polygon": [
+                    [1.0, 1.0],
+                    [5.0, 1.0],
+                    [5.0, -1.0],
+                    [1.0, -1.0],
+                ],
+            }
+        },
+    },
+    {
+        "episode_id": "fixture_unavailable_no_claim",
+        "robot_pos": np.zeros((10, 2)),
+        "peds_pos": np.zeros((10, 0, 2)),
+        "dt": 0.1,
+        "episode_metadata": None,
+    },
+    {
+        "episode_id": "fixture_proxy_only_denominator_excluded",
+        "robot_pos": np.zeros((10, 2)),
+        "peds_pos": np.zeros((10, 0, 2)),
+        "dt": 0.1,
+        "episode_metadata": {
+            "signal_state": {
+                "contract_state": "proxy_diagnostic",
+            }
+        },
+    },
+]
+
+
+class _FixtureEpisode:
+    """Minimal episode adapter for fixture construction."""
+
+    def __init__(
+        self,
+        robot_pos: np.ndarray,
+        peds_pos: np.ndarray,
+        dt: float,
+        episode_metadata: dict[str, Any] | None,
+    ):
+        self.robot_pos = robot_pos
+        self.peds_pos = peds_pos
+        self.dt = dt
+        self.episode_metadata = episode_metadata
+
+
+def _build_episodes() -> list[tuple[str, _FixtureEpisode]]:
+    episodes: list[tuple[str, _FixtureEpisode]] = []
+    for spec in _ROWS_SPEC:
+        ep = _FixtureEpisode(
+            robot_pos=spec["robot_pos"],
+            peds_pos=spec["peds_pos"],
+            dt=spec["dt"],
+            episode_metadata=spec["episode_metadata"],
+        )
+        episodes.append((spec["episode_id"], ep))
+    return episodes
+
+
+def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    observable = [r for r in rows if r["signal_compliance_eligible"]]
+    excluded = [r for r in rows if not r["signal_compliance_eligible"]]
+    row_types = [r["row_type"] for r in rows]
+    return {
+        "issue": 2753,
+        "title": "Signalized crossing metrics report-row fixture evidence",
+        "claim_boundary": (
+            "Fixture/report-table evidence only. "
+            "No simulator or runtime traces were executed. "
+            "No compliance claim is established beyond the report-row contract."
+        ),
+        "total_rows": len(rows),
+        "row_types_present": sorted(set(row_types)),
+        "observable_count": len(observable),
+        "excluded_count": len(excluded),
+        "eligible_rows": [
+            {
+                "episode_id": r["episode_id"],
+                "row_type": r["row_type"],
+                "planner_observable": r["planner_observable"],
+                "benchmark_evidence": r["benchmark_evidence"],
+                "signal_metrics_denominator": r["signal_metrics_denominator"],
+            }
+            for r in observable
+        ],
+        "excluded_rows": [
+            {
+                "episode_id": r["episode_id"],
+                "row_type": r["row_type"],
+                "planner_observable": r["planner_observable"],
+                "benchmark_evidence": r["benchmark_evidence"],
+                "signal_metrics_denominator": r["signal_metrics_denominator"],
+                "exclusion_reason": r["exclusion_reason"],
+            }
+            for r in excluded
+        ],
+        "excluded_denominator_zero": all(r["signal_metrics_denominator"] == 0 for r in excluded),
+        "excluded_not_compliance_eligible": all(
+            not r["signal_compliance_eligible"] for r in excluded
+        ),
+    }
+
+
+def _build_readme() -> str:
+    return """\
+# Issue #2753 Signalized Crossing Metrics Report-Row Fixture Evidence 2026-06-13
+
+**Date:** 2026-06-13
+**Commit:** (generated, see manifest)
+
+## Scope
+
+Fixture/report-table evidence for the four canonical signalized crossing
+metric row types defined in `robot_sf/benchmark/signal_metrics.py`:
+
+| Row type | planner_observable | benchmark_evidence | denominator | compliance_eligible |
+|---|---|---|---|---|
+| `red_required_stop` | true | true | 1 | true |
+| `green_proceed` | true | true | 1 | true |
+| `unavailable_no_claim` | false | false | 0 | false |
+| `proxy_only_denominator_excluded` | false | false | 0 | false |
+
+## Claim Boundary
+
+This is fixture/report-table evidence only.  The script constructs
+synthetic episodes and feeds them through `signal_metrics_report_rows`
+to verify the report-row contract.  No simulator or runtime traces were
+executed, so no compliance claim is established beyond the report-row
+structure. Simulator-backed runtime evidence is deferred to issue #2799.
+
+## Files
+
+- `summary.json`: machine-readable fixture summary
+- `report.md`: rendered Markdown report table
+- `README.md`: this file
+
+## Reproduction
+
+```bash
+uv run python scripts/tools/generate_signalized_crossing_metrics_report.py
+```
+"""
+
+
+def generate(output_dir: Path) -> None:
+    """Build fixture rows and write evidence artifacts."""
+    episodes = _build_episodes()
+    rows = signal_metrics_report_rows(episodes)
+    summary = _build_summary(rows)
+    markdown = render_report_rows_markdown(rows)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+
+    report_path = output_dir / "report.md"
+    report_md = (
+        "# Issue #2753 Signalized Crossing Metrics Report-Row Fixture 2026-06-13\n\n"
+        "## Claim Boundary\n\n"
+        "Fixture/report-table evidence only.  No simulator or runtime traces.\n\n"
+        "## Report Table\n\n"
+        f"{markdown}\n"
+    )
+    report_path.write_text(report_md)
+
+    readme_path = output_dir / "README.md"
+    readme_path.write_text(_build_readme())
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the generator CLI."""
+    parser = argparse.ArgumentParser(
+        description="Generate signalized crossing metrics fixture report for issue #2753."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_EVIDENCE_DIR,
+        help="Output directory for evidence artifacts.",
+    )
+    args = parser.parse_args(argv)
+    generate(args.output_dir)
+    print(f"Wrote evidence artifacts to {args.output_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_issue_2753_signalized_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2753_signalized_crossing_fixture.py
@@ -10,13 +10,15 @@ Validates that the generator script produces correct evidence artifacts:
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from scripts.tools.generate_signalized_crossing_metrics_report import generate
 
-_EVIDENCE_DIR = Path("docs/context/evidence/issue_2753_signalized_crossing_metrics")
+if TYPE_CHECKING:
+    from pathlib import Path
+
 _EXPECTED_FILES = {"summary.json", "report.md", "README.md"}
 _EXPECTED_ROW_TYPES = {
     "red_required_stop",

--- a/tests/benchmark/test_issue_2753_signalized_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2753_signalized_crossing_fixture.py
@@ -1,0 +1,115 @@
+"""Tests for the issue #2753 signalized crossing metrics report generator.
+
+Validates that the generator script produces correct evidence artifacts:
+- All expected files are written
+- All four canonical row types appear
+- Excluded rows have denominator 0 and compliance_eligible false
+- Observable rows are the only eligible rows
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.tools.generate_signalized_crossing_metrics_report import generate
+
+_EVIDENCE_DIR = Path("docs/context/evidence/issue_2753_signalized_crossing_metrics")
+_EXPECTED_FILES = {"summary.json", "report.md", "README.md"}
+_EXPECTED_ROW_TYPES = {
+    "red_required_stop",
+    "green_proceed",
+    "unavailable_no_claim",
+    "proxy_only_denominator_excluded",
+}
+
+
+@pytest.fixture()
+def evidence_dir(tmp_path: Path) -> Path:
+    """Generate evidence artifacts into a temporary directory."""
+    generate(tmp_path)
+    return tmp_path
+
+
+def test_generator_writes_all_expected_files(evidence_dir: Path) -> None:
+    """summary.json, report.md, and README.md must all be created."""
+    written = {f.name for f in evidence_dir.iterdir()}
+    assert _EXPECTED_FILES == written
+
+
+def test_summary_json_is_valid(evidence_dir: Path) -> None:
+    """summary.json must parse and contain required keys."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    assert summary["issue"] == 2753
+    assert "row_types_present" in summary
+    assert "eligible_rows" in summary
+    assert "excluded_rows" in summary
+    assert summary["claim_boundary"]  # non-empty
+
+
+def test_all_four_row_types_present(evidence_dir: Path) -> None:
+    """All four canonical row types must appear in the summary."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    assert set(summary["row_types_present"]) == _EXPECTED_ROW_TYPES
+
+
+def test_total_rows_count(evidence_dir: Path) -> None:
+    """Exactly four fixture rows must be generated."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    assert summary["total_rows"] == 4
+    assert summary["observable_count"] == 2
+    assert summary["excluded_count"] == 2
+
+
+def test_excluded_rows_denominator_zero(evidence_dir: Path) -> None:
+    """Excluded rows must have signal_metrics_denominator == 0."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    for row in summary["excluded_rows"]:
+        assert row["signal_metrics_denominator"] == 0, (
+            f"{row['episode_id']} has nonzero denominator"
+        )
+    assert summary["excluded_denominator_zero"] is True
+
+
+def test_excluded_rows_not_compliance_eligible(evidence_dir: Path) -> None:
+    """Excluded rows must not be compliance eligible."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    assert summary["excluded_not_compliance_eligible"] is True
+    for row in summary["excluded_rows"]:
+        assert row["planner_observable"] is False
+        assert row["benchmark_evidence"] is False
+
+
+def test_observable_rows_are_only_eligible(evidence_dir: Path) -> None:
+    """Only planner_observable + benchmark_evidence rows should be eligible."""
+    summary = json.loads((evidence_dir / "summary.json").read_text())
+    for row in summary["eligible_rows"]:
+        assert row["planner_observable"] is True
+        assert row["benchmark_evidence"] is True
+        assert row["signal_metrics_denominator"] == 1
+    eligible_ids = {r["episode_id"] for r in summary["eligible_rows"]}
+    assert "fixture_red_required_stop" in eligible_ids
+    assert "fixture_green_proceed" in eligible_ids
+
+
+def test_report_md_contains_table(evidence_dir: Path) -> None:
+    """report.md must contain a Markdown table with the expected episode IDs."""
+    content = (evidence_dir / "report.md").read_text()
+    assert "| episode_id" in content
+    assert "|---|" in content
+    for eid in [
+        "fixture_red_required_stop",
+        "fixture_green_proceed",
+        "fixture_unavailable_no_claim",
+        "fixture_proxy_only_denominator_excluded",
+    ]:
+        assert eid in content
+
+
+def test_readme_md_mentions_issue(evidence_dir: Path) -> None:
+    """README.md must reference issue #2753."""
+    content = (evidence_dir / "README.md").read_text()
+    assert "2753" in content
+    assert "fixture" in content.lower()

--- a/tests/benchmark/test_signal_metrics_report_rows.py
+++ b/tests/benchmark/test_signal_metrics_report_rows.py
@@ -1,0 +1,451 @@
+"""Tests for signal_metrics_report_rows and compliance eligibility gate.
+
+Covers all four row types:
+- red_required_stop: observable row where robot crosses stop line under red
+- green_proceed: observable row where robot crosses during green
+- unavailable_no_claim: no signal metadata
+- proxy_only_denominator_excluded: proxy diagnostic planner, excluded from denominator
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.benchmark.signal_metrics import (
+    SignalEpisode,
+    render_report_rows_markdown,
+    signal_metrics_report_rows,
+)
+
+
+class _MockEpisode(SignalEpisode):
+    """Minimal episode implementation for testing."""
+
+    def __init__(
+        self,
+        robot_pos: np.ndarray,
+        peds_pos: np.ndarray,
+        dt: float,
+        episode_metadata: dict | None,
+    ):
+        self.robot_pos = robot_pos
+        self.peds_pos = peds_pos
+        self.dt = dt
+        self.episode_metadata = episode_metadata
+
+
+def _observable_red_metadata() -> dict:
+    """Metadata for a planner_observable red-phase crossing."""
+    return {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [
+                {"state": "red", "duration": 5.0},
+                {"state": "green", "duration": 5.0},
+            ],
+            "stop_line": [[10.0, 10.0], [10.0, -10.0]],
+            "crosswalk_polygon": [
+                [11.0, 10.0],
+                [15.0, 10.0],
+                [15.0, -10.0],
+                [11.0, -10.0],
+            ],
+        }
+    }
+
+
+def _observable_green_metadata() -> dict:
+    """Metadata for a planner_observable green-phase crossing."""
+    return {
+        "signal_state": {
+            "contract_state": "planner_observable",
+            "benchmark_evidence": True,
+            "timeline": [
+                {"state": "red", "duration": 0.05},
+                {"state": "green", "duration": 5.0},
+            ],
+            "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+            "crosswalk_polygon": [
+                [1.0, 1.0],
+                [5.0, 1.0],
+                [5.0, -1.0],
+                [1.0, -1.0],
+            ],
+        }
+    }
+
+
+def _red_robot_trajectory() -> np.ndarray:
+    """Robot trajectory that crosses stop line during red phase."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [11.0, 0.0],
+            [12.0, 0.0],
+            [13.0, 0.0],
+            [14.0, 0.0],
+            [15.0, 0.0],
+        ]
+    )
+
+
+def _green_robot_trajectory() -> np.ndarray:
+    """Robot trajectory that crosses stop line only after green onset."""
+    return np.array(
+        [
+            [-1.0, 0.0],
+            [-0.5, 0.0],
+            [0.5, 0.0],
+            [1.5, 0.0],
+            [2.5, 0.0],
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Row type tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_rows_red_required_stop():
+    """Observable red crossing is classified as red_required_stop."""
+    episode = _MockEpisode(
+        _red_robot_trajectory(),
+        np.zeros((6, 0, 2)),
+        1.0,
+        _observable_red_metadata(),
+    )
+    rows = signal_metrics_report_rows([("ep_red_001", episode)])
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["episode_id"] == "ep_red_001"
+    assert r["row_type"] == "red_required_stop"
+    assert r["planner_observable"] is True
+    assert r["benchmark_evidence"] is True
+    assert r["signal_compliance_eligible"] is True
+    assert r["signal_metrics_denominator"] == 1
+    assert r["stop_line_behaviour"]["crossed_under_red"] is True
+    assert r["stop_line_behaviour"]["red_violation_count"] == 1
+    assert r["pedestrian_conflict"]["eligible"] is True
+    assert r["exclusion_reason"] == ""
+
+
+def test_report_rows_green_proceed():
+    """Observable green crossing is classified as green_proceed."""
+    episode = _MockEpisode(
+        _green_robot_trajectory(),
+        np.zeros((5, 0, 2)),
+        0.1,
+        _observable_green_metadata(),
+    )
+    rows = signal_metrics_report_rows([("ep_green_001", episode)])
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["episode_id"] == "ep_green_001"
+    assert r["row_type"] == "green_proceed"
+    assert r["planner_observable"] is True
+    assert r["benchmark_evidence"] is True
+    assert r["signal_compliance_eligible"] is True
+    assert r["signal_metrics_denominator"] == 1
+    assert r["stop_line_behaviour"]["crossed_under_red"] is False
+    assert r["stop_line_behaviour"]["red_violation_count"] == 0
+    assert r["pedestrian_conflict"]["eligible"] is True
+    assert r["exclusion_reason"] == ""
+
+
+def test_report_rows_unavailable_no_claim():
+    """Missing signal metadata is classified as unavailable_no_claim."""
+    episode = _MockEpisode(
+        np.zeros((10, 2)),
+        np.zeros((10, 0, 2)),
+        0.1,
+        None,
+    )
+    rows = signal_metrics_report_rows([("ep_unavail_001", episode)])
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["episode_id"] == "ep_unavail_001"
+    assert r["row_type"] == "unavailable_no_claim"
+    assert r["planner_observable"] is False
+    assert r["benchmark_evidence"] is False
+    assert r["signal_compliance_eligible"] is False
+    assert r["signal_metrics_denominator"] == 0
+    assert r["exclusion_reason"] == "signal_state_metadata_absent"
+    assert r["stop_line_behaviour"]["crossed_under_red"] is False
+    assert r["pedestrian_conflict"]["eligible"] is False
+
+
+def test_report_rows_proxy_only_denominator_excluded():
+    """Proxy diagnostic planner is classified as proxy_only_denominator_excluded."""
+    episode = _MockEpisode(
+        np.zeros((10, 2)),
+        np.zeros((10, 0, 2)),
+        0.1,
+        {
+            "signal_state": {
+                "contract_state": "proxy_diagnostic",
+            }
+        },
+    )
+    rows = signal_metrics_report_rows([("ep_proxy_001", episode)])
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["episode_id"] == "ep_proxy_001"
+    assert r["row_type"] == "proxy_only_denominator_excluded"
+    assert r["planner_observable"] is False
+    assert r["benchmark_evidence"] is False
+    assert r["signal_compliance_eligible"] is False
+    assert r["signal_metrics_denominator"] == 0
+    assert r["exclusion_reason"] == "signal_state_not_benchmark_evidence"
+    assert r["stop_line_behaviour"]["crossed_under_red"] is False
+    assert r["pedestrian_conflict"]["eligible"] is False
+
+
+# ---------------------------------------------------------------------------
+# Compliance eligibility gate
+# ---------------------------------------------------------------------------
+
+
+def test_compliance_eligible_requires_planner_observable_and_benchmark_evidence():
+    """Only rows with planner_observable=true AND benchmark_evidence=true are eligible."""
+    # Observable + benchmark evidence -> eligible
+    obs_episode = _MockEpisode(
+        _green_robot_trajectory(),
+        np.zeros((5, 0, 2)),
+        0.1,
+        _observable_green_metadata(),
+    )
+    # Observable but no benchmark evidence -> not eligible
+    no_evidence_episode = _MockEpisode(
+        np.zeros((2, 2)),
+        np.zeros((2, 0, 2)),
+        1.0,
+        {
+            "signal_state": {
+                "contract_state": "planner_observable",
+                "benchmark_evidence": False,
+                "timeline": [{"state": "green", "duration": 1.0}],
+                "stop_line": [[0.0, 1.0], [0.0, -1.0]],
+            }
+        },
+    )
+
+    rows = signal_metrics_report_rows(
+        [
+            ("eligible", obs_episode),
+            ("not_eligible", no_evidence_episode),
+        ]
+    )
+
+    eligible_rows = [r for r in rows if r["signal_compliance_eligible"]]
+    ineligible_rows = [r for r in rows if not r["signal_compliance_eligible"]]
+
+    assert len(eligible_rows) == 1
+    assert eligible_rows[0]["episode_id"] == "eligible"
+    assert len(ineligible_rows) == 1
+    assert ineligible_rows[0]["episode_id"] == "not_eligible"
+    assert ineligible_rows[0]["row_type"] == "unavailable_no_claim"
+    assert ineligible_rows[0]["exclusion_reason"] == "signal_state_not_benchmark_evidence"
+
+
+def test_proxy_row_never_claims_compliance():
+    """Proxy diagnostic rows must never claim traffic-light compliance."""
+    episodes = [
+        (
+            "proxy_a",
+            _MockEpisode(
+                np.zeros((5, 2)),
+                np.zeros((5, 0, 2)),
+                0.1,
+                {"signal_state": {"contract_state": "proxy_diagnostic"}},
+            ),
+        ),
+        (
+            "proxy_b",
+            _MockEpisode(
+                np.zeros((5, 2)),
+                np.zeros((5, 0, 2)),
+                0.1,
+                {
+                    "signal_state": {
+                        "contract_state": "proxy_diagnostic",
+                        "planner_observable": True,
+                        "benchmark_evidence": True,
+                    }
+                },
+            ),
+        ),
+    ]
+    rows = signal_metrics_report_rows(episodes)
+
+    for r in rows:
+        assert r["signal_compliance_eligible"] is False
+        assert r["row_type"] == "proxy_only_denominator_excluded"
+        assert r["signal_metrics_denominator"] == 0
+
+
+def test_unavailable_row_never_claims_compliance():
+    """Unavailable rows must never claim traffic-light compliance."""
+    rows = signal_metrics_report_rows(
+        [
+            (
+                "no_meta",
+                _MockEpisode(
+                    np.zeros((3, 2)),
+                    np.zeros((3, 0, 2)),
+                    0.5,
+                    None,
+                ),
+            ),
+            (
+                "empty_meta",
+                _MockEpisode(
+                    np.zeros((3, 2)),
+                    np.zeros((3, 0, 2)),
+                    0.5,
+                    {},
+                ),
+            ),
+        ]
+    )
+
+    for r in rows:
+        assert r["signal_compliance_eligible"] is False
+        assert r["row_type"] == "unavailable_no_claim"
+        assert r["signal_metrics_denominator"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Report structure tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_rows_contain_all_required_fields():
+    """Every row must contain all required report fields."""
+    episodes = [
+        (
+            "ep1",
+            _MockEpisode(
+                _red_robot_trajectory(),
+                np.zeros((6, 0, 2)),
+                1.0,
+                _observable_red_metadata(),
+            ),
+        ),
+        (
+            "ep2",
+            _MockEpisode(
+                np.zeros((3, 2)),
+                np.zeros((3, 0, 2)),
+                0.1,
+                None,
+            ),
+        ),
+        (
+            "ep3",
+            _MockEpisode(
+                np.zeros((5, 2)),
+                np.zeros((5, 0, 2)),
+                0.1,
+                {"signal_state": {"contract_state": "proxy_diagnostic"}},
+            ),
+        ),
+    ]
+    rows = signal_metrics_report_rows(episodes)
+
+    required_keys = {
+        "episode_id",
+        "row_type",
+        "planner_observable",
+        "benchmark_evidence",
+        "signal_compliance_eligible",
+        "signal_unavailable_exclusion_count",
+        "signal_metrics_denominator",
+        "exclusion_reason",
+        "stop_line_behaviour",
+        "pedestrian_conflict",
+        "delay_after_green_onset_s",
+        "signal_metrics_evidence",
+    }
+
+    for r in rows:
+        assert required_keys.issubset(r.keys()), f"Missing keys: {required_keys - r.keys()}"
+
+        stop = r["stop_line_behaviour"]
+        assert "crossed_under_red" in stop
+        assert "min_distance_m" in stop
+        assert "red_violation_count" in stop
+
+        ped = r["pedestrian_conflict"]
+        assert "count" in ped
+        assert "label" in ped
+        assert "eligible" in ped
+
+
+def test_report_rows_exclude_reason_for_non_observable():
+    """Non-observable rows must carry a non-empty exclusion reason."""
+    episodes = [
+        (
+            "unavail",
+            _MockEpisode(
+                np.zeros((3, 2)),
+                np.zeros((3, 0, 2)),
+                0.5,
+                None,
+            ),
+        ),
+        (
+            "proxy",
+            _MockEpisode(
+                np.zeros((3, 2)),
+                np.zeros((3, 0, 2)),
+                0.5,
+                {"signal_state": {"contract_state": "proxy_diagnostic"}},
+            ),
+        ),
+    ]
+    rows = signal_metrics_report_rows(episodes)
+
+    for r in rows:
+        if not r["signal_compliance_eligible"]:
+            assert r["exclusion_reason"], (
+                f"Non-compliance-eligible row {r['episode_id']} must have exclusion_reason"
+            )
+
+
+def test_markdown_rendering_produces_table():
+    """render_report_rows_markdown should produce a Markdown table."""
+    episodes = [
+        (
+            "ep_red",
+            _MockEpisode(
+                _red_robot_trajectory(),
+                np.zeros((6, 0, 2)),
+                1.0,
+                _observable_red_metadata(),
+            ),
+        ),
+        (
+            "ep_none",
+            _MockEpisode(
+                np.zeros((3, 2)),
+                np.zeros((3, 0, 2)),
+                0.5,
+                None,
+            ),
+        ),
+    ]
+    rows = signal_metrics_report_rows(episodes)
+    md = render_report_rows_markdown(rows)
+
+    assert md.startswith("| episode_id")
+    assert "|---|" in md
+    assert "ep_red" in md
+    assert "ep_none" in md
+    assert "red_required_stop" in md
+    assert "unavailable_no_claim" in md


### PR DESCRIPTION
## Summary
Adds signalized-crossing report-row helpers plus a reproducible fixture evidence bundle covering the four required row types and fail-closed denominator semantics.

## Linked Issues
- Closes `#2753`
- Follow-up: `#2799`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#2799`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `signal_metrics_report_rows(...)` and `render_report_rows_markdown(...)` in `robot_sf/benchmark/signal_metrics.py`.
- Added fixture/report tests for red/required-stop, green/proceed, unavailable/no-claim, and proxy-only/denominator-excluded rows.
- Added `scripts/tools/generate_signalized_crossing_metrics_report.py`, which writes a compact evidence bundle under `docs/context/evidence/issue_2753_signalized_crossing_metrics/`.
- Indexed the evidence bundle in `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.

## Why It Matters
- Added value: makes the signal-compliance denominator contract inspectable as structured report rows instead of only unit-level metrics.
- Expected impact: prevents proxy/unavailable rows from being presented as traffic-light compliance evidence.
- Why this is worth merging now: it closes the report-row fixture layer and creates #2799 for simulator-backed runtime traces.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #2753 needed signalized-crossing report rows with denominator/exclusion semantics.
- Comparator or baseline, if applicable: existing signal metric unit tests and proxy-only issue #2527 fixture.
- Evidence tier: targeted smoke / diagnostic fixture.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop when all four row types are generated, denominator/exclusion semantics are tested, and claim boundary is explicit.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/evidence/issue_2753_signalized_crossing_metrics/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `scripts/tools/generate_signalized_crossing_metrics_report.py` is exercised on bounded fixture inputs in this PR.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, report rows are generated through `calculate_signal_metrics(...)`.
- Did the intervention change command source, selected command, trajectory, or route progress? no live runtime trajectory claim is made.
- Did the scenario actually contain the targeted failure mode? fixture rows encode the targeted denominator/exclusion cases; simulator runtime remains #2799.
- Result route: continue via #2799 for runtime evidence.
- Follow-up question or issue for weak, negative, or non-transfer results: #2799.

## Next Empirical Action
- Rerun needed: no for fixture/report-row scope.
- Extractor or analysis tool needed: no for fixture/report-row scope.
- Artifact missing or unavailable: simulator-backed runtime traces are intentionally deferred to #2799.
- Stop / revise / continue decision: stop this fixture layer; continue runtime evidence in #2799.
- Proposed child issue or existing follow-up: #2799.

## Validation / Proof
- Commands run:
  - `uv run python scripts/tools/generate_signalized_crossing_metrics_report.py`
  - `uv run pytest tests/benchmark/test_signal_metrics.py tests/benchmark/test_signal_metrics_report_rows.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_issue_2753_signalized_crossing_fixture.py -q`
  - `uv run ruff check robot_sf/benchmark/signal_metrics.py scripts/tools/generate_signalized_crossing_metrics_report.py tests/benchmark/test_signal_metrics_report_rows.py tests/benchmark/test_issue_2753_signalized_crossing_fixture.py`
  - `uv run ruff format --check robot_sf/benchmark/signal_metrics.py scripts/tools/generate_signalized_crossing_metrics_report.py tests/benchmark/test_signal_metrics_report_rows.py tests/benchmark/test_issue_2753_signalized_crossing_fixture.py`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/evidence/README.md --path docs/context/evidence/issue_2753_signalized_crossing_metrics/README.md --path docs/context/evidence/issue_2753_signalized_crossing_metrics/report.md --path docs/context/evidence/issue_2753_signalized_crossing_metrics/summary.json`
  - `BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed with `42 passed`; final readiness passed from clean head `9389ce9d2428f7ebec934e20d52f0056d8bfe32a` with `6142 passed, 9 skipped, 10 warnings`.
- Benchmarks or smoke tests, if applicable: fixture/report-table smoke evidence only; no simulator runtime trace claim.

## Risks / Rollout
- Compatibility risks: low; new helper/report path and tests.
- Failure modes: readers may overinterpret fixture rows as runtime compliance evidence; docs and report explicitly defer runtime evidence to #2799.
- Rollback or fallback plan: revert helper, generator, tests, and evidence bundle.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, `docs/context/evidence/issue_2753_signalized_crossing_metrics/`.
- Relevant design or provenance notes: `docs/context/evidence/issue_2753_signalized_crossing_metrics/summary.json`.
- Any assumptions that need to be preserved: fixture/report-table evidence does not establish traffic-light compliance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR closes #2753 for fixture/report-row scope.
- Claim map / benchmark report updated (yes/no/NA): no; runtime evidence absent.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, context catalog updated.
- Context index / memory note updated (yes/no/NA): yes, evidence README and catalog updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #2799.
- Not applicable because: compliance claim promotion is deferred until runtime traces exist.

## Follow-Up Issues
- Deferred work: simulator-backed signalized crossing runtime traces and any claim-matrix promotion.
- Issues opened for follow-up: #2799.

## Reviewer Notes
- Please check the claim boundary closely: observable fixture rows are used to exercise the denominator gate, not to claim runtime traffic-light compliance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signalized crossing metrics reporting capabilities for benchmark evidence generation.

* **Tests**
  * Added comprehensive test coverage for the new metrics reporting functionality.

* **Documentation**
  * Added fixture evidence documentation and examples for signalized crossing metrics analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->