### PR TITLE
feat: add evidence-aware publication ranking

### DIFF
--- a/scripts/dev/publication_candidate_ranker.py
+++ b/scripts/dev/publication_candidate_ranker.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-SCHEMA = "publication_candidate_ranker.v1"
+SCHEMA = "publication_candidate_ranker.v2"
 
 DIMENSION_WEIGHTS: dict[str, float] = {
     "dissertation_relevance": 0.20,
@@ -29,6 +29,13 @@ DIMENSION_WEIGHTS: dict[str, float] = {
     "expected_research_value": 0.20,
     "duplication_safety": 0.10,
 }
+
+LEDGER_BOOST = 0.08
+NEGATIVE_RESULT_PENALTY = 0.10
+
+
+class RankerInputError(ValueError):
+    """Raised when an optional ranking input has the wrong schema or shape."""
 
 
 @dataclass(frozen=True)
@@ -63,6 +70,10 @@ class RankedCandidate:
     blocked_by: tuple[int, ...]
     linter_ok: bool
     linter_findings: tuple[dict[str, str], ...]
+    ledger_relevance: float
+    negative_result_awareness: float
+    ledger_notes: tuple[str, ...]
+    negative_result_caveats: tuple[str, ...]
 
 
 def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
@@ -138,6 +149,132 @@ def _parse_candidate(raw: dict[str, Any]) -> CandidateInput:
     )
 
 
