### PR TITLE
Add motion-rich forecast trace evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1268,6 +1268,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2756_occluded_emergence_2026-06-13/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -136,6 +136,11 @@ Policy caveats:
   pedestrian forecast baseline evaluation on bounded durable trace fixtures. The corridor traces
   produce short-horizon metrics; crossing, bottleneck, signalized, occluded, and dense-interaction
   coverage remains limited or unavailable.
+- `issue_2774_motion_rich_forecast_traces_2026-06-14/`: diagnostic-only refresh of the
+  constant-velocity pedestrian forecast baseline that promotes the durable occluded-emergence
+  trace fixture as non-corridor forecast evidence. Corridor and occluded-emergence traces are
+  evaluated; crossing and bottleneck remain zero-motion limitations, and signalized/dense/bottleneck
+  motion-rich coverage remains unavailable.
 - `issue_2749_observation_noise_diagnostics/`: diagnostic-only paired no-op vs
   perception-limited observation-noise step diagnostics for `hybrid_rule_v0_minimal` on a
   pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant

--- a/docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.json
+++ b/docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.json
@@ -1,0 +1,268 @@
+{
+  "issue": 2774,
+  "claim_boundary": "Diagnostic-only, not paper-facing evidence. Limited to bounded repository trace fixtures.",
+  "reproducibility": {
+    "issue": 2774,
+    "generated_at_utc": "2026-06-14T22:13:30.330195+00:00",
+    "command": "uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14",
+    "repo_head": "72c2425f",
+    "horizons_s": [
+      0.5,
+      1.0,
+      2.0
+    ]
+  },
+  "trace_family_gaps": {
+    "evaluated": [
+      "corridor_interaction",
+      "occluded_emergence"
+    ],
+    "limited": [
+      "bottleneck",
+      "crossing_proxy"
+    ],
+    "missing": [
+      "signalized_crossing",
+      "dense_pedestrian_interaction",
+      "bottleneck_with_motion"
+    ]
+  },
+  "results_by_trace": [
+    {
+      "label": "default_social_force",
+      "family": "corridor_interaction",
+      "trace_path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/default_social_force_trace_export.json",
+      "scenario_id": "classic_head_on_corridor_low",
+      "planner_id": "default_social_force",
+      "seed": 111,
+      "status": "evaluated",
+      "frame_count": 20,
+      "pedestrians_per_frame": 2,
+      "actor_classes": [
+        "pedestrian"
+      ],
+      "actor_class_counts": {
+        "pedestrian": 40
+      },
+      "pedestrian_forecast_denominator_policy": "Only pedestrian/person actors are scored by pedestrian forecast metrics; non-pedestrian actor classes are excluded and counted separately.",
+      "has_motion": true,
+      "dt_s": 0.1,
+      "horizons_s": [
+        0.5,
+        1.0,
+        2.0
+      ],
+      "metrics": {
+        "pedestrian_forecast_candidate_count": 40.0,
+        "pedestrian_forecast_included_actor_count": 40.0,
+        "pedestrian_forecast_excluded_actor_count": 0.0,
+        "forecast_evaluable_samples": 30.0,
+        "mean_ade_0.5s": 0.024280292893659475,
+        "count_ade_0.5s": 30.0,
+        "mean_ade_1s": 0.07693663848497238,
+        "count_ade_1s": 20.0,
+        "mean_calibration_error_0.5s": 0.050000000000000044,
+        "count_calibration_error_0.5s": 30.0,
+        "mean_calibration_error_1s": 0.050000000000000044,
+        "count_calibration_error_1s": 20.0,
+        "mean_collision_relevance_error_0.5s": 0.0,
+        "count_collision_relevance_error_0.5s": 30.0,
+        "mean_collision_relevance_error_1s": 0.0,
+        "count_collision_relevance_error_1s": 20.0,
+        "mean_log_likelihood_0.5s": -1.2676793071505172,
+        "count_log_likelihood_0.5s": 30.0,
+        "mean_log_likelihood_1s": -1.952169154331188,
+        "count_log_likelihood_1s": 20.0,
+        "mean_mahalanobis_dist_0.5s": 0.032373723858212626,
+        "count_mahalanobis_dist_0.5s": 30.0,
+        "mean_mahalanobis_dist_1s": 0.07327298903330705,
+        "count_mahalanobis_dist_1s": 20.0,
+        "mean_miss_rate_0.5s": 0.0,
+        "count_miss_rate_0.5s": 30.0,
+        "mean_miss_rate_1s": 0.0,
+        "count_miss_rate_1s": 20.0,
+        "mean_negative_log_likelihood_0.5s": 1.2676793071505172,
+        "count_negative_log_likelihood_0.5s": 30.0,
+        "mean_negative_log_likelihood_1s": 1.952169154331188,
+        "count_negative_log_likelihood_1s": 20.0,
+        "mean_within_95ci_0.5s": 1.0,
+        "count_within_95ci_0.5s": 30.0,
+        "mean_within_95ci_1s": 1.0,
+        "count_within_95ci_1s": 20.0
+      }
+    },
+    {
+      "label": "ammv_social_force",
+      "family": "corridor_interaction",
+      "trace_path": "docs/context/evidence/issue_2428_mechanism_trace_panels_2026-06-06/traces/ammv_social_force_trace_export.json",
+      "scenario_id": "classic_head_on_corridor_low",
+      "planner_id": "ammv_social_force",
+      "seed": 111,
+      "status": "evaluated",
+      "frame_count": 20,
+      "pedestrians_per_frame": 2,
+      "actor_classes": [
+        "pedestrian"
+      ],
+      "actor_class_counts": {
+        "pedestrian": 40
+      },
+      "pedestrian_forecast_denominator_policy": "Only pedestrian/person actors are scored by pedestrian forecast metrics; non-pedestrian actor classes are excluded and counted separately.",
+      "has_motion": true,
+      "dt_s": 0.1,
+      "horizons_s": [
+        0.5,
+        1.0,
+        2.0
+      ],
+      "metrics": {
+        "pedestrian_forecast_candidate_count": 40.0,
+        "pedestrian_forecast_included_actor_count": 40.0,
+        "pedestrian_forecast_excluded_actor_count": 0.0,
+        "forecast_evaluable_samples": 30.0,
+        "mean_ade_0.5s": 0.024280292893659475,
+        "count_ade_0.5s": 30.0,
+        "mean_ade_1s": 0.07693663848497238,
+        "count_ade_1s": 20.0,
+        "mean_calibration_error_0.5s": 0.050000000000000044,
+        "count_calibration_error_0.5s": 30.0,
+        "mean_calibration_error_1s": 0.050000000000000044,
+        "count_calibration_error_1s": 20.0,
+        "mean_collision_relevance_error_0.5s": 0.0,
+        "count_collision_relevance_error_0.5s": 30.0,
+        "mean_collision_relevance_error_1s": 0.0,
+        "count_collision_relevance_error_1s": 20.0,
+        "mean_log_likelihood_0.5s": -1.2676793071505172,
+        "count_log_likelihood_0.5s": 30.0,
+        "mean_log_likelihood_1s": -1.952169154331188,
+        "count_log_likelihood_1s": 20.0,
+        "mean_mahalanobis_dist_0.5s": 0.032373723858212626,
+        "count_mahalanobis_dist_0.5s": 30.0,
+        "mean_mahalanobis_dist_1s": 0.07327298903330705,
+        "count_mahalanobis_dist_1s": 20.0,
+        "mean_miss_rate_0.5s": 0.0,
+        "count_miss_rate_0.5s": 30.0,
+        "mean_miss_rate_1s": 0.0,
+        "count_miss_rate_1s": 20.0,
+        "mean_negative_log_likelihood_0.5s": 1.2676793071505172,
+        "count_negative_log_likelihood_0.5s": 30.0,
+        "mean_negative_log_likelihood_1s": 1.952169154331188,
+        "count_negative_log_likelihood_1s": 20.0,
+        "mean_within_95ci_0.5s": 1.0,
+        "count_within_95ci_0.5s": 30.0,
+        "mean_within_95ci_1s": 1.0,
+        "count_within_95ci_1s": 20.0
+      }
+    },
+    {
+      "label": "synthetic_crossing_proxy_orca",
+      "family": "crossing_proxy",
+      "trace_path": "docs/context/evidence/issue_2667_trace_failure_predicate_tables_2026-06-12/inputs/synthetic_crossing_proxy_orca_111_trace_export.json",
+      "scenario_id": "crossing_proxy",
+      "planner_id": "orca",
+      "seed": 111,
+      "status": "limited_no_pedestrian_motion",
+      "frame_count": 5,
+      "pedestrians_per_frame": 1,
+      "actor_classes": [
+        "pedestrian"
+      ],
+      "actor_class_counts": {
+        "pedestrian": 5
+      },
+      "pedestrian_forecast_denominator_policy": "Only pedestrian/person actors are scored by pedestrian forecast metrics; non-pedestrian actor classes are excluded and counted separately.",
+      "has_motion": false,
+      "metrics": {
+        "forecast_evaluable_samples": 0.0
+      },
+      "limitation": "All pedestrian velocities are zero; constant-velocity forecast produces degenerate predictions with no motion to evaluate against."
+    },
+    {
+      "label": "minimal_fixture",
+      "family": "bottleneck",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json",
+      "scenario_id": "classic_bottleneck_medium",
+      "planner_id": "hybrid_rule_v0_minimal",
+      "seed": 111,
+      "status": "limited_no_pedestrian_motion",
+      "frame_count": 2,
+      "pedestrians_per_frame": 1,
+      "actor_classes": [
+        "pedestrian"
+      ],
+      "actor_class_counts": {
+        "pedestrian": 2
+      },
+      "pedestrian_forecast_denominator_policy": "Only pedestrian/person actors are scored by pedestrian forecast metrics; non-pedestrian actor classes are excluded and counted separately.",
+      "has_motion": false,
+      "metrics": {
+        "forecast_evaluable_samples": 0.0
+      },
+      "limitation": "All pedestrian velocities are zero; constant-velocity forecast produces degenerate predictions with no motion to evaluate against."
+    },
+    {
+      "label": "deterministic_occluded_emergence",
+      "family": "occluded_emergence",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",
+      "scenario_id": "issue_2756_occluded_emergence",
+      "planner_id": "hybrid_rule_v0_minimal",
+      "seed": 111,
+      "status": "evaluated",
+      "frame_count": 16,
+      "pedestrians_per_frame": 1,
+      "actor_classes": [
+        "pedestrian"
+      ],
+      "actor_class_counts": {
+        "pedestrian": 16
+      },
+      "pedestrian_forecast_denominator_policy": "Only pedestrian/person actors are scored by pedestrian forecast metrics; non-pedestrian actor classes are excluded and counted separately.",
+      "has_motion": true,
+      "dt_s": 0.1,
+      "horizons_s": [
+        0.5,
+        1.0,
+        2.0
+      ],
+      "metrics": {
+        "pedestrian_forecast_candidate_count": 16.0,
+        "pedestrian_forecast_included_actor_count": 16.0,
+        "pedestrian_forecast_excluded_actor_count": 0.0,
+        "forecast_evaluable_samples": 11.0,
+        "mean_ade_0.5s": 1.5139404881252134e-17,
+        "count_ade_0.5s": 11.0,
+        "mean_ade_1s": 2.312964634635743e-17,
+        "count_ade_1s": 6.0,
+        "mean_calibration_error_0.5s": 0.050000000000000044,
+        "count_calibration_error_0.5s": 11.0,
+        "mean_calibration_error_1s": 0.050000000000000044,
+        "count_calibration_error_1s": 6.0,
+        "mean_collision_relevance_error_0.5s": 0.09090909090909091,
+        "count_collision_relevance_error_0.5s": 11.0,
+        "mean_collision_relevance_error_1s": 0.0,
+        "count_collision_relevance_error_1s": 6.0,
+        "mean_log_likelihood_0.5s": -1.2625129215057833,
+        "count_log_likelihood_0.5s": 11.0,
+        "mean_log_likelihood_1s": -1.935457394748209,
+        "count_log_likelihood_1s": 6.0,
+        "mean_mahalanobis_dist_0.5s": 2.0185873175002847e-17,
+        "count_mahalanobis_dist_0.5s": 11.0,
+        "mean_mahalanobis_dist_1s": 2.2028234615578508e-17,
+        "count_mahalanobis_dist_1s": 6.0,
+        "mean_miss_rate_0.5s": 0.0,
+        "count_miss_rate_0.5s": 11.0,
+        "mean_miss_rate_1s": 0.0,
+        "count_miss_rate_1s": 6.0,
+        "mean_negative_log_likelihood_0.5s": 1.2625129215057833,
+        "count_negative_log_likelihood_0.5s": 11.0,
+        "mean_negative_log_likelihood_1s": 1.935457394748209,
+        "count_negative_log_likelihood_1s": 6.0,
+        "mean_within_95ci_0.5s": 1.0,
+        "count_within_95ci_0.5s": 11.0,
+        "mean_within_95ci_1s": 1.0,
+        "count_within_95ci_1s": 6.0
+      }
+    }
+  ],
+  "failure_cases": []
+}

