### PR TITLE
feat: add forecast batch probabilistic metrics

### DIFF
--- a/robot_sf/benchmark/__init__.py
+++ b/robot_sf/benchmark/__init__.py
@@ -15,6 +15,12 @@ from robot_sf.benchmark.forecast_batch import (
     save_forecast_batch,
     validate_forecast_batch,
 )
+from robot_sf.benchmark.forecast_metrics import (
+    FORECAST_METRICS_SCHEMA_VERSION,
+    ForecastMetricRow,
+    evaluate_forecast_batch,
+    format_forecast_metrics_markdown,
+)
 from robot_sf.benchmark.helper_catalog import (
     load_trained_policy,
     prepare_classic_env,
@@ -30,16 +36,20 @@ from robot_sf.benchmark.helper_registry import (
 
 __all__ = [
     "FORECAST_BATCH_SCHEMA_VERSION",
+    "FORECAST_METRICS_SCHEMA_VERSION",
     "ActorForecast",
     "AggregationMetadataError",
     "CoordinateFrame",
     "ExampleOrchestrator",
     "ForecastBatch",
     "ForecastBatchProvenance",
+    "ForecastMetricRow",
     "HelperCapability",
     "HelperCategory",
     "OrchestratorUsage",
     "RegressionCheck",
+    "evaluate_forecast_batch",
+    "format_forecast_metrics_markdown",
     "load_forecast_batch",
     "load_trained_policy",
     "prepare_classic_env",

--- a/robot_sf/benchmark/forecast_metrics.py
+++ b/robot_sf/benchmark/forecast_metrics.py
@@ -1,0 +1,598 @@
+"""Predictor-agnostic metrics for ForecastBatch.v1 artifacts.
+
+These helpers evaluate forecast artifacts without making navigation-benefit
+claims. The output keeps metric availability, denominators, horizon metadata,
+actor class, scenario id, and observation tier explicit so deterministic and
+probabilistic predictors cannot be compared through silently merged rows.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.forecast_batch import (
+    FORECAST_BATCH_SCHEMA_VERSION,
+    ActorForecast,
+    ForecastBatch,
+    validate_forecast_batch,
+)
+
+FORECAST_METRICS_SCHEMA_VERSION = "ForecastMetrics.v1"
+
+
+@dataclass(frozen=True)
+class ForecastMetricRow:
+    """One per-actor or aggregate forecast metric row."""
+
+    metric: str
+    horizon_s: float
+    value: float | None
+    status: str
+    denominator: int
+    actor_class: str
+    scenario_id: str
+    observation_tier: str
+    dt_s: float
+    actor_id: str | None = None
+    scenario_family: str | None = None
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible metric row.
+
+        Returns:
+            Metric row dictionary.
+        """
+        data: dict[str, Any] = {
+            "metric": self.metric,
+            "horizon_s": float(self.horizon_s),
+            "value": self.value,
+            "status": self.status,
+            "denominator": int(self.denominator),
+            "actor_class": self.actor_class,
+            "scenario_id": self.scenario_id,
+            "observation_tier": self.observation_tier,
+            "dt_s": float(self.dt_s),
+        }
+        if self.actor_id is not None:
+            data["actor_id"] = self.actor_id
+        if self.scenario_family is not None:
+            data["scenario_family"] = self.scenario_family
+        if self.note is not None:
+            data["note"] = self.note
+        return data
+
+
+GroundTruthPositions = dict[str, list[list[float]] | tuple[tuple[float, float], ...] | np.ndarray]
+
+
+def evaluate_forecast_batch(
+    batch: ForecastBatch | dict[str, Any],
+    ground_truth: GroundTruthPositions,
+    *,
+    miss_threshold_m: float = 2.0,
+) -> dict[str, Any]:
+    """Evaluate ForecastBatch.v1 predictions against future positions.
+
+    Args:
+        batch: ForecastBatch object or JSON-compatible batch dictionary.
+        ground_truth: Mapping from actor id to future positions with shape
+            ``(T, 2)`` aligned to ``batch.provenance.horizons_s``.
+        miss_threshold_m: Displacement threshold used for final-horizon miss-rate rows.
+
+    Returns:
+        JSON-compatible metric report with per-actor rows and aggregate rows.
+    """
+    if miss_threshold_m <= 0:
+        raise ValueError("miss_threshold_m must be positive")
+
+    forecast_batch = validate_forecast_batch(batch)
+    rows: list[ForecastMetricRow] = []
+
+    active_actor_ids = {
+        actor_id
+        for actor_id, included in zip(
+            forecast_batch.provenance.actor_ids,
+            forecast_batch.provenance.actor_mask,
+            strict=True,
+        )
+        if included
+    }
+    forecasts_by_actor = {forecast.actor_id: forecast for forecast in forecast_batch.forecasts}
+    scenario_family = _scenario_family(forecast_batch)
+
+    for actor_id in sorted(active_actor_ids):
+        forecast = forecasts_by_actor[actor_id]
+        actor_class = _actor_class(forecast, forecast_batch)
+        truth = _ground_truth_array(
+            actor_id, ground_truth, len(forecast_batch.provenance.horizons_s)
+        )
+        rows.extend(
+            _actor_metric_rows(
+                forecast=forecast,
+                truth=truth,
+                actor_class=actor_class,
+                batch=forecast_batch,
+                scenario_family=scenario_family,
+                miss_threshold_m=miss_threshold_m,
+            )
+        )
+
+    aggregate_rows = _aggregate_rows(rows)
+    excluded_actor_count = int(len(forecast_batch.provenance.actor_ids) - len(active_actor_ids))
+    unavailable_count = int(sum(row.status == "unavailable" for row in rows + aggregate_rows))
+
+    return {
+        "schema_version": FORECAST_METRICS_SCHEMA_VERSION,
+        "forecast_schema_version": FORECAST_BATCH_SCHEMA_VERSION,
+        "evaluator": "ForecastBatchMetrics.v1",
+        "provenance": {
+            "predictor_id": forecast_batch.provenance.predictor_id,
+            "predictor_family": forecast_batch.provenance.predictor_family,
+            "scenario_id": forecast_batch.provenance.scenario_id,
+            "scenario_family": scenario_family,
+            "observation_tier": forecast_batch.provenance.observation_tier,
+            "dt_s": forecast_batch.provenance.dt_s,
+            "horizons_s": list(forecast_batch.provenance.horizons_s),
+        },
+        "metric_parameters": {
+            "miss_threshold_m": float(miss_threshold_m),
+        },
+        "denominator_health": {
+            "active_actor_count": len(active_actor_ids),
+            "excluded_actor_count": excluded_actor_count,
+            "metric_row_count": len(rows),
+            "aggregate_row_count": len(aggregate_rows),
+            "unavailable_row_count": unavailable_count,
+            "has_empty_denominator": any(row.denominator == 0 for row in rows + aggregate_rows),
+        },
+        "metric_rows": [row.to_dict() for row in rows],
+        "aggregate_rows": [row.to_dict() for row in aggregate_rows],
+        "claim_boundary": (
+            "Forecast metrics are open-loop evidence only and do not prove navigation "
+            "success, calibration, or planner benefit."
+        ),
+    }
+
+
+def _actor_metric_rows(
+    *,
+    forecast: ActorForecast,
+    truth: np.ndarray | None,
+    actor_class: str,
+    batch: ForecastBatch,
+    scenario_family: str | None,
+    miss_threshold_m: float,
+) -> list[ForecastMetricRow]:
+    rows: list[ForecastMetricRow] = []
+    horizons_s = batch.provenance.horizons_s
+
+    for index, horizon_s in enumerate(horizons_s):
+        if truth is None:
+            rows.extend(
+                _unavailable_rows(
+                    forecast=forecast,
+                    horizon_s=horizon_s,
+                    actor_class=actor_class,
+                    batch=batch,
+                    scenario_family=scenario_family,
+                    note="missing ground truth",
+                )
+            )
+            continue
+        target = truth[index]
+        deterministic_error = _point_error(forecast.deterministic, index, target)
+        sample_error = _min_sample_error(forecast.samples, index, target)
+        expected_error = _expected_sample_error(forecast, index, target)
+        final_horizon = index == len(horizons_s) - 1
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="ade",
+                horizon_s=horizon_s,
+                value=deterministic_error,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=None
+                if deterministic_error is not None
+                else "deterministic trajectory unavailable",
+            )
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="fde",
+                horizon_s=horizon_s,
+                value=deterministic_error if final_horizon else None,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=_final_horizon_note(
+                    final_horizon=final_horizon,
+                    value=deterministic_error,
+                    missing_note="deterministic trajectory unavailable",
+                ),
+            )
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="minade@k",
+                horizon_s=horizon_s,
+                value=sample_error,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=None if forecast.samples is not None else "sampled trajectories unavailable",
+            )
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="minfde@k",
+                horizon_s=horizon_s,
+                value=sample_error if final_horizon else None,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=_final_horizon_note(
+                    final_horizon=final_horizon,
+                    value=sample_error,
+                    missing_note="sampled trajectories unavailable",
+                ),
+            )
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="expected_ade",
+                horizon_s=horizon_s,
+                value=expected_error,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=None
+                if forecast.samples is not None and forecast.mode_probabilities is not None
+                else "mode probabilities unavailable",
+            )
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="expected_fde",
+                horizon_s=horizon_s,
+                value=expected_error if final_horizon else None,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=_final_horizon_note(
+                    final_horizon=final_horizon,
+                    value=expected_error,
+                    missing_note="mode probabilities unavailable",
+                ),
+            )
+        )
+        miss_value = _miss_rate_value(
+            deterministic_error=deterministic_error,
+            min_sample_error=sample_error,
+            final_horizon=final_horizon,
+            threshold_m=miss_threshold_m,
+        )
+        rows.append(
+            _row(
+                forecast=forecast,
+                metric="miss_rate",
+                horizon_s=horizon_s,
+                value=miss_value,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+                note=_final_horizon_note(
+                    final_horizon=final_horizon,
+                    value=miss_value,
+                    missing_note="requires deterministic or sampled final-horizon displacement",
+                ),
+            )
+        )
+        rows.extend(
+            _unavailable_hook_rows(
+                forecast=forecast,
+                horizon_s=horizon_s,
+                actor_class=actor_class,
+                batch=batch,
+                scenario_family=scenario_family,
+            )
+        )
+
+    return rows
+
+
+def _unavailable_rows(
+    *,
+    forecast: ActorForecast,
+    horizon_s: float,
+    actor_class: str,
+    batch: ForecastBatch,
+    scenario_family: str | None,
+    note: str,
+) -> list[ForecastMetricRow]:
+    return [
+        _row(
+            forecast=forecast,
+            metric=metric,
+            horizon_s=horizon_s,
+            value=None,
+            actor_class=actor_class,
+            batch=batch,
+            scenario_family=scenario_family,
+            note=note,
+        )
+        for metric in (
+            "ade",
+            "fde",
+            "minade@k",
+            "minfde@k",
+            "expected_ade",
+            "expected_fde",
+            "miss_rate",
+            "likelihood",
+            "coverage",
+            "collision_relevance",
+        )
+    ]
+
+
+def _unavailable_hook_rows(
+    *,
+    forecast: ActorForecast,
+    horizon_s: float,
+    actor_class: str,
+    batch: ForecastBatch,
+    scenario_family: str | None,
+) -> list[ForecastMetricRow]:
+    return [
+        _row(
+            forecast=forecast,
+            metric=metric,
+            horizon_s=horizon_s,
+            value=None,
+            actor_class=actor_class,
+            batch=batch,
+            scenario_family=scenario_family,
+            note=note,
+        )
+        for metric, note in (
+            ("likelihood", "requires forecast distribution density metadata"),
+            ("coverage", "requires calibrated set or occupancy coverage metadata"),
+            ("collision_relevance", "requires forecast-scene collision relevance metadata"),
+        )
+    ]
+
+
+def _row(
+    *,
+    forecast: ActorForecast,
+    metric: str,
+    horizon_s: float,
+    value: float | None,
+    actor_class: str,
+    batch: ForecastBatch,
+    scenario_family: str | None,
+    note: str | None,
+) -> ForecastMetricRow:
+    return ForecastMetricRow(
+        metric=metric,
+        horizon_s=float(horizon_s),
+        value=None if value is None else float(value),
+        status="unavailable" if value is None else "ok",
+        denominator=0 if value is None else 1,
+        actor_id=forecast.actor_id,
+        actor_class=actor_class,
+        scenario_id=batch.provenance.scenario_id,
+        scenario_family=scenario_family,
+        observation_tier=batch.provenance.observation_tier,
+        dt_s=batch.provenance.dt_s,
+        note=note,
+    )
+
+
+def _final_horizon_note(
+    *,
+    final_horizon: bool,
+    value: float | None,
+    missing_note: str,
+) -> str | None:
+    if not final_horizon:
+        return "final horizon only"
+    if value is None:
+        return missing_note
+    return None
+
+
+def _aggregate_rows(rows: list[ForecastMetricRow]) -> list[ForecastMetricRow]:
+    grouped: dict[tuple[str, float, str, str, str, float, str | None], list[float]] = defaultdict(
+        list
+    )
+    for row in rows:
+        if row.status != "ok" or row.value is None:
+            continue
+        key = (
+            row.metric,
+            row.horizon_s,
+            row.actor_class,
+            row.scenario_id,
+            row.observation_tier,
+            row.dt_s,
+            row.scenario_family,
+        )
+        grouped[key].append(row.value)
+
+    aggregate_rows: list[ForecastMetricRow] = []
+    seen_keys = {
+        (
+            row.metric,
+            row.horizon_s,
+            row.actor_class,
+            row.scenario_id,
+            row.observation_tier,
+            row.dt_s,
+            row.scenario_family,
+        )
+        for row in rows
+    }
+    for key in sorted(seen_keys):
+        metric, horizon_s, actor_class, scenario_id, observation_tier, dt_s, scenario_family = key
+        values = grouped.get(key, [])
+        aggregate_rows.append(
+            ForecastMetricRow(
+                metric=f"mean_{metric}",
+                horizon_s=horizon_s,
+                value=float(np.mean(values)) if values else None,
+                status="ok" if values else "unavailable",
+                denominator=len(values),
+                actor_class=actor_class,
+                scenario_id=scenario_id,
+                scenario_family=scenario_family,
+                observation_tier=observation_tier,
+                dt_s=dt_s,
+                note=None if values else "empty denominator",
+            )
+        )
+    return aggregate_rows
+
+
+def _ground_truth_array(
+    actor_id: str,
+    ground_truth: GroundTruthPositions,
+    expected_steps: int,
+) -> np.ndarray | None:
+    if actor_id not in ground_truth:
+        return None
+    array = np.asarray(ground_truth[actor_id], dtype=float)
+    if array.shape != (expected_steps, 2):
+        raise ValueError(
+            "ground_truth trajectories must align with horizons_s and have shape (T, 2)"
+        )
+    if not np.all(np.isfinite(array)):
+        raise ValueError("ground_truth trajectories must contain only finite values")
+    return array
+
+
+def _point_error(
+    trajectory: np.ndarray | None, horizon_index: int, target: np.ndarray
+) -> float | None:
+    if trajectory is None:
+        return None
+    return float(np.linalg.norm(trajectory[horizon_index] - target))
+
+
+def _min_sample_error(
+    samples: np.ndarray | None, horizon_index: int, target: np.ndarray
+) -> float | None:
+    if samples is None:
+        return None
+    errors = np.linalg.norm(samples[:, horizon_index, :] - target, axis=1)
+    return float(np.min(errors))
+
+
+def _miss_rate_value(
+    *,
+    deterministic_error: float | None,
+    min_sample_error: float | None,
+    final_horizon: bool,
+    threshold_m: float,
+) -> float | None:
+    if not final_horizon:
+        return None
+    error = min_sample_error if min_sample_error is not None else deterministic_error
+    if error is None:
+        return None
+    return float(error > threshold_m)
+
+
+def _expected_sample_error(
+    forecast: ActorForecast,
+    horizon_index: int,
+    target: np.ndarray,
+) -> float | None:
+    if forecast.samples is None or forecast.mode_probabilities is None:
+        return None
+    errors = np.linalg.norm(forecast.samples[:, horizon_index, :] - target, axis=1)
+    probabilities = np.asarray(forecast.mode_probabilities, dtype=float)
+    return float(np.sum(errors * probabilities))
+
+
+def _actor_class(forecast: ActorForecast, batch: ForecastBatch) -> str:
+    metadata_sources = (
+        forecast.uncertainty_metadata,
+        forecast.occupancy_summary,
+        batch.metadata.get("actor_classes"),
+    )
+    for source in metadata_sources:
+        if isinstance(source, dict):
+            if forecast.actor_id in source:
+                return str(source[forecast.actor_id])
+            if source.get("actor_class") is not None:
+                return str(source["actor_class"])
+    return "pedestrian"
+
+
+def _scenario_family(batch: ForecastBatch) -> str | None:
+    value = batch.metadata.get("scenario_family")
+    return str(value) if value is not None else None
+
+
+def format_forecast_metrics_markdown(report: dict[str, Any]) -> str:
+    """Format a compact Markdown summary for context evidence promotion.
+
+    Args:
+        report: JSON-compatible report returned by :func:`evaluate_forecast_batch`.
+
+    Returns:
+        Markdown summary with provenance, denominator health, and aggregate metrics.
+    """
+    provenance = report["provenance"]
+    health = report["denominator_health"]
+    lines = [
+        "# Forecast Metrics Summary",
+        "",
+        f"- Predictor: {provenance['predictor_id']} ({provenance['predictor_family']})",
+        f"- Scenario: {provenance['scenario_id']}",
+        f"- Observation tier: {provenance['observation_tier']}",
+        (
+            f"- Denominators: active={health['active_actor_count']}, "
+            f"excluded={health['excluded_actor_count']}, unavailable={health['unavailable_row_count']}"
+        ),
+        "",
+        "| metric | horizon_s | actor_class | denominator | status | value |",
+        "| --- | ---: | --- | ---: | --- | ---: |",
+    ]
+    for row in report["aggregate_rows"]:
+        value = row["value"]
+        rendered_value = "NA" if value is None else f"{float(value):.6g}"
+        lines.append(
+            "| {metric} | {horizon_s:g} | {actor_class} | {denominator} | {status} | "
+            "{value} |".format(
+                metric=row["metric"],
+                horizon_s=float(row["horizon_s"]),
+                actor_class=row["actor_class"],
+                denominator=int(row["denominator"]),
+                status=row["status"],
+                value=rendered_value,
+            )
+        )
+    lines.extend(["", report["claim_boundary"]])
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "FORECAST_METRICS_SCHEMA_VERSION",
+    "ForecastMetricRow",
+    "evaluate_forecast_batch",
+    "format_forecast_metrics_markdown",
+]

