### PR TITLE
feat: separate forecast metrics by actor class

### DIFF
--- a/robot_sf/benchmark/forecast_batch.py
+++ b/robot_sf/benchmark/forecast_batch.py
@@ -158,8 +158,8 @@ class ForecastBatchProvenance:
     actor_mask: list[bool]
     actor_mask_metadata: dict[str, Any]
     feature_schema: dict[str, Any]
-    actor_classes: dict[str, str] = field(default_factory=dict)
     oracle_state: bool = False
+    actor_classes: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Fail closed on missing provenance or inconsistent actor masks."""

--- a/robot_sf/benchmark/forecast_batch.py
+++ b/robot_sf/benchmark/forecast_batch.py
@@ -56,6 +56,29 @@ def _require_mapping(name: str, value: object) -> dict[str, Any]:
     return {str(key): item for key, item in value.items()}
 
 
+def _normalize_actor_classes(value: object, actor_ids: list[str]) -> dict[str, str]:
+    """Return optional actor-class labels keyed by actor id."""
+    if value is None:
+        return {}
+    if isinstance(value, (list, tuple, np.ndarray)):
+        if len(value) != len(actor_ids):
+            raise ValueError("actor_classes list must align with actor_ids")
+        value = {
+            actor_id: actor_class
+            for actor_id, actor_class in zip(actor_ids, value, strict=True)
+            if actor_class is not None
+        }
+    classes = _require_mapping("actor_classes", value)
+    unknown_actor_ids = sorted(set(classes) - set(actor_ids))
+    if unknown_actor_ids:
+        raise ValueError("actor_classes keys must be declared in actor_ids")
+    return {
+        actor_id: _require_non_empty_str("actor_classes[]", actor_class)
+        for actor_id, actor_class in classes.items()
+        if actor_class is not None
+    }
+
+
 def _contains_oracle_key(value: object) -> bool:
     """True when nested metadata contains oracle-looking keys or values.
 
@@ -135,6 +158,7 @@ class ForecastBatchProvenance:
     actor_mask: list[bool]
     actor_mask_metadata: dict[str, Any]
     feature_schema: dict[str, Any]
+    actor_classes: dict[str, str] = field(default_factory=dict)
     oracle_state: bool = False
 
     def __post_init__(self) -> None:
@@ -159,6 +183,7 @@ class ForecastBatchProvenance:
         ]
         if len(set(self.actor_ids)) != len(self.actor_ids):
             raise ValueError("actor_ids must be unique")
+        self.actor_classes = _normalize_actor_classes(self.actor_classes, self.actor_ids)
         if not isinstance(self.actor_mask, (list, tuple, np.ndarray)) or len(
             self.actor_mask
         ) != len(self.actor_ids):
@@ -207,6 +232,7 @@ class ForecastBatchProvenance:
             actor_mask=list(data.get("actor_mask", [])),
             actor_mask_metadata=data.get("actor_mask_metadata", {}),
             feature_schema=data.get("feature_schema", {}),
+            actor_classes=data.get("actor_classes", {}),
             oracle_state=bool(data.get("oracle_state", False)),
         )
 

--- a/robot_sf/benchmark/forecast_metrics.py
+++ b/robot_sf/benchmark/forecast_metrics.py
@@ -572,20 +572,24 @@ def _actor_class_denominators(
     active_actor_ids: set[str],
     forecasts_by_actor: dict[str, ActorForecast],
 ) -> list[dict[str, Any]]:
+    """Compute per-class active and excluded actor counts for report denominators.
+
+    Returns:
+        Sorted actor-class denominator rows for JSON and Markdown reports.
+    """
     counts: dict[str, dict[str, Any]] = {}
     for actor_id in batch.provenance.actor_ids:
         actor_class = _actor_class_for_denominator(actor_id, batch, forecasts_by_actor)
