### PR TITLE
workflow: feed worker manifests into PR-loop policy

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -381,6 +381,18 @@ recommendations" section. Route success and complete artifact presence are
 **route evidence only**; they are not task acceptance. The orchestrator must
 still inspect the diff and run the required local validation.
 
+PR-loop dry-run policy can consume the same routed-worker manifests directly:
+
+```bash
+uv run python scripts/dev/pr_loop_policy.py --snapshot output/pr_queue.json \
+  --manifest 1234=output/issue-2764/worker/routing_manifest.json --json
+```
+
+Manifest-driven decisions remain dry-run and mutation-free. Complete artifacts can unblock
+`ready_to_merge` classification only when the compact PR snapshot is otherwise ready; missing
+artifacts, failed validation text, stale expected heads, risky manifest paths, and draft PRs stay
+reroute/stop signals instead of task acceptance.
+
 For historical route audits, add `--dashboard` and pass multiple routed-worker
 manifest files. Dashboard mode emits `route_efficiency_dashboard.v1` JSON or
 Markdown with overall metrics, per-manifest breakdowns, provider trends,

--- a/scripts/dev/pr_loop_policy.py
+++ b/scripts/dev/pr_loop_policy.py
@@ -22,7 +22,14 @@ import argparse
 import json
 import sys
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any
+
+from scripts.dev.route_efficiency_report import (
+    EXPECTED_ARTIFACT_KEYS,
+    has_validation_success,
+    is_complete_artifact_set,
+)
 
 DEFAULT_MAX_ACTIONS = 5
 
