### PR TITLE
workflow: warn on repeated weak scenario candidates

### DIFF
--- a/scripts/dev/publication_scout_linter.py
+++ b/scripts/dev/publication_scout_linter.py
@@ -26,10 +26,16 @@ class LinterFinding:
 
     code: str
     detail: str
+    severity: str = "error"
 
     def to_payload(self) -> dict[str, str]:
         """Serialize to a JSON-friendly payload."""
-        return {"code": self.code, "detail": self.detail}
+        return {"code": self.code, "detail": self.detail, "severity": self.severity}
+
+    @property
+    def is_error(self) -> bool:
+        """Return true when this finding should fail readiness."""
+        return self.severity != "warning"
 
 
 def parse_iso_datetime(raw: object) -> datetime | None:
@@ -171,7 +177,77 @@ def validate_candidate(
             )
         )
 
+    findings.extend(check_negative_result_guard(issue))
+
     return findings
+
+
+def check_negative_result_guard(issue: dict[str, Any]) -> list[LinterFinding]:
+    """Advisory check for repeated weak scenarios without rationale."""
+    findings: list[LinterFinding] = []
+    content = _candidate_negative_result_text(issue)
+
+    has_rationale = "why this is different" in content
+
+    # NR-001: Topology reselection/threshold tweaks
+    is_nr001 = "topology" in content and (
+        "reselection" in content
+        or "threshold" in content
+        or any(
+            kw in content
+            for kw in ["bottleneck transfer", "doorway transfer", "t intersection transfer"]
+        )
+    )
+
+    # NR-002: observation-noise diagnostic on a distant pedestrian.
+    is_nr002 = "observation noise" in content and (
+        "distant pedestrian" in content
+        or "classic bottleneck medium" in content
+        or "scenario too weak" in content
+    )
+
+    if (is_nr001 or is_nr002) and not has_rationale:
+        findings.append(
+            LinterFinding(
+                code="repeated_negative_result_without_rationale",
+                detail=(
+                    "candidate resembles a registered weak-scenario repeat (NR-001 or NR-002) "
+                    "but lacks a 'why this is different' rationale in the body or metadata; "
+                    "please clarify why this rerun will produce new benchmark-strength information"
+                ),
+                severity="warning",
+            )
+        )
+
+    return findings
+
+
+def _candidate_negative_result_text(issue: dict[str, Any]) -> str:
+    """Collect candidate text fields relevant to negative-result guard matching.
+
+    Returns:
+        Lowercase text across title, body, labels, and simple metadata values.
+    """
+    parts = []
+    title = issue.get("title")
+    parts.append(str(title) if title is not None else "")
+    body = issue.get("body")
+    parts.append(str(body) if body is not None else "")
+    raw_labels = issue.get("labels")
+    labels = raw_labels if isinstance(raw_labels, list) else []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+            parts.append(str(name) if name is not None else "")
+        elif label is not None:
+            parts.append(str(label))
+    metadata = issue.get("metadata")
+    if isinstance(metadata, dict):
+        for key, value in metadata.items():
+            if isinstance(value, (str, int, float, bool)):
+                parts.append(str(key))
+                parts.append(str(value))
+    return "\n".join(parts).lower().replace("_", " ").replace("-", " ")
 
 
 def classify_comment_publication_result(raw_payload: object) -> dict[str, Any]:
@@ -233,9 +309,11 @@ def _build_report(
     has_recent_comments: bool,
 ) -> dict[str, Any]:
     """Build the machine-readable CLI report."""