--- a/robot_sf/benchmark/forecast_metrics.py
+++ b/robot_sf/benchmark/forecast_metrics.py
@@ -445,7 +445,7 @@ def _aggregate_rows(rows: list[ForecastMetricRow]) -> list[ForecastMetricRow]:
         )
         for row in rows
     }
-    for key in sorted(seen_keys):
+    for key in sorted(seen_keys, key=_aggregate_sort_key):
         metric, horizon_s, actor_class, scenario_id, observation_tier, dt_s, scenario_family = key
         values = grouped.get(key, [])
         aggregate_rows.append(
@@ -464,6 +464,19 @@ def _aggregate_rows(rows: list[ForecastMetricRow]) -> list[ForecastMetricRow]:
             )
         )
     return aggregate_rows
+
+
+def _aggregate_sort_key(key: tuple[str, float, str, str, str, float, str | None]) -> tuple:
+    metric, horizon_s, actor_class, scenario_id, observation_tier, dt_s, scenario_family = key
+    return (
+        metric,
+        horizon_s,
+        actor_class,
+        scenario_id,
+        observation_tier,
+        dt_s,
+        "" if scenario_family is None else scenario_family,
+    )
 
 
 def _ground_truth_array(
@@ -535,10 +548,12 @@ def _actor_class(forecast: ActorForecast, batch: ForecastBatch) -> str:
     )
     for source in metadata_sources:
         if isinstance(source, dict):
