### PR TITLE
fix: support direct CI watcher invocation

### DIFF
--- a/scripts/dev/watch_pr_ci_status.py
+++ b/scripts/dev/watch_pr_ci_status.py
@@ -16,12 +16,17 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-from scripts.dev.check_pr_ci_status import _fetch_ci_status
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.dev.check_pr_ci_status import _fetch_ci_status  # noqa: E402
 
 DEFAULT_BASELINE_SECONDS = 920
 DEFAULT_MULTIPLIER = 1.3

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -335,3 +337,52 @@ def test_help_includes_expected_head_sha_example(capsys: pytest.CaptureFixture[s
     assert "uv run python scripts/dev/watch_pr_ci_status.py" in captured.out
     assert "--json" in captured.out
     assert "long-poll" in captured.out.lower() or "long poll" in captured.out.lower()
+
+
+def test_repo_root_on_sys_path() -> None:
+    """The script should insert the repo root into sys.path before importing check_pr_ci_status."""
+    from pathlib import Path
+
+    from scripts.dev.watch_pr_ci_status import _REPO_ROOT
+
+    repo_root = str(Path(__file__).resolve().parent.parent.parent)
+    assert _REPO_ROOT == repo_root
+    assert _REPO_ROOT in sys.path
+
+
+def test_direct_invocation_help_succeeds() -> None:
+    """python scripts/dev/watch_pr_ci_status.py --help should succeed without PYTHONPATH."""
+    import subprocess
+    import sys as _sys
+
+    script = str(
+        Path(__file__).resolve().parent.parent.parent / "scripts" / "dev" / "watch_pr_ci_status.py"
+    )
+    result = subprocess.run(
+        [_sys.executable, script, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "--expected-head-sha" in result.stdout
+
+
+def test_direct_invocation_import_without_pythonpath() -> None:
+    """The module should be importable when the repo root is not explicitly on PYTHONPATH."""
+    import importlib
+    import sys as _sys
+
+    repo_root = str(Path(__file__).resolve().parent.parent.parent)
+    paths_to_remove = [p for p in _sys.path if p == repo_root]
+    for p in paths_to_remove:
+        _sys.path.remove(p)
+    try:
+        mod = importlib.import_module("scripts.dev.watch_pr_ci_status")
+        assert hasattr(mod, "_REPO_ROOT")
+        assert mod._REPO_ROOT == repo_root
+    finally:
+        for p in paths_to_remove:
+            if p not in _sys.path:
+                _sys.path.insert(0, p)

--- a/tests/dev/test_watch_pr_ci_status.py
+++ b/tests/dev/test_watch_pr_ci_status.py
@@ -352,18 +352,22 @@ def test_repo_root_on_sys_path() -> None:
 
 def test_direct_invocation_help_succeeds() -> None:
     """python scripts/dev/watch_pr_ci_status.py --help should succeed without PYTHONPATH."""
+    import os
     import subprocess
     import sys as _sys
 
     script = str(
         Path(__file__).resolve().parent.parent.parent / "scripts" / "dev" / "watch_pr_ci_status.py"
     )
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
     result = subprocess.run(
         [_sys.executable, script, "--help"],
         capture_output=True,
         text=True,
         timeout=15,
         check=False,
+        env=env,
     )
     assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
     assert "--expected-head-sha" in result.stdout
@@ -378,11 +382,18 @@ def test_direct_invocation_import_without_pythonpath() -> None:
     paths_to_remove = [p for p in _sys.path if p == repo_root]
     for p in paths_to_remove:
         _sys.path.remove(p)
+
+    saved_modules = {}
+    for name in ("scripts.dev.watch_pr_ci_status", "scripts.dev.check_pr_ci_status"):
+        if name in _sys.modules:
+            saved_modules[name] = _sys.modules.pop(name)
+
     try:
         mod = importlib.import_module("scripts.dev.watch_pr_ci_status")
         assert hasattr(mod, "_REPO_ROOT")
         assert mod._REPO_ROOT == repo_root
     finally:
+        _sys.modules.update(saved_modules)
         for p in paths_to_remove:
             if p not in _sys.path:
                 _sys.path.insert(0, p)


### PR DESCRIPTION
## Summary
Makes the compact CI watcher work when invoked directly from a worktree with `python scripts/dev/watch_pr_ci_status.py ...`, avoiding the PYTHONPATH/uv-run retry that triggered #2771.

## Linked Issues
- Closes #2771

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Adds a minimal repo-root `sys.path` shim before the watcher imports `scripts.dev.check_pr_ci_status`.
- Adds focused tests for repo-root path setup and direct `--help` invocation outside uv-run.

## Why It Matters
- Added value: removes a predictable retry during token-sensitive CI monitoring.
- Expected impact: agents can use the documented watcher command directly from a worktree.
- Why this is worth merging now: it tightens the CI-monitoring workflow that recent PR loops rely on.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `python scripts/dev/watch_pr_ci_status.py --help`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_watch_pr_ci_status.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/watch_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/watch_pr_ci_status.py tests/dev/test_watch_pr_ci_status.py`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: direct invocation no longer fails import; focused watcher tests passed with 24 tests; full readiness passed with 6410 passed, 9 skipped, 9 warnings on `d37f7c1eff10f92ff5e6080ca0d8e0e1019dc619`.
- Benchmarks or smoke tests, if applicable: NA - workflow CLI helper.

## Risks / Rollout
- Compatibility risks: low; the shim is local to the watcher entrypoint and idempotent.
- Failure modes: future scripts may need a shared helper if this pattern repeats elsewhere.
- Rollback or fallback plan: remove the shim/tests and require uv-run/PYTHONPATH invocation again.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #2771 documents the failed direct invocation.
- Any assumptions that need to be preserved: expected-head-SHA and JSON watcher behavior are unchanged.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR and closing link.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support workflow helper only; no benchmark or research evidence produced.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the direct invocation test uses the current Python executable and the script path, not uv-run.
- Any known limitations: this is a watcher-local shim, not a repo-wide `scripts/dev` import bootstrap.
