### PR TITLE
docs: record topology reselection runtime revise evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -469,6 +469,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2751_topology_reselection_runtime/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json
     status: evidence
     freshness: evidence

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -469,6 +469,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2751_topology_reselection_runtime/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2704_progress_gated_topology_successor/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,10 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2751_topology_reselection_runtime/`: diagnostic-only runtime evidence for the
+  clearance-targeted topology-reselection successor. The result is `revise`: all hard slices
+  remained `horizon_exhausted`, while the negative-control rows succeeded with zero topology
+  switching. Not benchmark or paper-facing evidence.
 - `issue_2755_observation_noise_envelope_2026-06-13/`: diagnostic trace-derived
   near-field observation-noise robustness envelope. Evaluates seven perturbation conditions
   (noop, low/medium Gaussian noise, missed detection, occlusion, delay, combined) against

--- a/docs/context/evidence/issue_2751_topology_reselection_runtime/README.md
+++ b/docs/context/evidence/issue_2751_topology_reselection_runtime/README.md
@@ -1,4 +1,4 @@
-# Issue #2751 Topology Reselection Runtime Evidence
+# Issue #2751 Topology Reselection Runtime Evidence (2026-06-13)
 
 Issue: [#2751](https://github.com/ll7/robot_sf_ll7/issues/2751)
 

--- a/docs/context/evidence/issue_2751_topology_reselection_runtime/README.md
+++ b/docs/context/evidence/issue_2751_topology_reselection_runtime/README.md
@@ -1,0 +1,34 @@
+# Issue #2751 Topology Reselection Runtime Evidence
+
+Issue: [#2751](https://github.com/ll7/robot_sf_ll7/issues/2751)
+
+This bundle preserves the compact result of the clearance-targeted topology-reselection successor
+runtime launched from the Issue #2742 packet. It is diagnostic-only evidence, not benchmark or
+paper-facing proof.
+
+## Result
+
+- Classification: `revise`
+- Runtime rows: 20
+- Hard slices: `bottleneck_transfer`, `doorway_transfer`, `t_intersection_transfer`
+- Negative control: `simple_negative_control`
+- Outcome: all hard-slice rows completed diagnostics but remained `horizon_exhausted`; all
+  negative-control rows succeeded with zero topology switching.
+
+## Reproduction
+
+```bash
+uv run python scripts/validation/run_topology_reselection_cross_slice.py \
+  --manifest configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml \
+  --output-dir <ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime
+```
+
+Runtime proof was collected on commit `952eff7e2f35bfe29fd65d90c7c43fa458ab8bb9`.
+The raw per-row trace files are reproducible from the tracked command and are not mirrored here.
+The compact row metrics in [summary.json](summary.json) and [report.md](report.md) preserve the
+durable decision evidence.
+
+## Files
+
+- [summary.json](summary.json): compact provenance, decision, and row summary.
+- [report.md](report.md): generated cross-slice decision table.

--- a/docs/context/evidence/issue_2751_topology_reselection_runtime/report.md
+++ b/docs/context/evidence/issue_2751_topology_reselection_runtime/report.md
@@ -1,0 +1,37 @@
+# Issue 2742 Topology Reselection Cross-Slice Diagnostic
+
+Claim boundary: `diagnostic_only_not_benchmark_or_paper_evidence`.
+Classification: `revise`.
+
+Hard progress-gated rows retained diagnostic influence but all remained horizon_exhausted.
+
+## Decision Table
+
+| Slice | Role | Candidate | Threshold | Status | Outcome | Progress m | Switches | Deadlock steps | Collision rate |
+|---|---|---|---:|---|---|---:|---:|---:|---:|
+| bottleneck_transfer | hard | baseline | NA | diagnostic_complete | horizon_exhausted | 5.200000077486036 | 0 | 159 | 0.0 |
+| bottleneck_transfer | hard | reuse_penalty | NA | diagnostic_complete | horizon_exhausted | 6.117157378678126 | 2 | 159 | 0.0 |
+| bottleneck_transfer | hard | progress_gated | 0.05 | diagnostic_complete | horizon_exhausted | 5.200000077486036 | 0 | 159 | 0.0 |
+| bottleneck_transfer | hard | progress_gated | 0.1 | diagnostic_complete | horizon_exhausted | 5.400000080466269 | 0 | 159 | 0.0 |
+| bottleneck_transfer | hard | progress_gated | 0.2 | diagnostic_complete | horizon_exhausted | 5.600000083446501 | 0 | 159 | 0.0 |
+| doorway_transfer | hard | baseline | NA | diagnostic_complete | horizon_exhausted | 1.4485281590086068 | 0 | 159 | 0.0 |
+| doorway_transfer | hard | reuse_penalty | NA | diagnostic_complete | horizon_exhausted | 1.4485281590086068 | 0 | 159 | 0.0 |
+| doorway_transfer | hard | progress_gated | 0.05 | diagnostic_complete | horizon_exhausted | 1.4485281590086068 | 0 | 159 | 0.0 |
+| doorway_transfer | hard | progress_gated | 0.1 | diagnostic_complete | horizon_exhausted | 1.4485281590086068 | 0 | 159 | 0.0 |
+| doorway_transfer | hard | progress_gated | 0.2 | diagnostic_complete | horizon_exhausted | 1.4485281590086068 | 0 | 159 | 0.0 |
+| t_intersection_transfer | hard | baseline | NA | diagnostic_complete | horizon_exhausted | 4.868629222649751 | 3 | 159 | 0.0 |
+| t_intersection_transfer | hard | reuse_penalty | NA | diagnostic_complete | horizon_exhausted | 6.3857865327825385 | 13 | 159 | 0.0 |
+| t_intersection_transfer | hard | progress_gated | 0.05 | diagnostic_complete | horizon_exhausted | 6.3857865327825385 | 13 | 159 | 0.0 |
+| t_intersection_transfer | hard | progress_gated | 0.1 | diagnostic_complete | horizon_exhausted | 6.3857865327825385 | 13 | 159 | 0.0 |
+| t_intersection_transfer | hard | progress_gated | 0.2 | diagnostic_complete | horizon_exhausted | 6.3857865327825385 | 13 | 159 | 0.0 |
+| simple_negative_control | negative_control | baseline | NA | diagnostic_complete | success | 1.7656854512600013 | 0 | 0 | 0.0 |
+| simple_negative_control | negative_control | reuse_penalty | NA | diagnostic_complete | success | 1.7656854512600013 | 0 | 0 | 0.0 |
+| simple_negative_control | negative_control | progress_gated | 0.05 | diagnostic_complete | success | 1.7656854512600013 | 0 | 0 | 0.0 |
+| simple_negative_control | negative_control | progress_gated | 0.1 | diagnostic_complete | success | 1.7656854512600013 | 0 | 0 | 0.0 |
+| simple_negative_control | negative_control | progress_gated | 0.2 | diagnostic_complete | success | 1.7656854512600013 | 0 | 0 | 0.0 |
+
+## Caveats
+
+- Evidence is diagnostic-only and fail-closed; failed, unavailable, or degraded rows are not success evidence.
+- `detour_cost_proxy` is the non-primary topology-command step count, not a path-optimality proof.
+- `oscillation_count` uses topology hypothesis switch count from existing diagnostics.

--- a/docs/context/evidence/issue_2751_topology_reselection_runtime/report.md
+++ b/docs/context/evidence/issue_2751_topology_reselection_runtime/report.md
@@ -1,4 +1,4 @@
-# Issue 2742 Topology Reselection Cross-Slice Diagnostic
+# Issue #2751 Topology Reselection Cross-Slice Diagnostic (2026-06-13)
 
 Claim boundary: `diagnostic_only_not_benchmark_or_paper_evidence`.
 Classification: `revise`.

--- a/docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json
+++ b/docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json
@@ -1,0 +1,173 @@
+{
+  "schema": "issue_2751_topology_reselection_runtime.v1",
+  "issue": 2751,
+  "source_launch_issue": 2742,
+  "commit": "952eff7e2f35bfe29fd65d90c7c43fa458ab8bb9",
+  "claim_boundary": "diagnostic_only_not_benchmark_or_paper_evidence",
+  "classification": "revise",
+  "classification_rationale": "Hard progress-gated rows retained diagnostic influence but all remained horizon_exhausted; the negative control succeeded with zero topology switching.",
+  "manifest": "configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml",
+  "runner": "scripts/validation/run_topology_reselection_cross_slice.py",
+  "command": "uv run python scripts/validation/run_topology_reselection_cross_slice.py --manifest configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml --output-dir <ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime",
+  "raw_trace_policy": "Raw per-row traces are reproducible from the tracked command but are not mirrored in git; compact row metrics below are the durable trace summary.",
+  "trace_links": [
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/bottleneck_transfer/baseline/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/bottleneck_transfer/reuse_penalty/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/bottleneck_transfer/progress_gated_threshold_0.05/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/bottleneck_transfer/progress_gated_threshold_0.1/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/bottleneck_transfer/progress_gated_threshold_0.2/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/doorway_transfer/baseline/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/doorway_transfer/reuse_penalty/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/doorway_transfer/progress_gated_threshold_0.05/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/doorway_transfer/progress_gated_threshold_0.1/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/doorway_transfer/progress_gated_threshold_0.2/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/t_intersection_transfer/baseline/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/t_intersection_transfer/reuse_penalty/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/t_intersection_transfer/progress_gated_threshold_0.05/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/t_intersection_transfer/progress_gated_threshold_0.1/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/t_intersection_transfer/progress_gated_threshold_0.2/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/simple_negative_control/baseline/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/simple_negative_control/reuse_penalty/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/simple_negative_control/progress_gated_threshold_0.05/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/simple_negative_control/progress_gated_threshold_0.1/topology_hypotheses.json",
+    "<ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime/runs/simple_negative_control/progress_gated_threshold_0.2/topology_hypotheses.json"
+  ],
+  "candidate_configs": {
+    "baseline": "configs/policy_search/candidates/topology_guided_hybrid_rule_v0.yaml",
+    "reuse_penalty": "configs/policy_search/candidates/topology_guided_hybrid_rule_v0_reuse_penalty.yaml",
+    "progress_gated": "configs/policy_search/candidates/topology_guided_hybrid_rule_v0_progress_gated_reselection.yaml"
+  },
+  "row_count": 20,
+  "hard_slices": [
+    "bottleneck_transfer",
+    "doorway_transfer",
+    "t_intersection_transfer"
+  ],
+  "negative_control": "simple_negative_control",
+  "decision_rule": {
+    "promote_if": "Every hard slice has at least one progress-gated row that clears and the negative-control slice shows no topology switching.",
+    "stop_if": "Progress-gated reselection loses topology-command influence on any hard slice, worsens negative-control switching, or only changes route labels without route-progress or terminal-outcome signal.",
+    "otherwise": "revise"
+  },
+  "slice_summary": [
+    {
+      "slice_id": "bottleneck_transfer",
+      "role": "hard",
+      "scenario": "classic_bottleneck_medium",
+      "progress_gated_outcomes": [
+        {
+          "threshold_m": 0.05,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 5.200000077486036,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.1,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 5.400000080466269,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.2,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 5.600000083446501,
+          "topology_switch_count": 0
+        }
+      ]
+    },
+    {
+      "slice_id": "doorway_transfer",
+      "role": "hard",
+      "scenario": "classic_doorway_medium",
+      "progress_gated_outcomes": [
+        {
+          "threshold_m": 0.05,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 1.4485281590086068,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.1,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 1.4485281590086068,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.2,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 1.4485281590086068,
+          "topology_switch_count": 0
+        }
+      ]
+    },
+    {
+      "slice_id": "t_intersection_transfer",
+      "role": "hard",
+      "scenario": "classic_t_intersection_medium",
+      "progress_gated_outcomes": [
+        {
+          "threshold_m": 0.05,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 6.3857865327825385,
+          "topology_switch_count": 13
+        },
+        {
+          "threshold_m": 0.1,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 6.3857865327825385,
+          "topology_switch_count": 13
+        },
+        {
+          "threshold_m": 0.2,
+          "outcome": "horizon_exhausted",
+          "success": false,
+          "route_progress_m": 6.3857865327825385,
+          "topology_switch_count": 13
+        }
+      ]
+    },
+    {
+      "slice_id": "simple_negative_control",
+      "role": "negative_control",
+      "scenario": "empty_map_8_directions_east",
+      "progress_gated_outcomes": [
+        {
+          "threshold_m": 0.05,
+          "outcome": "success",
+          "success": true,
+          "route_progress_m": 1.7656854512600013,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.1,
+          "outcome": "success",
+          "success": true,
+          "route_progress_m": 1.7656854512600013,
+          "topology_switch_count": 0
+        },
+        {
+          "threshold_m": 0.2,
+          "outcome": "success",
+          "success": true,
+          "route_progress_m": 1.7656854512600013,
+          "topology_switch_count": 0
+        }
+      ]
+    }
+  ],
+  "validation": [
+    "uv run ruff check scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py",
+    "uv run ruff format --check scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py",
+    "PYTEST_NUM_WORKERS=8 uv run pytest tests/validation/test_run_topology_reselection_cross_slice.py -q",
+    "uv run python scripts/validation/run_topology_reselection_cross_slice.py --manifest configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml --dry-run --max-runs 2 --output-dir <ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime_dryrun",
+    "tmux runtime command exited 0"
+  ]
+}

--- a/docs/context/issue_2742_topology_reselection_successor.md
+++ b/docs/context/issue_2742_topology_reselection_successor.md
@@ -83,7 +83,7 @@ runtime_rows: 0
 The dry-run output under `output/` is disposable. The summary JSON above is the durable tracked
 record for this launch packet.
 
-## Issue #2751 Runtime Decision
+## Issue #2751 Runtime Decision (2026-06-13)
 
 Issue [#2751](https://github.com/ll7/robot_sf_ll7/issues/2751) executed the clearance-targeted
 successor manifest on commit `952eff7e2f35bfe29fd65d90c7c43fa458ab8bb9`.

--- a/docs/context/issue_2742_topology_reselection_successor.md
+++ b/docs/context/issue_2742_topology_reselection_successor.md
@@ -82,3 +82,31 @@ runtime_rows: 0
 
 The dry-run output under `output/` is disposable. The summary JSON above is the durable tracked
 record for this launch packet.
+
+## Issue #2751 Runtime Decision
+
+Issue [#2751](https://github.com/ll7/robot_sf_ll7/issues/2751) executed the clearance-targeted
+successor manifest on commit `952eff7e2f35bfe29fd65d90c7c43fa458ab8bb9`.
+
+Durable evidence:
+
+- [runtime summary](evidence/issue_2751_topology_reselection_runtime/summary.json)
+- [runtime report](evidence/issue_2751_topology_reselection_runtime/report.md)
+
+Observed result:
+
+```yaml
+classification: revise
+runtime_rows: 20
+hard_slices:
+  bottleneck_transfer: horizon_exhausted
+  doorway_transfer: horizon_exhausted
+  t_intersection_transfer: horizon_exhausted
+negative_control:
+  simple_negative_control: success_zero_switching
+```
+
+The successor did not satisfy the promotion rule because no hard slice achieved terminal success.
+The negative-control rows succeeded without topology switching, so the result does not trigger the
+negative-control stop condition. The outcome remains diagnostic-only and not benchmark or
+paper-facing evidence.


### PR DESCRIPTION
## Summary

- executes the clearance-targeted topology reselection successor from the Issue #2742 launch packet for Issue #2751
- records the runtime result as `revise`: all hard slices remained `horizon_exhausted`, while the negative-control rows succeeded with zero topology switching
- promotes compact durable evidence under `docs/context/evidence/issue_2751_topology_reselection_runtime/` and updates the synthesis note/catalog

Closes #2751.
Follow-up: #2801 for the mechanism-backed post-#2751 successor decision.

## Validation

- `uv run ruff check scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py`
- `uv run ruff format --check scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py`
- `PYTEST_NUM_WORKERS=8 uv run pytest tests/validation/test_run_topology_reselection_cross_slice.py -q` (16 passed)
- `uv run python scripts/validation/run_topology_reselection_cross_slice.py --manifest configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml --dry-run --max-runs 2 --output-dir <ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime_dryrun`
- tmux runtime command exited 0: `uv run python scripts/validation/run_topology_reselection_cross_slice.py --manifest configs/policy_search/topology_reselection_cross_slice_issue_2742.yaml --output-dir <ignored-worktree-output>/diagnostics/issue_2751_topology_reselection_runtime`
- `uv run python -m json.tool docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/evidence/README.md --path docs/context/issue_2742_topology_reselection_successor.md --path docs/context/evidence/issue_2751_topology_reselection_runtime/README.md --path docs/context/evidence/issue_2751_topology_reselection_runtime/report.md --path docs/context/evidence/issue_2751_topology_reselection_runtime/summary.json`
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh` (6142 passed, 9 skipped, 8 warnings)

