### PR TITLE
test: cover focused test coverage cleanup

### DIFF
--- a/tests/dev/test_run_focused_tests_cleanup.py
+++ b/tests/dev/test_run_focused_tests_cleanup.py
@@ -1,0 +1,74 @@
+"""Contract test for scripts/dev/run_focused_tests.sh coverage cleanup."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "dev" / "run_focused_tests.sh"
+
+
+@pytest.fixture()
+def helper_repo(tmp_path: Path) -> Path:
+    """Return a tiny git repo with the focused-test helper and a fake uv binary."""
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts" / "dev"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(SCRIPT, scripts_dir / "run_focused_tests.sh")
+    shutil.copy2(REPO_ROOT / "scripts" / "dev" / "common_setup.sh", scripts_dir / "common_setup.sh")
+    (repo / "bin").mkdir()
+    (repo / "bin" / "uv").write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "mkdir -p output/coverage",
+                "printf fake > output/coverage/generated.txt",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo / "bin" / "uv").chmod(0o755)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    return repo
+
+
+def _run_focused(repo: Path, *, keep_coverage: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run the focused-test helper in *repo* and return the result."""
+    env = {**os.environ, "PATH": f"{repo / 'bin'}{os.pathsep}{os.environ['PATH']}"}
+    if keep_coverage:
+        env["FOCUSED_TEST_KEEP_COVERAGE"] = "1"
+    return subprocess.run(
+        ["scripts/dev/run_focused_tests.sh", "tests/dev/test_tiny.py", "-q"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_focused_tests_removes_coverage_on_success(helper_repo: Path) -> None:
+    """A successful focused run should delete output/coverage."""
+    result = _run_focused(helper_repo)
+
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    assert not (helper_repo / "output" / "coverage").exists(), (
+        "output/coverage should be removed after a successful focused run"
+    )
+
+
+def test_focused_tests_preserves_coverage_when_keep_flag_set(helper_repo: Path) -> None:
+    """FOCUSED_TEST_KEEP_COVERAGE=1 should leave output/coverage intact."""
+    result = _run_focused(helper_repo, keep_coverage=True)
+
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    assert (helper_repo / "output" / "coverage").exists(), (
+        "output/coverage should be preserved when FOCUSED_TEST_KEEP_COVERAGE=1"
+    )

--- a/tests/dev/test_run_focused_tests_cleanup.py
+++ b/tests/dev/test_run_focused_tests_cleanup.py
@@ -43,6 +43,8 @@ def _run_focused(repo: Path, *, keep_coverage: bool = False) -> subprocess.Compl
     env = {**os.environ, "PATH": f"{repo / 'bin'}{os.pathsep}{os.environ['PATH']}"}
     if keep_coverage:
         env["FOCUSED_TEST_KEEP_COVERAGE"] = "1"
+    else:
+        env.pop("FOCUSED_TEST_KEEP_COVERAGE", None)
     return subprocess.run(
         ["scripts/dev/run_focused_tests.sh", "tests/dev/test_tiny.py", "-q"],
         cwd=repo,


### PR DESCRIPTION
## Summary
Adds a focused contract test for scripts/dev/run_focused_tests.sh so the helper's coverage-cleanup behavior cannot silently regress.

## Linked Issues
- Closes #2816

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added tests that run the focused-test helper inside a throwaway git repo with a fake uv binary.
- Verified default mode removes output/coverage after a successful focused run.
- Verified FOCUSED_TEST_KEEP_COVERAGE=1 preserves output/coverage.

## Why It Matters
- Added value: preserves the existing compact cleanup helper as an enforced workflow contract.
- Expected impact: agents can use the helper before final status checks without rediscovering cleanup behavior.
- Why this is worth merging now: directly reduces token-wasting dirty-tree/status retries.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support test only.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper contract test.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_run_focused_tests_cleanup.py -q
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/dev/test_run_focused_tests_cleanup.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/dev/test_run_focused_tests_cleanup.py
  - git diff --check
  - PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh
- Evidence that the change works here: focused contract tests passed; full readiness passed with 6407 passed, 9 skipped, 9 warnings on e2d033b07b0a86ff7e7236716a3662dfdc34786d.
- Benchmarks or smoke tests, if applicable: NA - workflow support test.

## Risks / Rollout
- Compatibility risks: low; test-only change.
- Failure modes: if common_setup.sh gains broader side effects, this test may need a narrower fixture.
- Rollback or fallback plan: remove the new test; helper behavior remains unchanged.

## Docs / Provenance
- Updated docs: none; existing docs/dev_guide.md already documents the helper.
- Relevant design or provenance notes: issue #2816 documents the workflow friction.
- Any assumptions that need to be preserved: the helper cleans coverage only after successful focused runs unless FOCUSED_TEST_KEEP_COVERAGE=1.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR and closing link.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support workflow contract test only; no benchmark or research evidence produced.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the test uses a throwaway git repo and fake uv so it never removes the outer pytest-cov output directory.
- Any known limitations: negative-path cleanup on failing pytest is intentionally not covered because the helper only removes coverage after success.