### PR TITLE
benchmark: exclude cyclists from pedestrian forecast metrics

### DIFF
--- a/robot_sf/benchmark/pedestrian_forecast.py
+++ b/robot_sf/benchmark/pedestrian_forecast.py
@@ -10,6 +10,7 @@ from typing import Any
 import numpy as np
 
 DEFAULT_FORECAST_HORIZONS_S = (0.5, 1.0, 2.0)
+PEDESTRIAN_ACTOR_TYPES = frozenset({"pedestrian", "person"})
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,7 @@ class PedestrianState:
     intent: str | None = None
     signal: str | None = None
     signal_available: bool = False
+    actor_type: str = "pedestrian"
 
     @classmethod
     def from_trace(cls, payload: dict[str, Any]) -> PedestrianState:
@@ -55,7 +57,37 @@ class PedestrianState:
             else None,
             signal=signal,
             signal_available=signal_available,
+            actor_type=str(payload.get("actor_type") or "pedestrian"),
         )
+
+
+def is_pedestrian_actor(actor_type: str | None) -> bool:
+    """True when the actor type represents a pedestrian (the default).
+
+    Returns:
+        True for pedestrians, persons, or missing types.
+    """
+    if actor_type is None:
+        return True
+    return _canonical_actor_type(actor_type) in PEDESTRIAN_ACTOR_TYPES
+
+
+def _canonical_actor_type(actor_type: str | None) -> str:
+    """Return the stable actor-type label used by forecast denominator metadata."""
+    if actor_type is None:
+        return "pedestrian"
+    label = str(actor_type).strip().lower()
+    return label or "pedestrian"
+
+
+def actor_type_metric_key(actor_type: str | None) -> str:
+    """Normalize actor-type labels for flat metric keys.
+
+    Returns:
+        Lowercase alphanumeric/underscore key segment.
+    """
+    label = _canonical_actor_type(actor_type)
+    return "".join(ch if ch.isalnum() else "_" for ch in label).strip("_") or "unknown"
 
 
 @dataclass(frozen=True)
