### PR TITLE
Fix shared-venv coverage isolation for worktrees

### DIFF
--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -16,6 +16,7 @@ Wrapper options:
   -h, --help       Show this help message
 
 Environment overrides:
+  COVERAGE_FILE=<path>
   PYTEST_FAST_FAIL=1|0
   PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup
   PYTEST_ORDER_MODE=failed-first|new-first|none

--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -8,6 +8,8 @@ Usage: scripts/dev/run_worktree_shared_venv.sh [options] -- <uv-run-command> [ar
 Run a targeted validation command from the current checkout while reusing a shared virtualenv.
 The helper pins imports to this worktree by prepending PYTHONPATH=$PWD and sets UV_NO_SYNC=1 so
 `uv run` does not silently resync or rewrite the shared environment.
+For linked worktrees, the helper also derives a per-worktree COVERAGE_FILE unless one is already
+set, preventing parallel focused pytest runs from sharing output/coverage/.coverage state.
 
 Options:
   --venv PATH   Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the main
@@ -79,5 +81,10 @@ fi
 export UV_PROJECT_ENVIRONMENT="$venv_path"
 export UV_NO_SYNC=1
 export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+
+if [[ -z "${COVERAGE_FILE:-}" && "$git_common_dir" != "$repo_root/.git" ]]; then
+  worktree_id="$(printf '%s' "$repo_root" | git hash-object --stdin | cut -c1-12)"
+  export COVERAGE_FILE="$repo_root/output/coverage/.coverage.${worktree_id}"
+fi
 
 exec uv run "${cmd[@]}"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -401,6 +401,20 @@ def test_worktree_shared_venv_helper_pins_current_checkout_imports() -> None:
     assert 'exec uv run "${cmd[@]}"' in script_text
 
 
+def test_worktree_shared_venv_helper_isolates_linked_worktree_coverage() -> None:
+    """Linked worktrees should not share the default coverage database."""
+    script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")
+
+    assert 'if [[ -z "${COVERAGE_FILE:-}" && "$git_common_dir" != "$repo_root/.git" ]]' in (
+        script_text
+    )
+    assert "git hash-object --stdin" in script_text
+    assert "cut -c1-12" in script_text
+    assert 'export COVERAGE_FILE="$repo_root/output/coverage/.coverage.${worktree_id}"' in (
+        script_text
+    )
+
+
 def test_worktree_shared_venv_helper_has_valid_shell_and_help() -> None:
     """The shared-venv helper should be shell-valid and document its safety boundary."""
     syntax = subprocess.run(
@@ -425,6 +439,7 @@ def test_worktree_shared_venv_helper_has_valid_shell_and_help() -> None:
     assert "PYTHONPATH=$PWD" in help_result.stdout
     assert "UV_PROJECT_ENVIRONMENT" in help_result.stdout
     assert "UV_NO_SYNC=1" in help_result.stdout
+    assert "COVERAGE_FILE" in help_result.stdout
     assert "full local .venv" in help_result.stdout
 
 
@@ -707,6 +722,7 @@ def test_run_tests_parallel_help_does_not_invoke_pytest(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     assert "Usage:" in result.stdout
+    assert "COVERAGE_FILE" in result.stdout
     assert "uv should not be called" not in result.stderr
 
 


### PR DESCRIPTION
## Summary
- derive a per-linked-worktree `COVERAGE_FILE` in `scripts/dev/run_worktree_shared_venv.sh` when no explicit override is set
- document `COVERAGE_FILE` in the shared parallel test wrapper help
- add script-contract tests for linked-worktree coverage isolation and help discoverability

Closes #2833.

## Validation
- `bash -n scripts/dev/run_worktree_shared_venv.sh && bash -n scripts/dev/run_tests_parallel.sh`
- `uv run ruff check tests/test_ci_script_contract.py`
- `uv run ruff format --check tests/test_ci_script_contract.py`
- `uv run pytest tests/test_ci_script_contract.py -q -x` -> 45 passed
- `scripts/dev/run_worktree_shared_venv.sh -- python - <<PY ...` -> emitted worktree-specific `output/coverage/.coverage.<hash>`
- `COVERAGE_FILE=/tmp/robot_sf_custom_coverage scripts/dev/run_worktree_shared_venv.sh -- python - <<PY ...` -> preserved explicit override
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 6573 passed, 9 skipped, 9 warnings

## Research Result Guidance
NA: workflow reliability fix for focused validation; no benchmark, metric, planner, or paper-facing claim.

## Downstream Propagation
NA: no research artifacts or benchmark result surfaces changed. The relevant contributor-facing helper docs are updated in the wrapper help text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test environment documentation with `COVERAGE_FILE` environment variable guidance in helper scripts.
  * Enhanced coverage isolation for parallel test runs in linked worktrees to prevent shared coverage databases.

* **Tests**
  * Added validation for coverage file isolation in linked worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->