### PR TITLE
Add interaction-aware forecast baseline

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1348,3 +1348,15 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -369,3 +369,10 @@ Policy caveats:
   report. Existing durable fixtures lack signal/intent metadata, so the comparison proves
   baselines run correctly but does not show semantic conditioning improving calibration or
   collision relevance yet. Not benchmark or paper-facing evidence.
+- `issue_2781_interaction_aware_forecast_2026-06-15/`: diagnostic-only comparison of all five
+  forecast baselines (cv, signal_aware, goal_aware, semantic, interaction_aware) on bounded
+  repository trace fixtures. Adds interaction-aware deterministic forecast baseline with
+  proximity-based repulsion and crowding uncertainty. On matched evaluated rows, interaction-aware
+  conditioning improves the Gaussian likelihood/calibration proxy while worsening 1s point
+  accuracy, so the result is mixed, diagnostic-only, and a revise signal before closed-loop
+  coupling. Not benchmark or paper-facing evidence.

--- a/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.json
+++ b/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.json
@@ -1,0 +1,350 @@
+{
+  "issue": 2781,
+  "claim_boundary": "Diagnostic-only, not paper-facing evidence. Limited to bounded repository trace fixtures.",
+  "reproducibility": {
+    "issue": 2781,
+    "generated_at_utc": "2026-06-14T23:50:04.341120+00:00",
+    "command": "uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15 --compare-all --issue 2781",
+    "repo_head": "a965d7bc",
+    "horizons_s": [
+      0.5,
+      1.0,
+      2.0
+    ]
+  },
+  "semantic_usefulness": {
+    "fixtures_have_signal_metadata": false,
+    "fixtures_have_intent_metadata": false,
+    "conclusion": "Semantic conditioning is meaningful when fixtures carry signal/intent metadata. Existing durable fixtures lack this metadata, so the comparison shows whether baselines run correctly but does not yet show semantic conditioning improving calibration or collision relevance."
+  },
+  "summary_by_baseline": {
+    "cv": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "signal_aware": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "goal_aware": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "semantic": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    },
+    "interaction_aware": {
+      "evaluated_traces": 3,
+      "total_samples": 71.0
+    }
+  },
+  "comparison_rows": [
+    {
+      "baseline": "cv",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "cv",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "cv",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "cv",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "cv",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.935457394748209,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.952169154331188,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "signal_aware",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.935457394748209,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.6715050915270422,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 1.6715050915270422,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "goal_aware",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.6492557074668623,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 2.4700745388210485,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.024280292893659475,
+      "mean_ade_1s": 0.07693663848497238,
+      "mean_negative_log_likelihood_1s": 2.4700745388210485,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "semantic",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "semantic",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "semantic",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 2.4601859236831913,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "interaction_aware",
+      "family": "corridor_interaction",
+      "label": "default_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.04508757891504835,
+      "mean_ade_1s": 0.11391100018251157,
+      "mean_negative_log_likelihood_1s": 1.3500783901433155,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "interaction_aware",
+      "family": "corridor_interaction",
+      "label": "ammv_social_force",
+      "status": "evaluated",
+      "evaluable_samples": 30.0,
+      "mean_ade_0.5s": 0.04508757891504835,
+      "mean_ade_1s": 0.11391100018251157,
+      "mean_negative_log_likelihood_1s": 1.3500783901433155,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    },
+    {
+      "baseline": "interaction_aware",
+      "family": "crossing_proxy",
+      "label": "synthetic_crossing_proxy_orca",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "interaction_aware",
+      "family": "bottleneck",
+      "label": "minimal_fixture",
+      "status": "limited_no_pedestrian_motion",
+      "evaluable_samples": 0.0,
+      "mean_ade_0.5s": null,
+      "mean_ade_1s": null,
+      "mean_negative_log_likelihood_1s": null,
+      "mean_miss_rate_1s": null,
+      "mean_within_95ci_1s": null
+    },
+    {
+      "baseline": "interaction_aware",
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "status": "evaluated",
+      "evaluable_samples": 11.0,
+      "mean_ade_0.5s": 1.5139404881252134e-17,
+      "mean_ade_1s": 2.312964634635743e-17,
+      "mean_negative_log_likelihood_1s": 1.1245271785318804,
+      "mean_miss_rate_1s": 0.0,
+      "mean_within_95ci_1s": 1.0
+    }
+  ],
+  "interaction_effect": {
+    "matched_rows": 3,
+    "mean_ade_1s_delta_vs_cv": 0.024649574465026126,
+    "mean_nll_1s_delta_vs_cv": -0.6717039148640245,
+    "conclusion": "Interaction-aware heuristic improved Gaussian likelihood/calibration proxy but worsened point accuracy on matched diagnostic rows; revise before closed-loop coupling claims."
+  }
+}

