### PR TITLE
feat: add compact queue snapshot modes

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -164,11 +164,15 @@ Before each phase, run a delegation checkpoint:
   queue scout, PR blocker reviewer, bounded editor, validation verifier, CI wait monitor, or
   discovery scout.
 - Before broad issue or PR queue review, prefer compact parent-thread snapshots:
-  `uv run python scripts/dev/snapshot_issue_batch.py <first> <last> --json` for issue batches and
-  `uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json` for PR headline
-  state. Apply `uv run python scripts/dev/pr_loop_policy.py --snapshot <queue.json> --json` for
-  machine-checkable state classification and next-action decisions under a loop budget. Use `--capsule-dir <private-artifact-dir>` when an implementation worker should receive a
-  bounded issue context capsule instead of rediscovering files with broad search.
+  `uv run python scripts/dev/snapshot_issue_batch.py --claimable --limit <n> --json` for a
+  no-arg next-issue queue, `uv run python scripts/dev/snapshot_issue_batch.py <first> <last> --json`
+  for explicit issue batches, `uv run python scripts/dev/snapshot_pr_queue.py --active --limit <n>
+  --json` for the active PR queue, and `uv run python scripts/dev/snapshot_pr_queue.py --prs <pr>
+  [<pr> ...] --json` for explicit PR headline state. Apply
+  `uv run python scripts/dev/pr_loop_policy.py --snapshot <queue.json> --json` for
+  machine-checkable state classification and next-action decisions under a loop budget. Use
+  `--capsule-dir <private-artifact-dir>` when an implementation worker should receive a bounded
+  issue context capsule instead of rediscovering files with broad search.
 - For optional discovery scouts, default to a short hard timeout (120-180s) and require periodic
   evidence in the ledger. If a bounded scout emits no heartbeat within one timeout slice, treat it as
   incomplete and retry with an explicit local timeout + heartbeat plan.
@@ -258,11 +262,13 @@ uv run python scripts/dev/compact_worktree_snapshot.py --filter <issue-or-branch
 uv run python scripts/dev/compact_ci_snapshot.py <pr> [<pr> ...] \
   --expected-head-sha <sha> --json [--include-drift]
 
-# Compact issue batch snapshot with context capsules
+# Compact no-arg next-issue queue and explicit issue batch snapshots
+uv run python scripts/dev/snapshot_issue_batch.py --claimable --limit <n> --json
 uv run python scripts/dev/snapshot_issue_batch.py <first> <last> \
   --json --capsule-dir <artifact-dir>
 
-# Compact PR queue snapshot (headline state, next action)
+# Compact active PR queue and explicit PR headline snapshots
+uv run python scripts/dev/snapshot_pr_queue.py --active --limit <n> --json
 uv run python scripts/dev/snapshot_pr_queue.py --prs <pr> [<pr> ...] --json
 
 # Machine-checkable PR loop policy (state + next action under budget)

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -13,8 +13,19 @@ from typing import Any
 from scripts.dev.issue_claim import status_issue
 
 BODY_EXCERPT_CHARS = 300
+DEFAULT_CLAIMABLE_LIMIT = 20
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 DEFAULT_REMOTE = "origin"
+UNCLAIMABLE_LABELS = {
+    "blocked",
+    "decision-required",
+    "duplicate",
+    "invalid",
+    "state:blocked",
+    "state:hold",
+    "state:running",
+    "wontfix",
+}
 
 
 def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -51,6 +62,24 @@ def _assignees(issue: dict[str, Any]) -> list[str]:
         for user in issue.get("assignees", [])
         if isinstance(user, dict) and user.get("login")
     )
+
+
+def _issue_classification(
+    *,
+    assignees: list[str],
+    claim: dict[str, Any],
+    labels: list[str],
+) -> tuple[str, str]:
+    """Return a short claimability classification and rationale."""
+    if assignees:
+        return "assigned", "assigned; skip auto-claim"
+    if any(label in UNCLAIMABLE_LABELS for label in labels):
+        return "blocked_label", "label suggests skip in autonomous claim mode"
+    if claim.get("ok") is False:
+        return "claim_unknown", "unable to read claim state"
+    if claim.get("claimed"):
+        return "claimed", "already claimed by another worker"
+    return "claimable", "open, unassigned, and unclaimed"
 
 
 def _body_excerpt(body: Any, *, limit: int) -> tuple[str, bool]:
@@ -96,8 +125,14 @@ def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict
     except json.JSONDecodeError as exc:
         return {"number": number, "status": "error", "error": f"invalid gh JSON: {exc}"}
     labels = _labels(issue)