@@ -229,53 +261,116 @@ def compute_batch_forecast_metrics(
     """Compute aggregate forecast metrics over benchmark trace steps.
 
     Returns:
-        Mean metrics plus per-metric denominator counts.
+        Mean metrics plus per-metric denominator counts and actor exclusion metadata.
     """
 
     if dt_s <= 0.0:
         raise ValueError("dt_s must be positive")
 
-    sample_metrics: list[dict[str, float]] = []
-    for step_index, step in enumerate(trace_steps):
-        for pedestrian_payload in step.get("pedestrians", []):
-            state = PedestrianState.from_trace(pedestrian_payload)
-            ground_truth = _future_pedestrian_positions(
-                state.id,
-                step_index,
-                trace_steps,
-                horizons_s,
-                dt_s,
-            )
-            if not ground_truth:
-                continue
-            sample_metrics.append(
-                evaluate_forecast(
-                    constant_velocity_gaussian_baseline(state, horizons_s),
-                    ground_truth,
-                    confidence_level=confidence_level,
-                    robot_positions=_future_robot_positions(
-                        step_index,
-                        trace_steps,
-                        horizons_s,
-                        dt_s,
-                    ),
-                    collision_distance_m=collision_distance_m,
-                )
-            )
+    (
+        candidate_count,
+        excluded_count,
+        excluded_by_type,
+        sample_metrics,
+    ) = _collect_sample_metrics(
+        trace_steps,
+        horizons_s,
+        dt_s,
+        confidence_level,
+        collision_distance_m,
+    )
+
+    summary = {
+        "pedestrian_forecast_candidate_count": float(candidate_count),
+        "pedestrian_forecast_included_actor_count": float(candidate_count - excluded_count),
+        "pedestrian_forecast_excluded_actor_count": float(excluded_count),
+    }
+    for actor_type, count in excluded_by_type.items():
+        summary[f"pedestrian_forecast_excluded_{actor_type}_count"] = float(count)
 
     if not sample_metrics:
-        return {"forecast_evaluable_samples": 0.0}
+        summary["forecast_evaluable_samples"] = 0.0
+        return summary
 
     values_by_key: dict[str, list[float]] = defaultdict(list)
     for sample in sample_metrics:
         for key, value in sample.items():
             values_by_key[key].append(float(value))
 
-    summary = {"forecast_evaluable_samples": float(len(sample_metrics))}
+    summary["forecast_evaluable_samples"] = float(len(sample_metrics))
     for key, values in sorted(values_by_key.items()):
         summary[f"mean_{key}"] = float(np.mean(values))
         summary[f"count_{key}"] = float(len(values))
     return summary
+
+
+def _collect_sample_metrics(
+    trace_steps: list[dict[str, Any]],
+    horizons_s: list[float] | tuple[float, ...],
+    dt_s: float,
+    confidence_level: float,
+    collision_distance_m: float,
+) -> tuple[int, int, dict[str, int], list[dict[str, float]]]:
+    candidate_count = 0
+    excluded_count = 0
+    excluded_by_type: dict[str, int] = defaultdict(int)
+    sample_metrics: list[dict[str, float]] = []
+
+    for step_index, step in enumerate(trace_steps):
+        for pedestrian_payload in step.get("pedestrians", []):
+            candidate_count += 1
+            actor_type = pedestrian_payload.get("actor_type")
+            if not is_pedestrian_actor(actor_type):
+                excluded_count += 1
+                excluded_by_type[actor_type_metric_key(actor_type)] += 1
+                continue
+
+            metrics = _evaluate_single_pedestrian(
+                pedestrian_payload,
+                step_index,
+                trace_steps,
+                horizons_s,
+                dt_s,
+                confidence_level,
+                collision_distance_m,
+            )
+            if metrics:
+                sample_metrics.append(metrics)
+
+    return candidate_count, excluded_count, excluded_by_type, sample_metrics
+
+
+def _evaluate_single_pedestrian(
+    pedestrian_payload: dict[str, Any],
+    step_index: int,
+    trace_steps: list[dict[str, Any]],
+    horizons_s: list[float] | tuple[float, ...],
+    dt_s: float,
+    confidence_level: float,
+    collision_distance_m: float,
+) -> dict[str, float] | None:
+    state = PedestrianState.from_trace(pedestrian_payload)
+    ground_truth = _future_pedestrian_positions(
+        state.id,
+        step_index,
+        trace_steps,
+        horizons_s,
+        dt_s,
+    )
+    if not ground_truth:
+        return None
+    return evaluate_forecast(
+        constant_velocity_gaussian_baseline(state, horizons_s),
+        ground_truth,
+        confidence_level=confidence_level,
+        robot_positions=_future_robot_positions(
+            step_index,
+            trace_steps,
+            horizons_s,
+            dt_s,
+        ),
+        collision_distance_m=collision_distance_m,
+    )
 
 
 def _future_pedestrian_positions(

--- a/scripts/benchmark/run_cv_forecast_eval.py
+++ b/scripts/benchmark/run_cv_forecast_eval.py
@@ -27,6 +27,7 @@ import numpy as np
 
 from robot_sf.benchmark.pedestrian_forecast import (
     DEFAULT_FORECAST_HORIZONS_S,
+    actor_type_metric_key,
     compute_batch_forecast_metrics,
 )
 
@@ -153,6 +154,22 @@ def _pedestrian_count(trace: dict[str, Any]) -> int:
     return max_peds
 
 
+def _get_actor_classes(trace: dict[str, Any]) -> list[str]:
+    """Collect all unique actor_type values from pedestrians in the trace."""
+    return sorted(_actor_class_counts(trace))
+
+
+def _actor_class_counts(trace: dict[str, Any]) -> dict[str, int]:
+    """Count trace actors by declared actor_type, defaulting legacy traces to pedestrian."""
+    frames = trace.get("frames") or trace.get("steps") or []
+    counts: dict[str, int] = {}
+    for frame in frames:
+        for ped in frame.get("pedestrians", []):
+            actor_class = actor_type_metric_key(ped.get("actor_type"))
+            counts[actor_class] = counts.get(actor_class, 0) + 1
+    return dict(sorted(counts.items()))
+
+
 def _git_head() -> str:
     """Return the short git HEAD, or '' on failure."""
     try:
@@ -197,6 +214,12 @@ def evaluate_single_trace(
     frames = trace.get("frames") or trace.get("steps") or []
     result["frame_count"] = len(frames)
     result["pedestrians_per_frame"] = _pedestrian_count(trace)
+    result["actor_classes"] = _get_actor_classes(trace)
+    result["actor_class_counts"] = _actor_class_counts(trace)
+    result["pedestrian_forecast_denominator_policy"] = (
+        "Only pedestrian/person actors are scored by pedestrian forecast metrics; "
+        "non-pedestrian actor classes are excluded and counted separately."
+    )
     result["has_motion"] = _trace_has_motion(trace)
 
     if not _trace_has_motion(trace):

--- a/tests/benchmark/test_pedestrian_forecast.py
+++ b/tests/benchmark/test_pedestrian_forecast.py
@@ -185,10 +185,107 @@ def test_compute_batch_forecast_metrics_uses_trace_steps_and_denominators() -> N
     assert summary["count_collision_relevance_error_1s"] == 3.0
 
 
+def test_compute_batch_forecast_metrics_excludes_cyclists() -> None:
+    """Cyclist actors are excluded from scoring but tracked in metadata."""
+
+    dt_s = 0.1
+    trace_steps = [
+        {
+            "step": 0,
+            "time_s": 0.0,
+            "pedestrians": [
+                {"id": 1, "position": [0, 0], "velocity": [1, 0], "actor_type": "pedestrian"},
+                {"id": 2, "position": [0, 1], "velocity": [1, 0], "actor_type": "cyclist_like_vru"},
+            ],
+        },
+        {
+            "step": 1,
+            "time_s": 0.1,
+            "pedestrians": [
+                {"id": 1, "position": [0.1, 0], "velocity": [1, 0], "actor_type": "pedestrian"},
+                {
+                    "id": 2,
+                    "position": [0.1, 1],
+                    "velocity": [1, 0],
+                    "actor_type": "cyclist_like_vru",
+                },
+            ],
+        },
+        {
+            "step": 2,
+            "time_s": 0.2,
+            "pedestrians": [
+                {"id": 1, "position": [0.2, 0], "velocity": [1, 0], "actor_type": "pedestrian"},
+                {
+                    "id": 2,
+                    "position": [0.2, 1],
+                    "velocity": [1, 0],
+                    "actor_type": "cyclist_like_vru",
+                },
+            ],
+        },
+    ]
+
+    summary = compute_batch_forecast_metrics(
+        trace_steps,
+        horizons_s=(0.1,),
+        dt_s=dt_s,
+    )
+
+    # Step 0: ped 1 (evaluable), cyclist 2 (excluded)
+    # Step 1: ped 1 (evaluable), cyclist 2 (excluded)
+    # Step 2: ped 1 (not evaluable - no future), cyclist 2 (excluded)
+    assert summary["pedestrian_forecast_candidate_count"] == 6.0
+    assert summary["pedestrian_forecast_included_actor_count"] == 3.0
+    assert summary["pedestrian_forecast_excluded_actor_count"] == 3.0
+    assert summary["pedestrian_forecast_excluded_cyclist_like_vru_count"] == 3.0
+    assert summary["forecast_evaluable_samples"] == 2.0
+
+
+def test_compute_batch_forecast_metrics_normalizes_excluded_actor_type_keys() -> None:
+    """Excluded actor-type denominator keys stay flat even for display labels."""
+    summary = compute_batch_forecast_metrics(
+        [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "pedestrians": [
+                    {"id": 1, "position": [0, 0], "velocity": [1, 0], "actor_type": "Bicycle/VRU"}
+                ],
+            },
+            {
+                "step": 1,
+                "time_s": 0.1,
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [0.1, 0],
+                        "velocity": [1, 0],
+                        "actor_type": "Bicycle/VRU",
+                    }
+                ],
+            },
+        ],
+        horizons_s=(0.1,),
+        dt_s=0.1,
+    )
+
+    assert summary["pedestrian_forecast_candidate_count"] == 2.0
+    assert summary["pedestrian_forecast_included_actor_count"] == 0.0
+    assert summary["pedestrian_forecast_excluded_actor_count"] == 2.0
+    assert summary["pedestrian_forecast_excluded_bicycle_vru_count"] == 2.0
+    assert summary["forecast_evaluable_samples"] == 0.0
+
+
 def test_batch_metrics_report_empty_and_invalid_dt_cases() -> None:
     """Empty traces have an explicit denominator and invalid dt fails closed."""
 
