### PR TITLE
docs: route cheap read-only work to Spark sidecars

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -455,6 +455,31 @@ one of:
 A phase is not complete until the cleanup checkpoint passes for every delegate used
 in that phase.
 
+### Spark Sidecar Routing
+
+Spark (`gpt-5.3-codex-spark`, or the configured Spark sidecar model) is a first-class route for
+small, low-risk read-only task classes during the autopilot cycle. Route Spark when the task fits
+one of:
+
+- **tiny lookup** — file location, name resolution, short grep.
+- **read-only review** — narrow diff inspection, single-file summary.
+- **docs cross-check** — link validation, path reference checks.
+- **issue/file surface mapping** — issue-to-file coverage, surface enumeration.
+- **inspect small command output** — bounded stdout/stderr review.
+
+Spark prompts must require compact output: files inspected, exact evidence, uncertainty, and
+recommended next prompt.
+
+Do not route Spark to:
+
+- final benchmark interpretation and paper claims,
+- merge readiness and publication decisions,
+- GitHub mutation (labels, comments, PR creation, merge, close),
+- long CI polling unless a bounded monitor helper exists,
+- shell-executable fallback unless a real headless wrapper is available.
+
+This is routing guidance only; do not configure Spark as a shell-executable fallback.
+
 ## Delegation Failure Recovery
 
 Each delegate skill may fail. Handle failures per phase:

--- a/.agents/skills/tests/routing_cases.yaml
+++ b/.agents/skills/tests/routing_cases.yaml
@@ -91,3 +91,19 @@ cases:
   - gh-pr-merger
   - goal-pr-review
   - goal-issue-discovery
+- intent: Locate a file by name or content
+  primary: skill-picker
+  secondary:
+  - context-map
+- intent: Summarize a single file or narrow diff
+  primary: review-and-refactor
+  secondary:
+  - context-map
+- intent: Cross-check docs links and path references
+  primary: update-docs-on-code-change
+  secondary:
+  - context-note-maintainer
+- intent: Map issue to touched files and surfaces
+  primary: context-map
+  secondary:
+  - skill-picker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,29 @@ automation:
 - `.agents/skills/paper-facing-docs/SKILL.md`
 - `.agents/skills/review-benchmark-change/SKILL.md`
 
+## Spark Sidecar Routing
+
+Spark (`gpt-5.3-codex-spark`, or the configured Spark sidecar model) is eligible for small, low-risk
+read-only task classes:
+
+- **tiny lookup** — file location, name resolution, short grep.
+- **read-only review** — narrow diff inspection, single-file summary.
+- **docs cross-check** — link validation, path reference checks.
+- **issue/file surface mapping** — issue-to-file coverage, surface enumeration.
+
+Spark prompts must require compact output: files inspected, exact evidence, uncertainty, and
+recommended next prompt.
+
+Spark is explicitly excluded from:
+
+- final benchmark interpretation and paper claims,
+- merge readiness and publication decisions,
+- GitHub mutation (labels, comments, PR creation, merge, close),
+- long CI polling unless a bounded monitor helper exists,
+- shell-executable fallback unless a real headless wrapper is available.
+
+Do not configure Spark as a shell-executable fallback; this is routing guidance only.
+
 ## Donts
 
 - Never change code in `.venv`. To manage dependencies, edit `pyproject.toml` and run `uv sync` to update the virtual environment.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -417,6 +417,30 @@ When reviewing PRs with route-efficiency changes, ensure:
 - [ ] **Visible evidence warning**: Confirm the report still displays the route-evidence-only
   warning and does not let route metrics replace manual diff inspection or local validation.
 
