### PR TITLE
test: add semantic boundary diagnostics

### DIFF
--- a/configs/scenarios/single/issue_2728_semantic_boundaries.yaml
+++ b/configs/scenarios/single/issue_2728_semantic_boundaries.yaml
@@ -1,0 +1,73 @@
+schema_version: robot_sf.scenario_matrix.v1
+
+scenarios:
+- name: robot_route_around_separator
+  map_file: ../../../maps/svg_maps/issue_2728_semantic_boundaries.svg
+  simulation_config:
+    max_episode_steps: 300
+    ped_density: 0.0
+  single_pedestrians: []
+  robot_config: {}
+  metadata:
+    claim_boundary: diagnostic_only_not_benchmark
+    archetype: semantic_boundary_topology
+    density: diagnostic_fixture
+    purpose: semantic_boundary_route_around
+    semantic_boundary_expectations:
+    - id: separator
+      label: semantic_boundary_separator__vehicle_blocking__occluding
+      vehicle_blocking: true
+      pedestrian_passable: false
+      occluding: true
+      spawn_edge: false
+    - id: ped_spawn_edge
+      label: semantic_boundary_ped_edge__pedestrian_passable__spawn_edge
+      vehicle_blocking: false
+      pedestrian_passable: true
+      occluding: false
+      spawn_edge: true
+    route_assertions:
+    - description: robot authored route avoids crossing the vehicle_blocking separator
+      route_does_not_cross_boundary: separator
+  seeds:
+  - 2728001
+  - 2728002
+  - 2728003
+
+- name: pedestrian_emergence_from_spawn_edge
+  map_file: ../../../maps/svg_maps/issue_2728_semantic_boundaries.svg
+  simulation_config:
+    max_episode_steps: 300
+    ped_density: 0.0
+  single_pedestrians:
+  - id: ped_emerge_1
+    start: [3.0, 4.0]
+    goal: [12.0, 8.0]
+    note: pedestrian emerges from the pedestrian-passable spawn-edge boundary
+  robot_config: {}
+  metadata:
+    claim_boundary: diagnostic_only_not_benchmark
+    archetype: semantic_boundary_topology
+    density: diagnostic_fixture
+    purpose: semantic_boundary_pedestrian_emergence
+    semantic_boundary_expectations:
+    - id: separator
+      label: semantic_boundary_separator__vehicle_blocking__occluding
+      vehicle_blocking: true
+      pedestrian_passable: false
+      occluding: true
+      spawn_edge: false
+    - id: ped_spawn_edge
+      label: semantic_boundary_ped_edge__pedestrian_passable__spawn_edge
+      vehicle_blocking: false
+      pedestrian_passable: true
+      occluding: false
+      spawn_edge: true
+    emergence_assertions:
+    - description: pedestrian start is near the pedestrian_passable spawn_edge boundary
+      start_near_boundary: ped_spawn_edge
+      max_distance: 5.0
+  seeds:
+  - 2728011
+  - 2728012
+  - 2728013

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1304,3 +1304,11 @@ entries:
     status: evidence
     freshness: evidence
     area: adversarial_search
+  - path: docs/context/evidence/issue_2728_semantic_boundaries/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2728_semantic_boundaries/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_2728_semantic_boundaries/README.md
+++ b/docs/context/evidence/issue_2728_semantic_boundaries/README.md
@@ -1,0 +1,35 @@
+# Issue 2728: Semantic Boundaries - Evidence
+
+## Claim
+Diagnostic-only proof that 2D semantic boundary metadata can be parsed from SVG
+maps, carried through MapDefinition, and queried by downstream consumers without
+affecting collision physics or planner behaviour.
+
+## Evidence Classification
+`diagnostic_only_not_benchmark` - This evidence proves the metadata plumbing
+works. It does not make any benchmark, paper, or safety claim.
+
+## What Was Validated
+1. **Parser success**: `SemanticBoundary` dataclass is populated from SVG path
+   labels with the `semantic_boundary_` prefix. Flags are parsed from `__`-separated
+   tokens after the boundary name.
+2. **Unsupported token fail-closed**: An unsupported token in a semantic boundary
+   label raises `ValueError`.
+3. **Robot route avoidance**: The authored robot route does not cross the
+   `vehicle_blocking` separator, while a direct spawn-to-goal line would.
+4. **Pedestrian emergence**: The pedestrian start position is within the declared
+   `max_distance` of the `pedestrian_passable` `spawn_edge` boundary.
+
+## Files
+- `maps/svg_maps/issue_2728_semantic_boundaries.svg` - Fixture map
+- `configs/scenarios/single/issue_2728_semantic_boundaries.yaml` - Scenario definitions
+- `robot_sf/nav/nav_types.py` - `SemanticBoundary` dataclass
+- `robot_sf/nav/map_config.py` - `MapDefinition.semantic_boundaries` field
+- `robot_sf/nav/svg_map_parser.py` - Parser extension
+- `scripts/validation/validate_semantic_boundaries_issue_2728.py` - Validation script
+- `tests/test_semantic_boundaries_issue_2728.py` - Test suite
+
+## Risks
+- This is metadata-only. No collision physics, planner logic, or runtime
+  behaviour was changed.
+- Future consumers of `semantic_boundaries` must be implemented in follow-up work.

--- a/docs/context/evidence/issue_2728_semantic_boundaries/README.md
+++ b/docs/context/evidence/issue_2728_semantic_boundaries/README.md
@@ -1,4 +1,4 @@
-# Issue 2728: Semantic Boundaries - Evidence
+# Issue 2728: Semantic Boundaries - Evidence (2026-06-14)
 
 ## Claim
 Diagnostic-only proof that 2D semantic boundary metadata can be parsed from SVG

--- a/docs/context/evidence/issue_2728_semantic_boundaries/summary.json
+++ b/docs/context/evidence/issue_2728_semantic_boundaries/summary.json
@@ -1,0 +1,71 @@
+{
+  "ok": true,
+  "evidence_classification": "diagnostic_only_not_benchmark",
+  "checks": [
+    {
+      "name": "map_load",
+      "passed": true,
+      "detail": "Loaded map with 2 semantic boundaries"
+    },
+    {
+      "name": "boundary_count",
+      "passed": true,
+      "detail": "Expected 2, got 2"
+    },
+    {
+      "name": "separator_vehicle_blocking",
+      "passed": true,
+      "detail": "vehicle_blocking=True"
+    },
+    {
+      "name": "separator_occluding",
+      "passed": true,
+      "detail": "occluding=True"
+    },
+    {
+      "name": "separator_not_pedestrian_passable",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "separator_not_spawn_edge",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "ped_edge_pedestrian_passable",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "ped_edge_spawn_edge",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "ped_edge_not_vehicle_blocking",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "ped_edge_not_occluding",
+      "passed": true,
+      "detail": ""
+    },
+    {
+      "name": "unsupported_token_fail_closed",
+      "passed": true,
+      "detail": "Unsupported semantic boundary token 'bogus_token' in label 'semantic_boundary_test__vehicle_blocking__bogus_token'. Supported tokens: ['occluding', 'pedestrian_passable', 'spawn_edge', 'vehicle_blocking']"
+    },
+    {
+      "name": "robot_route_avoids_separator",
+      "passed": true,
+      "detail": "route crosses=False, direct line crosses=True"
+    },
+    {
+      "name": "ped_start_near_spawn_edge",
+      "passed": true,
+      "detail": "distance=2.24, max=5.0"
+    }
+  ]
+}