-            if forecast.actor_id in source:
-                return str(source[forecast.actor_id])
-            if source.get("actor_class") is not None:
-                return str(source["actor_class"])
+            actor_class = source.get(forecast.actor_id)
+            if actor_class is not None:
+                return str(actor_class)
+            default_actor_class = source.get("actor_class")
+            if default_actor_class is not None:
+                return str(default_actor_class)
     return "pedestrian"
 
 

--- a/tests/benchmark/test_forecast_metrics.py
+++ b/tests/benchmark/test_forecast_metrics.py
@@ -279,6 +279,26 @@ def test_forecast_metrics_accept_actor_class_from_batch_metadata() -> None:
     assert _aggregate(report, "mean_ade", 1.0, "child")["value"] == 0.0
 
 
+def test_forecast_metrics_ignore_none_actor_class_metadata() -> None:
+    """Explicit None metadata should not become a literal actor class."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+                uncertainty_metadata={"ped_1": None},
+            )
+        ],
+        metadata={"actor_classes": {"ped_1": None}},
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _aggregate(report, "mean_ade", 1.0, "pedestrian")["value"] == 0.0
+
+
 def test_forecast_metrics_reject_misaligned_ground_truth() -> None:
     """Ground-truth trajectories must align with ForecastBatch horizons."""
     batch = ForecastBatch(

--- a/tests/benchmark/test_forecast_metrics.py
+++ b/tests/benchmark/test_forecast_metrics.py
@@ -1,0 +1,290 @@
+"""Tests for ForecastBatch.v1 metric evaluation."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.forecast_batch import (
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+)
+from robot_sf.benchmark.forecast_metrics import (
+    evaluate_forecast_batch,
+    format_forecast_metrics_markdown,
+)
+
+
+def _provenance(**overrides: object) -> ForecastBatchProvenance:
+    data: dict[str, object] = {
+        "predictor_id": "predictor-v1",
+        "predictor_family": "synthetic",
+        "observation_tier": "deployable_observation",
+        "frame": CoordinateFrame(name="world", units="m", axes=("x", "y")),
+        "dt_s": 0.5,
+        "horizons_s": [0.5, 1.0],
+        "scenario_id": "scenario_a",
+        "seed": 11,
+        "fallback_status": "native",
+        "degraded_status": "none",
+        "actor_ids": ["ped_1", "ped_2"],
+        "actor_mask": [True, True],
+        "actor_mask_metadata": {"semantics": "true means included"},
+        "feature_schema": {"name": "forecast_fixture_v1"},
+    }
+    data.update(overrides)
+    return ForecastBatchProvenance(**data)
+
+
+def _row(report: dict, metric: str, actor_id: str, horizon_s: float) -> dict:
+    for row in report["metric_rows"]:
+        if (
+            row["metric"] == metric
+            and row.get("actor_id") == actor_id
+            and row["horizon_s"] == horizon_s
+        ):
+            return row
+    raise AssertionError(f"missing row {metric=} {actor_id=} {horizon_s=}")
+
+
+def _aggregate(
+    report: dict, metric: str, horizon_s: float, actor_class: str = "pedestrian"
+) -> dict:
+    for row in report["aggregate_rows"]:
+        if (
+            row["metric"] == metric
+            and row["horizon_s"] == horizon_s
+            and row["actor_class"] == actor_class
+        ):
+            return row
+    raise AssertionError(f"missing aggregate {metric=} {horizon_s=} {actor_class=}")
+
+
+def test_forecast_metrics_evaluate_deterministic_ade_fde() -> None:
+    """Deterministic trajectories should produce ADE rows and final-horizon FDE."""
+    batch = ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]]),
+            ActorForecast(actor_id="ped_2", deterministic=[[1.0, 1.0], [1.0, 2.0]]),
+        ],
+        metadata={"scenario_family": "unit"},
+    )
+    truth = {"ped_1": [[0.0, 0.0], [2.0, 0.0]], "ped_2": [[1.0, 1.0], [1.0, 3.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert report["schema_version"] == "ForecastMetrics.v1"
+    assert report["provenance"]["observation_tier"] == "deployable_observation"
+    assert _row(report, "ade", "ped_1", 1.0)["value"] == 1.0
+    assert _row(report, "fde", "ped_1", 1.0)["value"] == 1.0
+    assert _row(report, "fde", "ped_1", 0.5)["status"] == "unavailable"
+    assert _aggregate(report, "mean_ade", 1.0)["denominator"] == 2
+    assert _aggregate(report, "mean_ade", 1.0)["value"] == 1.0
+
+
+def test_forecast_metrics_evaluate_sampled_minade_minfde() -> None:
+    """Sampled trajectories should expose minADE@K/minFDE@K separately."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                samples=[
+                    [[0.0, 0.0], [2.5, 0.0]],
+                    [[0.0, 0.5], [2.0, 0.0]],
+                ],
+            )
+        ],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [2.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _row(report, "minade@k", "ped_1", 0.5)["value"] == 0.0
+    assert _row(report, "minfde@k", "ped_1", 1.0)["value"] == 0.0
+    assert _aggregate(report, "mean_minade@k", 1.0)["denominator"] == 1
+
+
+def test_forecast_metrics_evaluate_multimodal_expected_error() -> None:
+    """Mode probabilities should produce expected displacement rows."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                samples=[
+                    [[0.0, 0.0], [1.0, 0.0]],
+                    [[2.0, 0.0], [3.0, 0.0]],
+                ],
+                mode_probabilities=[0.75, 0.25],
+            )
+        ],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _row(report, "expected_ade", "ped_1", 0.5)["value"] == 0.5
+    assert _row(report, "expected_fde", "ped_1", 1.0)["value"] == 0.5
+
+
+def test_forecast_metrics_report_missing_mask_denominators() -> None:
+    """Masked actors should be excluded from denominators and reported."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]], "ped_2": [[10.0, 10.0], [10.0, 10.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert report["denominator_health"]["active_actor_count"] == 1
+    assert report["denominator_health"]["excluded_actor_count"] == 1
+    assert _aggregate(report, "mean_ade", 1.0)["denominator"] == 1
+
+
+def test_forecast_metrics_report_empty_denominator_as_unavailable() -> None:
+    """Missing ground truth should not become zero performance."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+    )
+
+    report = evaluate_forecast_batch(batch, {})
+
+    assert report["denominator_health"]["has_empty_denominator"] is True
+    assert _row(report, "ade", "ped_1", 0.5)["value"] is None
+    assert {row["metric"] for row in report["metric_rows"] if row.get("actor_id") == "ped_1"} == {
+        "ade",
+        "fde",
+        "minade@k",
+        "minfde@k",
+        "expected_ade",
+        "expected_fde",
+        "miss_rate",
+        "likelihood",
+        "coverage",
+        "collision_relevance",
+    }
+    assert _row(report, "miss_rate", "ped_1", 1.0)["status"] == "unavailable"
+    assert _row(report, "coverage", "ped_1", 0.5)["status"] == "unavailable"
+    assert _aggregate(report, "mean_ade", 0.5)["status"] == "unavailable"
+    assert _aggregate(report, "mean_ade", 0.5)["denominator"] == 0
+
+
+def test_forecast_metrics_mark_probabilistic_metrics_unavailable_for_deterministic() -> None:
+    """Deterministic-only forecasts should not report probabilistic metrics as zero."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _row(report, "minade@k", "ped_1", 0.5)["status"] == "unavailable"
+    assert _row(report, "expected_ade", "ped_1", 0.5)["status"] == "unavailable"
+    assert _row(report, "likelihood", "ped_1", 0.5)["status"] == "unavailable"
+    assert _row(report, "coverage", "ped_1", 0.5)["status"] == "unavailable"
+    assert _row(report, "collision_relevance", "ped_1", 0.5)["status"] == "unavailable"
+
+
+def test_forecast_metrics_compute_final_horizon_miss_rate() -> None:
+    """Miss rate should use final-horizon displacement and stay unavailable earlier."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [5.0, 0.0]])],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth, miss_threshold_m=2.0)
+
+    assert report["metric_parameters"]["miss_threshold_m"] == 2.0
+    assert _row(report, "miss_rate", "ped_1", 0.5)["status"] == "unavailable"
+    assert _row(report, "miss_rate", "ped_1", 0.5)["note"] == "final horizon only"
+    assert _row(report, "miss_rate", "ped_1", 1.0)["value"] == 1.0
+    assert "note" not in _row(report, "miss_rate", "ped_1", 1.0)
+    assert _aggregate(report, "mean_miss_rate", 1.0)["value"] == 1.0
+
+
+def test_forecast_metrics_explain_missing_final_horizon_payloads() -> None:
+    """Unavailable final-horizon metrics should carry a specific reason."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=None, samples=None)],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _row(report, "fde", "ped_1", 1.0)["note"] == "deterministic trajectory unavailable"
+    assert _row(report, "minfde@k", "ped_1", 1.0)["note"] == "sampled trajectories unavailable"
+    assert _row(report, "expected_fde", "ped_1", 1.0)["note"] == "mode probabilities unavailable"
+
+
+def test_forecast_metrics_markdown_summary_contains_denominators() -> None:
+    """Markdown output should be compact enough for context evidence promotion."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    markdown = format_forecast_metrics_markdown(evaluate_forecast_batch(batch, truth))
+
+    assert markdown.startswith("# Forecast Metrics Summary")
+    assert "active=1, excluded=1" in markdown
+    assert "| mean_ade | 1 | pedestrian | 1 | ok | 0 |" in markdown
+    assert "open-loop evidence only" in markdown
+
+
+def test_forecast_metrics_keep_actor_classes_separate() -> None:
+    """Actor-class metadata should split aggregate denominators."""
+    batch = ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+                uncertainty_metadata={"actor_class": "pedestrian"},
+            ),
+            ActorForecast(
+                actor_id="ped_2",
+                deterministic=[[0.0, 0.0], [3.0, 0.0]],
+                uncertainty_metadata={"actor_class": "bicycle"},
+            ),
+        ],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]], "ped_2": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _aggregate(report, "mean_ade", 1.0, "pedestrian")["value"] == 0.0
+    assert _aggregate(report, "mean_ade", 1.0, "bicycle")["value"] == 2.0
+
+
+def test_forecast_metrics_accept_actor_class_from_batch_metadata() -> None:
+    """Batch-level actor class metadata should work when forecast metadata is absent."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+        metadata={"actor_classes": {"ped_1": "child"}},
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _aggregate(report, "mean_ade", 1.0, "child")["value"] == 0.0
+
+
+def test_forecast_metrics_reject_misaligned_ground_truth() -> None:
+    """Ground-truth trajectories must align with ForecastBatch horizons."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+    )
+
+    with pytest.raises(ValueError, match="ground_truth"):
+        evaluate_forecast_batch(batch, {"ped_1": [[0.0, 0.0]]})