--- a/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.md
+++ b/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/comparison_report.md
@@ -1,0 +1,67 @@
+# Forecast Baseline Comparison
+
+## Claim Boundary
+
+**Diagnostic-only, not paper-facing evidence.** Compares constant-velocity, semantic, and interaction-aware forecast baselines on bounded repository trace fixtures when those baselines are requested.
+
+## Reproducibility
+
+- **Issue:** #2781
+- **Generated at (UTC):** 2026-06-14T23:50:04.341120+00:00
+- **Command:** `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15 --compare-all --issue 2781`
+- **Repo HEAD:** `a965d7bc`
+- **Forecast horizons:** [0.5, 1.0, 2.0]
+
+## Fixture Metadata Assessment
+
+- **Fixtures have signal metadata:** False
+- **Fixtures have intent metadata:** False
+
+Existing durable fixtures lack signal and intent metadata. Semantic conditioning baselines run correctly but their calibration/collision-relevance improvement cannot be measured until fixtures include this metadata.
+
+## Interaction-Aware Diagnostic Effect
+
+- **Matched evaluated rows:** 3
+- **Mean ADE 1s delta vs CV:** 0.0246
+- **Mean NLL 1s delta vs CV:** -0.6717
+- **Conclusion:** Interaction-aware heuristic improved Gaussian likelihood/calibration proxy but worsened point accuracy on matched diagnostic rows; revise before closed-loop coupling claims.
+
+## Baseline Summary
+
+| Baseline | Evaluated Traces | Total Samples |
+|----------|------------------|---------------|
+| cv | 3 | 71 |
+| signal_aware | 3 | 71 |
+| goal_aware | 3 | 71 |
+| semantic | 3 | 71 |
+| interaction_aware | 3 | 71 |
+
+## Comparison Table
+
+| Baseline | Family | Label | Status | Samples | ADE 1s | NLL 1s | Miss Rate 1s |
+|----------|--------|-------|--------|---------|--------|--------|-------------|
+| cv | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| cv | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| cv | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| cv | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| cv | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.9355 | 0.00% |
+| signal_aware | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| signal_aware | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.9522 | 0.00% |
+| signal_aware | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| signal_aware | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| signal_aware | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.9355 | 0.00% |
+| goal_aware | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 1.6715 | 0.00% |
+| goal_aware | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 1.6715 | 0.00% |
+| goal_aware | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| goal_aware | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| goal_aware | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.6493 | 0.00% |
+| semantic | corridor_interaction | default_social_force | evaluated | 30 | 0.0769 | 2.4701 | 0.00% |
+| semantic | corridor_interaction | ammv_social_force | evaluated | 30 | 0.0769 | 2.4701 | 0.00% |
+| semantic | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| semantic | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| semantic | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 2.4602 | 0.00% |
+| interaction_aware | corridor_interaction | default_social_force | evaluated | 30 | 0.1139 | 1.3501 | 0.00% |
+| interaction_aware | corridor_interaction | ammv_social_force | evaluated | 30 | 0.1139 | 1.3501 | 0.00% |
+| interaction_aware | crossing_proxy | synthetic_crossing_proxy_orca | limited_no_pedestrian_motion | 0 | - | - | - |
+| interaction_aware | bottleneck | minimal_fixture | limited_no_pedestrian_motion | 0 | - | - | - |
+| interaction_aware | occluded_emergence | deterministic_occluded_emergence | evaluated | 11 | 0.0000 | 1.1245 | 0.00% |

--- a/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/summary.json
+++ b/docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/summary.json
@@ -1,0 +1,30 @@
+{
+  "issue": 2781,
+  "claim_boundary": "Diagnostic-only, not paper-facing evidence. Adds interaction-aware deterministic forecast baseline to the open-loop forecast baseline registry. On matched evaluated rows, the heuristic improves the Gaussian likelihood/calibration proxy while worsening 1s point accuracy, so it should be revised before any closed-loop coupling claim.",
+  "generated_at_utc": "2026-06-14T23:50:04.341120+00:00",
+  "repo_head": "a965d7bc",
+  "baselines": ["cv", "signal_aware", "goal_aware", "semantic", "interaction_aware"],
+  "interaction_aware_mechanism": {
+    "model": "interaction_aware_cv",
+    "repulsion": "Mean displacement deflected away from nearby pedestrians within interaction_radius_m",
+    "crowding": "Uncertainty increased proportionally to sqrt(density) of active neighbors",
+    "parameters": {
+      "interaction_radius_m": 2.0,
+      "avoidance_strength": 0.15,
+      "crowding_std_factor": 0.25
+    }
+  },
+  "interaction_effect": {
+    "matched_rows": 3,
+    "mean_ade_1s_delta_vs_cv": 0.02464957446502613,
+    "mean_nll_1s_delta_vs_cv": -0.6717039148640245,
+    "conclusion": "Interaction-aware heuristic improved Gaussian likelihood/calibration proxy but worsened point accuracy on matched diagnostic rows; revise before closed-loop coupling claims."
+  },
+  "fixture_limitation": "Existing durable fixtures still lack signal and intent metadata, so semantic conditioning remains unproven. Interaction-aware neighbor proximity is available in matched evaluated rows, but the result is mixed and diagnostic-only.",
+  "results_summary": {
+    "total_baselines": 5,
+    "traces_evaluated_per_baseline": 3,
+    "traces_limited_per_baseline": 2,
+    "total_evaluable_samples_per_baseline": 71
+  }
+}