-    assert compute_batch_forecast_metrics([]) == {"forecast_evaluable_samples": 0.0}
+    assert compute_batch_forecast_metrics([]) == {
+        "forecast_evaluable_samples": 0.0,
+        "pedestrian_forecast_candidate_count": 0.0,
+        "pedestrian_forecast_included_actor_count": 0.0,
+        "pedestrian_forecast_excluded_actor_count": 0.0,
+    }
     with pytest.raises(ValueError, match="dt_s must be positive"):
         compute_batch_forecast_metrics([], dt_s=0.0)
 

--- a/tests/benchmark/test_pedestrian_forecast_cv_eval.py
+++ b/tests/benchmark/test_pedestrian_forecast_cv_eval.py
@@ -25,10 +25,12 @@ _mod = _load_script_module()
 
 MISSING_FAMILIES = _mod.MISSING_FAMILIES
 TRACE_CANDIDATES = _mod.TRACE_CANDIDATES
+_actor_class_counts = _mod._actor_class_counts
 _build_failure_cases = _mod._build_failure_cases
 _compute_dt_s = _mod._compute_dt_s
 _extract_trace_steps = _mod._extract_trace_steps
 _generate_markdown = _mod._generate_markdown
+_get_actor_classes = _mod._get_actor_classes
 _pedestrian_count = _mod._pedestrian_count
 _trace_has_motion = _mod._trace_has_motion
 evaluate_single_trace = _mod.evaluate_single_trace