+def _parse_ledger(raw: Any) -> dict[int, list[dict[str, Any]]]:
+    """Parse a dissertation evidence ledger into {issue_number: rows} lookup.
+
+    Expected schema: dissertation_evidence_ledger.v2 with top-level ``rows``.
+    """
+    lookup: dict[int, list[dict[str, Any]]] = {}
+    if not isinstance(raw, dict):
+        raise RankerInputError("ledger-json payload must be an object")
+    if raw.get("schema_version") != "dissertation_evidence_ledger.v2":
+        raise RankerInputError("ledger-json schema_version must be dissertation_evidence_ledger.v2")
+    rows = raw.get("rows", [])
+    if not isinstance(rows, list):
+        raise RankerInputError("ledger-json rows must be a list")
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        source_issues = row.get("source_issues", [])
+        if not isinstance(source_issues, list):
+            continue
+        for issue_num in source_issues:
+            issue = _safe_int(issue_num)
+            if issue is not None:
+                lookup.setdefault(issue, []).append(row)
+    return lookup
+
+
+def _parse_register(raw: Any) -> dict[int, list[dict[str, Any]]]:
+    """Parse a negative result register into {issue_number: entries} lookup.
+
+    Expected schema: negative_result_register.v1 with a top-level
+    ``entries`` list where each entry has ``linked_issues`` (list of ints)
+    and ``result_classification`` such as revise or diagnostic_only.
+    """
+    lookup: dict[int, list[dict[str, Any]]] = {}
+    if not isinstance(raw, dict):
+        raise RankerInputError("register-json payload must be an object")
+    if raw.get("schema_version") != "negative_result_register.v1":
+        raise RankerInputError("register-json schema_version must be negative_result_register.v1")
+    entries = raw.get("entries", [])
+    if not isinstance(entries, list):
+        raise RankerInputError("register-json entries must be a list")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        linked_issues = entry.get("linked_issues", [])
+        if not isinstance(linked_issues, list):
+            continue
+        for issue_num in linked_issues:
+            issue = _safe_int(issue_num)
+            if issue is not None:
+                lookup.setdefault(issue, []).append(entry)
+    return lookup
+
+
+def _safe_int(value: object) -> int | None:
+    """Return a strict issue number int, skipping bools and float coercions."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _short_text(value: object) -> str:
+    """Return a stripped string when value is meaningful, otherwise empty."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _ledger_notes_for_rows(rows: list[dict[str, Any]]) -> tuple[float, tuple[str, ...]]:
+    """Return ledger relevance and human-readable notes for matched ledger rows."""
+    if not rows:
+        return 0.0, ()
+
+    notes: list[str] = []
+    actionable = False
+    for row in rows:
+        area = _short_text(row.get("area"))
+        prefix = f"ledger {area}:" if area else "ledger:"
+        claim_gap = _short_text(row.get("claim_gap"))
+        if claim_gap:
+            actionable = True
+            notes.append(f"{prefix} open claim gap - {claim_gap}")
+        promotion = _short_text(row.get("evidence_promotion_path"))
+        if promotion:
+            actionable = True
+            notes.append(f"{prefix} promotion path - {promotion}")
+        tier = _short_text(row.get("evidence_tier"))
+        if tier:
+            notes.append(f"{prefix} evidence tier {tier}")
+
+    if not notes:
+        notes.append("ledger: issue tracked in evidence ledger")
+    return (1.0 if actionable else 0.0), tuple(notes)
+
+
+def _register_caveats_for_entries(entries: list[dict[str, Any]]) -> tuple[float, tuple[str, ...]]:
+    """Return negative-result awareness and conservative caveats for register entries."""
+    negative_statuses = {"revise", "diagnostic_only", "failed", "inconclusive"}
+    caveats: list[str] = []
+    awareness = 0.0
+
+    for entry in entries:
+        status = _short_text(entry.get("result_classification")).lower()
+        if status not in negative_statuses:
+            continue
+        awareness = 1.0
+        message = f"negative-result register: status={status}"
+        if status == "diagnostic_only":
+            message += (
+                "; diagnostic-only repetition requires an explicit why-this-is-different rationale"
+            )
+        caveats.append(message)
+        for key, label in (
+            ("why_failed_or_inconclusive", "reason"),
+            ("recommended_next_action", "next action"),
+            ("claim_boundary", "boundary"),
+        ):
+            value = _short_text(entry.get(key))
+            if value:
+                caveats.append(f"negative-result {label}: {value}")
+
+    return awareness, tuple(caveats)
+
+
 def _compute_total_score(scores: dict[str, float]) -> float:
     """Compute a weighted aggregate score from dimension scores.
 
@@ -164,11 +301,62 @@ def _compute_total_score(scores: dict[str, float]) -> float:
     return round(total, 6)
 
 
-def rank_candidates(candidates: list[CandidateInput]) -> list[RankedCandidate]:
-    """Rank candidates by aggregate score (descending), breaking ties by issue number."""
+def _apply_ledger_register_modifiers(
+    candidate: CandidateInput,
+    ledger: dict[int, list[dict[str, Any]]],
+    register: dict[int, list[dict[str, Any]]],
+) -> tuple[float, float, tuple[str, ...], tuple[str, ...]]:
+    """Compute ledger_relevance, negative_result_awareness, and notes.
+
+    Returns (ledger_relevance, negative_result_awareness, ledger_notes,
+    negative_result_caveats) where both relevance scores are in [0, 1] and
+    notes/caveats are human-readable strings.
+    """
+    issue_num = candidate.issue_number
+    ledger_relevance, ledger_notes = _ledger_notes_for_rows(
+        ledger.get(issue_num, []) if issue_num is not None else []
+    )
+    negative_result_awareness, negative_caveats = _register_caveats_for_entries(
+        register.get(issue_num, []) if issue_num is not None else []
+    )
+    return ledger_relevance, negative_result_awareness, ledger_notes, negative_caveats
+
+
+def rank_candidates(
+    candidates: list[CandidateInput],
+    *,
+    ledger: dict[int, list[dict[str, Any]]] | None = None,
+    register: dict[int, list[dict[str, Any]]] | None = None,
+) -> list[RankedCandidate]:
+    """Rank candidates by aggregate score (descending), breaking ties by issue number.
+
+    Optional ``ledger`` and ``register`` lookups add bounded additive modifiers
+    and human-readable notes/caveats.
+    """
+    if ledger is None:
+        ledger = {}
+    if register is None:
+        register = {}
+
     ranked: list[RankedCandidate] = []
     for idx, candidate in enumerate(candidates):
         total_score = _compute_total_score(candidate.scores)
+        ledger_rel, neg_aware, ledger_notes, neg_caveats = _apply_ledger_register_modifiers(
+            candidate, ledger, register
+        )
+
+        modifier = 0.0
+        if ledger_rel > 0:
+            modifier += LEDGER_BOOST * ledger_rel
+        if neg_aware > 0:
+            modifier -= NEGATIVE_RESULT_PENALTY * neg_aware
+        total_score = _clamp(round(total_score + modifier, 6))
+
+        new_reasons = list(candidate.reasons)
+        new_caveats = list(candidate.evidence_caveats)
+        new_reasons.extend(ledger_notes)
+        new_caveats.extend(neg_caveats)
+
         ranked.append(
             RankedCandidate(
                 rank=0,
@@ -177,12 +365,16 @@ def rank_candidates(candidates: list[CandidateInput]) -> list[RankedCandidate]:
                 title=candidate.title,
                 total_score=total_score,
                 scores=candidate.scores,
-                reasons=candidate.reasons,
-                evidence_caveats=candidate.evidence_caveats,
+                reasons=tuple(new_reasons),
+                evidence_caveats=tuple(new_caveats),
                 duplication_notes=candidate.duplication_notes,
                 blocked_by=candidate.blocked_by,
                 linter_ok=candidate.linter_ok,
                 linter_findings=candidate.linter_findings,
+                ledger_relevance=ledger_rel,
+                negative_result_awareness=neg_aware,
+                ledger_notes=ledger_notes,
+                negative_result_caveats=neg_caveats,
             )
         )
 
@@ -204,6 +396,10 @@ def rank_candidates(candidates: list[CandidateInput]) -> list[RankedCandidate]:
             blocked_by=item.blocked_by,
             linter_ok=item.linter_ok,
             linter_findings=item.linter_findings,
+            ledger_relevance=item.ledger_relevance,
+            negative_result_awareness=item.negative_result_awareness,
+            ledger_notes=item.ledger_notes,
+            negative_result_caveats=item.negative_result_caveats,
         )
 
     return ranked
@@ -223,6 +419,45 @@ def _format_issue_link(issue_url: str | None, issue_number: int | None) -> str:
     if issue_number:
         return f"#{issue_number}"
     return "N/A"
+
+
+def _format_candidate_detail(item: RankedCandidate) -> list[str]:
+    """Format the detail section for a single ranked candidate."""
+    lines: list[str] = []
+    issue_ref = _format_issue_link(item.issue_url, item.issue_number)
+    lines.append(f"### {issue_ref} - {item.title}")
+    lines.append("")
+    lines.append(f"**Total score:** {item.total_score:.4f}")
+    lines.append("")
+
+    reasons = "; ".join(item.reasons) if item.reasons else "none"
+    lines.append(f"**Reasons:** {reasons}")
+    evidence_caveats = "; ".join(item.evidence_caveats) if item.evidence_caveats else "none"
+    lines.append(f"**Evidence caveats:** {evidence_caveats}")
+    duplication_notes = "; ".join(item.duplication_notes) if item.duplication_notes else "none"
+    lines.append(f"**Duplication notes:** {duplication_notes}")
+    blocked_by = ", ".join(f"#{b}" for b in item.blocked_by) if item.blocked_by else "none"
+    lines.append(f"**Blocked by:** {blocked_by}")
+    ledger_notes = "; ".join(item.ledger_notes) if item.ledger_notes else "none"
+    lines.append(f"**Ledger notes:** {ledger_notes}")
+    if item.ledger_notes:
+        lines.append(f"**Ledger relevance:** {item.ledger_relevance:.2f}")
+    negative_result_caveats = (
+        "; ".join(item.negative_result_caveats) if item.negative_result_caveats else "none"
+    )
+    lines.append(f"**Negative-result caveats:** {negative_result_caveats}")
+    if item.negative_result_caveats:
+        lines.append(f"**Negative-result awareness:** {item.negative_result_awareness:.2f}")
+
+    linter_status = "pass" if item.linter_ok else "fail"
+    lines.append(f"**Linter:** {linter_status}")
+    for finding in item.linter_findings:
+        code = finding.get("code", "")
+        detail = finding.get("detail", "")
+        lines.append(f"- `{code}`: {detail}")
+
+    lines.append("")
+    return lines
 
 
 def format_markdown_report(ranked: list[RankedCandidate], *, total_count: int) -> str:
@@ -267,41 +502,7 @@ def format_markdown_report(ranked: list[RankedCandidate], *, total_count: int) -
     lines.extend(["", "## Candidate Details", ""])
 
     for item in ranked:
-        issue_ref = _format_issue_link(item.issue_url, item.issue_number)
-        lines.append(f"### {issue_ref} - {item.title}")
-        lines.append("")
-        lines.append(f"**Total score:** {item.total_score:.4f}")
-        lines.append("")
-
-        if item.reasons:
-            lines.append("**Reasons:** " + "; ".join(item.reasons))
-        else:
-            lines.append("**Reasons:** none")
-
-        if item.evidence_caveats:
-            lines.append("**Evidence caveats:** " + "; ".join(item.evidence_caveats))
-        else:
-            lines.append("**Evidence caveats:** none")
-
-        if item.duplication_notes:
-            lines.append("**Duplication notes:** " + "; ".join(item.duplication_notes))
-        else:
-            lines.append("**Duplication notes:** none")
-
-        if item.blocked_by:
-            lines.append("**Blocked by:** " + ", ".join(f"#{b}" for b in item.blocked_by))
-        else:
-            lines.append("**Blocked by:** none")
-
-        linter_status = "pass" if item.linter_ok else "fail"
-        lines.append(f"**Linter:** {linter_status}")
-        if item.linter_findings:
-            for finding in item.linter_findings:
-                code = finding.get("code", "")
-                detail = finding.get("detail", "")
-                lines.append(f"- `{code}`: {detail}")
-
-        lines.append("")
+        lines.extend(_format_candidate_detail(item))
 
     return "\n".join(lines)
 
@@ -333,6 +534,10 @@ def _build_report(
                 "blocked_by": list(item.blocked_by),
                 "linter_ok": item.linter_ok,
                 "linter_findings": list(item.linter_findings),
+                "ledger_relevance": item.ledger_relevance,
+                "negative_result_awareness": item.negative_result_awareness,
+                "ledger_notes": list(item.ledger_notes),
+                "negative_result_caveats": list(item.negative_result_caveats),
             }
             for item in ranked
         ],
@@ -372,6 +577,18 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Write output to file instead of stdout.",
     )
+    parser.add_argument(
+        "--ledger-json",
+        type=Path,
+        default=None,
+        help="Optional dissertation evidence ledger JSON (dissertation_evidence_ledger.v2).",
+    )
+    parser.add_argument(
+        "--register-json",
+        type=Path,
+        default=None,
+        help="Optional negative result register JSON (negative_result_register.v1).",
+    )
     return parser
 
 
@@ -405,8 +622,42 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
+    ledger: dict[int, list[dict[str, Any]]] = {}
+    if args.ledger_json is not None:
+        try:
+            ledger_raw = _load_json(args.ledger_json)
+            ledger = _parse_ledger(ledger_raw)
+        except (OSError, json.JSONDecodeError, RankerInputError) as exc:
+            _dump_json(
+                {
+                    "schema": SCHEMA,
+                    "ok": False,
+                    "read_only": True,
+                    "project_writes": False,
+                    "error": f"ledger-json load failed: {exc}",
+                }
+            )
+            return 2
+
+    register: dict[int, list[dict[str, Any]]] = {}
+    if args.register_json is not None:
+        try:
+            register_raw = _load_json(args.register_json)
+            register = _parse_register(register_raw)
+        except (OSError, json.JSONDecodeError, RankerInputError) as exc:
+            _dump_json(
+                {
+                    "schema": SCHEMA,
+                    "ok": False,
+                    "read_only": True,
+                    "project_writes": False,
+                    "error": f"register-json load failed: {exc}",
+                }
+            )
+            return 2
+
     candidates = [_parse_candidate(item) for item in payload if isinstance(item, dict)]
-    ranked = rank_candidates(candidates)
+    ranked = rank_candidates(candidates, ledger=ledger, register=register)
 
     if args.format == "json":
         report = _build_report(ranked, total_count=len(candidates))

--- a/tests/dev/test_publication_candidate_ranker.py
+++ b/tests/dev/test_publication_candidate_ranker.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.dev import publication_candidate_ranker as ranker
 
 FIXTURE_DIR = Path(__file__).resolve().parents[2] / "tests/fixtures/publication_candidate_ranker"
@@ -182,7 +184,7 @@ def test_main_json_output(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
 
     assert exit_code == 0
-    assert payload["schema"] == "publication_candidate_ranker.v1"
+    assert payload["schema"] == "publication_candidate_ranker.v2"
     assert payload["ok"] is True
     assert payload["read_only"] is True
     assert payload["project_writes"] is False
@@ -281,3 +283,326 @@ def test_cli_markdown_output_includes_linter(capsys) -> None:
     assert "**Linter:** fail" in output
     assert "`MISSING_DOCSTRING`" in output
     assert "`UNUSED_IMPORT`" in output
+
+
+def test_ledger_boosts_candidate_score() -> None:
+    """Candidate in ledger with claim_gap_closed should receive a score boost."""
+    candidates_raw = _fixture("candidates_ledger_register.json")
+    ledger_raw = _fixture("ledger_evidence.json")
+    register_raw = _fixture("register_negative_results.json")
+    assert isinstance(candidates_raw, list)
+
+    candidates = [ranker._parse_candidate(item) for item in candidates_raw]
+    ledger = ranker._parse_ledger(ledger_raw)
+    register = ranker._parse_register(register_raw)
+    ranked = ranker.rank_candidates(candidates, ledger=ledger, register=register)
+
+    ledger_candidate = next(r for r in ranked if r.issue_number == 2750)
+    nonclaimable_candidate = next(r for r in ranked if r.issue_number == 2751)
+    no_entry_candidate = next(r for r in ranked if r.issue_number == 2754)
+
+    assert ledger_candidate.ledger_relevance == 1.0
+    assert ledger_candidate.negative_result_awareness == 0.0
+    assert any("open claim gap" in n for n in ledger_candidate.ledger_notes)
+    assert any("promotion path" in n for n in ledger_candidate.ledger_notes)
+    assert any("evidence tier diagnostic" in n for n in ledger_candidate.ledger_notes)
+    assert ledger_candidate.negative_result_caveats == ()
+
+    assert nonclaimable_candidate.ledger_relevance == 0.0
+    assert any("evidence tier non-claimable" in n for n in nonclaimable_candidate.ledger_notes)
+
+    assert no_entry_candidate.ledger_relevance == 0.0
+    assert no_entry_candidate.negative_result_awareness == 0.0
+
+
+def test_negative_result_penalizes_candidate() -> None:
+    """Candidate in register with diagnostic_only status should be penalized."""
+    candidates_raw = _fixture("candidates_ledger_register.json")
+    ledger_raw = _fixture("ledger_evidence.json")
+    register_raw = _fixture("register_negative_results.json")
+    assert isinstance(candidates_raw, list)
+
+    candidates = [ranker._parse_candidate(item) for item in candidates_raw]
+    ledger = ranker._parse_ledger(ledger_raw)
+    register = ranker._parse_register(register_raw)
+    ranked = ranker.rank_candidates(candidates, ledger=ledger, register=register)
+
+    diag_candidate = next(r for r in ranked if r.issue_number == 2752)
+    failed_candidate = next(r for r in ranked if r.issue_number == 2753)
+
+    assert diag_candidate.negative_result_awareness == 1.0
+    assert any("diagnostic_only" in c for c in diag_candidate.negative_result_caveats)
+    assert any("why-this-is-different" in c for c in diag_candidate.negative_result_caveats)
+
+    assert failed_candidate.negative_result_awareness == 1.0
+    assert any("failed" in c for c in failed_candidate.negative_result_caveats)
+    assert not any("why-this-is-different" in c for c in failed_candidate.negative_result_caveats)
+
+
+def test_ranking_changes_with_ledger_register() -> None:
+    """Ranking order should change when ledger/register signals are present."""
+    candidates_raw = _fixture("candidates_ledger_register.json")
+    assert isinstance(candidates_raw, list)
+
+    candidates = [ranker._parse_candidate(item) for item in candidates_raw]
+    ranked_without = ranker.rank_candidates(candidates)
+    ranked_with = ranker.rank_candidates(
+        candidates,
+        ledger=ranker._parse_ledger(_fixture("ledger_evidence.json")),
+        register=ranker._parse_register(_fixture("register_negative_results.json")),
+    )
+
+    without_order = [r.issue_number for r in ranked_without]
+    with_order = [r.issue_number for r in ranked_with]
+
+    assert without_order != with_order
+
+    with_scores = {r.issue_number: r.total_score for r in ranked_with}
+    without_scores = {r.issue_number: r.total_score for r in ranked_without}
+
+    assert with_scores[2750] > without_scores[2750]
+    assert with_scores[2752] < without_scores[2752]
+    assert with_scores[2753] < without_scores[2753]
+
+
+def test_cli_with_ledger_and_register_json(capsys) -> None:
+    """CLI with --ledger-json and --register-json should produce valid output."""
+    candidates_path = FIXTURE_DIR / "candidates_ledger_register.json"
+    ledger_path = FIXTURE_DIR / "ledger_evidence.json"
+    register_path = FIXTURE_DIR / "register_negative_results.json"
+    exit_code = ranker.main(
+        [
+            "--candidates-json",
+            str(candidates_path),
+            "--ledger-json",
+            str(ledger_path),
+            "--register-json",
+            str(register_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["schema"] == "publication_candidate_ranker.v2"
+    assert payload["ranked_count"] == 5
+
+    ledger_candidate = next(c for c in payload["ranked_candidates"] if c["issue_number"] == 2750)
+    assert ledger_candidate["ledger_relevance"] == 1.0
+    assert ledger_candidate["negative_result_awareness"] == 0.0
+    assert any("claim gap" in n for n in ledger_candidate["ledger_notes"])
+
+    diag_candidate = next(c for c in payload["ranked_candidates"] if c["issue_number"] == 2752)
+    assert diag_candidate["negative_result_awareness"] == 1.0
+    assert any("why-this-is-different" in c for c in diag_candidate["negative_result_caveats"])
+
+
+def test_cli_rejects_wrong_ledger_schema(capsys, tmp_path) -> None:
+    """Explicit ledger/register files should fail closed when schema versions drift."""
+    candidates_path = FIXTURE_DIR / "candidates_ledger_register.json"
+    ledger_path = tmp_path / "bad-ledger.json"
+    ledger_path.write_text(
+        json.dumps({"schema_version": "wrong", "rows": []}),
+        encoding="utf-8",
+    )
+
+    exit_code = ranker.main(
+        [
+            "--candidates-json",
+            str(candidates_path),
+            "--ledger-json",
+            str(ledger_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["ok"] is False
+    assert "schema_version" in payload["error"]
+
+
+def test_cli_rejects_wrong_register_shape(capsys, tmp_path) -> None:
+    """Explicit register files should fail closed when the entries shape is wrong."""
+    candidates_path = FIXTURE_DIR / "candidates_ledger_register.json"
+    register_path = tmp_path / "bad-register.json"
+    register_path.write_text(
+        json.dumps({"schema_version": "negative_result_register.v1", "entries": {}}),
+        encoding="utf-8",
+    )
+
+    exit_code = ranker.main(
+        [
+            "--candidates-json",
+            str(candidates_path),
+            "--register-json",
+            str(register_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["ok"] is False
+    assert "entries must be a list" in payload["error"]
+
+
+def test_cli_without_ledger_register_backward_compat(capsys) -> None:
+    """CLI without --ledger-json/--register-json should preserve v1-like behavior."""
+    candidates_path = FIXTURE_DIR / "candidates_mixed.json"
+    exit_code = ranker.main(
+        [
+            "--candidates-json",
+            str(candidates_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["schema"] == "publication_candidate_ranker.v2"
+    for item in payload["ranked_candidates"]:
+        assert item["ledger_relevance"] == 0.0
+        assert item["negative_result_awareness"] == 0.0
+        assert item["ledger_notes"] == []
+        assert item["negative_result_caveats"] == []
+
+
+def test_markdown_report_includes_ledger_and_negative_result() -> None:
+    """Markdown report must include ledger notes and negative-result caveats."""
+    candidates_raw = _fixture("candidates_ledger_register.json")
+    candidates = [ranker._parse_candidate(item) for item in candidates_raw]
+    ranked = ranker.rank_candidates(
+        candidates,
+        ledger=ranker._parse_ledger(_fixture("ledger_evidence.json")),
+        register=ranker._parse_register(_fixture("register_negative_results.json")),
+    )
+    report = ranker.format_markdown_report(ranked, total_count=len(candidates))
+
+    assert "**Ledger notes:**" in report
+    assert "**Ledger relevance:**" in report
+    assert "**Negative-result caveats:**" in report
+    assert "**Negative-result awareness:**" in report
+    assert "open claim gap" in report
+    assert "why-this-is-different" in report
+
+
+def test_parse_ledger_empty_inputs() -> None:
+    """_parse_ledger should reject bad top-level schema and skip bad source_issues."""
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_ledger({})
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_ledger("not a dict")
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_ledger(
+            {"schema_version": "dissertation_evidence_ledger.v2", "rows": "not a list"}
+        )
+    assert (
+        ranker._parse_ledger(
+            {
+                "schema_version": "dissertation_evidence_ledger.v2",
+                "rows": [{"source_issues": "bad"}],
+            }
+        )
+        == {}
+    )
+
+
+def test_parse_ledger_accepts_real_rows_schema() -> None:
+    """_parse_ledger should match the current dissertation ledger rows schema."""
+    payload = {
+        "schema_version": "dissertation_evidence_ledger.v2",
+        "rows": [
+            {
+                "area": "prediction",
+                "source_issues": [2475],
+                "claim_gap": "Needs denominator repair.",
+                "evidence_promotion_path": "executed planner campaign",
+                "evidence_tier": "diagnostic",
+            }
+        ],
+    }
+    parsed = ranker._parse_ledger(payload)
+    assert 2475 in parsed
+    assert parsed[2475][0]["area"] == "prediction"
+
+
+def test_parse_ledger_skips_non_strict_issue_numbers() -> None:
+    """Ledger parsing should skip bools and float issue identifiers."""
+    row = {"source_issues": [True, False, 2475.5, float("nan"), float("inf"), 2476.0, 2477]}
+
+    parsed = ranker._parse_ledger(
+        {"schema_version": "dissertation_evidence_ledger.v2", "rows": [row]}
+    )
+
+    assert parsed == {2477: [row]}
+
+
+def test_ledger_notes_ignore_null_promotion_path() -> None:
+    """Null promotion paths should not render as notes or crash."""
+    relevance, notes = ranker._ledger_notes_for_rows(
+        [
+            {
+                "area": "observation_robustness",
+                "claim_gap": "Needs perception proof.",
+                "evidence_promotion_path": None,
+                "evidence_tier": "release-backed",
+            }
+        ]
+    )
+
+    assert relevance == 1.0
+    assert any("Needs perception proof" in note for note in notes)
+    assert not any("promotion path" in note for note in notes)
+
+
+def test_parse_register_empty_inputs() -> None:
+    """_parse_register should reject bad top-level schema and skip bad linked_issues."""
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_register({})
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_register("not a dict")
+    with pytest.raises(ranker.RankerInputError):
+        ranker._parse_register(
+            {"schema_version": "negative_result_register.v1", "entries": "not a list"}
+        )
+    assert (
+        ranker._parse_register(
+            {"schema_version": "negative_result_register.v1", "entries": [{"linked_issues": "bad"}]}
+        )
+        == {}
+    )
+
+
+def test_parse_register_accepts_real_result_classification_schema() -> None:
+    """_parse_register should preserve current negative-result register entries."""
+    payload = {
+        "schema_version": "negative_result_register.v1",
+        "entries": [
+            {
+                "linked_issues": [2716],
+                "result_classification": "revise",
+                "why_failed_or_inconclusive": "No hard slice cleared.",
+                "recommended_next_action": "Change mechanism.",
+                "claim_boundary": "Diagnostic-only.",
+            }
+        ],
+    }
+    parsed = ranker._parse_register(payload)
+    assert 2716 in parsed
+    assert parsed[2716][0]["result_classification"] == "revise"
+
+
+def test_parse_register_skips_non_strict_issue_numbers() -> None:
+    """Register parsing should skip bools and float issue identifiers."""
+    entry = {"linked_issues": [True, False, 2716.2, float("nan"), float("inf"), 2717.0, 2718]}
+
+    parsed = ranker._parse_register(
+        {"schema_version": "negative_result_register.v1", "entries": [entry]}
+    )
+
+    assert parsed == {2718: [entry]}

--- a/tests/fixtures/publication_candidate_ranker/candidates_ledger_register.json
+++ b/tests/fixtures/publication_candidate_ranker/candidates_ledger_register.json
@@ -1,0 +1,97 @@
+[
+  {
+    "issue_number": 2750,
+    "issue_url": "https://github.com/ll7/robot_sf_ll7/issues/2750",
+    "title": "ledger boost candidate with claim gap closed",
+    "linter_ok": true,
+    "linter_findings": [],
+    "scores": {
+      "dissertation_relevance": 0.8,
+      "evidence_readiness": 0.65,
+      "implementation_boundedness": 0.75,
+      "artifact_dependency": 0.2,
+      "expected_research_value": 0.8,
+      "duplication_risk": 0.1
+    },
+    "reasons": ["strong evidence", "clear scope"],
+    "evidence_caveats": [],
+    "duplication_notes": [],
+    "blocked_by": []
+  },
+  {
+    "issue_number": 2751,
+    "issue_url": "https://github.com/ll7/robot_sf_ll7/issues/2751",
+    "title": "ledger tracked candidate without promotion",
+    "linter_ok": true,
+    "linter_findings": [],
+    "scores": {
+      "dissertation_relevance": 0.7,
+      "evidence_readiness": 0.6,
+      "implementation_boundedness": 0.65,
+      "artifact_dependency": 0.3,
+      "expected_research_value": 0.6,
+      "duplication_risk": 0.15
+    },
+    "reasons": ["moderate relevance"],
+    "evidence_caveats": [],
+    "duplication_notes": [],
+    "blocked_by": []
+  },
+  {
+    "issue_number": 2752,
+    "issue_url": "https://github.com/ll7/robot_sf_ll7/issues/2752",
+    "title": "negative result diagnostic_only candidate",
+    "linter_ok": true,
+    "linter_findings": [],
+    "scores": {
+      "dissertation_relevance": 0.75,
+      "evidence_readiness": 0.7,
+      "implementation_boundedness": 0.7,
+      "artifact_dependency": 0.25,
+      "expected_research_value": 0.65,
+      "duplication_risk": 0.1
+    },
+    "reasons": ["similar to prior work"],
+    "evidence_caveats": [],
+    "duplication_notes": [],
+    "blocked_by": []
+  },
+  {
+    "issue_number": 2753,
+    "issue_url": "https://github.com/ll7/robot_sf_ll7/issues/2753",
+    "title": "negative result failed candidate",
+    "linter_ok": true,
+    "linter_findings": [],
+    "scores": {
+      "dissertation_relevance": 0.7,
+      "evidence_readiness": 0.65,
+      "implementation_boundedness": 0.6,
+      "artifact_dependency": 0.3,
+      "expected_research_value": 0.55,
+      "duplication_risk": 0.2
+    },
+    "reasons": ["retry of failed benchmark"],
+    "evidence_caveats": [],
+    "duplication_notes": [],
+    "blocked_by": []
+  },
+  {
+    "issue_number": 2754,
+    "issue_url": "https://github.com/ll7/robot_sf_ll7/issues/2754",
+    "title": "no ledger or register entry candidate",
+    "linter_ok": true,
+    "linter_findings": [],
+    "scores": {
+      "dissertation_relevance": 0.8,
+      "evidence_readiness": 0.8,
+      "implementation_boundedness": 0.75,
+      "artifact_dependency": 0.2,
+      "expected_research_value": 0.75,
+      "duplication_risk": 0.1
+    },
+    "reasons": ["clean candidate"],
+    "evidence_caveats": [],
+    "duplication_notes": [],
+    "blocked_by": []
+  }
+]

--- a/tests/fixtures/publication_candidate_ranker/ledger_evidence.json
+++ b/tests/fixtures/publication_candidate_ranker/ledger_evidence.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "dissertation_evidence_ledger.v2",
+  "rows": [
+    {
+      "area": "topology_guidance",
+      "source_issues": [2750],
+      "claim_gap": "Needs a fresh benchmark run before dissertation wording.",
+      "evidence_promotion_path": "benchmark_run",
+      "evidence_tier": "diagnostic"
+    },
+    {
+      "area": "prediction",
+      "source_issues": [2751],
+      "claim_gap": "",
+      "evidence_promotion_path": "",
+      "evidence_tier": "non-claimable"
+    }
+  ]
+}

--- a/tests/fixtures/publication_candidate_ranker/register_negative_results.json
+++ b/tests/fixtures/publication_candidate_ranker/register_negative_results.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "negative_result_register.v1",
+  "entries": [
+    {
+      "linked_issues": [2752],
+      "result_classification": "diagnostic_only",
+      "why_failed_or_inconclusive": "Previous attempt produced diagnostic-only evidence.",
+      "recommended_next_action": "Change the scenario before retrying.",
+      "claim_boundary": "Diagnostic-only, not benchmark evidence."
+    },
+    {
+      "linked_issues": [2753],
+      "result_classification": "failed",
+      "why_failed_or_inconclusive": "Benchmark run failed closed.",
+      "recommended_next_action": "Repair fail-closed contract first.",
+      "claim_boundary": "Failed run must not be promoted."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2783.

## Summary
- add optional `--ledger-json` and `--register-json` inputs to the read-only publication candidate ranker
- parse real dissertation ledger rows and negative-result register entries into bounded ranking signals
- surface ledger notes, negative-result caveats, and feature scores in Markdown/JSON output
- add fixture-backed coverage proving ranking changes, conservative caveats, backward compatibility, and real-schema parsing

## Validation
- `uv run ruff check scripts/dev/publication_candidate_ranker.py tests/dev/test_publication_candidate_ranker.py`
- `uv run ruff format scripts/dev/publication_candidate_ranker.py tests/dev/test_publication_candidate_ranker.py`
- `uv run pytest tests/dev/test_publication_candidate_ranker.py -q` (27 passed)
- real-data dry run with temporary #2475/#2716 candidates, current ledger/register JSON, and `--format json` (ledger relevance and negative-result awareness both exercised)
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (6259 passed, 9 skipped)

## Research Result Guidance
- Target: planning/ranking workflow, not new benchmark or paper evidence.
- Evidence tier: nominal tooling validation plus current-data dry run.
- Result classification: support/tooling; it improves prioritization discipline without promoting diagnostic evidence.
- Stop rule: ranker remains read-only, deterministic, and explicitly caveats diagnostic-only or negative-result repetition.

## Downstream Propagation
- No GitHub issue/Project mutation is performed by the ranker.
- The publication ranker schema is bumped to `publication_candidate_ranker.v2` with additive output fields.
- Future candidate-ranking consumers can pass the tracked ledger/register paths to include evidence-gap and negative-result signals.

## Delegation
- OpenCode scout found the ranker and proposed the implementation path.
- Command Code implementation route was rejected as uneconomic: print mode hit turn cap and could not write.
- OpenCode implementation produced the first diff and validation artifacts.
- Codex repaired real-schema handling, removed loose fallbacks, added null-path coverage, and ran final validation.
- Command Code read-only review passed with non-blocking cleanup suggestions, which were addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated dissertation evidence ledger and negative-result register as external ranking modifiers.
  * Added CLI arguments to input ledger and register data files.
  * Enhanced ranking output with ledger relevance scores and negative-result awareness metrics.
  * Markdown and JSON reports now include ledger and negative-result information.

* **Tests**
  * Added comprehensive test coverage for ledger/register integration, backward compatibility, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->