### PR TITLE
fix: harden CI watcher agent flags

### DIFF
--- a/scripts/dev/watch_pr_ci_status.py
+++ b/scripts/dev/watch_pr_ci_status.py
@@ -51,6 +51,7 @@ class WatchResult:
     baseline_seconds: int
     multiplier: float
     budget_seconds: int
+    budget_overridden: bool
     poll_interval_seconds: int
     final_status: str
     checks: dict[str, Any]
@@ -180,12 +181,13 @@ def _build_drift_sample(
     )
 
 
-def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectable dependencies.
+def watch_pr_ci_status(  # noqa: PLR0913, C901 - CLI/test seam with explicit injectable dependencies.
     *,
     pr_number: str,
     expected_head_sha: str = "",
     baseline_seconds: int = DEFAULT_BASELINE_SECONDS,
     multiplier: float = DEFAULT_MULTIPLIER,
+    budget_override_seconds: int | None = None,
     poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
     workflow: str = DEFAULT_WORKFLOW,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
@@ -198,7 +200,10 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
     progress_stream: Any = sys.stderr,
 ) -> WatchResult:
     """Poll PR CI status until success, failure, stale head, or budget timeout."""
-    budget_seconds = wait_budget_seconds(baseline_seconds, multiplier)
+    if budget_override_seconds is not None:
+        budget_seconds = max(budget_override_seconds, 0)
+    else:
+        budget_seconds = wait_budget_seconds(baseline_seconds, multiplier)
     deadline = monotonic() + budget_seconds
     last_status: dict[str, Any] = {}
     last_progress_at = 0.0
@@ -216,6 +221,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status="error",
                 checks={},
@@ -231,6 +237,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status="error",
                 checks=last_status.get("checks", {}),
@@ -245,6 +252,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status="error",
                 checks=last_status.get("checks", {}),
@@ -262,6 +270,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status=str(overall),
                 checks=checks,
@@ -276,6 +285,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status=str(overall or "pending"),
                 checks=checks,
@@ -319,6 +329,7 @@ def watch_pr_ci_status(  # noqa: PLR0913 - CLI/test seam with explicit injectabl
                 baseline_seconds=baseline_seconds,
                 multiplier=multiplier,
                 budget_seconds=budget_seconds,
+                budget_overridden=budget_override_seconds is not None,
                 poll_interval_seconds=poll_interval_seconds,
                 final_status="timeout",
                 checks=checks,
@@ -333,11 +344,14 @@ def format_human(result: WatchResult) -> str:
     lines = [
         f"PR #{result.pr} CI watch: {result.final_status}",
         (f"  head: {result.head_sha}  |  expected: {result.expected_head_sha or 'not set'}"),
-        (
+    ]
+    if result.budget_overridden:
+        lines.append(f"  budget: {result.budget_seconds}s (direct override)")
+    else:
+        lines.append(
             f"  budget: {result.budget_seconds}s "
             f"(baseline {result.baseline_seconds}s * {result.multiplier:g})"
-        ),
-    ]
+        )
     if result.checks:
         lines.append(f"  checks: {result.checks.get('overall', 'unknown')}")
     if result.error:
@@ -352,8 +366,21 @@ def format_human(result: WatchResult) -> str:
     return "\n".join(lines)
 
 