--- a/robot_sf/benchmark/pedestrian_forecast.py
+++ b/robot_sf/benchmark/pedestrian_forecast.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import math
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import cache
 from typing import Any
 
 import numpy as np
@@ -113,6 +115,15 @@ ForecastBaselineFunction = Callable[
     [PedestrianState, list[float] | tuple[float, ...]],
     PedestrianForecast,
 ]
+
+
+@dataclass(frozen=True)
+class NeighborContext:
+    """Snapshot of a neighboring pedestrian's state for interaction-aware forecasts."""
+
+    position: np.ndarray
+    velocity: np.ndarray
+    actor_type: str = "pedestrian"
 
 
 def constant_velocity_gaussian_baseline(
@@ -370,11 +381,135 @@ def semantic_cv_baseline(  # noqa: PLR0913
     return PedestrianForecast(id=state.id, predictions=predictions)
 
 
+def interaction_aware_cv_baseline(
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...] = DEFAULT_FORECAST_HORIZONS_S,
+    *,
+    base_std_m: float = 0.3,
+    velocity_std_rate: float = 0.4,
+    interaction_radius_m: float = 2.0,
+    avoidance_strength: float = 0.15,
+    crowding_std_factor: float = 0.25,
+    neighbors: list[NeighborContext] | None = None,
+) -> PedestrianForecast:
+    """Interaction-aware constant-velocity baseline.
+
+    Modulates the mean displacement and uncertainty based on proximity to
+    neighboring pedestrians: nearby agents push the forecast away (repulsive
+    interaction) and increase uncertainty proportionally to crowding density.
+
+    When no neighbor context is provided the forecast degrades to plain CV
+    without widening uncertainty, preserving a deterministic diagnostic-only
+    baseline.  This is labeled and deterministic; it does not claim human
+    realism.
+
+    Returns:
+        Forecast distributions for the requested horizons.
+    """
+    predictions: list[ForecastDistribution] = []
+
+    effective_neighbors = neighbors or []
+    active_neighbors = (
+        _active_neighbor_repulsion(
+            state.position,
+            effective_neighbors,
+            interaction_radius_m,
+        )
+        if effective_neighbors
+        else []
+    )
+    active_neighbor_count = len(active_neighbors)
+    repulsion = np.zeros(2, dtype=float)
+    crowding_std_increment = 0.0
+    interaction_status = "no_neighbors"
+    if effective_neighbors:
+        if active_neighbors:
+            repulsion = _compute_repulsion(
+                state.position,
+                active_neighbors,
+                interaction_radius_m,
+                avoidance_strength,
+            )
+            crowding_density = active_neighbor_count / (math.pi * interaction_radius_m**2)
+            crowding_std_increment = crowding_std_factor * math.sqrt(crowding_density)
+            interaction_status = "repulsion_active"
+        else:
+            interaction_status = "no_neighbors_in_radius"
+
+    for horizon_s in horizons_s:
+        horizon = float(horizon_s)
+        std_m = base_std_m + velocity_std_rate * horizon + crowding_std_increment
+        mean = state.position + state.velocity * horizon + repulsion * horizon
+
+        if std_m <= 0.0:
+            raise ValueError("forecast standard deviation must be positive")
+
+        predictions.append(
+            ForecastDistribution(
+                horizon_s=horizon,
+                mean=mean,
+                covariance=np.eye(2, dtype=float) * (std_m**2),
+                metadata={
+                    "model": "interaction_aware_cv",
+                    "std_m": float(std_m),
+                    "is_intent_aware": state.intent is not None,
+                    "is_signal_aware": state.signal_available,
+                    "signal_state": state.signal if state.signal_available else "unknown",
+                    "interaction_status": interaction_status,
+                    "neighbor_count": float(len(effective_neighbors)),
+                    "active_neighbor_count": float(active_neighbor_count),
+                },
+            )
+        )
+
+    return PedestrianForecast(id=state.id, predictions=predictions)
+
+
+def _active_neighbor_repulsion(
+    ego_position: np.ndarray,
+    neighbors: list[NeighborContext],
+    interaction_radius_m: float,
+) -> list[NeighborContext]:
+    """Return neighbors within the interaction radius."""
+    return [
+        n
+        for n in neighbors
+        if float(np.linalg.norm(n.position - ego_position)) <= interaction_radius_m
+    ]
+
+
+def _compute_repulsion(
+    ego_position: np.ndarray,
+    active_neighbors: list[NeighborContext],
+    interaction_radius_m: float,
+    avoidance_strength: float,
+) -> np.ndarray:
+    """Compute a mean repulsive displacement vector from active neighbors.
+
+    Each neighbor contributes a repulsive force inversely proportional to
+    distance, bounded by the interaction radius.  The result is a per-step
+    displacement correction that accumulates linearly with horizon.
+
+    Returns:
+        2D repulsive displacement vector.
+    """
+    repulsion = np.zeros(2, dtype=float)
+    for neighbor in active_neighbors:
+        diff = ego_position - neighbor.position
+        dist = float(np.linalg.norm(diff))
+        if dist < 1e-6:
+            continue
+        weight = 1.0 - dist / interaction_radius_m
+        repulsion += (diff / dist) * weight * avoidance_strength
+    return repulsion
+
+
 BASELINE_FUNCTIONS: dict[str, ForecastBaselineFunction] = {
     "cv": constant_velocity_gaussian_baseline,
     "signal_aware": signal_aware_cv_baseline,
     "goal_aware": goal_aware_cv_baseline,
     "semantic": semantic_cv_baseline,
+    "interaction_aware": interaction_aware_cv_baseline,
 }
 
 
@@ -600,8 +735,12 @@ def _evaluate_single_pedestrian(
     )
     if not ground_truth:
         return None
+
+    neighbors = _collect_neighbor_context(pedestrian_payload, step_index, trace_steps)
+    forecast = _call_baseline_with_neighbors(baseline_function, state, horizons_s, neighbors)
+
     return evaluate_forecast(
-        baseline_function(state, horizons_s),
+        forecast,
         ground_truth,
         confidence_level=confidence_level,
         robot_positions=_future_robot_positions(
@@ -612,6 +751,60 @@ def _evaluate_single_pedestrian(
         ),
         collision_distance_m=collision_distance_m,
     )
+
+
+def _collect_neighbor_context(
+    ego_payload: dict[str, Any],
+    step_index: int,
+    trace_steps: list[dict[str, Any]],
+) -> list[NeighborContext]:
+    """Build neighbor context from the current step, excluding the ego pedestrian.
+
+    Returns:
+        List of NeighborContext for nearby pedestrians.
+    """
+    if step_index >= len(trace_steps):
+        return []
+    ego_id = int(ego_payload["id"])
+    neighbors: list[NeighborContext] = []
+    for ped in trace_steps[step_index].get("pedestrians", []):
+        if int(ped["id"]) == ego_id:
+            continue
+        neighbors.append(
+            NeighborContext(
+                position=np.asarray(ped["position"], dtype=float),
+                velocity=np.asarray(ped["velocity"], dtype=float),
+                actor_type=str(ped.get("actor_type") or "pedestrian"),
+            )
+        )
+    return neighbors
+
+
+def _call_baseline_with_neighbors(
+    baseline_function: ForecastBaselineFunction,
+    state: PedestrianState,
+    horizons_s: list[float] | tuple[float, ...],
+    neighbors: list[NeighborContext],
+) -> PedestrianForecast:
+    """Call baseline, passing neighbors if the function accepts them.
+
+    Returns:
+        Forecast from the baseline function.
+    """
+
+    if _baseline_accepts_neighbors(baseline_function):
+        return baseline_function(state, horizons_s, neighbors=neighbors)  # type: ignore[call-arg]
+    return baseline_function(state, horizons_s)
+
+
+@cache
+def _baseline_accepts_neighbors(baseline_function: ForecastBaselineFunction) -> bool:
+    """Return whether a baseline accepts neighbor context.
+
+    Returns:
+        True when ``baseline_function`` declares a ``neighbors`` parameter.
+    """
+    return "neighbors" in inspect.signature(baseline_function).parameters
 
 
 def _future_pedestrian_positions(

--- a/scripts/benchmark/run_cv_forecast_eval.py
+++ b/scripts/benchmark/run_cv_forecast_eval.py
@@ -534,6 +534,12 @@ def main() -> None:
         action="store_true",
         help="Run all baselines and write a comparison report.",
     )
+    parser.add_argument(
+        "--issue",
+        type=int,
+        default=2758,
+        help="Issue number to record in generated evidence metadata.",
+    )
     args = parser.parse_args()
 
     output_dir = REPO_ROOT / args.output_dir
@@ -546,10 +552,11 @@ def main() -> None:
     command = (
         f"uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir {args.output_dir}"
         + (f" --baseline {args.baseline}" if not args.compare_all else " --compare-all")
+        + f" --issue {args.issue}"
     )
 
     repro = {
-        "issue": 2758,
+        "issue": args.issue,
         "generated_at_utc": generated_at,
         "command": command,
         "repo_head": repo_head,
@@ -575,7 +582,7 @@ def main() -> None:
         limited_families = sorted({r["family"] for r in results if r["status"] != "evaluated"})
 
         report_json: dict[str, Any] = {
-            "issue": 2758,
+            "issue": args.issue,
             "claim_boundary": (
                 "Diagnostic-only, not paper-facing evidence. "
                 "Limited to bounded repository trace fixtures."
@@ -644,6 +651,7 @@ def _write_comparison_report(
 
     fixture_has_signal = _fixtures_have_signal_metadata(all_results)
     fixture_has_intent = _fixtures_have_intent_metadata(all_results)
+    interaction_effect = _summarize_interaction_effect(comparison_rows)
 
     summary_by_baseline: dict[str, dict[str, Any]] = {}
     for baseline_name in baselines:
@@ -658,7 +666,7 @@ def _write_comparison_report(
         }
 
     report: dict[str, Any] = {
-        "issue": 2758,
+        "issue": repro["issue"],
         "claim_boundary": (
             "Diagnostic-only, not paper-facing evidence. "
             "Limited to bounded repository trace fixtures."
@@ -677,18 +685,21 @@ def _write_comparison_report(
         "summary_by_baseline": summary_by_baseline,
         "comparison_rows": comparison_rows,
     }
+    if interaction_effect is not None:
+        report["interaction_effect"] = interaction_effect
 
     json_path = output_dir / "comparison_report.json"
     with open(json_path, "w") as fh:
         json.dump(report, fh, indent=2)
 
     md_lines = [
-        "# Semantic Forecast Baseline Comparison",
+        "# Forecast Baseline Comparison",
         "",
         "## Claim Boundary",
         "",
-        "**Diagnostic-only, not paper-facing evidence.** Compares constant-velocity and "
-        "semantic forecast baselines on bounded repository trace fixtures.",
+        "**Diagnostic-only, not paper-facing evidence.** Compares constant-velocity, "
+        "semantic, and interaction-aware forecast baselines on bounded repository trace "
+        "fixtures when those baselines are requested.",
         "",
         "## Reproducibility",
         "",
@@ -711,6 +722,19 @@ def _write_comparison_report(
                 "Existing durable fixtures lack signal and intent metadata. Semantic "
                 "conditioning baselines run correctly but their calibration/collision-relevance "
                 "improvement cannot be measured until fixtures include this metadata.",
+                "",
+            ]
+        )
+
+    if interaction_effect is not None:
+        md_lines.extend(
+            [
+                "## Interaction-Aware Diagnostic Effect",
+                "",
+                f"- **Matched evaluated rows:** {interaction_effect['matched_rows']}",
+                f"- **Mean ADE 1s delta vs CV:** {interaction_effect['mean_ade_1s_delta_vs_cv']:.4f}",
+                f"- **Mean NLL 1s delta vs CV:** {interaction_effect['mean_nll_1s_delta_vs_cv']:.4f}",
+                f"- **Conclusion:** {interaction_effect['conclusion']}",
                 "",
             ]
         )
@@ -759,6 +783,87 @@ def _write_comparison_report(
 
     print(f"Wrote {json_path}")
     print(f"Wrote {md_path}")
+
+
+def _summarize_interaction_effect(
+    comparison_rows: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Summarize interaction-aware row deltas against matching CV rows.
+
+    Returns:
+        Interaction effect summary, or None when comparison rows are unavailable.
+    """
+    rows_by_key = {
+        (row["baseline"], row["family"], row["label"]): row
+        for row in comparison_rows
+        if row["status"] == "evaluated"
+    }
+    deltas: list[tuple[float, float]] = []
+    for (baseline, family, label), interaction_row in rows_by_key.items():
+        if baseline != "interaction_aware":
+            continue
+        cv_row = rows_by_key.get(("cv", family, label))
+        if cv_row is None:
+            continue
+        ade_delta = _metric_delta(interaction_row, cv_row, "mean_ade_1s")
+        nll_delta = _metric_delta(
+            interaction_row,
+            cv_row,
+            "mean_negative_log_likelihood_1s",
+        )
+        if ade_delta is not None and nll_delta is not None:
+            deltas.append((ade_delta, nll_delta))
+
+    if not deltas:
+        return None
+
+    mean_ade_delta = sum(delta[0] for delta in deltas) / len(deltas)
+    mean_nll_delta = sum(delta[1] for delta in deltas) / len(deltas)
+    if mean_nll_delta < 0.0 and mean_ade_delta > 0.0:
+        conclusion = (
+            "Interaction-aware heuristic improved Gaussian likelihood/calibration proxy "
+            "but worsened point accuracy on matched diagnostic rows; revise before "
+            "closed-loop coupling claims."
+        )
+    elif mean_nll_delta < 0.0 and mean_ade_delta <= 0.0:
+        conclusion = (
+            "Interaction-aware heuristic improved likelihood without worsening point "
+            "accuracy on matched diagnostic rows; still diagnostic-only."
+        )
+    elif mean_nll_delta >= 0.0 and mean_ade_delta > 0.0:
+        conclusion = (
+            "Interaction-aware heuristic worsened both likelihood proxy and point "
+            "accuracy on matched diagnostic rows; treat as a negative result."
+        )
+    else:
+        conclusion = (
+            "Interaction-aware heuristic has mixed or negligible open-loop effect on "
+            "matched diagnostic rows."
+        )
+
+    return {
+        "matched_rows": len(deltas),
+        "mean_ade_1s_delta_vs_cv": mean_ade_delta,
+        "mean_nll_1s_delta_vs_cv": mean_nll_delta,
+        "conclusion": conclusion,
+    }
+
+
+def _metric_delta(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    metric: str,
+) -> float | None:
+    """Return ``left - right`` for a numeric metric when both rows define it.
+
+    Returns:
+        Metric delta, or None when either value is missing.
+    """
+    left_value = left.get(metric)
+    right_value = right.get(metric)
+    if left_value is None or right_value is None:
+        return None
+    return float(left_value) - float(right_value)
 
 
 def _fixtures_have_signal_metadata(all_results: dict[str, list[dict[str, Any]]]) -> bool:

--- a/tests/benchmark/test_pedestrian_forecast.py
+++ b/tests/benchmark/test_pedestrian_forecast.py
@@ -6,12 +6,14 @@ import numpy as np
 import pytest
 
 from robot_sf.benchmark.pedestrian_forecast import (
+    NeighborContext,
     PedestrianState,
     chi_square_2d_threshold,
     compute_batch_forecast_metrics,
     constant_velocity_gaussian_baseline,
     evaluate_forecast,
     goal_aware_cv_baseline,
+    interaction_aware_cv_baseline,
     semantic_cv_baseline,
     signal_aware_cv_baseline,
 )
@@ -549,3 +551,182 @@ def test_compute_batch_forecast_metrics_with_baseline_function() -> None:
     assert cv_summary["forecast_evaluable_samples"] > 0
     assert signal_summary["forecast_evaluable_samples"] > 0
     assert cv_summary["forecast_evaluable_samples"] == signal_summary["forecast_evaluable_samples"]
+
+
+def test_interaction_aware_cv_no_neighbors_matches_cv() -> None:
+    """Without neighbors, interaction-aware CV degrades to plain CV."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    forecast = interaction_aware_cv_baseline(state, horizons_s=(1.0,))
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    np.testing.assert_allclose(
+        forecast.predictions[0].covariance, cv_forecast.predictions[0].covariance
+    )
+    assert forecast.predictions[0].metadata["interaction_status"] == "no_neighbors"
+    assert forecast.predictions[0].metadata["neighbor_count"] == 0.0
+    assert forecast.predictions[0].metadata["model"] == "interaction_aware_cv"
+
+
+def test_interaction_aware_cv_nearby_neighbor_deflects_mean() -> None:
+    """A nearby neighbor pushes the forecast mean away (repulsion)."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    neighbor = NeighborContext(
+        position=np.array([0.5, 0.5]),
+        velocity=np.array([-0.5, 0.0]),
+    )
+    forecast = interaction_aware_cv_baseline(state, horizons_s=(1.0,), neighbors=[neighbor])
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    # Mean should be deflected away from neighbor (repulsion is toward -y and -x relative to neighbor)
+    pred = forecast.predictions[0]
+    assert pred.metadata["interaction_status"] == "repulsion_active"
+    assert pred.metadata["active_neighbor_count"] == 1.0
+    # Repulsion pushes ego away from neighbor, so mean x < cv mean x
+    assert pred.mean[0] < cv_forecast.predictions[0].mean[0]
+    # Uncertainty increases due to crowding
+    assert pred.metadata["std_m"] > cv_forecast.predictions[0].metadata["std_m"]
+
+
+def test_interaction_aware_cv_far_neighbor_no_effect() -> None:
+    """A neighbor outside the interaction radius has no effect."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+    )
+    far_neighbor = NeighborContext(
+        position=np.array([10.0, 10.0]),
+        velocity=np.array([0.0, 0.0]),
+    )
+    forecast = interaction_aware_cv_baseline(state, horizons_s=(1.0,), neighbors=[far_neighbor])
+    cv_forecast = constant_velocity_gaussian_baseline(state, horizons_s=(1.0,))
+
+    np.testing.assert_allclose(forecast.predictions[0].mean, cv_forecast.predictions[0].mean)
+    assert forecast.predictions[0].metadata["interaction_status"] == "no_neighbors_in_radius"
+
+
+def test_interaction_aware_cv_multiple_neighbors_increase_crowding() -> None:
+    """More nearby neighbors increase uncertainty more than fewer."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+    )
+    one_neighbor = [NeighborContext(position=np.array([0.5, 0.0]), velocity=np.zeros(2))]
+    three_neighbors = [
+        NeighborContext(position=np.array([0.5, 0.0]), velocity=np.zeros(2)),
+        NeighborContext(position=np.array([-0.3, 0.4]), velocity=np.zeros(2)),
+        NeighborContext(position=np.array([0.2, -0.5]), velocity=np.zeros(2)),
+    ]
+
+    forecast_one = interaction_aware_cv_baseline(state, horizons_s=(1.0,), neighbors=one_neighbor)
+    forecast_many = interaction_aware_cv_baseline(
+        state, horizons_s=(1.0,), neighbors=three_neighbors
+    )
+
+    assert (
+        forecast_many.predictions[0].metadata["std_m"]
+        > forecast_one.predictions[0].metadata["std_m"]
+    )
+    assert forecast_many.predictions[0].metadata["active_neighbor_count"] == 3.0
+
+
+def test_interaction_aware_cv_is_deterministic() -> None:
+    """Interaction-aware forecast is deterministic for fixed inputs."""
+    state = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+    )
+    neighbors = [NeighborContext(position=np.array([0.5, 0.0]), velocity=np.zeros(2))]
+
+    first = interaction_aware_cv_baseline(state, horizons_s=(0.5, 1.0), neighbors=neighbors)
+    second = interaction_aware_cv_baseline(state, horizons_s=(0.5, 1.0), neighbors=neighbors)
+
+    for left, right in zip(first.predictions, second.predictions, strict=True):
+        np.testing.assert_allclose(left.mean, right.mean)
+        np.testing.assert_allclose(left.covariance, right.covariance)
+
+
+def test_interaction_aware_cv_composes_with_semantic_context() -> None:
+    """Interaction-aware forecast respects signal/intent context when provided."""
+    state_with_context = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent="crossing",
+        signal="green",
+        signal_available=True,
+    )
+    state_no_context = PedestrianState(
+        id=1,
+        position=np.array([0.0, 0.0]),
+        velocity=np.array([1.0, 0.0]),
+        intent=None,
+        signal=None,
+        signal_available=False,
+    )
+    neighbors = [NeighborContext(position=np.array([0.5, 0.0]), velocity=np.zeros(2))]
+
+    forecast_ctx = interaction_aware_cv_baseline(
+        state_with_context, horizons_s=(1.0,), neighbors=neighbors
+    )
+    forecast_no_ctx = interaction_aware_cv_baseline(
+        state_no_context, horizons_s=(1.0,), neighbors=neighbors
+    )
+
+    assert forecast_ctx.predictions[0].metadata["is_intent_aware"] is True
+    assert forecast_ctx.predictions[0].metadata["is_signal_aware"] is True
+    assert forecast_no_ctx.predictions[0].metadata["is_intent_aware"] is False
+    assert forecast_no_ctx.predictions[0].metadata["is_signal_aware"] is False
+
+
+def test_compute_batch_forecast_metrics_with_interaction_aware_baseline() -> None:
+    """Batch metrics accept interaction_aware baseline via the registry."""
+    dt_s = 0.5
+    trace_steps = []
+    for index in range(5):
+        x = index * dt_s
+        trace_steps.append(
+            {
+                "step": index,
+                "time_s": x,
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [x, 0.0],
+                        "velocity": [1.0, 0.0],
+                    },
+                    {
+                        "id": 2,
+                        "position": [x, 1.0],
+                        "velocity": [0.5, 0.0],
+                    },
+                ],
+            }
+        )
+
+    summary = compute_batch_forecast_metrics(
+        trace_steps,
+        horizons_s=(0.5, 1.0),
+        dt_s=dt_s,
+        baseline_function=interaction_aware_cv_baseline,
+    )
+
+    assert summary["forecast_evaluable_samples"] > 0
+    assert summary["mean_ade_0.5s"] >= 0.0

--- a/tests/benchmark/test_pedestrian_forecast_cv_eval.py
+++ b/tests/benchmark/test_pedestrian_forecast_cv_eval.py
@@ -10,6 +10,7 @@ import pytest
 
 from robot_sf.benchmark.pedestrian_forecast import (
     goal_aware_cv_baseline,
+    interaction_aware_cv_baseline,
     semantic_cv_baseline,
     signal_aware_cv_baseline,
 )
@@ -39,6 +40,7 @@ _extract_trace_steps = _mod._extract_trace_steps
 _generate_markdown = _mod._generate_markdown
 _get_actor_classes = _mod._get_actor_classes
 _pedestrian_count = _mod._pedestrian_count
+_summarize_interaction_effect = _mod._summarize_interaction_effect
 _trace_has_motion = _mod._trace_has_motion
 _evaluate_single_trace = _mod.evaluate_single_trace
 
@@ -444,3 +446,45 @@ def test_baseline_functions_dict_has_all_keys() -> None:
     assert "signal_aware" in BASELINE_FUNCTIONS
     assert "goal_aware" in BASELINE_FUNCTIONS
     assert "semantic" in BASELINE_FUNCTIONS
+    assert "interaction_aware" in BASELINE_FUNCTIONS
+
+
+def test_evaluate_single_trace_with_interaction_aware_baseline() -> None:
+    """Trace can be evaluated with interaction_aware baseline."""
+    result = _evaluate_single_trace(
+        TRACE_CANDIDATES[0],
+        baseline_function=interaction_aware_cv_baseline,
+    )
+    assert "status" in result
+    assert "metrics" in result
+    assert result["status"] != "evaluation_error"
+
+
+def test_summarize_interaction_effect_reports_matched_deltas() -> None:
+    """Interaction summary compares matched interaction-aware and CV rows."""
+    summary = _summarize_interaction_effect(
+        [
+            {
+                "baseline": "cv",
+                "family": "corridor_interaction",
+                "label": "default",
+                "status": "evaluated",
+                "mean_ade_1s": 0.1,
+                "mean_negative_log_likelihood_1s": 2.0,
+            },
+            {
+                "baseline": "interaction_aware",
+                "family": "corridor_interaction",
+                "label": "default",
+                "status": "evaluated",
+                "mean_ade_1s": 0.2,
+                "mean_negative_log_likelihood_1s": 1.5,
+            },
+        ]
+    )
+
+    assert summary is not None
+    assert summary["matched_rows"] == 1
+    assert summary["mean_ade_1s_delta_vs_cv"] == pytest.approx(0.1)
+    assert summary["mean_nll_1s_delta_vs_cv"] == pytest.approx(-0.5)
+    assert "improved Gaussian likelihood" in summary["conclusion"]


### PR DESCRIPTION
## Summary

- Adds `interaction_aware_cv_baseline`, a deterministic open-loop forecast baseline that uses nearby pedestrian context for proximity repulsion and crowding uncertainty.
- Registers it in the existing forecast baseline registry so `run_cv_forecast_eval.py --compare-all` includes `interaction_aware`.
- Adds a diagnostic evidence bundle for #2781 comparing `cv`, `signal_aware`, `goal_aware`, `semantic`, and `interaction_aware` on the bounded durable trace fixtures.

Closes #2781.

## Result

Diagnostic-only. On matched evaluated rows, the interaction-aware heuristic improved the Gaussian likelihood/calibration proxy while worsening 1s point accuracy versus CV:

- matched evaluated rows: 3
- mean ADE 1s delta vs CV: `+0.02464957446502613`
- mean NLL 1s delta vs CV: `-0.6717039148640245`

Interpretation: revise before closed-loop coupling claims; this does not justify learned-predictor training or planner coupling by itself.

## Validation

- `uv run pytest tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py` -> 55 passed
- `uv run python scripts/benchmark/run_cv_forecast_eval.py --output-dir docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15 --compare-all --issue 2781` -> pass
- `uv run ruff check robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py` -> pass
- `uv run ruff format --check robot_sf/benchmark/pedestrian_forecast.py scripts/benchmark/run_cv_forecast_eval.py tests/benchmark/test_pedestrian_forecast.py tests/benchmark/test_pedestrian_forecast_cv_eval.py` -> pass
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 6519 passed, 9 skipped, 9 warnings

## Downstream Propagation

- Evidence bundle: `docs/context/evidence/issue_2781_interaction_aware_forecast_2026-06-15/`
- Evidence index updated: `docs/context/evidence/README.md`
- Context catalog updated: `docs/context/catalog.yaml`
- Follow-up relevance: #2843 should treat this as a mixed diagnostic revise signal, not a green-light gate for learned predictor training.

## Research Result Guidance

- Target claim/hypothesis/blocker: whether deterministic interaction cues add useful open-loop forecast signal before learned prediction.
- Comparator/baseline: CV and semantic CV baselines on the same bounded trace fixtures.
- Evidence tier: nominal diagnostic evidence, not benchmark or paper-facing evidence.
- Result classification: mixed/revise.
- Decision/stop rule: do not proceed to closed-loop coupling or learned-predictor training based on this open-loop result alone; use the mixed result to shape #2843 gate criteria.
- Synthesis surface/update target: prediction lane under #2835 and closed-loop gate issue #2843.
