### PR TITLE
feat: add manifest lineage backfill checker

### DIFF
--- a/robot_sf/benchmark/manifest_lineage_backfill.py
+++ b/robot_sf/benchmark/manifest_lineage_backfill.py
@@ -1,0 +1,554 @@
+"""Check-only and optional write-backfill for research manifest lineage fields.
+
+This module scans manifest files for lineage contract completeness, classifies
+each missing field as missing / inferred / ambiguous / blocked, and produces a
+reviewable backfill plan.  It never scans or rewrites the repository by default.
+
+Usage::
+
+    # Check-only (default): report what needs attention
+    python -m robot_sf.benchmark.manifest_lineage_backfill manifest.json
+
+    # Check-only with explicit paths
+    python -m robot_sf.benchmark.manifest_lineage_backfill manifest.json other.json
+
+    # Write-backfill (requires explicit paths + flag)
+    python -m robot_sf.benchmark.manifest_lineage_backfill --write-backfill manifest.json
+
+The module reuses the shared ``MANDATORY_LINEAGE_FIELDS`` and
+``validate_lineage_contract`` from :mod:`robot_sf.benchmark.manifest_lineage`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.manifest_lineage import (
+    MANDATORY_LINEAGE_FIELDS,
+    validate_lineage_contract,
+)
+
+# Field status classification
+
+
+class FieldStatus(StrEnum):
+    """Classification for a lineage field's state in a manifest."""
+
+    PRESENT = "present"
+    MISSING = "missing"
+    INFERRED = "inferred"
+    AMBIGUOUS = "ambiguous"
+    BLOCKED = "blocked"
+
+
+# Inference rules
+
+InferenceValue = str | dict[str, Any]
+
+# Mapping: lineage field -> nearby proxy paths that may already carry the same
+# lineage fact in old manifests. Each path is explicit so a single proxy source
+# is counted once, and conflicting sources remain review-visible.
+INFERENCE_PATHS: dict[str, tuple[str, ...]] = {
+    "source": ("metadata.source", "provenance"),
+    "generator_id": ("metadata.generator_id", "config.generator_id"),
+    "validator_version": (
+        "metadata.validator_version",
+        "metadata.version",
+        "config.validator_version",
+    ),
+    "schema_version": ("metadata.schema_version",),
+    "claim_boundary": ("metadata.claim_boundary", "claim.claim_boundary"),
+    "evidence_tier": ("metadata.evidence_tier", "claim.evidence_tier"),
+    "denominator_policy": ("metadata.denominator_policy",),
+    "execution_gate": ("metadata.execution_gate",),
+}
+
+
+_ABSENT = object()
+
+
+def _lookup_path(manifest: dict[str, Any], path: str) -> Any:
+    """Return a dotted-path value from a manifest, or a sentinel when absent."""
+    current: Any = manifest
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return _ABSENT
+        current = current[part]
+    return current
+
+
+def _valid_candidate(field_name: str, value: Any) -> InferenceValue | None:
+    """Normalize a proxy value when it has the required lineage field type.
+
+    Returns:
+        Normalized proxy value, or None when the candidate is absent or invalid.
+    """
+    if field_name in {
+        "generator_id",
+        "validator_version",
+        "schema_version",
+        "evidence_tier",
+        "denominator_policy",
+        "execution_gate",
+    }:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+    if field_name == "source":
+        return value if isinstance(value, dict) and value else None
+    if field_name == "claim_boundary":
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return value if isinstance(value, dict) and value else None
+    return None
+
+
+def _candidate_values(
+    manifest: dict[str, Any], field_name: str
+) -> list[tuple[str, InferenceValue]]:
+    """Return labeled candidate lineage values from explicit nearby paths."""
+    candidates: list[tuple[str, InferenceValue]] = []
+    for source_label in INFERENCE_PATHS.get(field_name, ()):
+        value = _valid_candidate(field_name, _lookup_path(manifest, source_label))
+        if value is not None:
+            candidates.append((source_label, value))
+    return candidates
+
+
+def _invalid_candidate_labels(manifest: dict[str, Any], field_name: str) -> list[str]:
+    """Return labels for present nearby values that cannot safely infer a field.
+
+    Returns:
+        Dotted proxy labels whose values are present but invalid for the field.
+    """
+    invalid: list[str] = []
+    for source_label in INFERENCE_PATHS.get(field_name, ()):
+        raw_value = _lookup_path(manifest, source_label)
+        if raw_value is _ABSENT:
+            continue
+        if _valid_candidate(field_name, raw_value) is None:
+            invalid.append(source_label)
+    return invalid
+
+
+# Backfill plan data model
+
+
+@dataclass(frozen=True, slots=True)
+class FieldBackfillEntry:
+    """One lineage field needing attention in a manifest."""
+
+    field_name: str
+    status: FieldStatus
+    inferred_value: str | dict[str, Any] | None = None
+    inferred_from: str | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestBackfillPlan:
+    """Backfill plan for a single manifest file."""
+
+    path: str
+    validation_errors: list[str]
+    fields: list[FieldBackfillEntry]
+    has_inferred: bool = False
+    has_ambiguous: bool = False
+    has_blocked: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping.
+
+        Returns:
+            Dictionary with path, validation_errors, and field details.
+        """
+        return {
+            "path": self.path,
+            "validation_errors": self.validation_errors,
+            "fields": [asdict(f) for f in self.fields],
+            "has_inferred": self.has_inferred,
+            "has_ambiguous": self.has_ambiguous,
+            "has_blocked": self.has_blocked,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillPlan:
+    """Full backfill plan across all scanned manifests."""
+
+    manifests: list[ManifestBackfillPlan]
+    total_missing: int = 0
+    total_inferred: int = 0
+    total_ambiguous: int = 0
+    total_blocked: int = 0
+    write_mode: bool = False
+    written_paths: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping.
+
+        Returns:
+            Dictionary with summary counts and per-manifest details.
+        """
+        return {
+            "manifests": [m.to_dict() for m in self.manifests],
+            "total_missing": self.total_missing,
+            "total_inferred": self.total_inferred,
+            "total_ambiguous": self.total_ambiguous,
+            "total_blocked": self.total_blocked,
+            "write_mode": self.write_mode,
+            "written_paths": self.written_paths,
+        }
+
+
+# Core analysis
+
+
+def _classify_field(
+    manifest: dict[str, Any],
+    field_name: str,
+) -> FieldBackfillEntry:
+    """Classify the status of a single lineage field in a manifest.
+
+    Args:
+        manifest: The parsed manifest payload.
+        field_name: The lineage field to classify.
+
+    Returns:
+        FieldBackfillEntry with status, inferred value, and reason.
+    """
+    # Already present?
+    if field_name in manifest:
+        return FieldBackfillEntry(
+            field_name=field_name,
+            status=FieldStatus.PRESENT,
+        )
+
+    # Try nearby proxy fields.
+    values = _candidate_values(manifest, field_name)
+    invalid_labels = _invalid_candidate_labels(manifest, field_name)
+
+    if len(values) == 0:
+        if invalid_labels:
+            return FieldBackfillEntry(
+                field_name=field_name,
+                status=FieldStatus.BLOCKED,
+                reason=(
+                    f"nearby field has incompatible value for {field_name}: "
+                    f"{', '.join(invalid_labels)}"
+                ),
+            )
+        return FieldBackfillEntry(
+            field_name=field_name,
+            status=FieldStatus.MISSING,
+            reason=f"no nearby field available to infer {field_name}",
+        )
+    if invalid_labels:
+        source_labels = [label for label, _ in values] + invalid_labels
+        return FieldBackfillEntry(
+            field_name=field_name,
+            status=FieldStatus.AMBIGUOUS,
+            reason=(
+                f"valid and invalid inference candidates for {field_name}: "
+                f"{', '.join(source_labels)}"
+            ),
+        )
+    if len(values) == 1:
+        source_label, val = values[0]
+        return FieldBackfillEntry(
+            field_name=field_name,
+            status=FieldStatus.INFERRED,
+            inferred_value=val,
+            inferred_from=source_label,
+            reason=f"inferred from {source_label}",
+        )
+    first_label, first_value = values[0]
+    if all(value == first_value for _, value in values[1:]):
+        return FieldBackfillEntry(
+            field_name=field_name,
+            status=FieldStatus.INFERRED,
+            inferred_value=first_value,
+            inferred_from=first_label,
+            reason=f"inferred from matching candidates: {', '.join(label for label, _ in values)}",
+        )
+
+    # Multiple conflicting candidates: ambiguous.
+    source_labels = ", ".join(label for label, _ in values)
+    return FieldBackfillEntry(
+        field_name=field_name,
+        status=FieldStatus.AMBIGUOUS,
+        reason=f"multiple inference candidates: {source_labels}",
+    )
+
+
+def analyze_manifest(
+    manifest: dict[str, Any],
+    *,
+    path: str | None = None,
+) -> ManifestBackfillPlan:
+    """Analyze a single manifest for lineage field completeness.
+
+    Args:
+        manifest: The parsed manifest payload (must be a dict).
+        path: Optional path label for the manifest (for reporting).
+
+    Returns:
+        ManifestBackfillPlan with per-field classification.
+    """
+    validation_errors = validate_lineage_contract(manifest)
+    fields: list[FieldBackfillEntry] = []
+    for field_name in MANDATORY_LINEAGE_FIELDS:
+        entry = _classify_field(manifest, field_name)
+        fields.append(entry)
+
+    has_inferred = any(f.status == FieldStatus.INFERRED for f in fields)
+    has_ambiguous = any(f.status == FieldStatus.AMBIGUOUS for f in fields)
+    has_blocked = any(f.status == FieldStatus.BLOCKED for f in fields)
+
+    return ManifestBackfillPlan(
+        path=path or "<inline>",
+        validation_errors=validation_errors,
+        fields=fields,
+        has_inferred=has_inferred,
+        has_ambiguous=has_ambiguous,
+        has_blocked=has_blocked,
+    )
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    """Load a JSON manifest from disk.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Parsed manifest dictionary.
+
+    Raises:
+        SystemExit: If the file cannot be read or parsed.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(f"Error reading {path}: {exc}\n")
+        raise SystemExit(1) from exc
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"Error parsing {path}: {exc}\n")
+        raise SystemExit(1) from exc
+    if not isinstance(payload, dict):
+        sys.stderr.write(f"Error: {path} must contain a JSON object\n")
+        raise SystemExit(1)
+    return payload
+
+
+def _validate_write_paths(paths: list[str]) -> list[Path]:
+    """Validate that write-backfill paths are explicit file paths.
+
+    Refuses broad directory paths (like repo root) to prevent accidental
+    repository-wide rewrites.
+
+    Args:
+        paths: List of path strings to validate.
+
+    Returns:
+        List of validated Path objects.
+
+    Raises:
+        SystemExit: If any path is too broad or not an explicit file path.
+    """
+    resolved: list[Path] = []
+    for p in paths:
+        path = Path(p).resolve()
+        # Refuse directory paths
+        if path.is_dir():
+            sys.stderr.write(
+                f"Error: --write-backfill refuses directory path '{p}'. "
+                "Provide explicit file paths.\n"
+            )
+            raise SystemExit(1)
+        resolved.append(path)
+    return resolved
+
+
+# Write-backfill
+
+
+def _apply_backfill(
+    manifest: dict[str, Any],
+    plan: ManifestBackfillPlan,
+) -> dict[str, Any]:
+    """Apply inferred lineage fields to a manifest payload.
+
+    Only INFERRED fields are written.  AMBIGUOUS and BLOCKED fields are left
+    untouched so the reviewer can resolve them.
+
+    Args:
+        manifest: The mutable manifest payload.
+        plan: The backfill plan for this manifest.
+
+    Returns:
+        The updated manifest (same dict, mutated in place).
+    """
+    for entry in plan.fields:
+        if entry.status == FieldStatus.INFERRED and entry.inferred_value is not None:
+            manifest[entry.field_name] = entry.inferred_value
+    return manifest
+
+
+# Public API
+
+
+def run_backfill_check(
+    paths: list[str],
+    *,
+    write_backfill: bool = False,
+    json_output: bool = False,
+) -> BackfillPlan:
+    """Run lineage backfill analysis on the given manifest paths.
+
+    In check-only mode (default), this never modifies files.  In write mode,
+    it requires explicit file paths and only writes inferred fields.
+
+    Args:
+        paths: List of manifest file paths to analyze.
+        write_backfill: If True, apply inferred backfill and write files.
+        json_output: If True, return JSON output; otherwise print human-readable.
+
+    Returns:
+        BackfillPlan with full analysis results.
+    """
+    resolved_paths: list[Path]
+    if write_backfill:
+        resolved_paths = _validate_write_paths(paths)
+    else:
+        resolved_paths = [Path(p).resolve() for p in paths]
+
+    plans: list[ManifestBackfillPlan] = []
+    written: list[str] = []
+
+    for path in resolved_paths:
+        manifest = _load_manifest(path)
+        plan = analyze_manifest(
+            manifest,
+            path=str(path.relative_to(Path.cwd()))
+            if path.is_relative_to(Path.cwd())
+            else str(path),
+        )
+        plans.append(plan)
+
+        if write_backfill:
+            manifest = _apply_backfill(manifest, plan)
+            path.write_text(
+                json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+            )
+            written.append(str(path))
+
+    total_missing = sum(1 for p in plans for f in p.fields if f.status == FieldStatus.MISSING)
+    total_inferred = sum(1 for p in plans for f in p.fields if f.status == FieldStatus.INFERRED)
+    total_ambiguous = sum(1 for p in plans for f in p.fields if f.status == FieldStatus.AMBIGUOUS)
+    total_blocked = sum(1 for p in plans for f in p.fields if f.status == FieldStatus.BLOCKED)
+
+    plan = BackfillPlan(
+        manifests=plans,
+        total_missing=total_missing,
+        total_inferred=total_inferred,
+        total_ambiguous=total_ambiguous,
+        total_blocked=total_blocked,
+        write_mode=write_backfill,
+        written_paths=written,
+    )
+
+    if json_output:
+        sys.stdout.write(json.dumps(plan.to_dict(), indent=2, ensure_ascii=False) + "\n")
+    else:
+        _print_human_readable(plan)
+
+    return plan
+
+
+def _print_human_readable(plan: BackfillPlan) -> None:
+    """Print a human-readable summary of the backfill plan.
+
+    Args:
+        plan: The full backfill plan to summarize.
+    """
+    mode_label = "WRITE-BACKFILL" if plan.write_mode else "CHECK-ONLY"
+    sys.stdout.write(f"=== Manifest Lineage Backfill ({mode_label}) ===\n")
+    sys.stdout.write(
+        f"Manifests: {len(plan.manifests)} | "
+        f"Missing: {plan.total_missing} | "
+        f"Inferred: {plan.total_inferred} | "
+        f"Ambiguous: {plan.total_ambiguous} | "
+        f"Blocked: {plan.total_blocked}\n"
+    )
+    if plan.written_paths:
+        sys.stdout.write(f"Written: {', '.join(plan.written_paths)}\n")
+    sys.stdout.write("\n")
+
+    for mp in plan.manifests:
+        sys.stdout.write(f"--- {mp.path} ---\n")
+        if mp.validation_errors:
+            sys.stdout.write(f"  Validation errors: {'; '.join(mp.validation_errors)}\n")
+        for f in mp.fields:
+            if f.status == FieldStatus.PRESENT:
+                continue
+            marker = {
+                FieldStatus.MISSING: "MISSING",
+                FieldStatus.INFERRED: f"INFERRED from {f.inferred_from}",
+                FieldStatus.AMBIGUOUS: "AMBIGUOUS",
+                FieldStatus.BLOCKED: "BLOCKED",
+            }[f.status]
+            reason = f" ({f.reason})" if f.reason else ""
+            sys.stdout.write(f"  {f.field_name}: {marker}{reason}\n")
+        sys.stdout.write("\n")
+
+
+# CLI entry point
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for manifest lineage backfill.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv[1:]).
+    """
+    parser = argparse.ArgumentParser(
+        prog="manifest_lineage_backfill",
+        description="Check or backfill lineage fields in research manifests.",
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="+",
+        help="Manifest JSON files to analyze.",
+    )
+    parser.add_argument(
+        "--write-backfill",
+        action="store_true",
+        default=False,
+        help="Apply inferred backfill and write files. Requires explicit paths.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        dest="json_output",
+        help="Output machine-readable JSON.",
+    )
+    args = parser.parse_args(argv)
+    run_backfill_check(
+        args.manifests,
+        write_backfill=args.write_backfill,
+        json_output=args.json_output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/robot_sf/benchmark/manifest_lineage_backfill.py
+++ b/robot_sf/benchmark/manifest_lineage_backfill.py
@@ -112,7 +112,15 @@ def _valid_candidate(field_name: str, value: Any) -> InferenceValue | None:
 def _candidate_values(
     manifest: dict[str, Any], field_name: str
 ) -> list[tuple[str, InferenceValue]]:
-    """Return labeled candidate lineage values from explicit nearby paths."""
+    """Return labeled candidate lineage values from explicit nearby paths.
+
+    Args:
+        manifest: The parsed manifest payload.
+        field_name: The lineage field to collect candidates for.
+
+    Returns:
+        List of ``(source_label, normalized_value)`` tuples for valid candidates.
+    """
     candidates: list[tuple[str, InferenceValue]] = []
     for source_label in INFERENCE_PATHS.get(field_name, ()):
         value = _valid_candidate(field_name, _lookup_path(manifest, source_label))
@@ -300,7 +308,12 @@ def analyze_manifest(
 
     Returns:
         ManifestBackfillPlan with per-field classification.
+
+    Raises:
+        ValueError: If manifest is not a dictionary mapping.
     """
+    if not isinstance(manifest, dict):
+        raise ValueError("Manifest contract payload must be a dictionary mapping.")
     validation_errors = validate_lineage_contract(manifest)
     fields: list[FieldBackfillEntry] = []
     for field_name in MANDATORY_LINEAGE_FIELDS:
@@ -444,7 +457,7 @@ def run_backfill_check(
         )
         plans.append(plan)
 
-        if write_backfill:
+        if write_backfill and plan.has_inferred:
             manifest = _apply_backfill(manifest, plan)
             path.write_text(
                 json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"

--- a/tests/benchmark/fixtures/manifest_lineage_backfill/ambiguous_fields.json
+++ b/tests/benchmark/fixtures/manifest_lineage_backfill/ambiguous_fields.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "metadata": {
+    "validator_version": "2.0.0",
+    "evidence_tier": "diagnostic"
+  },
+  "config": {
+    "validator_version": "3.0.0"
+  }
+}

--- a/tests/benchmark/fixtures/manifest_lineage_backfill/blocked_fields.json
+++ b/tests/benchmark/fixtures/manifest_lineage_backfill/blocked_fields.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "metadata": {
+    "source": "not-a-source-map",
+    "generator_id": "",
+    "claim_boundary": ""
+  }
+}

--- a/tests/benchmark/fixtures/manifest_lineage_backfill/complete_lineage.json
+++ b/tests/benchmark/fixtures/manifest_lineage_backfill/complete_lineage.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "generator_id": "test-generator",
+  "validator_version": "1.0.0",
+  "claim_boundary": "unit-test-only",
+  "evidence_tier": "test",
+  "denominator_policy": "all-attempts",
+  "execution_gate": "pass",
+  "source": {"type": "test", "path": "fixture"}
+}

--- a/tests/benchmark/fixtures/manifest_lineage_backfill/inferred_candidate.json
+++ b/tests/benchmark/fixtures/manifest_lineage_backfill/inferred_candidate.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "metadata": {
+    "generator_id": "inferred-gen",
+    "validator_version": "2.1.0",
+    "evidence_tier": "diagnostic",
+    "denominator_policy": "successful-only",
+    "execution_gate": "pass"
+  }
+}

--- a/tests/benchmark/fixtures/manifest_lineage_backfill/missing_all.json
+++ b/tests/benchmark/fixtures/manifest_lineage_backfill/missing_all.json
@@ -1,0 +1,3 @@
+{
+  "schema_version": "benchmark_claim.v1"
+}

--- a/tests/benchmark/test_manifest_lineage_backfill.py
+++ b/tests/benchmark/test_manifest_lineage_backfill.py
@@ -1,0 +1,426 @@
+"""Tests for manifest lineage backfill check-only and write modes."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.manifest_lineage_backfill import (
+    FieldStatus,
+    ManifestBackfillPlan,
+    analyze_manifest,
+    main,
+    run_backfill_check,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[0] / "fixtures" / "manifest_lineage_backfill"
+
+
+# Fixture helpers
+
+
+def _load_fixture(name: str) -> dict:
+    """Load a JSON fixture by name."""
+    path = FIXTURE_DIR / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_fixture(tmp_path: Path, name: str, payload: dict) -> Path:
+    """Write a manifest payload to a temporary file."""
+    dest = tmp_path / name
+    dest.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return dest
+
+
+# analyze_manifest tests
+
+
+def test_complete_lineage_classified_as_present() -> None:
+    """All fields present means every field is classified as PRESENT."""
+    manifest = _load_fixture("complete_lineage.json")
+    plan = analyze_manifest(manifest, path="complete_lineage.json")
+
+    assert isinstance(plan, ManifestBackfillPlan)
+    assert plan.validation_errors == []
+    for entry in plan.fields:
+        assert entry.status == FieldStatus.PRESENT, f"{entry.field_name} should be present"
+    assert not plan.has_inferred
+    assert not plan.has_ambiguous
+    assert not plan.has_blocked
+
+
+def test_missing_all_fields_classified_missing_or_blocked() -> None:
+    """Manifest missing most fields has MISSING field statuses."""
+    manifest = _load_fixture("missing_all.json")
+    plan = analyze_manifest(manifest, path="missing_all.json")
+
+    # schema_version is at top level, so it is PRESENT.
+    sv = next(f for f in plan.fields if f.field_name == "schema_version")
+    assert sv.status == FieldStatus.PRESENT
+
+    # source has no nearby field, so it is MISSING.
+    src = next(f for f in plan.fields if f.field_name == "source")
+    assert src.status == FieldStatus.MISSING
+
+    # Other fields with no nearby source are MISSING.
+    for f in plan.fields:
+        if f.field_name == "schema_version":
+            continue
+        assert f.status == FieldStatus.MISSING, f"{f.field_name} should be missing"
+
+
+def test_inferred_candidate_fields() -> None:
+    """Manifest with metadata proxies has fields classified as INFERRED."""
+    manifest = _load_fixture("inferred_candidate.json")
+    plan = analyze_manifest(manifest, path="inferred_candidate.json")
+
+    # schema_version is PRESENT at the top level.
+    sv = next(f for f in plan.fields if f.field_name == "schema_version")
+    assert sv.status == FieldStatus.PRESENT
+
+    # generator_id is INFERRED from metadata.generator_id.
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.INFERRED
+    assert gid.inferred_value == "inferred-gen"
+    assert gid.inferred_from is not None
+
+    # validator_version is INFERRED from metadata.validator_version.
+    vv = next(f for f in plan.fields if f.field_name == "validator_version")
+    assert vv.status == FieldStatus.INFERRED
+    assert vv.inferred_value == "2.1.0"
+
+    # evidence_tier is INFERRED from metadata.evidence_tier.
+    et = next(f for f in plan.fields if f.field_name == "evidence_tier")
+    assert et.status == FieldStatus.INFERRED
+    assert et.inferred_value == "diagnostic"
+
+    # denominator_policy is INFERRED.
+    dp = next(f for f in plan.fields if f.field_name == "denominator_policy")
+    assert dp.status == FieldStatus.INFERRED
+
+    # execution_gate is INFERRED.
+    eg = next(f for f in plan.fields if f.field_name == "execution_gate")
+    assert eg.status == FieldStatus.INFERRED
+
+    assert plan.has_inferred
+    assert not plan.has_ambiguous
+
+
+def test_ambiguous_fields_detected() -> None:
+    """Manifest with conflicting proxy sources has AMBIGUOUS classification."""
+    manifest = _load_fixture("ambiguous_fields.json")
+    plan = analyze_manifest(manifest, path="ambiguous_fields.json")
+
+    # validator_version is AMBIGUOUS because metadata and config conflict.
+    vv = next(f for f in plan.fields if f.field_name == "validator_version")
+    assert vv.status == FieldStatus.AMBIGUOUS
+    assert "multiple" in vv.reason.lower() or "ambiguous" in vv.reason.lower()
+
+    assert plan.has_ambiguous
+
+
+def test_matching_duplicate_proxy_values_inferred() -> None:
+    """Matching values in multiple proxy paths are safe to infer."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {
+            "generator_id": "gen-a",
+        },
+        "config": {
+            "generator_id": "gen-a",
+        },
+    }
+    plan = analyze_manifest(manifest, path="matching_proxy_values.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.INFERRED
+    assert gid.inferred_value == "gen-a"
+    assert "matching candidates" in gid.reason
+
+
+def test_valid_and_invalid_proxy_values_ambiguous() -> None:
+    """Mixed valid and invalid proxy values stay review-visible."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {
+            "generator_id": "gen-a",
+        },
+        "config": {
+            "generator_id": "",
+        },
+    }
+    plan = analyze_manifest(manifest, path="mixed_proxy_values.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.AMBIGUOUS
+    assert "valid and invalid" in gid.reason
+
+
+def test_blocked_fields_when_no_inference_source() -> None:
+    """Manifest with invalid nearby fields for required lineage is BLOCKED."""
+    manifest = _load_fixture("blocked_fields.json")
+    plan = analyze_manifest(manifest, path="blocked_fields.json")
+
+    # Only schema_version is present
+    sv = next(f for f in plan.fields if f.field_name == "schema_version")
+    assert sv.status == FieldStatus.PRESENT
+
+    # source, generator_id, and claim_boundary have invalid nearby proxies.
+    for name in ("source", "generator_id", "claim_boundary"):
+        entry = next(f for f in plan.fields if f.field_name == name)
+        assert entry.status == FieldStatus.BLOCKED, f"{name} should be blocked"
+
+    assert plan.has_blocked
+
+
+# Check-only mode tests
+
+
+def test_check_only_does_not_modify_files(tmp_path: Path) -> None:
+    """Check-only mode must not modify any files."""
+    src = FIXTURE_DIR / "inferred_candidate.json"
+    dest = tmp_path / "inferred_candidate.json"
+    shutil.copy2(src, dest)
+    original_content = dest.read_text(encoding="utf-8")
+
+    plan = run_backfill_check(
+        [str(dest)],
+        write_backfill=False,
+        json_output=False,
+    )
+
+    assert not plan.write_mode
+    assert plan.written_paths == []
+    assert dest.read_text(encoding="utf-8") == original_content
+
+
+def test_check_only_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Check-only mode with --json produces machine-readable output."""
+    src = FIXTURE_DIR / "complete_lineage.json"
+    dest = tmp_path / "complete_lineage.json"
+    shutil.copy2(src, dest)
+
+    run_backfill_check(
+        [str(dest)],
+        write_backfill=False,
+        json_output=True,
+    )
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "manifests" in output
+    assert output["write_mode"] is False
+
+
+# Write-backfill mode tests
+
+
+def test_write_backfill_applies_inferred_fields(tmp_path: Path) -> None:
+    """Write-backfill mode writes inferred fields to the manifest."""
+    src = FIXTURE_DIR / "inferred_candidate.json"
+    dest = tmp_path / "inferred_candidate.json"
+    shutil.copy2(src, dest)
+
+    plan = run_backfill_check(
+        [str(dest)],
+        write_backfill=True,
+        json_output=False,
+    )
+
+    assert plan.write_mode
+    assert len(plan.written_paths) == 1
+
+    # Verify the file was updated
+    updated = json.loads(dest.read_text(encoding="utf-8"))
+    assert updated["generator_id"] == "inferred-gen"
+    assert updated["validator_version"] == "2.1.0"
+    assert updated["evidence_tier"] == "diagnostic"
+    assert updated["denominator_policy"] == "successful-only"
+    assert updated["execution_gate"] == "pass"
+
+
+def test_write_backfill_refuses_directory(tmp_path: Path) -> None:
+    """Write-backfill mode refuses directory paths."""
+    with pytest.raises(SystemExit):
+        run_backfill_check(
+            [str(tmp_path)],
+            write_backfill=True,
+            json_output=False,
+        )
+
+
+def test_write_backfill_refuses_broad_path(tmp_path: Path) -> None:
+    """Write-backfill mode refuses short/broad paths like '/' or '/tmp'."""
+    with pytest.raises(SystemExit):
+        run_backfill_check(
+            ["/"],
+            write_backfill=True,
+            json_output=False,
+        )
+
+
+def test_write_backfill_refuses_repo_root_relative(tmp_path: Path) -> None:
+    """Write-backfill mode refuses paths that resolve to repo root."""
+    with pytest.raises(SystemExit):
+        run_backfill_check(
+            ["."],
+            write_backfill=True,
+            json_output=False,
+        )
+
+
+def test_write_backfill_allows_shallow_explicit_file() -> None:
+    """Write-backfill allows an explicit shallow absolute file path."""
+    payload = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {
+            "generator_id": "gen-shallow",
+        },
+    }
+    shallow_path = Path(tempfile.gettempdir()) / "issue2723_manifest_lineage_backfill.json"
+    try:
+        shallow_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        plan = run_backfill_check(
+            [str(shallow_path)],
+            write_backfill=True,
+            json_output=False,
+        )
+
+        updated = json.loads(shallow_path.read_text(encoding="utf-8"))
+        assert plan.write_mode
+        assert updated["generator_id"] == "gen-shallow"
+    finally:
+        shallow_path.unlink(missing_ok=True)
+
+
+# Multiple manifest batch tests
+
+
+def test_batch_check_only_multiple_manifests() -> None:
+    """Check-only mode handles multiple manifests in one run."""
+    paths = [
+        str(FIXTURE_DIR / "complete_lineage.json"),
+        str(FIXTURE_DIR / "inferred_candidate.json"),
+        str(FIXTURE_DIR / "missing_all.json"),
+    ]
+
+    plan = run_backfill_check(paths, write_backfill=False, json_output=False)
+
+    assert len(plan.manifests) == 3
+    assert plan.total_inferred > 0
+    assert plan.total_missing > 0 or plan.total_blocked > 0
+
+
+def test_batch_check_only_json_structure() -> None:
+    """Batch check-only JSON output has expected top-level keys."""
+    paths = [
+        str(FIXTURE_DIR / "complete_lineage.json"),
+        str(FIXTURE_DIR / "ambiguous_fields.json"),
+    ]
+
+    plan = run_backfill_check(paths, write_backfill=False, json_output=False)
+
+    d = plan.to_dict()
+    assert "manifests" in d
+    assert "total_missing" in d
+    assert "total_inferred" in d
+    assert "total_ambiguous" in d
+    assert "total_blocked" in d
+    assert "write_mode" in d
+    assert "written_paths" in d
+
+
+# CLI tests
+
+
+def test_cli_check_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI in check-only mode runs without error."""
+    path = str(FIXTURE_DIR / "complete_lineage.json")
+    main([path])
+    captured = capsys.readouterr()
+    assert "CHECK-ONLY" in captured.out
+
+
+def test_cli_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI --json produces valid JSON."""
+    path = str(FIXTURE_DIR / "complete_lineage.json")
+    main([path, "--json"])
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "manifests" in output
+
+
+# FieldStatus enum tests
+
+
+def test_field_status_values() -> None:
+    """FieldStatus enum has all expected values."""
+    expected = {"present", "missing", "inferred", "ambiguous", "blocked"}
+    assert {s.value for s in FieldStatus} == expected
+
+
+# Edge cases
+
+
+def test_analyze_manifest_non_dict_returns_errors() -> None:
+    """validate_lineage_contract reports non-dict payloads."""
+    errors = analyze_manifest({"not_a_dict": True}, path="edge.json")
+    # Non-dict payload is caught by validate_lineage_contract
+    assert isinstance(errors, ManifestBackfillPlan)
+
+
+def test_empty_manifest_all_fields_blocked() -> None:
+    """Empty manifest has all mandatory fields missing."""
+    plan = analyze_manifest({}, path="empty.json")
+
+    for entry in plan.fields:
+        assert entry.status == FieldStatus.MISSING, f"{entry.field_name} should be missing"
+
+
+def test_inferred_fields_write_backfill_only_writes_inferred(tmp_path: Path) -> None:
+    """Write-backfill writes only INFERRED fields, not AMBIGUOUS/BLOCKED."""
+    payload = {
+        "schema_version": "v1",
+        "metadata": {
+            "validator_version": "2.0",
+            "generator_id": "gen-x",
+        },
+        "config": {
+            "validator_version": "3.0",
+        },
+    }
+    dest = _write_fixture(tmp_path, "mixed.json", payload)
+
+    run_backfill_check(
+        [str(dest)],
+        write_backfill=True,
+        json_output=False,
+    )
+
+    updated = json.loads(dest.read_text(encoding="utf-8"))
+    # schema_version is already present, so it is unchanged.
+    assert updated["schema_version"] == "v1"
+    # generator_id is inferred from metadata, so it is written.
+    assert updated["generator_id"] == "gen-x"
+    # validator_version is ambiguous (metadata vs config), so it is not written.
+    assert "validator_version" not in updated or updated.get("validator_version") == payload.get(
+        "validator_version"
+    )
+
+
+def test_human_readable_output_includes_status_markers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Human-readable output includes INFERRED/AMBIGUOUS/BLOCKED markers."""
+    run_backfill_check(
+        [str(FIXTURE_DIR / "inferred_candidate.json")],
+        write_backfill=False,
+        json_output=False,
+    )
+    captured = capsys.readouterr()
+    assert "INFERRED" in captured.out

--- a/tests/benchmark/test_manifest_lineage_backfill.py
+++ b/tests/benchmark/test_manifest_lineage_backfill.py
@@ -243,6 +243,24 @@ def test_write_backfill_applies_inferred_fields(tmp_path: Path) -> None:
     assert updated["execution_gate"] == "pass"
 
 
+def test_write_backfill_skips_files_without_inferred_fields(tmp_path: Path) -> None:
+    """Write-backfill avoids rewriting files when no fields are inferred."""
+    src = FIXTURE_DIR / "complete_lineage.json"
+    dest = tmp_path / "complete_lineage.json"
+    shutil.copy2(src, dest)
+    original_content = dest.read_text(encoding="utf-8")
+
+    plan = run_backfill_check(
+        [str(dest)],
+        write_backfill=True,
+        json_output=False,
+    )
+
+    assert plan.write_mode
+    assert plan.written_paths == []
+    assert dest.read_text(encoding="utf-8") == original_content
+
+
 def test_write_backfill_refuses_directory(tmp_path: Path) -> None:
     """Write-backfill mode refuses directory paths."""
     with pytest.raises(SystemExit):
@@ -367,11 +385,13 @@ def test_field_status_values() -> None:
 # Edge cases
 
 
-def test_analyze_manifest_non_dict_returns_errors() -> None:
-    """validate_lineage_contract reports non-dict payloads."""
-    errors = analyze_manifest({"not_a_dict": True}, path="edge.json")
-    # Non-dict payload is caught by validate_lineage_contract
-    assert isinstance(errors, ManifestBackfillPlan)
+def test_analyze_manifest_non_dict_raises_value_error() -> None:
+    """analyze_manifest fails closed for non-dictionary payloads."""
+    with pytest.raises(ValueError) as exc_info:
+        analyze_manifest(None, path="edge.json")  # type: ignore[arg-type]
+    assert "Manifest contract payload must be a dictionary mapping" in str(exc_info.value), (
+        f"Expected ValueError with contract mapping message, got: {exc_info.value}"
+    )
 
 
 def test_empty_manifest_all_fields_blocked() -> None:
@@ -408,9 +428,7 @@ def test_inferred_fields_write_backfill_only_writes_inferred(tmp_path: Path) -> 
     # generator_id is inferred from metadata, so it is written.
     assert updated["generator_id"] == "gen-x"
     # validator_version is ambiguous (metadata vs config), so it is not written.
-    assert "validator_version" not in updated or updated.get("validator_version") == payload.get(
-        "validator_version"
-    )
+    assert "validator_version" not in updated
 
 
 def test_human_readable_output_includes_status_markers(


### PR DESCRIPTION
## Summary
Adds a manifest lineage backfill checker that reports missing, inferred, ambiguous, and blocked lineage fields in check-only mode, with an explicit-file write mode for safe inferred backfills only.

## Linked Issues
- Closes `#2723`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf/benchmark/manifest_lineage_backfill.py` with a CLI/API for check-only lineage reporting and guarded `--write-backfill`.
- Added fixtures and focused tests covering complete, missing, inferred, ambiguous, blocked, check-only immutability, explicit-path writeback, CLI JSON output, and shallow explicit file paths.
- Reuses `MANDATORY_LINEAGE_FIELDS` and `validate_lineage_contract` from `robot_sf.benchmark.manifest_lineage`.

## Why It Matters
- Added value: old manifest families can be audited without blind repository rewrites.
- Expected impact: makes lineage migration/backfill work reviewable and safer for research artifacts.
- Why this is worth merging now: it unblocks bounded migration planning while keeping ambiguous provenance visible.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: lineage completeness blocker for manifest families requiring provenance/evidence fields.
- Comparator or baseline, if applicable: current manual inspection/no checker.
- Evidence tier: targeted smoke / support helper.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: check-only reports all required states and write mode only writes inferred fields to explicit paths.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent issue `#2723`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper for migration planning; representative use covered by committed fixtures and CLI smoke.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop for this issue scope.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_backfill.py -q` -> 23 passed
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/manifest_lineage_backfill.py tests/benchmark/test_manifest_lineage_backfill.py` -> passed
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/manifest_lineage_backfill.py tests/benchmark/test_manifest_lineage_backfill.py` -> passed
  - `rtk git diff --check` -> passed
  - CLI check-only JSON on committed fixture -> worktree status unchanged except intended branch files
  - CLI write-backfill on temp fixture -> wrote only inferred fields
  - `BASE_REF=origin/main PR_READY_MODE=final rtk scripts/dev/pr_ready_check.sh` -> passed; 6439 passed, 9 skipped; changed-file coverage warning only: `manifest_lineage_backfill.py` 94.7%
- Evidence that the change works here: committed fixtures exercise missing/inferred/ambiguous/blocked states and explicit writeback behavior; final readiness stamp status `passed` at head `04ab4c4439227b8cc0e60c8c0c0ae3c06148039c`.
- Benchmarks or smoke tests, if applicable: NA - no benchmark claim.

## Risks / Rollout
- Compatibility risks: new additive module/CLI only.
- Failure modes: non-standard old manifests may classify as missing/blocked and require manual review rather than automatic migration.
- Rollback or fallback plan: remove the additive module/tests if needed.

## Docs / Provenance
- Updated docs: none; module docstring includes usage.
- Relevant design or provenance notes: explicit nearby proxy paths are used to avoid broad inference; ambiguous/blocked fields remain visible and unwritten.
- Any assumptions that need to be preserved: write mode is for explicitly listed files, not repository scans.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is an additive support helper and does not publish new benchmark evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that `--write-backfill` never scans directories and only writes fields classified as `INFERRED`.
- Known limitation: this tool plans/reports backfills; it deliberately leaves missing, ambiguous, and blocked lineage unresolved for reviewer action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest lineage completeness analysis that classifies fields as present, missing, inferred, ambiguous, or blocked.
  * Automatically infers missing values from nearby fields when possible.
  * Optionally writes inferred data back to manifests.
  * Supports JSON and human-readable output formats with command-line interface for batch processing.

* **Tests**
  * Comprehensive test coverage for all analysis scenarios and modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->