### PR TITLE
test: add trace-seeded adversarial candidate

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1296,3 +1296,11 @@ entries:
     status: evidence
     freshness: evidence
     area: evidence_policy
+  - path: docs/context/evidence/issue_2724_adversarial_candidate/candidate.json
+    status: evidence
+    freshness: evidence
+    area: adversarial_search
+  - path: docs/context/evidence/issue_2724_adversarial_candidate/README.md
+    status: evidence
+    freshness: evidence
+    area: adversarial_search

--- a/docs/context/evidence/issue_2724_adversarial_candidate/README.md
+++ b/docs/context/evidence/issue_2724_adversarial_candidate/README.md
@@ -1,0 +1,51 @@
+# Issue #2724 - Adversarial Candidate Scout Register
+
+**Status:** diagnostic-only, not benchmark evidence
+**Parent issue:** [#2724](https://github.com/ll7/robot_sf_ll7/issues/2724)
+**Negative-result source:** NR-001, `issue-2716-topology-reselection-cross-slice`
+**Schema:** `robot_sf/benchmark/schemas/generated_scenario_candidate.v1.json`
+**Claim boundary:** single scout candidate; no adversarial diversity or benchmark-strength claim
+
+---
+
+## Purpose
+
+This directory holds a single trace-seeded diagnostic candidate derived from the negative-result
+register. NR-001 recorded that progress-gated topology reselection reached `horizon_exhausted` on
+all hard non-canonical slices, including `bottleneck_transfer`. This candidate encodes one bounded
+successor perturbation so the `generated_scenario_candidate.v1` path can be validated without
+claiming broad adversarial diversity, benchmark-strength evidence, or paper-facing evidence.
+
+## Candidate
+
+| Field | Value |
+|---|---|
+| `candidate_id` | `issue-2724-nr001-bottleneck-route-offset-001` |
+| `generator_family` | `heuristic_perturbation` |
+| `negative_result_source` | NR-001, `issue-2716-topology-reselection-cross-slice` |
+| `source_scenario` | `bottleneck_transfer/classic_bottleneck_medium` |
+| `perturbation` | `robot_route_offset` (dx_m=0.25, dy_m=0.0, max_magnitude_m=0.5) |
+| `promotion_status` | `not_promoted` |
+| `scenario_certified` | `false` |
+| `severity_metrics` | null (unevaluated) |
+| `diversity_metrics` | null (unevaluated) |
+
+## Validation
+
+```bash
+uv run python scripts/validation/validate_generated_scenario_candidate.py \
+  docs/context/evidence/issue_2724_adversarial_candidate/candidate.json
+uv run pytest tests/docs/test_generated_scenario_candidate_register.py -q
+uv run pytest tests/benchmark/test_generated_scenario_candidate_schema.py -q
+```
+
+## Claim Boundary
+
+- This is a **scout diagnostic** to verify schema encoding and validation plumbing.
+- The source scenario is **not certified** for benchmark claims in this candidate packet.
+- The candidate is derived from a `revise`-classified negative-result entry and does not rerun or
+  repair the failed topology mechanism.
+- Severity and diversity metrics are **unevaluated** (null).
+- `promotion_status` is **not_promoted**.
+- Do **not** cite this candidate as adversarial diversity evidence, benchmark-strength
+  evidence, or paper-facing evidence.

--- a/docs/context/evidence/issue_2724_adversarial_candidate/candidate.json
+++ b/docs/context/evidence/issue_2724_adversarial_candidate/candidate.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "generated_scenario_candidate.v1",
+  "candidate_id": "issue-2724-nr001-bottleneck-route-offset-001",
+  "generator_family": "heuristic_perturbation",
+  "generator_run_id": "issue-2724-nr001-topology-trace-scout",
+  "generator_config_ref": {
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9"
+  },
+  "source_scenario_ref": {
+    "scenario_name": "bottleneck_transfer/classic_bottleneck_medium",
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9",
+    "map_id": "classic_bottleneck_medium"
+  },
+  "source_split": "train",
+  "perturbations": [
+    {
+      "family": "robot_route_offset",
+      "parameters": {
+        "dx_m": 0.25,
+        "dy_m": 0.0,
+        "max_magnitude_m": 0.5
+      },
+      "rationale": "Trace-seeded diagnostic from negative-result register NR-001: the bottleneck_transfer hard slice ended horizon_exhausted under progress-gated topology reselection, so a bounded route offset probes whether small topology-route pressure can create a follow-up candidate without re-running the failed threshold family."
+    }
+  ],
+  "validity": {
+    "preflight_passed": true,
+    "scenario_certified": false,
+    "map_exists": true,
+    "spawn_collision_free": true,
+    "goal_reachable": true,
+    "rejection_reasons": [
+      "scenario_certified is false; this candidate is derived from negative-result register NR-001 and has not run scenario certification, severity evaluation, diversity evaluation, replay determinism, or leakage audit"
+    ]
+  },
+  "metrics_summary": {
+    "severity": {
+      "ttc_min_s": null,
+      "min_clearance_m": null,
+      "comfort_force_max_N": null,
+      "near_miss_count": null,
+      "collision_count": null,
+      "timeout_risk": null,
+      "objective_value": null
+    },
+    "diversity": {
+      "param_distance_min_m": null,
+      "param_distance_mean_m": null,
+      "unique_scenario_families": null,
+      "coverage_fraction": null,
+      "dedup_rate": null
+    }
+  },
+  "trace_lineage": {
+    "seed": 42,
+    "generated_at_utc": "2026-06-13T23:35:00Z",
+    "git_hash": "e808947ae4a7e9184cff80373c2f2c01c4dc6b41",
+    "provenance": {
+      "source_issue": "#2724"
+    }
+  },
+  "promotion_status": "not_promoted",
+  "notes": "Scout diagnostic candidate for issue #2724 derived from negative-result register NR-001 (issue-2716-topology-reselection-cross-slice). Instantiates ONE bounded robot_route_offset on the bottleneck_transfer hard slice to encode a trace-seeded successor candidate. Does NOT claim adversarial diversity, benchmark-strength evidence, or paper-facing evidence. Severity and diversity metrics are null (unevaluated). scenario_certified is false. status is not_promoted."
+}