-    excerpt, truncated = _body_excerpt(issue.get("body"), limit=body_limit)
+    assignees = _assignees(issue)
     claim = status_issue(number, remote=remote)
+    classification, reason = _issue_classification(
+        assignees=assignees,
+        claim=claim,
+        labels=labels,
+    )
+    excerpt, truncated = _body_excerpt(issue.get("body"), limit=body_limit)
     return {
         "number": issue.get("number", number),
         "status": "ok",
@@ -105,7 +140,7 @@ def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict
         "state": issue.get("state", ""),
         "url": issue.get("url", ""),
         "labels": labels,
-        "assignees": _assignees(issue),
+        "assignees": assignees,
         "body_excerpt": excerpt,
         "body_truncated": truncated,
         "claim": {
@@ -114,10 +149,121 @@ def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict
             "claim_ref": claim.get("claim_ref"),
             "sha": claim.get("sha"),
         },
+        "classification": classification,
+        "reason": reason,
         "linked_prs": [],
         "recommended_context_pack": _recommended_context_pack(
             int(issue.get("number", number)), labels, str(issue.get("title", ""))
         ),
+    }
+
+
+def _snapshot_from_issue_list(issue: dict[str, Any], *, remote: str) -> dict[str, Any]:
+    """Build an issue snapshot using preloaded issue fields."""
+    try:
+        number = int(issue.get("number"))
+    except (TypeError, ValueError):
+        return {"status": "error", "error": "invalid issue number in gh list payload"}
+
+    labels = _labels(issue)
+    assignees = _assignees(issue)
+    claim = status_issue(number, remote=remote)
+    classification, reason = _issue_classification(
+        assignees=assignees,
+        claim=claim,
+        labels=labels,
+    )
+    return {
+        "number": number,
+        "status": "ok",
+        "title": issue.get("title", ""),
+        "state": issue.get("state", ""),
+        "url": issue.get("url", ""),
+        "labels": labels,
+        "assignees": assignees,
+        "claim": {
+            "ok": claim.get("ok"),
+            "claimed": claim.get("claimed"),
+            "claim_ref": claim.get("claim_ref"),
+            "sha": claim.get("sha"),
+        },
+        "body_excerpt": "",
+        "body_truncated": False,
+        "classification": classification,
+        "reason": reason,
+        "linked_prs": [],
+    }
+
+
+def snapshot_claimable_issues(
+    *, repo: str, remote: str, body_limit: int, limit: int
+) -> dict[str, Any]:
+    """Return a compact claimable/open issue snapshot."""
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,state,labels,url,assignees",
+        ]
+    )
+    if result.returncode != 0:
+        return {
+            "schema": "issue_batch_snapshot.v1",
+            "repo": repo,
+            "body_excerpt_chars": body_limit,
+            "mode": "claimable",
+            "issues": [
+                {
+                    "status": "error",
+                    "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+                }
+            ],
+        }
+    try:
+        listed = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "schema": "issue_batch_snapshot.v1",
+            "repo": repo,
+            "body_excerpt_chars": body_limit,
+            "mode": "claimable",
+            "issues": [
+                {
+                    "status": "error",
+                    "error": f"invalid gh JSON: {exc}",
+                }
+            ],
+        }
+    if not isinstance(listed, list):
+        return {
+            "schema": "issue_batch_snapshot.v1",
+            "repo": repo,
+            "body_excerpt_chars": body_limit,
+            "mode": "claimable",
+            "issues": [
+                {
+                    "status": "error",
+                    "error": "expected gh issue list JSON array",
+                }
+            ],
+        }
+
+    issues = [_snapshot_from_issue_list(issue, remote=remote) for issue in listed]
+    if body_limit <= 0:
+        body_limit = BODY_EXCERPT_CHARS
+    return {
+        "schema": "issue_batch_snapshot.v1",
+        "repo": repo,
+        "body_excerpt_chars": body_limit,
+        "mode": "claimable",
+        "issues": issues,
     }
 
 
@@ -177,11 +323,22 @@ def snapshot_issues(
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "issues", nargs="+", type=int, help="Issue numbers; two values form a range."
+        "issues", nargs="*", type=int, help="Issue numbers; two values form a range."
+    )
+    parser.add_argument(
+        "--claimable",
+        action="store_true",
+        help="Discover bounded open claimable issues without explicit issue numbers.",
     )
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--remote", default=DEFAULT_REMOTE)
     parser.add_argument("--body-chars", type=int, default=BODY_EXCERPT_CHARS)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_CLAIMABLE_LIMIT,