--- a/maps/svg_maps/issue_2728_semantic_boundaries.svg
+++ b/maps/svg_maps/issue_2728_semantic_boundaries.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Fixture map for issue 2728: semantic boundary metadata validation.
+
+     Features:
+     - Vehicle-blocking/occluding separator at x=18 (y=5..15)
+     - Pedestrian-passable/spawn-edge boundary at x=1 (y=5..15)
+     - Robot route that goes around the separator (above it)
+     - Pedestrian route that emerges from the spawn-edge boundary
+-->
+
+<svg
+   width="40"
+   height="20"
+   viewBox="0 0 40 20"
+   version="1.1"
+   id="svg_issue_2728"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns="http://www.w3.org/2000/svg">
+  <defs id="defs1" />
+  <g id="layer1" inkscape:label="Layer 1">
+    <!-- Boundary walls -->
+    <rect style="fill:#000000;fill-opacity:1;stroke:none"
+          id="wall_left" width="1" height="20" x="0" y="0"
+          inkscape:label="obstacle" />
+    <rect style="fill:#000000;fill-opacity:1;stroke:none"
+          id="wall_right" width="1" height="20" x="39" y="0"
+          inkscape:label="obstacle" />
+    <rect style="fill:#000000;fill-opacity:1;stroke:none"
+          id="wall_top" width="40" height="1" x="0" y="0"
+          inkscape:label="obstacle" />
+    <rect style="fill:#000000;fill-opacity:1;stroke:none"
+          id="wall_bottom" width="40" height="1" x="0" y="19"
+          inkscape:label="obstacle" />
+
+    <!-- Robot spawn zone (yellow) -->
+    <rect style="fill:#ffdf00;fill-opacity:1;stroke:none"
+          id="robot_spawn_zone" width="4" height="4" x="2" y="8"
+          inkscape:label="robot_spawn_zone" />
+    <!-- Robot goal zone (orange) -->
+    <rect style="fill:#ff6c00;fill-opacity:1;stroke:none"
+          id="robot_goal_zone" width="4" height="4" x="34" y="8"
+          inkscape:label="robot_goal_zone" />
+    <!-- Pedestrian spawn zone (light green) -->
+    <rect style="fill:#90ee90;fill-opacity:1;stroke:none"
+          id="ped_spawn_zone" width="4" height="4" x="2" y="2"
+          inkscape:label="ped_spawn_zone" />
+    <!-- Pedestrian goal zone (dark green) -->
+    <rect style="fill:#228b22;fill-opacity:1;stroke:none"
+          id="ped_goal_zone" width="4" height="4" x="2" y="14"
+          inkscape:label="ped_goal_zone" />
+
+    <!-- Semantic boundary: vehicle-blocking / occluding separator (red) -->
+    <path style="fill:none;stroke:#ff0000;stroke-width:0.3;stroke-opacity:1"
+          d="M 18,5 L 18,15"
+          id="separator"
+          inkscape:label="semantic_boundary_separator__vehicle_blocking__occluding" />
+
+    <!-- Semantic boundary: pedestrian-passable / spawn-edge (blue) -->
+    <path style="fill:none;stroke:#0000ff;stroke-width:0.3;stroke-opacity:1"
+          d="M 1,5 L 1,15"
+          id="ped_spawn_edge"
+          inkscape:label="semantic_boundary_ped_edge__pedestrian_passable__spawn_edge" />
+
+    <!-- Robot route: goes above the separator (around it) -->
+    <path style="fill:none;stroke:#0310b4;stroke-width:0.2;stroke-opacity:0.5"
+          d="M 4,10 L 10,10 L 16,3 L 22,3 L 28,10 L 36,10"
+          id="robot_route_0_0"
+          inkscape:label="robot_route_0_0" />
+
+    <!-- Pedestrian route: emerges from spawn-edge boundary, crosses to goal -->
+    <path style="fill:none;stroke:#006400;stroke-width:0.2;stroke-opacity:0.5"
+          d="M 3,4 L 8,6 L 12,8"
+          id="ped_route_0_0"
+          inkscape:label="ped_route_0_0" />
+  </g>
+</svg>

--- a/robot_sf/nav/map_config.py
+++ b/robot_sf/nav/map_config.py
@@ -16,6 +16,7 @@ from shapely.geometry import Point, Polygon
 
 from robot_sf.common.types import Line2D, Rect, Vec2D
 from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.nav_types import SemanticBoundary
 from robot_sf.nav.obstacle import Obstacle
 
 
@@ -326,6 +327,14 @@ class MapDefinition:
 
     allowed_areas: list[Polygon] | None = None
     """Explicit driveable areas from OSM. Optional, used for path planning bounds."""
+
+    semantic_boundaries: list[SemanticBoundary] = field(default_factory=list)
+    """2D semantic boundary metadata parsed from SVG path labels.
+
+    This is diagnostic-only metadata: it does not affect collision physics,
+    obstacle logic, or planner behaviour.  It is consumed by topology,
+    prediction, and observation-noise diagnostics.
+    """
 
     _poi_positions_by_label: dict[str, Vec2D] = field(init=False, default_factory=dict, repr=False)
     """Internal lookup table from POI label to position for faster access."""
@@ -641,6 +650,8 @@ class MapDefinition:
             self.poi_positions = []
         if not hasattr(self, "single_pedestrians"):
             self.single_pedestrians = []
+        if not hasattr(self, "semantic_boundaries"):
+            self.semantic_boundaries = []
         self._build_poi_lookup()
 
 

--- a/robot_sf/nav/nav_types.py
+++ b/robot_sf/nav/nav_types.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 
 from robot_sf.common.types import Vec2D, Zone
 
+SUPPORTED_SEMANTIC_BOUNDARY_FLAGS = frozenset(
+    {"vehicle_blocking", "pedestrian_passable", "occluding", "spawn_edge"}
+)
+
 
 @dataclass
 class SvgRectangle:
