### PR TITLE
test: add negative route efficiency fixtures

### DIFF
--- a/tests/dev/test_route_efficiency_report.py
+++ b/tests/dev/test_route_efficiency_report.py
@@ -1255,3 +1255,164 @@ def test_dashboard_markdown_includes_recommendations_section() -> None:
     assert "## Routing recommendations" in md
     assert "avoid_provider" in md
     assert "not task acceptance" in md
+
+
+# ---------------------------------------------------------------------------
+# Negative-fixture tests (issue-2817): ensure the report cannot overinterpret
+# bad delegated outputs.
+# ---------------------------------------------------------------------------
+
+
+def test_negative_fixture_all_attempts_failed() -> None:
+    """All attempts failed should yield zero completion and clear missing counts."""
+    manifest = _load_fixture("negative_all_attempts_failed.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 3
+    assert report["complete_artifacts"]["count"] == 0
+    assert report["complete_artifacts"]["rate"] == 0.0
+    assert report["validation_presence"]["present"] == 0
+    assert report["validation_presence"]["success_inferable"] == 0
+    assert report["reroutes"] == 2
+    assert report["incomplete_by_provider"]["gemini"] == 2
+    assert report["incomplete_by_provider"]["copilot"] == 1
+    assert report["incomplete_by_failure_class"]["timeout"] == 2
+    assert report["incomplete_by_failure_class"]["route-collapse"] == 1
+    expected_missing = len(rer._EXPECTED_ARTIFACT_KEYS) * 3
+    assert sum(report["missing_artifacts"].values()) == expected_missing
+
+
+def test_negative_fixture_partial_artifacts_not_complete() -> None:
+    """Partial artifacts should not be counted as complete."""
+    manifest = _load_fixture("negative_partial_artifacts.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 2
+    assert report["complete_artifacts"]["count"] == 0
+    assert report["complete_artifacts"]["rate"] == 0.0
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 0
+    assert report["incomplete_by_failure_class"]["partial-artifacts"] == 1
+    assert report["incomplete_by_failure_class"]["validation"] == 1
+
+
+def test_negative_fixture_malformed_compact_artifacts() -> None:
+    """Malformed compact_artifacts should be counted as incomplete, not crash."""
+    manifest = _load_fixture("negative_malformed_compact_artifacts.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 3
+    assert report["complete_artifacts"]["count"] == 1
+    assert report["complete_artifacts"]["rate"] == round(1 / 3, 4)
+    assert report["incomplete_by_provider"]["qwen"] == 1
+    assert report["incomplete_by_provider"]["gemini"] == 1
+    assert report["incomplete_by_failure_class"]["malformed"] == 2
+
+
+def test_negative_fixture_empty_routes() -> None:
+    """Empty attempted_routes should yield zeroed report without error."""
+    manifest = _load_fixture("negative_empty_routes.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 0
+    assert report["complete_artifacts"]["count"] == 0
+    assert report["complete_artifacts"]["rate"] == 0.0
+    assert report["incomplete_by_provider"] == {}
+    assert report["incomplete_by_failure_class"] == {}
+    assert report["missing_artifacts"] == {}
+
+
+def test_negative_fixture_validation_failure_with_complete_artifacts() -> None:
+    """Complete artifacts with failing validation should not count as success."""
+    manifest = _load_fixture("negative_validation_failure_complete_artifacts.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 1
+    assert report["complete_artifacts"]["count"] == 1
+    assert report["complete_artifacts"]["rate"] == 1.0
+    assert report["validation_presence"]["present"] == 1
+    assert report["validation_presence"]["success_inferable"] == 0
+
+
+def test_negative_fixture_single_attempt_all_missing() -> None:
+    """Single attempt with all artifacts missing should show full missing counts."""
+    manifest = _load_fixture("negative_single_attempt_all_missing.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 1
+    assert report["complete_artifacts"]["count"] == 0
+    assert report["complete_artifacts"]["rate"] == 0.0
+    assert report["incomplete_by_provider"]["gemini"] == 1
+    assert report["incomplete_by_failure_class"]["route-collapse"] == 1
+    for key in rer._EXPECTED_ARTIFACT_KEYS:
+        assert report["missing_artifacts"][key] == 1
+
+
+def test_negative_fixture_reroute_success_not_accepted() -> None:
+    """A reroute can complete validation while still lacking task acceptance."""
+    manifest = _load_fixture("negative_reroute_success_not_accepted.json")
+    report = rer.analyze_manifests([manifest])
+
+    assert report["delegated_attempts"] == 2
+    assert report["complete_artifacts"] == {"count": 1, "rate": 0.5}
+    assert report["validation_presence"] == {"present": 1, "success_inferable": 1}
+    assert report["reroutes"] == 1
+    assert report["incomplete_by_provider"]["gemini"] == 1
+    assert report["incomplete_by_failure_class"]["missing-artifact-paths"] == 1
+    assert report["by_provider"]["qwen"] == {"total": 1, "complete": 1}
+    for key in rer._EXPECTED_ARTIFACT_KEYS:
+        assert report["missing_artifacts"][key] == 1
+    assert report["final_outcome"]["accepted"] is None
+    assert "not task acceptance" in report["final_outcome"]["note"]
+    assert "not task acceptance" in report["warning"]
+
+
+def test_negative_fixture_reroute_threshold_triggered() -> None:
+    """All-failed manifest should trigger reroute_threshold_met recommendation."""
+    manifest = _load_fixture("negative_all_attempts_failed.json")
+    report = rer.analyze_manifests([manifest])
+
+    recs = report["routing_recommendations"]
+    reroute = [r for r in recs if r["class"] == "reroute_threshold_met"]
+    assert len(reroute) >= 1
+    assert "0/3" in reroute[0]["action"]
+    assert "not task acceptance" in reroute[0]["caveat"]
+
+
+def test_negative_fixture_avoid_provider_triggered() -> None:
+    """Provider with 0% completion across >= 2 attempts should trigger avoid."""
+    manifest = _load_fixture("negative_all_attempts_failed.json")
+    report = rer.analyze_manifests([manifest])
+
+    recs = report["routing_recommendations"]
+    avoid = [r for r in recs if r["class"] == "avoid_provider"]
+    assert len(avoid) >= 1
+    assert "gemini" in avoid[0]["action"]
+    assert "0/2" in avoid[0]["action"]
+
+
+def test_negative_fixture_dashboard_all_failed() -> None:
+    """Dashboard with all-failed fixture should surface zero completion."""
+    manifest, source = _manifest_with_source("negative_all_attempts_failed.json")
+    dashboard = rer.analyze_dashboard([(manifest, source)])
+
+    assert dashboard["overall"]["delegated_attempts"] == 3
+    assert dashboard["overall"]["complete_artifacts"]["count"] == 0
+    assert dashboard["overall"]["complete_artifacts"]["rate"] == 0.0
+    assert len(dashboard["per_manifest"]) == 1
+    assert dashboard["per_manifest"][0]["source"] == source
+    assert dashboard["per_manifest"][0]["complete_artifacts"]["rate"] == 0.0
+
+
+def test_negative_fixture_dashboard_mixed_with_positive() -> None:
+    """Dashboard mixing positive and negative fixtures should aggregate correctly."""
+    pos, src_pos = _manifest_with_source("routing_manifest_complete.json")
+    neg, src_neg = _manifest_with_source("negative_all_attempts_failed.json")
+    dashboard = rer.analyze_dashboard([(pos, src_pos), (neg, src_neg)])
+
+    assert dashboard["overall"]["delegated_attempts"] == 4
+    assert dashboard["overall"]["complete_artifacts"]["count"] == 1
+    assert dashboard["overall"]["complete_artifacts"]["rate"] == 0.25
+    assert len(dashboard["per_manifest"]) == 2
+    assert dashboard["per_manifest"][0]["complete_artifacts"]["rate"] == 1.0
+    assert dashboard["per_manifest"][1]["complete_artifacts"]["rate"] == 0.0

--- a/tests/fixtures/route_efficiency/negative_all_attempts_failed.json
+++ b/tests/fixtures/route_efficiency/negative_all_attempts_failed.json
@@ -1,0 +1,138 @@
+{
+  "chosen_route": {
+    "model": "gemini-pro",
+    "provider": "gemini"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-001/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-neg-001/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-001/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-001/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-neg-001/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "timeout",
+      "returncode": 1,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-neg-001"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-002/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-neg-002/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-002/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-002/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-neg-002/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "route-collapse",
+      "returncode": 2,
+      "route": {
+        "model": "gpt-4o",
+        "provider": "copilot"
+      },
+      "run_dir": "output/worker-neg-002"
+    },
+    {
+      "attempt_index": 2,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-003/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-neg-003/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-003/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-003/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-neg-003/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "timeout",
+      "returncode": 1,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-neg-003"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/negative_empty_routes.json
+++ b/tests/fixtures/route_efficiency/negative_empty_routes.json
@@ -1,0 +1,8 @@
+{
+  "chosen_route": null,
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": []
+}

--- a/tests/fixtures/route_efficiency/negative_malformed_compact_artifacts.json
+++ b/tests/fixtures/route_efficiency/negative_malformed_compact_artifacts.json
@@ -1,0 +1,77 @@
+{
+  "chosen_route": {
+    "model": "unknown",
+    "provider": "unknown"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": "not-a-dict",
+      "failure_class": "malformed",
+      "returncode": 1,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-neg-006"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": null,
+      "failure_class": "malformed",
+      "returncode": 1,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-neg-007"
+    },
+    {
+      "attempt_index": 2,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-008/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-neg-008/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-neg-008/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-neg-008/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-neg-008/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "pytest passed",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-neg-008"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/negative_partial_artifacts.json
+++ b/tests/fixtures/route_efficiency/negative_partial_artifacts.json
@@ -1,0 +1,97 @@
+{
+  "chosen_route": {
+    "model": "qwen-max",
+    "provider": "qwen"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-004/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-neg-004/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-neg-004/RESULT.md",
+          "present": false,
+          "reason": "truncated",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-004/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-neg-004/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "partial-artifacts",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-neg-004"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-005/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-neg-005/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-005/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-neg-005/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-neg-005/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "2 errors found",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "validation",
+      "returncode": 1,
+      "route": {
+        "model": "gpt-4o",
+        "provider": "copilot"
+      },
+      "run_dir": "output/worker-neg-005"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/negative_reroute_success_not_accepted.json
+++ b/tests/fixtures/route_efficiency/negative_reroute_success_not_accepted.json
@@ -1,0 +1,97 @@
+{
+  "chosen_route": {
+    "model": "qwen-max",
+    "provider": "qwen"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-011/diffstat.txt",
+          "present": false,
+          "reason": "path does not exist",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-neg-011/result.json",
+          "present": false,
+          "reason": "path does not exist",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-011/RESULT.md",
+          "present": false,
+          "reason": "path does not exist",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-011/status.txt",
+          "present": false,
+          "reason": "path does not exist",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-neg-011/validation.json",
+          "present": false,
+          "reason": "path does not exist",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "missing-artifact-paths",
+      "returncode": 1,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-neg-011"
+    },
+    {
+      "attempt_index": 1,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-012/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 44
+        },
+        "result_json": {
+          "path": "output/worker-neg-012/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 384
+        },
+        "result_md": {
+          "path": "output/worker-neg-012/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 180
+        },
+        "status": {
+          "path": "output/worker-neg-012/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 18
+        },
+        "validation": {
+          "path": "output/worker-neg-012/validation.json",
+          "present": true,
+          "reason": null,
+          "result": "51 passed",
+          "size_bytes": 72
+        }
+      },
+      "failure_class": "none",
+      "returncode": 0,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-neg-012"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/negative_single_attempt_all_missing.json
+++ b/tests/fixtures/route_efficiency/negative_single_attempt_all_missing.json
@@ -1,0 +1,54 @@
+{
+  "chosen_route": {
+    "model": "gemini-pro",
+    "provider": "gemini"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-010/diffstat.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_json": {
+          "path": "output/worker-neg-010/result.json",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "result_md": {
+          "path": "output/worker-neg-010/RESULT.md",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "status": {
+          "path": "output/worker-neg-010/status.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        },
+        "validation": {
+          "path": "output/worker-neg-010/validation.txt",
+          "present": false,
+          "reason": "missing",
+          "size_bytes": 0
+        }
+      },
+      "failure_class": "route-collapse",
+      "returncode": 2,
+      "route": {
+        "model": "gemini-pro",
+        "provider": "gemini"
+      },
+      "run_dir": "output/worker-neg-010"
+    }
+  ]
+}

--- a/tests/fixtures/route_efficiency/negative_validation_failure_complete_artifacts.json
+++ b/tests/fixtures/route_efficiency/negative_validation_failure_complete_artifacts.json
@@ -1,0 +1,55 @@
+{
+  "chosen_route": {
+    "model": "qwen-max",
+    "provider": "qwen"
+  },
+  "route_evidence_only": true,
+  "schema": "routed_worker_manifest.v1",
+  "task_class": "workflow/reporting",
+  "warning": "Wrapper success, zero exit, and manifest presence are route evidence only; they are not task acceptance.",
+  "attempted_routes": [
+    {
+      "attempt_index": 0,
+      "compact_artifacts": {
+        "diffstat": {
+          "path": "output/worker-neg-009/diffstat.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 42
+        },
+        "result_json": {
+          "path": "output/worker-neg-009/result.json",
+          "present": true,
+          "reason": null,
+          "size_bytes": 256
+        },
+        "result_md": {
+          "path": "output/worker-neg-009/RESULT.md",
+          "present": true,
+          "reason": null,
+          "size_bytes": 128
+        },
+        "status": {
+          "path": "output/worker-neg-009/status.txt",
+          "present": true,
+          "reason": null,
+          "size_bytes": 16
+        },
+        "validation": {
+          "path": "output/worker-neg-009/validation.txt",
+          "present": true,
+          "reason": null,
+          "result": "3 failed, 12 passed, 15 total",
+          "size_bytes": 64
+        }
+      },
+      "failure_class": "validation",
+      "returncode": 1,
+      "route": {
+        "model": "qwen-max",
+        "provider": "qwen"
+      },
+      "run_dir": "output/worker-neg-009"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add compact negative route-efficiency fixtures for missing artifacts, failed validation, malformed artifact summaries, empty routes, nonexistent artifact paths, reroute recovery, and route success without task acceptance
- add focused tests so artifact presence, validation presence, validation success, reroute evidence, and final acceptance remain distinct

Closes #2817

## Validation
- python3 -m json.tool on each new negative fixture
- uv run ruff check tests/dev/test_route_efficiency_report.py
- uv run pytest tests/dev/test_route_efficiency_report.py -q (52 passed)
- PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh (6296 passed, 9 skipped, 9 warnings)

## Downstream Propagation
- No downstream benchmark/report propagation required; this is local workflow test-fixture hardening.

## Research Result Guidance
- NA: workflow/test fixture hardening only; no benchmark, metric, model, or paper-facing result claim.

## Delegation Notes
- OpenCode Go produced scoped fixture/test edits but streamed broad Ruff output and omitted compact artifacts, so the route was classified uneconomic.
- Command Code hit its turn cap before writing artifacts or completing shell validation, so Codex performed final integration review.