--- a/scripts/validation/validate_generated_scenario_candidate.py
+++ b/scripts/validation/validate_generated_scenario_candidate.py
@@ -1,0 +1,72 @@
+"""Validate a generated_scenario_candidate.v1 JSON file against the canonical schema."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "generated_scenario_candidate.v1.json"
+)
+
+
+def load_schema() -> dict:
+    """Load the generated_scenario_candidate.v1 JSON Schema."""
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def validate_candidate(candidate_path: str) -> list[str]:
+    """Validate a candidate JSON file against the schema.
+
+    Returns a list of error messages (empty if valid).
+    """
+    path = Path(candidate_path)
+    if not path.exists():
+        return [f"Candidate file not found: {path}"]
+
+    schema = load_schema()
+    try:
+        candidate = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"Invalid JSON syntax in {path}: {exc}"]
+
+    errors: list[str] = []
+    validator = jsonschema.Draft202012Validator(schema)
+    for error in validator.iter_errors(candidate):
+        errors.append(f"  {error.json_path}: {error.message}")
+
+    return errors
+
+
+def main() -> None:
+    """CLI entry point: validate one or more candidate files."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: validate_generated_scenario_candidate.py <candidate.json> [candidate2.json ...]"
+        )
+        sys.exit(1)
+
+    all_ok = True
+    for candidate_path in sys.argv[1:]:
+        errors = validate_candidate(candidate_path)
+        if errors:
+            all_ok = False
+            print(f"FAIL: {candidate_path}")
+            for err in errors:
+                print(err)
+        else:
+            print(f"PASS: {candidate_path}")
+
+    if not all_ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/docs/test_generated_scenario_candidate_register.py
+++ b/tests/docs/test_generated_scenario_candidate_register.py
@@ -1,0 +1,169 @@
+"""Validation tests for the issue #2724 adversarial candidate register."""
+
+# ruff: noqa: D102
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from scripts.validation.validate_generated_scenario_candidate import validate_candidate
+
+CANDIDATE_JSON = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "context"
+    / "evidence"
+    / "issue_2724_adversarial_candidate"
+    / "candidate.json"
+)
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "generated_scenario_candidate.v1.json"
+)
+SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+SCOUT_CANDIDATE_ID = "issue-2724-nr001-bottleneck-route-offset-001"
+NEGATIVE_RESULT_SOURCE = "issue-2716-topology-reselection-cross-slice"
+BLOCKED_PROMOTION_WORDS = {"promote", "benchmark evidence", "paper evidence", "results tier"}
+
+
+def _load_candidate() -> dict:
+    return json.loads(CANDIDATE_JSON.read_text(encoding="utf-8"))
+
+
+class TestCandidateFile:
+    """Candidate file must exist and be valid JSON."""
+
+    def test_candidate_json_exists(self) -> None:
+        assert CANDIDATE_JSON.exists(), f"Candidate not found at {CANDIDATE_JSON}"
+
+    def test_candidate_is_valid_json(self) -> None:
+        candidate = _load_candidate()
+        assert isinstance(candidate, dict), "Candidate root must be a JSON object"
+
+
+class TestSchemaValidation:
+    """Candidate must pass the generated_scenario_candidate.v1 schema."""
+
+    def test_candidate_validates_against_schema(self) -> None:
+        candidate = _load_candidate()
+        jsonschema.validate(instance=candidate, schema=SCHEMA)
+
+
+class TestScoutCandidateContract:
+    """Scout candidate must satisfy the minimal diagnostic-only contract."""
+
+    def test_scout_candidate_id(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["candidate_id"] == SCOUT_CANDIDATE_ID
+
+    def test_generator_family_is_heuristic(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["generator_family"] == "heuristic_perturbation"
+
+    def test_promotion_status_not_promoted(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["promotion_status"] == "not_promoted"
+
+    def test_scenario_not_certified(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["validity"]["scenario_certified"] is False
+
+    def test_preflight_passed(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["validity"]["preflight_passed"] is True
+
+    def test_map_exists(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["validity"]["map_exists"] is True
+
+    def test_has_single_perturbation(self) -> None:
+        candidate = _load_candidate()
+        assert len(candidate["perturbations"]) == 1
+
+    def test_perturbation_is_route_offset(self) -> None:
+        candidate = _load_candidate()
+        pert = candidate["perturbations"][0]
+        assert pert["family"] == "robot_route_offset"
+        assert "dx_m" in pert["parameters"]
+        assert "dy_m" in pert["parameters"]
+        assert "max_magnitude_m" in pert["parameters"]
+
+    def test_candidate_is_grounded_in_negative_result_register(self) -> None:
+        candidate = _load_candidate()
+        haystack = " ".join(
+            [
+                candidate["candidate_id"],
+                candidate["generator_run_id"],
+                candidate["source_scenario_ref"]["scenario_name"],
+                candidate["perturbations"][0].get("rationale", ""),
+                candidate.get("notes", ""),
+            ]
+        )
+        assert "nr-001" in haystack.lower()
+        assert NEGATIVE_RESULT_SOURCE in haystack
+
+    def test_severity_metrics_are_null(self) -> None:
+        candidate = _load_candidate()
+        severity = candidate["metrics_summary"]["severity"]
+        for key in severity:
+            assert severity[key] is None, f"Severity metric {key} should be null (unevaluated)"
+
+    def test_diversity_metrics_are_null(self) -> None:
+        candidate = _load_candidate()
+        diversity = candidate["metrics_summary"]["diversity"]
+        for key in diversity:
+            assert diversity[key] is None, f"Diversity metric {key} should be null (unevaluated)"
+
+    def test_trace_lineage_has_source_issue(self) -> None:
+        candidate = _load_candidate()
+        assert candidate["trace_lineage"]["provenance"]["source_issue"] == "#2724"
+
+    def test_notes_declares_scout_scope(self) -> None:
+        candidate = _load_candidate()
+        notes = candidate.get("notes", "").lower()
+        assert "scout" in notes, "Notes should declare scout diagnostic scope"
+        assert "not_promoted" in notes, "Notes should reference not_promoted status"
+
+
+class TestNoClaimOverreach:
+    """Scout candidate must not contain promotion or benchmark-strength language."""
+
+    def test_notes_no_benchmark_claim(self) -> None:
+        candidate = _load_candidate()
+        notes = candidate.get("notes", "").lower()
+        # Remove the schema field value "not_promoted" before checking,
+        # since "promote" is a substring of the allowed status string.
+        notes_safe = notes.replace("not_promoted", "")
+        for word in BLOCKED_PROMOTION_WORDS:
+            assert word not in notes_safe, (
+                f"Notes must not contain promotion word '{word}': {candidate.get('notes')}"
+            )
+
+    def test_rejection_reasons_explain_not_certified(self) -> None:
+        candidate = _load_candidate()
+        reasons = candidate["validity"].get("rejection_reasons", [])
+        assert len(reasons) > 0, "Should have rejection reasons explaining non-certified status"
+        reason_text = " ".join(reasons).lower()
+        assert "not certified" in reason_text or "certification" in reason_text, (
+            "Rejection reasons should explain certification status"
+        )
+
+
+class TestValidatorCli:
+    """Validator helper should fail closed with readable errors."""
+
+    def test_malformed_candidate_json_returns_error(self, tmp_path: Path) -> None:
+        bad_candidate = tmp_path / "bad_candidate.json"
+        bad_candidate.write_text("{not valid json", encoding="utf-8")
+
+        errors = validate_candidate(str(bad_candidate))
+
+        assert len(errors) == 1
+        assert "Invalid JSON syntax" in errors[0]


### PR DESCRIPTION
## Summary
- add one trace-seeded `generated_scenario_candidate.v1` candidate derived from negative-result register NR-001 / issue #2716 topology reselection cross-slice
- add a small validator CLI for generated scenario candidates
- add tests that enforce schema validity, NR-001 grounding, null severity/diversity metrics, and diagnostic-only `not_promoted` status

## Evidence Boundary
This is diagnostic-only candidate plumbing. It does not claim adversarial diversity, benchmark-strength evidence, paper-facing evidence, or training readiness. The candidate remains `not_promoted`; severity/diversity metrics are null, and scenario certification is false for this packet.

## Validation
- `uv run python scripts/validation/validate_generated_scenario_candidate.py docs/context/evidence/issue_2724_adversarial_candidate/candidate.json` PASS
- `uv run pytest tests/docs/test_generated_scenario_candidate_register.py -q` PASS, 18 passed
- `uv run pytest tests/benchmark/test_generated_scenario_candidate_schema.py -q` PASS, 39 passed
- `uv run ruff check scripts/validation/validate_generated_scenario_candidate.py tests/docs/test_generated_scenario_candidate_register.py` PASS
- `uv run ruff format --check scripts/validation/validate_generated_scenario_candidate.py tests/docs/test_generated_scenario_candidate_register.py` PASS
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` PASS, 6185 passed, 9 skipped

## Research Result Guidance
- Target: prove the generated-scenario candidate schema can encode a trace-seeded successor candidate from an existing negative topology result.
- Comparator/baseline: NR-001 / issue #2716 cross-slice topology diagnostic, classified `revise`.
- Evidence tier: diagnostic-only schema/evidence artifact validation.
- Result classification: diagnostic-only, not benchmark evidence.
- Stop rule: no promotion until certification, severity, diversity, replay determinism, leakage audit, and benchmark manifest inclusion are all complete.
- Synthesis surface: `docs/context/evidence/issue_2724_adversarial_candidate/` and `docs/context/catalog.yaml`.

## Downstream Propagation
- Parent issue #2724 should cite the new candidate path and diagnostic boundary.
- No leaderboard, benchmark report, claim map, or Results wording update is warranted from this diagnostic candidate alone.

Closes #2724.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation tooling to verify scenario candidate files against the canonical schema.

* **Documentation**
  * Added documentation and evidence entries for issue `#2724` adversarial candidate, including schema and validation details.

* **Tests**
  * Added comprehensive test suite to validate scenario candidate registration, schema compliance, and metadata constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->