+        help="Limit for --claimable discovery mode.",
+    )
     parser.add_argument(
         "--capsule-dir",
         default="",
@@ -199,15 +356,35 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = _parse_args(argv)
+    if args.claimable and args.issues:
+        print(
+            "--claimable cannot be combined with explicit issue numbers",
+            file=sys.stderr,
+        )
+        return 1
     numbers = expand_issue_numbers(args.issues, expand_range=not args.no_expand_range)
     try:
-        payload = snapshot_issues(
-            numbers,
-            repo=args.repo,
-            body_limit=max(args.body_chars, 0),
-            remote=args.remote,
-            capsule_dir=args.capsule_dir,
-        )
+        if args.claimable:
+            payload = snapshot_claimable_issues(
+                repo=args.repo,
+                remote=args.remote,
+                body_limit=max(args.body_chars, 0),
+                limit=max(args.limit, 1),
+            )
+        elif args.issues:
+            payload = snapshot_issues(
+                numbers,
+                repo=args.repo,
+                body_limit=max(args.body_chars, 0),
+                remote=args.remote,
+                capsule_dir=args.capsule_dir,
+            )
+        else:
+            print(
+                "at least one issue number is required unless --claimable is used",
+                file=sys.stderr,
+            )
+            return 1
     except FileNotFoundError:
         print("gh or git command not found", file=sys.stderr)
         return 1

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -18,6 +18,7 @@ from scripts.dev.check_pr_ci_status import (
 )
 
 DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_ACTIVE_LIMIT = 20
 
 
 def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -95,6 +96,48 @@ def _next_action(*, is_draft: bool, labels: list[str], checks: dict[str, Any]) -
     return "review_for_merge_ready"
 
 
+def _attention(*, next_action: str, is_draft: bool, labels: list[str]) -> str:
+    """Return a compact attention category for queue triage."""
+    if is_draft:
+        return "draft_ready_or_review"
+    if next_action == "inspect_failing_checks":
+        return "ci_attention"
+    if next_action == "await_ci_or_start_read_only_monitor":
+        return "ci_pending"
+    if "merge-ready" in labels:
+        return "merge_attention"
+    return "review_attention"
+
+
+def _pr_payload_from_dict(
+    pr: dict[str, Any],
+    *,
+    default_number: int,
+) -> dict[str, Any]:
+    """Build a compact PR snapshot from already-loaded fields."""
+    is_draft = bool(pr.get("isDraft"))
+    labels = _labels(pr)
+    checks = _checks(pr)
+    pr_payload = {
+        "number": pr.get("number", default_number),
+        "status": "ok",
+        "title": pr.get("title", ""),
+        "state": pr.get("state", ""),
+        "draft": is_draft,
+        "url": pr.get("url", ""),
+        "labels": labels,
+        "head_branch": pr.get("headRefName", ""),
+        "head_sha": pr.get("headRefOid", ""),
+        "mergeable": pr.get("mergeable", "unknown"),
+        "checks": checks,
+        "reviews": _reviews(pr),
+    }
+    next_action = _next_action(is_draft=is_draft, labels=labels, checks=checks)
+    pr_payload["next_action"] = next_action
+    pr_payload["attention"] = _attention(next_action=next_action, is_draft=is_draft, labels=labels)
+    return pr_payload
+
+
 def fetch_pr(number: int, *, repo: str) -> dict[str, Any]:
     """Fetch one PR and return a compact queue snapshot."""
     result = _gh(
@@ -118,23 +161,71 @@ def fetch_pr(number: int, *, repo: str) -> dict[str, Any]:
         pr = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
         return {"number": number, "status": "error", "error": f"invalid gh JSON: {exc}"}
-    labels = _labels(pr)
-    checks = _checks(pr)
-    is_draft = bool(pr.get("isDraft"))
+    return _pr_payload_from_dict(pr, default_number=number)
+
+
+def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
+    """Return a compact active PR queue snapshot."""
+    result = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,state,isDraft,labels,url,headRefName,headRefOid,mergeable,statusCheckRollup,reviews",
+        ]
+    )
+
+    if result.returncode != 0:
+        return {
+            "schema": "pr_queue_snapshot.v1",
+            "repo": repo,
+            "mode": "active",
+            "prs": [
+                {
+                    "status": "error",
+                    "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+                }
+            ],
+        }
+    try:
+        listed = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "schema": "pr_queue_snapshot.v1",
+            "repo": repo,
+            "mode": "active",
+            "prs": [
+                {
+                    "status": "error",
+                    "error": f"invalid gh JSON: {exc}",
+                }
+            ],
+        }
+    if not isinstance(listed, list):
+        return {
+            "schema": "pr_queue_snapshot.v1",
+            "repo": repo,
+            "mode": "active",
+            "prs": [
+                {
+                    "status": "error",
+                    "error": "expected gh pr list JSON array",
+                }
+            ],
+        }
+
+    prs = [_pr_payload_from_dict(pr, default_number=-1) for pr in listed if isinstance(pr, dict)]
     return {
-        "number": pr.get("number", number),
-        "status": "ok",
-        "title": pr.get("title", ""),
-        "state": pr.get("state", ""),
-        "draft": is_draft,
-        "url": pr.get("url", ""),
-        "labels": labels,
-        "head_branch": pr.get("headRefName", ""),
-        "head_sha": pr.get("headRefOid", ""),
-        "mergeable": pr.get("mergeable", "unknown"),
-        "checks": checks,
-        "reviews": _reviews(pr),
-        "next_action": _next_action(is_draft=is_draft, labels=labels, checks=checks),
+        "schema": "pr_queue_snapshot.v1",
+        "repo": repo,
+        "mode": "active",
+        "prs": prs,
     }
 
 
