### PR TITLE
Add semantic forecast baselines

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1336,3 +1336,15 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -363,3 +363,9 @@ Policy caveats:
   investigation of the t_intersection_transfer hard slice. Follows #2801 stop decision and
   implements the recommended non-topology successor target. Hypothesis: per-step scoring will
   separate blocked_geometry from switch_too_often. Not benchmark or paper-facing evidence.
+- `issue_2758_semantic_forecast_baselines_2026-06-14/`: diagnostic-only comparison of
+  constant-velocity and semantic (signal-aware, goal-aware, combined) forecast baselines on
+  bounded repository trace fixtures. Includes a compact summary plus JSON/Markdown comparison
+  report. Existing durable fixtures lack signal/intent metadata, so the comparison proves
+  baselines run correctly but does not show semantic conditioning improving calibration or
+  collision relevance yet. Not benchmark or paper-facing evidence.

--- a/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.json
+++ b/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.json
@@ -1,0 +1,280 @@
+{
+  "issue": 2758,
+  "claim_boundary": "Diagnostic-only, not paper-facing evidence. Limited to bounded repository trace fixtures.",
+  "reproducibility": {
+    "issue": 2758,
+    "generated_at_utc": "2026-06-14T23:18:12.251491+00:00",
+    "command": "uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14 --compare-all",
+    "repo_head": "9ae4a6eb",
+    "horizons_s": [
+      0.5,
+      1.0,
+      2.0
+    ]
+  },
+  "semantic_usefulness": {
+    "fixtures_have_signal_metadata": false,
+    "fixtures_have_intent_metadata": false,
+    "conclusion": "Semantic conditioning is meaningful when fixtures carry signal/intent metadata. Existing durable fixtures lack this metadata, so the comparison shows whether baselines run correctly but does not yet show semantic conditioning improving calibration or collision relevance."
+  },
+  "summary_by_baseline": {
+    "cv": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "signal_aware": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "goal_aware": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "semantic": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    }
+  },
+  "comparison_rows": [
+    {
+      "baseline": "cv",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "cv",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "cv",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "cv",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "cv",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.935457394748209,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.935457394748209,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.6715050915270422,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.6715050915270422,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.6492557074668623,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 2.4700745388210485,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 2.4700745388210485,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "semantic",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "semantic",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 2.4601859236831913,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    }
+  ]
+}

--- a/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.md
+++ b/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.md
@@ -1,0 +1,54 @@
+# Semantic Forecast Baseline Comparison
+
+## Claim Boundary
+
+**Diagnostic-only, not paper-facing evidence.** Compares constant-velocity and semantic forecast baselines on bounded repository trace fixtures.
+
+## Reproducibility
+
+- **Issue:** #2758
+- **Generated at (UTC):** 2026-06-14T23:18:12.251491+00:00
+- **Command:** `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14 --compare-all`
+- **Repo HEAD:** `9ae4a6eb`
+- **Forecast horizons:** [0.5, 1.0, 2.0]
+
+## Fixture Metadata Assessment
+
+- **Fixtures have signal metadata:** False
+- **Fixtures have intent metadata:** False
+
+Existing durable fixtures lack signal and intent metadata. Semantic conditioning baselines run correctly but their calibration/collision-relevance improvement cannot be measured until fixtures include this metadata.
+
+## Baseline Summary
+
+| Baseline | Evaluated Traces | Total Samples |
+|----------|------------------|---------------|
+| cv | 3 | 71 |
+| signal_aware | 3 | 71 |
+| goal_aware | 3 | 71 |
+| semantic | 3 | 71 |
+
+## Comparison Table
+
+| Baseline | Family | Label | Status | Samples | ADE 1s | NLL 1s | Miss Rate 1s |
+|----------|--------|-------|--------|---------|--------|--------|-------------|
+| cv | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| cv | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| cv | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| cv | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| cv | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.9355 | 0.00% |
+| signal_aware | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| signal_aware | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| signal_aware | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| signal_aware | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| signal_aware | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.9355 | 0.00% |
+| goal_aware | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.6715 | 0.00% |
+| goal_aware | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.6715 | 0.00% |
+| goal_aware | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| goal_aware | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| goal_aware | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.6493 | 0.00% |
+| semantic | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 2.4701 | 0.00% |
+| semantic | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 2.4701 | 0.00% |
+| semantic | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| semantic | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| semantic | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 2.4602 | 0.00% |

--- a/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/summary.json
+++ b/docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/summary.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "semantic_forecast_baselines_summary.v1",
+  "issue": 2758,
+  "claim_boundary": "diagnostic_only_not_benchmark_or_paper_evidence",
+  "input_fixture_source": "bounded repository trace fixtures from the #2774 forecast evidence set",
+  "baselines": [
+    "cv",
+    "signal_aware",
+    "goal_aware",
+    "semantic"
+  ],
+  "fixture_metadata": {
+    "has_signal_metadata": false,
+    "has_intent_metadata": false
+  },
+  "result_classification": "diagnostic_only",
+  "conclusion": "Semantic forecast baselines run on the durable trace set, but the current fixtures lack signal and intent metadata, so this evidence does not show semantic conditioning improving calibration or collision relevance.",
+  "artifacts": {
+    "comparison_json": "docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.json",
+    "comparison_markdown": "docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/comparison_report.md"
+  },
+  "validation": {
+    "targeted_tests": "uv run pytest tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py",
+    "comparison_smoke": "uv run python scripts/benchmark/run_cv_forecast_eval.py --compare-all --output-dir docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14"
+  }
+}

--- a/robot_sf/benchmark/pedestrian_forecast.py
+++ b/robot_sf/benchmark/pedestrian_forecast.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -108,6 +109,12 @@ class PedestrianForecast:
     predictions: list[ForecastDistribution]
 
 