--- a/docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.md
+++ b/docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.md
@@ -1,0 +1,98 @@
+# CV Forecast Baseline Evaluation
+
+## Claim Boundary
+
+**Diagnostic-only, not paper-facing evidence.** This evaluates the constant-velocity Gaussian forecast baseline on a bounded set of existing repository trace fixtures. Results are per-family rollups, not statistically powered population claims.
+
+## Reproducibility
+
+- **Issue:** #2774
+- **Generated at (UTC):** 2026-06-14T22:13:30.330195+00:00
+- **Command:** `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14`
+- **Repo HEAD:** `72c2425f`
+- **Forecast horizons:** [0.5, 1.0, 2.0]
+
+## Selected Trace Families
+
+| Family | Label | Scenario | Frames | Peds | Motion | dt (s) | Status |
+|--------|-------|----------|--------|------|--------|--------|--------|
+| corridor_interaction | default_social_force | classic_head_on_corridor_low | 20 | 2 | yes | 0.1 | evaluated |
+| corridor_interaction | ammv_social_force | classic_head_on_corridor_low | 20 | 2 | yes | 0.1 | evaluated |
+| crossing_proxy | synthetic_crossing_proxy_orca | crossing_proxy | 5 | 1 | no | - | limited_no_pedestrian_motion |
+| bottleneck | minimal_fixture | classic_bottleneck_medium | 2 | 1 | no | - | limited_no_pedestrian_motion |
+| occluded_emergence | deterministic_occluded_emergence | issue_2756_occluded_emergence | 16 | 1 | yes | 0.1 | evaluated |
+
+## Missing Trace Families
+
+These scenario families have no durable trace fixtures in the repository and were not evaluated:
+
+- **signalized_crossing**: no durable trace fixture available
+- **dense_pedestrian_interaction**: no durable trace fixture available
+- **bottleneck_with_motion**: existing bottleneck fixture has zero pedestrian velocity
+
+## Aggregate Metrics by Trace Family
+
+### corridor_interaction / default_social_force
+
+- Evaluable samples: 30
+- **Horizon 0.5s:**
+  - ADE: 0.0243 m
+  - NLL: 1.2677
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 1s:**
+  - ADE: 0.0769 m
+  - NLL: 1.9522
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 2s:**
+  - Not available for this trace length.
+
+### corridor_interaction / ammv_social_force
+
+- Evaluable samples: 30
+- **Horizon 0.5s:**
+  - ADE: 0.0243 m
+  - NLL: 1.2677
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 1s:**
+  - ADE: 0.0769 m
+  - NLL: 1.9522
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 2s:**
+  - Not available for this trace length.
+
+### occluded_emergence / deterministic_occluded_emergence
+
+- Evaluable samples: 11
+- **Horizon 0.5s:**
+  - ADE: 0.0000 m
+  - NLL: 1.2625
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 1s:**
+  - ADE: 0.0000 m
+  - NLL: 1.9355
+  - Miss rate: 0.00%
+  - Within 95% CI: 100.00%
+  - Calibration error: 0.0500
+- **Horizon 2s:**
+  - Not available for this trace length.
+
+
+## Interpretation
+
+The constant-velocity Gaussian baseline is adequate for short horizons (0.5s) on traces with relatively smooth, low-acceleration pedestrian motion (such as the corridor_interaction family). In this bounded evidence set, 1s metrics remain available and low-error, while 2s metrics are unavailable because the durable traces are too short for that forecast horizon.
+
+The occluded_emergence family is now evaluated with the durable fixture from #2756. It produces 11 evaluable samples with motion-rich pedestrian trajectories, extending forecast evidence beyond the corridor family. This is diagnostic-only evidence for a single occluded-emergence episode, not a statistically powered claim across the family.
+
+The available crossing_proxy and bottleneck fixtures are limitation records, not forecast-quality evidence: they contain zero pedestrian motion, so they do not test whether constant velocity handles crossing, bottleneck, or dense interaction dynamics.
+
+All traces in this evaluation lack intent and signal context metadata, so the forecast operates in 'uncertain' mode with 1.5x widened standard deviation. This is a systematic limitation of the available trace fixtures.