+    error_findings = [finding for finding in findings if finding.is_error]
+    warning_findings = [finding for finding in findings if not finding.is_error]
     return {
         "schema": SCHEMA,
-        "ok": not findings,
+        "ok": not error_findings,
         "read_only": True,
         "project_writes": False,
         "expected_repo": expected_repo,
@@ -252,11 +330,12 @@ def _build_report(
         "issue_number": issue.get("number"),
         "issue_url": issue.get("url"),
         "findings": [finding.to_payload() for finding in findings],
+        "warnings": [finding.to_payload() for finding in warning_findings],
         "failure_summary": None
-        if not findings
+        if not error_findings
         else {
-            "count": len(findings),
-            "codes": [finding.code for finding in findings],
+            "count": len(error_findings),
+            "codes": [finding.code for finding in error_findings],
         },
     }
 

--- a/tests/dev/test_publication_scout_linter.py
+++ b/tests/dev/test_publication_scout_linter.py
@@ -103,7 +103,7 @@ def test_main_reports_failures_for_stale_issue(
             "--comments-json",
             str(comments_path),
             "--recent-comment-hours",
-            "24",
+            "999",
         ]
     )
     payload = json.loads(capsys.readouterr().out)
@@ -114,3 +114,139 @@ def test_main_reports_failures_for_stale_issue(
     assert any(
         check["name"] == "issue_state_open" and check["ok"] is False for check in payload["checks"]
     )
+
+
+def test_negative_result_guard_flags_repeat_without_rationale() -> None:
+    """Repeated weak scenarios without a 'why this is different' rationale should be flagged."""
+    issue = {
+        "title": "Rerunning NR-001 topology reselection",
+        "body": "We need to check the doorway_transfer scenario again with same thresholds.",
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+    findings = linter.check_negative_result_guard(issue)
+    assert any(
+        finding.code == "repeated_negative_result_without_rationale"
+        and finding.severity == "warning"
+        for finding in findings
+    )
+
+
+def test_negative_result_guard_allows_repeat_with_rationale() -> None:
+    """Repeated weak scenarios WITH a rationale should not be flagged."""
+    issue = {
+        "title": "Rerunning NR-002 observation-noise",
+        "body": (
+            "Observation-noise distant pedestrian test. Retest with a closer pedestrian and "
+            "higher pedestrian count."
+        ),
+        "metadata": {
+            "why_this_is_different": (
+                "Addresses NR-002 by replacing the distant pedestrian with a near-field "
+                "avoidance requirement."
+            )
+        },
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+    findings = linter.check_negative_result_guard(issue)
+    assert not any(
+        finding.code == "repeated_negative_result_without_rationale" for finding in findings
+    )
+
+
+def test_negative_result_guard_ignores_unrelated_issues() -> None:
+    """Unrelated issues should not trigger the negative result guard."""
+    issue = {
+        "title": "Fix bug in path planner",
+        "body": "The A* implementation has a small bug when handling off-grid goals.",
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+    findings = linter.check_negative_result_guard(issue)
+    assert not findings
+
+
+def test_negative_result_guard_flags_space_separated_observation_noise_repeat() -> None:
+    """Observation noise wording should not need the exact hyphenated form."""
+    issue = {
+        "title": "Observation noise diagnostic for classic_bottleneck_medium",
+        "body": "Repeat the scenario_too_weak distant pedestrian diagnostic.",
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+
+    findings = linter.check_negative_result_guard(issue)
+
+    assert any(finding.code == "repeated_negative_result_without_rationale" for finding in findings)
+
+
+def test_negative_result_guard_ignores_null_optional_text_fields() -> None:
+    """Null optional issue fields should not be coerced into searchable 'None' text."""
+    issue = {
+        "title": None,
+        "body": 0,
+        "labels": [{"name": None}, 0],
+        "metadata": {"why_this_is_different": "0"},
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+
+    findings = linter.check_negative_result_guard(issue)
+
+    assert not findings
+
+
+def test_negative_result_guard_ignores_non_list_labels() -> None:
+    """Malformed scalar label payloads should not abort candidate text extraction."""
+    issue = {
+        "title": "Fix bug in path planner",
+        "body": "No negative-result repeat here.",
+        "labels": 1,
+        "state": "open",
+        "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+    }
+
+    findings = linter.check_negative_result_guard(issue)
+
+    assert not findings
+
+
+def test_main_reports_negative_result_guard_as_warning(tmp_path, capsys) -> None:
+    """Negative-result repeats should warn without failing the read-only linter."""
+    issue_path = tmp_path / "issue.json"
+    comments_path = tmp_path / "comments.json"
+    issue_path.write_text(
+        json.dumps(
+            {
+                "number": 2785,
+                "url": "https://github.com/ll7/robot_sf_ll7/issues/2785",
+                "title": "Observation noise diagnostic for classic_bottleneck_medium",
+                "body": "Repeat the scenario_too_weak distant pedestrian diagnostic.",
+                "state": "open",
+                "repository": {"owner": {"login": "ll7"}, "name": "robot_sf_ll7"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    comments_path.write_text(
+        json.dumps([{"createdAt": "2026-06-12T12:00:00Z"}]),
+        encoding="utf-8",
+    )
+
+    exit_code = linter.main(
+        [
+            "--issue-json",
+            str(issue_path),
+            "--comments-json",
+            str(comments_path),
+            "--recent-comment-hours",
+            "999",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["failure_summary"] is None
+    assert payload["warnings"][0]["code"] == "repeated_negative_result_without_rationale"


### PR DESCRIPTION
## Summary
Adds an advisory negative-result-repeat guard to `publication_scout_linter` so candidates resembling registered weak scenarios warn unless they explain why the new attempt is different.

## Linked Issues
- Closes `#2785`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `repeated_negative_result_without_rationale` warnings for NR-001-style topology reselection/threshold repeats and NR-002-style observation-noise distant-pedestrian repeats.
- Added warning severity support so advisory findings appear in `warnings` without making the linter fail when there are no hard errors.
- Added tests for repeated weak scenarios, metadata/body rationale, space-separated observation-noise wording, unrelated issues, and CLI warning behavior.

## Why It Matters
- Added value: future issue candidates get a cheap warning before repeating known weak scenarios.
- Expected impact: reduces duplicate diagnostic loops while preserving advisory/non-blocking workflow.
- Why this is worth merging now: the negative-result register is only useful if candidate generation consults it.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: negative-result register entries should prevent repeated weak scenario proposals without a new mechanism/rationale.
- Comparator or baseline, if applicable: previous publication-scout linter did not warn on NR-001/NR-002 repeats.
- Evidence tier: targeted workflow smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: weak-scenario repeats warn unless `why this is different` / `why_this_is_different` is present.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2785.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support workflow guard, not a research interpretation tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; tests show NR-001/NR-002-like repeats warn.
- Did the intervention change command source, selected command, trajectory, or route progress? NA; workflow guard only.
- Did the scenario actually contain the targeted failure mode? yes in fixture candidate text for topology repeats and distant-pedestrian observation-noise repeats.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue using the guard in candidate linting.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run ruff format scripts/dev/publication_scout_linter.py tests/dev/test_publication_scout_linter.py`
  - `uv run ruff check scripts/dev/publication_scout_linter.py tests/dev/test_publication_scout_linter.py`
  - `uv run pytest tests/dev/test_publication_scout_linter.py -q` -> 11 passed.
  - `scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 6325 passed, 9 skipped, 9 warnings.
- Evidence that the change works here: tests cover repeated weak scenario warning, valid modified scenario with rationale, and CLI advisory behavior.
- Benchmarks or smoke tests, if applicable: targeted workflow smoke only.

## Risks / Rollout
- Compatibility risks: output payloads now include `severity` and `warnings`; existing `findings[].code` remains present.
- Failure modes: lightweight text matching can miss variants; it is intentionally advisory.
- Rollback or fallback plan: revert the linter/test changes.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: `docs/context/negative_result_register.md` NR-001 and NR-002.
- Any assumptions that need to be preserved: warning is advisory, not a hard blocker.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2785.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: workflow guard only, no new benchmark result or durable artifact.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: warning severity remains non-blocking.
- Any known limitations: current matching intentionally covers only the known NR-001/NR-002 families.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reports now distinguish between error and warning findings, with only errors determining success/failure
  * Added validation check that flags repeated scenario patterns without explanation

* **Tests**
  * Added test coverage for new validation checks and error/warning classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->