### PR DESCRIPTION
## Summary
Adds a ForecastBatch.v1 metric evaluator for deterministic, sampled, and multimodal open-loop pedestrian forecasts, plus a compact Markdown formatter for reviewable evidence summaries.

## Linked Issues
- Closes `#2840`
- Relates to `#2835`
- Builds on `#2836`

## Stack / Dependency
- Base dependency: merged `PR #2849` / `ForecastBatch.v1`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: this PR consumes the ForecastBatch schema added by #2849.

## What Changed
- Added `robot_sf.benchmark.forecast_metrics` with `ForecastMetrics.v1` JSON reports.
- Computes per-actor and aggregate ADE, FDE, minADE@K, minFDE@K, expected displacement, and final-horizon miss-rate rows.
- Emits explicit unavailable rows for likelihood, coverage, and collision-relevance hooks when the ForecastBatch lacks the required distribution/calibrated-set/collision metadata.
- Keeps actor mask exclusions, actor class, scenario id/family, observation tier, horizon, and `dt_s` in metric rows.
- Added `format_forecast_metrics_markdown` for compact context-evidence summaries.
- Added focused tests for deterministic, sampled, multimodal, missing-truth, mask, empty-denominator, actor-class, note, and Markdown behavior.

## Why It Matters
- Added value: provides the first schema-aligned probabilistic forecast metric surface for prediction-lane artifacts.
- Expected impact: downstream forecast experiments can compare deterministic and probabilistic outputs without collapsing unavailable metrics into zeroes or mixing denominators.
- Why this is worth merging now: it unblocks future calibrated-set and predictor comparisons while preserving a conservative open-loop claim boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocks lack of a reproducible ForecastBatch-compatible metric contract for probabilistic predictor evaluation.
- Comparator or baseline, if applicable: deterministic ForecastBatch rows and sampled/multimodal synthetic fixtures.
- Evidence tier: targeted smoke / metric unit tests plus full PR readiness.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: merge when metric rows distinguish unavailable from zero, preserve denominator/provenance metadata, and pass readiness.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent `#2835`; no benchmark claim map updated because this adds support infrastructure only.
- New research/benchmark/metric/paper-facing analysis tool, if any: support metric helper exercised on committed synthetic fixtures in `tests/benchmark/test_forecast_metrics.py`; no durable experimental result is claimed.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, synthetic fixtures exercise deterministic, sampled, multimodal, missing-ground-truth, and empty-denominator paths.
- Did the intervention change command source, selected command, trajectory, or route progress? NA, open-loop metric support only.
- Did the scenario actually contain the targeted failure mode? yes, tests include unavailable probabilistic rows and missing denominator cases.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none from this support PR.

