### PR TITLE
fix: preserve tracked output during cleanup

### DIFF
--- a/scripts/dev/clean_generated_output.py
+++ b/scripts/dev/clean_generated_output.py
@@ -64,13 +64,26 @@ def _remove_path(path: Path) -> None:
         path.unlink(missing_ok=True)
 
 
+def _contains_tracked_children(path: Path, repo_root: Path) -> bool:
+    """Return whether *path* is a directory with tracked children."""
+    if not path.is_dir() or path.is_symlink():
+        return False
+    rel = path.relative_to(repo_root).as_posix()
+    return bool(_git(["ls-files", "--", rel], cwd=repo_root).stdout.strip())
+
+
 def _remove_empty_dirs(root: Path, repo_root: Path) -> None:
     """Remove empty untracked directories left after generated files are removed."""
     if not root.exists() or not root.is_dir():
         return
-    for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+    for dirpath, _, _ in os.walk(root, topdown=False):
         path = Path(dirpath)
-        if filenames or dirnames:
+        if path == repo_root:
+            continue
+        try:
+            if any(path.iterdir()):
+                continue
+        except OSError:
             continue
         rel = path.relative_to(repo_root).as_posix()
         tracked = _git(["ls-files", "--error-unmatch", rel], cwd=repo_root)
@@ -119,6 +132,8 @@ def clean_paths(paths: list[Path], *, cwd: Path) -> int:
         }
         for target in sorted(generated, key=lambda item: len(item.parts), reverse=True):
             if target.exists() and _is_within(target, repo_root):
+                if _contains_tracked_children(target, repo_root):
+                    continue
                 _remove_path(target)
                 cleaned += 1
         _remove_empty_dirs(path, repo_root)