@@ -47,6 +54,7 @@ VALID_STATES = frozenset(
     {
         "pending_ci",
         "failed_ci",
+        "failed_validation",
         "missing_artifacts",
         "stale_worktree",
         "ready_to_merge",
@@ -71,13 +79,76 @@ class PolicyDecision:
         return asdict(self)
 
 
-def classify_pr_state(pr: dict[str, Any]) -> str:
+def _extract_manifest_compact_artifacts(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return compact artifact records from a routed-worker manifest."""
+    compact = manifest.get("compact_artifacts")
+    if isinstance(compact, dict):
+        return compact
+    attempts = manifest.get("attempted_routes")
+    if not isinstance(attempts, list):
+        return {}
+    for attempt in attempts:
+        if not isinstance(attempt, dict):
+            continue
+        if attempt.get("run_dir") == manifest.get("chosen_run_dir"):
+            compact = attempt.get("compact_artifacts")
+            return compact if isinstance(compact, dict) else {}
+    return {}
+
+
+def _compact_artifacts_present(compact_artifacts: dict[str, Any] | None) -> bool | None:
+    """Return compact artifact completeness, or None when no manifest was supplied."""
+    if compact_artifacts is None:
+        return None
+    return is_complete_artifact_set(compact_artifacts)
+
+
+def _validation_failed(compact_artifacts: dict[str, Any] | None) -> bool:
+    """Return True when the validation artifact is present and not successful."""
+    if compact_artifacts is None:
+        return False
+    return has_validation_success(compact_artifacts) is not True
+
+
+def _artifact_state(
+    artifacts: Any,
+    *,
+    compact_artifacts: dict[str, Any] | None,
+) -> str | None:
+    """Return a PR-loop state derived from artifact evidence, if any."""
+    compact_present = _compact_artifacts_present(compact_artifacts)
+    if compact_present is False:
+        return "missing_artifacts"
+    if _validation_failed(compact_artifacts):
+        return "failed_validation"
+    if artifacts is not None and not artifacts:
+        return "missing_artifacts"
+    return None
+
+
+def _compact_artifacts_from_pr(
+    pr: dict[str, Any],
+    compact_artifacts: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return explicit compact artifacts or compact artifacts embedded in a PR dict."""
+    if compact_artifacts is not None:
+        return compact_artifacts
+    compact_raw = pr.get("compact_artifacts")
+    return compact_raw if isinstance(compact_raw, dict) else None
+
+
+def classify_pr_state(
+    pr: dict[str, Any],
+    *,
+    compact_artifacts: dict[str, Any] | None = None,
+) -> str:
     """Classify a single PR into a machine-checkable loop state.
 
     Pure function: no side effects, no GitHub calls.
     """
     if not isinstance(pr, dict):
         return "no_action"
+    compact_artifacts = _compact_artifacts_from_pr(pr, compact_artifacts)
     status = str(pr.get("status", ""))
     if status == "error":
         return "no_action"
@@ -100,8 +171,9 @@ def classify_pr_state(pr: dict[str, Any]) -> str:
         return "pending_ci"
     if expected and head_sha and head_sha != expected:
         return "stale_worktree"
-    if artifacts is not None and not artifacts:
-        return "missing_artifacts"
+    artifact_state = _artifact_state(artifacts, compact_artifacts=compact_artifacts)
+    if artifact_state is not None:
+        return artifact_state
     if "merge-ready" in label_names and overall == "success":
         return "ready_to_merge"
     return "no_action"
@@ -145,7 +217,7 @@ def _compute_flow_decision(
       - CHANGES_REQUESTED -> escalate (review blocker overrides other routing)
       - pending_ci -> continue
       - ready_to_merge -> continue
-      - failed_ci, missing_artifacts, stale_worktree -> reroute
+      - failed_ci, failed_validation, missing_artifacts, stale_worktree -> reroute
       - no_action -> stop
     """
     if budget_exhausted:
@@ -155,7 +227,7 @@ def _compute_flow_decision(
     match state:
         case "pending_ci" | "ready_to_merge":
             return "continue"
-        case "failed_ci" | "missing_artifacts" | "stale_worktree":
+        case "failed_ci" | "failed_validation" | "missing_artifacts" | "stale_worktree":
             return "reroute"
         case _:
             return "stop"
@@ -218,6 +290,15 @@ def recommend_action(
                 reason="CI checks failed; inspect failures before retry",
                 actions_remaining=remaining,
             )
+        case "failed_validation":
+            return PolicyDecision(
+                pr=pr_number,
+                action="verify_artifacts",
+                state=state,
+                flow_decision=flow_decision,
+                reason="validation artifact present but reports failure",
+                actions_remaining=remaining,
+            )
         case "missing_artifacts":
             return PolicyDecision(
                 pr=pr_number,
@@ -270,6 +351,7 @@ def evaluate_queue(
     max_actions: int = DEFAULT_MAX_ACTIONS,
     expected_head_shas: dict[int, str] | None = None,
     artifact_presence: dict[int, bool] | None = None,
+    compact_artifacts: dict[int, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Evaluate a PR queue and emit per-PR decisions under a loop budget.
 
@@ -279,6 +361,7 @@ def evaluate_queue(
     actions_used = 0
     expected_shas = expected_head_shas or {}
     artifacts = artifact_presence or {}
+    compact_by_pr = compact_artifacts or {}
     for pr in prs:
         num = _pr_number(pr)
         enriched: dict[str, Any] = dict(pr)
@@ -286,7 +369,10 @@ def evaluate_queue(
             enriched["expected_head_sha"] = expected_shas[num]
         if num in artifacts:
             enriched["artifacts"] = artifacts[num]
-        state = classify_pr_state(enriched)
+        compact = compact_by_pr.get(num)
+        if compact is not None:
+            enriched["compact_artifacts"] = compact
+        state = classify_pr_state(enriched, compact_artifacts=compact)
         review = _review_state(enriched)
         labels = enriched.get("labels") or []
         label_names = [str(label) for label in labels] if isinstance(labels, list) else []
@@ -368,6 +454,12 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         metavar="PR=true|false",
         help="Artifact presence as PR=true|false pairs.",
     )
+    parser.add_argument(
+        "--manifest",
+        nargs="*",
+        metavar="PR=PATH",
+        help="Routed-worker manifest paths as PR=PATH pairs; overrides --artifact-present.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser.parse_args(argv)
 
@@ -390,6 +482,105 @@ def _parse_pairs(pairs: list[str] | None, *, as_bool: bool = False) -> dict[int,
         else:
             result[key] = value
     return result
+
+
+def _resolve_manifest_path(path_str: str, *, target_repo: Path) -> Path:
+    """Resolve a manifest path inside the target repository."""
+    path = Path(path_str)
+    unresolved = path if path.is_absolute() else target_repo / path
+    if unresolved.is_symlink():
+        raise ValueError("manifest path must not be a symlink")
+    resolved = unresolved.resolve(strict=False)
+    if not resolved.is_relative_to(target_repo.resolve()):
+        raise ValueError("manifest path must resolve inside target repository")
+    return resolved
+
+
+def _read_compact_artifact_text(
+    artifact_path: str,
+    *,
+    target_repo: Path,
+    max_chars: int = 4000,
+) -> str | None:
+    """Read a compact artifact text file from inside the target repository."""
+    try:
+        resolved = _resolve_manifest_path(artifact_path, target_repo=target_repo)
+    except ValueError:
+        return None
+    if not resolved.is_file():
+        return None
+    try:
+        return resolved.read_text(encoding="utf-8", errors="replace")[:max_chars]
+    except OSError:
+        return None
+
+
+def _hydrate_validation_result(
+    compact: dict[str, Any],
+    *,
+    target_repo: Path,
+) -> dict[str, Any]:
+    """Populate validation.result from the compact validation artifact file when absent."""
+    validation = compact.get("validation")
+    if not isinstance(validation, dict) or isinstance(validation.get("result"), str):
+        return compact
+    path = validation.get("path")
+    if not isinstance(path, str):
+        return compact
+    result = _read_compact_artifact_text(path, target_repo=target_repo)
+    if result is None:
+        return compact
+    hydrated = dict(compact)
+    hydrated["validation"] = {**validation, "result": result}
+    return hydrated
+
+
+def load_manifest_artifacts(
+    manifest_pairs: list[str] | None,
+    *,
+    target_repo: str | Path = ".",
+) -> tuple[dict[int, bool], dict[int, dict[str, Any]], list[str]]:
+    """Load routed-worker manifest pairs into PR artifact policy inputs."""
+    artifact_presence: dict[int, bool] = {}
+    compact_artifacts: dict[int, dict[str, Any]] = {}
+    warnings: list[str] = []
+    repo_root = Path(target_repo).resolve()
+    if not manifest_pairs:
+        return artifact_presence, compact_artifacts, warnings
+
+    for pair in manifest_pairs:
+        if "=" not in pair:
+            warnings.append(f"ignored malformed manifest pair: {pair}")
+            continue
+        key_str, _, path_str = pair.partition("=")
+        try:
+            pr_number = int(key_str)
+        except ValueError:
+            warnings.append(f"ignored manifest pair with non-integer PR: {pair}")
+            continue
+        try:
+            manifest_path = _resolve_manifest_path(path_str, target_repo=repo_root)
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            warnings.append(f"ignored manifest for PR {pr_number}: {exc}")
+            continue
+        if not isinstance(manifest, dict):
+            warnings.append(f"ignored manifest for PR {pr_number}: JSON root is not an object")
+            continue
+        compact = _hydrate_validation_result(
+            _extract_manifest_compact_artifacts(manifest),
+            target_repo=repo_root,
+        )
+        compact_artifacts[pr_number] = compact
+        artifact_presence[pr_number] = is_complete_artifact_set(compact)
+        missing = sorted(
+            key
+            for key in EXPECTED_ARTIFACT_KEYS
+            if not isinstance(compact.get(key), dict) or compact[key].get("present") is not True
+        )
+        if missing:
+            warnings.append(f"manifest for PR {pr_number} missing artifacts: {', '.join(missing)}")
+    return artifact_presence, compact_artifacts, warnings
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -424,11 +615,19 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     expected_shas = _parse_pairs(args.expected_sha)
     artifact_presence = _parse_pairs(args.artifact_present, as_bool=True)
+    manifest_presence, compact_artifacts, manifest_warnings = load_manifest_artifacts(
+        args.manifest,
+        target_repo=Path.cwd(),
+    )
+    artifact_presence.update(manifest_presence)
+    for warning in manifest_warnings:
+        print(warning, file=sys.stderr)
     result = evaluate_queue(
         prs,
         max_actions=args.max_actions,
         expected_head_shas=expected_shas,
         artifact_presence=artifact_presence,
+        compact_artifacts=compact_artifacts,
     )
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/dev/route_efficiency_report.py
+++ b/scripts/dev/route_efficiency_report.py
@@ -29,6 +29,7 @@ ROUTE_EVIDENCE_WARNING = (
 _EXPECTED_ARTIFACT_KEYS = frozenset(
     {"result_json", "result_md", "diffstat", "status", "validation"}
 )
+EXPECTED_ARTIFACT_KEYS = _EXPECTED_ARTIFACT_KEYS
 
 
 def _is_complete_artifact_set(compact: dict[str, Any]) -> bool:
@@ -39,6 +40,11 @@ def _is_complete_artifact_set(compact: dict[str, Any]) -> bool:
         isinstance(compact.get(k), dict) and compact[k].get("present") is True
         for k in _EXPECTED_ARTIFACT_KEYS
     )
+
+
+def is_complete_artifact_set(compact: dict[str, Any]) -> bool:
+    """Public wrapper for routed-worker artifact completeness checks."""
+    return _is_complete_artifact_set(compact)
 
 
 def _has_validation_success(compact: dict[str, Any]) -> bool | None:
@@ -61,6 +67,11 @@ def _has_validation_success(compact: dict[str, Any]) -> bool | None:
         if re.search(r"\b(?:pass|passed|success|successful|succeeded|ok)\b", neutralized):
             return True
     return None
+
+
+def has_validation_success(compact: dict[str, Any]) -> bool | None:
+    """Public wrapper for routed-worker validation-result parsing."""
+    return _has_validation_success(compact)
 
 
 def _provider_name(route: Any) -> str:

--- a/tests/dev/test_pr_loop_policy.py
+++ b/tests/dev/test_pr_loop_policy.py
@@ -15,6 +15,7 @@ from scripts.dev.pr_loop_policy import (
     classify_pr_state,
     evaluate_queue,
     format_text,
+    load_manifest_artifacts,
     main,
     recommend_action,
 )
@@ -58,6 +59,53 @@ def _pr(
 def _snapshot(prs: list[dict[str, object]]) -> dict[str, object]:
     """Build a snapshot dict wrapping multiple PRs."""
     return {"schema": "pr_queue_snapshot.v1", "prs": prs}
+
+
+def _compact_artifacts(*, validation_result: str = "passed") -> dict[str, object]:
+    """Build a complete routed-worker compact artifact map."""
+    return {
+        "result_json": {"present": True, "path": "result.json", "size_bytes": 2},
+        "result_md": {"present": True, "path": "RESULT.md", "size_bytes": 2},
+        "diffstat": {"present": True, "path": "diffstat.txt", "size_bytes": 2},
+        "status": {"present": True, "path": "status.txt", "size_bytes": 2},
+        "validation": {
+            "present": True,
+            "path": "validation.txt",
+            "size_bytes": 2,
+            "result": validation_result,
+        },
+    }
+
+
+def _write_manifest(
+    tmp_path: Path,
+    *,
+    compact: dict[str, object] | None = None,
+    name: str = "routing_manifest.json",
+) -> Path:
+    """Write a minimal routed-worker manifest fixture."""
+    path = tmp_path / name
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "routed_worker_manifest.v1",
+                "route_evidence_only": True,
+                "chosen_run_dir": "output/worker",
+                "compact_artifacts": compact if compact is not None else _compact_artifacts(),
+                "attempted_routes": [
+                    {
+                        "attempt_index": 0,
+                        "run_dir": "output/worker",
+                        "compact_artifacts": compact
+                        if compact is not None
+                        else _compact_artifacts(),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +179,64 @@ def test_classify_artifacts_true_not_missing() -> None:
     assert classify_pr_state(pr) == "no_action"
 
 
+def test_classify_complete_manifest_success_ready_to_merge() -> None:
+    """Complete manifest artifacts allow an otherwise ready PR to continue."""
+    pr = _pr(110, overall="success", labels=["merge-ready"])
+    state = classify_pr_state(pr, compact_artifacts=_compact_artifacts())
+    assert state == "ready_to_merge"
+
+
+def test_classify_manifest_missing_validation_artifact() -> None:
+    """Missing validation artifact should classify as missing_artifacts."""
+    compact = _compact_artifacts()
+    compact.pop("validation")
+    pr = _pr(111, overall="success", labels=["merge-ready"])
+    assert classify_pr_state(pr, compact_artifacts=compact) == "missing_artifacts"
+
+
+def test_classify_manifest_failed_validation() -> None:
+    """Failed validation artifact should classify as failed_validation."""
+    pr = _pr(112, overall="success", labels=["merge-ready"])
+    assert (
+        classify_pr_state(
+            pr,
+            compact_artifacts=_compact_artifacts(validation_result="2 errors found"),
+        )
+        == "failed_validation"
+    )
+
+
+def test_classify_manifest_ambiguous_validation() -> None:
+    """Ambiguous validation artifact should fail closed."""
+    pr = _pr(115, overall="success", labels=["merge-ready"])
+    assert (
+        classify_pr_state(
+            pr,
+            compact_artifacts=_compact_artifacts(validation_result="unknown status"),
+        )
+        == "failed_validation"
+    )
+
+
+def test_classify_reads_enriched_compact_artifacts() -> None:
+    """Enriched PR dict compact artifacts should be honored."""
+    pr = _pr(116, overall="success", labels=["merge-ready"])
+    pr["compact_artifacts"] = _compact_artifacts(validation_result="unknown status")
+    assert classify_pr_state(pr) == "failed_validation"
+
+
+def test_classify_manifest_stale_head_takes_priority() -> None:
+    """Stale head should still reroute before manifest artifact checks."""
+    pr = _pr(113, head_sha="new", expected_head_sha="old", labels=["merge-ready"])
+    assert classify_pr_state(pr, compact_artifacts=_compact_artifacts()) == "stale_worktree"
+
+
+def test_classify_manifest_draft_no_action() -> None:
+    """Draft PRs ignore otherwise complete manifest artifacts."""
+    pr = _pr(114, overall="success", labels=["merge-ready"], draft=True)
+    assert classify_pr_state(pr, compact_artifacts=_compact_artifacts()) == "no_action"
+
+
 # ---------------------------------------------------------------------------
 # recommend_action
 # ---------------------------------------------------------------------------
@@ -153,6 +259,13 @@ def test_recommend_verify_for_missing_artifacts() -> None:
     """Missing artifacts should recommend verify_artifacts."""
     decision = recommend_action("missing_artifacts", pr_number=202, actions_remaining=3)
     assert decision.action == "verify_artifacts"
+
+
+def test_recommend_verify_for_failed_validation() -> None:
+    """Failed validation artifact should recommend artifact verification."""
+    decision = recommend_action("failed_validation", pr_number=208, actions_remaining=3)
+    assert decision.action == "verify_artifacts"
+    assert decision.flow_decision == "reroute"
 
 
 def test_recommend_refresh_for_stale() -> None:
@@ -251,6 +364,19 @@ def test_evaluate_queue_artifact_presence_injection() -> None:
     )
     # Artifact check overrides ready_to_merge when artifacts are missing
     assert result["decisions"][0]["state"] == "missing_artifacts"
+
+
+def test_evaluate_queue_manifest_failed_validation() -> None:
+    """Compact manifest artifacts should drive failed-validation decisions."""
+    prs = [_pr(701, overall="success", labels=["merge-ready"])]
+    result = evaluate_queue(
+        prs,
+        max_actions=3,
+        compact_artifacts={701: _compact_artifacts(validation_result="FAILED")},
+    )
+    decision = result["decisions"][0]
+    assert decision["state"] == "failed_validation"
+    assert decision["flow_decision"] == "reroute"
 
 
 def test_evaluate_queue_mixed_states() -> None:
@@ -425,6 +551,51 @@ def test_main_artifact_present_pairs(capsys: pytest.CaptureFixture[str], tmp_pat
     assert output["decisions"][0]["state"] == "missing_artifacts"
 
 
+def test_main_manifest_pair_overrides_artifact_present(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CLI --manifest should override a conflicting --artifact-present pair."""
+    monkeypatch.chdir(tmp_path)
+    snapshot = _snapshot([_pr(1501, overall="success", labels=["merge-ready"])])
+    snap_file = tmp_path / "queue.json"
+    snap_file.write_text(json.dumps(snapshot), encoding="utf-8")
+    manifest = _write_manifest(tmp_path)
+
+    rc = main(
+        [
+            "--snapshot",
+            str(snap_file),
+            "--artifact-present",
+            "1501=false",
+            "--manifest",
+            f"1501={manifest}",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["decisions"][0]["state"] == "ready_to_merge"
+
+
+def test_load_manifest_artifacts_rejects_symlink(tmp_path: Path) -> None:
+    """Symlink manifest paths should warn and provide no artifact signal."""
+    manifest = _write_manifest(tmp_path)
+    symlink = tmp_path / "manifest-link.json"
+    symlink.symlink_to(manifest)
+
+    artifact_presence, compact, warnings = load_manifest_artifacts(
+        [f"1502={symlink}"],
+        target_repo=tmp_path,
+    )
+
+    assert artifact_presence == {}
+    assert compact == {}
+    assert warnings
+
+
 def test_main_cli_dry_run_no_gh(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     """CLI dry-run should never call gh, even with a realistic snapshot."""
     snapshot = _snapshot(
@@ -541,6 +712,12 @@ def test_flow_decision_failed_ci_reroutes() -> None:
 def test_flow_decision_missing_artifacts_reroutes() -> None:
     """Missing artifacts should yield reroute."""
     decision = recommend_action("missing_artifacts", pr_number=9104, actions_remaining=3)
+    assert decision.flow_decision == "reroute"
+
+
+def test_flow_decision_failed_validation_reroutes() -> None:
+    """Failed validation should yield reroute."""
+    decision = recommend_action("failed_validation", pr_number=9111, actions_remaining=3)
     assert decision.flow_decision == "reroute"
 
 


### PR DESCRIPTION
## Summary
Connects PR-loop dry-run policy to routed-worker artifact manifests so loops can classify complete artifacts, missing artifacts, failed validation, stale heads, risky manifest paths, and no-action states without reading raw logs.

## Linked Issues
- Closes `#2763`
- Relates to `#2764`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `--manifest PR=PATH` support to `scripts/dev/pr_loop_policy.py`.
- Added compact routed-worker manifest loading with path safety checks, artifact completeness, and failed-validation classification.
- Added fixture-driven policy tests for success, missing validation artifact, failed validation, stale head, risky symlink manifest path, draft/no-action, CLI override, and no GitHub mutation dry-run behavior.
- Documented manifest-driven PR-loop usage in `docs/dev_guide.md`.

## Why It Matters
- Added value: autonomous loops can reroute/stop from compact worker artifacts instead of raw logs.
- Expected impact: fewer parent-thread log reads and clearer route failure classification.
- Why this is worth merging now: recent delegated runs repeatedly failed artifact contracts; this gives the PR loop a machine-checkable policy input for that exact failure mode.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support, not a research claim.
- Comparator or baseline, if applicable: existing `--artifact-present` boolean policy path.
- Evidence tier: targeted smoke / workflow fixture validation.
- Result classification: blocker-resolution for workflow routing.
- Decision or stop rule, if applicable: missing artifacts, failed validation, stale heads, risky paths, and draft PRs must not be treated as task acceptance.
- Parent issue, claim map, registry, context note, or synthesis surface to update: closes #2763; docs updated in `docs/dev_guide.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; no research evidence interpretation.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, fixture manifest drove PR-loop decisions.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? yes, tests include missing validation artifact, failed validation, stale head, risky symlink path, and draft PR.
- Result route: continue for workflow; route evidence remains separate from task acceptance.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for this workflow PR.
- Stop / revise / continue decision: continue using manifest-driven dry-run policy.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/dev/test_pr_loop_policy.py -q`
  - `rtk uv run ruff check scripts/dev/pr_loop_policy.py tests/dev/test_pr_loop_policy.py`
  - `rtk uv run ruff format --check scripts/dev/pr_loop_policy.py tests/dev/test_pr_loop_policy.py`
  - `rtk uv run python scripts/dev/routed_worker_manifest.py --attempts-json output/issue2763_attempts.json --chosen-index 0 --target-repo . --task-class fixture`
  - `rtk uv run python scripts/dev/pr_loop_policy.py --snapshot output/issue2763_pr_snapshot.json --manifest 1234=output/issue2763_worker/routing_manifest.json --json`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main rtk scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests passed with 72 tests; dry-run fixture emitted `mark_ready_candidate`; final readiness passed with 6396 passed, 9 skipped, 8 warnings.
- Benchmarks or smoke tests, if applicable: NA, workflow-only.

## Risks / Rollout
- Compatibility risks: low; existing `--artifact-present` remains supported and manifests override it only for matching PRs.
- Failure modes: malformed or unsafe manifest paths are ignored with stderr warnings, leaving the PR without manifest enrichment.
- Rollback or fallback plan: revert this PR and use the prior boolean `--artifact-present` path.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`.
- Relevant design or provenance notes: private Command Code design artifact under agent-run artifacts; PR text records validation.
- Any assumptions that need to be preserved: complete worker artifacts are route evidence only, not task acceptance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes #2763.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: workflow-only; docs were updated at the relevant usage surface.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Check that manifest-derived route success remains separate from task acceptance.
- The dry-run fixture outputs were removed before final readiness because generated `output/` manifests can intentionally affect route-efficiency source availability tests.
