### PR TITLE
Add opt-in forecast risk scoring diagnostic

### DIFF
--- a/configs/algos/policy_stack_v1.yaml
+++ b/configs/algos/policy_stack_v1.yaml
@@ -8,6 +8,8 @@ hard_stop_clearance: 0.35
 max_linear_speed: 1.0
 max_angular_speed: 1.2
 goal_tolerance: 0.25
+forecast_risk_weight: 0.0
+forecast_risk_observation_key: forecast_risk_channel
 
 risk_dwa:
   max_linear_speed: 1.0

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-06-14
+updated_at: 2026-06-15
 policy: context-catalog.v1
 description: >
   Machine-readable catalog for the current retrieval-first context index. This is not a full
@@ -1373,6 +1373,18 @@ entries:
     freshness: evidence
     area: benchmark_evidence
   - path: docs/context/evidence/issue_2843_closed_loop_forecast_coupling_gate_2026-06-15/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/summary.json
     status: evidence
     freshness: evidence
     area: benchmark_evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -381,3 +381,10 @@ Policy caveats:
   metrics. Recommendation: revise. Forecast interaction_aware worsened 1s ADE by 0.0246 m vs CV
   while improving NLL by 0.6717; closed-loop gate failed (global_success_delta 0.0). No learned
   training involved. Not benchmark or paper-facing evidence.
+- `issue_2759_forecast_risk_policy_stack_2026-06-15/`: diagnostic-only same-seed comparison
+  of baseline (forecast_risk_weight=0) vs diagnostic (forecast_risk_weight=5.0) scoring in
+  PolicyStackV1Adapter. Two deterministic fixture cases: high_risk_diagnostic_slows_goal
+  (penalty shifts selection to risk_dwa, speed/progress proxy reduced) and
+  false_positive_suppresses_penalty (penalty suppressed, goal retained with zero unnecessary
+  slowdown count).
+  claim_boundary=diagnostic_only_not_benchmark_evidence. Not a safety or live benchmark claim.

