### PR TITLE
docs: add route efficiency review checklist

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -387,6 +387,24 @@ Markdown with overall metrics, per-manifest breakdowns, provider trends,
 incomplete-provider and failure-class totals, common missing artifact counts,
 and the same route-evidence-only recommendations and warning.
 
+### PR Review: Route Efficiency
+
+When reviewing PRs with route-efficiency changes, ensure:
+
+- [ ] **Route completeness vs task success**: Complete artifacts or a zero exit code are
+  not evidence that the task was accepted, correct, or merged.
+- [ ] **Validation presence vs validation success**: Check `validation_presence.present`
+  separately from `validation_presence.success_inferable`; a validation artifact can exist
+  while the validation result failed or stayed ambiguous.
+- [ ] **Reroute count interpretation**: Treat high reroute counts (2 or more) and
+  `reroute_threshold_met` warnings as routing-friction evidence, not as proof that the
+  final diff is wrong.
+- [ ] **Raw-log avoidance**: Start from `scripts/dev/route_efficiency_report.py` outputs and
+  compact worker artifacts; read raw worker logs only when compact evidence is missing,
+  inconsistent, failed, or suspicious.
+- [ ] **Visible evidence warning**: Confirm the report still displays the route-evidence-only
+  warning and does not let route metrics replace manual diff inspection or local validation.
+
 Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a concise PR-review checklist to the route-efficiency section in docs/dev_guide.md
- call out route completeness vs task success, validation presence vs success, reroute interpretation, raw-log avoidance, and the visible route-evidence-only warning

Closes #2818

## Validation
- git diff --check
- verified scripts/dev/route_efficiency_report.py exists
- scripts/dev/check_docs_proof_consistency_diff.sh (passed for 1 changed file)

## Downstream Propagation
- No benchmark/report propagation required; this is docs-only workflow guidance.

## Research Result Guidance
- NA: docs-only workflow guidance; no benchmark, metric, model, or paper-facing result claim.

## Delegation Notes
- Gemini drafted the checklist in docs/dev_guide.md.
- Codex tightened wording to match report fields and evidence boundaries, then validated.