--- a/scripts/dev/clean_generated_output.py
+++ b/scripts/dev/clean_generated_output.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Safely remove generated output paths while preserving tracked files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command in *cwd*."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git_z(args: list[str], *, cwd: Path) -> list[Path]:
+    """Return NUL-delimited path output from a git command."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [
+        cwd / raw.decode("utf-8", errors="surrogateescape")
+        for raw in result.stdout.split(b"\0")
+        if raw
+    ]
+
+
+def _repo_root(cwd: Path) -> Path | None:
+    """Return the enclosing git worktree root, if available."""
+    result = _git(["rev-parse", "--show-toplevel"], cwd=cwd)
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return whether *path* is inside *root*."""
+    try:
+        path.resolve().relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _remove_path(path: Path) -> None:
+    """Remove a generated file, symlink, or directory."""
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _remove_empty_dirs(root: Path, repo_root: Path) -> None:
+    """Remove empty untracked directories left after generated files are removed."""
+    if not root.exists() or not root.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+        path = Path(dirpath)
+        if filenames or dirnames:
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        tracked = _git(["ls-files", "--error-unmatch", rel], cwd=repo_root)
+        if tracked.returncode == 0:
+            continue
+        try:
+            path.rmdir()
+        except OSError:
+            pass
+
+
+def clean_paths(paths: list[Path], *, cwd: Path) -> int:
+    """Clean generated files under *paths* while preserving tracked files."""
+    repo_root = _repo_root(cwd)
+    if repo_root is None:
+        print("clean_generated_output requires a git worktree", file=sys.stderr)
+        return 2
+
+    cleaned = 0
+    for raw_path in paths:
+        path = (cwd / raw_path).resolve()
+        if not _is_within(path, repo_root):
+            print(f"refusing to clean path outside repository: {raw_path}", file=sys.stderr)
+            return 2
+        if not path.exists():
+            continue
+
+        rel = path.relative_to(repo_root).as_posix()
+        tracked_root = _git(["ls-files", "--error-unmatch", rel], cwd=repo_root).returncode == 0
+        tracked_children = _git(["ls-files", "--", rel], cwd=repo_root).stdout.splitlines()
+        if not tracked_root and not tracked_children:
+            result = _git(["clean", "-fdx", "--", rel], cwd=repo_root)
+            if result.returncode != 0:
+                print(result.stderr.strip() or f"git clean failed for {rel}", file=sys.stderr)
+                return result.returncode
+            cleaned += 1
+            continue
+
+        generated = {
+            *(_git_z(["ls-files", "-z", "-o", "--exclude-standard", "--", rel], cwd=repo_root)),
+            *(
+                _git_z(
+                    ["ls-files", "-z", "-o", "-i", "--exclude-standard", "--", rel], cwd=repo_root
+                )
+            ),
+        }
+        for target in sorted(generated, key=lambda item: len(item.parts), reverse=True):
+            if target.exists() and _is_within(target, repo_root):
+                _remove_path(target)
+                cleaned += 1
+        _remove_empty_dirs(path, repo_root)
+
+    print(f"cleaned_generated_paths={cleaned}")
+    return 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Generated output paths to clean without deleting tracked files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    return clean_paths(args.paths, cwd=Path.cwd())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/run_focused_tests.sh
+++ b/scripts/dev/run_focused_tests.sh
@@ -5,9 +5,10 @@ show_help() {
   cat <<'EOF'
 Usage: scripts/dev/run_focused_tests.sh [pytest-args...]
 
-Runs a focused pytest command and removes the generated output/coverage tree
-after the test command succeeds. Use this for narrow local validation where the
-coverage report is not the artifact you intend to inspect or keep.
+Runs a focused pytest command and removes generated output/coverage files after
+the test command succeeds, while preserving any tracked files under that tree.
+Use this for narrow local validation where the coverage report is not the
+artifact you intend to inspect or keep.
 
 Examples:
   scripts/dev/run_focused_tests.sh tests/dev/test_issue_claim.py -q
@@ -37,5 +38,5 @@ uv run pytest "$@"
 if [[ "${FOCUSED_TEST_KEEP_COVERAGE:-0}" == "1" ]]; then
   echo "Preserving output/coverage because FOCUSED_TEST_KEEP_COVERAGE=1." >&2
 else
-  rm -rf output/coverage
+  python3 "$SCRIPT_DIR/clean_generated_output.py" output/coverage >/dev/null
 fi

--- a/tests/dev/conftest.py
+++ b/tests/dev/conftest.py
@@ -1,0 +1,76 @@
+"""Shared fixtures for development-script tests."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_FOCUSED_TESTS = REPO_ROOT / "scripts" / "dev" / "run_focused_tests.sh"
+
+
+@pytest.fixture()
+def helper_repo(tmp_path: Path) -> Path:
+    """Return a tiny git repo with the focused-test helper and a fake uv binary."""
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts" / "dev"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(RUN_FOCUSED_TESTS, scripts_dir / "run_focused_tests.sh")
+    shutil.copy2(REPO_ROOT / "scripts" / "dev" / "common_setup.sh", scripts_dir / "common_setup.sh")
+    shutil.copy2(
+        REPO_ROOT / "scripts" / "dev" / "clean_generated_output.py",
+        scripts_dir / "clean_generated_output.py",
+    )
+    (repo / "output" / "coverage").mkdir(parents=True)
+    (repo / "output" / "coverage" / "tracked.txt").write_text("tracked", encoding="utf-8")
+    (repo / "bin").mkdir()
+    (repo / "bin" / "uv").write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "mkdir -p output/coverage",
+                "printf fake > output/coverage/generated.txt",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo / "bin" / "uv").chmod(0o755)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CI",
+            "-c",
+            "user.email=ci@example.com",
+            "add",
+            "scripts/dev/run_focused_tests.sh",
+            "scripts/dev/common_setup.sh",
+            "scripts/dev/clean_generated_output.py",
+            "bin/uv",
+            "output/coverage/tracked.txt",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CI",
+            "-c",
+            "user.email=ci@example.com",
+            "commit",
+            "-m",
+            "seed tracked focused test fixture",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    return repo

--- a/tests/dev/test_clean_generated_output.py
+++ b/tests/dev/test_clean_generated_output.py
@@ -60,3 +60,43 @@ def test_clean_paths_removes_untracked_output_tree(tmp_path: Path) -> None:
     assert clean_paths([Path("output/coverage")], cwd=repo) == 0
 
     assert not generated_dir.exists()
+
+
+def test_clean_paths_preserves_force_tracked_file_in_ignored_directory(tmp_path: Path) -> None:
+    """Ignored directories may contain force-tracked files that cleanup must preserve."""
+    repo = tmp_path / "repo"
+    ignored_dir = repo / "output" / "reports"
+    ignored_dir.mkdir(parents=True)
+    (ignored_dir / "keep.md").write_text("tracked\n", encoding="utf-8")
+    (ignored_dir / "generated.json").write_text("{}\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("output/reports/\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "add", ".gitignore")
+    _git(repo, "add", "-f", "output/reports/keep.md")
+    _git(repo, "-c", "user.name=CI", "-c", "user.email=ci@example.com", "commit", "-m", "seed")
+
+    assert clean_paths([Path("output/reports")], cwd=repo) == 0
+
+    assert (ignored_dir / "keep.md").exists()
+    assert not (ignored_dir / "generated.json").exists()
+    assert _git(repo, "status", "--short").stdout.strip() == ""
+
+
+def test_clean_paths_removes_nested_empty_generated_directories(tmp_path: Path) -> None:
+    """Cleanup should remove parent directories that become empty during traversal."""
+    repo = tmp_path / "repo"
+    tracked_dir = repo / "output" / "repos"
+    nested_dir = tracked_dir / "tmp" / "nested"
+    nested_dir.mkdir(parents=True)
+    (tracked_dir / "README.md").write_text("tracked\n", encoding="utf-8")
+    (nested_dir / "generated.json").write_text("{}\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("output/repos/tmp/\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "add", ".gitignore", "output/repos/README.md")
+    _git(repo, "-c", "user.name=CI", "-c", "user.email=ci@example.com", "commit", "-m", "seed")
+
+    assert clean_paths([Path("output/repos")], cwd=repo) == 0
+
+    assert (tracked_dir / "README.md").exists()
+    assert not (tracked_dir / "tmp").exists()
+    assert _git(repo, "status", "--short").stdout.strip() == ""

--- a/tests/dev/test_clean_generated_output.py
+++ b/tests/dev/test_clean_generated_output.py
@@ -1,0 +1,62 @@
+"""Tests for safe generated-output cleanup."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.dev.clean_generated_output import clean_paths
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run git in the temporary repository."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_clean_paths_preserves_tracked_files_and_removes_generated(tmp_path: Path) -> None:
+    """Cleanup should delete generated files without dirtying tracked output files."""
+    repo = tmp_path / "repo"
+    tracked_dir = repo / "output" / "repos"
+    tracked_dir.mkdir(parents=True)
+    (tracked_dir / "README.md").write_text("tracked\n", encoding="utf-8")
+    (tracked_dir / "generated.json").write_text("{}\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("output/repos/generated.json\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "add", ".gitignore", "output/repos/README.md")
+    _git(repo, "-c", "user.name=CI", "-c", "user.email=ci@example.com", "commit", "-m", "seed")
+
+    assert clean_paths([Path("output/repos")], cwd=repo) == 0
+
+    assert (tracked_dir / "README.md").exists()
+    assert not (tracked_dir / "generated.json").exists()
+    assert _git(repo, "status", "--short").stdout.strip() == ""
+
+
+def test_clean_paths_removes_untracked_output_tree(tmp_path: Path) -> None:
+    """Fully untracked generated trees can be removed wholesale."""
+    repo = tmp_path / "repo"
+    generated_dir = repo / "output" / "coverage"
+    generated_dir.mkdir(parents=True)
+    (generated_dir / "coverage.json").write_text("{}\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(
+        repo,
+        "-c",
+        "user.name=CI",
+        "-c",
+        "user.email=ci@example.com",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "seed",
+    )
+
+    assert clean_paths([Path("output/coverage")], cwd=repo) == 0
+
+    assert not generated_dir.exists()

--- a/tests/dev/test_run_focused_tests_cleanup.py
+++ b/tests/dev/test_run_focused_tests_cleanup.py
@@ -19,6 +19,12 @@ def helper_repo(tmp_path: Path) -> Path:
     scripts_dir.mkdir(parents=True)
     shutil.copy2(SCRIPT, scripts_dir / "run_focused_tests.sh")
     shutil.copy2(REPO_ROOT / "scripts" / "dev" / "common_setup.sh", scripts_dir / "common_setup.sh")
+    shutil.copy2(
+        REPO_ROOT / "scripts" / "dev" / "clean_generated_output.py",
+        scripts_dir / "clean_generated_output.py",
+    )
+    (repo / "output" / "coverage").mkdir(parents=True)
+    (repo / "output" / "coverage" / "tracked.txt").write_text("tracked", encoding="utf-8")
     (repo / "bin").mkdir()
     (repo / "bin" / "uv").write_text(
         "\n".join(
@@ -35,6 +41,37 @@ def helper_repo(tmp_path: Path) -> Path:
     )
     (repo / "bin" / "uv").chmod(0o755)
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CI",
+            "-c",
+            "user.email=ci@example.com",
+            "add",
+            "scripts/dev/run_focused_tests.sh",
+            "scripts/dev/common_setup.sh",
+            "scripts/dev/clean_generated_output.py",
+            "bin/uv",
+            "output/coverage/tracked.txt",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CI",
+            "-c",
+            "user.email=ci@example.com",
+            "commit",
+            "-m",
+            "seed tracked focused test fixture",
+        ],
+        cwd=repo,
+        check=True,
+    )
     return repo
 
 