+ForecastBaselineFunction = Callable[
+    [PedestrianState, list[float] | tuple[float, ...]],
+    PedestrianForecast,
+]
+
+
 def constant_velocity_gaussian_baseline(
     state: PedestrianState,
     horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
@@ -152,6 +159,223 @@ def constant_velocity_gaussian_baseline(
         )
 
     return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+def signal_aware_cv_baseline(
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    base_std_m: float = 0.3,
+    velocity_std_rate: float = 0.4,
+    red_slowdown_factor: float = 0.4,
+    signal_unavailable_multiplier: float = 1.5,
+) -> PedestrianForecast:
+    """Signal-aware constant-velocity baseline.
+
+    When signal is available: red reduces mean displacement (slowdown_factor),
+    green preserves mean displacement, and unrecognized present values preserve
+    plain-CV without widening uncertainty.  When signal is unavailable the mean
+    stays at plain-CV and uncertainty is widened rather than assuming a phase.
+
+    This is deterministic and labeled; it does not claim human realism.
+
+    Returns:
+        Forecast distributions for the requested horizons.
+    """
+
+    predictions: list[ForecastDistribution] = []
+
+    for horizon_s in horizons_s:
+        horizon = float(horizon_s)
+        std_m = base_std_m + velocity_std_rate * horizon
+
+        if not state.signal_available or state.signal is None:
+            mean = state.position + state.velocity * horizon
+            signal_status = "unknown_widened"
+            std_m *= signal_unavailable_multiplier
+        elif state.signal == "red":
+            mean = state.position + state.velocity * horizon * red_slowdown_factor
+            signal_status = "red_slowed"
+        elif state.signal == "green":
+            mean = state.position + state.velocity * horizon
+            signal_status = "green_preserved"
+        else:
+            mean = state.position + state.velocity * horizon
+            signal_status = "unrecognized_preserved"
+
+        if std_m <= 0.0:
+            raise ValueError("forecast standard deviation must be positive")
+
+        predictions.append(
+            ForecastDistribution(
+                horizon_s=horizon,
+                mean=mean,
+                covariance=np.eye(2, dtype=float) * (std_m**2),
+                metadata={
+                    "model": "signal_aware_cv",
+                    "std_m": float(std_m),
+                    "is_intent_aware": state.intent is not None,
+                    "is_signal_aware": state.signal_available,
+                    "signal_state": state.signal if state.signal_available else "unknown",
+                    "signal_status": signal_status,
+                },
+            )
+        )
+
+    return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+def goal_aware_cv_baseline(
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    base_std_m: float = 0.3,
+    velocity_std_rate: float = 0.4,
+    crossing_speed_factor: float = 1.2,
+    walking_along_speed_factor: float = 0.8,
+    intent_unavailable_multiplier: float = 1.3,
+) -> PedestrianForecast:
+    """Goal-aware constant-velocity baseline.
+
+    When intent metadata is present: crossing increases mean displacement,
+    walking_along decreases mean displacement, and unrecognized present values
+    preserve plain-CV without widening uncertainty.  Absent intent keeps
+    plain-CV mean and widens uncertainty rather than assuming a goal.
+
+    This is deterministic and labeled; it does not claim human realism.
+
+    Returns:
+        Forecast distributions for the requested horizons.
+    """
+
+    predictions: list[ForecastDistribution] = []
+
+    for horizon_s in horizons_s:
+        horizon = float(horizon_s)
+        std_m = base_std_m + velocity_std_rate * horizon
+
+        if state.intent is None:
+            mean = state.position + state.velocity * horizon
+            intent_status = "unknown_widened"
+            std_m *= intent_unavailable_multiplier
+        elif state.intent == "crossing":
+            mean = state.position + state.velocity * horizon * crossing_speed_factor
+            intent_status = "crossing_adjusted"
+        elif state.intent == "walking_along":
+            mean = state.position + state.velocity * horizon * walking_along_speed_factor
+            intent_status = "walking_along_adjusted"
+        else:
+            mean = state.position + state.velocity * horizon
+            intent_status = "unrecognized_preserved"
+
+        if std_m <= 0.0:
+            raise ValueError("forecast standard deviation must be positive")
+
+        predictions.append(
+            ForecastDistribution(
+                horizon_s=horizon,
+                mean=mean,
+                covariance=np.eye(2, dtype=float) * (std_m**2),
+                metadata={
+                    "model": "goal_aware_cv",
+                    "std_m": float(std_m),
+                    "is_intent_aware": state.intent is not None,
+                    "is_signal_aware": state.signal_available,
+                    "intent_state": state.intent or "unknown",
+                    "intent_status": intent_status,
+                },
+            )
+        )
+
+    return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+def semantic_cv_baseline(  # noqa: PLR0913
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    base_std_m: float = 0.3,
+    velocity_std_rate: float = 0.4,
+    red_slowdown_factor: float = 0.4,
+    signal_unavailable_multiplier: float = 1.5,
+    crossing_speed_factor: float = 1.2,
+    walking_along_speed_factor: float = 0.8,
+    intent_unavailable_multiplier: float = 1.3,
+) -> PedestrianForecast:
+    """Combined semantic CV baseline composing signal and goal factors.
+
+    Applies signal_aware adjustments to the mean, then goal_aware adjustments.
+    Unavailable context widens uncertainty; present but unrecognized context is
+    labeled and preserved as neutral.  This is deterministic and labeled; it
+    does not claim human realism.
+
+    Returns:
+        Forecast distributions for the requested horizons.
+    """
+
+    predictions: list[ForecastDistribution] = []
+
+    for horizon_s in horizons_s:
+        horizon = float(horizon_s)
+        std_m = base_std_m + velocity_std_rate * horizon
+
+        speed_factor = 1.0
+        signal_status = "unknown_widened"
+        intent_status = "unknown_widened"
+
+        if not state.signal_available or state.signal is None:
+            std_m *= signal_unavailable_multiplier
+        elif state.signal == "red":
+            speed_factor *= red_slowdown_factor
+            signal_status = "red_slowed"
+        elif state.signal == "green":
+            signal_status = "green_preserved"
+        else:
+            signal_status = "unrecognized_preserved"
+
+        if state.intent is None:
+            std_m *= intent_unavailable_multiplier
+        elif state.intent == "crossing":
+            speed_factor *= crossing_speed_factor
+            intent_status = "crossing_adjusted"
+        elif state.intent == "walking_along":
+            speed_factor *= walking_along_speed_factor
+            intent_status = "walking_along_adjusted"
+        else:
+            intent_status = "unrecognized_preserved"
+
+        mean = state.position + state.velocity * horizon * speed_factor
+
+        if std_m <= 0.0:
+            raise ValueError("forecast standard deviation must be positive")
+
+        predictions.append(
+            ForecastDistribution(
+                horizon_s=horizon,
+                mean=mean,
+                covariance=np.eye(2, dtype=float) * (std_m**2),
+                metadata={
+                    "model": "semantic_cv",
+                    "std_m": float(std_m),
+                    "is_intent_aware": state.intent is not None,
+                    "is_signal_aware": state.signal_available,
+                    "signal_state": state.signal if state.signal_available else "unknown",
+                    "signal_status": signal_status,
+                    "intent_state": state.intent or "unknown",
+                    "intent_status": intent_status,
+                },
+            )
+        )
+
+    return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+BASELINE_FUNCTIONS: dict[str, ForecastBaselineFunction] = {
+    "cv": constant_velocity_gaussian_baseline,
+    "signal_aware": signal_aware_cv_baseline,
+    "goal_aware": goal_aware_cv_baseline,
+    "semantic": semantic_cv_baseline,
+}
 
 
 def evaluate_forecast(
@@ -257,8 +481,18 @@ def compute_batch_forecast_metrics(
     dt_s: float = 0.1,
     confidence_level: float = 0.95,
     collision_distance_m: float = 0.8,
+    baseline_function: ForecastBaselineFunction | None = None,
 ) -> dict[str, float]:
     """Compute aggregate forecast metrics over benchmark trace steps.
+
+    Args:
+        trace_steps: Sequence of simulation step dicts with pedestrian lists.
+        horizons_s: Forecast horizons to evaluate.
+        dt_s: Simulation timestep for horizon alignment.
+        confidence_level: Confidence level for evaluation ellipse.
+        collision_distance_m: Collision proximity threshold.
+        baseline_function: Forecast function taking (state, horizons_s) and
+            returning a PedestrianForecast. Defaults to constant_velocity_gaussian_baseline.
 
     Returns:
         Mean metrics plus per-metric denominator counts and actor exclusion metadata.
@@ -266,6 +500,9 @@ def compute_batch_forecast_metrics(
 
     if dt_s <= 0.0:
         raise ValueError("dt_s must be positive")
+
+    if baseline_function is None:
+        baseline_function = constant_velocity_gaussian_baseline
 
     (
         candidate_count,
@@ -278,6 +515,7 @@ def compute_batch_forecast_metrics(
         dt_s,
         confidence_level,
         collision_distance_m,
+        baseline_function,
     )
 
     summary = {
@@ -310,6 +548,7 @@ def _collect_sample_metrics(
     dt_s: float,
     confidence_level: float,
     collision_distance_m: float,
+    baseline_function: ForecastBaselineFunction,
 ) -> tuple[int, int, dict[str, int], list[dict[str, float]]]:
     candidate_count = 0
     excluded_count = 0
@@ -333,6 +572,7 @@ def _collect_sample_metrics(
                 dt_s,
                 confidence_level,
                 collision_distance_m,
+                baseline_function,
             )
             if metrics:
                 sample_metrics.append(metrics)
@@ -348,6 +588,7 @@ def _evaluate_single_pedestrian(
     dt_s: float,
     confidence_level: float,
     collision_distance_m: float,
+    baseline_function: ForecastBaselineFunction,
 ) -> dict[str, float] | None:
     state = PedestrianState.from_trace(pedestrian_payload)
     ground_truth = _future_pedestrian_positions(
@@ -360,7 +601,7 @@ def _evaluate_single_pedestrian(
     if not ground_truth:
         return None
     return evaluate_forecast(
-        constant_velocity_gaussian_baseline(state, horizons_s),
+        baseline_function(state, horizons_s),
         ground_truth,
         confidence_level=confidence_level,
         robot_positions=_future_robot_positions(

--- a/scripts/benchmark/run_cv_forecast_eval.py
+++ b/scripts/benchmark/run_cv_forecast_eval.py
@@ -21,15 +21,20 @@ import hashlib
 import json
 import pathlib
 import subprocess
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from robot_sf.benchmark.pedestrian_forecast import (
+    BASELINE_FUNCTIONS,
     DEFAULT_FORECAST_HORIZONS_S,
+    ForecastBaselineFunction,
     actor_type_metric_key,
     compute_batch_forecast_metrics,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
@@ -188,6 +193,7 @@ def _git_head() -> str:
 
 def evaluate_single_trace(
     candidate: dict[str, Any],
+    baseline_function: ForecastBaselineFunction | None = None,
 ) -> dict[str, Any]:
     """Run CV forecast eval on one trace candidate and return a result dict."""
     rel_path = candidate["path"]
@@ -247,6 +253,7 @@ def evaluate_single_trace(
             trace_steps,
             horizons_s=list(DEFAULT_FORECAST_HORIZONS_S),
             dt_s=dt_s,
+            baseline_function=baseline_function,
         )
     except Exception as exc:
         result["status"] = "evaluation_error"
@@ -515,6 +522,18 @@ def main() -> None:
         default="docs/context/evidence/issue_2774_motion_rich_forecast_traces_2026-06-14",
         help="Output directory for evidence artifacts.",
     )
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default="cv",
+        choices=list(BASELINE_FUNCTIONS.keys()),
+        help="Baseline function to use (default: cv).",
+    )
+    parser.add_argument(
+        "--compare-all",
+        action="store_true",
+        help="Run all baselines and write a comparison report.",
+    )
     args = parser.parse_args()
 
     output_dir = REPO_ROOT / args.output_dir
@@ -522,61 +541,265 @@ def main() -> None:
 
     repo_head = _git_head()
     generated_at = datetime.datetime.now(datetime.UTC).isoformat()
+
+    baselines_to_run = list(BASELINE_FUNCTIONS.keys()) if args.compare_all else [args.baseline]
     command = (
         f"uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir {args.output_dir}"
+        + (f" --baseline {args.baseline}" if not args.compare_all else " --compare-all")
     )
 
     repro = {
-        "issue": 2774,
+        "issue": 2758,
         "generated_at_utc": generated_at,
         "command": command,
         "repo_head": repo_head,
         "horizons_s": list(DEFAULT_FORECAST_HORIZONS_S),
     }
 
-    results: list[dict[str, Any]] = []
-    for candidate in TRACE_CANDIDATES:
-        result = evaluate_single_trace(candidate)
-        results.append(result)
+    all_results: dict[str, list[dict[str, Any]]] = {}
+    for baseline_name in baselines_to_run:
+        baseline_fn = BASELINE_FUNCTIONS[baseline_name]
+        results: list[dict[str, Any]] = []
+        for candidate in TRACE_CANDIDATES:
+            result = evaluate_single_trace(candidate, baseline_function=baseline_fn)
+            result["baseline"] = baseline_name
+            results.append(result)
+        all_results[baseline_name] = results
 
-    failure_cases = _build_failure_cases(results)
-    evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
-    limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
+    if args.compare_all:
+        _write_comparison_report(all_results, repro, output_dir)
+    else:
+        results = all_results[args.baseline]
+        failure_cases = _build_failure_cases(results)
+        evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
+        limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
 
-    report_json: dict[str, Any] = {
-        "issue": 2774,
+        report_json: dict[str, Any] = {
+            "issue": 2758,
+            "claim_boundary": (
+                "Diagnostic-only, not paper-facing evidence. "
+                "Limited to bounded repository trace fixtures."
+            ),
+            "reproducibility": repro,
+            "trace_family_gaps": {
+                "evaluated": evaluated_families,
+                "limited": limited_families,
+                "missing": [mf["family"] for mf in MISSING_FAMILIES],
+            },
+            "results_by_trace": results,
+            "failure_cases": failure_cases,
+        }
+
+        json_path = output_dir / "report.json"
+        with open(json_path, "w") as fh:
+            json.dump(report_json, fh, indent=2)
+
+        md_content = _generate_markdown(results, failure_cases, repro)
+        md_path = output_dir / "report.md"
+        with open(md_path, "w") as fh:
+            fh.write(md_content)
+
+        print(f"Wrote {json_path}")
+        print(f"Wrote {md_path}")
+
+    for baseline_name, results in all_results.items():
+        for r in results:
+            status_icon = "+" if r["status"] == "evaluated" else "~"
+            samples = r.get("metrics", {}).get("forecast_evaluable_samples", 0)
+            print(
+                f"  [{status_icon}] {baseline_name}/{r['family']}/{r['label']}: "
+                f"{r['status']} ({samples:.0f} samples)"
+            )
+
+
+def _write_comparison_report(
+    all_results: dict[str, list[dict[str, Any]]],
+    repro: dict[str, Any],
+    output_dir: pathlib.Path,
+) -> None:
+    """Write a comparison report across all baselines."""
+    baselines = list(all_results.keys())
+
+    comparison_rows: list[dict[str, Any]] = []
+    for baseline_name in baselines:
+        results = all_results[baseline_name]
+        for r in results:
+            metrics = r.get("metrics", {})
+            comparison_rows.append(
+                {
+                    "baseline": baseline_name,
+                    "family": r["family"],
+                    "label": r["label"],
+                    "status": r["status"],
+                    "evaluable_samples": metrics.get("forecast_evaluable_samples", 0.0),
+                    "mean_ade_0.5s": metrics.get("mean_ade_0.5s"),
+                    "mean_ade_1s": metrics.get("mean_ade_1s"),
+                    "mean_negative_log_likelihood_1s": metrics.get(
+                        "mean_negative_log_likelihood_1s"
+                    ),
+                    "mean_miss_rate_1s": metrics.get("mean_miss_rate_1s"),
+                    "mean_within_95ci_1s": metrics.get("mean_within_95ci_1s"),
+                }
+            )
+
+    fixture_has_signal = _fixtures_have_signal_metadata(all_results)
+    fixture_has_intent = _fixtures_have_intent_metadata(all_results)
+
+    summary_by_baseline: dict[str, dict[str, Any]] = {}
+    for baseline_name in baselines:
+        results = all_results[baseline_name]
+        evaluable = [r for r in results if r["status"] == "evaluated"]
+        total_samples = sum(
+            r.get("metrics", {}).get("forecast_evaluable_samples", 0.0) for r in evaluable
+        )
+        summary_by_baseline[baseline_name] = {
+            "evaluated_traces": len(evaluable),
+            "total_samples": float(total_samples),
+        }
+
+    report: dict[str, Any] = {
+        "issue": 2758,
         "claim_boundary": (
             "Diagnostic-only, not paper-facing evidence. "
             "Limited to bounded repository trace fixtures."
         ),
         "reproducibility": repro,
-        "trace_family_gaps": {
-            "evaluated": evaluated_families,
-            "limited": limited_families,
-            "missing": [mf["family"] for mf in MISSING_FAMILIES],
+        "semantic_usefulness": {
+            "fixtures_have_signal_metadata": fixture_has_signal,
+            "fixtures_have_intent_metadata": fixture_has_intent,
+            "conclusion": (
+                "Semantic conditioning is meaningful when fixtures carry signal/intent "
+                "metadata. Existing durable fixtures lack this metadata, so the comparison "
+                "shows whether baselines run correctly but does not yet show semantic "
+                "conditioning improving calibration or collision relevance."
+            ),
         },
-        "results_by_trace": results,
-        "failure_cases": failure_cases,
+        "summary_by_baseline": summary_by_baseline,
+        "comparison_rows": comparison_rows,
     }
 
-    json_path = output_dir / "report.json"
+    json_path = output_dir / "comparison_report.json"
     with open(json_path, "w") as fh:
-        json.dump(report_json, fh, indent=2)
+        json.dump(report, fh, indent=2)
 
-    md_content = _generate_markdown(results, failure_cases, repro)
-    md_path = output_dir / "report.md"
+    md_lines = [
+        "# Semantic Forecast Baseline Comparison",
+        "",
+        "## Claim Boundary",
+        "",
+        "**Diagnostic-only, not paper-facing evidence.** Compares constant-velocity and "
+        "semantic forecast baselines on bounded repository trace fixtures.",
+        "",
+        "## Reproducibility",
+        "",
+        f"- **Issue:** #{repro['issue']}",
+        f"- **Generated at (UTC):** {repro['generated_at_utc']}",
+        f"- **Command:** `{repro['command']}`",
+        f"- **Repo HEAD:** `{repro['repo_head']}`",
+        f"- **Forecast horizons:** {repro['horizons_s']}",
+        "",
+        "## Fixture Metadata Assessment",
+        "",
+        f"- **Fixtures have signal metadata:** {fixture_has_signal}",
+        f"- **Fixtures have intent metadata:** {fixture_has_intent}",
+        "",
+    ]
+
+    if not fixture_has_signal and not fixture_has_intent:
+        md_lines.extend(
+            [
+                "Existing durable fixtures lack signal and intent metadata. Semantic "
+                "conditioning baselines run correctly but their calibration/collision-relevance "
+                "improvement cannot be measured until fixtures include this metadata.",
+                "",
+            ]
+        )
+
+    md_lines.extend(
+        [
+            "## Baseline Summary",
+            "",
+            "| Baseline | Evaluated Traces | Total Samples |",
+            "|----------|------------------|---------------|",
+        ]
+    )
+    for baseline_name in baselines:
+        s = summary_by_baseline[baseline_name]
+        md_lines.append(
+            f"| {baseline_name} | {s['evaluated_traces']:.0f} | {s['total_samples']:.0f} |"
+        )
+
+    md_lines.extend(
+        [
+            "",
+            "## Comparison Table",
+            "",
+            "| Baseline | Family | Label | Status | Samples | ADE 1s | NLL 1s | Miss Rate 1s |",
+            "|----------|--------|-------|--------|---------|--------|--------|-------------|",
+        ]
+    )
+    for row in comparison_rows:
+        ade = f"{row['mean_ade_1s']:.4f}" if row["mean_ade_1s"] is not None else "-"
+        nll = (
+            f"{row['mean_negative_log_likelihood_1s']:.4f}"
+            if row["mean_negative_log_likelihood_1s"] is not None
+            else "-"
+        )
+        miss = f"{row['mean_miss_rate_1s']:.2%}" if row["mean_miss_rate_1s"] is not None else "-"
+        md_lines.append(
+            f"| {row['baseline']} | {row['family']} | {row['label']} "
+            f"| {row['status']} | {row['evaluable_samples']:.0f} "
+            f"| {ade} | {nll} | {miss} |"
+        )
+
+    md_content = "\n".join(md_lines)
+    md_path = output_dir / "comparison_report.md"
     with open(md_path, "w") as fh:
         fh.write(md_content)
 
     print(f"Wrote {json_path}")
     print(f"Wrote {md_path}")
 
-    for r in results:
-        status_icon = "+" if r["status"] == "evaluated" else "~"
-        samples = r.get("metrics", {}).get("forecast_evaluable_samples", 0)
-        print(
-            f"  [{status_icon}] {r['family']}/{r['label']}: {r['status']} ({samples:.0f} samples)"
-        )
+
+def _fixtures_have_signal_metadata(all_results: dict[str, list[dict[str, Any]]]) -> bool:
+    """Check whether any evaluated trace has signal metadata on pedestrians."""
+    for ped in _iter_unique_evaluated_pedestrians(all_results):
+        if ped.get("signal_label") is not None:
+            return True
+        ss = ped.get("signal_state")
+        if isinstance(ss, dict) and ss.get("label") is not None:
+            return True
+    return False
+
+
+def _fixtures_have_intent_metadata(all_results: dict[str, list[dict[str, Any]]]) -> bool:
+    """Check whether any evaluated trace has intent metadata on pedestrians."""
+    return any(
+        ped.get("intent_label") is not None
+        for ped in _iter_unique_evaluated_pedestrians(all_results)
+    )
+
+
+def _iter_unique_evaluated_pedestrians(
+    all_results: dict[str, list[dict[str, Any]]],
+) -> Iterator[dict[str, Any]]:
+    """Yield pedestrians from each unique evaluated trace with forecast samples."""
+    checked_paths: set[pathlib.Path] = set()
+    for results in all_results.values():
+        for r in results:
+            if r["status"] != "evaluated":
+                continue
+            metrics = r.get("metrics", {})
+            if metrics.get("forecast_evaluable_samples", 0.0) <= 0.0:
+                continue
+            path = REPO_ROOT / r["trace_path"]
+            if path in checked_paths or not path.exists():
+                continue
+            checked_paths.add(path)
+            trace = _load_trace(path)
+            frames = trace.get("frames") or trace.get("steps") or []
+            for frame in frames:
+                yield from frame.get("pedestrians", [])
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_pedestrian_forecast.py
+++ b/tests/benchmark/test_pedestrian_forecast.py
@@ -11,6 +11,9 @@ from robot_sf.benchmark.pedestrian_forecast import (
     compute_batch_forecast_metrics,
     constant_velocity_gaussian_baseline,
     evaluate_forecast,
+    goal_aware_cv_baseline,
+    semantic_cv_baseline,
+    signal_aware_cv_baseline,
 )
 
 
@@ -297,3 +300,252 @@ def test_confidence_threshold_rejects_invalid_probability() -> None:
         chi_square_2d_threshold(0.0)
     with pytest.raises(ValueError, match="between 0 and 1"):
         chi_square_2d_threshold(1.0)
+
+
+def test_signal_aware_cv_red_slows_mean() -> None:
+    """Signal-aware CV with red signal reduces mean displacement."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="red",
+        signal_available=True,
+    )
+    forecast = signal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    assert forecast.predictions[0].mean[0] < cv_forecast.predictions[0].mean[0]
+    assert forecast.predictions[0].metadata["signal_status"] == "red_slowed"
+    assert forecast.predictions[0].metadata["model"] == "signal_aware_cv"
+
+
+def test_signal_aware_cv_green_preserves_mean() -> None:
+    """Signal-aware CV with green signal preserves CV mean."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    forecast = signal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    assert forecast.predictions[0].metadata["signal_status"] == "green_preserved"
+
+
+def test_signal_aware_cv_unavailable_widens_uncertainty() -> None:
+    """Signal-aware CV with unavailable signal widens uncertainty, not assuming phase."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal=None,
+        signal_available=False,
+    )
+    cv_state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal=None,
+        signal_available=False,
+    )
+    forecast = signal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(cv_state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    assert forecast.predictions[0].metadata["signal_status"] == "unknown_widened"
+    assert forecast.predictions[0].metadata["std_m"] == pytest.approx(
+        cv_forecast.predictions[0].metadata["std_m"]
+    )
+
+
+def test_signal_aware_cv_unrecognized_signal_preserves_uncertainty() -> None:
+    """Available but unrecognized signal values are labeled without widening uncertainty."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="yellow",
+        signal_available=True,
+    )
+    forecast = signal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    assert forecast.predictions[0].metadata["signal_status"] == "unrecognized_preserved"
+    assert forecast.predictions[0].metadata["std_m"] == pytest.approx(
+        cv_forecast.predictions[0].metadata["std_m"]
+    )
+
+
+def test_goal_aware_cv_crossing_adjusts_mean() -> None:
+    """Goal-aware CV with crossing intent increases mean displacement."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    forecast = goal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    assert forecast.predictions[0].mean[0] > cv_forecast.predictions[0].mean[0]
+    assert forecast.predictions[0].metadata["intent_status"] == "crossing_adjusted"
+    assert forecast.predictions[0].metadata["model"] == "goal_aware_cv"
+
+
+def test_goal_aware_cv_walking_along_adjusts_mean() -> None:
+    """Goal-aware CV with walking_along intent decreases mean displacement."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="walking_along",
+        signal="green",
+        signal_available=True,
+    )
+    forecast = goal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    assert forecast.predictions[0].mean[0] < cv_forecast.predictions[0].mean[0]
+    assert forecast.predictions[0].metadata["intent_status"] == "walking_along_adjusted"
+
+
+def test_goal_aware_cv_unavailable_widens_uncertainty() -> None:
+    """Goal-aware CV with absent intent widens uncertainty, not assuming a goal."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent=None,
+        signal="green",
+        signal_available=True,
+    )
+    forecast = goal_aware_cv_baseline(state, horizons_s=(1.0,))
+
+    assert forecast.predictions[0].metadata["intent_status"] == "unknown_widened"
+    assert forecast.predictions[0].metadata["std_m"] == pytest.approx((0.3 + 0.4 * 1.0) * 1.3)
+
+
+def test_goal_aware_cv_unrecognized_intent_preserves_uncertainty() -> None:
+    """Present but unrecognized intent values are labeled without widening uncertainty."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="standing",
+        signal="green",
+        signal_available=True,
+    )
+    forecast = goal_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    assert forecast.predictions[0].metadata["intent_status"] == "unrecognized_preserved"
+    assert forecast.predictions[0].metadata["std_m"] == pytest.approx(
+        cv_forecast.predictions[0].metadata["std_m"]
+    )
+
+
+def test_semantic_cv_composes_signal_and_goal() -> None:
+    """Semantic CV composes signal and goal factors correctly."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="red",
+        signal_available=True,
+    )
+    forecast = semantic_cv_baseline(state, horizons_s=(1.0,))
+    pred = forecast.predictions[0]
+
+    expected_mean_x = 0.0 + 1.0 * 1.0 * 0.4 * 1.2
+    np.testing.assert_allclose(pred.mean[0], expected_mean_x)
+    assert pred.metadata["signal_status"] == "red_slowed"
+    assert pred.metadata["intent_status"] == "crossing_adjusted"
+    assert pred.metadata["model"] == "semantic_cv"
+
+
+def test_semantic_cv_unavailable_widens_both() -> None:
+    """Semantic CV widens uncertainty for both unavailable signal and intent."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent=None,
+        signal=None,
+        signal_available=False,
+    )
+    forecast = semantic_cv_baseline(state, horizons_s=(1.0,))
+    pred = forecast.predictions[0]
+
+    base_std = 0.3 + 0.4 * 1.0
+    expected_std = base_std * 1.5 * 1.3
+    assert pred.metadata["std_m"] == pytest.approx(expected_std)
+    assert pred.metadata["signal_status"] == "unknown_widened"
+    assert pred.metadata["intent_status"] == "unknown_widened"
+
+
+def test_semantic_cv_unrecognized_context_preserves_uncertainty() -> None:
+    """Semantic CV labels present unrecognized context without treating it as unavailable."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="standing",
+        signal="yellow",
+        signal_available=True,
+    )
+    forecast = semantic_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+    pred = forecast.predictions[0]
+
+    np.testing.assert_allclose(pred.mean, cv_forecast.predictions[0].mean)
+    assert pred.metadata["std_m"] == pytest.approx(cv_forecast.predictions[0].metadata["std_m"])
+    assert pred.metadata["signal_status"] == "unrecognized_preserved"
+    assert pred.metadata["intent_status"] == "unrecognized_preserved"
+
+
+def test_compute_batch_forecast_metrics_with_baseline_function() -> None:
+    """Batch metrics accept an explicit baseline function."""
+    dt_s = 0.5
+    trace_steps = []
+    for index in range(5):
+        x = index * dt_s
+        trace_steps.append(
+            {
+                "step": index,
+                "time_s": x,
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [x, 0.0],
+                        "velocity": [1.0, 0.0],
+                        "intent_label": "crossing",
+                        "signal_state": {"available": True, "label": "green"},
+                    }
+                ],
+            }
+        )
+
+    cv_summary = compute_batch_forecast_metrics(trace_steps, horizons_s=(0.5, 1.0), dt_s=dt_s)
+    signal_summary = compute_batch_forecast_metrics(
+        trace_steps,
+        horizons_s=(0.5, 1.0),
+        dt_s=dt_s,
+        baseline_function=signal_aware_cv_baseline,
+    )
+
+    assert cv_summary["forecast_evaluable_samples"] > 0
+    assert signal_summary["forecast_evaluable_samples"] > 0
+    assert cv_summary["forecast_evaluable_samples"] == signal_summary["forecast_evaluable_samples"]