-        class_counts = counts.setdefault(
-            actor_class,
-            {
+        if actor_class not in counts:
+            counts[actor_class] = {
                 "actor_class": actor_class,
                 "active_actor_count": 0,
                 "excluded_actor_count": 0,
                 "horizons_s": list(batch.provenance.horizons_s),
                 "dt_s": batch.provenance.dt_s,
                 "caveat": _actor_class_caveat(actor_class),
-            },
-        )
+            }
+        class_counts = counts[actor_class]
         if actor_id in active_actor_ids:
             class_counts["active_actor_count"] += 1
         else:
@@ -598,6 +602,11 @@ def _actor_class_for_denominator(
     batch: ForecastBatch,
     forecasts_by_actor: dict[str, ActorForecast],
 ) -> str:
+    """Resolve the class used for denominator accounting, including excluded actors.
+
+    Returns:
+        Actor class label used to bucket active or excluded actor counts.
+    """
     forecast = forecasts_by_actor.get(actor_id)
     if forecast is not None:
         return _actor_class(forecast, batch)
@@ -617,6 +626,7 @@ def _actor_class_for_denominator(
 
 
 def _actor_class_caveat(actor_class: str) -> str:
+    """Return the claim-boundary caveat associated with an actor class."""
     normalized = actor_class.strip().lower()
     if normalized in {"pedestrian", "person"}:
         return "pedestrian forecast denominator"

--- a/robot_sf/benchmark/forecast_metrics.py
+++ b/robot_sf/benchmark/forecast_metrics.py
@@ -104,6 +104,11 @@ def evaluate_forecast_batch(
     }
     forecasts_by_actor = {forecast.actor_id: forecast for forecast in forecast_batch.forecasts}
     scenario_family = _scenario_family(forecast_batch)
+    actor_class_denominators = _actor_class_denominators(
+        forecast_batch,
+        active_actor_ids,
+        forecasts_by_actor,
+    )
 
     for actor_id in sorted(active_actor_ids):
         forecast = forecasts_by_actor[actor_id]
@@ -145,11 +150,13 @@ def evaluate_forecast_batch(
         "denominator_health": {
             "active_actor_count": len(active_actor_ids),
             "excluded_actor_count": excluded_actor_count,
+            "by_actor_class": actor_class_denominators,
             "metric_row_count": len(rows),
             "aggregate_row_count": len(aggregate_rows),
             "unavailable_row_count": unavailable_count,
             "has_empty_denominator": any(row.denominator == 0 for row in rows + aggregate_rows),
         },
+        "actor_class_denominators": actor_class_denominators,
         "metric_rows": [row.to_dict() for row in rows],
         "aggregate_rows": [row.to_dict() for row in aggregate_rows],
         "claim_boundary": (
@@ -541,6 +548,9 @@ def _expected_sample_error(
 
 
 def _actor_class(forecast: ActorForecast, batch: ForecastBatch) -> str:
+    provenance_actor_class = batch.provenance.actor_classes.get(forecast.actor_id)
+    if provenance_actor_class is not None:
+        return provenance_actor_class
     metadata_sources = (
         forecast.uncertainty_metadata,
         forecast.occupancy_summary,
@@ -555,6 +565,65 @@ def _actor_class(forecast: ActorForecast, batch: ForecastBatch) -> str:
             if default_actor_class is not None:
                 return str(default_actor_class)
     return "pedestrian"
+
+
+def _actor_class_denominators(
+    batch: ForecastBatch,
+    active_actor_ids: set[str],
+    forecasts_by_actor: dict[str, ActorForecast],
+) -> list[dict[str, Any]]:
+    counts: dict[str, dict[str, Any]] = {}
+    for actor_id in batch.provenance.actor_ids:
+        actor_class = _actor_class_for_denominator(actor_id, batch, forecasts_by_actor)
+        class_counts = counts.setdefault(
+            actor_class,
+            {
+                "actor_class": actor_class,
+                "active_actor_count": 0,
+                "excluded_actor_count": 0,
+                "horizons_s": list(batch.provenance.horizons_s),
+                "dt_s": batch.provenance.dt_s,
+                "caveat": _actor_class_caveat(actor_class),
+            },
+        )
+        if actor_id in active_actor_ids:
+            class_counts["active_actor_count"] += 1
+        else:
+            class_counts["excluded_actor_count"] += 1
+    return [counts[key] for key in sorted(counts)]
+
+
+def _actor_class_for_denominator(
+    actor_id: str,
+    batch: ForecastBatch,
+    forecasts_by_actor: dict[str, ActorForecast],
+) -> str:
+    forecast = forecasts_by_actor.get(actor_id)
+    if forecast is not None:
+        return _actor_class(forecast, batch)
+
+    actor_class = batch.provenance.actor_classes.get(actor_id)
+    if actor_class is not None:
+        return actor_class
+    batch_actor_classes = batch.metadata.get("actor_classes")
+    if isinstance(batch_actor_classes, dict):
+        actor_class = batch_actor_classes.get(actor_id)
+        if actor_class is not None:
+            return str(actor_class)
+        batch_default_actor_class = batch_actor_classes.get("actor_class")
+        if batch_default_actor_class is not None:
+            return str(batch_default_actor_class)
+    return "pedestrian"
+
+
+def _actor_class_caveat(actor_class: str) -> str:
+    normalized = actor_class.strip().lower()
+    if normalized in {"pedestrian", "person"}:
+        return "pedestrian forecast denominator"
+    return (
+        "fast dynamic actor forecast denominator; compare only with matching actor class, "
+        "horizon, and dt_s settings"
+    )
 
 
 def _scenario_family(batch: ForecastBatch) -> str | None:
@@ -582,6 +651,14 @@ def format_forecast_metrics_markdown(report: dict[str, Any]) -> str:
         (
             f"- Denominators: active={health['active_actor_count']}, "
             f"excluded={health['excluded_actor_count']}, unavailable={health['unavailable_row_count']}"
+        ),
+        "- Actor classes: "
+        + ", ".join(
+            (
+                f"{row['actor_class']}(active={row['active_actor_count']}, "
+                f"excluded={row['excluded_actor_count']})"
+            )
+            for row in report.get("actor_class_denominators", [])
         ),
         "",
         "| metric | horizon_s | actor_class | denominator | status | value |",

--- a/tests/benchmark/test_forecast_batch.py
+++ b/tests/benchmark/test_forecast_batch.py
@@ -124,6 +124,33 @@ def test_forecast_batch_actor_classes_round_trip() -> None:
     assert loaded.provenance.actor_classes == {"ped_1": "pedestrian", "ped_2": "bicycle"}
 
 
+def test_forecast_batch_preserves_positional_oracle_state_argument_order() -> None:
+    """Adding actor_classes should not shift the positional oracle_state argument."""
+    provenance = ForecastBatchProvenance(
+        "cv-baseline-v1",
+        "constant_velocity",
+        "deployable_observation",
+        CoordinateFrame(name="world", units="m", axes=("x", "y"), origin="map origin"),
+        0.5,
+        [0.5, 1.0],
+        "crosswalk_001",
+        7,
+        "native",
+        "none",
+        ["ped_1", "ped_2"],
+        [True, True],
+        {
+            "semantics": "true means forecast payload is available for actor_id",
+            "missing_actor_reasons": {},
+        },
+        {"name": "socnav_observation_v1", "features": ["position_m", "velocity_mps"]},
+        True,
+    )
+
+    assert provenance.oracle_state is True
+    assert provenance.actor_classes == {}
+
+
 def test_forecast_batch_actor_class_list_aligns_with_actor_ids() -> None:
     """Aligned actor-class lists should normalize to an actor-id keyed mapping."""
     provenance = _provenance(actor_classes=["pedestrian", "bicycle"])

--- a/tests/benchmark/test_forecast_batch.py
+++ b/tests/benchmark/test_forecast_batch.py
@@ -109,6 +109,40 @@ def test_forecast_batch_sampled_modes_round_trip() -> None:
     assert loaded.forecasts[0].mode_probabilities == [0.6, 0.4]
 
 
+def test_forecast_batch_actor_classes_round_trip() -> None:
+    """Actor classes should survive the ForecastBatch artifact boundary."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_classes={"ped_1": "pedestrian", "ped_2": "bicycle"}),
+        forecasts=[
+            ActorForecast(actor_id="ped_1", deterministic=[[1.0, 0.0], [1.5, 0.0]]),
+            ActorForecast(actor_id="ped_2", deterministic=[[0.0, 1.0], [0.0, 1.5]]),
+        ],
+    )
+
+    loaded = ForecastBatch.from_dict(batch.to_dict())
+
+    assert loaded.provenance.actor_classes == {"ped_1": "pedestrian", "ped_2": "bicycle"}
+
+
+def test_forecast_batch_actor_class_list_aligns_with_actor_ids() -> None:
+    """Aligned actor-class lists should normalize to an actor-id keyed mapping."""
+    provenance = _provenance(actor_classes=["pedestrian", "bicycle"])
+
+    assert provenance.actor_classes == {"ped_1": "pedestrian", "ped_2": "bicycle"}
+
+
+def test_forecast_batch_actor_classes_reject_unknown_actor_ids() -> None:
+    """Actor-class labels must only reference declared actors."""
+    with pytest.raises(ValueError, match="actor_classes"):
+        _provenance(actor_classes={"bike_1": "bicycle"})
+
+
+def test_forecast_batch_actor_classes_reject_misaligned_lists() -> None:
+    """List-style actor classes must align exactly with actor_ids."""
+    with pytest.raises(ValueError, match="actor_classes"):
+        _provenance(actor_classes=["pedestrian"])
+
+
 def test_forecast_batch_serializes_numpy_scalar_metadata(tmp_path) -> None:
     """JSON output should normalize numpy scalar metadata values."""
     batch = ForecastBatch(

--- a/tests/benchmark/test_forecast_metrics.py
+++ b/tests/benchmark/test_forecast_metrics.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+import yaml
 
 from robot_sf.benchmark.forecast_batch import (
     ActorForecast,
@@ -265,6 +268,109 @@ def test_forecast_metrics_keep_actor_classes_separate() -> None:
     assert _aggregate(report, "mean_ade", 1.0, "bicycle")["value"] == 2.0
 
 
+def test_forecast_metrics_prefer_provenance_actor_classes() -> None:
+    """Provenance actor classes should override legacy per-forecast hints."""
+    batch = ForecastBatch(
+        provenance=_provenance(
+            actor_mask=[True, False],
+            actor_classes={"ped_1": "bicycle", "ped_2": "pedestrian"},
+        ),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+                uncertainty_metadata={"actor_class": "pedestrian"},
+            )
+        ],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _aggregate(report, "mean_ade", 1.0, "bicycle")["value"] == 0.0
+    with pytest.raises(AssertionError, match="missing aggregate"):
+        _aggregate(report, "mean_ade", 1.0, "pedestrian")
+
+
+def test_forecast_metrics_report_actor_class_denominators_and_caveats() -> None:
+    """Mixed fast-agent traces should expose separate active and excluded denominators."""
+    batch = ForecastBatch(
+        provenance=_provenance(
+            actor_ids=["ped_1", "bike_1", "bike_2"],
+            actor_mask=[True, True, False],
+            actor_mask_metadata={
+                "semantics": "true means included",
+                "missing_actor_reasons": {"bike_2": "outside forecast crop"},
+            },
+            actor_classes={
+                "ped_1": "pedestrian",
+                "bike_1": "bicycle",
+                "bike_2": "bicycle",
+            },
+        ),
+        forecasts=[
+            ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]]),
+            ActorForecast(actor_id="bike_1", deterministic=[[0.0, 0.0], [3.0, 0.0]]),
+        ],
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]], "bike_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    denominators = {row["actor_class"]: row for row in report["actor_class_denominators"]}
+    assert denominators["pedestrian"]["active_actor_count"] == 1
+    assert denominators["pedestrian"]["excluded_actor_count"] == 0
+    assert denominators["bicycle"]["active_actor_count"] == 1
+    assert denominators["bicycle"]["excluded_actor_count"] == 1
+    assert "fast dynamic actor" in denominators["bicycle"]["caveat"]
+    assert report["denominator_health"]["by_actor_class"] == report["actor_class_denominators"]
+    assert _aggregate(report, "mean_ade", 1.0, "pedestrian")["value"] == 0.0
+    assert _aggregate(report, "mean_ade", 1.0, "bicycle")["value"] == 2.0
+
+
+def test_forecast_metrics_fast_bicycle_fixture_smoke_actor_class_report() -> None:
+    """The #2727 fast-bicycle fixture should flow into bicycle metric denominators."""
+    fixture_path = (
+        Path(__file__).resolve().parents[2]
+        / "configs/scenarios/single/issue_2727_fast_bicycle_dynamic_actor.yaml"
+    )
+    scenario = yaml.safe_load(fixture_path.read_text())["scenarios"][0]
+    actor = scenario["single_pedestrians"][0]
+    actor_class = actor["metadata"]["fast_bicycle_actor"]["actor_type"]
+
+    batch = ForecastBatch(
+        provenance=_provenance(
+            scenario_id=scenario["name"],
+            actor_ids=[actor["id"]],
+            actor_mask=[True],
+            actor_mask_metadata={"semantics": "true means included"},
+            actor_classes={actor["id"]: actor_class},
+        ),
+        forecasts=[ActorForecast(actor_id=actor["id"], deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+        metadata={"scenario_family": scenario["metadata"]["behavior"]},
+    )
+    truth = {actor["id"]: [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+    markdown = format_forecast_metrics_markdown(report)
+
+    assert report["actor_class_denominators"] == [
+        {
+            "actor_class": "bicycle",
+            "active_actor_count": 1,
+            "excluded_actor_count": 0,
+            "horizons_s": [0.5, 1.0],
+            "dt_s": 0.5,
+            "caveat": (
+                "fast dynamic actor forecast denominator; compare only with matching "
+                "actor class, horizon, and dt_s settings"
+            ),
+        }
+    ]
+    assert _aggregate(report, "mean_ade", 1.0, "bicycle")["denominator"] == 1
+    assert "bicycle(active=1, excluded=0)" in markdown
+
+
 def test_forecast_metrics_accept_actor_class_from_batch_metadata() -> None:
     """Batch-level actor class metadata should work when forecast metadata is absent."""
     batch = ForecastBatch(
@@ -277,6 +383,54 @@ def test_forecast_metrics_accept_actor_class_from_batch_metadata() -> None:
     report = evaluate_forecast_batch(batch, truth)
 
     assert _aggregate(report, "mean_ade", 1.0, "child")["value"] == 0.0
+    assert report["actor_class_denominators"] == [
+        {
+            "actor_class": "child",
+            "active_actor_count": 1,
+            "excluded_actor_count": 0,
+            "horizons_s": [0.5, 1.0],
+            "dt_s": 0.5,
+            "caveat": (
+                "fast dynamic actor forecast denominator; compare only with matching "
+                "actor class, horizon, and dt_s settings"
+            ),
+        },
+        {
+            "actor_class": "pedestrian",
+            "active_actor_count": 0,
+            "excluded_actor_count": 1,
+            "horizons_s": [0.5, 1.0],
+            "dt_s": 0.5,
+            "caveat": "pedestrian forecast denominator",
+        },
+    ]
+
+
+def test_forecast_metrics_apply_batch_actor_class_default_to_exclusions() -> None:
+    """Batch actor-class defaults should classify active and excluded actors consistently."""
+    batch = ForecastBatch(
+        provenance=_provenance(actor_mask=[True, False]),
+        forecasts=[ActorForecast(actor_id="ped_1", deterministic=[[0.0, 0.0], [1.0, 0.0]])],
+        metadata={"actor_classes": {"actor_class": "bicycle"}},
+    )
+    truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
+
+    report = evaluate_forecast_batch(batch, truth)
+
+    assert _aggregate(report, "mean_ade", 1.0, "bicycle")["value"] == 0.0
+    assert report["actor_class_denominators"] == [
+        {
+            "actor_class": "bicycle",
+            "active_actor_count": 1,
+            "excluded_actor_count": 1,
+            "horizons_s": [0.5, 1.0],
+            "dt_s": 0.5,
+            "caveat": (
+                "fast dynamic actor forecast denominator; compare only with matching "
+                "actor class, horizon, and dt_s settings"
+            ),
+        }
+    ]
 
 
 def test_forecast_metrics_ignore_none_actor_class_metadata() -> None:


### PR DESCRIPTION
## Summary
- Add `ForecastBatchProvenance.actor_classes` so forecast artifacts can carry pedestrian, bicycle, and other actor-class labels at the artifact boundary.
- Report actor-class denominators and caveats in `ForecastMetrics.v1`, keeping mixed pedestrian/bicycle aggregate rows separate.
- Add regression tests for provenance precedence, metadata fallback consistency, excluded actor denominators, and the #2727 fast-bicycle fixture smoke.

Closes #2846.

## Validation
- `uv run pytest tests/benchmark/test_forecast_batch.py tests/benchmark/test_forecast_metrics.py` — 44 passed.
- `uv run ruff check robot_sf/benchmark/forecast_batch.py robot_sf/benchmark/forecast_metrics.py tests/benchmark/test_forecast_batch.py tests/benchmark/test_forecast_metrics.py` — passed.
- `uv run ruff format --check robot_sf/benchmark/forecast_batch.py robot_sf/benchmark/forecast_metrics.py tests/benchmark/test_forecast_batch.py tests/benchmark/test_forecast_metrics.py` — passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 6490 passed, 9 skipped, 9 warnings; changed-file coverage warnings only (`forecast_batch.py` 91.4%, `forecast_metrics.py` 98.4%).

## Research Result Guidance
- Target claim/blocker: forecast metric artifacts must not silently merge pedestrian and fast dynamic actor evidence.
- Comparator/baseline: prior `ForecastMetrics.v1` actor-class grouping depended on optional forecast/batch metadata and denominator health only reported total active/excluded counts.
- Evidence tier: schema/metric unit tests plus full PR readiness; diagnostic fixture smoke using the #2727 fast-bicycle YAML.
- Result classification: support/tooling evidence boundary improvement, not cyclist realism or planner-ranking benchmark evidence.
- Decision/stop rule: accept when mixed actor traces expose separate actor-class denominator rows and aggregate rows cannot merge pedestrian/bicycle metrics.
- Synthesis surface/update target: #2846 and downstream #2843 forecast/occupancy gate work.

## Downstream Propagation
- Parent issue: #2846 will close on merge.
- Claim maps/leaderboards: no benchmark ranking or planner claim updated.
- Artifact catalog/registry: no durable generated artifacts added; validation output was worktree-local and removed.
- Context/memory: active delegation ledger updated under `.git/codex-agent-runs/active/issue-2846-delegation-ledger.md`.

## Delegated Review
- Gemini mapping identified the minimal ForecastBatch/ForecastMetrics scope.
- Command Code review found a denominator/aggregate mismatch; fixed before PR.
- Gemini/OpenCode second-pass review found a metadata default edge case; fixed before PR.
- Qwen route produced a compact review but its oracle-state note was unrelated pre-existing behavior, not a blocker for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actors can now be assigned class labels in forecast batches, with automatic validation and persistence.
  * Forecast metric reports now display per-actor-class denominator counts and breakdowns in summaries.

* **Tests**
  * Added comprehensive test coverage for actor class validation, round-trip persistence, and metric aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->