### PR TITLE
feat: add forecast dataset recorder

### DIFF
--- a/robot_sf/benchmark/__init__.py
+++ b/robot_sf/benchmark/__init__.py
@@ -15,6 +15,13 @@ from robot_sf.benchmark.forecast_batch import (
     save_forecast_batch,
     validate_forecast_batch,
 )
+from robot_sf.benchmark.forecast_dataset_recorder import (
+    DEFAULT_FORECAST_DATASET_ID,
+    FORECAST_DATASET_SCHEMA_VERSION,
+    ForecastDatasetRecordResult,
+    record_forecast_dataset_from_trace_exports,
+    validate_forecast_dataset_manifest,
+)
 from robot_sf.benchmark.forecast_metrics import (
     FORECAST_METRICS_SCHEMA_VERSION,
     ForecastMetricRow,
@@ -43,7 +50,9 @@ from robot_sf.benchmark.helper_registry import (
 )
 
 __all__ = [
+    "DEFAULT_FORECAST_DATASET_ID",
     "FORECAST_BATCH_SCHEMA_VERSION",
+    "FORECAST_DATASET_SCHEMA_VERSION",
     "FORECAST_METRICS_SCHEMA_VERSION",
     "ActorForecast",
     "AggregationMetadataError",
@@ -52,6 +61,7 @@ __all__ = [
     "ForecastActorObservation",
     "ForecastBatch",
     "ForecastBatchProvenance",
+    "ForecastDatasetRecordResult",
     "ForecastMetricRow",
     "ForecastObservationAdapter",
     "ForecastObservationBatch",
@@ -67,7 +77,9 @@ __all__ = [
     "load_forecast_batch",
     "load_trained_policy",
     "prepare_classic_env",
+    "record_forecast_dataset_from_trace_exports",
     "run_episodes_with_recording",
     "save_forecast_batch",
     "validate_forecast_batch",
+    "validate_forecast_dataset_manifest",
 ]

--- a/robot_sf/benchmark/forecast_dataset_recorder.py
+++ b/robot_sf/benchmark/forecast_dataset_recorder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from bisect import bisect_left
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -134,6 +135,7 @@ def _build_dataset_rows(
     for trace in traces:
         trace_dict = _trace_dict_for_adapter(trace)
         dt_s = _trace_dt_s(trace)
+        frame_times = [frame.time_s for frame in trace.frames]
         for frame_index, frame in enumerate(trace.frames):
             try:
                 observed = adapter.adapt_trace(
@@ -154,6 +156,7 @@ def _build_dataset_rows(
                     start_index=frame_index,
                     horizons_s=horizons_s,
                     dt_s=dt_s,
+                    frame_times=frame_times,
                 )
                 if future_positions is None:
                     continue
@@ -314,11 +317,20 @@ def _future_positions(
     start_index: int,
     horizons_s: Sequence[float],
     dt_s: float,
+    frame_times: list[float] | None = None,
 ) -> list[list[float]] | None:
     positions: list[list[float]] = []
+    start_time = trace.frames[start_index].time_s
     for horizon_s in horizons_s:
-        target_index = start_index + round(float(horizon_s) / dt_s)
-        if target_index >= len(trace.frames):
+        if frame_times is None:
+            target_index = start_index + round(float(horizon_s) / dt_s)
+        else:
+            target_index = _nearest_frame_index(
+                frame_times,
+                target_time=start_time + float(horizon_s),
+                tolerance_s=dt_s * 0.5,
+            )
+        if target_index is None or target_index >= len(trace.frames):
             return None
         target = _pedestrian_by_id(trace.frames[target_index].pedestrians, actor_id)
         if target is None:
@@ -327,11 +339,36 @@ def _future_positions(
     return positions
 
 
+def _nearest_frame_index(
+    frame_times: Sequence[float],
+    *,
+    target_time: float,
+    tolerance_s: float,
+) -> int | None:
+    """Return the nearest frame index within tolerance of the target time."""
+    insert_at = bisect_left(frame_times, target_time)
+    candidates = []
+    if insert_at < len(frame_times):
+        candidates.append(insert_at)
+    if insert_at > 0:
+        candidates.append(insert_at - 1)
+    if not candidates:
+        return None
+    nearest = min(candidates, key=lambda index: abs(frame_times[index] - target_time))
+    if abs(frame_times[nearest] - target_time) > tolerance_s:
+        return None
+    return nearest
+
+
 def _pedestrian_by_id(
     pedestrians: Iterable[dict[str, Any]], actor_id: str
 ) -> dict[str, Any] | None:
     for pedestrian in pedestrians:
-        if str(pedestrian.get("id")) == actor_id or str(pedestrian.get("actor_id")) == actor_id:
+        pedestrian_id = pedestrian.get("id")
+        pedestrian_actor_id = pedestrian.get("actor_id")
+        if (pedestrian_id is not None and str(pedestrian_id) == actor_id) or (
+            pedestrian_actor_id is not None and str(pedestrian_actor_id) == actor_id
+        ):
             return pedestrian
     return None
 
@@ -362,17 +399,25 @@ def _validate_horizons(horizons_s: Sequence[float]) -> list[float]:
 
 def _write_jsonl(path: Path, rows: Sequence[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
-        encoding="utf-8",
-    )
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp_path.write_text(
+            "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp_path.replace(path)
+    try:
+        tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp_path.replace(path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 __all__ = [

--- a/robot_sf/benchmark/forecast_dataset_recorder.py
+++ b/robot_sf/benchmark/forecast_dataset_recorder.py
@@ -57,6 +57,7 @@ def record_forecast_dataset_from_trace_exports(
     paths = [Path(path) for path in trace_paths]
     if not paths:
         raise ValueError("trace_paths must be non-empty")
+    safe_dataset_id = _validate_dataset_id(dataset_id)
     schema = _require_feature_schema(feature_schema)
     horizons = _validate_horizons(horizons_s)
     observation_adapter = adapter or OracleFullStateForecastAdapter()
@@ -65,7 +66,7 @@ def record_forecast_dataset_from_trace_exports(
 
     output = Path(output_dir)
     output.mkdir(parents=True, exist_ok=True)
-    dataset_path = output / f"{dataset_id}.jsonl"
+    dataset_path = output / f"{safe_dataset_id}.jsonl"
     rows = _build_dataset_rows(
         traces,
         splits=splits,
@@ -81,7 +82,7 @@ def record_forecast_dataset_from_trace_exports(
         traces=traces,
         rows=rows,
         splits=splits,
-        dataset_id=dataset_id,
+        dataset_id=safe_dataset_id,
         dataset_path=dataset_path,
         output_dir=output,
         adapter=observation_adapter,
@@ -89,7 +90,7 @@ def record_forecast_dataset_from_trace_exports(
         horizons_s=horizons,
     )
     validate_forecast_dataset_manifest(manifest)
-    manifest_path = output / f"{dataset_id}.manifest.json"
+    manifest_path = output / f"{safe_dataset_id}.manifest.json"
     _atomic_write_json(manifest_path, manifest)
     return ForecastDatasetRecordResult(
         dataset_path=dataset_path,
@@ -397,14 +398,24 @@ def _validate_horizons(horizons_s: Sequence[float]) -> list[float]:
     return horizons
 
 
+def _validate_dataset_id(dataset_id: str) -> str:
+    """Return a filename-safe dataset id for artifact path construction."""
+    value = str(dataset_id).strip()
+    if not value or value in {".", ".."}:
+        raise ValueError("dataset_id is required")
+    if Path(value).name != value or "/" in value or "\\" in value:
+        raise ValueError("dataset_id must not contain path separators")
+    return value
+
+
 def _write_jsonl(path: Path, rows: Sequence[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     try:
-        tmp_path.write_text(
-            "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
-            encoding="utf-8",
-        )
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, sort_keys=True))
+                handle.write("\n")
         tmp_path.replace(path)
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/robot_sf/benchmark/forecast_dataset_recorder.py
+++ b/robot_sf/benchmark/forecast_dataset_recorder.py
@@ -132,6 +132,14 @@ def _build_dataset_rows(
     feature_schema: dict[str, Any],
     horizons_s: list[float],
 ) -> list[dict[str, Any]]:
+    """Build supervised forecast rows from traces using the requested observation adapter.
+
+    Frames without observable actors, missing future labels, or missing future actor states are
+    skipped so emitted rows always contain both model input provenance and complete labels.
+
+    Returns:
+        JSON-serializable supervised forecast rows.
+    """
     rows: list[dict[str, Any]] = []
     for trace in traces:
         trace_dict = _trace_dict_for_adapter(trace)
@@ -147,6 +155,7 @@ def _build_dataset_rows(
                     step_index=frame_index,
                 )
             except ValueError as exc:
+                # Empty observed frames are valid trace states, but not supervised examples.
                 if "actor_ids must be non-empty" in str(exc):
                     continue
                 raise
@@ -160,6 +169,7 @@ def _build_dataset_rows(
                     frame_times=frame_times,
                 )
                 if future_positions is None:
+                    # Drop rows that cannot provide a complete label at every requested horizon.
                     continue
                 rows.append(
                     {
@@ -320,6 +330,11 @@ def _future_positions(
     dt_s: float,
     frame_times: list[float] | None = None,
 ) -> list[list[float]] | None:
+    """Return complete future actor positions or None when any horizon lacks a label.
+
+    When frame timestamps are supplied, targets use nearest-frame lookup within half a nominal
+    step, which keeps labels robust to minor trace timing irregularity without extrapolation.
+    """
     positions: list[list[float]] = []
     start_time = trace.frames[start_index].time_s
     for horizon_s in horizons_s:

--- a/robot_sf/benchmark/forecast_dataset_recorder.py
+++ b/robot_sf/benchmark/forecast_dataset_recorder.py
@@ -1,0 +1,384 @@
+"""Forecast dataset recorder and split manifest helpers."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from itertools import pairwise
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SimulationTraceExport,
+    load_simulation_trace_export,
+)
+from robot_sf.benchmark.forecast_observation_adapters import (
+    ForecastObservationAdapter,
+    OracleFullStateForecastAdapter,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+FORECAST_DATASET_SCHEMA_VERSION = "forecast_dataset.v1"
+DEFAULT_FORECAST_DATASET_ID = "forecast_dataset_smoke_v1"
+SPLIT_NAMES = ("train", "validation", "test")
+
+
+@dataclass(frozen=True)
+class ForecastDatasetRecordResult:
+    """Paths and manifest payload produced by a forecast dataset recording run."""
+
+    dataset_path: Path
+    manifest_path: Path
+    manifest: dict[str, Any]
+
+
+def record_forecast_dataset_from_trace_exports(
+    trace_paths: Sequence[Path | str],
+    output_dir: Path | str,
+    *,
+    adapter: ForecastObservationAdapter | None = None,
+    feature_schema: dict[str, Any],
+    horizons_s: Sequence[float] = (0.5, 1.0),
+    dataset_id: str = DEFAULT_FORECAST_DATASET_ID,
+) -> ForecastDatasetRecordResult:
+    """Record forecast examples and a split manifest from trace exports.
+
+    Returns:
+        Paths and manifest payload for the generated dataset.
+    """
+
+    paths = [Path(path) for path in trace_paths]
+    if not paths:
+        raise ValueError("trace_paths must be non-empty")
+    schema = _require_feature_schema(feature_schema)
+    horizons = _validate_horizons(horizons_s)
+    observation_adapter = adapter or OracleFullStateForecastAdapter()
+    traces = [load_simulation_trace_export(path) for path in paths]
+    splits = _assign_trace_splits(traces)
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    dataset_path = output / f"{dataset_id}.jsonl"
+    rows = _build_dataset_rows(
+        traces,
+        splits=splits,
+        adapter=observation_adapter,
+        feature_schema=schema,
+        horizons_s=horizons,
+    )
+    if not rows:
+        raise ValueError("no forecast dataset rows were produced")
+    _write_jsonl(dataset_path, rows)
+
+    manifest = _build_manifest(
+        traces=traces,
+        rows=rows,
+        splits=splits,
+        dataset_id=dataset_id,
+        dataset_path=dataset_path,
+        output_dir=output,
+        adapter=observation_adapter,
+        feature_schema=schema,
+        horizons_s=horizons,
+    )
+    validate_forecast_dataset_manifest(manifest)
+    manifest_path = output / f"{dataset_id}.manifest.json"
+    _atomic_write_json(manifest_path, manifest)
+    return ForecastDatasetRecordResult(
+        dataset_path=dataset_path,
+        manifest_path=manifest_path,
+        manifest=manifest,
+    )
+
+
+def validate_forecast_dataset_manifest(payload: dict[str, Any]) -> None:
+    """Validate manifest structure and split leakage constraints."""
+
+    if payload.get("schema_version") != FORECAST_DATASET_SCHEMA_VERSION:
+        raise ValueError("schema_version must be forecast_dataset.v1")
+    if not str(payload.get("dataset_id", "")).strip():
+        raise ValueError("dataset_id is required")
+    if int(payload.get("example_count", 0)) <= 0:
+        raise ValueError("example_count must be positive")
+    splits = payload.get("splits")
+    if not isinstance(splits, dict):
+        raise ValueError("splits must be a mapping")
+    missing_splits = set(SPLIT_NAMES) - set(splits)
+    if missing_splits:
+        raise ValueError(f"splits missing required keys: {sorted(missing_splits)}")
+    _validate_disjoint_split_values(splits, "scenario_ids")
+    _validate_disjoint_split_values(splits, "scenario_seed_keys")
+    examples_path = payload.get("examples_path")
+    if not isinstance(examples_path, str) or not examples_path.strip():
+        raise ValueError("examples_path is required")
+    feature_schema = payload.get("feature_schema")
+    if not isinstance(feature_schema, dict) or not feature_schema:
+        raise ValueError("feature_schema is required")
+
+
+def _build_dataset_rows(
+    traces: Sequence[SimulationTraceExport],
+    *,
+    splits: dict[str, str],
+    adapter: ForecastObservationAdapter,
+    feature_schema: dict[str, Any],
+    horizons_s: list[float],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for trace in traces:
+        trace_dict = _trace_dict_for_adapter(trace)
+        dt_s = _trace_dt_s(trace)
+        for frame_index, frame in enumerate(trace.frames):
+            try:
+                observed = adapter.adapt_trace(
+                    trace_dict,
+                    feature_schema=feature_schema,
+                    horizons_s=horizons_s,
+                    dt_s=dt_s,
+                    step_index=frame_index,
+                )
+            except ValueError as exc:
+                if "actor_ids must be non-empty" in str(exc):
+                    continue
+                raise
+            for actor in observed.actors:
+                future_positions = _future_positions(
+                    trace,
+                    actor_id=actor.actor_id,
+                    start_index=frame_index,
+                    horizons_s=horizons_s,
+                    dt_s=dt_s,
+                )
+                if future_positions is None:
+                    continue
+                rows.append(
+                    {
+                        "schema_version": "forecast_dataset_row.v1",
+                        "dataset_role": "supervised_forecast_example",
+                        "trace_id": trace.trace_id,
+                        "episode_id": trace.source.episode_id,
+                        "scenario_id": trace.source.scenario_id,
+                        "map_id": trace.source.scenario_id,
+                        "map_id_source": "simulation_trace_export.source.scenario_id",
+                        "seed": trace.source.seed,
+                        "planner_id": trace.source.planner_id,
+                        "split": splits[trace.trace_id],
+                        "frame_step": frame.step,
+                        "frame_time_s": frame.time_s,
+                        "actor_id": actor.actor_id,
+                        "actor_type": actor.state.actor_type,
+                        "observation_tier": observed.provenance.observation_tier,
+                        "oracle_state": observed.provenance.oracle_state,
+                        "feature_schema": feature_schema,
+                        "dt_s": observed.provenance.dt_s,
+                        "horizons_s": list(observed.provenance.horizons_s),
+                        "input": {
+                            "position_m": actor.state.position.astype(float).tolist(),
+                            "velocity_mps": actor.state.velocity.astype(float).tolist(),
+                        },
+                        "label": {
+                            "future_positions_m": future_positions,
+                            "source": "simulation_trace_export.pedestrians",
+                        },
+                    }
+                )
+    return rows
+
+
+def _build_manifest(  # noqa: PLR0913
+    *,
+    traces: Sequence[SimulationTraceExport],
+    rows: Sequence[dict[str, Any]],
+    splits: dict[str, str],
+    dataset_id: str,
+    dataset_path: Path,
+    output_dir: Path,
+    adapter: ForecastObservationAdapter,
+    feature_schema: dict[str, Any],
+    horizons_s: list[float],
+) -> dict[str, Any]:
+    rows_by_split: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    traces_by_split: dict[str, list[SimulationTraceExport]] = defaultdict(list)
+    for row in rows:
+        rows_by_split[str(row["split"])].append(row)
+    for trace in traces:
+        traces_by_split[splits[trace.trace_id]].append(trace)
+
+    return {
+        "schema_version": FORECAST_DATASET_SCHEMA_VERSION,
+        "dataset_id": dataset_id,
+        "created_at_utc": datetime.now(UTC).isoformat(),
+        "examples_path": str(dataset_path.relative_to(output_dir)),
+        "example_count": len(rows),
+        "observation_tiers": [adapter.observation_tier],
+        "oracle_state": adapter.oracle_state,
+        "feature_schema": feature_schema,
+        "horizons_s": horizons_s,
+        "split_policy": {
+            "strategy": "deterministic_trace_order",
+            "leakage_prevention": ["scenario_ids", "scenario_seed_keys"],
+            "split_names": list(SPLIT_NAMES),
+        },
+        "source_traces": [_trace_manifest_entry(trace, splits[trace.trace_id]) for trace in traces],
+        "splits": {
+            split: _split_manifest_entry(rows_by_split[split], traces_by_split[split])
+            for split in SPLIT_NAMES
+        },
+    }
+
+
+def _assign_trace_splits(traces: Sequence[SimulationTraceExport]) -> dict[str, str]:
+    """Assign traces to deterministic train/validation/test splits.
+
+    Returns:
+        Mapping from trace id to split name.
+    """
+
+    ordered = sorted(traces, key=lambda trace: trace.trace_id)
+    if len({trace.trace_id for trace in ordered}) != len(ordered):
+        raise ValueError("trace_id values must be unique")
+    if len(ordered) == 1:
+        split_sequence = ["train"]
+    elif len(ordered) == 2:
+        split_sequence = ["train", "validation"]
+    else:
+        split_sequence = ["train"] * (len(ordered) - 2) + ["validation", "test"]
+    return {trace.trace_id: split for trace, split in zip(ordered, split_sequence, strict=True)}
+
+
+def _split_manifest_entry(
+    rows: Sequence[dict[str, Any]],
+    traces: Sequence[SimulationTraceExport],
+) -> dict[str, Any]:
+    scenario_ids = sorted({trace.source.scenario_id for trace in traces})
+    seeds = sorted({trace.source.seed for trace in traces})
+    scenario_seed_keys = sorted(
+        f"{trace.source.scenario_id}:{trace.source.seed}" for trace in traces
+    )
+    return {
+        "example_count": len(rows),
+        "trace_count": len(traces),
+        "trace_ids": sorted(trace.trace_id for trace in traces),
+        "scenario_ids": scenario_ids,
+        "seeds": seeds,
+        "scenario_seed_keys": scenario_seed_keys,
+    }
+
+
+def _trace_manifest_entry(trace: SimulationTraceExport, split: str) -> dict[str, Any]:
+    return {
+        "trace_id": trace.trace_id,
+        "split": split,
+        "scenario_id": trace.source.scenario_id,
+        "map_id": trace.source.scenario_id,
+        "map_id_source": "simulation_trace_export.source.scenario_id",
+        "seed": trace.source.seed,
+        "planner_id": trace.source.planner_id,
+        "episode_id": trace.source.episode_id,
+        "frame_count": len(trace.frames),
+    }
+
+
+def _validate_disjoint_split_values(splits: dict[str, Any], field: str) -> None:
+    seen: dict[str, str] = {}
+    for split in SPLIT_NAMES:
+        values = splits.get(split, {}).get(field, [])
+        if not isinstance(values, list):
+            raise ValueError(f"splits.{split}.{field} must be a list")
+        for value in values:
+            key = str(value)
+            previous = seen.get(key)
+            if previous is not None and previous != split:
+                raise ValueError(f"{field} leakage across splits: {key}")
+            seen[key] = split
+
+
+def _trace_dict_for_adapter(trace: SimulationTraceExport) -> dict[str, Any]:
+    return {
+        "scenario_id": trace.source.scenario_id,
+        "seed": trace.source.seed,
+        "frames": [asdict(frame) for frame in trace.frames],
+    }
+
+
+def _future_positions(
+    trace: SimulationTraceExport,
+    *,
+    actor_id: str,
+    start_index: int,
+    horizons_s: Sequence[float],
+    dt_s: float,
+) -> list[list[float]] | None:
+    positions: list[list[float]] = []
+    for horizon_s in horizons_s:
+        target_index = start_index + round(float(horizon_s) / dt_s)
+        if target_index >= len(trace.frames):
+            return None
+        target = _pedestrian_by_id(trace.frames[target_index].pedestrians, actor_id)
+        if target is None:
+            return None
+        positions.append(np.asarray(target["position"], dtype=float).tolist())
+    return positions
+
+
+def _pedestrian_by_id(
+    pedestrians: Iterable[dict[str, Any]], actor_id: str
+) -> dict[str, Any] | None:
+    for pedestrian in pedestrians:
+        if str(pedestrian.get("id")) == actor_id or str(pedestrian.get("actor_id")) == actor_id:
+            return pedestrian
+    return None
+
+
+def _trace_dt_s(trace: SimulationTraceExport) -> float:
+    if len(trace.frames) < 2:
+        return 0.1
+    dt_s = trace.frames[1].time_s - trace.frames[0].time_s
+    return float(dt_s) if dt_s > 0.0 else 0.1
+
+
+def _require_feature_schema(feature_schema: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(feature_schema, dict) or not feature_schema:
+        raise ValueError("feature_schema is required")
+    return {str(key): value for key, value in feature_schema.items()}
+
+
+def _validate_horizons(horizons_s: Sequence[float]) -> list[float]:
+    horizons = [float(value) for value in horizons_s]
+    if not horizons:
+        raise ValueError("horizons_s must be non-empty")
+    if any(value <= 0.0 for value in horizons):
+        raise ValueError("horizons_s values must be positive")
+    if any(later <= earlier for earlier, later in pairwise(horizons)):
+        raise ValueError("horizons_s values must be strictly increasing")
+    return horizons
+
+
+def _write_jsonl(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+
+
+__all__ = [
+    "DEFAULT_FORECAST_DATASET_ID",
+    "FORECAST_DATASET_SCHEMA_VERSION",
+    "ForecastDatasetRecordResult",
+    "record_forecast_dataset_from_trace_exports",
+    "validate_forecast_dataset_manifest",
+]

--- a/scripts/benchmark/record_forecast_dataset.py
+++ b/scripts/benchmark/record_forecast_dataset.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Record a tiny ForecastDataset.v1 artifact from simulation trace exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.forecast_dataset_recorder import (
+    DEFAULT_FORECAST_DATASET_ID,
+    record_forecast_dataset_from_trace_exports,
+)
+
+
+def main() -> None:
+    """Run the forecast dataset recorder CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", nargs="+", type=Path, help="simulation_trace_export.v1 JSON files")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--dataset-id", default=DEFAULT_FORECAST_DATASET_ID)
+    parser.add_argument(
+        "--feature-schema-name",
+        default="forecast_dataset_recorder_oracle_state_v1",
+    )
+    parser.add_argument("--horizon-s", type=float, action="append")
+    args = parser.parse_args()
+
+    result = record_forecast_dataset_from_trace_exports(
+        args.trace,
+        args.output_dir,
+        dataset_id=args.dataset_id,
+        feature_schema={
+            "name": args.feature_schema_name,
+            "features": ["position_m", "velocity_mps"],
+        },
+        horizons_s=args.horizon_s or [0.1],
+    )
+    print(
+        json.dumps(
+            {
+                "dataset_path": str(result.dataset_path),
+                "manifest_path": str(result.manifest_path),
+                "example_count": result.manifest["example_count"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/test_forecast_dataset_recorder.py
+++ b/tests/benchmark/test_forecast_dataset_recorder.py
@@ -12,6 +12,7 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
 )
 from robot_sf.benchmark.forecast_dataset_recorder import (
     FORECAST_DATASET_SCHEMA_VERSION,
+    _pedestrian_by_id,
     record_forecast_dataset_from_trace_exports,
     validate_forecast_dataset_manifest,
 )
@@ -176,3 +177,33 @@ def test_recorder_rows_use_trace_source_metadata(tmp_path: Path) -> None:
     assert first_row["seed"] == trace.source.seed
     assert first_row["planner_id"] == trace.source.planner_id
     assert first_row["episode_id"] == trace.source.episode_id
+
+
+def test_recorder_uses_nearest_timestamp_for_irregular_frame_spacing(tmp_path: Path) -> None:
+    """Future labels should align by time instead of assuming constant frame indexes."""
+    payload = load_simulation_trace_export(TRACE_FIXTURES[0]).to_dict()
+    payload["frames"].append(dict(payload["frames"][1]))
+    payload["frames"][1]["step"] = 1
+    payload["frames"][1]["time_s"] = 0.07
+    payload["frames"][1]["pedestrians"][0]["position"] = [7.0, 0.0]
+    payload["frames"][2]["step"] = 2
+    payload["frames"][2]["time_s"] = 0.1
+    payload["frames"][2]["pedestrians"][0]["position"] = [10.0, 0.0]
+    path = tmp_path / "irregular_trace.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    result = record_forecast_dataset_from_trace_exports(
+        [path],
+        tmp_path,
+        feature_schema=_feature_schema(),
+        horizons_s=[0.1],
+    )
+    first_row = json.loads(result.dataset_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert first_row["label"]["future_positions_m"] == [[10.0, 0.0]]
+
+
+def test_pedestrian_lookup_does_not_match_missing_ids_to_none_actor_id() -> None:
+    """Missing target ids should not stringify to a false actor-id match."""
+    assert _pedestrian_by_id([{"position": [0.0, 0.0]}], "None") is None
+    assert _pedestrian_by_id([{"id": 0, "position": [0.0, 0.0]}], "0") is not None

--- a/tests/benchmark/test_forecast_dataset_recorder.py
+++ b/tests/benchmark/test_forecast_dataset_recorder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 
@@ -182,7 +183,7 @@ def test_recorder_rows_use_trace_source_metadata(tmp_path: Path) -> None:
 def test_recorder_uses_nearest_timestamp_for_irregular_frame_spacing(tmp_path: Path) -> None:
     """Future labels should align by time instead of assuming constant frame indexes."""
     payload = load_simulation_trace_export(TRACE_FIXTURES[0]).to_dict()
-    payload["frames"].append(dict(payload["frames"][1]))
+    payload["frames"].append(copy.deepcopy(payload["frames"][1]))
     payload["frames"][1]["step"] = 1
     payload["frames"][1]["time_s"] = 0.07
     payload["frames"][1]["pedestrians"][0]["position"] = [7.0, 0.0]
@@ -207,3 +208,15 @@ def test_pedestrian_lookup_does_not_match_missing_ids_to_none_actor_id() -> None
     """Missing target ids should not stringify to a false actor-id match."""
     assert _pedestrian_by_id([{"position": [0.0, 0.0]}], "None") is None
     assert _pedestrian_by_id([{"id": 0, "position": [0.0, 0.0]}], "0") is not None
+
+
+def test_recorder_rejects_dataset_id_path_separators(tmp_path: Path) -> None:
+    """Dataset ids should never be able to steer artifact paths outside output_dir."""
+    with pytest.raises(ValueError, match="dataset_id"):
+        record_forecast_dataset_from_trace_exports(
+            TRACE_FIXTURES[:1],
+            tmp_path,
+            feature_schema=_feature_schema(),
+            horizons_s=[0.1],
+            dataset_id="../forecast_dataset_escape",
+        )

--- a/tests/benchmark/test_forecast_dataset_recorder.py
+++ b/tests/benchmark/test_forecast_dataset_recorder.py
@@ -1,0 +1,178 @@
+"""Tests for ForecastDataset.v1 recording and split manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    load_simulation_trace_export,
+)
+from robot_sf.benchmark.forecast_dataset_recorder import (
+    FORECAST_DATASET_SCHEMA_VERSION,
+    record_forecast_dataset_from_trace_exports,
+    validate_forecast_dataset_manifest,
+)
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+)
+TRACE_FIXTURES = [
+    FIXTURE_ROOT / "minimal_trace.json",
+]
+
+
+def _feature_schema() -> dict[str, object]:
+    return {
+        "name": "forecast_dataset_recorder_test_v1",
+        "features": ["position_m", "velocity_mps"],
+    }
+
+
+def _write_trace_copy(tmp_path: Path, index: int) -> Path:
+    """Write a valid trace fixture copy with distinct split metadata."""
+    payload = load_simulation_trace_export(TRACE_FIXTURES[0]).to_dict()
+    payload["trace_id"] = f"fixture_trace_{index:03d}"
+    payload["source"]["scenario_id"] = f"fixture_scenario_{index:03d}"
+    payload["source"]["seed"] = index
+    payload["source"]["episode_id"] = f"fixture_episode_{index:03d}"
+    path = tmp_path / f"fixture_trace_{index:03d}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_record_forecast_dataset_writes_jsonl_and_manifest(tmp_path: Path) -> None:
+    """A tiny durable trace set should produce rows plus a validated manifest."""
+    result = record_forecast_dataset_from_trace_exports(
+        TRACE_FIXTURES[:1],
+        tmp_path,
+        feature_schema=_feature_schema(),
+        horizons_s=[0.1],
+        dataset_id="forecast_dataset_test",
+    )
+
+    assert result.dataset_path.exists()
+    assert result.manifest_path.exists()
+    assert result.manifest["schema_version"] == FORECAST_DATASET_SCHEMA_VERSION
+    assert result.manifest["example_count"] > 0
+    rows = [
+        json.loads(line) for line in result.dataset_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert rows[0]["observation_tier"] == "oracle_full_state"
+    assert rows[0]["oracle_state"] is True
+    assert rows[0]["map_id"] == rows[0]["scenario_id"]
+    assert rows[0]["map_id_source"] == "simulation_trace_export.source.scenario_id"
+    assert rows[0]["feature_schema"]["name"] == "forecast_dataset_recorder_test_v1"
+    assert rows[0]["label"]["source"] == "simulation_trace_export.pedestrians"
+
+
+def test_record_forecast_dataset_manifest_has_train_validation_test_splits(
+    tmp_path: Path,
+) -> None:
+    """Split metadata should expose all three split names without leakage."""
+    result = record_forecast_dataset_from_trace_exports(
+        [_write_trace_copy(tmp_path, index) for index in range(3)],
+        tmp_path,
+        feature_schema=_feature_schema(),
+        horizons_s=[0.1],
+        dataset_id="forecast_dataset_split_test",
+    )
+
+    validate_forecast_dataset_manifest(result.manifest)
+    assert set(result.manifest["splits"]) == {"train", "validation", "test"}
+    split_trace_counts = {
+        split: payload["trace_count"] for split, payload in result.manifest["splits"].items()
+    }
+    assert split_trace_counts["train"] >= 1
+    assert split_trace_counts["validation"] == 1
+    assert split_trace_counts["test"] == 1
+
+
+def test_validate_manifest_rejects_scenario_leakage() -> None:
+    """A scenario cannot appear in more than one split."""
+    manifest = {
+        "schema_version": FORECAST_DATASET_SCHEMA_VERSION,
+        "dataset_id": "leaky",
+        "example_count": 2,
+        "examples_path": "leaky.jsonl",
+        "feature_schema": _feature_schema(),
+        "splits": {
+            "train": {
+                "scenario_ids": ["same"],
+                "scenario_seed_keys": ["same:1"],
+            },
+            "validation": {
+                "scenario_ids": ["same"],
+                "scenario_seed_keys": ["same:2"],
+            },
+            "test": {
+                "scenario_ids": [],
+                "scenario_seed_keys": [],
+            },
+        },
+    }
+
+    with pytest.raises(ValueError, match="scenario_ids leakage"):
+        validate_forecast_dataset_manifest(manifest)
+
+
+def test_validate_manifest_rejects_scenario_seed_leakage() -> None:
+    """A scenario/seed key cannot appear in more than one split."""
+    manifest = {
+        "schema_version": FORECAST_DATASET_SCHEMA_VERSION,
+        "dataset_id": "leaky-seed",
+        "example_count": 2,
+        "examples_path": "leaky.jsonl",
+        "feature_schema": _feature_schema(),
+        "splits": {
+            "train": {
+                "scenario_ids": ["a"],
+                "scenario_seed_keys": ["a:1"],
+            },
+            "validation": {
+                "scenario_ids": ["b"],
+                "scenario_seed_keys": ["a:1"],
+            },
+            "test": {
+                "scenario_ids": [],
+                "scenario_seed_keys": [],
+            },
+        },
+    }
+
+    with pytest.raises(ValueError, match="scenario_seed_keys leakage"):
+        validate_forecast_dataset_manifest(manifest)
+
+
+def test_recorder_rejects_missing_feature_schema(tmp_path: Path) -> None:
+    """Dataset rows must not be emitted without feature-schema provenance."""
+    with pytest.raises(ValueError, match="feature_schema is required"):
+        record_forecast_dataset_from_trace_exports(
+            TRACE_FIXTURES[:1],
+            tmp_path,
+            feature_schema={},
+            horizons_s=[0.1],
+        )
+
+
+def test_recorder_rows_use_trace_source_metadata(tmp_path: Path) -> None:
+    """Rows should preserve scenario, seed, planner, and episode metadata."""
+    result = record_forecast_dataset_from_trace_exports(
+        [TRACE_FIXTURES[0]],
+        tmp_path,
+        feature_schema=_feature_schema(),
+        horizons_s=[0.1],
+    )
+    trace = load_simulation_trace_export(TRACE_FIXTURES[0])
+    first_row = json.loads(result.dataset_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert first_row["scenario_id"] == trace.source.scenario_id
+    assert first_row["map_id"] == trace.source.scenario_id
+    assert first_row["seed"] == trace.source.seed
+    assert first_row["planner_id"] == trace.source.planner_id
+    assert first_row["episode_id"] == trace.source.episode_id


### PR DESCRIPTION
## Summary
Adds a `ForecastDataset.v1` recorder that turns `simulation_trace_export.v1` traces into supervised forecast JSONL rows plus a split/leakage manifest.

## Linked Issues
- Closes #2839
- Relates to #2835
- Relates to #2838

## Stack / Dependency
- Base dependency: PR #2860 / `origin/main`
- Required prior PRs: #2860
- Stack follow-up issues: #2835
- Safe to review independently: yes
- Review dependency reason, if any: uses the observation-tier adapter API added by #2860.

## What Changed
- Added `robot_sf.benchmark.forecast_dataset_recorder` with JSONL row recording, manifest writing, split assignment, and leakage validation.
- Added `scripts/benchmark/record_forecast_dataset.py` for a tiny reproducible trace-fixture smoke command.
- Exported recorder symbols from `robot_sf.benchmark`.
- Added tests for dataset/manifest writes, train/validation/test split metadata, scenario and scenario/seed leakage rejection, feature-schema fail-closed behavior, and source metadata preservation.

## Why It Matters
- Added value: forecast datasets now carry observation tier, feature schema, actor/source metadata, and split provenance before learned-predictor work begins.
- Expected impact: reduces leakage and oracle/deployable confusion in later prediction-lane experiments.
- Why this is worth merging now: it provides the small recorder contract needed before learned predictors or transferability studies consume forecast examples.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for auditable forecast dataset/split provenance under #2835.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: recorder must produce a fixture-backed JSONL/manifest and fail closed on split leakage.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2835 prediction lane.
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper; representative use is the fixture-backed CLI smoke listed below.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? NA - data recorder/provenance helper.
- Did the scenario actually contain the targeted failure mode? yes, tests inject split leakage and missing feature-schema cases.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for the contract smoke.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable large dataset is added; smoke artifacts remain ignored under `output/`.
- Stop / revise / continue decision: continue to downstream forecast dataset consumption.
- Proposed child issue or existing follow-up: #2835.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_forecast_dataset_recorder.py -q`
  - `ruff check robot_sf/benchmark/forecast_dataset_recorder.py tests/benchmark/test_forecast_dataset_recorder.py scripts/benchmark/record_forecast_dataset.py robot_sf/benchmark/__init__.py`
  - `uv run pytest tests/benchmark/test_forecast_dataset_recorder.py tests/benchmark/test_forecast_observation_adapters.py -q`
  - `uv run python scripts/benchmark/record_forecast_dataset.py tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --output-dir output/issue_2839_forecast_dataset_smoke --dataset-id issue_2839_smoke --horizon-s 0.1`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed; CLI smoke wrote one JSONL example and a manifest with oracle tier, feature schema, split metadata, source trace metadata, and scenario-derived `map_id`.
- Benchmarks or smoke tests, if applicable: full PR readiness passed with `6592 passed, 9 skipped`; changed-file coverage warning was 86.3% for the new recorder module.

## Risks / Rollout
- Compatibility risks: `map_id` is a scenario-derived proxy because `simulation_trace_export.v1` has no separate map field.
- Failure modes: default library adapter is oracle/full-state; deployable tracked datasets must pass a tracked adapter explicitly.
- Rollback or fallback plan: remove the recorder module, CLI, exports, and tests; existing ForecastBatch/trace export behavior is otherwise untouched.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: split leakage is checked by scenario id and scenario/seed key; rows preserve observation tier and oracle-state fields.
- Any assumptions that need to be preserved: worktree-local `output/` smoke artifacts are not durable dependencies.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #2839.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a recorder/provenance support helper, not a benchmark result.

## Follow-Up Issues
- Deferred work: broader deployable sensor adapters and durable large dataset publication remain out of scope.
- Issues opened for follow-up: none; downstream work remains under #2835.

## Reviewer Notes
- Anything a reviewer should verify closely: the `map_id` proxy choice and default oracle/full-state adapter behavior.
- Any known limitations: CLI default horizon is `0.1s` so the tiny committed fixture produces a row; longer horizons should be passed explicitly for real datasets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added forecast dataset recorder to convert simulation trace exports into structured JSONL datasets with validation manifests capturing schema metadata and split assignments.
  * Added CLI script for recording forecast datasets from simulation trace files.

* **Tests**
  * Added comprehensive tests for forecast dataset recording, manifest validation, and split generation without data leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->