+EXAMPLE = """\
+long-poll with SHA guard (agents should always pass --expected-head-sha):
+
+  uv run python scripts/dev/watch_pr_ci_status.py 123 --json \\
+      --expected-head-sha $(gh pr view 123 --json headRefOid -q .headRefOid) \\
+      --poll-interval 90 --budget-seconds 900
+"""
+
+
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=EXAMPLE,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("pr_number", help="GitHub PR number to monitor.")
     parser.add_argument("--expected-head-sha", default="", help="Optional PR head SHA guard.")
     parser.add_argument(
@@ -368,8 +395,19 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--multiplier", type=float, default=DEFAULT_MULTIPLIER)
     parser.add_argument(
         "--poll-interval-seconds",
+        "--poll-interval",
         type=int,
         default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help="Seconds between CI status polls.",
+    )
+    parser.add_argument(
+        "--budget-seconds",
+        type=int,
+        default=None,
+        help=(
+            "Override the computed wait budget (baseline * multiplier) with a fixed "
+            "second count.  Use this when agents must not inherit drift-tuned budgets."
+        ),
     )
     parser.add_argument("--sample-limit", type=int, default=DEFAULT_SAMPLE_LIMIT)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -396,6 +434,7 @@ def main(argv: list[str] | None = None) -> int:
             expected_head_sha=args.expected_head_sha,
             baseline_seconds=args.baseline_seconds,
             multiplier=args.multiplier,
+            budget_override_seconds=args.budget_seconds,
             poll_interval_seconds=args.poll_interval_seconds,
             workflow=args.workflow,
             sample_limit=args.sample_limit,

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -325,16 +325,13 @@ def test_main_poll_interval_alias_cli_flag(capsys: pytest.CaptureFixture[str]) -
 
 def test_help_includes_expected_head_sha_example(capsys: pytest.CaptureFixture[str]) -> None:
     """--help should contain the SHA-guarded long-poll example."""
-    import subprocess as _sp
+    from scripts.dev.watch_pr_ci_status import _parse_args
 
-    result = _sp.run(
-        ["python", "-m", "scripts.dev.watch_pr_ci_status", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
-    assert "--expected-head-sha" in result.stdout
-    assert "uv run python scripts/dev/watch_pr_ci_status.py" in result.stdout
-    assert "--json" in result.stdout
-    assert "long-poll" in result.stdout.lower() or "long poll" in result.stdout.lower()
+    with pytest.raises(SystemExit):
+        _parse_args(["--help"])
+
+    captured = capsys.readouterr()
+    assert "--expected-head-sha" in captured.out
+    assert "uv run python scripts/dev/watch_pr_ci_status.py" in captured.out
+    assert "--json" in captured.out
+    assert "long-poll" in captured.out.lower() or "long poll" in captured.out.lower()

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -243,3 +243,98 @@ def test_main_valueerror_on_invalid_args(capsys: pytest.CaptureFixture[str]) -> 
     captured = capsys.readouterr()
     assert "ERROR" in captured.err
     assert "multiplier" in captured.err
+
+
+def test_poll_interval_alias_sets_same_dest() -> None:
+    """--poll-interval should write to poll_interval_seconds like --poll-interval-seconds."""
+    from scripts.dev.watch_pr_ci_status import _parse_args
+
+    args_alias = _parse_args(["42", "--poll-interval", "45"])
+    args_long = _parse_args(["42", "--poll-interval-seconds", "45"])
+    assert args_alias.poll_interval_seconds == 45
+    assert args_long.poll_interval_seconds == 45
+    assert args_alias.poll_interval_seconds == args_long.poll_interval_seconds
+
+
+def test_budget_seconds_override_sets_budget_overridden() -> None:
+    """--budget-seconds should bypass the baseline*multiplier computation."""
+    result = watch_pr_ci_status(
+        pr_number="42",
+        budget_override_seconds=300,
+        baseline_seconds=920,
+        multiplier=1.3,
+        fetch_status=MagicMock(return_value=_status("success")),
+        fetch_durations=MagicMock(return_value=[1000]),
+    )
+    assert result.budget_seconds == 300
+    assert result.budget_overridden is True
+    assert result.baseline_seconds == 920
+    assert result.multiplier == 1.3
+
+
+def test_budget_seconds_zero_causes_immediate_timeout() -> None:
+    """--budget-seconds 0 should exhaust budget on first poll and return timeout."""
+    result = watch_pr_ci_status(
+        pr_number="42",
+        budget_override_seconds=0,
+        baseline_seconds=920,
+        multiplier=1.3,
+        fetch_status=MagicMock(return_value=_status("pending")),
+        fetch_durations=MagicMock(return_value=[800]),
+    )
+    assert result.final_status == "timeout"
+    assert result.budget_seconds == 0
+    assert result.budget_overridden is True
+
+
+def test_budget_overridden_false_by_default() -> None:
+    """When --budget-seconds is not set, budget_overridden should be False."""
+    result = watch_pr_ci_status(
+        pr_number="42",
+        baseline_seconds=920,
+        multiplier=1.3,
+        fetch_status=MagicMock(return_value=_status("success")),
+        fetch_durations=MagicMock(return_value=[1000]),
+    )
+    assert result.budget_overridden is False
+    assert result.budget_seconds == 1196
+
+
+def test_main_budget_seconds_cli_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI --budget-seconds should pass through to watch result."""
+    with patch("scripts.dev.watch_pr_ci_status._fetch_ci_status") as fetch_status:
+        fetch_status.return_value = _status("success")
+        rc = main(["42", "--budget-seconds", "500", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["budget_seconds"] == 500
+    assert payload["budget_overridden"] is True
+
+
+def test_main_poll_interval_alias_cli_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI --poll-interval should be accepted alongside --poll-interval-seconds."""
+    with patch("scripts.dev.watch_pr_ci_status._fetch_ci_status") as fetch_status:
+        fetch_status.return_value = _status("success")
+        rc = main(["42", "--poll-interval", "90", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["poll_interval_seconds"] == 90
+
+
+def test_help_includes_expected_head_sha_example(capsys: pytest.CaptureFixture[str]) -> None:
+    """--help should contain the SHA-guarded long-poll example."""
+    import subprocess as _sp
+
+    result = _sp.run(
+        ["python", "-m", "scripts.dev.watch_pr_ci_status", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert "--expected-head-sha" in result.stdout
+    assert "uv run python scripts/dev/watch_pr_ci_status.py" in result.stdout
+    assert "--json" in result.stdout
+    assert "long-poll" in result.stdout.lower() or "long poll" in result.stdout.lower()


### PR DESCRIPTION
## Summary
Makes the compact CI watcher accept the agent-friendly flags that were previously retried, and adds a SHA-guarded long-poll example to --help.

## Linked Issues
- Closes #2815

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added --poll-interval as an alias for --poll-interval-seconds.
- Added --budget-seconds as a native wait-budget override and exposes budget_overridden in JSON/human output.
- Added a copy-pasteable --help example using uv run, --json, --expected-head-sha, --poll-interval, and --budget-seconds.
- Added focused CLI/parser/help tests.

## Why It Matters
- Added value: avoids avoidable flag-retry turns during token-sensitive CI waits.
- Expected impact: agents can use the compact watcher command from the issue body without retrying.
- Why this is worth merging now: it directly improves autonomous PR/CI monitoring reliability.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper; no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_watch_pr_ci_status.py -q
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/watch_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/watch_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py
  - git diff --check
  - PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh
- Evidence that the change works here: focused watcher tests passed; full readiness passed with 6405 passed, 9 skipped, 10 warnings on ec07dd729f37a3905c17713de91601dc5660670b.
- Benchmarks or smoke tests, if applicable: NA - workflow CLI helper.

## Risks / Rollout
- Compatibility risks: low; new flags are additive aliases/options.
- Failure modes: --budget-seconds overrides drift-tuned budgets, so callers can choose too small a budget.
- Rollback or fallback plan: remove the alias/override and keep existing --poll-interval-seconds behavior.

## Docs / Provenance
- Updated docs: --help epilog in scripts/dev/watch_pr_ci_status.py.
- Relevant design or provenance notes: issue #2815 documents the failed command shape.
- Any assumptions that need to be preserved: --budget-seconds is a direct watcher budget, not a shell timeout wrapper.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR and closing link.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support workflow helper only; no benchmark or research evidence produced.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the --help example command is intentionally uv-run based for normal worktrees.
- Any known limitations: negative --budget-seconds values currently clamp to zero through the watcher budget path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PR CI status watch tool with explicit budget override capability via new `--budget-seconds` parameter.
  * Renamed poll interval CLI flag from `--poll-interval-seconds` to `--poll-interval`.
  * Improved help text with usage examples.
  * Expanded test coverage for argument parsing and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->