### PR TITLE
feat: add route efficiency dashboard

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -381,6 +381,12 @@ recommendations" section. Route success and complete artifact presence are
 **route evidence only**; they are not task acceptance. The orchestrator must
 still inspect the diff and run the required local validation.
 
+For historical route audits, add `--dashboard` and pass multiple routed-worker
+manifest files. Dashboard mode emits `route_efficiency_dashboard.v1` JSON or
+Markdown with overall metrics, per-manifest breakdowns, provider trends,
+incomplete-provider and failure-class totals, common missing artifact counts,
+and the same route-evidence-only recommendations and warning.
+
 Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
 
 ```bash

--- a/scripts/dev/route_efficiency_report.py
+++ b/scripts/dev/route_efficiency_report.py
@@ -15,10 +15,12 @@ import argparse
 import json
 import re
 from collections import Counter
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "route_efficiency_report.v1"
+DASHBOARD_SCHEMA_VERSION = "route_efficiency_dashboard.v1"
 ROUTE_EVIDENCE_WARNING = (
     "Route success and complete artifact presence are route evidence only; "
     "they are not task acceptance. The orchestrator must still inspect the "
@@ -89,6 +91,7 @@ class _Accumulator:
         self.provider_total: Counter[str] = Counter()
         self.provider_complete: Counter[str] = Counter()
         self.failure_class_incomplete: Counter[str] = Counter()
+        self.missing_artifacts: Counter[str] = Counter()
 
     def process_attempt(self, idx: int, attempt: dict[str, Any]) -> None:
         if not isinstance(attempt, dict):
@@ -108,6 +111,11 @@ class _Accumulator:
         else:
             self.provider_incomplete[provider] += 1
             self.failure_class_incomplete[str(fc)] += 1
+            if isinstance(compact, dict):
+                for key in sorted(_EXPECTED_ARTIFACT_KEYS):
+                    artifact = compact.get(key)
+                    if not isinstance(artifact, dict) or artifact.get("present") is not True:
+                        self.missing_artifacts[key] += 1
 
         if _validate_present(compact):
             self.validation_present += 1
@@ -246,6 +254,220 @@ def _derive_routing_recommendations(report: dict[str, Any]) -> list[dict[str, st
     ]
 
 
+def _analyze_single_manifest(
+    manifest: dict[str, Any],
+    source: str,
+) -> dict[str, Any]:
+    """Build a per-manifest sub-report with source label."""
+    acc = _Accumulator()
+    attempts = manifest.get("attempted_routes") if isinstance(manifest, dict) else None
+    if isinstance(attempts, list):
+        acc.total_attempts = len(attempts)
+        for idx, attempt in enumerate(attempts):
+            acc.process_attempt(idx, attempt)
+
+    rate = round(acc.complete_count / acc.total_attempts, 4) if acc.total_attempts else 0.0
+    return {
+        "source": source,
+        "delegated_attempts": acc.total_attempts,
+        "complete_artifacts": {"count": acc.complete_count, "rate": rate},
+        "validation_presence": {
+            "present": acc.validation_present,
+            "success_inferable": acc.validation_success,
+        },
+        "reroutes": acc.reroutes,
+        "incomplete_by_provider": dict(acc.provider_incomplete),
+        "incomplete_by_failure_class": dict(acc.failure_class_incomplete),
+        "missing_artifacts": dict(acc.missing_artifacts),
+        "by_provider": {
+            p: {"total": t, "complete": acc.provider_complete[p]}
+            for p, t in acc.provider_total.items()
+        },
+    }
+
+
+def analyze_dashboard(
+    manifests_with_sources: list[tuple[dict[str, Any], str]],
+    *,
+    snapshot: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a dashboard report from multiple manifests with source labels."""
+    per_manifest: list[dict[str, Any]] = []
+    for manifest, source in manifests_with_sources:
+        per_manifest.append(_analyze_single_manifest(manifest, source))
+
+    overall_acc = _Accumulator()
+    for manifest, _source in manifests_with_sources:
+        attempts = manifest.get("attempted_routes") if isinstance(manifest, dict) else None
+        if isinstance(attempts, list):
+            overall_acc.total_attempts += len(attempts)
+            for idx, attempt in enumerate(attempts):
+                overall_acc.process_attempt(idx, attempt)
+
+    total = overall_acc.total_attempts
+    rate = round(overall_acc.complete_count / total, 4) if total else 0.0
+
+    provider_trend_map: dict[str, list[dict[str, Any]]] = {}
+    for sub in per_manifest:
+        for provider, counts in sub.get("by_provider", {}).items():
+            p_total = counts.get("total", 0)
+            p_complete = counts.get("complete", 0)
+            p_rate = round(p_complete / p_total, 4) if p_total else 0.0
+            entry = {
+                "source": sub["source"],
+                "total": p_total,
+                "complete": p_complete,
+                "rate": p_rate,
+            }
+            provider_trend_map.setdefault(provider, []).append(entry)
+
+    provider_trend = [
+        {"provider": provider, "per_manifest": entries}
+        for provider, entries in sorted(provider_trend_map.items())
+    ]
+
+    accepted, acceptance_note = _extract_snapshot_outcome(snapshot)
+
+    overall_report = {
+        "schema": DASHBOARD_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "manifests_analyzed": len(manifests_with_sources),
+        "overall": {
+            "delegated_attempts": overall_acc.total_attempts,
+            "complete_artifacts": {"count": overall_acc.complete_count, "rate": rate},
+            "validation_presence": {
+                "present": overall_acc.validation_present,
+                "success_inferable": overall_acc.validation_success,
+            },
+            "total_reroutes": overall_acc.reroutes,
+            "estimated_inspections_avoided": overall_acc.complete_count,
+        },
+        "per_manifest": per_manifest,
+        "provider_trend": provider_trend,
+        "incomplete_by_provider": dict(overall_acc.provider_incomplete),
+        "incomplete_by_failure_class": dict(overall_acc.failure_class_incomplete),
+        "missing_artifacts": dict(overall_acc.missing_artifacts),
+        "by_provider": {
+            p: {"total": t, "complete": overall_acc.provider_complete[p]}
+            for p, t in overall_acc.provider_total.items()
+        },
+        "final_outcome": {
+            "accepted": accepted,
+            "note": (
+                acceptance_note
+                if acceptance_note is not None
+                else "route evidence only; not task acceptance"
+            ),
+        },
+        "warning": ROUTE_EVIDENCE_WARNING,
+    }
+
+    recommendations_source = {
+        "delegated_attempts": overall_acc.total_attempts,
+        "complete_artifacts": {"count": overall_acc.complete_count, "rate": rate},
+        "incomplete_by_provider": dict(overall_acc.provider_incomplete),
+        "incomplete_by_failure_class": dict(overall_acc.failure_class_incomplete),
+        "missing_artifacts": dict(overall_acc.missing_artifacts),
+        "by_provider": {
+            p: {"total": t, "complete": overall_acc.provider_complete[p]}
+            for p, t in overall_acc.provider_total.items()
+        },
+    }
+    overall_report["routing_recommendations"] = _derive_routing_recommendations(
+        recommendations_source
+    )
+    return overall_report
+
+
+def _append_dashboard_summary(lines: list[str], dashboard: dict[str, Any]) -> None:
+    """Append dashboard headline metrics."""
+    overall = dashboard["overall"]
+    ca = overall["complete_artifacts"]
+    vp = overall["validation_presence"]
+    lines.append("# Route Efficiency Dashboard\n")
+    lines.append(f"- **Manifests analyzed:** {dashboard['manifests_analyzed']}")
+    lines.append(f"- **Generated at:** {dashboard['generated_at']}")
+    lines.append(f"- **Delegated attempts:** {overall['delegated_attempts']}")
+    lines.append(
+        f"- **Complete artifacts:** {ca['count']}/{overall['delegated_attempts']} ({ca['rate']:.0%})"
+    )
+    lines.append(
+        f"- **Validation present:** {vp['present']}"
+        f" | **success inferable:** {vp['success_inferable']}"
+    )
+    lines.append(f"- **Total reroutes:** {overall['total_reroutes']}")
+    lines.append(f"- **Estimated inspections avoided:** {overall['estimated_inspections_avoided']}")
+
+    ibp = dashboard.get("incomplete_by_provider", {})
+    if ibp:
+        parts = [f"{k}: {v}" for k, v in sorted(ibp.items())]
+        lines.append(f"- **Incomplete by provider:** {', '.join(parts)}")
+
+    ibf = dashboard.get("incomplete_by_failure_class", {})
+    if ibf:
+        parts = [f"{k}: {v}" for k, v in sorted(ibf.items())]
+        lines.append(f"- **Incomplete by failure class:** {', '.join(parts)}")
+
+    missing_artifacts = dashboard.get("missing_artifacts", {})
+    if missing_artifacts:
+        parts = [f"{k}: {v}" for k, v in sorted(missing_artifacts.items())]
+        lines.append(f"- **Missing artifacts:** {', '.join(parts)}")
+
+    lines.append(f"\n> {dashboard['warning']}\n")
+
+
+def _append_dashboard_tables(lines: list[str], dashboard: dict[str, Any]) -> None:
+    """Append dashboard per-manifest and provider-trend tables."""
+    per_manifest = dashboard.get("per_manifest", [])
+    if per_manifest:
+        lines.append("## Per-manifest breakdown\n")
+        lines.append("| Source | Attempts | Complete | Rate | Reroutes |")
+        lines.append("|--------|----------|----------|------|----------|")
+        for sub in per_manifest:
+            src = sub["source"]
+            att = sub["delegated_attempts"]
+            cnt = sub["complete_artifacts"]["count"]
+            r = sub["complete_artifacts"]["rate"]
+            rr = sub["reroutes"]
+            lines.append(f"| {src} | {att} | {cnt} | {r:.0%} | {rr} |")
+        lines.append("")
+
+    provider_trend = dashboard.get("provider_trend", [])
+    if provider_trend:
+        lines.append("## Provider trend\n")
+        lines.append("| Provider | Source | Total | Complete | Rate |")
+        lines.append("|----------|--------|-------|----------|------|")
+        for pt in provider_trend:
+            provider = pt["provider"]
+            for entry in pt["per_manifest"]:
+                lines.append(
+                    f"| {provider} | {entry['source']} | {entry['total']} |"
+                    f" {entry['complete']} | {entry['rate']:.0%} |"
+                )
+        lines.append("")
+
+
+def _append_routing_recommendations(lines: list[str], recs: list[dict[str, str]]) -> None:
+    """Append compact routing recommendation bullets."""
+    lines.append("## Routing recommendations\n")
+    for rec in recs:
+        lines.append(f"- **{rec['class']}**: {rec['action']}")
+        lines.append(f"  - Evidence: {rec['evidence']}")
+        lines.append(f"  - Caveat: {rec['caveat']}")
+    lines.append("")
+
+
+def _format_dashboard_markdown(dashboard: dict[str, Any]) -> str:
+    """Render the dashboard as a compact Markdown summary."""
+    lines: list[str] = []
+    _append_dashboard_summary(lines, dashboard)
+    _append_dashboard_tables(lines, dashboard)
+    recs = dashboard.get("routing_recommendations")
+    if recs:
+        _append_routing_recommendations(lines, recs)
+    return "\n".join(lines)
+
+
 def analyze_manifests(
     manifests: list[dict[str, Any]],
     *,
@@ -279,6 +501,7 @@ def analyze_manifests(
         "reroutes": acc.reroutes,
         "incomplete_by_provider": dict(acc.provider_incomplete),
         "incomplete_by_failure_class": dict(acc.failure_class_incomplete),
+        "missing_artifacts": dict(acc.missing_artifacts),
         "by_provider": {
             p: {"total": t, "complete": acc.provider_complete[p]}
             for p, t in acc.provider_total.items()
@@ -366,6 +589,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output",
         help="Write report to this file instead of stdout.",
     )
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="Enable dashboard mode over multiple manifests with per-manifest breakdown and provider trends.",
+    )
     return parser.parse_args(argv)
 
 
@@ -392,10 +620,19 @@ def main(argv: list[str] | None = None) -> int:
     if args.snapshot:
         snapshot = json.loads(Path(args.snapshot).read_text(encoding="utf-8"))
 
-    report = analyze_manifests(manifests, snapshot=snapshot)
+    if args.dashboard:
+        manifests_with_sources: list[tuple[dict[str, Any], str]] = [
+            (m, str(p)) for p in (Path(s) for s in args.manifests) for m in _load_manifest_file(p)
+        ]
+        report = analyze_dashboard(manifests_with_sources, snapshot=snapshot)
+    else:
+        report = analyze_manifests(manifests, snapshot=snapshot)
 
     if args.output_format == "markdown":
-        text = _format_markdown(report)
+        if args.dashboard:
+            text = _format_dashboard_markdown(report)
+        else:
+            text = _format_markdown(report)
     else:
         text = json.dumps(report, indent=2, sort_keys=True) + "\n"
 

--- a/tests/dev/test_route_efficiency_report.py
+++ b/tests/dev/test_route_efficiency_report.py
@@ -809,3 +809,449 @@ def test_markdown_includes_routing_recommendations_section() -> None:
     assert "## Routing recommendations" in md
     assert "avoid_provider" in md
     assert "not task acceptance" in md
+
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "route_efficiency"
+
+
+def _load_fixture(name: str) -> dict:
+    """Load a fixture JSON file from tests/fixtures/route_efficiency/."""
+    return json.loads((_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _manifest_with_source(name: str) -> tuple[dict, str]:
+    """Load a fixture and return (manifest, source_label)."""
+    manifest = _load_fixture(name)
+    return manifest, name
+
+
+def test_dashboard_single_manifest_equals_single_report() -> None:
+    """Dashboard with one manifest should produce consistent overall metrics."""
+    manifest = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(manifest, "single.json")])
+    report = rer.analyze_manifests([manifest])
+
+    assert dashboard["schema"] == "route_efficiency_dashboard.v1"
+    assert dashboard["manifests_analyzed"] == 1
+    assert dashboard["overall"]["delegated_attempts"] == report["delegated_attempts"]
+    assert dashboard["overall"]["complete_artifacts"] == report["complete_artifacts"]
+    assert dashboard["overall"]["total_reroutes"] == report["reroutes"]
+    assert len(dashboard["per_manifest"]) == 1
+    assert dashboard["per_manifest"][0]["source"] == "single.json"
+    assert "warning" in dashboard
+    assert "not task acceptance" in dashboard["warning"]
+
+
+def test_dashboard_multiple_manifests_per_manifest_breakdown() -> None:
+    """Dashboard with multiple manifests should include per-manifest breakdown."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json"), (m2, "m2.json")])
+
+    assert dashboard["manifests_analyzed"] == 2
+    assert len(dashboard["per_manifest"]) == 2
+    assert dashboard["per_manifest"][0]["source"] == "m1.json"
+    assert dashboard["per_manifest"][1]["source"] == "m2.json"
+    assert dashboard["per_manifest"][0]["delegated_attempts"] == 1
+    assert dashboard["per_manifest"][1]["delegated_attempts"] == 2
+    assert dashboard["per_manifest"][0]["complete_artifacts"]["rate"] == 1.0
+    assert dashboard["per_manifest"][1]["complete_artifacts"]["rate"] == 0.5
+
+
+def test_dashboard_provider_trend_time_series() -> None:
+    """Dashboard should expose per-provider trend across manifests."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json"), (m2, "m2.json")])
+
+    trend = dashboard["provider_trend"]
+    qwen_trend = [t for t in trend if t["provider"] == "qwen"]
+    gemini_trend = [t for t in trend if t["provider"] == "gemini"]
+    assert len(qwen_trend) == 1
+    assert len(qwen_trend[0]["per_manifest"]) == 2
+    assert qwen_trend[0]["per_manifest"][0]["source"] == "m1.json"
+    assert qwen_trend[0]["per_manifest"][0]["complete"] == 1
+    assert qwen_trend[0]["per_manifest"][1]["source"] == "m2.json"
+    assert qwen_trend[0]["per_manifest"][1]["complete"] == 1
+    assert len(gemini_trend) == 1
+    assert gemini_trend[0]["per_manifest"][0]["source"] == "m2.json"
+    assert gemini_trend[0]["per_manifest"][0]["complete"] == 0
+
+
+def test_dashboard_overall_metrics_match_aggregate() -> None:
+    """Dashboard overall metrics should match sum of per-manifest attempts."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json"), (m2, "m2.json")])
+
+    overall = dashboard["overall"]
+    assert overall["delegated_attempts"] == 3
+    assert overall["complete_artifacts"]["count"] == 2
+    assert overall["complete_artifacts"]["rate"] == round(2 / 3, 4)
+    assert overall["total_reroutes"] == 1
+    assert overall["estimated_inspections_avoided"] == 2
+
+    per_total = sum(p["delegated_attempts"] for p in dashboard["per_manifest"])
+    per_complete = sum(p["complete_artifacts"]["count"] for p in dashboard["per_manifest"])
+    assert overall["delegated_attempts"] == per_total
+    assert overall["complete_artifacts"]["count"] == per_complete
+
+
+def test_dashboard_empty_manifest_list() -> None:
+    """Dashboard with empty manifest list should produce zeroed-out report."""
+    dashboard = rer.analyze_dashboard([])
+
+    assert dashboard["manifests_analyzed"] == 0
+    assert dashboard["overall"]["delegated_attempts"] == 0
+    assert dashboard["overall"]["complete_artifacts"]["rate"] == 0.0
+    assert dashboard["overall"]["estimated_inspections_avoided"] == 0
+    assert dashboard["per_manifest"] == []
+    assert dashboard["provider_trend"] == []
+
+
+def test_dashboard_markdown_output_compactness() -> None:
+    """Dashboard markdown should be shorter than JSON and contain key sections."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json"), (m2, "m2.json")])
+    md = rer._format_dashboard_markdown(dashboard)
+    js = json.dumps(dashboard, indent=2, sort_keys=True)
+
+    assert "# Route Efficiency Dashboard" in md
+    assert "Delegated attempts" in md
+    assert "Complete artifacts" in md
+    assert "Per-manifest breakdown" in md
+    assert "Provider trend" in md
+    assert "not task acceptance" in md
+    assert len(md) <= len(js)
+
+
+def test_dashboard_cli_json_output(tmp_path: Path) -> None:
+    """CLI --dashboard should produce valid JSON dashboard."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+    p1 = tmp_path / "m1.json"
+    p2 = tmp_path / "m2.json"
+    p1.write_text(json.dumps(m1), encoding="utf-8")
+    p2.write_text(json.dumps(m2), encoding="utf-8")
+
+    exit_code = rer.main(["--dashboard", str(p1), str(p2)])
+    assert exit_code == 0
+
+
+def test_dashboard_cli_markdown_output(tmp_path: Path) -> None:
+    """CLI --dashboard --format markdown should produce dashboard markdown."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    p1 = tmp_path / "m1.json"
+    p1.write_text(json.dumps(m1), encoding="utf-8")
+    out_path = tmp_path / "dashboard.md"
+
+    exit_code = rer.main(
+        ["--dashboard", "--format", "markdown", "--output", str(out_path), str(p1)]
+    )
+    assert exit_code == 0
+    text = out_path.read_text(encoding="utf-8")
+    assert "# Route Efficiency Dashboard" in text
+    assert "Per-manifest breakdown" in text
+
+
+def test_dashboard_no_raw_logs_or_secrets() -> None:
+    """Dashboard output should not contain raw logs, secrets, or quota fields."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            }
+        ]
+    )
+    dashboard = rer.analyze_dashboard([(m1, "m1.json")])
+    text = json.dumps(dashboard, indent=2, sort_keys=True)
+
+    forbidden = ["api_key", "secret", "token", "quota", "raw_log", "stdout", "stderr"]
+    for key in forbidden:
+        assert key not in text.lower()
+
+
+def test_dashboard_incomplete_failure_visibility() -> None:
+    """Dashboard should surface incomplete and failure class trends."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "copilot"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+    m2 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "validation",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json"), (m2, "m2.json")])
+
+    assert "timeout" in dashboard["incomplete_by_failure_class"]
+    assert dashboard["incomplete_by_failure_class"]["timeout"] == 2
+    assert "validation" in dashboard["incomplete_by_failure_class"]
+    assert dashboard["incomplete_by_failure_class"]["validation"] == 1
+    assert dashboard["incomplete_by_provider"]["gemini"] == 2
+    assert dashboard["incomplete_by_provider"]["copilot"] == 1
+    assert dashboard["missing_artifacts"]["result_json"] == 3
+    assert dashboard["missing_artifacts"]["validation"] == 3
+
+
+def test_dashboard_routing_recommendations_have_caveats() -> None:
+    """Dashboard routing recommendations should include route-evidence-only caveats."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 2,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json")])
+    recs = dashboard["routing_recommendations"]
+    assert len(recs) >= 1
+    for rec in recs:
+        assert "not task acceptance" in rec["caveat"]
+
+
+def test_dashboard_with_fixture_files() -> None:
+    """Dashboard should load and analyze real fixture files correctly."""
+    fixtures = [
+        "historical_manifest_20260610.json",
+        "historical_manifest_20260612.json",
+        "historical_manifest_20260614.json",
+    ]
+    manifests_with_sources = [_manifest_with_source(f) for f in fixtures]
+
+    dashboard = rer.analyze_dashboard(manifests_with_sources)
+
+    assert dashboard["manifests_analyzed"] == 3
+    assert dashboard["overall"]["delegated_attempts"] == 6
+    assert dashboard["missing_artifacts"]["diffstat"] == 2
+    assert len(dashboard["per_manifest"]) == 3
+    assert len(dashboard["provider_trend"]) >= 2
+    assert "qwen" in [t["provider"] for t in dashboard["provider_trend"]]
+    assert "gemini" in [t["provider"] for t in dashboard["provider_trend"]]
+
+
+def test_dashboard_markdown_includes_recommendations_section() -> None:
+    """Dashboard markdown should include routing recommendations when present."""
+    m1 = _manifest(
+        [
+            {
+                "attempt_index": 0,
+                "route": {"provider": "qwen"},
+                "returncode": 0,
+                "failure_class": "none",
+                "compact_artifacts": _compact_artifacts(present=True),
+            },
+            {
+                "attempt_index": 1,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+            {
+                "attempt_index": 2,
+                "route": {"provider": "gemini"},
+                "returncode": 1,
+                "failure_class": "timeout",
+                "compact_artifacts": _compact_artifacts(present=False),
+            },
+        ]
+    )
+
+    dashboard = rer.analyze_dashboard([(m1, "m1.json")])
+    md = rer._format_dashboard_markdown(dashboard)
+
+    assert "## Routing recommendations" in md
+    assert "avoid_provider" in md
+    assert "not task acceptance" in md

--- a/tests/fixtures/route_efficiency/historical_manifest_20260610.json
+++ b/tests/fixtures/route_efficiency/historical_manifest_20260610.json
@@ -1,0 +1,97 @@
+{
+  "chosen_route": {
+    "model": "qwen-max",
+    "provider": "qwen"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-001/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-001/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-001/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-001/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-001/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-001"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-002/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-002/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-002/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-002/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-002/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "timeout",
+      "returncode": 1,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-002"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/historical_manifest_20260612.json
+++ b/tests/fixtures/route_efficiency/historical_manifest_20260612.json
@@ -1,0 +1,140 @@
+{
+  "chosen_route": {
+    "model": "qwen-max",
+    "provider": "qwen"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-003/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-003/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-003/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-003/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-003/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-003"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-004/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-004/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-004/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-004/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-004/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-004"
+    },
+    {
+      "attempt_index": 2,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-005/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-005/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-005/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-005/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-005/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "validation",
+      "returncode": 1,
+      "route": {
+        "model": "gpt-4o",
+        "provider": "copilot"
+      },
+      "run_dir": "output/worker-005"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/historical_manifest_20260614.json
+++ b/tests/fixtures/route_efficiency/historical_manifest_20260614.json
@@ -1,0 +1,55 @@
+{
+  "chosen_route": {
+    "model": "mimo-v2.5",
+    "provider": "opencode-go"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-006/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-006/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-006/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-006/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-006/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "mimo-v2.5",
+        "provider": "opencode-go"
+      },
+      "run_dir": "output/worker-006"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add route_efficiency_dashboard.v1 dashboard mode for multiple routed-worker manifests
- include overall metrics, per-manifest breakdowns, provider trends, incomplete provider/failure totals, missing artifact counts, and routing recommendations
- document dashboard mode in docs/dev_guide.md and add fixture-backed tests

Closes #2786

## Validation
- uv run ruff format scripts/dev/route_efficiency_report.py tests/dev/test_route_efficiency_report.py
- uv run ruff check docs/dev_guide.md scripts/dev/route_efficiency_report.py tests/dev/test_route_efficiency_report.py
- uv run pytest tests/dev/test_route_efficiency_report.py -q (41 passed)
- uv run python scripts/dev/route_efficiency_report.py --dashboard tests/fixtures/route_efficiency/historical_manifest_20260610.json tests/fixtures/route_efficiency/historical_manifest_20260612.json tests/fixtures/route_efficiency/historical_manifest_20260614.json --format json
- uv run python scripts/dev/route_efficiency_report.py --dashboard tests/fixtures/route_efficiency/historical_manifest_20260610.json tests/fixtures/route_efficiency/historical_manifest_20260612.json tests/fixtures/route_efficiency/historical_manifest_20260614.json --format markdown
- PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh (6285 passed, 9 skipped, 9 warnings)

## Delegation
- OpenCode Go scout produced useful result.json/RESULT.md but stalled before diffstat; controller recorded it as incomplete route evidence.
- OpenCode Go implementation produced dashboard code, fixtures, tests, and artifacts; Codex integration review added missing-artifact visibility, docs, refactored complexity, and reran validation.

## Research Result Guidance
- Target: workflow analysis over delegated-worker route manifests.
- Evidence tier: analysis-only workflow evidence.
- Result classification: support/tooling; not benchmark, dissertation, paper, or safety evidence.
- Stop rule: deterministic JSON/Markdown dashboard over fixture manifests with route-evidence-only warning.
- Synthesis surface: docs/dev_guide.md route-efficiency section.

## Downstream Propagation
- Future save-codex-tokens route audits can consume route_efficiency_dashboard.v1.
- No raw worker logs, external API calls, quota/account fields, or automatic routing-policy rewrites are added.
- Route success and complete artifacts remain route evidence only; task acceptance still requires diff review and local validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Route efficiency reports now support dashboard mode to analyze multiple manifest files simultaneously
  * Dashboard output includes overall performance metrics, individual manifest breakdowns, provider trend analysis, failure totals, and routing recommendations in JSON or Markdown formats

* **Documentation**
  * Added instructions for conducting historical route audits using the new dashboard feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->