--- a/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.json
+++ b/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.json
@@ -1,0 +1,60 @@
+{
+  "cases": [
+    {
+      "baseline": {
+        "forecast_penalty": 0.0,
+        "high_risk_speed_reduction": 0.0,
+        "progress_proxy": 1.0,
+        "ranking_top": "goal",
+        "selected_proposal": "goal",
+        "shield_intervened": false,
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "case_name": "high_risk_diagnostic_slows_goal",
+      "delta_forecast_penalty": 5.0,
+      "delta_progress_proxy": -0.8,
+      "diagnostic": {
+        "forecast_penalty": 5.0,
+        "high_risk_speed_reduction": 1.0,
+        "progress_proxy": 0.2,
+        "ranking_top": "risk_dwa",
+        "selected_proposal": "risk_dwa",
+        "shield_intervened": false,
+        "shield_stop_count": 0,
+        "speed": 0.2
+      },
+      "false_positive_unnecessary_slowdown_count": 0
+    },
+    {
+      "baseline": {
+        "forecast_penalty": 0.0,
+        "high_risk_speed_reduction": 0.0,
+        "progress_proxy": 1.0,
+        "ranking_top": "goal",
+        "selected_proposal": "goal",
+        "shield_intervened": false,
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "case_name": "false_positive_suppresses_penalty",
+      "delta_forecast_penalty": 0.0,
+      "delta_progress_proxy": 0.0,
+      "diagnostic": {
+        "forecast_penalty": 0.0,
+        "high_risk_speed_reduction": 0.0,
+        "progress_proxy": 1.0,
+        "ranking_top": "goal",
+        "selected_proposal": "goal",
+        "shield_intervened": false,
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "false_positive_unnecessary_slowdown_count": 0
+    }
+  ],
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "diagnostic_weight": 5.0,
+  "recommendation": "forecast_risk_scoring_diagnostic_consistent",
+  "schema_version": "forecast_risk_policy_stack.diagnostic_comparison.v1"
+}

--- a/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.md
+++ b/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/report.md
@@ -1,0 +1,37 @@
+# Forecast Risk Policy Stack Diagnostic Comparison
+
+- **claim_boundary**: `diagnostic_only_not_benchmark_evidence`
+- **diagnostic_weight**: 5.0
+- **recommendation**: `forecast_risk_scoring_diagnostic_consistent`
+
+## Cases
+
+### high_risk_diagnostic_slows_goal
+
+| Field | Baseline | Diagnostic | Delta |
+|---|---|---|---|
+| selected_proposal | goal | risk_dwa |  |
+| speed | 1.0 | 0.2 | -0.8 |
+| progress_proxy | 1.0 | 0.2 | -0.8 |
+| forecast_penalty | 0.0 | 5.0 | 5.0 |
+| high_risk_speed_reduction | 0.0 | 1.0 | 1.0 |
+| shield_stop_count | 0 | 0 | 0 |
+| false_positive_unnecessary_slowdown_count |  | 0 |  |
+
+### false_positive_suppresses_penalty
+
+| Field | Baseline | Diagnostic | Delta |
+|---|---|---|---|
+| selected_proposal | goal | goal |  |
+| speed | 1.0 | 1.0 | 0.0 |
+| progress_proxy | 1.0 | 1.0 | 0.0 |
+| forecast_penalty | 0.0 | 0.0 | 0.0 |
+| high_risk_speed_reduction | 0.0 | 0.0 | 0.0 |
+| shield_stop_count | 0 | 0 | 0 |
+| false_positive_unnecessary_slowdown_count |  | 0 |  |
+
+## Recommendation
+
+```forecast_risk_scoring_diagnostic_consistent```
+
+> This is a diagnostic-only comparison. No safety claim is made. claim_boundary=diagnostic_only_not_benchmark_evidence

--- a/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/summary.json
+++ b/docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15/summary.json
@@ -1,0 +1,7 @@
+{
+  "case_count": 2,
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "diagnostic_weight": 5.0,
+  "false_positive_unnecessary_slowdown_count": 0,
+  "recommendation": "forecast_risk_scoring_diagnostic_consistent"
+}

--- a/robot_sf/planner/policy_stack_v1.py
+++ b/robot_sf/planner/policy_stack_v1.py
@@ -45,6 +45,18 @@ _LEAKAGE_EXCLUSIONS = (
     "route_outcome_label",
     "benchmark_metric_rollups",
 )
+_FORECAST_RISK_ACTIVE_STATUSES = {"available", "computed", "diagnostic"}
+_FORECAST_PRIMARY_RISK_FIELDS = (
+    "risk",
+    "occupancy_risk",
+    "collision_relevance",
+    "collision_relevance_risk",
+    "miss_rate",
+)
+_FORECAST_FALSE_POSITIVE_FIELDS = (
+    "false_positive_risk",
+    "unnecessary_stop_risk",
+)
 
 
 @dataclass(frozen=True)
@@ -67,6 +79,9 @@ class PolicyStackV1Config:
     heading_weight: float = 0.8
     angular_penalty_weight: float = 0.2
     clearance_weight: float = 0.8
+
+    forecast_risk_weight: float = 0.0
+    forecast_risk_observation_key: str = "forecast_risk_channel"
 
 
 @dataclass(frozen=True)
@@ -254,6 +269,9 @@ class PolicyStackV1Adapter:
             Trace packet with proposal, action, observation, cadence, and status contracts.
         """
         diagnostics = self.diagnostics()
+        inference_features = list(_INFERENCE_AVAILABLE_FEATURES)
+        if float(self.config.forecast_risk_weight) > 0.0:
+            inference_features.append(self.config.forecast_risk_observation_key)
         return {
             "schema_version": ARBITRATION_TRACE_SCHEMA,
             "planner_key": "policy_stack_v1",
@@ -269,7 +287,9 @@ class PolicyStackV1Adapter:
                 "executable_statuses": sorted(_COMMAND_STATUSES),
             },
             "observation_contract": {
-                "inference_available_features": list(_INFERENCE_AVAILABLE_FEATURES),
+                "inference_available_features": inference_features,
+                "forecast_risk_observation_key": self.config.forecast_risk_observation_key,
+                "forecast_risk_active_statuses": sorted(_FORECAST_RISK_ACTIVE_STATUSES),
                 "leakage_exclusions": list(_LEAKAGE_EXCLUSIONS),
             },
             "switching_contract": {
@@ -438,13 +458,36 @@ class PolicyStackV1Adapter:
             + float(self.config.clearance_weight) * clearance_bonus
             - float(self.config.angular_penalty_weight) * angular_penalty
         )
-        return {
+        result: dict[str, float] = {
             "total": float(total),
             "goal_progress": float(progress),
             "heading_alignment": float(heading_alignment),
             "ped_clearance": float(clearance_bonus),
             "angular_penalty": float(angular_penalty),
         }
+
+        fr_weight = float(self.config.forecast_risk_weight)
+        if fr_weight > 0.0:
+            fr_key = self.config.forecast_risk_observation_key
+            payload = observation.get(fr_key) if isinstance(observation.get(fr_key), dict) else None
+            raw_risk, effective_risk, false_positive, available = _forecast_risk_values(payload)
+
+            linear_frac = (
+                min(abs(float(command[0])) / float(self.config.max_linear_speed), 1.0)
+                if float(self.config.max_linear_speed) > 0.0
+                else 0.0
+            )
+            forecast_penalty = fr_weight * effective_risk * linear_frac
+
+            total -= forecast_penalty
+            result["total"] = float(total)
+            result["forecast_risk_raw"] = float(raw_risk)
+            result["forecast_risk_effective"] = float(effective_risk)
+            result["forecast_risk_penalty"] = float(forecast_penalty)
+            result["forecast_risk_false_positive"] = float(false_positive)
+            result["forecast_risk_available"] = float(available)
+
+        return result
 
     def _violates_hard_stop(
         self,
@@ -503,6 +546,11 @@ def build_policy_stack_v1_build_config(
         heading_weight=float(merged_stack.get("heading_weight", 0.8)),
         angular_penalty_weight=float(merged_stack.get("angular_penalty_weight", 0.2)),
         clearance_weight=float(merged_stack.get("clearance_weight", 0.8)),
+        forecast_risk_weight=_as_float(merged_stack.get("forecast_risk_weight")),
+        forecast_risk_observation_key=_config_string(
+            merged_stack.get("forecast_risk_observation_key"),
+            default="forecast_risk_channel",
+        ),
     )
     risk_raw = cfg.get("risk_dwa", {}) if isinstance(cfg.get("risk_dwa"), dict) else {}
     return PolicyStackV1BuildConfig(
@@ -557,6 +605,66 @@ def _as_vector(value: Any, *, pad: int) -> np.ndarray:
     if arr.size < pad:
         arr = np.pad(arr, (0, pad - arr.size), constant_values=0.0)
     return arr
+
+
+def _as_float(value: Any, *, default: float = 0.0) -> float:
+    """Safely coerce a payload value to float, returning *default* on failure.
+
+    Returns:
+        float: Coerced value or *default* when conversion or finiteness fails.
+    """
+    if value is None:
+        return default
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not np.isfinite(result):
+        return default
+    return result
+
+
+def _config_string(value: Any, *, default: str) -> str:
+    """Return a stripped config string with a fallback for null or blank values.
+
+    Returns:
+        str: Normalized config value.
+    """
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text if text else default
+
+
+def _bounded_unit_float(value: Any) -> float:
+    """Return a finite float clamped to the unit interval.
+
+    Returns:
+        float: Value in ``[0, 1]``; invalid inputs become ``0``.
+    """
+    return min(max(_as_float(value), 0.0), 1.0)
+
+
+def _forecast_risk_values(payload: dict[str, Any] | None) -> tuple[float, float, float, float]:
+    """Extract bounded forecast-risk values from an optional observation payload.
+
+    Returns:
+        tuple[float, float, float, float]: Raw risk, effective risk, false-positive
+        attenuation, and availability flag.
+    """
+    if payload is None:
+        return 0.0, 0.0, 0.0, 0.0
+
+    status = str(payload.get("status") or "").strip().lower()
+    if status not in _FORECAST_RISK_ACTIVE_STATUSES:
+        return 0.0, 0.0, 0.0, 0.0
+
+    raw_risk = max(_bounded_unit_float(payload.get(key)) for key in _FORECAST_PRIMARY_RISK_FIELDS)
+    false_positive = max(
+        _bounded_unit_float(payload.get(key)) for key in _FORECAST_FALSE_POSITIVE_FIELDS
+    )
+    effective_risk = raw_risk * (1.0 - false_positive)
+    return float(raw_risk), float(effective_risk), float(false_positive), 1.0
 
 
 def _tuple_of_strings(value: Any, *, default: tuple[str, ...] = ()) -> tuple[str, ...]:

--- a/scripts/validation/validate_forecast_risk_policy_stack.py
+++ b/scripts/validation/validate_forecast_risk_policy_stack.py
@@ -1,0 +1,312 @@
+"""Diagnostic same-seed comparison for forecast risk scoring in policy_stack_v1.
+
+Produces a bounded diagnostic report comparing baseline (forecast_risk_weight=0)
+versus diagnostic (forecast_risk_weight>0) on identical deterministic observations.
+This is NOT a live benchmark claim. The output carries claim_boundary
+``diagnostic_only_not_benchmark_evidence``.
+
+Usage::
+
+    uv run python scripts/validation/validate_forecast_risk_policy_stack.py
+    uv run python scripts/validation/validate_forecast_risk_policy_stack.py \
+        --out-dir docs/context/evidence/issue_2759_forecast_risk_policy_stack_2026-06-15
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.planner.policy_stack_v1 import (
+    PolicyStackV1Adapter,
+    PolicyStackV1Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+CLAIM_BOUNDARY = "diagnostic_only_not_benchmark_evidence"
+SCHEMA_VERSION = "forecast_risk_policy_stack.diagnostic_comparison.v1"
+_DIAGNOSTIC_WEIGHT = 5.0
+
+
+class _FixedRiskDWA:
+    """Deterministic risk_dwa test double returning a fixed command."""
+
+    def __init__(self, command: tuple[float, float] = (0.2, 0.0)) -> None:
+        self.command = command
+        self.calls = 0
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        _ = observation
+        self.calls += 1
+        return self.command
+
+    def reset(self) -> None:
+        self.calls = 0
+
+
+def _base_observation() -> dict[str, Any]:
+    """Return the canonical deterministic observation fixture."""
+    return {
+        "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+        "goal": {"current": [1.0, 0.0]},
+        "pedestrians": {"positions": [[2.0, 0.5]]},
+    }
+
+
+def _case_high_risk() -> dict[str, Any]:
+    """High-risk scenario: diagnostic scoring should slow/stop the goal proposal."""
+    obs = _base_observation()
+    obs["forecast_risk_channel"] = {
+        "status": "available",
+        "risk": 1.0,
+        "occupancy_risk": 0.9,
+        "collision_relevance": 0.8,
+    }
+    return obs
+
+
+def _case_false_positive_suppress() -> dict[str, Any]:
+    """False-positive scenario: penalty suppressed, unnecessary stop avoided."""
+    obs = _base_observation()
+    obs["forecast_risk_channel"] = {
+        "status": "available",
+        "risk": 1.0,
+        "false_positive_risk": 1.0,
+        "unnecessary_stop_risk": 1.0,
+    }
+    return obs
+
+
+_CASES: list[dict[str, Any]] = [
+    {"name": "high_risk_diagnostic_slows_goal", "observation": _case_high_risk()},
+    {"name": "false_positive_suppresses_penalty", "observation": _case_false_positive_suppress()},
+]
+
+
+def _run_single(
+    config: PolicyStackV1Config,
+    observation: dict[str, Any],
+    *,
+    risk_dwa: _FixedRiskDWA,
+) -> dict[str, Any]:
+    """Run one adapter step and return the last-step diagnostic packet."""
+    stack = PolicyStackV1Adapter(config=config, risk_dwa=risk_dwa)
+    stack.plan(observation)
+    last = stack.diagnostics()["last_step"]
+    if last is None:
+        raise AssertionError("diagnostics last_step must exist after plan()")
+    return last
+
+
+def _extract_metrics(step: dict[str, Any]) -> dict[str, Any]:
+    """Pull scalar metrics from a diagnostics last_step packet."""
+    ranking = step.get("candidate_ranking", [])
+    goal_components = step.get("risk_score_components", {}).get("goal", {})
+    linear_speed = abs(float(step.get("selected_command", [0.0, 0.0])[0]))
+    forecast_penalty = float(goal_components.get("forecast_risk_penalty", 0.0))
+    high_risk_speed_reduction = 1.0 if linear_speed < 0.5 else 0.0
+    shield_stop_count = 1 if step.get("selected_proposal_key") == "shield_stop" else 0
+    return {
+        "selected_proposal": step.get("selected_proposal_key", ""),
+        "speed": round(linear_speed, 6),
+        "progress_proxy": round(linear_speed, 6),
+        "forecast_penalty": round(forecast_penalty, 6),
+        "high_risk_speed_reduction": high_risk_speed_reduction,
+        "shield_stop_count": shield_stop_count,
+        "ranking_top": ranking[0]["proposal_key"] if ranking else "",
+        "shield_intervened": bool(step.get("shield_intervened", False)),
+    }
+
+
+def build_report() -> dict[str, Any]:
+    """Build the full diagnostic comparison report.
+
+    Returns:
+        dict with claim_boundary, cases, and recommendation fields.
+    """
+    baseline_config = PolicyStackV1Config(
+        proposal_sources=("goal", "risk_dwa"),
+        forecast_risk_weight=0.0,
+    )
+    diagnostic_config = PolicyStackV1Config(
+        proposal_sources=("goal", "risk_dwa"),
+        forecast_risk_weight=_DIAGNOSTIC_WEIGHT,
+    )
+
+    case_results: list[dict[str, Any]] = []
+    for case in _CASES:
+        baseline_dwa = _FixedRiskDWA()
+        diagnostic_dwa = _FixedRiskDWA()
+        baseline_step = _run_single(baseline_config, case["observation"], risk_dwa=baseline_dwa)
+        diagnostic_step = _run_single(
+            diagnostic_config, case["observation"], risk_dwa=diagnostic_dwa
+        )
+        baseline_metrics = _extract_metrics(baseline_step)
+        diagnostic_metrics = _extract_metrics(diagnostic_step)
+
+        delta_progress = round(
+            diagnostic_metrics["progress_proxy"] - baseline_metrics["progress_proxy"], 6
+        )
+        delta_penalty = round(
+            diagnostic_metrics["forecast_penalty"] - baseline_metrics["forecast_penalty"], 6
+        )
+        false_positive_unnecessary_slowdown = int(
+            "false_positive" in str(case["name"])
+            and diagnostic_metrics["speed"] < baseline_metrics["speed"]
+        )
+
+        case_results.append(
+            {
+                "case_name": case["name"],
+                "baseline": baseline_metrics,
+                "diagnostic": diagnostic_metrics,
+                "delta_progress_proxy": delta_progress,
+                "delta_forecast_penalty": delta_penalty,
+                "false_positive_unnecessary_slowdown_count": false_positive_unnecessary_slowdown,
+            }
+        )
+
+    recommendation = _decide_recommendation(case_results)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "diagnostic_weight": _DIAGNOSTIC_WEIGHT,
+        "cases": case_results,
+        "recommendation": recommendation,
+    }
+
+
+def _decide_recommendation(cases: list[dict[str, Any]]) -> str:
+    """Classify the diagnostic outcome into a short recommendation string.
+
+    Returns:
+        One of the bounded diagnostic recommendation labels.
+    """
+    high_risk = next(
+        (c for c in cases if c["case_name"] == "high_risk_diagnostic_slows_goal"), None
+    )
+    fp_case = next(
+        (c for c in cases if c["case_name"] == "false_positive_suppresses_penalty"), None
+    )
+    if high_risk is None or fp_case is None:
+        return "incomplete_cases"
+
+    hr_diag = high_risk["diagnostic"]
+    hr_base = high_risk["baseline"]
+    fp_diag = fp_case["diagnostic"]
+
+    high_risk_slows = hr_diag["forecast_penalty"] > 0.0 and hr_diag["speed"] < hr_base["speed"]
+    fp_suppressed = fp_diag["forecast_penalty"] == 0.0 and fp_diag["selected_proposal"] == "goal"
+
+    if high_risk_slows and fp_suppressed:
+        return "forecast_risk_scoring_diagnostic_consistent"
+    if high_risk_slows and not fp_suppressed:
+        return "false_positive_suppression_inconsistent"
+    if not high_risk_slows and fp_suppressed:
+        return "high_risk_penalization_inconsistent"
+    return "no_diagnostic_signal"
+
+
+def _human_summary(report: dict[str, Any]) -> str:
+    """Render the report as a human-readable Markdown string."""
+    lines = [
+        "# Forecast Risk Policy Stack Diagnostic Comparison",
+        "",
+        f"- **claim_boundary**: `{report['claim_boundary']}`",
+        f"- **diagnostic_weight**: {report['diagnostic_weight']}",
+        f"- **recommendation**: `{report['recommendation']}`",
+        "",
+        "## Cases",
+        "",
+    ]
+    for case in report["cases"]:
+        lines.append(f"### {case['case_name']}")
+        lines.append("")
+        lines.append("| Field | Baseline | Diagnostic | Delta |")
+        lines.append("|---|---|---|---|")
+        for key in (
+            "selected_proposal",
+            "speed",
+            "progress_proxy",
+            "forecast_penalty",
+            "high_risk_speed_reduction",
+            "shield_stop_count",
+        ):
+            b = case["baseline"][key]
+            d = case["diagnostic"][key]
+            if key == "delta_progress_proxy":
+                continue
+            if isinstance(b, float):
+                delta = round(d - b, 6)
+            elif isinstance(b, int):
+                delta = d - b
+            else:
+                delta = ""
+            lines.append(f"| {key} | {b} | {d} | {delta} |")
+        lines.append(
+            f"| false_positive_unnecessary_slowdown_count |  | "
+            f"{case['false_positive_unnecessary_slowdown_count']} |  |"
+        )
+        lines.append("")
+    lines.append("## Recommendation")
+    lines.append("")
+    lines.append(f"```{report['recommendation']}```")
+    lines.append("")
+    lines.append(
+        "> This is a diagnostic-only comparison. "
+        "No safety claim is made. "
+        f"claim_boundary={CLAIM_BOUNDARY}"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Directory for report.json, report.md, summary.json (default: stdout only).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the diagnostic comparison and optionally write artifacts.
+
+    Returns:
+        Exit code 0 on success.
+    """
+    args = build_arg_parser().parse_args(argv)
+    report = build_report()
+    summary = {
+        "claim_boundary": CLAIM_BOUNDARY,
+        "recommendation": report["recommendation"],
+        "case_count": len(report["cases"]),
+        "diagnostic_weight": report["diagnostic_weight"],
+        "false_positive_unnecessary_slowdown_count": sum(
+            case["false_positive_unnecessary_slowdown_count"] for case in report["cases"]
+        ),
+    }
+    print(json.dumps({"summary": summary, "report": report}, indent=2, sort_keys=True))
+
+    if args.out_dir is not None:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "report.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        (args.out_dir / "report.md").write_text(_human_summary(report), encoding="utf-8")
+        (args.out_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -11,6 +11,7 @@ import pytest
 from robot_sf.planner.policy_stack_v1 import (
     PolicyStackV1Adapter,
     PolicyStackV1Config,
+    build_policy_stack_v1_build_config,
 )
 
 
@@ -140,6 +141,10 @@ def test_policy_stack_arbitration_trace_packet_contract() -> None:
     assert packet["proposal_sources"] == ["goal", "missing_optional"]
     assert packet["command_contract"]["action_space"] == "unicycle_vw"
     assert packet["switching_contract"]["min_dwell_steps"] == 1
+    assert (
+        "forecast_risk_channel"
+        not in packet["observation_contract"]["inference_available_features"]
+    )
     assert "future_trajectory" in packet["observation_contract"]["leakage_exclusions"]
     assert "not_available" in packet["status_policy"]["not_available_statuses"]
     assert packet["status_policy"]["non_executable_statuses"] == [
@@ -243,8 +248,6 @@ def test_policy_stack_hard_shield_stops_unsafe_moving_command_and_resets() -> No
 
 def test_policy_stack_build_config_preserves_nested_risk_dwa_fields() -> None:
     """Config builder should pass nested risk_dwa settings to the existing builder."""
-    from robot_sf.planner.policy_stack_v1 import build_policy_stack_v1_build_config
-
     build = build_policy_stack_v1_build_config(
         {
             "proposal_sources": ["goal", "risk_dwa"],
@@ -348,3 +351,180 @@ def test_policy_stack_runs_atomic_topology_smoke_through_map_runner(tmp_path: Pa
     assert runtime["proposal_status_counts"]["native"] > 0
     assert runtime["proposal_status_counts"]["adapter"] > 0
     assert runtime["last_step"]["selected_proposal_key"] in {"goal", "risk_dwa", "shield_stop"}
+
+
+def test_forecast_risk_default_off_ignores_channel() -> None:
+    """Default weight=0.0 should not inject forecast risk keys into scores."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(proposal_sources=("goal",)),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = {"status": "available", "risk": 1.0}
+    stack.plan(obs)
+    last = stack.diagnostics()["last_step"]
+    for components in last["risk_score_components"].values():
+        assert "forecast_risk_raw" not in components
+        assert "forecast_risk_penalty" not in components
+
+
+def test_forecast_risk_high_can_shift_selection_to_risk_dwa() -> None:
+    """High forecast risk with weight>0 should penalize goal enough to select risk_dwa."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal", "risk_dwa"),
+            forecast_risk_weight=5.0,
+        ),
+        risk_dwa=_DummyRiskDWA(command=(0.2, 0.0)),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = {"status": "available", "risk": 1.0}
+    stack.plan(obs)
+    last = stack.diagnostics()["last_step"]
+    assert last["selected_proposal_key"] == "risk_dwa"
+    goal_components = last["risk_score_components"]["goal"]
+    assert goal_components["forecast_risk_available"] == 1.0
+    assert goal_components["forecast_risk_raw"] == 1.0
+    assert goal_components["forecast_risk_penalty"] > 0.0
+    assert last["candidate_ranking"][0]["proposal_key"] == "risk_dwa"
+
+
+def test_forecast_risk_false_positive_suppresses_penalty() -> None:
+    """false_positive_risk=1 should cancel the forecast penalty; goal stays preferred."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal",),
+            forecast_risk_weight=10.0,
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = {
+        "status": "available",
+        "risk": 1.0,
+        "false_positive_risk": 1.0,
+    }
+    stack.plan(obs)
+    last = stack.diagnostics()["last_step"]
+    assert last["selected_proposal_key"] == "goal"
+    goal_components = last["risk_score_components"]["goal"]
+    assert goal_components["forecast_risk_penalty"] == 0.0
+    assert goal_components["forecast_risk_false_positive"] == 1.0
+    assert goal_components["forecast_risk_effective"] == 0.0
+
+
+def test_forecast_risk_unavailable_status_is_trace_visible_without_penalty() -> None:
+    """Unavailable forecast-risk payloads should be visible but non-penalizing."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal",),
+            forecast_risk_weight=10.0,
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = {"status": "unavailable", "risk": 1.0}
+    stack.plan(obs)
+    goal_components = stack.diagnostics()["last_step"]["risk_score_components"]["goal"]
+    assert goal_components["forecast_risk_available"] == 0.0
+    assert goal_components["forecast_risk_raw"] == 0.0
+    assert goal_components["forecast_risk_penalty"] == 0.0
+
+
+@pytest.mark.parametrize("payload", [{"risk": 1.0}, {"status": "", "risk": 1.0}])
+def test_forecast_risk_requires_explicit_active_status(payload: dict[str, float | str]) -> None:
+    """Missing or blank forecast-risk status should not change scoring."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal",),
+            forecast_risk_weight=10.0,
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = payload
+    stack.plan(obs)
+    goal_components = stack.diagnostics()["last_step"]["risk_score_components"]["goal"]
+    assert goal_components["forecast_risk_available"] == 0.0
+    assert goal_components["forecast_risk_raw"] == 0.0
+    assert goal_components["forecast_risk_penalty"] == 0.0
+
+
+def test_forecast_risk_trace_packet_declares_enabled_observation_key() -> None:
+    """Forecast-risk-enabled traces should declare the configured diagnostic input."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal",),
+            forecast_risk_weight=2.0,
+            forecast_risk_observation_key="my_forecast_risk",
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    stack.plan(_obs())
+    observation_contract = stack.arbitration_trace_packet()["observation_contract"]
+    assert "my_forecast_risk" in observation_contract["inference_available_features"]
+    assert observation_contract["forecast_risk_observation_key"] == "my_forecast_risk"
+    assert "" not in observation_contract["forecast_risk_active_statuses"]
+    assert "diagnostic" in observation_contract["forecast_risk_active_statuses"]
+
+
+def test_forecast_risk_build_config_parses_fields() -> None:
+    """Build config should parse forecast_risk_weight and forecast_risk_observation_key."""
+    build = build_policy_stack_v1_build_config(
+        {
+            "proposal_sources": ["goal", "risk_dwa"],
+            "forecast_risk_weight": 3.5,
+            "forecast_risk_observation_key": "my_custom_channel",
+        }
+    )
+    assert build.policy_stack.forecast_risk_weight == 3.5
+    assert build.policy_stack.forecast_risk_observation_key == "my_custom_channel"
+
+
+def test_forecast_risk_build_config_defaults() -> None:
+    """Build config should default forecast fields when absent."""
+    build = build_policy_stack_v1_build_config({"proposal_sources": ["goal"]})
+    assert build.policy_stack.forecast_risk_weight == 0.0
+    assert build.policy_stack.forecast_risk_observation_key == "forecast_risk_channel"
+
+
+def test_forecast_risk_build_config_treats_null_fields_as_defaults() -> None:
+    """Explicit null forecast-risk config values should use safe defaults."""
+    build = build_policy_stack_v1_build_config(
+        {
+            "proposal_sources": ["goal"],
+            "forecast_risk_weight": None,
+            "forecast_risk_observation_key": None,
+        }
+    )
+    assert build.policy_stack.forecast_risk_weight == 0.0
+    assert build.policy_stack.forecast_risk_observation_key == "forecast_risk_channel"
+
+
+def test_forecast_risk_diagnostics_json_safe() -> None:
+    """Diagnostics and trace packet should remain JSON-serializable with forecast risk."""
+    stack = PolicyStackV1Adapter(
+        config=PolicyStackV1Config(
+            proposal_sources=("goal",),
+            forecast_risk_weight=2.0,
+        ),
+        risk_dwa=_DummyRiskDWA(),
+    )
+    obs = _obs()
+    obs["forecast_risk_channel"] = {
+        "status": "diagnostic",
+        "risk": 0.5,
+        "occupancy_risk": 0.3,
+        "collision_relevance": 0.2,
+        "false_positive_risk": 0.1,
+        "unnecessary_stop_risk": 0.05,
+    }
+    stack.plan(obs)
+    diagnostics = stack.diagnostics()
+    goal_components = diagnostics["last_step"]["risk_score_components"]["goal"]
+    assert goal_components["forecast_risk_raw"] == 0.5
+    assert goal_components["forecast_risk_false_positive"] == 0.1
+    assert goal_components["forecast_risk_effective"] == pytest.approx(0.45)
+    packet = stack.arbitration_trace_packet()
+    json.dumps(diagnostics, allow_nan=False)
+    json.dumps(packet, allow_nan=False)

--- a/tests/validation/test_forecast_risk_policy_stack.py
+++ b/tests/validation/test_forecast_risk_policy_stack.py
@@ -1,0 +1,179 @@
+"""Tests for the forecast risk policy stack diagnostic comparison validator."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.validation import validate_forecast_risk_policy_stack as validator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestBuildReport:
+    """Structural assertions on the diagnostic report."""
+
+    def test_report_schema_version(self) -> None:
+        """Report schema version should match the module constant."""
+        report = validator.build_report()
+        assert report["schema_version"] == validator.SCHEMA_VERSION
+
+    def test_claim_boundary_is_diagnostic_only(self) -> None:
+        """Claim boundary must be diagnostic-only, not benchmark evidence."""
+        report = validator.build_report()
+        assert report["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+
+    def test_diagnostic_weight_matches_constant(self) -> None:
+        """Diagnostic weight should match the module constant."""
+        report = validator.build_report()
+        assert report["diagnostic_weight"] == validator._DIAGNOSTIC_WEIGHT
+
+    def test_case_count(self) -> None:
+        """Report should contain exactly two diagnostic cases."""
+        report = validator.build_report()
+        assert len(report["cases"]) == 2
+
+    def test_case_names(self) -> None:
+        """Both expected case names should be present."""
+        report = validator.build_report()
+        names = [c["case_name"] for c in report["cases"]]
+        assert "high_risk_diagnostic_slows_goal" in names
+        assert "false_positive_suppresses_penalty" in names
+
+
+class TestHighRiskCase:
+    """Verify the high-risk case diagnostic behavior."""
+
+    def _get_case(self) -> dict:
+        """Return the high_risk_diagnostic_slows_goal case."""
+        report = validator.build_report()
+        return next(
+            c for c in report["cases"] if c["case_name"] == "high_risk_diagnostic_slows_goal"
+        )
+
+    def test_baseline_selects_goal(self) -> None:
+        """Baseline should select goal without forecast risk penalty."""
+        case = self._get_case()
+        assert case["baseline"]["selected_proposal"] == "goal"
+
+    def test_diagnostic_penalizes_goal(self) -> None:
+        """Diagnostic scoring should apply a positive forecast penalty."""
+        case = self._get_case()
+        assert case["diagnostic"]["forecast_penalty"] > 0.0
+
+    def test_diagnostic_reduces_progress_proxy(self) -> None:
+        """Diagnostic progress proxy should not exceed baseline."""
+        case = self._get_case()
+        assert case["diagnostic"]["progress_proxy"] < case["baseline"]["progress_proxy"]
+        assert case["delta_progress_proxy"] == -0.8
+
+    def test_delta_forecast_penalty_positive(self) -> None:
+        """Delta forecast penalty should be positive for the high-risk case."""
+        case = self._get_case()
+        assert case["delta_forecast_penalty"] > 0.0
+
+
+class TestFalsePositiveCase:
+    """Verify the false-positive suppression case."""
+
+    def _get_case(self) -> dict:
+        """Return the false_positive_suppresses_penalty case."""
+        report = validator.build_report()
+        return next(
+            c for c in report["cases"] if c["case_name"] == "false_positive_suppresses_penalty"
+        )
+
+    def test_baseline_selects_goal(self) -> None:
+        """Baseline should select goal without forecast risk."""
+        case = self._get_case()
+        assert case["baseline"]["selected_proposal"] == "goal"
+
+    def test_diagnostic_suppresses_penalty(self) -> None:
+        """False positive risk=1 should suppress the forecast penalty."""
+        case = self._get_case()
+        assert case["diagnostic"]["forecast_penalty"] == 0.0
+
+    def test_diagnostic_still_selects_goal(self) -> None:
+        """With penalty suppressed, goal should remain the selected proposal."""
+        case = self._get_case()
+        assert case["diagnostic"]["selected_proposal"] == "goal"
+
+    def test_no_false_positive_unnecessary_slowdown(self) -> None:
+        """False-positive suppression should avoid unnecessary slowing."""
+        case = self._get_case()
+        assert case["false_positive_unnecessary_slowdown_count"] == 0
+        assert case["diagnostic"]["shield_stop_count"] == 0
+
+    def test_delta_forecast_penalty_zero(self) -> None:
+        """Delta should be zero when false positive suppresses the penalty."""
+        case = self._get_case()
+        assert case["delta_forecast_penalty"] == 0.0
+
+
+class TestRecommendation:
+    """Verify the recommendation field."""
+
+    def test_recommendation_is_deterministic(self) -> None:
+        """Two builds should produce the same recommendation."""
+        r1 = validator.build_report()["recommendation"]
+        r2 = validator.build_report()["recommendation"]
+        assert r1 == r2
+
+    def test_recommendation_valid_label(self) -> None:
+        """Recommendation must be one of the known diagnostic labels."""
+        valid = {
+            "forecast_risk_scoring_diagnostic_consistent",
+            "false_positive_suppression_inconsistent",
+            "high_risk_penalization_inconsistent",
+            "no_diagnostic_signal",
+            "incomplete_cases",
+        }
+        report = validator.build_report()
+        assert report["recommendation"] in valid
+
+
+class TestMainCLI:
+    """Verify the main() CLI entry point."""
+
+    def test_main_returns_zero(self) -> None:
+        """CLI should exit with code 0 on success."""
+        assert validator.main([]) == 0
+
+    def test_main_json_output(self, capsys) -> None:
+        """CLI should print JSON with summary and report keys."""
+        validator.main([])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "summary" in data
+        assert "report" in data
+        assert data["summary"]["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+
+    def test_main_writes_artifacts(self, tmp_path: Path) -> None:
+        """--out-dir should produce report.json, report.md, and summary.json."""
+        exit_code = validator.main(["--out-dir", str(tmp_path)])
+        assert exit_code == 0
+        assert (tmp_path / "report.json").exists()
+        assert (tmp_path / "report.md").exists()
+        assert (tmp_path / "summary.json").exists()
+
+    def test_main_summary_json_content(self, tmp_path: Path) -> None:
+        """summary.json should carry the diagnostic claim boundary."""
+        validator.main(["--out-dir", str(tmp_path)])
+        summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+        assert summary["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+        assert summary["false_positive_unnecessary_slowdown_count"] == 0
+        assert summary["recommendation"] in {
+            "forecast_risk_scoring_diagnostic_consistent",
+            "false_positive_suppression_inconsistent",
+            "high_risk_penalization_inconsistent",
+            "no_diagnostic_signal",
+            "incomplete_cases",
+        }
+
+    def test_main_report_md_contains_claim_boundary(self, tmp_path: Path) -> None:
+        """report.md should state the diagnostic-only claim boundary."""
+        validator.main(["--out-dir", str(tmp_path)])
+        md = (tmp_path / "report.md").read_text(encoding="utf-8")
+        assert "diagnostic_only_not_benchmark_evidence" in md
+        assert "No safety claim" in md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forecast risk weighting capability to policy stack, enabling configurable risk weight and observation parameters for decision-making
  * Added diagnostic validation tools for evaluating and comparing forecast risk behavior

* **Tests**
  * Added comprehensive test coverage for forecast risk functionality including configuration parsing, behavioral impact, and edge cases
  * Added evidence documentation for diagnostic comparison validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->