@@ -150,8 +241,19 @@ def snapshot_prs(numbers: list[int], *, repo: str) -> dict[str, Any]:
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("prs", nargs="*", type=int, help="PR numbers to snapshot.")
+    parser.add_argument(
+        "--active",
+        action="store_true",
+        help="Discover bounded open PRs that need queue attention.",
+    )
     parser.add_argument("--prs", dest="prs_option", nargs="+", type=int, help="PR numbers.")
     parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_ACTIVE_LIMIT,
+        help="Limit for --active discovery mode.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser.parse_args(argv)
 
@@ -159,12 +261,18 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = _parse_args(argv)
-    numbers = args.prs_option if args.prs_option is not None else args.prs
-    if not numbers:
-        print("at least one PR number is required", file=sys.stderr)
+    if args.active and (args.prs_option is not None or args.prs):
+        print("--active cannot be combined with explicit PR numbers", file=sys.stderr)
         return 1
+    numbers = args.prs_option if args.prs_option is not None else args.prs
     try:
-        payload = snapshot_prs(numbers, repo=args.repo)
+        if args.active:
+            payload = snapshot_active_prs(repo=args.repo, limit=max(args.limit, 1))
+        elif not numbers:
+            print("at least one PR number is required", file=sys.stderr)
+            return 1
+        else:
+            payload = snapshot_prs(numbers, repo=args.repo)
     except FileNotFoundError:
         print("gh command not found", file=sys.stderr)
         return 1

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-from scripts.dev.snapshot_issue_batch import expand_issue_numbers, main, snapshot_issues
+from scripts.dev.snapshot_issue_batch import (
+    expand_issue_numbers,
+    main,
+    snapshot_claimable_issues,
+    snapshot_issues,
+)
 
 
 def test_expand_issue_numbers_treats_two_values_as_range() -> None:
@@ -105,3 +110,74 @@ def test_snapshot_issues_can_write_context_capsules(tmp_path) -> None:  # type: 
     assert capsule["issue"]["number"] == 2666
     assert capsule["claim"]["claimed"] is True
     assert capsule["files_to_read"] == ["docs/context/INDEX.md"]
+
+
+def test_snapshot_claimable_issues_includes_classification_without_body() -> None:
+    """Claimable discovery should return compact entries without raw body data."""
+    issue_list = [
+        {
+            "number": 2667,
+            "title": "claimable issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2667",
+            "labels": [{"name": "workflow"}],
+            "assignees": [],
+            "body": "secret body that should not appear",
+        },
+        {
+            "number": 2668,
+            "title": "blocked issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2668",
+            "labels": [{"name": "state:blocked"}],
+            "assignees": [],
+            "body": "another secret body that should not appear",
+        },
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.side_effect = [
+                {"ok": True, "claimed": False, "claim_ref": "agent-claims/issue-2667", "sha": None},
+                {"ok": True, "claimed": False, "claim_ref": "agent-claims/issue-2668", "sha": None},
+            ]
+            payload = snapshot_claimable_issues(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                body_limit=150,
+                limit=2,
+            )
+
+    assert payload["mode"] == "claimable"
+    assert payload["issues"][0]["classification"] == "claimable"
+    assert payload["issues"][0]["body_excerpt"] == ""
+    assert payload["issues"][0]["body_truncated"] is False
+    assert payload["issues"][1]["classification"] == "blocked_label"
+    assert "reason" in payload["issues"][1]
+
+
+def test_main_claimable_mode_can_be_called_without_issue_numbers() -> None:  # type: ignore[no-untyped-def]
+    """CLI should run compact claim discovery when issue numbers are intentionally omitted."""
+    issue_list = [
+        {
+            "number": 2669,
+            "title": "no-arg mode issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2669",
+            "labels": [],
+            "assignees": [],
+        }
+    ]
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue-2669",
+                "sha": None,
+            }
+            rc = main(["--claimable", "--json", "--limit", "1"])
+
+    assert rc == 0

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-from scripts.dev.snapshot_pr_queue import main, snapshot_prs
+from scripts.dev.snapshot_pr_queue import main, snapshot_active_prs, snapshot_prs
 
 
 def test_snapshot_prs_emits_headline_state() -> None:
@@ -67,3 +67,51 @@ def test_main_requires_pr_number(capsys) -> None:  # type: ignore[no-untyped-def
     rc = main(["--json"])
     assert rc == 1
     assert "at least one PR" in capsys.readouterr().err
+
+
+def test_main_active_mode_discovers_open_prs() -> None:
+    """Active-mode queue snapshot should emit compact PR attention entries."""
+    pr_payload = [
+        {
+            "number": 2681,
+            "title": "active PR",
+            "state": "OPEN",
+            "isDraft": False,
+            "url": "https://github.test/pull/2681",
+            "labels": [{"name": "merge-ready"}],
+            "headRefName": "feature",
+            "headRefOid": "cafe00",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [{"name": "ci", "status": "in_progress", "conclusion": ""}],
+            "reviews": [],
+        },
+        {
+            "number": 2682,
+            "title": "draft PR",
+            "state": "OPEN",
+            "isDraft": True,
+            "url": "https://github.test/pull/2682",
+            "labels": [],
+            "headRefName": "feat2",
+            "headRefOid": "cafe01",
+            "mergeable": "UNKNOWN",
+            "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "failure"}],
+            "reviews": [{"state": "APPROVED"}],
+        },
+    ]
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh_active:
+        mock_gh_active.return_value = MagicMock(
+            returncode=0, stdout=json.dumps(pr_payload), stderr=""
+        )
+        active_queue = snapshot_active_prs(repo="ll7/robot_sf_ll7", limit=2)
+
+    assert active_queue["mode"] == "active"
+    assert len(active_queue["prs"]) == 2
+    assert active_queue["prs"][0]["next_action"] == "await_ci_or_start_read_only_monitor"
+    assert active_queue["prs"][0]["attention"] == "ci_pending"
+    assert active_queue["prs"][1]["attention"] == "draft_ready_or_review"
+
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_main:
+        mock_main.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        rc = main(["--active", "--json", "--limit", "2"])
+    assert rc == 0


### PR DESCRIPTION
## Summary

- Add `snapshot_issue_batch.py --claimable --limit <n> --json` for bounded no-arg next-issue discovery.
- Add `snapshot_pr_queue.py --active --limit <n> --json` for bounded active PR queue discovery.
- Update goal-autopilot guidance and focused tests so explicit-ID snapshot behavior remains available.

Closes #2872

## Validation

- `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
- `uv run pytest tests/dev/test_snapshot_issue_batch.py tests/dev/test_snapshot_pr_queue.py`
- `ruff check scripts/dev/snapshot_issue_batch.py scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_issue_batch.py tests/dev/test_snapshot_pr_queue.py`
- `uv run python scripts/dev/snapshot_issue_batch.py --claimable --limit 5 --json`
- `uv run python scripts/dev/snapshot_pr_queue.py --active --limit 5 --json`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`6617 passed, 9 skipped`, clean tree, head `3f9a9c89`)

## Research Result Guidance

- Target claim/hypothesis/blocker: NA - workflow/tooling support helper; no benchmark or paper-facing research claim.
- Comparator/baseline: previous helpers required explicit issue/PR IDs for compact queue snapshots.
- Evidence tier: nominal workflow evidence from focused tests, live helper smoke, and final PR readiness.
- Result classification: support/tooling improvement.
- Decision/stop rule: stop after no-arg issue and PR snapshots produce bounded JSON and explicit-ID paths remain tested.
- Synthesis surface/update target: `.agents/skills/goal-autopilot/SKILL.md` updated to advertise the new compact snapshot modes.

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes, PR closes #2872.
- Claim map / registry / context note updated (yes/no/NA): NA - no benchmark artifact or model provenance registry.
- Context index or memory note updated (yes/no/NA): NA - skill guidance updated in-place.
- Follow-up issue opened for deferred propagation (yes/no/NA): no deferred propagation identified.

## Artifact Decision

- `output/coverage/*` and `output/validation/pr_ready/*` were generated by readiness validation and left ignored as disposable local validation artifacts.