--- a/scripts/benchmark/run_cv_forecast_eval.py
+++ b/scripts/benchmark/run_cv_forecast_eval.py
@@ -8,7 +8,7 @@ and writes JSON + Markdown evidence to the requested output directory.
 Usage::
 
     uv run python scripts/benchmark/run_cv_forecast_eval.py \\
-        --output-dir docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13
+        --output-dir docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14
 
 This is diagnostic-only evidence, not paper-facing benchmark proof.
 """
@@ -470,10 +470,16 @@ def _md_interpretation() -> list[str]:
         "1s metrics remain available and low-error, while 2s metrics are unavailable "
         "because the durable traces are too short for that forecast horizon.",
         "",
+        "The occluded_emergence family is now evaluated with the durable fixture "
+        "from #2756. It produces 11 evaluable samples with motion-rich pedestrian "
+        "trajectories, extending forecast evidence beyond the corridor family. "
+        "This is diagnostic-only evidence for a single occluded-emergence episode, "
+        "not a statistically powered claim across the family.",
+        "",
         "The available crossing_proxy and bottleneck fixtures are limitation records, "
         "not forecast-quality evidence: they contain zero pedestrian motion, so they "
-        "do not test whether constant velocity handles crossing, bottleneck, occluded, "
-        "or dense interaction dynamics.",
+        "do not test whether constant velocity handles crossing, bottleneck, or "
+        "dense interaction dynamics.",
         "",
         "All traces in this evaluation lack intent and signal context metadata, "
         "so the forecast operates in 'uncertain' mode with 1.5x widened standard "
@@ -506,7 +512,7 @@ def main() -> None:
     parser.add_argument(
         "--output-dir",
         type=str,
-        default="docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13",
+        default="docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14",
         help="Output directory for evidence artifacts.",
     )
     args = parser.parse_args()
@@ -521,7 +527,7 @@ def main() -> None:
     )
 
     repro = {
-        "issue": 2757,
+        "issue": 2774,
         "generated_at_utc": generated_at,
         "command": command,
         "repo_head": repo_head,
@@ -538,7 +544,7 @@ def main() -> None:
     limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
 
     report_json: dict[str, Any] = {
-        "issue": 2757,
+        "issue": 2774,
         "claim_boundary": (
             "Diagnostic-only, not paper-facing evidence. "
             "Limited to bounded repository trace fixtures."

--- a/scripts/tools/generate_mixed_scenario_matrix.py
+++ b/scripts/tools/generate_mixed_scenario_matrix.py
@@ -22,7 +22,7 @@ DEFAULT_OBS_NOISE_SUMMARY = Path(
     "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13/summary.json"
 )
 DEFAULT_CV_FORECAST = Path(
-    "docs/context/evidence/issue_2757_cv_forecast_eval_2026-06-13/report.json"
+    "docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.json"
 )
 DEFAULT_GAP_REPORT = Path(
     "docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json"

--- a/tests/benchmark/test_pedestrian_forecast_cv_eval.py
+++ b/tests/benchmark/test_pedestrian_forecast_cv_eval.py
@@ -347,3 +347,54 @@ def test_generate_markdown_includes_failure_cases() -> None:
     assert "Failure Cases" in md
     assert "test_trace" in md
     assert "test/path.json" in md
+
+
+def test_occluded_emergence_candidate_is_evaluated_with_samples() -> None:
+    """The occluded_emergence trace produces evaluated status with evaluable samples."""
+    candidate = next(c for c in TRACE_CANDIDATES if c["family"] == "occluded_emergence")
+    result = evaluate_single_trace(candidate)
+    assert result["status"] == "evaluated", (
+        f"occluded_emergence expected 'evaluated', got '{result['status']}'"
+    )
+    assert result["metrics"]["forecast_evaluable_samples"] > 0, (
+        "occluded_emergence should have forecast_evaluable_samples > 0"
+    )
+    assert result["has_motion"] is True
+
+
+def test_non_corridor_evaluated_families_appear_in_gap_summary() -> None:
+    """Evaluated non-corridor families are in the evaluated set, not limited or missing."""
+    results = []
+    for candidate in TRACE_CANDIDATES:
+        results.append(evaluate_single_trace(candidate))
+
+    evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
+    limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
+
+    assert "corridor_interaction" in evaluated_families
+    assert "occluded_emergence" in evaluated_families
+    assert "occluded_emergence" not in limited_families
+    assert "occluded_emergence" not in [mf["family"] for mf in MISSING_FAMILIES]
+
+
+def test_report_json_distinguishes_evaluated_limited_missing() -> None:
+    """JSON report separates evaluated, limited, and missing trace families."""
+    results = []
+    for candidate in TRACE_CANDIDATES:
+        results.append(evaluate_single_trace(candidate))
+
+    evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
+    limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
+
+    assert "corridor_interaction" in evaluated_families
+    assert "occluded_emergence" in evaluated_families
+
+    # crossing_proxy and bottleneck should be limited (zero motion)
+    for fam in ["crossing_proxy", "bottleneck"]:
+        assert fam in limited_families, (
+            f"{fam} should be in limited families, got {limited_families}"
+        )
+
+    # occluded_emergence should NOT be in limited or missing
+    assert "occluded_emergence" not in limited_families
+    assert "occluded_emergence" not in [mf["family"] for mf in MISSING_FAMILIES]


### PR DESCRIPTION
## Summary
Promotes the durable occluded-emergence trace fixture into the constant-velocity forecast evidence set for #2774, producing a new compact JSON/Markdown report where non-corridor `occluded_emergence` has evaluable forecast samples.

## Linked Issues
- Closes `#2774`
- Relates to `#2756`
- Relates to `#2757`
- Relates to `#2766`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated `scripts/benchmark/run_cv_forecast_eval.py` to default to #2774 evidence output, use #2774 provenance, and describe occluded-emergence as evaluated diagnostic evidence rather than a missing/limited family.
- Added `docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.{json,md}` with corridor and occluded-emergence evaluated, crossing/bottleneck limited, and remaining unavailable families explicit.
- Pointed `scripts/tools/generate_mixed_scenario_matrix.py` at the refreshed #2774 forecast report.
- Added forecast evaluator tests for non-corridor evaluated samples and evaluated/limited/missing classification.
- Registered the new compact evidence in `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.

## Why It Matters
- Added value: moves the CV forecast evidence set beyond corridor-only motion by reusing the durable #2756 occluded-emergence trace fixture.
- Expected impact: downstream mixed-scenario coverage now sees occluded-emergence as diagnostic forecast evidence instead of inheriting stale #2757 limitations.
- Why this is worth merging now: it unblocks forecast evidence synthesis without inventing synthetic traces or making paper-facing claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #2774 blocker that forecast trace evidence was corridor-only or missing motion-rich non-corridor coverage.
- Comparator or baseline, if applicable: constant-velocity Gaussian pedestrian forecast baseline.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop when at least one non-corridor durable trace family has `forecast_evaluable_samples > 0` and unavailable families remain caveated.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2774 and downstream mixed-scenario matrix forecast column.
- New research/benchmark/metric/paper-facing analysis tool, if any: no new tool; representative use is the committed #2774 report generated from durable repository trace fixtures.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, occluded-emergence produced 11 evaluable forecast samples.
- Did the intervention change command source, selected command, trajectory, or route progress? no planner trajectory change; this is trace/evidence promotion and report generation.
- Did the scenario actually contain the targeted failure mode? partially; it contains motion-rich occluded-emergence trace coverage, but it remains one deterministic diagnostic episode.
- Result route: continue, narrowly.
- Follow-up question or issue for weak, negative, or non-transfer results: broader forecast claims still need more families and live/evaluable traces; this PR does not make them.

## Next Empirical Action
- Rerun needed: no for #2774 acceptance.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: signalized, dense pedestrian interaction, and motion-rich bottleneck forecast traces remain unavailable.
- Stop / revise / continue decision: continue from diagnostic-only occluded-emergence support; do not promote to paper-facing evidence.
- Proposed child issue or existing follow-up: existing broader synthesis/unblocker work can consume this report; no new issue opened.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py tests/tools/test_generate_mixed_scenario_matrix.py`
  - `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14`
  - `uv run ruff check scripts/benchmark/run_cv_forecast_eval.py scripts/tools/generate_mixed_scenario_matrix.py tests/benchmark/test_pedestrian_forecast_cv_eval.py tests/benchmark/test_pedestrian_forecast.py tests/tools/test_generate_mixed_scenario_matrix.py`
  - `uv run ruff format --check scripts/benchmark/run_cv_forecast_eval.py scripts/tools/generate_mixed_scenario_matrix.py tests/benchmark/test_pedestrian_forecast_cv_eval.py tests/benchmark/test_pedestrian_forecast.py tests/tools/test_generate_mixed_scenario_matrix.py`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final PR readiness passed on head `5753e2af850b16ba7777f7d7d38d13f4c12fa196` with `6494 passed, 9 skipped, 8 warnings` and clean tree state.
- Benchmarks or smoke tests, if applicable: forecast evaluator smoke wrote #2774 `report.json`/`report.md`; `occluded_emergence/deterministic_occluded_emergence` is evaluated with 11 samples.

## Risks / Rollout
- Compatibility risks: the evaluator default output now points to #2774. Historical #2757 artifacts remain tracked, and explicit `--output-dir` still supports regenerating alternate locations.
- Failure modes: future downstream consumers may still hardcode older forecast reports; this PR updates the known mixed-scenario matrix consumer.
- Rollback or fallback plan: revert to the previous default report path or pass `--output-dir` explicitly.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: #2774 report records command, repo head, trace paths, family statuses, and diagnostic-only claim boundary.
- Any assumptions that need to be preserved: this is a single deterministic occluded-emergence episode, not a statistically powered family-level forecast claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #2774.
- Claim map / benchmark report updated (yes/no/NA): yes, #2774 compact forecast report added.
- Leaderboard / artifact catalog updated (yes/no/NA): yes, `docs/context/catalog.yaml`.
- Registry or config index updated (yes/no/NA): yes, `scripts/tools/generate_mixed_scenario_matrix.py` now consumes #2774 forecast report.
- Context index / memory note updated (yes/no/NA): yes, `docs/context/evidence/README.md`.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: broader benchmark/paper propagation is intentionally deferred until more forecast families are available.

## Follow-Up Issues
- Deferred work: add durable signalized/dense/motion-rich bottleneck forecast traces before broader forecast claims.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify closely that `docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14/report.json` keeps `trace_family_gaps` separated into evaluated, limited, and missing.
- Known limitations: diagnostic-only, one occluded-emergence fixture, no paper-facing forecast claim.
- Delegation: OpenCode Zen implemented the bounded change; Command Code found the stale downstream #2757 consumer and docstring/index gaps; Gemini final review found no blockers after the fix.
