### PR TITLE
adversarial: add negative-result scenario candidates

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,10 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2788_negative_result_scenario_candidates/`: diagnostic-only generated scenario candidate
+  manifests derived from negative-result register entries NR-001 and NR-002. The manifests encode
+  clearance-targeted topology variants and a near-field observation-noise successor candidate;
+  all remain `not_promoted` with null severity/diversity metrics and are not benchmark evidence.
 - `issue_2751_topology_reselection_runtime/`: diagnostic-only runtime evidence for the
   clearance-targeted topology-reselection successor. The result is `revise`: all hard slices
   remained `horizon_exhausted`, while the negative-control rows succeeded with zero topology

--- a/docs/context/evidence/issue_2788_negative_result_scenario_candidates/README.md
+++ b/docs/context/evidence/issue_2788_negative_result_scenario_candidates/README.md
@@ -1,0 +1,25 @@
+# Negative Result Scenario Candidates (Issue #2788)
+
+## Purpose
+This directory contains diagnostic-only scenario candidates derived from the `docs/context/negative_result_register.md`. These candidates encode trace-seeded starting points for future adversarial research, grounded in known failed or diagnostic-only results.
+
+## Candidates
+- `candidate_nr001_doorway.json`: Derived from NR-001 (issue-2716), targeting `doorway_transfer`.
+- `candidate_nr001_t_intersection.json`: Derived from NR-001 (issue-2716), targeting `t_intersection_transfer`.
+- `candidate_nr002_observation.json`: Derived from NR-002 (issue-2749), targeting a near-field `classic_bottleneck_medium` pedestrian-route mutation for future observation-noise stress.
+
+## Scope: Diagnostic Only
+All candidates in this directory are `not_promoted`. They do NOT constitute benchmark-strength evidence, paper-facing results, or safety claims. They are used for:
+1. Encoding trace-level failure modes for generator testing.
+2. Providing candidate mutations for heuristic perturbation design.
+3. Validating the `generated_scenario_candidate.v1` schema on real-world negative results.
+
+## Validation
+To validate these candidates against the schema:
+```bash
+uv run python scripts/validation/validate_generated_scenario_candidate.py \
+  docs/context/evidence/issue_2788_negative_result_scenario_candidates/*.json
+```
+
+## Promotion Path
+Promotion to `promoted` status requires passing all gates defined in `docs/context/issue_2725_generator_readiness.md`.

--- a/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr001_doorway.json
+++ b/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr001_doorway.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "generated_scenario_candidate.v1",
+  "candidate_id": "issue-2788-nr001-doorway-transfer-scout",
+  "generator_family": "heuristic_perturbation",
+  "generator_run_id": "issue-2788-nr001-topology-trace-scout",
+  "generator_config_ref": {
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9"
+  },
+  "source_scenario_ref": {
+    "scenario_name": "doorway_transfer/classic_doorway_medium",
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9",
+    "map_id": "classic_doorway_medium"
+  },
+  "source_split": "train",
+  "perturbations": [
+    {
+      "family": "robot_route_offset",
+      "parameters": {
+        "dx_m": 0.15,
+        "dy_m": 0.1,
+        "max_magnitude_m": 0.5
+      },
+      "rationale": "Trace-seeded diagnostic from negative-result register NR-001: the doorway_transfer hard slice ended horizon_exhausted under progress-gated topology reselection. This bounded route offset addresses the prior failure mode by creating a clearance-targeted topology variant rather than repeating the failed threshold sweep."
+    }
+  ],
+  "validity": {
+    "preflight_passed": true,
+    "scenario_certified": false,
+    "map_exists": true,
+    "spawn_collision_free": true,
+    "goal_reachable": true,
+    "rejection_reasons": [
+      "scenario_certified is false; this candidate is derived from negative-result register NR-001 and has not run scenario certification."
+    ]
+  },
+  "metrics_summary": {
+    "severity": {
+      "ttc_min_s": null,
+      "min_clearance_m": null,
+      "comfort_force_max_N": null,
+      "near_miss_count": null,
+      "collision_count": null,
+      "timeout_risk": null,
+      "objective_value": null
+    },
+    "diversity": {
+      "param_distance_min_m": null,
+      "param_distance_mean_m": null,
+      "unique_scenario_families": null,
+      "coverage_fraction": null,
+      "dedup_rate": null
+    }
+  },
+  "trace_lineage": {
+    "seed": 2788,
+    "generated_at_utc": "2026-06-14T10:00:00Z",
+    "git_hash": "d0e394d17f7b17f8cfaef7b36258cf22a9010ec9",
+    "provenance": {
+      "source_issue": "#2788"
+    }
+  },
+  "promotion_status": "not_promoted",
+  "notes": "Scout diagnostic candidate for issue #2788 derived from NR-001 (issue-2716-topology-reselection-cross-slice). Addresses the prior mechanism_failed result with a clearance-targeted doorway_transfer mutation. Diagnostic-only, not_promoted; severity and diversity metrics are null because this manifest has not run certification, replay, or benchmark evaluation."
+}

--- a/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr001_t_intersection.json
+++ b/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr001_t_intersection.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "generated_scenario_candidate.v1",
+  "candidate_id": "issue-2788-nr001-t-intersection-transfer-scout",
+  "generator_family": "heuristic_perturbation",
+  "generator_run_id": "issue-2788-nr001-topology-trace-scout",
+  "generator_config_ref": {
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9"
+  },
+  "source_scenario_ref": {
+    "scenario_name": "t_intersection_transfer/classic_t_intersection_medium",
+    "config_path": "configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml",
+    "config_hash": "591f7642a370597084b439acdd39f402d1f3a301000c29a144ccf7ebd82e30f9",
+    "map_id": "classic_t_intersection_medium"
+  },
+  "source_split": "train",
+  "perturbations": [
+    {
+      "family": "robot_route_offset",
+      "parameters": {
+        "dx_m": -0.1,
+        "dy_m": 0.2,
+        "max_magnitude_m": 0.5
+      },
+      "rationale": "Trace-seeded diagnostic from negative-result register NR-001: the t_intersection_transfer hard slice ended horizon_exhausted under progress-gated topology reselection. This bounded route offset addresses the prior failure mode by probing terminal clearance pressure at the intersection rather than repeating the failed threshold sweep."
+    }
+  ],
+  "validity": {
+    "preflight_passed": true,
+    "scenario_certified": false,
+    "map_exists": true,
+    "spawn_collision_free": true,
+    "goal_reachable": true,
+    "rejection_reasons": [
+      "scenario_certified is false; this candidate is derived from negative-result register NR-001 and has not run scenario certification."
+    ]
+  },
+  "metrics_summary": {
+    "severity": {
+      "ttc_min_s": null,
+      "min_clearance_m": null,
+      "comfort_force_max_N": null,
+      "near_miss_count": null,
+      "collision_count": null,
+      "timeout_risk": null,
+      "objective_value": null
+    },
+    "diversity": {
+      "param_distance_min_m": null,
+      "param_distance_mean_m": null,
+      "unique_scenario_families": null,
+      "coverage_fraction": null,
+      "dedup_rate": null
+    }
+  },
+  "trace_lineage": {
+    "seed": 2788,
+    "generated_at_utc": "2026-06-14T10:00:00Z",
+    "git_hash": "d0e394d17f7b17f8cfaef7b36258cf22a9010ec9",
+    "provenance": {
+      "source_issue": "#2788"
+    }
+  },
+  "promotion_status": "not_promoted",
+  "notes": "Scout diagnostic candidate for issue #2788 derived from NR-001 (issue-2716-topology-reselection-cross-slice). Addresses the prior mechanism_failed result with a clearance-targeted t_intersection_transfer mutation. Diagnostic-only, not_promoted; severity and diversity metrics are null because this manifest has not run certification, replay, or benchmark evaluation."
+}

--- a/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr002_observation.json
+++ b/docs/context/evidence/issue_2788_negative_result_scenario_candidates/candidate_nr002_observation.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "generated_scenario_candidate.v1",
+  "candidate_id": "issue-2788-nr002-observation-noise-scout",
+  "generator_family": "heuristic_perturbation",
+  "generator_run_id": "issue-2788-nr002-obs-noise-scout",
+  "generator_config_ref": {
+    "config_path": "configs/scenarios/archetypes/classic_bottleneck.yaml",
+    "config_hash": "69770b7c852687e81b5f9400352cd16df77a0e1f5a79993d63172ca0042a8f13"
+  },
+  "source_scenario_ref": {
+    "scenario_name": "classic_bottleneck_medium",
+    "config_path": "configs/scenarios/archetypes/classic_bottleneck.yaml",
+    "config_hash": "69770b7c852687e81b5f9400352cd16df77a0e1f5a79993d63172ca0042a8f13",
+    "map_id": "classic_bottleneck_medium"
+  },
+  "source_split": "train",
+  "perturbations": [
+    {
+      "family": "pedestrian_route_offset",
+      "parameters": {
+        "dx_m": -0.35,
+        "dy_m": 0.0,
+        "max_magnitude_m": 0.5
+      },
+      "rationale": "Trace-seeded diagnostic from negative-result register NR-002: classic_bottleneck_medium with observation noise showed identical metrics because the pedestrian was too far from the robot. This near-field pedestrian route offset addresses the scenario_too_weak failure mode by moving the candidate toward a closer interaction before any future observation-noise rerun."
+    }
+  ],
+  "validity": {
+    "preflight_passed": true,
+    "scenario_certified": false,
+    "map_exists": true,
+    "spawn_collision_free": true,
+    "goal_reachable": true,
+    "rejection_reasons": [
+      "scenario_certified is false; this candidate is derived from negative-result register NR-002 and has not run scenario certification, replay, or observation-noise evaluation."
+    ]
+  },
+  "metrics_summary": {
+    "severity": {
+      "ttc_min_s": null,
+      "min_clearance_m": null,
+      "comfort_force_max_N": null,
+      "near_miss_count": null,
+      "collision_count": null,
+      "timeout_risk": null,
+      "objective_value": null
+    },
+    "diversity": {
+      "param_distance_min_m": null,
+      "param_distance_mean_m": null,
+      "unique_scenario_families": null,
+      "coverage_fraction": null,
+      "dedup_rate": null
+    }
+  },
+  "trace_lineage": {
+    "seed": 2788,
+    "generated_at_utc": "2026-06-14T10:00:00Z",
+    "git_hash": "d0e394d17f7b17f8cfaef7b36258cf22a9010ec9",
+    "provenance": {
+      "source_issue": "#2788"
+    }
+  },
+  "promotion_status": "not_promoted",
+  "notes": "Scout diagnostic candidate for issue #2788 derived from NR-002 (issue-2749-observation-noise-distant-pedestrian). Addresses the prior scenario_too_weak result with a near-field pedestrian_route_offset mutation rather than repeating the distant-pedestrian slice. Diagnostic-only, not_promoted; severity and diversity metrics are null because this manifest has not run certification, replay, or benchmark evaluation."
+}

--- a/tests/docs/test_issue_2788_candidates.py
+++ b/tests/docs/test_issue_2788_candidates.py
@@ -1,0 +1,142 @@
+"""Validation tests for the issue #2788 negative-result candidate directory."""
+
+# ruff: noqa: D102
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+EVIDENCE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "context"
+    / "evidence"
+    / "issue_2788_negative_result_scenario_candidates"
+)
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "generated_scenario_candidate.v1.json"
+)
+SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+BLOCKED_PROMOTION_WORDS = {"promote", "benchmark evidence", "paper evidence", "results tier"}
+EXPECTED_CANDIDATE_COUNT = 3
+EXPECTED_NEGATIVE_RESULT_IDS = {"nr-001", "nr-002"}
+EXPECTED_SEVERITY_KEYS = {
+    "collision_count",
+    "comfort_force_max_N",
+    "min_clearance_m",
+    "near_miss_count",
+    "objective_value",
+    "timeout_risk",
+    "ttc_min_s",
+}
+EXPECTED_DIVERSITY_KEYS = {
+    "coverage_fraction",
+    "dedup_rate",
+    "param_distance_mean_m",
+    "param_distance_min_m",
+    "unique_scenario_families",
+}
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def get_candidates() -> list[Path]:
+    """Retrieve all JSON candidate files from the evidence directory."""
+    return sorted(EVIDENCE_DIR.glob("*.json"))
+
+
+def _load_candidate(candidate_path: Path) -> dict[str, Any]:
+    return json.loads(candidate_path.read_text(encoding="utf-8"))
+
+
+def _candidate_text(candidate: dict[str, Any]) -> str:
+    perturbations = candidate["perturbations"]
+    rationale = " ".join(pert.get("rationale", "") for pert in perturbations)
+    return " ".join(
+        [
+            candidate["candidate_id"],
+            candidate["generator_run_id"],
+            candidate["source_scenario_ref"]["scenario_name"],
+            rationale,
+            candidate.get("notes", ""),
+        ]
+    ).lower()
+
+
+def test_candidate_count_matches_issue_contract() -> None:
+    """Issue #2788 requires at least three candidate manifests."""
+    assert len(get_candidates()) >= EXPECTED_CANDIDATE_COUNT
+
+
+@pytest.mark.parametrize("candidate_path", get_candidates(), ids=lambda p: p.name)
+class TestIssue2788Candidates:
+    """Validate all candidates in the issue #2788 directory."""
+
+    def test_candidate_validates_against_schema(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        jsonschema.validate(instance=candidate, schema=SCHEMA)
+
+    def test_promotion_status_not_promoted(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        assert candidate["promotion_status"] == "not_promoted"
+
+    def test_scenario_not_certified(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        assert candidate["validity"]["scenario_certified"] is False
+
+    def test_trace_lineage_has_source_issue(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        assert candidate["trace_lineage"]["provenance"]["source_issue"] == "#2788"
+
+    def test_notes_declares_scout_scope(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        notes = candidate.get("notes", "").lower()
+        assert "scout" in notes
+        assert "not_promoted" in notes
+
+    def test_no_claim_overreach(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        notes = candidate.get("notes", "").lower()
+        notes_safe = notes.replace("not_promoted", "")
+        for word in BLOCKED_PROMOTION_WORDS:
+            assert word not in notes_safe, f"Notes must not contain promotion word '{word}'"
+
+    def test_grounded_in_negative_result_register(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        haystack = _candidate_text(candidate).replace("-", "")
+        normalized_ids = {
+            negative_id.replace("-", "") for negative_id in EXPECTED_NEGATIVE_RESULT_IDS
+        }
+        assert any(negative_id in haystack for negative_id in normalized_ids)
+
+    def test_config_paths_exist_and_hashes_are_not_placeholders(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        for ref in (candidate["generator_config_ref"], candidate["source_scenario_ref"]):
+            config_path = Path(ref["config_path"])
+            assert (Path(__file__).resolve().parents[2] / config_path).exists()
+            assert SHA256_RE.fullmatch(ref["config_hash"])
+
+    def test_candidate_states_how_it_addresses_failure_mode(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        haystack = _candidate_text(candidate)
+        assert "addresses the prior" in haystack
+        assert "rather than repeating" in haystack
+
+    def test_severity_and_diversity_are_unevaluated(self, candidate_path: Path) -> None:
+        candidate = _load_candidate(candidate_path)
+        severity = candidate["metrics_summary"]["severity"]
+        diversity = candidate["metrics_summary"]["diversity"]
+        assert set(severity) == EXPECTED_SEVERITY_KEYS
+        assert set(diversity) == EXPECTED_DIVERSITY_KEYS
+        assert severity == dict.fromkeys(EXPECTED_SEVERITY_KEYS)
+        assert diversity == dict.fromkeys(EXPECTED_DIVERSITY_KEYS)


### PR DESCRIPTION
## Summary
- Adds three generated_scenario_candidate.v1 manifests derived from negative-result register entries NR-001 and NR-002.
- Records clearance-targeted topology successor candidates and a near-field observation-noise successor candidate.
- Adds tests that enforce schema validity, negative-result lineage, real config paths/hashes, not_promoted status, null severity/diversity metrics, and no benchmark-claim overreach.

## Validation
- rtk uv run python scripts/validation/validate_generated_scenario_candidate.py docs/context/evidence/issue_2788_negative_result_scenario_candidates/*.json
- rtk uv run pytest tests/docs/test_issue_2788_candidates.py tests/docs/test_generated_scenario_candidate_register.py tests/benchmark/test_generated_scenario_candidate_schema.py tests/docs/test_negative_result_register.py -q
- rtk uv run ruff check tests/docs/test_issue_2788_candidates.py tests/docs/test_generated_scenario_candidate_register.py tests/benchmark/test_generated_scenario_candidate_schema.py tests/docs/test_negative_result_register.py
- rtk git diff --check
- PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh -> 6358 passed, 9 skipped, 9 warnings

## Research Result Guidance
Target claim/hypothesis/blocker: negative-result register entries should seed scenario-candidate manifests instead of repeated weak reruns.
Comparator/baseline: NR-001 and NR-002 failure modes in docs/context/negative_result_register.md.
Evidence tier: smoke/diagnostic manifest evidence only.
Result classification: diagnostic-only, not benchmark evidence.
Decision/stop rule: candidates remain not_promoted until generator-readiness gates, scenario certification, severity/diversity evaluation, replay, and leakage checks pass.
Synthesis surface/update target: docs/context/evidence/README.md and docs/context/evidence/issue_2788_negative_result_scenario_candidates/.

## Downstream Propagation
- Parent issue: closes #2788.
- Claim map / benchmark report / leaderboard: not updated; no benchmark result is promoted.
- Registry/config index: evidence bundle is listed in docs/context/evidence/README.md.
- Context/memory: no broader memory update needed; this is a bounded diagnostic packet.

Closes #2788