@@ -105,3 +109,31 @@ class SvgPath:
     coordinates: tuple[Vec2D, ...]
     label: str
     id: str
+
+
+@dataclass(frozen=True)
+class SemanticBoundary:
+    """2D semantic boundary metadata parsed from SVG path labels.
+
+    This is pure metadata: it does not affect collision physics, obstacle
+    logic, or planner behaviour.  It is consumed by diagnostic, topology,
+    prediction, and observation-noise consumers.
+
+    Attributes:
+        coordinates: Ordered 2D polyline waypoints.
+        label: Raw SVG inkscape:label value.
+        id_: Raw SVG element id.
+        vehicle_blocking: If True, vehicles (including the robot) should not
+            cross this boundary.
+        pedestrian_passable: If True, pedestrians are allowed to cross.
+        occluding: If True, this boundary may occlude line-of-sight.
+        spawn_edge: If True, pedestrians may emerge from this boundary.
+    """
+
+    coordinates: tuple[Vec2D, ...]
+    label: str
+    id_: str
+    vehicle_blocking: bool = False
+    pedestrian_passable: bool = False
+    occluding: bool = False
+    spawn_edge: bool = False

--- a/robot_sf/nav/svg_map_parser.py
+++ b/robot_sf/nav/svg_map_parser.py
@@ -1009,6 +1009,11 @@ class SvgMapConverter:
         as ``semantic_boundary_separator__vehicle_blocking__occluding``. The
         prefix ``semantic_boundary_`` is stripped and ``__`` separates tokens.
 
+        Fail-closed policy: if no supported semantic flag is found among the
+        parsed tokens the function raises ``ValueError`` rather than returning
+        an empty flag set.  This prevents silently accepting labels that
+        contain only an unsupported name or typo tokens.
+
         Args:
             label: Raw SVG inkscape:label value.
 
@@ -1016,7 +1021,8 @@ class SvgMapConverter:
             tuple[str, frozenset[str]]: Boundary name and validated flag set.
 
         Raises:
-            ValueError: If an unsupported token is encountered.
+            ValueError: If an unsupported token is encountered or no supported
+                flag is present in the label.
         """
         prefix = "semantic_boundary_"
         rest = label[len(prefix) :]
@@ -1033,6 +1039,11 @@ class SvgMapConverter:
                     f"Supported tokens: {sorted(SUPPORTED_SEMANTIC_BOUNDARY_FLAGS)}"
                 )
             flags.add(token)
+        if not flags:
+            raise ValueError(
+                f"No supported semantic boundary flag found in label {label!r}. "
+                f"Supported tokens: {sorted(SUPPORTED_SEMANTIC_BOUNDARY_FLAGS)}"
+            )
         return name, frozenset(flags)
 
     def _process_semantic_boundary_path(self, path: SvgPath) -> SemanticBoundary:

--- a/robot_sf/nav/svg_map_parser.py
+++ b/robot_sf/nav/svg_map_parser.py
@@ -48,7 +48,13 @@ from robot_sf.common.errors import raise_fatal_with_remedy
 from robot_sf.common.types import Line2D, Rect, Zone
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
-from robot_sf.nav.nav_types import SvgCircle, SvgPath, SvgRectangle
+from robot_sf.nav.nav_types import (
+    SUPPORTED_SEMANTIC_BOUNDARY_FLAGS,
+    SemanticBoundary,
+    SvgCircle,
+    SvgPath,
+    SvgRectangle,
+)
 from robot_sf.nav.obstacle import Obstacle, obstacle_from_svgrectangle
 
 _LOGGED_OBSTACLE_PATH_EVENTS: set[tuple[str, str, str]] = set()
@@ -994,6 +1000,58 @@ class SvgMapConverter:
         """
         return Zone(list(path.coordinates))
 
+    @staticmethod
+    def _parse_semantic_boundary_label(label: str) -> tuple[str, frozenset[str]]:
+        """Parse a semantic boundary label into a name and set of flags.
+
+        Labels may be simple flag labels such as
+        ``semantic_boundary_vehicle_blocking`` or named multi-flag labels such
+        as ``semantic_boundary_separator__vehicle_blocking__occluding``. The
+        prefix ``semantic_boundary_`` is stripped and ``__`` separates tokens.
+
+        Args:
+            label: Raw SVG inkscape:label value.
+
+        Returns:
+            tuple[str, frozenset[str]]: Boundary name and validated flag set.
+
+        Raises:
+            ValueError: If an unsupported token is encountered.
+        """
+        prefix = "semantic_boundary_"
+        rest = label[len(prefix) :]
+        parts = rest.split("__")
+        name = parts[0] if parts else ""
+        flags: set[str] = set()
+        tokens = parts
+        if name not in SUPPORTED_SEMANTIC_BOUNDARY_FLAGS:
+            tokens = parts[1:]
+        for token in tokens:
+            if token not in SUPPORTED_SEMANTIC_BOUNDARY_FLAGS:
+                raise ValueError(
+                    f"Unsupported semantic boundary token {token!r} in label {label!r}. "
+                    f"Supported tokens: {sorted(SUPPORTED_SEMANTIC_BOUNDARY_FLAGS)}"
+                )
+            flags.add(token)
+        return name, frozenset(flags)
+
+    def _process_semantic_boundary_path(self, path: SvgPath) -> SemanticBoundary:
+        """Convert a semantic-boundary-prefixed SVG path into a SemanticBoundary.
+
+        Returns:
+            SemanticBoundary: Parsed boundary with coordinates and boolean flags.
+        """
+        _name, flags = self._parse_semantic_boundary_label(path.label)
+        return SemanticBoundary(
+            coordinates=path.coordinates,
+            label=path.label,
+            id_=path.id,
+            vehicle_blocking="vehicle_blocking" in flags,
+            pedestrian_passable="pedestrian_passable" in flags,
+            occluding="occluding" in flags,
+            spawn_edge="spawn_edge" in flags,
+        )
+
     def _process_paths(
         self,
         obstacles: list[Obstacle],
@@ -1002,8 +1060,8 @@ class SvgMapConverter:
         robot_goal_zones: list[Rect],
         ped_goal_zones: list[Rect],
         ped_crowded_zones: list[Rect],
-    ) -> tuple[list[GlobalRoute], list[GlobalRoute]]:
-        """Convert parsed paths into routes, obstacles, or crowded zones.
+    ) -> tuple[list[GlobalRoute], list[GlobalRoute], list[SemanticBoundary]]:
+        """Convert parsed paths into routes, obstacles, crowded zones, or semantic boundaries.
 
         Args:
             obstacles: Mutable obstacle list to append parsed obstacle paths to.