--- a/tests/benchmark/test_pedestrian_forecast_cv_eval.py
+++ b/tests/benchmark/test_pedestrian_forecast_cv_eval.py
@@ -8,6 +8,12 @@ import sys
 
 import pytest
 
+from robot_sf.benchmark.pedestrian_forecast import (
+    goal_aware_cv_baseline,
+    semantic_cv_baseline,
+    signal_aware_cv_baseline,
+)
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 _SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_cv_forecast_eval.py"
 
@@ -23,6 +29,7 @@ def _load_script_module():
 
 _mod = _load_script_module()
 
+BASELINE_FUNCTIONS = _mod.BASELINE_FUNCTIONS if hasattr(_mod, "BASELINE_FUNCTIONS") else {}
 MISSING_FAMILIES = _mod.MISSING_FAMILIES
 TRACE_CANDIDATES = _mod.TRACE_CANDIDATES
 _actor_class_counts = _mod._actor_class_counts
@@ -33,7 +40,7 @@ _generate_markdown = _mod._generate_markdown
 _get_actor_classes = _mod._get_actor_classes
 _pedestrian_count = _mod._pedestrian_count
 _trace_has_motion = _mod._trace_has_motion
-evaluate_single_trace = _mod.evaluate_single_trace
+_evaluate_single_trace = _mod.evaluate_single_trace
 
 
 def test_extract_trace_steps_converts_frames_key() -> None:
