### PR TITLE
feat: add ForecastBatch schema contract

### DIFF
--- a/docs/context/issue_2836_forecast_batch_schema.md
+++ b/docs/context/issue_2836_forecast_batch_schema.md
@@ -1,0 +1,21 @@
+# Issue #2836: ForecastBatch.v1 Schema (2026-06-14)
+
+`ForecastBatch.v1` is a benchmark artifact contract for exchanging pedestrian
+forecast outputs without making prediction-quality, calibration, or planning
+benefit claims. Those claims still require separate benchmark evidence.
+
+The required provenance records predictor identity and family, observation tier,
+coordinate frame, units, axis semantics, `dt_s`, forecast horizons in seconds,
+scenario id, seed, fallback/degraded status, actor ids, actor mask metadata, and
+feature schema. Positions are two-dimensional coordinates in meters. The
+coordinate frame must name the frame and its axes so downstream evaluators do not
+mix world-frame, robot-frame, or map-frame forecasts silently.
+
+The payload is additive. Producers may emit deterministic trajectories, sampled
+trajectories, mode probabilities, occupancy summaries, and uncertainty metadata.
+They do not need to emit every optional field. Missing actor payloads are allowed
+only when the actor mask and mask metadata describe the missingness semantics.
+
+Oracle or deployable-oracle feature fields are rejected unless the artifact is
+explicitly marked with `oracle_state=True`. This keeps deployable-observation
+artifacts separate from diagnostic oracle-state artifacts.