## Next Empirical Action
- Rerun needed: no for this PR.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for this support metric surface.
- Stop / revise / continue decision: continue with downstream predictor fixture/evaluator integration under the prediction lane.
- Proposed child issue or existing follow-up: parent `#2835` remains the synthesis surface.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_forecast_metrics.py`
  - `uv run pytest tests/benchmark/test_forecast_metrics.py tests/benchmark/test_forecast_batch.py`
  - `uv run ruff check robot_sf/benchmark/forecast_metrics.py tests/benchmark/test_forecast_metrics.py robot_sf/benchmark/__init__.py`
  - `uv run ruff format --check robot_sf/benchmark/forecast_metrics.py tests/benchmark/test_forecast_metrics.py robot_sf/benchmark/__init__.py`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: full readiness passed with `6475 passed, 9 skipped, 9 warnings`; changed-file coverage warning only for `robot_sf/benchmark/forecast_metrics.py` at 98.7%.
- Benchmarks or smoke tests, if applicable: committed synthetic ForecastBatch fixtures cover deterministic, sampled, multimodal, masked actor, missing ground truth, unavailable metric, miss-rate, and Markdown summary paths.

## Risks / Rollout
- Compatibility risks: low; new module and exports only, no existing metric behavior changed.
- Failure modes: future predictors with richer distribution metadata will still need real likelihood/coverage/collision implementations instead of the current unavailable hook rows.
- Rollback or fallback plan: remove the new module/export/tests; ForecastBatch schema remains unaffected.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: report rows include `schema_version`, `forecast_schema_version`, predictor/scenario provenance, actor class, horizon, `dt_s`, and claim boundary.
- Any assumptions that need to be preserved: these are open-loop forecast metrics and do not establish navigation success or planner benefit.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closure of `#2840`.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result claimed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA, support helper with tests and PR body provenance.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR creates the metric surface and synthetic proof only; downstream empirical propagation remains under parent `#2835`.

## Follow-Up Issues
- Deferred work: implement likelihood/coverage/collision metrics once ForecastBatch artifacts carry distribution density, calibrated-set, or collision-relevance metadata.
- Issues opened for follow-up: none; existing parent `#2835` tracks the prediction-lane continuation.

## Reviewer Notes
- Anything a reviewer should verify closely: unavailable rows must be treated as unavailable, not zero, especially for deterministic-only predictors.
- Any known limitations: `miss_rate` is a binary per-actor final-horizon indicator and becomes a rate through aggregate `mean_miss_rate`; likelihood/coverage/collision rows are explicit hooks until richer metadata exists.

Delegate review summary:
- Gemini read-only review: found note-quality issues; fixed.
- Command Code read-only review: found missing-truth row consistency issue; fixed and re-reviewed as accepted.
- OpenCode read-only review: attempted but stopped as uneconomic after no compact result in the bounded window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forecast batch metrics evaluation supporting deterministic, sampled, and multimodal predictions
  * Introduced accuracy metrics including ADE, FDE, minADE@K calculations and miss-rate reporting with configurable thresholds
  * Per-actor and aggregate metrics with optional actor class breakdowns
  * Markdown-formatted evaluation summary generation for benchmark reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->