@@ -173,7 +180,7 @@ def test_actor_class_counts_default_legacy_pedestrians_and_count_cyclists() -> N
 
 def test_evaluate_single_trace_missing_file() -> None:
     """Missing trace file produces trace_file_missing status."""
-    result = evaluate_single_trace(
+    result = _evaluate_single_trace(
         {
             "family": "test",
             "label": "missing",
@@ -189,7 +196,7 @@ def test_evaluate_single_trace_missing_file() -> None:
 
 def test_evaluate_single_trace_with_motion() -> None:
     """Trace with motion produces evaluated status."""
-    result = evaluate_single_trace(
+    result = _evaluate_single_trace(
         {
             "family": "corridor_interaction",
             "label": "test_default_sf",
@@ -206,7 +213,7 @@ def test_evaluate_single_trace_with_motion() -> None:
 def test_evaluate_all_candidate_traces() -> None:
     """All defined trace candidates can be evaluated without crashing."""
     for candidate in TRACE_CANDIDATES:
-        result = evaluate_single_trace(candidate)
+        result = _evaluate_single_trace(candidate)
         assert "status" in result
         assert "metrics" in result
         assert result["status"] != "evaluation_error", (
@@ -352,7 +359,7 @@ def test_generate_markdown_includes_failure_cases() -> None:
 def test_occluded_emergence_candidate_is_evaluated_with_samples() -> None:
     """The occluded_emergence trace produces evaluated status with evaluable samples."""
     candidate = next(c for c in TRACE_CANDIDATES if c["family"] == "occluded_emergence")
-    result = evaluate_single_trace(candidate)
+    result = _evaluate_single_trace(candidate)
     assert result["status"] == "evaluated", (
         f"occluded_emergence expected 'evaluated', got '{result['status']}'"
     )
@@ -366,7 +373,7 @@ def test_non_corridor_evaluated_families_appear_in_gap_summary() -> None:
     """Evaluated non-corridor families are in the evaluated set, not limited or missing."""
     results = []
     for candidate in TRACE_CANDIDATES:
-        results.append(evaluate_single_trace(candidate))
+        results.append(_evaluate_single_trace(candidate))
 
     evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
     limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
@@ -381,7 +388,7 @@ def test_report_json_distinguishes_evaluated_limited_missing() -> None:
     """JSON report separates evaluated, limited, and missing trace families."""
     results = []
     for candidate in TRACE_CANDIDATES:
-        results.append(evaluate_single_trace(candidate))
+        results.append(_evaluate_single_trace(candidate))
 
     evaluated_families = sorted({r["family"] for r in results if r["status"] == "evaluated"})
     limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
@@ -389,12 +396,51 @@ def test_report_json_distinguishes_evaluated_limited_missing() -> None:
     assert "corridor_interaction" in evaluated_families
     assert "occluded_emergence" in evaluated_families
 
-    # crossing_proxy and bottleneck should be limited (zero motion)
     for fam in ["crossing_proxy", "bottleneck"]:
         assert fam in limited_families, (
             f"{fam} should be in limited families, got {limited_families}"
         )
 
-    # occluded_emergence should NOT be in limited or missing
     assert "occluded_emergence" not in limited_families
     assert "occluded_emergence" not in [mf["family"] for mf in MISSING_FAMILIES]
+
+
+def test_evaluate_single_trace_with_signal_aware_baseline() -> None:
+    """Trace can be evaluated with signal_aware baseline."""
+    result = _evaluate_single_trace(
+        TRACE_CANDIDATES[0],
+        baseline_function=signal_aware_cv_baseline,
+    )
+    assert "status" in result
+    assert "metrics" in result
+    assert result["status"] != "evaluation_error"
+
+
+def test_evaluate_single_trace_with_goal_aware_baseline() -> None:
+    """Trace can be evaluated with goal_aware baseline."""
+    result = _evaluate_single_trace(
+        TRACE_CANDIDATES[0],
+        baseline_function=goal_aware_cv_baseline,
+    )
+    assert "status" in result
+    assert "metrics" in result
+    assert result["status"] != "evaluation_error"
+
+
+def test_evaluate_single_trace_with_semantic_baseline() -> None:
+    """Trace can be evaluated with semantic baseline."""
+    result = _evaluate_single_trace(
+        TRACE_CANDIDATES[0],
+        baseline_function=semantic_cv_baseline,
+    )
+    assert "status" in result
+    assert "metrics" in result
+    assert result["status"] != "evaluation_error"
+
+
+def test_baseline_functions_dict_has_all_keys() -> None:
+    """BASELINE_FUNCTIONS dict contains all expected baseline names."""
+    assert "cv" in BASELINE_FUNCTIONS
+    assert "signal_aware" in BASELINE_FUNCTIONS
+    assert "goal_aware" in BASELINE_FUNCTIONS
+    assert "semantic" in BASELINE_FUNCTIONS


### PR DESCRIPTION
## Summary
Adds deterministic signal-aware, goal-aware, and combined semantic forecast baselines on top of the existing constant-velocity forecast path, plus a comparison report for the durable #2774 trace set.

## Linked Issues
- Closes `#2758`
- Relates to `#2774`
- Relates to `#2781`
- Relates to `#2843`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: #2853 is merged
- Stack follow-up issues: #2781, #2843
- Safe to review independently: yes
- Review dependency reason, if any: #2781 can build on the semantic baseline registry/comparison report added here.

## What Changed
- Added `signal_aware_cv_baseline`, `goal_aware_cv_baseline`, and `semantic_cv_baseline` in `robot_sf/benchmark/pedestrian_forecast.py`.
- Added a typed optional baseline function path to `compute_batch_forecast_metrics`, preserving the existing CV default.
- Extended `scripts/benchmark/run_cv_forecast_eval.py` with `--baseline` and `--compare-all`.
- Added compact #2758 evidence under `docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14/`.
- Updated evidence README/catalog and added semantic baseline tests.

## Why It Matters
- Added value: exhausts deterministic semantic forecast baselines before learned predictor work.
- Expected impact: #2781 and #2843 can now consume a concrete semantic baseline comparison rather than relying on CV-only evidence.
- Why this is worth merging now: it clarifies that current durable fixtures run the semantic baselines but lack signal/intent metadata needed to show semantic improvement.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether controlled signal/goal conditioning adds measurable forecast value on current durable fixtures.
- Comparator or baseline, if applicable: plain constant-velocity Gaussian forecast baseline.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: continue to interaction-aware baseline work, but do not claim semantic conditioning improves calibration/collision relevance until fixtures include signal/intent metadata.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2758, #2781, #2843 prediction-lane gate.
- New research/benchmark/metric/paper-facing analysis tool, if any: no new standalone tool; representative use is committed #2758 comparison evidence on durable/versioned repository fixtures.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes in unit fixtures with signal/intent metadata; no improvement claim on durable fixtures because they lack those metadata.
- Did the intervention change command source, selected command, trajectory, or route progress? no planner action path changes; this is open-loop forecast scoring/reporting.
- Did the scenario actually contain the targeted failure mode? partially; durable traces contain motion-rich forecast samples but not signal/intent metadata.
- Result route: continue, narrow.
- Follow-up question or issue for weak, negative, or non-transfer results: #2781 should test interaction-aware cues on motion-rich traces; #2843 should gate closed-loop coupling only after baseline evidence exists.

## Next Empirical Action
- Rerun needed: no for #2758 acceptance.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: durable signal/intent-bearing forecast traces are still missing.
- Stop / revise / continue decision: continue to #2781, but keep semantic-improvement claims blocked.
- Proposed child issue or existing follow-up: #2781 and #2843.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run python scripts/benchmark/run_cv_forecast_eval.py --compare-all --output-dir docs/context/evidence/issue_2758_semantic_forecast_baselines_2026-06-14`
  - `uv run ruff check robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `uv run ruff format --check robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final PR readiness passed on head `3718f24571a86acc7f63e6ab8014dcdb836684fd` with `6507 passed, 9 skipped, 9 warnings` and a clean tree.
- Benchmarks or smoke tests, if applicable: `--compare-all` generated JSON/Markdown reports for `cv`, `signal_aware`, `goal_aware`, and `semantic`; all baselines evaluated the same three motion-capable traces and caveated missing semantic metadata.

## Risks / Rollout
- Compatibility risks: low; default forecast metrics still use the existing CV baseline.
- Failure modes: semantic baselines may be misread as evidence of improved calibration; the report explicitly blocks that claim on current fixtures.
- Rollback or fallback plan: use default `cv` baseline or revert the baseline registry additions.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`.
- Relevant design or provenance notes: #2758 summary/report record diagnostic-only claim boundary, fixture metadata status, command, and repo head.
- Any assumptions that need to be preserved: deterministic baselines are controlled probes, not human-realistic pedestrian prediction.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2758.
- Claim map / benchmark report updated (yes/no/NA): yes, compact #2758 comparison report added.
- Leaderboard / artifact catalog updated (yes/no/NA): yes, `docs/context/catalog.yaml`.
- Registry or config index updated (yes/no/NA): yes, forecast baseline registry added in code.
- Context index / memory note updated (yes/no/NA): yes, `docs/context/evidence/README.md`.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: existing follow-ups #2781 and #2843 cover the next prediction-lane steps.

## Follow-Up Issues
- Deferred work: durable signal/intent-bearing traces are needed before claiming semantic conditioning improves metrics.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the claim boundary in `summary.json` and `comparison_report.md`: semantic baselines run, but current fixtures lack signal/intent metadata.
- Known limitations: diagnostic-only, open-loop forecast metrics, no learned model and no closed-loop planner coupling.
- Delegation: Command Code mapped the implementation, OpenCode Go implemented, Command Code reviewed and flagged cleanup, Gemini final-reviewed with no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signal-aware, goal-aware, and semantic forecast baseline options to complement existing constant-velocity baseline.
  * Enabled baseline comparison functionality in benchmark evaluation with `--baseline` and `--compare-all` options.

* **Documentation**
  * Added diagnostic evidence and comparison reports for semantic forecast baseline evaluation (issue 2758).

* **Tests**
  * Added comprehensive test coverage for new baseline functions and comparison capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->