+### Spark Sidecar Routing
+
+Spark (`gpt-5.3-codex-spark`, or the configured Spark sidecar model) is a first-class route for
+small, low-risk read-only task classes. Route Spark when the task fits one of:
+
+- **tiny lookup** — file location, name resolution, short grep.
+- **read-only review** — narrow diff inspection, single-file summary.
+- **docs cross-check** — link validation, path reference checks.
+- **issue/file surface mapping** — issue-to-file coverage, surface enumeration.
+- **inspect small command output** — bounded stdout/stderr review.
+
+Spark prompts must require compact output: files inspected, exact evidence, uncertainty, and
+recommended next prompt.
+
+Do not route Spark to:
+
+- final benchmark interpretation and paper claims,
+- merge readiness and publication decisions,
+- GitHub mutation (labels, comments, PR creation, merge, close),
+- long CI polling unless a bounded monitor helper exists,
+- shell-executable fallback unless a real headless wrapper is available.
+
+This is routing guidance only; do not configure Spark as a shell-executable fallback.
+
 Assume `OWNER`, `REPO`, `ISSUE`, `BRANCH`, and `BASE` are set:
 
 ```bash

--- a/scripts/dev/check_skills.py
+++ b/scripts/dev/check_skills.py
@@ -100,6 +100,20 @@ GOAL_AUTOPILOT_LEDGER_REQUIRED_PHRASES = (
     "compact_worktree_snapshot.py",
     "compact_ci_snapshot.py",
 )
+GOAL_AUTOPILOT_SPARK_REQUIRED_PHRASES = (
+    "spark sidecar routing",
+    "gpt-5.3-codex-spark",
+    "tiny lookup",
+    "read-only review",
+    "docs cross-check",
+    "issue/file surface mapping",
+    "files inspected",
+    "exact evidence",
+    "uncertainty",
+    "recommended next prompt",
+    "github mutation",
+    "shell-executable fallback",
+)
 
 
 def _read_yaml(path: Path) -> Any:
@@ -314,6 +328,9 @@ def _validate_artifact_first_contract(path: Path, metadata: dict[str, Any], text
         for phrase in GOAL_AUTOPILOT_LEDGER_REQUIRED_PHRASES:
             if phrase not in lower:
                 errors.append(f"{rel}: missing active-ledger requirement {phrase!r}")
+        for phrase in GOAL_AUTOPILOT_SPARK_REQUIRED_PHRASES:
+            if phrase not in lower:
+                errors.append(f"{rel}: missing Spark sidecar routing requirement {phrase!r}")
 
     if metadata.get("name") == "goal-pr-review":
         for phrase in GOAL_PR_REVIEW_REQUIRED_PHRASES:

--- a/tests/dev/test_check_skills.py
+++ b/tests/dev/test_check_skills.py
@@ -91,6 +91,10 @@ Use compact_worktree_snapshot.py and compact_ci_snapshot.py before broad worktre
 Pass ledger snapshot paths to workers, avoid repeating broad state polling, and run
 fresh live checks before issue claim, push, PR publication, label/project mutation,
 or merge-ready decisions.
+Spark sidecar routing supports gpt-5.3-codex-spark for tiny lookup, read-only review,
+docs cross-check, and issue/file surface mapping. Spark prompts must report files inspected,
+exact evidence, uncertainty, and recommended next prompt. Do not use Spark for GitHub mutation
+or shell-executable fallback.
 """
     errors = check_skills._validate_artifact_first_contract(
         skill_path,
@@ -116,6 +120,7 @@ def test_artifact_first_contract_fails_when_missing_required_artifacts(tmp_path:
     assert any("artifact-first phrase requirement" in e for e in errors)
     assert any("worker-output limit requirement" in e for e in errors)
     assert any("active-ledger requirement" in e for e in errors)
+    assert any("Spark sidecar routing requirement" in e for e in errors)
 
 
 def test_artifact_first_contract_requires_canonical_result_markdown_case(


### PR DESCRIPTION
## Summary
- Document Spark sidecar routing for tiny/read-only orchestration tasks in goal-autopilot, AGENTS, and the dev guide.
- Add routing golden cases for low-risk lookup/review/mapping intents.
- Add `check_skills.py` phrase coverage so the Spark sidecar contract stays enforced.

Closes #2713.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/sync_ai_config.py --check` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_skills.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_skills.py` -> passed
- `git diff --check` -> passed

## Delegated Work
- Gemini issue scout selected #2713 as the best token-efficiency follow-up after #2692-#2695 were confirmed closed.
- OpenCode Zen mapped the relevant routing/docs/check surfaces.
- Command Code implementation route failed without changes and was rejected.
- OpenCode Go implemented the bounded docs/config patch.
- Gemini read-only review found no blockers after local validation.

## Downstream Propagation
Workflow/docs/checker-only change. No benchmark report, claim map, leaderboard, artifact catalog, or experiment registry update needed.

## Research Result Guidance
NA: routing/workflow guidance only; no research claim, metric interpretation, benchmark result, or paper-facing conclusion.