@@ -1014,11 +1072,13 @@ class SvgMapConverter:
             ped_crowded_zones: Crowded zones list mutated when crowded paths are parsed.
 
         Returns:
-            tuple[list[GlobalRoute], list[GlobalRoute]]: Parsed robot and pedestrian routes
-                (robot_routes, ped_routes) extracted from the SVG paths.
+            tuple[list[GlobalRoute], list[GlobalRoute], list[SemanticBoundary]]: Parsed
+                robot routes, pedestrian routes, and semantic boundaries extracted from
+                the SVG paths.
         """
         robot_routes: list[GlobalRoute] = []
         ped_routes: list[GlobalRoute] = []
+        semantic_boundaries: list[SemanticBoundary] = []
         ped_route_only_mode = not ped_spawn_zones and not ped_goal_zones
         robot_route_only_mode = not robot_spawn_zones and not robot_goal_zones
 
@@ -1060,19 +1120,20 @@ class SvgMapConverter:
 
         for path in self.path_info:
             label = path.label
-            if "ped_route" in label:
-                processor = path_processors["ped_route"]
+            if label.startswith("semantic_boundary_"):
+                semantic_boundaries.append(self._process_semantic_boundary_path(path))
+            elif "ped_route" in label:
+                path_processors["ped_route"](path)
             elif "robot_route" in label:
-                processor = path_processors["robot_route"]
+                path_processors["robot_route"](path)
             else:
                 processor = path_processors.get(label)
+                if processor:
+                    processor(path)
+                else:
+                    logger.error(f"Unknown label <{label}> in id <{path.id}>")
 
-            if processor:
-                processor(path)
-            else:
-                logger.error(f"Unknown label <{label}> in id <{path.id}>")
-
-        return robot_routes, ped_routes
+        return robot_routes, ped_routes, semantic_boundaries
 
     def _process_single_pedestrians_from_circles(self) -> list[SinglePedestrianDefinition]:
         """
@@ -1473,7 +1534,7 @@ class SvgMapConverter:
             ped_crowded_zones,
         ) = self._process_rects(width, height)
 
