### PR TITLE
feat: add fast bicycle actor fixtures

### DIFF
--- a/configs/scenarios/single/issue_2727_fast_bicycle_dynamic_actor.yaml
+++ b/configs/scenarios/single/issue_2727_fast_bicycle_dynamic_actor.yaml
@@ -1,0 +1,158 @@
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+- name: issue_2727_fast_bicycle_crossing
+  map_file: ../../../maps/svg_maps/francis2023/francis2023_intersection_no_gesture.svg
+  simulation_config:
+    max_episode_steps: 160
+    ped_density: 0.0
+  single_pedestrians:
+  - id: h1
+    goal: null
+    speed_m_s: 5.5
+    trajectory:
+    - - 8.0
+      - 16.0
+    - - 14.0
+      - 10.0
+    - - 20.0
+      - 4.0
+    metadata:
+      fast_bicycle_actor:
+        schema_version: fast-bicycle-actor.v1
+        actor_type: bicycle
+        speed_m_s: 5.5
+        acceleration_m_s2: 1.4
+        actor_radius_m: 0.45
+        robot_radius_m: 0.3
+        interaction_role: oblique_crossing_fast_bicycle
+        diagnostic_metric_subset:
+        - time_to_conflict_zone_s
+        - clearance_m
+        - pass_overtake_state
+        claim_boundary: >
+          Authored fast-bicycle proxy metadata only; not a full bicycle dynamics model,
+          cyclist realism evidence, or planner-ranking benchmark evidence.
+    note: issue #2727 fast bicycle crossing proxy
+  robot_config: {}
+  metadata:
+    purpose: Deterministic fast-bicycle crossing fixture for trace-compatible dynamic-obstacle diagnostics.
+    behavior: fast_bicycle_crossing
+    authoring:
+      status: draft
+      template: francis2023-single-pedestrian-fast-bicycle-proxy
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/2727
+      benchmark_evidence: false
+    fast_bicycle_actor:
+      case: crossing
+      status: diagnostic_metadata_only
+      benchmark_evidence: false
+      claim_boundary: >
+        This fixture records authored fast-bicycle proxy speed, acceleration,
+        time-to-conflict, clearance, and pass/overtake diagnostics only. It does
+        not prove realistic cyclist behavior or planner performance.
+  seeds:
+  - 2727
+- name: issue_2727_fast_bicycle_overtaking
+  map_file: ../../../maps/svg_maps/francis2023/francis2023_intersection_no_gesture.svg
+  simulation_config:
+    max_episode_steps: 160
+    ped_density: 0.0
+  single_pedestrians:
+  - id: h1
+    goal: null
+    speed_m_s: 6.2
+    trajectory:
+    - - 9.2
+      - 8.0
+    - - 11.4
+      - 10.2
+    - - 13.6
+      - 12.4
+    metadata:
+      fast_bicycle_actor:
+        schema_version: fast-bicycle-actor.v1
+        actor_type: bicycle
+        speed_m_s: 6.2
+        acceleration_m_s2: 1.0
+        actor_radius_m: 0.45
+        robot_radius_m: 0.3
+        interaction_role: overtaking_fast_bicycle
+        diagnostic_metric_subset:
+        - time_to_conflict_zone_s
+        - clearance_m
+        - pass_overtake_state
+        claim_boundary: >
+          Authored fast-bicycle proxy metadata only; not a full bicycle dynamics model,
+          cyclist realism evidence, or planner-ranking benchmark evidence.
+    note: issue #2727 fast bicycle overtaking proxy
+  robot_config: {}
+  metadata:
+    purpose: Deterministic fast-bicycle overtaking fixture for trace-compatible dynamic-obstacle diagnostics.
+    behavior: fast_bicycle_overtaking
+    authoring:
+      status: draft
+      template: francis2023-single-pedestrian-fast-bicycle-proxy
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/2727
+      benchmark_evidence: false
+    fast_bicycle_actor:
+      case: overtaking
+      status: diagnostic_metadata_only
+      benchmark_evidence: false
+      claim_boundary: >
+        This fixture records authored fast-bicycle proxy speed, acceleration,
+        time-to-conflict, clearance, and pass/overtake diagnostics only. It does
+        not prove realistic cyclist behavior or planner performance.
+  seeds:
+  - 2728
+- name: issue_2727_fast_bicycle_parallel_lane
+  map_file: ../../../maps/svg_maps/francis2023/francis2023_intersection_no_gesture.svg
+  simulation_config:
+    max_episode_steps: 160
+    ped_density: 0.0
+  single_pedestrians:
+  - id: h1
+    goal: null
+    speed_m_s: 4.8
+    trajectory:
+    - - 7.5
+      - 12.0
+    - - 12.0
+      - 12.2
+    - - 16.5
+      - 12.4
+    metadata:
+      fast_bicycle_actor:
+        schema_version: fast-bicycle-actor.v1
+        actor_type: bicycle
+        speed_m_s: 4.8
+        acceleration_m_s2: 0.6
+        actor_radius_m: 0.45
+        robot_radius_m: 0.3
+        interaction_role: parallel_lane_fast_bicycle
+        diagnostic_metric_subset:
+        - time_to_conflict_zone_s
+        - clearance_m
+        - pass_overtake_state
+        claim_boundary: >
+          Authored fast-bicycle proxy metadata only; not a full bicycle dynamics model,
+          cyclist realism evidence, or planner-ranking benchmark evidence.
+    note: issue #2727 fast bicycle parallel-lane proxy
+  robot_config: {}
+  metadata:
+    purpose: Deterministic fast-bicycle parallel-lane fixture for trace-compatible dynamic-obstacle diagnostics.
+    behavior: fast_bicycle_parallel_lane
+    authoring:
+      status: draft
+      template: francis2023-single-pedestrian-fast-bicycle-proxy
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/2727
+      benchmark_evidence: false
+    fast_bicycle_actor:
+      case: parallel_lane
+      status: diagnostic_metadata_only
+      benchmark_evidence: false
+      claim_boundary: >
+        This fixture records authored fast-bicycle proxy speed, acceleration,
+        time-to-conflict, clearance, and pass/overtake diagnostics only. It does
+        not prove realistic cyclist behavior or planner performance.
+  seeds:
+  - 2729

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2953,7 +2953,7 @@ def _single_pedestrian_intent_metadata(scenario: dict[str, Any]) -> list[dict[st
 
 
 def _single_pedestrian_vru_metadata(scenario: dict[str, Any]) -> list[dict[str, Any] | None]:
-    """Return authored cyclist-like VRU metadata aligned with scenario single pedestrians."""
+    """Return authored fast-VRU metadata aligned with scenario single pedestrians."""
     single_peds = (
         scenario.get("single_pedestrians")
         if isinstance(scenario.get("single_pedestrians"), list)
@@ -2966,11 +2966,15 @@ def _single_pedestrian_vru_metadata(scenario: dict[str, Any]) -> list[dict[str, 
             result.append(None)
             continue
         ped_metadata = ped.get("metadata") if isinstance(ped.get("metadata"), dict) else {}
-        vru = (
-            ped_metadata.get("cyclist_like_vru")
-            if isinstance(ped_metadata.get("cyclist_like_vru"), dict)
-            else {}
-        )
+        payload_key = "cyclist_like_vru"
+        vru = ped_metadata.get("cyclist_like_vru")
+        if not isinstance(vru, dict):
+            fast_bicycle = ped_metadata.get("fast_bicycle_actor")
+            if isinstance(fast_bicycle, dict):
+                payload_key = "fast_bicycle_actor"
+                vru = fast_bicycle
+            else:
+                vru = {}
         if not vru:
             result.append(None)
             continue
@@ -2983,7 +2987,11 @@ def _single_pedestrian_vru_metadata(scenario: dict[str, Any]) -> list[dict[str, 
             {
                 "single_index": idx,
                 "pedestrian_id": str(ped.get("id") or f"single_{idx}"),
-                "actor_type": str(vru.get("actor_type") or "cyclist_like_vru"),
+                "actor_type": str(
+                    vru.get("actor_type")
+                    or ("bicycle" if payload_key == "fast_bicycle_actor" else "cyclist_like_vru")
+                ),
+                "diagnostic_payload_key": payload_key,
                 "speed_m_s": speed_m_s,
                 "acceleration_m_s2": acceleration_m_s2,
                 "actor_radius_m": actor_radius_m,
@@ -3003,8 +3011,8 @@ def _single_pedestrian_vru_metadata(scenario: dict[str, Any]) -> list[dict[str, 
                 ],
                 "claim_boundary": str(
                     vru.get("claim_boundary")
-                    or "Authored cyclist-like VRU proxy metadata only; not cyclist realism or "
-                    "planner-ranking evidence."
+                    or "Authored fast-VRU proxy metadata only; not cyclist realism or "
+                    "planner-ranking benchmark evidence."
                 ),
             }
         )
@@ -3340,12 +3348,13 @@ def _vru_trace_payload(
                 "pass_overtake_state": _pass_overtake_state(closing_speed),
             }
         )
+    payload_key = str(metadata.get("diagnostic_payload_key") or "cyclist_like_vru")
     return {
         "pedestrian_id": metadata["pedestrian_id"],
         "actor_type": metadata["actor_type"],
         "interaction_role": metadata["interaction_role"],
         "claim_boundary": metadata["claim_boundary"],
-        "cyclist_like_vru": diagnostics,
+        payload_key: diagnostics,
     }
 
 
@@ -3437,22 +3446,62 @@ def _cyclist_like_vru_summary(
     vru_metadata: list[dict[str, Any] | None],
 ) -> dict[str, Any] | None:
     """Return an analysis-only summary for authored cyclist-like VRU fixtures."""
+    return _vru_diagnostic_summary(
+        scenario,
+        vru_metadata,
+        payload_key="cyclist_like_vru",
+        schema_version="cyclist-like-vru-smoke-summary.v1",
+        claim_boundary=(
+            "Authored cyclist-like VRU proxy metadata records speed, acceleration, "
+            "time-to-conflict, clearance, and pass/overtake diagnostics only; it is not "
+            "cyclist realism, cyclist behavior, or planner-ranking evidence."
+        ),
+    )
+
+
+def _fast_bicycle_actor_summary(
+    scenario: dict[str, Any],
+    vru_metadata: list[dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    """Return an analysis-only summary for authored fast-bicycle actor fixtures."""
+    return _vru_diagnostic_summary(
+        scenario,
+        vru_metadata,
+        payload_key="fast_bicycle_actor",
+        schema_version="fast-bicycle-actor-summary.v1",
+        claim_boundary=(
+            "Authored fast-bicycle actor proxy metadata records speed, acceleration, "
+            "time-to-conflict, clearance, and pass/overtake diagnostics only; it is not "
+            "a full bicycle dynamics model, cyclist realism evidence, or planner-ranking evidence."
+        ),
+    )
+
+
+def _vru_diagnostic_summary(
+    scenario: dict[str, Any],
+    vru_metadata: list[dict[str, Any] | None],
+    *,
+    payload_key: str,
+    schema_version: str,
+    claim_boundary: str,
+) -> dict[str, Any] | None:
+    """Return an analysis-only summary for authored fast-VRU fixtures."""
     if not vru_metadata:
         return None
-    summarized = [metadata for metadata in vru_metadata if metadata is not None]
+    summarized = [
+        metadata
+        for metadata in vru_metadata
+        if metadata is not None and metadata.get("diagnostic_payload_key") == payload_key
+    ]
     if not summarized:
         return None
     return {
-        "schema_version": "cyclist-like-vru-smoke-summary.v1",
+        "schema_version": schema_version,
         "scenario_name": _scenario_id(scenario),
         "status": "diagnostic_metadata_only",
         "benchmark_evidence": False,
         "trace_field_source": "algorithm_metadata.simulation_step_trace.steps[].pedestrians[]",
-        "claim_boundary": (
-            "Authored cyclist-like VRU proxy metadata records speed, acceleration, time-to-conflict, "
-            "clearance, and pass/overtake diagnostics only; it is not cyclist realism, cyclist "
-            "behavior, or planner-ranking evidence."
-        ),
+        "claim_boundary": claim_boundary,
         "pedestrians": summarized,
     }
 
@@ -4535,6 +4584,12 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     )
     if vru_summary is not None:
         algo_meta["cyclist_like_vru"] = vru_summary
+    fast_bicycle_summary = _fast_bicycle_actor_summary(
+        scenario,
+        single_pedestrian_vru_metadata,
+    )
+    if fast_bicycle_summary is not None:
+        algo_meta["fast_bicycle_actor"] = fast_bicycle_summary
     if actuation_controller is not None:
         actuation_summary = actuation_controller.summary()
         algo_meta["synthetic_actuation"] = {

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -3491,7 +3491,8 @@ def _vru_diagnostic_summary(
     summarized = [
         metadata
         for metadata in vru_metadata
-        if metadata is not None and metadata.get("diagnostic_payload_key") == payload_key
+        if metadata is not None
+        and (metadata.get("diagnostic_payload_key") or "cyclist_like_vru") == payload_key
     ]
     if not summarized:
         return None

--- a/tests/benchmark/test_issue_2727_fast_bicycle_actor.py
+++ b/tests/benchmark/test_issue_2727_fast_bicycle_actor.py
@@ -1,0 +1,107 @@
+"""Smoke tests for issue #2727 fast-bicycle actor fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from robot_sf.benchmark.map_runner import (
+    _fast_bicycle_actor_summary,
+    _single_pedestrian_vru_metadata,
+    _trace_pedestrians,
+)
+from robot_sf.benchmark.pedestrian_forecast import is_pedestrian_actor
+from scripts.tools.scenario_authoring import validate_scenario_file
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = REPO_ROOT / "configs/scenarios/single/issue_2727_fast_bicycle_dynamic_actor.yaml"
+EXPECTED_CASES = {
+    "issue_2727_fast_bicycle_crossing": "crossing",
+    "issue_2727_fast_bicycle_overtaking": "overtaking",
+    "issue_2727_fast_bicycle_parallel_lane": "parallel_lane",
+}
+
+
+def _scenario_payloads() -> list[dict]:
+    """Load the fast-bicycle fixture scenarios."""
+    payload = yaml.safe_load(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return payload["scenarios"]
+
+
+def test_issue_2727_fixture_validates_and_declares_three_cases() -> None:
+    """The authored fast-bicycle fixture matrix should stay diagnostic-only."""
+    report = validate_scenario_file(FIXTURE_PATH)
+    scenarios = _scenario_payloads()
+
+    assert report.ok is True
+    assert {scenario["name"] for scenario in scenarios} == set(EXPECTED_CASES)
+    for scenario in scenarios:
+        case = EXPECTED_CASES[scenario["name"]]
+        bicycle = scenario["metadata"]["fast_bicycle_actor"]
+        assert bicycle["case"] == case
+        assert bicycle["status"] == "diagnostic_metadata_only"
+        assert bicycle["benchmark_evidence"] is False
+        assert "does not prove" in bicycle["claim_boundary"]
+
+
+@pytest.mark.parametrize("scenario", _scenario_payloads(), ids=lambda item: item["name"])
+def test_issue_2727_bicycle_metadata_reaches_trace_payload(scenario: dict) -> None:
+    """Fast-bicycle actor metadata should reach trace frames under a distinct key."""
+    vru_metadata = _single_pedestrian_vru_metadata(scenario)
+
+    assert len(vru_metadata) == 1
+    assert vru_metadata[0] is not None
+    assert vru_metadata[0]["actor_type"] == "bicycle"
+    assert vru_metadata[0]["diagnostic_payload_key"] == "fast_bicycle_actor"
+    assert is_pedestrian_actor(vru_metadata[0]["actor_type"]) is False
+
+    frames = _trace_pedestrians(
+        np.array([[10.0, 11.0]], dtype=float),
+        np.array([[10.0, 11.6]], dtype=float),
+        0.1,
+        vru_metadata=vru_metadata,
+        robot_position=np.array([10.0, 10.0], dtype=float),
+        robot_velocity=np.array([0.0, 0.0], dtype=float),
+    )
+    summary = _fast_bicycle_actor_summary(scenario, vru_metadata)
+
+    assert frames[0]["pedestrian_id"] == vru_metadata[0]["pedestrian_id"]
+    assert frames[0]["actor_type"] == "bicycle"
+    assert "cyclist_like_vru" not in frames[0]
+    diagnostics = frames[0]["fast_bicycle_actor"]
+    assert diagnostics["configured_speed_m_s"] == pytest.approx(vru_metadata[0]["speed_m_s"])
+    assert diagnostics["acceleration_m_s2"] == pytest.approx(vru_metadata[0]["acceleration_m_s2"])
+    assert diagnostics["relative_closing_speed_m_s"] > 0.0
+    assert diagnostics["time_to_conflict_zone_s"] is not None
+    assert diagnostics["clearance_m"] == pytest.approx(0.25)
+    assert diagnostics["pass_overtake_state"] == "approaching_conflict_zone"
+    assert summary is not None
+    assert summary["schema_version"] == "fast-bicycle-actor-summary.v1"
+    assert summary["status"] == "diagnostic_metadata_only"
+    assert summary["benchmark_evidence"] is False
+    assert summary["trace_field_source"].endswith("pedestrians[]")
+
+
+def test_issue_2727_existing_cyclist_like_payload_key_is_preserved() -> None:
+    """The new fast-bicycle key should not rename existing cyclist-like fixtures."""
+    fixture = REPO_ROOT / "configs/scenarios/single/issue_2526_cyclist_vru_smoke.yaml"
+    scenario = yaml.safe_load(fixture.read_text(encoding="utf-8"))["scenarios"][0]
+    vru_metadata = _single_pedestrian_vru_metadata(scenario)
+
+    frames = _trace_pedestrians(
+        np.array([[10.0, 11.0]], dtype=float),
+        np.array([[10.0, 11.45]], dtype=float),
+        0.1,
+        vru_metadata=vru_metadata,
+        robot_position=np.array([10.0, 10.0], dtype=float),
+        robot_velocity=np.array([0.0, 0.0], dtype=float),
+    )
+
+    assert vru_metadata[0] is not None
+    assert vru_metadata[0]["diagnostic_payload_key"] == "cyclist_like_vru"
+    assert frames[0]["actor_type"] == "cyclist_like_vru"
+    assert "cyclist_like_vru" in frames[0]
+    assert "fast_bicycle_actor" not in frames[0]

--- a/tests/benchmark/test_issue_2727_fast_bicycle_actor.py
+++ b/tests/benchmark/test_issue_2727_fast_bicycle_actor.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from robot_sf.benchmark.map_runner import (
+    _cyclist_like_vru_summary,
     _fast_bicycle_actor_summary,
     _single_pedestrian_vru_metadata,
     _trace_pedestrians,
@@ -105,3 +106,28 @@ def test_issue_2727_existing_cyclist_like_payload_key_is_preserved() -> None:
     assert frames[0]["actor_type"] == "cyclist_like_vru"
     assert "cyclist_like_vru" in frames[0]
     assert "fast_bicycle_actor" not in frames[0]
+
+
+def test_issue_2727_legacy_vru_metadata_defaults_to_cyclist_summary() -> None:
+    """Legacy mock metadata without a payload key should still summarize as cyclist-like."""
+    scenario = {"name": "legacy_cyclist_like"}
+    legacy_metadata = [
+        {
+            "pedestrian_id": "h1",
+            "actor_type": "cyclist_like_vru",
+            "speed_m_s": 4.5,
+            "acceleration_m_s2": 1.0,
+            "actor_radius_m": 0.35,
+            "robot_radius_m": 0.3,
+            "interaction_role": "legacy_fixture",
+            "claim_boundary": "legacy diagnostic-only fixture",
+        }
+    ]
+
+    summary = _cyclist_like_vru_summary(scenario, legacy_metadata)
+    fast_bicycle_summary = _fast_bicycle_actor_summary(scenario, legacy_metadata)
+
+    assert summary is not None
+    assert summary["schema_version"] == "cyclist-like-vru-smoke-summary.v1"
+    assert summary["pedestrians"] == legacy_metadata
+    assert fast_bicycle_summary is None


### PR DESCRIPTION
## Summary
Adds deterministic fast-bicycle actor fixtures as trace-compatible dynamic-obstacle diagnostics, with explicit `actor_type: bicycle` metadata and separate `fast_bicycle_actor` trace/summary payloads.

## Linked Issues
- Closes `#2727`
- Relates to `#2846`
- Relates to `#2843`

## Stack / Dependency
- Base dependency: `PR #2850` / `ForecastMetrics.v1` is already merged on `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#2846`, `#2843`
- Safe to review independently: yes
- Review dependency reason, if any: this PR is a trace/fixture support slice that future forecast and closed-loop gate issues can consume.

## What Changed
- Extended the existing fast-VRU trace metadata path to support a distinct `fast_bicycle_actor` diagnostic payload while preserving `cyclist_like_vru` compatibility.
- Added three deterministic authored fixtures in `configs/scenarios/single/issue_2727_fast_bicycle_dynamic_actor.yaml`: crossing, overtaking, and parallel-lane.
- Added tests proving scenario authoring validation, actor-type metadata, non-pedestrian forecast exclusion semantics, trace payload propagation, summary generation, and backward compatibility for the #2526 cyclist-like fixture.

## Why It Matters
- Added value: gives the prediction lane a fast dynamic actor fixture with explicit actor class metadata.
- Expected impact: unblocks actor-class forecast denominator work (#2846) and later closed-loop prediction gate work (#2843).
- Why this is worth merging now: it adds deterministic, diagnostic-only fixtures without claiming cyclist realism or planner-ranking evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: fast dynamic actors need trace-compatible metadata before forecast and planner-coupling diagnostics can separate pedestrian vs bicycle denominators.
- Comparator or baseline, if applicable: existing #2526 `cyclist_like_vru` diagnostic fixture pattern.
- Evidence tier: targeted smoke plus full PR readiness.
- Result classification: blocker-resolution / diagnostic-only support fixture.
- Decision or stop rule, if applicable: merge when three fixture cases validate and trace payloads preserve diagnostic-only boundaries.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent prediction lane under `#2835`; follow-up forecast actor-class support in `#2846`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support fixture and trace metadata helper; no benchmark result is interpreted.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, tests show `fast_bicycle_actor` payloads reach trace-style pedestrian frames and summaries.
- Did the intervention change command source, selected command, trajectory, or route progress? NA, fixture/metadata support only.
- Did the scenario actually contain the targeted failure mode? yes, authored crossing, overtaking, and parallel-lane fast-bicycle diagnostic cases are present.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: `#2846` should consume these fixtures for actor-class forecast metric separation.

## Next Empirical Action
- Rerun needed: no for this PR.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for the fixture support slice.
- Stop / revise / continue decision: continue to #2846/#2843.
- Proposed child issue or existing follow-up: existing `#2846` and `#2843`.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_issue_2727_fast_bicycle_actor.py tests/benchmark/test_issue_2526_cyclist_vru_smoke.py`
  - `uv run ruff check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2727_fast_bicycle_actor.py`
  - `uv run ruff format --check robot_sf/benchmark/map_runner.py tests/benchmark/test_issue_2727_fast_bicycle_actor.py`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: full readiness passed with `6481 passed, 9 skipped, 9 warnings`; changed-file coverage warning only for `robot_sf/benchmark/map_runner.py` at 89.4%.
- Benchmarks or smoke tests, if applicable: targeted smoke validates all three fast-bicycle fixture cases and trace metadata propagation.

## Risks / Rollout
- Compatibility risks: low; existing `cyclist_like_vru` payload key is preserved and covered by regression test.
- Failure modes: fixtures are authored proxy pedestrians with bicycle metadata, not a full non-holonomic cyclist dynamics model.
- Rollback or fallback plan: remove the new fixture/test and fast-bicycle payload/summary branch; existing cyclist-like VRU behavior remains covered.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: fixture metadata and PR body state diagnostic-only claim boundaries.
- Any assumptions that need to be preserved: `fast_bicycle_actor` rows are trace-compatible dynamic-obstacle diagnostics only, not benchmark evidence or real cyclist behavior claims.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#2727`.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result claimed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA, fixture support is discoverable through committed path and issue/PR linkage.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA, existing `#2846` and `#2843` cover downstream use.
- Not applicable because: this PR adds diagnostic fixtures and metadata support only.

## Follow-Up Issues
- Deferred work: consume these fixtures in actor-class forecast metrics and closed-loop prediction gate work.
- Issues opened for follow-up: none; use existing `#2846` and `#2843`.

## Reviewer Notes
- Anything a reviewer should verify closely: `cyclist_like_vru` compatibility and the diagnostic-only claim boundary.
- Any known limitations: no full cyclist dynamics; the actor is still simulator-compatible authored motion with explicit bicycle metadata.

Delegate review summary:
- Gemini mapping and implementation review accepted; suggested scoped validation, which was run.
- Command Code mapping/review hit turn caps and produced no actionable compact findings; classified uneconomic.
- OpenCode review was attempted; it read scoped files but produced no compact findings; classified no-result.