@@ -138,6 +140,35 @@ def test_pedestrian_count_returns_max() -> None:
         ]
     }
     assert _pedestrian_count(trace) == 3
+
+
+def test_actor_class_counts_default_legacy_pedestrians_and_count_cyclists() -> None:
+    """Trace metadata exposes actor classes for denominator treatment."""
+    trace = {
+        "frames": [
+            {
+                "pedestrians": [
+                    {"id": 1},
+                    {"id": 2, "actor_type": "cyclist_like_vru"},
+                ]
+            },
+            {
+                "pedestrians": [
+                    {"id": 1, "actor_type": "pedestrian"},
+                    {"id": 2, "actor_type": " cyclist_like_vru "},
+                    {"id": 3, "actor_type": "Pedestrian"},
+                    {"id": 4, "actor_type": "Bicycle/VRU"},
+                ]
+            },
+        ]
+    }
+
+    assert _get_actor_classes(trace) == ["bicycle_vru", "cyclist_like_vru", "pedestrian"]
+    assert _actor_class_counts(trace) == {
+        "bicycle_vru": 1,
+        "cyclist_like_vru": 2,
+        "pedestrian": 3,
+    }
 
 
 def test_evaluate_single_trace_missing_file() -> None:


### PR DESCRIPTION
## Summary
Adds an explicit actor-class contract for pedestrian forecast metrics so bicycle/cyclist-like actors are excluded from pedestrian scoring and reported in denominator metadata.