## Research Result Guidance

- Target claim/hypothesis/blocker: test whether progress-gated topology reselection clears the non-canonical hard slices from the #2742 successor packet.
- Comparator/baseline: `topology_guided_hybrid_rule_v0`, `topology_guided_hybrid_rule_v0_reuse_penalty`, and thresholded `topology_guided_hybrid_rule_v0_progress_gated_reselection`.
- Evidence tier: diagnostic-only runtime evidence; not benchmark or paper-facing proof.
- Result classification: `revise`.
- Decision/stop rule: promotion required every hard slice to have at least one progress-gated terminal success plus zero negative-control switching. Hard slices did not clear; negative control stayed clean.
- Synthesis surface/update target: `docs/context/issue_2742_topology_reselection_successor.md`, `docs/context/evidence/issue_2751_topology_reselection_runtime/`, and follow-up #2801.

## Downstream Propagation

- Parent issue: #2751 closes with `revise`.
- Claim map/benchmark report: no stronger claim promoted; diagnostic-only boundary preserved.
- Registry/config index: no candidate/config changes.
- Context/evidence index: `docs/context/evidence/README.md` and `docs/context/catalog.yaml` updated.
- Follow-up: #2801 opened for post-#2751 successor selection; #2752 remains relevant for mechanism analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive diagnostic runtime evidence documentation for topology reselection behavior, including detailed test summary data, diagnostic report with decision tables, outcome classification, and reproduction instructions
  * Updated evidence catalog and index with new topology reselection runtime evidence bundle entries
  * Recorded runtime execution results, validation test outcomes, and decision classifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->