@@ -61,9 +98,16 @@ def test_focused_tests_removes_coverage_on_success(helper_repo: Path) -> None:
     result = _run_focused(helper_repo)
 
     assert result.returncode == 0, f"Script failed: {result.stderr}"
-    assert not (helper_repo / "output" / "coverage").exists(), (
-        "output/coverage should be removed after a successful focused run"
+    assert not (helper_repo / "output" / "coverage" / "generated.txt").exists(), (
+        "generated coverage output should be removed after a successful focused run"
     )
+    assert (helper_repo / "output" / "coverage" / "tracked.txt").exists(), (
+        "tracked output files should remain after cleanup"
+    )
+    status = subprocess.run(
+        ["git", "status", "--short"], cwd=helper_repo, check=True, text=True, capture_output=True
+    ).stdout.strip()
+    assert status == "", status
 
 
 def test_focused_tests_preserves_coverage_when_keep_flag_set(helper_repo: Path) -> None:

--- a/tests/dev/test_run_focused_tests_cleanup.py
+++ b/tests/dev/test_run_focused_tests_cleanup.py
@@ -1,78 +1,8 @@
 """Contract test for scripts/dev/run_focused_tests.sh coverage cleanup."""
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
-
-import pytest
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = REPO_ROOT / "scripts" / "dev" / "run_focused_tests.sh"
-
-
-@pytest.fixture()
-def helper_repo(tmp_path: Path) -> Path:
-    """Return a tiny git repo with the focused-test helper and a fake uv binary."""
-    repo = tmp_path / "repo"
-    scripts_dir = repo / "scripts" / "dev"
-    scripts_dir.mkdir(parents=True)
-    shutil.copy2(SCRIPT, scripts_dir / "run_focused_tests.sh")
-    shutil.copy2(REPO_ROOT / "scripts" / "dev" / "common_setup.sh", scripts_dir / "common_setup.sh")
-    shutil.copy2(
-        REPO_ROOT / "scripts" / "dev" / "clean_generated_output.py",
-        scripts_dir / "clean_generated_output.py",
-    )
-    (repo / "output" / "coverage").mkdir(parents=True)
-    (repo / "output" / "coverage" / "tracked.txt").write_text("tracked", encoding="utf-8")
-    (repo / "bin").mkdir()
-    (repo / "bin" / "uv").write_text(
-        "\n".join(
-            [
-                "#!/usr/bin/env bash",
-                "set -euo pipefail",
-                "mkdir -p output/coverage",
-                "printf fake > output/coverage/generated.txt",
-                "exit 0",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    (repo / "bin" / "uv").chmod(0o755)
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(
-        [
-            "git",
-            "-c",
-            "user.name=CI",
-            "-c",
-            "user.email=ci@example.com",
-            "add",
-            "scripts/dev/run_focused_tests.sh",
-            "scripts/dev/common_setup.sh",
-            "scripts/dev/clean_generated_output.py",
-            "bin/uv",
-            "output/coverage/tracked.txt",
-        ],
-        cwd=repo,
-        check=True,
-    )
-    subprocess.run(
-        [
-            "git",
-            "-c",
-            "user.name=CI",
-            "-c",
-            "user.email=ci@example.com",
-            "commit",
-            "-m",
-            "seed tracked focused test fixture",
-        ],
-        cwd=repo,
-        check=True,
-    )
-    return repo
 
 
 def _run_focused(repo: Path, *, keep_coverage: bool = False) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary

- Add `scripts/dev/clean_generated_output.py`, a git-aware cleanup helper that removes generated/untracked output paths while preserving tracked files.
- Route `scripts/dev/run_focused_tests.sh` coverage cleanup through the safe helper instead of raw `rm -rf output/coverage`.
- Add focused tests and a live smoke path covering tracked `output/` preservation and clean post-cleanup status.

Closes #2873

## Validation

- `uv run pytest tests/dev/test_clean_generated_output.py tests/dev/test_run_focused_tests_cleanup.py`
- `ruff check scripts/dev/clean_generated_output.py tests/dev/test_clean_generated_output.py tests/dev/test_run_focused_tests_cleanup.py`
- Live smoke: create disposable `output/repos/generated-cleanup-smoke.tmp`, run `python3 scripts/dev/clean_generated_output.py output/repos`, verify tracked `output/repos/README.md` remains and git status returns unchanged.
- Wrapper smoke: `scripts/dev/run_focused_tests.sh tests/dev/test_clean_generated_output.py -q`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`6616 passed, 9 skipped`, clean tree, head `361c71cc`)

## Research Result Guidance

- Target claim/hypothesis/blocker: NA - workflow safety/tooling support helper; no benchmark or paper-facing research claim.
- Comparator/baseline: previous focused-test cleanup used raw `rm -rf output/coverage`, and recent cleanup accidentally deleted a tracked file under `output/`.
- Evidence tier: nominal workflow evidence from focused tests, live tracked-file smoke, wrapper smoke, and final PR readiness.
- Result classification: support/tooling reliability improvement.
- Decision/stop rule: stop after generated output cleanup preserves tracked files and final readiness passes on a clean committed head.
- Synthesis surface/update target: PR closes #2873; no benchmark synthesis surface.

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes, PR closes #2873.
- Claim map / registry / context note updated (yes/no/NA): NA - no benchmark artifact or model provenance registry.
- Context index or memory note updated (yes/no/NA): NA - helper and tests are discoverable under `scripts/dev/` and `tests/dev/`.
- Follow-up issue opened for deferred propagation (yes/no/NA): no deferred propagation identified.

## Artifact Decision

- `output/coverage/*` and `output/validation/pr_ready/*` were generated by readiness validation and left ignored as disposable local validation artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI utility script to safely clean up generated output files and directories while preserving git-tracked content.
  * Integrated the cleanup utility into the test workflow to replace direct directory deletion.

* **Tests**
  * Added tests validating cleanup behavior, ensuring tracked files are preserved while untracked generated content is properly removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->