## Linked Issues
- Closes `#2793`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added pedestrian actor filtering and normalized excluded-actor denominator keys in `robot_sf/benchmark/pedestrian_forecast.py`.
- Added per-trace `actor_classes`, `actor_class_counts`, and `pedestrian_forecast_denominator_policy` metadata to the CV forecast eval report path.
- Added tests for mixed pedestrian/cyclist-like traces, arbitrary actor-label normalization, and report actor-class metadata.

## Why It Matters
- Added value: prevents bicycle/cyclist-like actors from silently contaminating pedestrian forecast metrics.
- Expected impact: benchmark/report consumers can see included and excluded denominators before interpreting pedestrian forecast results.
- Why this is worth merging now: it establishes the contract before broader bicycle/dynamic-actor scenarios are promoted.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: pedestrian forecast metrics must not score bicycle actors as pedestrians.
- Comparator or baseline, if applicable: previous CV forecast evaluator treated all `pedestrians[]` trace entries as pedestrian forecast candidates.
- Evidence tier: targeted smoke / contract test.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: mixed pedestrian + cyclist-like fixture must score only pedestrian actors and count cyclist exclusions.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2793.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - updates an existing metric/report path, with representative use via committed tests and smoke command.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; cyclist-like actors are excluded and counted.
- Did the intervention change command source, selected command, trajectory, or route progress? no; metric/report contract only.
- Did the scenario actually contain the targeted failure mode? yes; tests include mixed pedestrian and `cyclist_like_vru` actors in `pedestrians[]`.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none required for this contract-only fix.

## Next Empirical Action
- Rerun needed: no for this contract.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for the targeted contract.
- Stop / revise / continue decision: continue with future bicycle scenarios after this denominator guard lands.
- Proposed child issue or existing follow-up: none opened.

## Validation / Proof
- Commands run:
  - `uv run ruff format robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run ruff check robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run pytest tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py tests/benchmark/test_issue_2526_cyclist_vru_smoke.py -q` -> 31 passed.
  - `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir output/issue_2793_cv_forecast_eval_smoke`
  - `scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 6320 passed, 9 skipped, 9 warnings.
- Evidence that the change works here: targeted tests prove `cyclist_like_vru` and display-style bicycle labels are excluded from pedestrian forecast scoring while denominator metadata records exclusions.
- Benchmarks or smoke tests, if applicable: CV forecast eval smoke generated report JSON with `actor_classes`, `actor_class_counts`, denominator policy, and `pedestrian_forecast_*` metrics.

## Risks / Rollout
- Compatibility risks: legacy traces with no `actor_type` intentionally continue to default to pedestrian.
- Failure modes: future actor labels that should be scored as pedestrian need to be added to `PEDESTRIAN_ACTOR_TYPES`.
- Rollback or fallback plan: revert the metric filtering commit; no schema migration required.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #2793 and existing cyclist-like VRU tests.
- Any assumptions that need to be preserved: `pedestrians[]` remains the trace container name, but actor type now controls forecast denominator treatment.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2793.
- Claim map / benchmark report updated (yes/no/NA): NA; this is a metric contract guard, not a benchmark result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no new benchmark result, durable artifact, or registry surface is introduced.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether `pedestrian` and `person` are the right initial included actor labels.
- Any known limitations: contract-only; does not implement bicycle behavior or claim bicycle benchmark readiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pedestrian forecast benchmark now distinguishes and filters pedestrian actors from other actor types (e.g., cyclists) during evaluation. Non-pedestrian actors are excluded from scoring but tracked.
  * Evaluation results now include actor-type metadata and denominator policy documentation.

* **Tests**
  * Added comprehensive test coverage for actor-type filtering, classification, and exclusion counting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->