-        robot_routes, ped_routes = self._process_paths(
+        robot_routes, ped_routes, semantic_boundaries = self._process_paths(
             obstacles,
             robot_spawn_zones,
             ped_spawn_zones,
@@ -1507,6 +1568,7 @@ class SvgMapConverter:
             single_pedestrians,
             poi_positions=poi_positions,
             poi_labels=poi_labels,
+            semantic_boundaries=semantic_boundaries,
         )
         logger.debug(f"MapDefinition object created: {type(self.map_definition)}")
 

--- a/scripts/validation/validate_semantic_boundaries_issue_2728.py
+++ b/scripts/validation/validate_semantic_boundaries_issue_2728.py
@@ -1,0 +1,231 @@
+"""Validation script for issue 2728: 2D semantic boundary metadata.
+
+Loads the fixture map and scenarios, then emits compact JSON proving:
+- Semantic boundary flags are parsed correctly.
+- Unsupported tokens fail closed with ValueError.
+- The robot authored route avoids the vehicle_blocking separator.
+- The pedestrian emergence route starts near the spawn-edge boundary.
+- Evidence classification is diagnostic_only_not_benchmark.
+"""
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAP_PATH = REPO_ROOT / "maps" / "svg_maps" / "issue_2728_semantic_boundaries.svg"
+SCENARIO_PATH = (
+    REPO_ROOT / "configs" / "scenarios" / "single" / "issue_2728_semantic_boundaries.yaml"
+)
+
+
+def _line_segment_intersection(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    p3: tuple[float, float],
+    p4: tuple[float, float],
+) -> bool:
+    """Check if segment p1-p2 intersects segment p3-p4 using orientation tests."""
+
+    def _orient(a: tuple[float, float], b: tuple[float, float], c: tuple[float, float]) -> int:
+        val = (b[1] - a[1]) * (c[0] - b[0]) - (b[0] - a[0]) * (c[1] - b[1])
+        if abs(val) < 1e-9:
+            return 0
+        return 1 if val > 0 else 2
+
+    o1 = _orient(p1, p2, p3)
+    o2 = _orient(p1, p2, p4)
+    o3 = _orient(p3, p4, p1)
+    o4 = _orient(p3, p4, p2)
+    if o1 != o2 and o3 != o4:
+        return True
+    return False
+
+
+def _segment_distance_to_point(
+    seg_start: tuple[float, float],
+    seg_end: tuple[float, float],
+    point: tuple[float, float],
+) -> float:
+    """Approximate distance from a point to a polyline segment."""
+    dx = seg_end[0] - seg_start[0]
+    dy = seg_end[1] - seg_start[1]
+    length_sq = dx * dx + dy * dy
+    if length_sq < 1e-12:
+        return math.hypot(point[0] - seg_start[0], point[1] - seg_start[1])
+    t = max(
+        0.0, min(1.0, ((point[0] - seg_start[0]) * dx + (point[1] - seg_start[1]) * dy) / length_sq)
+    )
+    proj_x = seg_start[0] + t * dx
+    proj_y = seg_start[1] + t * dy
+    return math.hypot(point[0] - proj_x, point[1] - proj_y)
+
+
+def _route_crosses_boundary(
+    route_waypoints: list[tuple[float, float]],
+    boundary_coords: tuple[tuple[float, float], ...],
+) -> bool:
+    """Check if any segment of the route crosses any segment of the boundary."""
+    for i in range(len(route_waypoints) - 1):
+        r_start = route_waypoints[i]
+        r_end = route_waypoints[i + 1]
+        for j in range(len(boundary_coords) - 1):
+            b_start = boundary_coords[j]
+            b_end = boundary_coords[j + 1]
+            if _line_segment_intersection(r_start, r_end, b_start, b_end):
+                return True
+    return False
+
+
+def _min_distance_to_boundary(
+    point: tuple[float, float],
+    boundary_coords: tuple[tuple[float, float], ...],
+) -> float:
+    """Minimum distance from a point to any segment of the boundary."""
+    min_dist = float("inf")
+    for j in range(len(boundary_coords) - 1):
+        d = _segment_distance_to_point(boundary_coords[j], boundary_coords[j + 1], point)
+        min_dist = min(min_dist, d)
+    return min_dist
+
+
+def run_validation() -> dict:
+    """Run all validation checks and return a summary dict."""
+    import yaml
+
+    from robot_sf.nav.svg_map_parser import convert_map
+
+    results: dict = {
+        "ok": True,
+        "evidence_classification": "diagnostic_only_not_benchmark",
+        "checks": [],
+    }
+
+    def _check(name: str, passed: bool, detail: str = "") -> None:
+        results["checks"].append({"name": name, "passed": passed, "detail": detail})
+        if not passed:
+            results["ok"] = False
+
+    # --- 1. Load map and verify semantic boundary flags parsed ---
+    try:
+        map_def = convert_map(str(MAP_PATH))
+        assert map_def is not None
+    except Exception as exc:
+        results["ok"] = False
+        results["checks"].append({"name": "map_load", "passed": False, "detail": str(exc)})
+        return results
+
+    _check(
+        "map_load", True, f"Loaded map with {len(map_def.semantic_boundaries)} semantic boundaries"
+    )
+
+    boundaries_by_id = {b.id_: b for b in map_def.semantic_boundaries}
+    _check(
+        "boundary_count",
+        len(map_def.semantic_boundaries) == 2,
+        f"Expected 2, got {len(map_def.semantic_boundaries)}",
+    )
+
+    sep = boundaries_by_id.get("separator")
+    ped_edge = boundaries_by_id.get("ped_spawn_edge")
+
+    if sep:
+        _check(
+            "separator_vehicle_blocking",
+            sep.vehicle_blocking,
+            f"vehicle_blocking={sep.vehicle_blocking}",
+        )
+        _check("separator_occluding", sep.occluding, f"occluding={sep.occluding}")
+        _check("separator_not_pedestrian_passable", not sep.pedestrian_passable)
+        _check("separator_not_spawn_edge", not sep.spawn_edge)
+    else:
+        _check("separator_found", False, "separator boundary not found")
+
+    if ped_edge:
+        _check("ped_edge_pedestrian_passable", ped_edge.pedestrian_passable)
+        _check("ped_edge_spawn_edge", ped_edge.spawn_edge)
+        _check("ped_edge_not_vehicle_blocking", not ped_edge.vehicle_blocking)
+        _check("ped_edge_not_occluding", not ped_edge.occluding)
+    else:
+        _check("ped_edge_found", False, "ped_spawn_edge boundary not found")
+
+    # --- 2. Unsupported token fails closed ---
+    from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+    try:
+        SvgMapConverter._parse_semantic_boundary_label(
+            "semantic_boundary_test__vehicle_blocking__bogus_token"
+        )
+        _check("unsupported_token_fail_closed", False, "No ValueError raised for bogus token")
+    except ValueError as exc:
+        _check("unsupported_token_fail_closed", True, str(exc))
+
+    # --- 3. Robot route does not cross vehicle_blocking separator ---
+    if sep and map_def.robot_routes:
+        route = map_def.robot_routes[0]
+        crosses = _route_crosses_boundary(list(route.waypoints), sep.coordinates)
+        direct_crosses = _line_segment_intersection(
+            route.waypoints[0],
+            route.waypoints[-1],
+            sep.coordinates[0],
+            sep.coordinates[-1],
+        )
+        _check(
+            "robot_route_avoids_separator",
+            not crosses,
+            f"route crosses={crosses}, direct line crosses={direct_crosses}",
+        )
+    else:
+        _check("robot_route_avoids_separator", False, "No robot routes or separator found")
+
+    # --- 4. Pedestrian emergence near spawn-edge boundary ---
+    scenario_path = SCENARIO_PATH
+    with open(scenario_path, encoding="utf-8") as f:
+        scenario_data = yaml.safe_load(f)
+
+    ped_scenario = scenario_data["scenarios"][1]
+    ped_start = tuple(ped_scenario["single_pedestrians"][0]["start"])
+
+    if ped_edge:
+        dist = _min_distance_to_boundary(ped_start, ped_edge.coordinates)
+        max_dist = float(ped_scenario["metadata"]["emergence_assertions"][0]["max_distance"])
+        _check(
+            "ped_start_near_spawn_edge",
+            dist <= max_dist,
+            f"distance={dist:.2f}, max={max_dist}",
+        )
+    else:
+        _check("ped_start_near_spawn_edge", False, "ped_spawn_edge boundary not found")
+
+    return results
+
+
+def main() -> None:
+    """Entry point for the validation script."""
+    parser = argparse.ArgumentParser(description="Validate issue 2728 semantic boundaries")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Path to write JSON summary",
+    )
+    args = parser.parse_args()
+
+    results = run_validation()
+    json_str = json.dumps(results, indent=2)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json_str, encoding="utf-8")
+        print(f"Written to {out_path}")
+    else:
+        print(json_str)
+
+    sys.exit(0 if results["ok"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validation/validate_semantic_boundaries_issue_2728.py
+++ b/scripts/validation/validate_semantic_boundaries_issue_2728.py
@@ -27,7 +27,11 @@ def _line_segment_intersection(
     p3: tuple[float, float],
     p4: tuple[float, float],
 ) -> bool:
-    """Check if segment p1-p2 intersects segment p3-p4 using orientation tests."""
+    """Check if segment p1-p2 intersects segment p3-p4.
+
+    Handles general crossing, collinear overlap, and endpoint-touch cases
+    using orientation tests.
+    """
 
     def _orient(a: tuple[float, float], b: tuple[float, float], c: tuple[float, float]) -> int:
         val = (b[1] - a[1]) * (c[0] - b[0]) - (b[0] - a[0]) * (c[1] - b[1])
@@ -35,12 +39,34 @@ def _line_segment_intersection(
             return 0
         return 1 if val > 0 else 2
 
+    def _on_segment(
+        s: tuple[float, float],
+        e: tuple[float, float],
+        p: tuple[float, float],
+    ) -> bool:
+        """Return True when collinear point *p* lies on segment *s*-*e*."""
+        return (
+            min(s[0], e[0]) - 1e-9 <= p[0] <= max(s[0], e[0]) + 1e-9
+            and min(s[1], e[1]) - 1e-9 <= p[1] <= max(s[1], e[1]) + 1e-9
+        )
+
     o1 = _orient(p1, p2, p3)
     o2 = _orient(p1, p2, p4)
     o3 = _orient(p3, p4, p1)
     o4 = _orient(p3, p4, p2)
+
     if o1 != o2 and o3 != o4:
         return True
+
+    if o1 == 0 and _on_segment(p1, p2, p3):
+        return True
+    if o2 == 0 and _on_segment(p1, p2, p4):
+        return True
+    if o3 == 0 and _on_segment(p3, p4, p1):
+        return True
+    if o4 == 0 and _on_segment(p3, p4, p2):
+        return True
+
     return False
 
 
@@ -91,7 +117,12 @@ def _min_distance_to_boundary(
     return min_dist
 
 
-def run_validation() -> dict:
+def _find_scenario_by_name(scenarios: list[dict], name: str) -> dict | None:
+    """Return the scenario with the requested name, if present."""
+    return next((scenario for scenario in scenarios if scenario.get("name") == name), None)
+
+
+def run_validation() -> dict:  # noqa: C901, PLR0915
     """Run all validation checks and return a summary dict."""
     import yaml
 
@@ -165,18 +196,25 @@ def run_validation() -> dict:
     # --- 3. Robot route does not cross vehicle_blocking separator ---
     if sep and map_def.robot_routes:
         route = map_def.robot_routes[0]
-        crosses = _route_crosses_boundary(list(route.waypoints), sep.coordinates)
-        direct_crosses = _line_segment_intersection(
-            route.waypoints[0],
-            route.waypoints[-1],
-            sep.coordinates[0],
-            sep.coordinates[-1],
-        )
-        _check(
-            "robot_route_avoids_separator",
-            not crosses,
-            f"route crosses={crosses}, direct line crosses={direct_crosses}",
-        )
+        if len(route.waypoints) < 2:
+            _check(
+                "robot_route_avoids_separator",
+                False,
+                f"Robot route has only {len(route.waypoints)} waypoint(s); need >= 2",
+            )
+        else:
+            crosses = _route_crosses_boundary(list(route.waypoints), sep.coordinates)
+            direct_crosses = _line_segment_intersection(
+                route.waypoints[0],
+                route.waypoints[-1],
+                sep.coordinates[0],
+                sep.coordinates[-1],
+            )
+            _check(
+                "robot_route_avoids_separator",
+                not crosses,
+                f"route crosses={crosses}, direct line crosses={direct_crosses}",
+            )
     else:
         _check("robot_route_avoids_separator", False, "No robot routes or separator found")
 
@@ -185,7 +223,12 @@ def run_validation() -> dict:
     with open(scenario_path, encoding="utf-8") as f:
         scenario_data = yaml.safe_load(f)
 
-    ped_scenario = scenario_data["scenarios"][1]
+    ped_scenario = _find_scenario_by_name(
+        scenario_data["scenarios"], "pedestrian_emergence_from_spawn_edge"
+    )
+    if ped_scenario is None:
+        _check("ped_start_near_spawn_edge", False, "Pedestrian emergence scenario not found")
+        return results
     ped_start = tuple(ped_scenario["single_pedestrians"][0]["start"])
 
     if ped_edge:

--- a/tests/test_semantic_boundaries_issue_2728.py
+++ b/tests/test_semantic_boundaries_issue_2728.py
@@ -1,0 +1,262 @@
+"""Tests for issue 2728: 2D semantic boundary metadata.
+
+Covers parser success, unsupported token failure, scenario load,
+and validation summary contract.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAP_PATH = REPO_ROOT / "maps" / "svg_maps" / "issue_2728_semantic_boundaries.svg"
+SCENARIO_PATH = (
+    REPO_ROOT / "configs" / "scenarios" / "single" / "issue_2728_semantic_boundaries.yaml"
+)
+
+
+class TestSemanticBoundaryDataclass:
+    """Tests for the SemanticBoundary dataclass."""
+
+    def test_defaults(self):
+        """Default flags are all False."""
+        from robot_sf.nav.nav_types import SemanticBoundary
+
+        sb = SemanticBoundary(coordinates=((0, 0), (1, 1)), label="test", id_="t1")
+        assert sb.vehicle_blocking is False
+        assert sb.pedestrian_passable is False
+        assert sb.occluding is False
+        assert sb.spawn_edge is False
+
+    def test_all_flags(self):
+        """All flags can be set to True."""
+        from robot_sf.nav.nav_types import SemanticBoundary
+
+        sb = SemanticBoundary(
+            coordinates=((0, 0),),
+            label="test",
+            id_="t1",
+            vehicle_blocking=True,
+            pedestrian_passable=True,
+            occluding=True,
+            spawn_edge=True,
+        )
+        assert sb.vehicle_blocking
+        assert sb.pedestrian_passable
+        assert sb.occluding
+        assert sb.spawn_edge
+
+    def test_frozen(self):
+        """Dataclass is frozen (immutable)."""
+        from robot_sf.nav.nav_types import SemanticBoundary
+
+        sb = SemanticBoundary(coordinates=(), label="x", id_="x")
+        with pytest.raises(AttributeError):
+            sb.label = "y"  # type: ignore[misc]
+
+
+class TestParseSemanticBoundaryLabel:
+    """Tests for SvgMapConverter._parse_semantic_boundary_label."""
+
+    def test_single_flag(self):
+        """Single flag is parsed correctly."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        name, flags = SvgMapConverter._parse_semantic_boundary_label(
+            "semantic_boundary_vehicle_blocking"
+        )
+        assert name == "vehicle_blocking"
+        assert flags == frozenset({"vehicle_blocking"})
+
+    def test_named_single_flag(self):
+        """Named single flag labels are parsed correctly."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        name, flags = SvgMapConverter._parse_semantic_boundary_label(
+            "semantic_boundary_wall__vehicle_blocking"
+        )
+        assert name == "wall"
+        assert flags == frozenset({"vehicle_blocking"})
+
+    def test_multiple_flags(self):
+        """Multiple flags are parsed correctly."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        name, flags = SvgMapConverter._parse_semantic_boundary_label(
+            "semantic_boundary_vehicle_blocking__occluding"
+        )
+        assert name == "vehicle_blocking"
+        assert flags == frozenset({"vehicle_blocking", "occluding"})
+
+    def test_named_multiple_flags(self):
+        """Named multi-flag labels are parsed correctly."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        name, flags = SvgMapConverter._parse_semantic_boundary_label(
+            "semantic_boundary_sep__vehicle_blocking__occluding"
+        )
+        assert name == "sep"
+        assert flags == frozenset({"vehicle_blocking", "occluding"})
+
+    def test_no_flags(self):
+        """No flags produces empty frozenset."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        name, flags = SvgMapConverter._parse_semantic_boundary_label("semantic_boundary_barrier")
+        assert name == "barrier"
+        assert flags == frozenset()
+
+    def test_unsupported_token_raises(self):
+        """Unsupported token raises ValueError."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        with pytest.raises(ValueError, match="Unsupported semantic boundary token"):
+            SvgMapConverter._parse_semantic_boundary_label("semantic_boundary_x__bogus_flag")
+
+    def test_all_supported_flags(self):
+        """All supported flags are accepted."""
+        from robot_sf.nav.nav_types import SUPPORTED_SEMANTIC_BOUNDARY_FLAGS
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        label = "semantic_boundary_all__" + "__".join(sorted(SUPPORTED_SEMANTIC_BOUNDARY_FLAGS))
+        name, flags = SvgMapConverter._parse_semantic_boundary_label(label)
+        assert name == "all"
+        assert flags == SUPPORTED_SEMANTIC_BOUNDARY_FLAGS
+
+
+class TestSvgMapParserSemanticBoundaries:
+    """Tests for parsing semantic boundaries from SVG maps."""
+
+    def test_fixture_map_loads(self):
+        """Fixture map loads without error."""
+        from robot_sf.nav.svg_map_parser import convert_map
+
+        map_def = convert_map(str(MAP_PATH))
+        assert map_def is not None
+
+    def test_fixture_map_has_two_boundaries(self):
+        """Fixture map has exactly two semantic boundaries."""
+        from robot_sf.nav.svg_map_parser import convert_map
+
+        map_def = convert_map(str(MAP_PATH))
+        assert map_def is not None
+        assert len(map_def.semantic_boundaries) == 2
+
+    def test_separator_flags(self):
+        """Separator has vehicle_blocking and occluding flags."""
+        from robot_sf.nav.svg_map_parser import convert_map
+
+        map_def = convert_map(str(MAP_PATH))
+        assert map_def is not None
+        sep = next(b for b in map_def.semantic_boundaries if b.id_ == "separator")
+        assert sep.vehicle_blocking is True
+        assert sep.occluding is True
+        assert sep.pedestrian_passable is False
+        assert sep.spawn_edge is False
+
+    def test_ped_spawn_edge_flags(self):
+        """Ped spawn edge has pedestrian_passable and spawn_edge flags."""
+        from robot_sf.nav.svg_map_parser import convert_map
+
+        map_def = convert_map(str(MAP_PATH))
+        assert map_def is not None
+        ped = next(b for b in map_def.semantic_boundaries if b.id_ == "ped_spawn_edge")
+        assert ped.pedestrian_passable is True
+        assert ped.spawn_edge is True
+        assert ped.vehicle_blocking is False
+        assert ped.occluding is False
+
+    def test_backward_compat_empty_semantic_boundaries(self):
+        """MapDefinition without semantic_boundaries should still work."""
+        from robot_sf.nav.map_config import MapDefinition
+
+        md = MapDefinition(
+            width=10,
+            height=10,
+            obstacles=[],
+            robot_spawn_zones=[((0, 0), (1, 0), (1, 1))],
+            ped_spawn_zones=[],
+            robot_goal_zones=[((9, 9), (10, 9), (10, 10))],
+            bounds=[(0, 10, 0, 0), (0, 10, 10, 10), (0, 0, 0, 10), (10, 10, 0, 10)],
+            robot_routes=[],
+            ped_goal_zones=[],
+            ped_crowded_zones=[],
+            ped_routes=[],
+        )
+        assert md.semantic_boundaries == []
+
+
+class TestScenarioLoad:
+    """Tests for loading the scenario YAML."""
+
+    def test_scenario_file_exists(self):
+        """Scenario file exists."""
+        assert SCENARIO_PATH.exists()
+
+    def test_scenario_loads(self):
+        """Scenario YAML loads without error."""
+        import yaml
+
+        with open(SCENARIO_PATH) as f:
+            data = yaml.safe_load(f)
+        assert "scenarios" in data
+        assert len(data["scenarios"]) == 2
+
+    def test_scenario_metadata_has_claim_boundary(self):
+        """Both scenarios have diagnostic_only_not_benchmark claim boundary."""
+        import yaml
+
+        with open(SCENARIO_PATH) as f:
+            data = yaml.safe_load(f)
+        for scenario in data["scenarios"]:
+            assert scenario["metadata"]["claim_boundary"] == "diagnostic_only_not_benchmark"
+
+    def test_scenario_metadata_has_expectations(self):
+        """Both scenarios have semantic_boundary_expectations."""
+        import yaml
+
+        with open(SCENARIO_PATH) as f:
+            data = yaml.safe_load(f)
+        for scenario in data["scenarios"]:
+            assert "semantic_boundary_expectations" in scenario["metadata"]
+            expectations = scenario["metadata"]["semantic_boundary_expectations"]
+            assert len(expectations) == 2
+
+
+class TestValidationSummaryContract:
+    """Tests for the validation script output contract."""
+
+    def test_validation_runs(self):
+        """Validation script runs successfully."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import run_validation
+
+        results = run_validation()
+        assert results["ok"] is True
+        assert results["evidence_classification"] == "diagnostic_only_not_benchmark"
+        assert len(results["checks"]) > 0
+
+    def test_all_checks_pass(self):
+        """All validation checks pass."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import run_validation
+
+        results = run_validation()
+        failed = [c for c in results["checks"] if not c["passed"]]
+        assert not failed, f"Failed checks: {failed}"
+
+    def test_separator_route_avoidance(self):
+        """Robot route avoids the vehicle_blocking separator."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import run_validation
+
+        results = run_validation()
+        route_check = next(
+            c for c in results["checks"] if c["name"] == "robot_route_avoids_separator"
+        )
+        assert route_check["passed"]
+
+    def test_ped_start_near_boundary(self):
+        """Pedestrian start is near the spawn-edge boundary."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import run_validation
+
+        results = run_validation()
+        ped_check = next(c for c in results["checks"] if c["name"] == "ped_start_near_spawn_edge")
+        assert ped_check["passed"]

--- a/tests/test_semantic_boundaries_issue_2728.py
+++ b/tests/test_semantic_boundaries_issue_2728.py
@@ -98,13 +98,19 @@ class TestParseSemanticBoundaryLabel:
         assert name == "sep"
         assert flags == frozenset({"vehicle_blocking", "occluding"})
 
-    def test_no_flags(self):
-        """No flags produces empty frozenset."""
+    def test_no_flags_raises(self):
+        """No flags in label raises ValueError (fail-closed)."""
         from robot_sf.nav.svg_map_parser import SvgMapConverter
 
-        name, flags = SvgMapConverter._parse_semantic_boundary_label("semantic_boundary_barrier")
-        assert name == "barrier"
-        assert flags == frozenset()
+        with pytest.raises(ValueError, match="No supported semantic boundary flag found"):
+            SvgMapConverter._parse_semantic_boundary_label("semantic_boundary_barrier")
+
+    def test_single_typo_token_raises(self):
+        """Single typo token raises ValueError (fail-closed)."""
+        from robot_sf.nav.svg_map_parser import SvgMapConverter
+
+        with pytest.raises(ValueError, match="No supported semantic boundary flag found"):
+            SvgMapConverter._parse_semantic_boundary_label("semantic_boundary_vehicle_blockingg")
 
     def test_unsupported_token_raises(self):
         """Unsupported token raises ValueError."""
@@ -197,7 +203,7 @@ class TestScenarioLoad:
         """Scenario YAML loads without error."""
         import yaml
 
-        with open(SCENARIO_PATH) as f:
+        with open(SCENARIO_PATH, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         assert "scenarios" in data
         assert len(data["scenarios"]) == 2
@@ -206,7 +212,7 @@ class TestScenarioLoad:
         """Both scenarios have diagnostic_only_not_benchmark claim boundary."""
         import yaml
 
-        with open(SCENARIO_PATH) as f:
+        with open(SCENARIO_PATH, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         for scenario in data["scenarios"]:
             assert scenario["metadata"]["claim_boundary"] == "diagnostic_only_not_benchmark"
@@ -215,7 +221,7 @@ class TestScenarioLoad:
         """Both scenarios have semantic_boundary_expectations."""
         import yaml
 
-        with open(SCENARIO_PATH) as f:
+        with open(SCENARIO_PATH, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         for scenario in data["scenarios"]:
             assert "semantic_boundary_expectations" in scenario["metadata"]
@@ -260,3 +266,71 @@ class TestValidationSummaryContract:
         results = run_validation()
         ped_check = next(c for c in results["checks"] if c["name"] == "ped_start_near_spawn_edge")
         assert ped_check["passed"]
+
+
+class TestLineSegmentIntersection:
+    """Focused tests for _line_segment_intersection endpoint and collinear cases."""
+
+    def test_general_cross(self):
+        """Two segments that cross at a single interior point."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (4, 4), (0, 4), (4, 0)) is True
+
+    def test_no_intersection(self):
+        """Two non-intersecting segments."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (1, 0), (0, 1), (1, 1)) is False
+
+    def test_endpoint_touch(self):
+        """Segments share exactly one endpoint."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (2, 2), (2, 2), (4, 0)) is True
+
+    def test_collinear_partial_overlap(self):
+        """Collinear segments that partially overlap."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (3, 0), (2, 0), (5, 0)) is True
+
+    def test_collinear_no_overlap(self):
+        """Collinear segments that do not overlap."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (1, 0), (2, 0), (3, 0)) is False
+
+    def test_collinear_endpoint_touch(self):
+        """Collinear segments that touch at a single endpoint."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (2, 0), (2, 0), (4, 0)) is True
+
+    def test_identical_segments(self):
+        """Identical segments overlap entirely."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((0, 0), (3, 3), (0, 0), (3, 3)) is True
+
+    def test_vertical_endpoint_touch(self):
+        """Vertical segments touching at an endpoint."""
+        from scripts.validation.validate_semantic_boundaries_issue_2728 import (
+            _line_segment_intersection,
+        )
+
+        assert _line_segment_intersection((1, 0), (1, 3), (1, 3), (1, 6)) is True


### PR DESCRIPTION
Closes #2728.

## Summary

- Adds diagnostic-only `SemanticBoundary` metadata parsed from SVG paths labeled `semantic_boundary_*`.
- Carries semantic boundaries through `MapDefinition` without changing collision physics, obstacle logic, or planner behavior.
- Adds a small fixture SVG, two scenario-matrix entries, a validation script, tests, and tracked evidence under `docs/context/evidence/issue_2728_semantic_boundaries/`.

## Validation

- `uv run python scripts/validation/validate_semantic_boundaries_issue_2728.py --output docs/context/evidence/issue_2728_semantic_boundaries/summary.json`
- `uv run robot_sf_bench validate-config --matrix configs/scenarios/single/issue_2728_semantic_boundaries.yaml`
  - Warnings are limited to intentional `ped_density=0.0` diagnostic-fixture warnings, not schema errors.
- `uv run pytest tests/test_semantic_boundaries_issue_2728.py -q`
- `uv run pytest tests/test_svg_path_parsing_commands.py tests/map_test.py -q`
- `uv run ruff check robot_sf/nav/nav_types.py robot_sf/nav/map_config.py robot_sf/nav/svg_map_parser.py scripts/validation/validate_semantic_boundaries_issue_2728.py tests/test_semantic_boundaries_issue_2728.py`
- `uv run ruff format --check robot_sf/nav/nav_types.py robot_sf/nav/map_config.py robot_sf/nav/svg_map_parser.py scripts/validation/validate_semantic_boundaries_issue_2728.py tests/test_semantic_boundaries_issue_2728.py`
- `git diff --check`
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - 6209 passed, 9 skipped, readiness stamp passed at `410e4259a35ea21d1d66ff89922965af70a7b507`.

## Research Result Guidance

- Target claim/hypothesis/blocker: diagnostic-only plumbing for 2D semantic topology boundaries with `vehicle_blocking`, `pedestrian_passable`, `occluding`, and `spawn_edge` flags.
- Comparator/baseline: existing SVG parsing carried obstacles/routes/zones but no non-physics semantic boundary metadata.
- Evidence tier: nominal diagnostic evidence only.
- Result classification: support/tooling evidence; not benchmark evidence and not a paper/safety claim.
- Decision/stop rule: accepted if parser stores both fixture boundaries, unsupported flag tokens fail closed, the authored robot route avoids the vehicle-blocking separator, and the pedestrian start is near the spawn edge.
- Synthesis surface/update target: `docs/context/evidence/issue_2728_semantic_boundaries/` and `docs/context/catalog.yaml`.

## Downstream Propagation

- Parent issue: closes #2728.
- Claim map/benchmark report/leaderboard: NA; this is diagnostic-only metadata plumbing and does not move benchmark results.
- Artifact catalog/registry/config index: updated `docs/context/catalog.yaml`; scenario fixture added under `configs/scenarios/single/`.
- Context index or memory note: evidence README and summary are tracked under `docs/context/evidence/issue_2728_semantic_boundaries/`.
- Follow-up issue: none required for this slice; future consumers of `MapDefinition.semantic_boundaries` remain separate planner/diagnostic work.

## Delegation

- OpenCode Zen scout selected #2728 as the best eligible issue.
- OpenCode Zen map scout identified the bounded map/parser/test slice.
- OpenCode Go implemented the first pass; Codex repaired parser label semantics and finalized validation.
- Command Code read-only review hit its turn cap and was treated as uneconomic.
- OpenCode Zen read-only review accepted the final diff with info-only findings; accidental root review artifacts were removed before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 2D semantic boundary metadata in SVG maps with customizable flags (vehicle-blocking, pedestrian-passable, occluding, spawn-edge) enabling spatial region definitions for planning constraints.
  
* **Tests**
  * Added comprehensive test suite validating semantic boundary parsing, flag handling, map integration, and scenario-based validation across multiple test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->