--- a/robot_sf/benchmark/__init__.py
+++ b/robot_sf/benchmark/__init__.py
@@ -5,6 +5,16 @@ and analyzing robot navigation performance in social environments.
 """
 
 from robot_sf.benchmark.errors import AggregationMetadataError
+from robot_sf.benchmark.forecast_batch import (
+    FORECAST_BATCH_SCHEMA_VERSION,
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+    load_forecast_batch,
+    save_forecast_batch,
+    validate_forecast_batch,
+)
 from robot_sf.benchmark.helper_catalog import (
     load_trained_policy,
     prepare_classic_env,
@@ -19,13 +29,21 @@ from robot_sf.benchmark.helper_registry import (
 )
 
 __all__ = [
+    "FORECAST_BATCH_SCHEMA_VERSION",
+    "ActorForecast",
     "AggregationMetadataError",
+    "CoordinateFrame",
     "ExampleOrchestrator",
+    "ForecastBatch",
+    "ForecastBatchProvenance",
     "HelperCapability",
     "HelperCategory",
     "OrchestratorUsage",
     "RegressionCheck",
+    "load_forecast_batch",
     "load_trained_policy",
     "prepare_classic_env",
     "run_episodes_with_recording",
+    "save_forecast_batch",
+    "validate_forecast_batch",
 ]

--- a/robot_sf/benchmark/forecast_batch.py
+++ b/robot_sf/benchmark/forecast_batch.py
@@ -1,0 +1,418 @@
+"""ForecastBatch.v1 artifact contract for benchmark forecast interchange.
+
+The schema is an artifact boundary, not a prediction-quality claim. It records
+enough provenance for benchmark consumers to decide whether a forecast was
+produced from deployable observations, degraded/fallback execution, or an
+explicit oracle-state source before using it in downstream evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields, is_dataclass
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+FORECAST_BATCH_SCHEMA_VERSION = "ForecastBatch.v1"
+
+
+def _require_non_empty_str(name: str, value: object) -> str:
+    """Return a stripped string or raise for missing required provenance."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} is required")
+    return value.strip()
+
+
+def _require_positive_float(name: str, value: object) -> float:
+    """Return a finite positive float."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be numeric, not bool")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+    if not np.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return number
+
+
+def _require_float_list(name: str, value: object) -> list[float]:
+    """Return a non-empty list of finite positive floats."""
+    if not isinstance(value, (list, tuple, np.ndarray)) or len(value) == 0:
+        raise ValueError(f"{name} must be a non-empty list or array")
+    parsed = [_require_positive_float(f"{name}[]", item) for item in value]
+    if any(later <= earlier for earlier, later in pairwise(parsed)):
+        raise ValueError(f"{name} must be strictly increasing")
+    return parsed
+
+
+def _require_mapping(name: str, value: object) -> dict[str, Any]:
+    """Return a mapping with string keys."""
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a mapping")
+    return {str(key): item for key, item in value.items()}
+
+
+def _contains_oracle_key(value: object) -> bool:
+    """True when nested metadata contains oracle-looking keys or values.
+
+    Returns:
+        True when nested metadata would blur deployable and oracle state.
+    """
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = str(key).lower()
+            if normalized != "oracle_state" and "oracle" in normalized:
+                return True
+            if _contains_oracle_key(item):
+                return True
+    elif isinstance(value, list | tuple):
+        return any(_contains_oracle_key(item) for item in value)
+    elif isinstance(value, str):
+        return "oracle" in value.lower()
+    return False
+
+
+@dataclass
+class CoordinateFrame:
+    """Coordinate-frame semantics for forecast positions.
+
+    Attributes:
+        name: Stable frame label such as ``"world"`` or ``"robot"``.
+        units: Position units. ForecastBatch.v1 expects meters.
+        axes: Ordered axis names for each point coordinate.
+        origin: Optional human-readable origin description.
+    """
+
+    name: str
+    units: str = "m"
+    axes: tuple[str, str] = ("x", "y")
+    origin: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate coordinate-frame fields."""
+        self.name = _require_non_empty_str("frame.name", self.name)
+        self.units = _require_non_empty_str("frame.units", self.units)
+        if self.units != "m":
+            raise ValueError("frame.units must be 'm'")
+        if len(self.axes) != 2:
+            raise ValueError("frame.axes must contain exactly two axes")
+        self.axes = tuple(_require_non_empty_str("frame.axes[]", axis) for axis in self.axes)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CoordinateFrame:
+        """Build a coordinate frame from JSON-compatible data.
+
+        Returns:
+            Validated coordinate-frame metadata.
+        """
+        return cls(
+            name=data.get("name", ""),
+            units=data.get("units", "m"),
+            axes=tuple(data.get("axes", ("x", "y"))),
+            origin=data.get("origin"),
+        )
+
+
+@dataclass
+class ForecastBatchProvenance:
+    """Required provenance for a ForecastBatch.v1 artifact."""
+
+    predictor_id: str
+    predictor_family: str
+    observation_tier: str
+    frame: CoordinateFrame
+    dt_s: float
+    horizons_s: list[float]
+    scenario_id: str
+    seed: int
+    fallback_status: str
+    degraded_status: str
+    actor_ids: list[str]
+    actor_mask: list[bool]
+    actor_mask_metadata: dict[str, Any]
+    feature_schema: dict[str, Any]
+    oracle_state: bool = False
+
+    def __post_init__(self) -> None:
+        """Fail closed on missing provenance or inconsistent actor masks."""
+        self.predictor_id = _require_non_empty_str("predictor_id", self.predictor_id)
+        self.predictor_family = _require_non_empty_str("predictor_family", self.predictor_family)
+        self.observation_tier = _require_non_empty_str("observation_tier", self.observation_tier)
+        if not isinstance(self.frame, CoordinateFrame):
+            self.frame = CoordinateFrame.from_dict(_require_mapping("frame", self.frame))
+        self.dt_s = _require_positive_float("dt_s", self.dt_s)
+        self.horizons_s = _require_float_list("horizons_s", self.horizons_s)
+        self.scenario_id = _require_non_empty_str("scenario_id", self.scenario_id)
+        if isinstance(self.seed, bool) or not isinstance(self.seed, (int, np.integer)):
+            raise ValueError("seed must be an integer")
+        self.seed = int(self.seed)
+        self.fallback_status = _require_non_empty_str("fallback_status", self.fallback_status)
+        self.degraded_status = _require_non_empty_str("degraded_status", self.degraded_status)
+        if not isinstance(self.actor_ids, (list, tuple, np.ndarray)) or len(self.actor_ids) == 0:
+            raise ValueError("actor_ids must be a non-empty list, tuple, or array")
+        self.actor_ids = [
+            _require_non_empty_str("actor_ids[]", actor_id) for actor_id in self.actor_ids
+        ]
+        if len(set(self.actor_ids)) != len(self.actor_ids):
+            raise ValueError("actor_ids must be unique")
+        if not isinstance(self.actor_mask, (list, tuple, np.ndarray)) or len(
+            self.actor_mask
+        ) != len(self.actor_ids):
+            raise ValueError("actor_mask must align with actor_ids")
+        if not all(isinstance(value, (bool, np.bool_)) for value in self.actor_mask):
+            raise ValueError("actor_mask values must be boolean")
+        self.actor_mask = [bool(value) for value in self.actor_mask]
+        self.actor_mask_metadata = _require_mapping(
+            "actor_mask_metadata",
+            self.actor_mask_metadata,
+        )
+        if not self.actor_mask_metadata:
+            raise ValueError("actor_mask_metadata is required")
+        self.feature_schema = _require_mapping("feature_schema", self.feature_schema)
+        if not self.feature_schema:
+            raise ValueError("feature_schema is required")
+        self.oracle_state = bool(self.oracle_state)
+        if (
+            _contains_oracle_key(self.feature_schema)
+            or _contains_oracle_key(self.actor_mask_metadata)
+        ) and not self.oracle_state:
+            raise ValueError("oracle fields require explicit oracle_state=True")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ForecastBatchProvenance:
+        """Build provenance from JSON-compatible data.
+
+        Returns:
+            Validated forecast-batch provenance.
+        """
+        frame = data.get("frame")
+        if isinstance(frame, dict):
+            frame = CoordinateFrame.from_dict(frame)
+        return cls(
+            predictor_id=data.get("predictor_id", ""),
+            predictor_family=data.get("predictor_family", ""),
+            observation_tier=data.get("observation_tier", ""),
+            frame=frame,
+            dt_s=data.get("dt_s"),
+            horizons_s=data.get("horizons_s"),
+            scenario_id=data.get("scenario_id", ""),
+            seed=data.get("seed", 0),
+            fallback_status=data.get("fallback_status", ""),
+            degraded_status=data.get("degraded_status", ""),
+            actor_ids=list(data.get("actor_ids", [])),
+            actor_mask=list(data.get("actor_mask", [])),
+            actor_mask_metadata=data.get("actor_mask_metadata", {}),
+            feature_schema=data.get("feature_schema", {}),
+            oracle_state=bool(data.get("oracle_state", False)),
+        )
+
+
+def _array_or_none(name: str, value: object, *, ndim: int) -> np.ndarray | None:
+    """Normalize an optional numeric array.
+
+    Returns:
+        Float array or None when the optional payload is absent.
+    """
+    if value is None:
+        return None
+    array = np.asarray(value, dtype=float)
+    if array.ndim != ndim or array.shape[-1] != 2:
+        raise ValueError(f"{name} must have shape ending in (..., 2)")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+@dataclass
+class ActorForecast:
+    """Optional forecast payloads for one actor.
+
+    Every predictor may emit any subset of deterministic trajectories, samples,
+    modes, occupancy summaries, and uncertainty metadata as long as the shared
+    provenance is present.
+    """
+
+    actor_id: str
+    deterministic: np.ndarray | None = None
+    samples: np.ndarray | None = None
+    mode_probabilities: list[float] | None = None
+    occupancy_summary: dict[str, Any] | None = None
+    uncertainty_metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate per-actor forecast payload shapes."""
+        self.actor_id = _require_non_empty_str("actor_id", self.actor_id)
+        self.deterministic = _array_or_none("deterministic", self.deterministic, ndim=2)
+        self.samples = _array_or_none("samples", self.samples, ndim=3)
+        if self.mode_probabilities is not None:
+            probs = np.asarray(self.mode_probabilities, dtype=float)
+            if probs.ndim != 1 or probs.size == 0 or not np.all(np.isfinite(probs)):
+                raise ValueError("mode_probabilities must be a finite 1D list")
+            if np.any(probs < 0.0) or not np.isclose(float(np.sum(probs)), 1.0):
+                raise ValueError("mode_probabilities must be non-negative and sum to 1")
+            self.mode_probabilities = [float(value) for value in probs]
+            if self.samples is not None and len(self.mode_probabilities) != self.samples.shape[0]:
+                raise ValueError("mode_probabilities must align with samples")
+        if self.occupancy_summary is not None:
+            self.occupancy_summary = _require_mapping("occupancy_summary", self.occupancy_summary)
+        if self.uncertainty_metadata is not None:
+            self.uncertainty_metadata = _require_mapping(
+                "uncertainty_metadata",
+                self.uncertainty_metadata,
+            )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActorForecast:
+        """Build an actor forecast from JSON-compatible data.
+
+        Returns:
+            Validated actor forecast payload.
+        """
+        return cls(
+            actor_id=data.get("actor_id", ""),
+            deterministic=data.get("deterministic"),
+            samples=data.get("samples"),
+            mode_probabilities=data.get("mode_probabilities"),
+            occupancy_summary=data.get("occupancy_summary"),
+            uncertainty_metadata=data.get("uncertainty_metadata"),
+        )
+
+
+@dataclass
+class ForecastBatch:
+    """Versioned, JSON-serializable forecast artifact."""
+
+    provenance: ForecastBatchProvenance
+    forecasts: list[ActorForecast]
+    schema_version: str = FORECAST_BATCH_SCHEMA_VERSION
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate schema version, provenance, payload alignment, and oracle scope."""
+        if self.schema_version != FORECAST_BATCH_SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {FORECAST_BATCH_SCHEMA_VERSION}")
+        if not isinstance(self.provenance, ForecastBatchProvenance):
+            self.provenance = ForecastBatchProvenance.from_dict(
+                _require_mapping("provenance", self.provenance),
+            )
+        self.forecasts = [
+            forecast if isinstance(forecast, ActorForecast) else ActorForecast.from_dict(forecast)
+            for forecast in self.forecasts
+        ]
+        forecast_ids = [forecast.actor_id for forecast in self.forecasts]
+        if len(forecast_ids) != len(set(forecast_ids)):
+            raise ValueError("forecasts must not contain duplicate actor_ids")
+        forecast_id_set = set(forecast_ids)
+        expected_ids = {
+            actor_id
+            for actor_id, included in zip(
+                self.provenance.actor_ids,
+                self.provenance.actor_mask,
+                strict=True,
+            )
+            if included
+        }
+        if forecast_id_set != expected_ids:
+            raise ValueError("forecast actor_ids must exactly match actor_mask=True actors")
+        expected_steps = len(self.provenance.horizons_s)
+        for forecast in self.forecasts:
+            if (
+                forecast.deterministic is not None
+                and forecast.deterministic.shape[0] != expected_steps
+            ):
+                raise ValueError("deterministic trajectories must align with horizons_s")
+            if forecast.samples is not None and forecast.samples.shape[1] != expected_steps:
+                raise ValueError("sampled trajectories must align with horizons_s")
+        self.metadata = _require_mapping("metadata", self.metadata)
+        if (
+            _contains_oracle_key(self.metadata)
+            or any(
+                _contains_oracle_key(forecast.occupancy_summary)
+                or _contains_oracle_key(forecast.uncertainty_metadata)
+                for forecast in self.forecasts
+            )
+        ) and not self.provenance.oracle_state:
+            raise ValueError("oracle fields require explicit oracle_state=True")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ForecastBatch:
+        """Build and validate a ForecastBatch from JSON-compatible data.
+
+        Returns:
+            Validated forecast batch.
+        """
+        return cls(
+            schema_version=data.get("schema_version", ""),
+            provenance=ForecastBatchProvenance.from_dict(data.get("provenance", {})),
+            forecasts=[ActorForecast.from_dict(item) for item in data.get("forecasts", [])],
+            metadata=data.get("metadata", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return as_dict(self)
+
+
+def as_dict(value: Any) -> Any:
+    """Convert dataclasses and numpy arrays to JSON-compatible values.
+
+    Returns:
+        JSON-compatible value.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if is_dataclass(value):
+        return {item.name: as_dict(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, dict):
+        return {str(key): as_dict(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [as_dict(item) for item in value]
+    return value
+
+
+def load_forecast_batch(path: str | Path) -> ForecastBatch:
+    """Load a ForecastBatch.v1 JSON artifact from disk.
+
+    Returns:
+        Validated forecast batch loaded from JSON.
+    """
+    with Path(path).open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    if not isinstance(data, dict):
+        raise ValueError("forecast batch JSON must be an object")
+    return ForecastBatch.from_dict(data)
+
+
+def save_forecast_batch(batch: ForecastBatch, path: str | Path) -> None:
+    """Write a ForecastBatch.v1 JSON artifact to disk."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as stream:
+        json.dump(batch.to_dict(), stream, indent=2, sort_keys=True)
+        stream.write("\n")
+
+
+def validate_forecast_batch(data: ForecastBatch | dict[str, Any]) -> ForecastBatch:
+    """Return a validated ForecastBatch, raising ValueError on contract failures."""
+    if isinstance(data, ForecastBatch):
+        data.__post_init__()
+        return data
+    return ForecastBatch.from_dict(data)
+
+
+__all__ = [
+    "FORECAST_BATCH_SCHEMA_VERSION",
+    "ActorForecast",
+    "CoordinateFrame",
+    "ForecastBatch",
+    "ForecastBatchProvenance",
+    "load_forecast_batch",
+    "save_forecast_batch",
+    "validate_forecast_batch",
+]

--- a/tests/benchmark/test_forecast_batch.py
+++ b/tests/benchmark/test_forecast_batch.py
@@ -1,0 +1,309 @@
+"""Tests for the ForecastBatch.v1 artifact contract."""
+
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.forecast_batch import (
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+    load_forecast_batch,
+    save_forecast_batch,
+    validate_forecast_batch,
+)
+
+
+def _provenance(**overrides: object) -> ForecastBatchProvenance:
+    """Build valid baseline provenance for tests."""
+    data: dict[str, object] = {
+        "predictor_id": "cv-baseline-v1",
+        "predictor_family": "constant_velocity",
+        "observation_tier": "deployable_observation",
+        "frame": CoordinateFrame(
+            name="world",
+            units="m",
+            axes=("x", "y"),
+            origin="map origin",
+        ),
+        "dt_s": 0.5,
+        "horizons_s": [0.5, 1.0],
+        "scenario_id": "crosswalk_001",
+        "seed": 7,
+        "fallback_status": "native",
+        "degraded_status": "none",
+        "actor_ids": ["ped_1", "ped_2"],
+        "actor_mask": [True, True],
+        "actor_mask_metadata": {
+            "semantics": "true means forecast payload is available for actor_id",
+            "missing_actor_reasons": {},
+        },
+        "feature_schema": {
+            "name": "socnav_observation_v1",
+            "features": ["position_m", "velocity_mps"],
+        },
+        "oracle_state": False,
+    }
+    data.update(overrides)
+    return ForecastBatchProvenance(**data)
+
+
+def _batch_dict() -> dict[str, object]:
+    """Return a JSON-compatible valid ForecastBatch fixture."""
+    return ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(actor_id="ped_1", deterministic=[[1.0, 0.0], [1.5, 0.0]]),
+            ActorForecast(actor_id="ped_2", deterministic=[[0.0, 1.0], [0.0, 1.5]]),
+        ],
+        metadata={"artifact_role": "schema_smoke"},
+    ).to_dict()
+
+
+def test_forecast_batch_deterministic_round_trip(tmp_path) -> None:
+    """Deterministic forecasts should serialize and reload with provenance intact."""
+    batch = ForecastBatch.from_dict(_batch_dict())
+    path = tmp_path / "forecast_batch.json"
+
+    save_forecast_batch(batch, path)
+    loaded = load_forecast_batch(path)
+
+    assert loaded.schema_version == "ForecastBatch.v1"
+    assert loaded.provenance.observation_tier == "deployable_observation"
+    assert loaded.provenance.frame.units == "m"
+    assert loaded.forecasts[0].deterministic is not None
+    assert loaded.forecasts[0].deterministic.shape == (2, 2)
+
+
+def test_forecast_batch_sampled_modes_round_trip() -> None:
+    """Sampled trajectories and mode probabilities are optional but validated when present."""
+    batch = ForecastBatch(
+        provenance=_provenance(
+            actor_mask=[True, False],
+            actor_mask_metadata={
+                "semantics": "true means forecast payload is available for actor_id",
+                "missing_actor_reasons": {"ped_2": "not visible"},
+            },
+        ),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                samples=[
+                    [[1.0, 0.0], [1.5, 0.0]],
+                    [[1.0, 0.1], [1.4, 0.2]],
+                ],
+                mode_probabilities=[0.6, 0.4],
+                uncertainty_metadata={"sample_source": "scenario_branches"},
+            ),
+        ],
+    )
+
+    loaded = ForecastBatch.from_dict(batch.to_dict())
+
+    assert loaded.forecasts[0].samples is not None
+    assert loaded.forecasts[0].samples.shape == (2, 2, 2)
+    assert loaded.forecasts[0].mode_probabilities == [0.6, 0.4]
+
+
+def test_forecast_batch_serializes_numpy_scalar_metadata(tmp_path) -> None:
+    """JSON output should normalize numpy scalar metadata values."""
+    batch = ForecastBatch(
+        provenance=_provenance(feature_schema={"name": "socnav_v1", "input_dim": np.int64(4)}),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[1.0, 0.0], [1.5, 0.0]],
+                occupancy_summary={"peak_probability": np.float32(0.25)},
+            ),
+            ActorForecast(actor_id="ped_2", deterministic=[[0.0, 1.0], [0.0, 1.5]]),
+        ],
+        metadata={"generator_version": np.int64(2)},
+    )
+    path = tmp_path / "forecast_batch.json"
+
+    save_forecast_batch(batch, path)
+    loaded = load_forecast_batch(path)
+
+    assert loaded.metadata["generator_version"] == 2
+    assert loaded.forecasts[0].occupancy_summary["peak_probability"] == 0.25
+
+
+def test_forecast_batch_accepts_numpy_horizons_and_tuple_actor_masks() -> None:
+    """Scientific-Python container types should normalize at the artifact boundary."""
+    batch = ForecastBatch(
+        provenance=_provenance(
+            horizons_s=np.array([0.5, 1.0], dtype=np.float32),
+            actor_ids=("ped_1", "ped_2"),
+            actor_mask=(True, False),
+            actor_mask_metadata={
+                "semantics": "true means forecast payload is available for actor_id",
+                "missing_actor_reasons": {"ped_2": "not visible"},
+            },
+        ),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[1.0, 0.0], [1.5, 0.0]])],
+    )
+
+    assert batch.provenance.horizons_s == [0.5, 1.0]
+    assert batch.provenance.actor_ids == ["ped_1", "ped_2"]
+
+
+def test_forecast_batch_allows_missing_actor_with_explicit_mask_metadata() -> None:
+    """Missing actor payloads are allowed only when the actor mask documents semantics."""
+    provenance = _provenance(
+        actor_mask=[True, False],
+        actor_mask_metadata={
+            "semantics": "true means forecast payload is available for actor_id",
+            "missing_actor_reasons": {"ped_2": "not visible at forecast time"},
+        },
+    )
+
+    batch = ForecastBatch(
+        provenance=provenance,
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[1.0, 0.0], [1.5, 0.0]])],
+    )
+
+    assert batch.provenance.actor_mask == [True, False]
+    assert batch.provenance.actor_mask_metadata["missing_actor_reasons"]["ped_2"]
+
+
+@pytest.mark.parametrize(
+    ("actor_mask", "forecast_ids"),
+    [
+        ([True, True], ["ped_1"]),
+        ([True, False], ["ped_1", "ped_2"]),
+    ],
+)
+def test_forecast_batch_requires_payloads_to_match_actor_mask(
+    actor_mask: list[bool],
+    forecast_ids: list[str],
+) -> None:
+    """Forecast payloads must exactly match actors marked present by actor_mask."""
+    batch = _batch_dict()
+    provenance = copy.deepcopy(batch["provenance"])
+    assert isinstance(provenance, dict)
+    provenance["actor_mask"] = actor_mask
+    provenance["actor_mask_metadata"] = {
+        "semantics": "true means forecast payload is available for actor_id",
+        "missing_actor_reasons": {"ped_2": "not visible"},
+    }
+    batch["provenance"] = provenance
+    batch["forecasts"] = [
+        {"actor_id": actor_id, "deterministic": [[1.0, 0.0], [1.5, 0.0]]}
+        for actor_id in forecast_ids
+    ]
+
+    with pytest.raises(ValueError, match="actor_mask"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_rejects_duplicate_forecast_actor_ids() -> None:
+    """Duplicate forecast payloads for one actor are ambiguous and rejected."""
+    data = _batch_dict()
+    data["forecasts"] = [
+        {"actor_id": "ped_1", "deterministic": [[1.0, 0.0], [1.5, 0.0]]},
+        {"actor_id": "ped_1", "deterministic": [[1.0, 0.0], [1.5, 0.0]]},
+    ]
+
+    with pytest.raises(ValueError, match="duplicate actor_ids"):
+        validate_forecast_batch(data)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("observation_tier", "", "observation_tier"),
+        ("dt_s", 0.0, "dt_s"),
+        ("dt_s", True, "bool"),
+        ("horizons_s", [], "horizons_s"),
+        ("horizons_s", [1.0, 0.5], "horizons_s"),
+        ("horizons_s", [True, 1.0], "bool"),
+        ("seed", "7", "seed"),
+        ("frame", {"name": "", "units": "m", "axes": ["x", "y"]}, "frame.name"),
+        ("actor_mask", [1, True], "actor_mask"),
+        ("actor_mask_metadata", {}, "actor_mask_metadata"),
+    ],
+)
+def test_forecast_batch_rejects_missing_required_provenance(
+    field: str,
+    value: object,
+    match: str,
+) -> None:
+    """Required provenance fields fail closed."""
+    data = _batch_dict()
+    provenance = copy.deepcopy(data["provenance"])
+    assert isinstance(provenance, dict)
+    provenance[field] = value
+    data["provenance"] = provenance
+
+    with pytest.raises(ValueError, match=match):
+        validate_forecast_batch(data)
+
+
+def test_forecast_batch_rejects_undeclared_oracle_fields() -> None:
+    """Oracle-looking fields must be explicitly marked as oracle_state."""
+    data = _batch_dict()
+    provenance = copy.deepcopy(data["provenance"])
+    assert isinstance(provenance, dict)
+    provenance["feature_schema"] = {"name": "deployable_oracle_features"}
+    provenance["oracle_state"] = False
+    data["provenance"] = provenance
+
+    with pytest.raises(ValueError, match="oracle_state"):
+        validate_forecast_batch(data)
+
+    provenance["oracle_state"] = True
+    loaded = validate_forecast_batch(data)
+    assert loaded.provenance.oracle_state is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("metadata", {"oracle_hint": "diagnostic"}),
+        (
+            "actor_mask_metadata",
+            {
+                "semantics": "true means forecast payload is available for actor_id",
+                "missing_actor_reasons": {"ped_2": "oracle_occlusion_state"},
+            },
+        ),
+        ("uncertainty_metadata", {"source": "oracle_rollout"}),
+    ],
+)
+def test_forecast_batch_rejects_undeclared_oracle_metadata(
+    field: str,
+    value: dict[str, object],
+) -> None:
+    """Oracle-looking metadata is rejected outside explicit oracle-state artifacts."""
+    data = _batch_dict()
+    if field == "metadata":
+        data["metadata"] = value
+    elif field == "actor_mask_metadata":
+        provenance = copy.deepcopy(data["provenance"])
+        assert isinstance(provenance, dict)
+        provenance["actor_mask_metadata"] = value
+        data["provenance"] = provenance
+    else:
+        forecasts = copy.deepcopy(data["forecasts"])
+        assert isinstance(forecasts, list)
+        forecasts[0][field] = value
+        data["forecasts"] = forecasts
+
+    with pytest.raises(ValueError, match="oracle_state"):
+        validate_forecast_batch(data)
+
+
+def test_forecast_batch_rejects_horizon_shape_mismatch() -> None:
+    """Forecast payload steps must align with horizons_s."""
+    data = _batch_dict()
+    forecasts = copy.deepcopy(data["forecasts"])
+    assert isinstance(forecasts, list)
+    forecasts[0]["deterministic"] = [[1.0, 0.0]]
+    data["forecasts"] = forecasts
+
+    with pytest.raises(ValueError, match="horizons_s"):
+        validate_forecast_batch(data)


### PR DESCRIPTION
## Summary
- Adds a standalone `ForecastBatch.v1` benchmark artifact contract with strict provenance validation, JSON round-trip helpers, and package exports.
- Documents required units/frame semantics, actor-mask semantics, fallback/degraded status, feature schema provenance, and deployable-vs-oracle claim boundaries.
- Adds tests for deterministic, sampled/mode, missing-mask, numpy-scalar metadata, actor-mask alignment, missing provenance, horizon shape, and undeclared oracle metadata cases.

Closes #2836.

## Research Result Guidance
- Target claim / blocker: defines the forecast artifact contract needed before comparing predictive planners or forecast adapters without mixing deployable, degraded, fallback, and oracle-state artifacts.
- Comparator / baseline: no predictor-quality comparison in this PR; this is schema/tooling support only.
- Evidence tier: local schema/serialization tests plus full repo readiness.
- Result classification: support contract, not benchmark evidence and not a prediction-quality claim.
- Decision / stop rule: ForecastBatch.v1 accepts additive deterministic/sample/mode/occupancy payloads while failing closed on missing required provenance and undeclared oracle fields.
- Synthesis surface / update target: `docs/context/issue_2836_forecast_batch_schema.md`; informs prediction-lane follow-ups under #2835.

## Downstream Propagation
- Parent issue / claim map: #2836 under #2835.
- Benchmark report / leaderboard: NA; no benchmark result or metric claim produced.
- Registry / config index: NA; no model, planner, or config registry changes.
- Context index / memory note: added `docs/context/issue_2836_forecast_batch_schema.md` as the discoverable schema note.
- Follow-up issue needed: not for this contract PR; downstream adapter/evaluator integration remains in the existing prediction-lane issue set.

## Validation
- `uv sync --all-extras`
- `uv run pytest tests/benchmark/test_forecast_batch.py` -> 17 passed
- `uv run ruff check robot_sf/benchmark/forecast_batch.py tests/benchmark/test_forecast_batch.py robot_sf/benchmark/__init__.py`
- `uv run ruff format --check robot_sf/benchmark/forecast_batch.py tests/benchmark/test_forecast_batch.py robot_sf/benchmark/__init__.py`
- `uv run python -c "from robot_sf.benchmark import ForecastBatch, FORECAST_BATCH_SCHEMA_VERSION; print(FORECAST_BATCH_SCHEMA_VERSION, ForecastBatch.__name__)"`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 6457 passed, 9 skipped, 8 warnings; changed-file coverage warning only for `robot_sf/benchmark/forecast_batch.py` at 90.0% (minimum 80.0%, goal 100.0%).

## Delegation
- Qwen issue-selection scout: rejected as uneconomic after tool-call cap failures.
- Gemini read-only mapping: accepted as advisory; recommended standalone typed schema and validation tests.
- Command Code implementation: rejected as uneconomic after max-turn cap without artifacts or edits.
- OpenCode implementation: rejected as uneconomic after no edits/artifacts and manual termination.
- Gemini and Command Code read-only reviews: accepted; led to actor-mask strictness, oracle-boundary hardening, metadata-only oracle scanning, numpy scalar JSON conversion, and extra tests.

## Risks
- `ForecastBatch.v1` is a schema contract only. It does not prove prediction accuracy, calibration, or planner benefit.
- Oracle keyword detection is intentionally fail-closed for metadata dictionaries and may reject metadata values containing `oracle` unless `oracle_state=True`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ForecastBatch.v1 artifact contract for exchanging pedestrian forecast outputs with built-in validation and serialization support.
  * Made forecast batch functionality publicly available through the benchmark module.

* **Documentation**
  * Added documentation specifying benchmark artifact contract requirements including provenance fields, coordinate frames, and allowed payload types.

* **Tests**
  * Added comprehensive test coverage for forecast batch serialization, validation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->