### PR TITLE
docs: add forecast claim boundaries to dissertation ledger

### DIFF
--- a/docs/context/dissertation_evidence_ledger.md
+++ b/docs/context/dissertation_evidence_ledger.md
@@ -78,29 +78,29 @@ explicitly blocked from manuscript promotion.
 
 | Field | Value |
 |---|---|
-| **Claim** | The forecast lane now has support for typed `ForecastBatch.v1` artifacts, observation-tier separation with adapters, probabilistic metric/calibration reporting, deterministic baseline comparison, dataset/adapter scaffolding, transferability tooling, conformal pilot support, and closed-loop coupling gates. |
+| **Claim** | The forecast lane now has scaffolded support for typed `ForecastBatch.v1` artifacts, observation-tier separation via adapters, probabilistic forecast and calibration metrics, deterministic baseline comparison rows, dataset/split scaffolding, transferability tooling, conformal pilot support, and a closed-loop coupling gate recommendation. |
 | **Artifact status** | current |
 | **Evidence tier** | diagnostic |
-| **Allowed wording** | "Forecast lane infrastructure is in place for typed artifacts, observation-tier separation, probabilistic metrics/calibration, deterministic baselines, transferability tooling, conformal pilots, and closed-loop coupling gates; this is an implementation and diagnostic readiness boundary." |
-| **Caveat** | The row is infrastructure-oriented and does not establish planner-quality, transfer, or safety claims. Conformal and transfer results remain diagnostic-only and are not safety claims. |
+| **Allowed wording** | "The repository now supports forecast-lane infrastructure for typed artifact contracts, observation tiers, probabilistic metric pipelines, deterministic baselines, dataset-level provenance, transfer diagnostics, uncertainty pilots, and a closed-loop coupling gate." |
+| **Caveat** | Current evidence is infrastructure and diagnostic in nature: it marks what is implemented and what the next coupling step reports, but it is not yet benchmark- or paper-grade claim support. |
 | **Source PR/issue** | [#2761](https://github.com/ll7/robot_sf_ll7/issues/2761), [#2835](https://github.com/ll7/robot_sf_ll7/issues/2835), [#2836](https://github.com/ll7/robot_sf_ll7/issues/2836), [#2838](https://github.com/ll7/robot_sf_ll7/issues/2838), [#2839](https://github.com/ll7/robot_sf_ll7/issues/2839), [#2840](https://github.com/ll7/robot_sf_ll7/issues/2840), [#2841](https://github.com/ll7/robot_sf_ll7/issues/2841), [#2842](https://github.com/ll7/robot_sf_ll7/issues/2842), [#2843](https://github.com/ll7/robot_sf_ll7/issues/2843), [#2846](https://github.com/ll7/robot_sf_ll7/issues/2846), [#2847](https://github.com/ll7/robot_sf_ll7/issues/2847); local routing: [forecast schema](issue_2836_forecast_batch_schema.md), [prediction lane](../ai/prediction_lane.md), [dependency graph](prediction_lane_dependency_graph.json) |
 | **Dissertation chapter** | Methods, Outlook |
-| **Claim gap** | Requires a transfer-aware, same-seed closed-loop planner campaign with calibrated ADE/FDE/miss-rate, collision, and progress metrics before benchmark-level claims. |
-| **Evidence promotion path** | **benchmark promotion**: run closed-loop planner comparisons (including deterministic baselines) with calibrated, failure-safe transfer-aware rows and explicitly state gate outcome changes before any manuscript claim upgrade. |
+| **Claim gap** | Requires a transfer-aware, same-seed closed-loop campaign that compares forecast-enabled planners to deterministic and baseline modes using calibrated, fail-closed, and same-denominator metrics. |
+| **Evidence promotion path** | **benchmark promotion**: requires executed transfer-aware closed-loop comparison rows with calibrated ADE/FDE/miss-rate and collision/progress metrics. |
 
 #### Forecast-lane unsupported claim boundaries
 
 | Field | Value |
 |---|---|
-| **Claim** | The current evidence does **not** support claims that forecast integration improves local-navigation safety, progression, or transfer robustness. |
+| **Claim** | No durable evidence yet shows that forecast integration improves local-navigation safety, route progress, or transfer robustness; current results classify these outcomes as unsupported or mixed. |
 | **Artifact status** | current |
 | **Evidence tier** | diagnostic |
-| **Allowed wording** | "Forecasting infrastructure is active, but no durable evidence yet shows it improves local-navigation safety or progress under transfer." |
-| **Caveat** | Do not promote diagnostic infrastructure to benchmark, safety, or paper-facing claims. Closed-loop coupling currently recommends `revise`; baseline comparisons are mixed and transfer matrices are stress diagnostics. |
+| **Allowed wording** | "Forecast artifacts and tooling are in place, but forecast-driven gains in safety, progress, or transfer performance are not established." |
+| **Caveat** | Forecast coupling and transfer diagnostics currently show mixed or insufficient evidence (#2843 revise recommendation; mixed baseline-point results in #2781; transferability matrix is not a safety proof). |
 | **Source PR/issue** | [#2761](https://github.com/ll7/robot_sf_ll7/issues/2761), [#2835](https://github.com/ll7/robot_sf_ll7/issues/2835), [#2781](https://github.com/ll7/robot_sf_ll7/issues/2781), [#2843](https://github.com/ll7/robot_sf_ll7/issues/2843), [#2847](https://github.com/ll7/robot_sf_ll7/issues/2847); local routing: [dependency graph](prediction_lane_dependency_graph.json) |
 | **Dissertation chapter** | Discussion, Outlook |
-| **Claim gap** | Requires transfer-aware closed-loop planner benchmarks with false-positive accounting, non-regression on success/progress, and explicit significance checks before any upgrade. |
-| **Evidence promotion path** | **transfer-aware closed-loop promotion**: publish matched transfer, same-seed planner comparisons against deterministic baselines before any safety/progress transfer claim. |
+| **Claim gap** | Requires transfer-aware transferability campaigns with false-positive accounting, non-regression on success/progress, and statistical uncertainty before any safety/progress claim. |
+| **Evidence promotion path** | **transfer-aware closed-loop promotion**: run transfer-focused closed-loop planner campaigns with matched deterministic baselines and explicit safety/progress deltas before promoting this claim. |
 
 ### 5. Pedestrian-Density Stress
 
@@ -146,11 +146,15 @@ explicitly blocked from manuscript promotion.
    describe infrastructure readiness. Do not cite as traffic-signal compliance or planner ranking.
 3. **Observation robustness**: Methods only. Use the observation-level vocabulary to describe
    benchmark contract discipline. Do not cite as perception or sim-to-real validity.
-4. **Prediction**: Methods/Outlook only. Use the merged interface and contract smoke to
-   describe infrastructure readiness. Do not cite as prediction-quality or planner-improvement evidence.
-5. **Pedestrian-density stress**: Methods/Limitations only. Use coverage entropy to describe
+4. **Prediction supported boundary**: Methods, Outlook only. Use the forecast-lane scaffold
+   evidence (artifacts, adapters, metrics, baselines, transferability tooling, conformal pilots,
+   and coupling gates) to describe infrastructure readiness. Do not cite as safety/progress results.
+5. **Prediction unsupported boundary**: Discussion/Outlook only. Do not claim forecast-driven
+   safety, progress, or transfer gains until transfer-aware closed-loop planner evidence is
+   published with explicit false-positive and regression accounting.
+6. **Pedestrian-density stress**: Methods/Limitations only. Use coverage entropy to describe
    scenario curation discipline. Do not cite as runtime stress or planner-ranking evidence.
-6. **Exported tables**: Blocked. Do not use until payload files are recovered or re-exported.
+7. **Exported tables**: Blocked. Do not use until payload files are recovered or re-exported.
 
 ## Claim Boundaries
 

--- a/docs/context/dissertation_evidence_ledger.md
+++ b/docs/context/dissertation_evidence_ledger.md
@@ -74,17 +74,33 @@ explicitly blocked from manuscript promotion.
 
 ### 4. Prediction
 
+#### Forecast-lane supported claim boundaries
+
 | Field | Value |
 |---|---|
-| **Claim** | The probabilistic prediction interface is merged and the contract smoke emits native/fail-closed rows for reactive, single-trajectory, multimodal-equal-weight, and multimodal-confidence-weighted rows, but no planner-campaign comparison has been executed. |
+| **Claim** | The forecast lane now has support for typed `ForecastBatch.v1` artifacts, observation-tier separation with adapters, probabilistic metric/calibration reporting, deterministic baseline comparison, dataset/adapter scaffolding, transferability tooling, conformal pilot support, and closed-loop coupling gates. |
 | **Artifact status** | current |
 | **Evidence tier** | diagnostic |
-| **Allowed wording** | "The repository has a merged probabilistic prediction interface and a contract-smoke runner that materializes native and fail-closed row shapes for multimodal prediction configurations." |
-| **Caveat** | This is contract evidence only. The runner uses deterministic fixtures, does not execute a planner campaign, and does not measure prediction quality or compare planning performance. |
-| **Source PR/issue** | [#2475](issue_2475_probabilistic_prediction_interface.md), [#2476](issue_2476_multimodal_prediction_benchmark.md), [#2496](issue_2496_multimodal_prediction_smoke.md) |
+| **Allowed wording** | "Forecast lane infrastructure is in place for typed artifacts, observation-tier separation, probabilistic metrics/calibration, deterministic baselines, transferability tooling, conformal pilots, and closed-loop coupling gates; this is an implementation and diagnostic readiness boundary." |
+| **Caveat** | The row is infrastructure-oriented and does not establish planner-quality, transfer, or safety claims. Conformal and transfer results remain diagnostic-only and are not safety claims. |
+| **Source PR/issue** | [#2761](https://github.com/ll7/robot_sf_ll7/issues/2761), [#2835](https://github.com/ll7/robot_sf_ll7/issues/2835), [#2836](https://github.com/ll7/robot_sf_ll7/issues/2836), [#2838](https://github.com/ll7/robot_sf_ll7/issues/2838), [#2839](https://github.com/ll7/robot_sf_ll7/issues/2839), [#2840](https://github.com/ll7/robot_sf_ll7/issues/2840), [#2841](https://github.com/ll7/robot_sf_ll7/issues/2841), [#2842](https://github.com/ll7/robot_sf_ll7/issues/2842), [#2843](https://github.com/ll7/robot_sf_ll7/issues/2843), [#2846](https://github.com/ll7/robot_sf_ll7/issues/2846), [#2847](https://github.com/ll7/robot_sf_ll7/issues/2847); local routing: [forecast schema](issue_2836_forecast_batch_schema.md), [prediction lane](../ai/prediction_lane.md), [dependency graph](prediction_lane_dependency_graph.json) |
 | **Dissertation chapter** | Methods, Outlook |
-| **Claim gap** | Requires executed planner campaign with reactive, single-trajectory, and multimodal rows; matched metrics (success, collision, min-ped-distance, time-to-goal); and fail-closed row handling before any benchmark claim. |
-| **Evidence promotion path** | **denominator repair**: an executed planner campaign with matched metrics and fail-closed row handling is required before any benchmark claim. |
+| **Claim gap** | Requires a transfer-aware, same-seed closed-loop planner campaign with calibrated ADE/FDE/miss-rate, collision, and progress metrics before benchmark-level claims. |
+| **Evidence promotion path** | **benchmark promotion**: run closed-loop planner comparisons (including deterministic baselines) with calibrated, failure-safe transfer-aware rows and explicitly state gate outcome changes before any manuscript claim upgrade. |
+
+#### Forecast-lane unsupported claim boundaries
+
+| Field | Value |
+|---|---|
+| **Claim** | The current evidence does **not** support claims that forecast integration improves local-navigation safety, progression, or transfer robustness. |
+| **Artifact status** | current |
+| **Evidence tier** | diagnostic |
+| **Allowed wording** | "Forecasting infrastructure is active, but no durable evidence yet shows it improves local-navigation safety or progress under transfer." |
+| **Caveat** | Do not promote diagnostic infrastructure to benchmark, safety, or paper-facing claims. Closed-loop coupling currently recommends `revise`; baseline comparisons are mixed and transfer matrices are stress diagnostics. |
+| **Source PR/issue** | [#2761](https://github.com/ll7/robot_sf_ll7/issues/2761), [#2835](https://github.com/ll7/robot_sf_ll7/issues/2835), [#2781](https://github.com/ll7/robot_sf_ll7/issues/2781), [#2843](https://github.com/ll7/robot_sf_ll7/issues/2843), [#2847](https://github.com/ll7/robot_sf_ll7/issues/2847); local routing: [dependency graph](prediction_lane_dependency_graph.json) |
+| **Dissertation chapter** | Discussion, Outlook |
+| **Claim gap** | Requires transfer-aware closed-loop planner benchmarks with false-positive accounting, non-regression on success/progress, and explicit significance checks before any upgrade. |
+| **Evidence promotion path** | **transfer-aware closed-loop promotion**: publish matched transfer, same-seed planner comparisons against deterministic baselines before any safety/progress transfer claim. |
 
 ### 5. Pedestrian-Density Stress
 

--- a/docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json
+++ b/docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "dissertation_evidence_ledger.v2",
-  "created_at_utc": "2026-06-13",
+  "created_at_utc": "2026-06-15",
   "issue": 2760,
   "purpose": "synthesis/dissertation-planning aid; not new benchmark, paper, or safety evidence",
   "source_artifacts": {
@@ -45,16 +45,28 @@
       "evidence_promotion_path": null
     },
     {
-      "area": "prediction",
-      "claim": "The probabilistic prediction interface is merged and the contract smoke emits native/fail-closed rows for reactive, single-trajectory, multimodal-equal-weight, and multimodal-confidence-weighted rows, but no planner-campaign comparison has been executed.",
+      "area": "prediction_supported",
+      "claim": "The forecast lane now has scaffolded support for typed `ForecastBatch.v1` artifacts, observation-tier separation via adapters, probabilistic forecast and calibration metrics, deterministic baseline comparison rows, dataset/split scaffolding, transferability tooling, conformal pilot support, and a closed-loop coupling gate recommendation.",
       "artifact_status": "current",
       "evidence_tier": "diagnostic",
-      "allowed_wording": "The repository has a merged probabilistic prediction interface and a contract-smoke runner that materializes native and fail-closed row shapes for multimodal prediction configurations.",
-      "caveat": "This is contract evidence only. The runner uses deterministic fixtures, does not execute a planner campaign, and does not measure prediction quality or compare planning performance.",
-      "source_issues": [2475, 2476, 2496],
+      "allowed_wording": "The repository now supports forecast-lane infrastructure for typed artifact contracts, observation tiers, probabilistic metric pipelines, deterministic baselines, dataset-level provenance, transfer diagnostics, uncertainty pilots, and a closed-loop coupling gate.",
+      "caveat": "Current evidence is infrastructure and diagnostic in nature: it marks what is implemented and what the next coupling step reports, but it is not yet benchmark- or paper-grade claim support.",
+      "source_issues": [2761, 2835, 2836, 2838, 2839, 2840, 2841, 2842, 2843, 2846, 2847],
       "dissertation_chapter": "Methods, Outlook",
-      "claim_gap": "Requires executed planner campaign with reactive, single-trajectory, and multimodal rows; matched metrics (success, collision, min-ped-distance, time-to-goal); and fail-closed row handling before any benchmark claim.",
-      "evidence_promotion_path": "denominator repair: an executed planner campaign with matched metrics and fail-closed row handling is required before any benchmark claim."
+      "claim_gap": "Requires a transfer-aware, same-seed closed-loop campaign that compares forecast-enabled planners to deterministic and baseline modes using calibrated, fail-closed, and same-denominator metrics.",
+      "evidence_promotion_path": "benchmark promotion requires executed transfer-aware closed-loop comparison rows with calibrated ADE/FDE/miss-rate and collision/progress metrics."
+    },
+    {
+      "area": "prediction_unsupported",
+      "claim": "No durable evidence yet shows that forecast integration improves local-navigation safety, route progress, or transfer robustness; current results classify these outcomes as unsupported or mixed.",
+      "artifact_status": "current",
+      "evidence_tier": "diagnostic",
+      "allowed_wording": "Forecast artifacts and tooling are in place, but forecast-driven gains in safety, progress, or transfer performance are not established.",
+      "caveat": "Forecast coupling and transfer diagnostics currently show mixed or insufficient evidence (#2843 revise recommendation; mixed baseline-point results in #2781; transferability matrix is not a safety proof).",
+      "source_issues": [2761, 2781, 2835, 2843, 2847],
+      "dissertation_chapter": "Discussion, Outlook",
+      "claim_gap": "Requires transfer-aware transferability campaigns with false-positive accounting, non-regression on success/progress, and statistical uncertainty before any safety/progress claim.",
+      "evidence_promotion_path": "run transfer-focused closed-loop planner campaigns with matched deterministic baselines and explicit safety/progress deltas before promoting this claim."
     },
     {
       "area": "pedestrian_density_stress",
@@ -102,7 +114,8 @@
     "topology_guidance": "Methods/Outlook only. Use the stop-lane synthesis from #2706 to explain why same-family selector reruns were exhausted. Do not cite as benchmark improvement.",
     "signalized_behavior": "Methods/Limitations only. Use the proxy diagnostic surface to describe infrastructure readiness. Do not cite as traffic-signal compliance or planner ranking.",
     "observation_robustness": "Methods only. Use the observation-level vocabulary to describe benchmark contract discipline. Do not cite as perception or sim-to-real validity.",
-    "prediction": "Methods/Outlook only. Use the merged interface and contract smoke to describe infrastructure readiness. Do not cite as prediction-quality or planner-improvement evidence.",
+    "prediction_supported": "Methods, Outlook only. Use the forecast-lane scaffold evidence (artifacts, adapters, metrics, baselines, transferability tooling, conformal pilots, and coupling gates) to describe infrastructure readiness. Do not cite as safety/progress results.",
+    "prediction_unsupported": "Discussion/Outlook only. Do not claim forecast-driven safety, progress, or transfer gains until transfer-aware closed-loop planner evidence is published with explicit false-positive and regression accounting.",
     "pedestrian_density_stress": "Methods/Limitations only. Use coverage entropy to describe scenario curation discipline. Do not cite as runtime stress or planner-ranking evidence.",
     "exported_tables": "Blocked. Do not use until payload files are recovered or re-exported."
   },

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "dissertation_gap_report.v1",
-  "generated_at": "2026-06-13",
+  "generated_at": "2026-06-15",
   "purpose": "synthesis/planning aid; not new benchmark, paper, dissertation, or safety evidence",
   "source_ledger": {
     "path": "docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json",
     "issue": 2760,
-    "row_count": 6
+    "row_count": 7
   },
   "source_register": {
     "path": "docs/context/evidence/issue_2762_negative_result_register/register.json",
@@ -53,17 +53,30 @@
       "claim_gap_or_reason": "Requires actual perception pipeline, calibrated tracking, or simulator-level observation fidelity before any robustness claim. Cross-track comparison is not valid without matched observation contracts."
     },
     {
-      "area": "prediction",
+      "area": "prediction_supported",
       "entry_id": null,
       "bucket": "blocked",
-      "promotion_step_or_reason": "denominator repair: an executed planner campaign with matched metrics and fail-closed row handling is required before any benchmark claim.",
+      "promotion_step_or_reason": "benchmark promotion requires executed transfer-aware closed-loop comparison rows with calibrated ADE/FDE/miss-rate and collision/progress metrics.",
       "source": "ledger",
-      "source_issue": 2475,
+      "source_issue": 2761,
       "evidence_tier": "diagnostic",
       "result_classification": null,
-      "allowed_wording_or_boundary": "The repository has a merged probabilistic prediction interface and a contract-smoke runner that materializes native and fail-closed row shapes for multimodal prediction configurations.",
-      "caveat": "This is contract evidence only. The runner uses deterministic fixtures, does not execute a planner campaign, and does not measure prediction quality or compare planning performance.",
-      "claim_gap_or_reason": "Requires executed planner campaign with reactive, single-trajectory, and multimodal rows; matched metrics (success, collision, min-ped-distance, time-to-goal); and fail-closed row handling before any benchmark claim."
+      "allowed_wording_or_boundary": "The repository now supports forecast-lane infrastructure for typed artifact contracts, observation tiers, probabilistic metric pipelines, deterministic baselines, dataset-level provenance, transfer diagnostics, uncertainty pilots, and a closed-loop coupling gate.",
+      "caveat": "Current evidence is infrastructure and diagnostic in nature: it marks what is implemented and what the next coupling step reports, but it is not yet benchmark- or paper-grade claim support.",
+      "claim_gap_or_reason": "Requires a transfer-aware, same-seed closed-loop campaign that compares forecast-enabled planners to deterministic and baseline modes using calibrated, fail-closed, and same-denominator metrics."
+    },
+    {
+      "area": "prediction_unsupported",
+      "entry_id": null,
+      "bucket": "blocked",
+      "promotion_step_or_reason": "run transfer-focused closed-loop planner campaigns with matched deterministic baselines and explicit safety/progress deltas before promoting this claim.",
+      "source": "ledger",
+      "source_issue": 2761,
+      "evidence_tier": "diagnostic",
+      "result_classification": null,
+      "allowed_wording_or_boundary": "Forecast artifacts and tooling are in place, but forecast-driven gains in safety, progress, or transfer performance are not established.",
+      "caveat": "Forecast coupling and transfer diagnostics currently show mixed or insufficient evidence (#2843 revise recommendation; mixed baseline-point results in #2781; transferability matrix is not a safety proof).",
+      "claim_gap_or_reason": "Requires transfer-aware transferability campaigns with false-positive accounting, non-regression on success/progress, and statistical uncertainty before any safety/progress claim."
     },
     {
       "area": "pedestrian_density_stress",

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
@@ -2,9 +2,9 @@
 
 **Purpose**: synthesis/planning aid; not new benchmark, paper, dissertation, or safety evidence.
 
-Generated: 2026-06-13  | Schema: dissertation_gap_report.v1
+Generated: 2026-06-15  | Schema: dissertation_gap_report.v1
 
-Sources: ledger #2760 (6 rows), register #2762 (3 entries)
+Sources: ledger #2760 (7 rows), register #2762 (3 entries)
 
 ## Supported (release-backed, current)
 
@@ -34,13 +34,21 @@ Sources: ledger #2760 (6 rows), register #2762 (3 entries)
 - **Caveat**: Signal state is proxy_diagnostic only. Do not claim planner observability, forced-waiting reasoning, legality compliance, or benchmark ranking improvement.
 - **Claim gap / reason**: Requires explicit runtime signal phase state, planner-observation policy, zone/legality trace fields, and planner_observable promotion before any benchmark row.
 
-### prediction [ledger]
+### prediction_supported [ledger]
 
 - **Tier/Classification**: diagnostic
-- **Promotion step or reason**: denominator repair: an executed planner campaign with matched metrics and fail-closed row handling is required before any benchmark claim.
-- **Allowed wording / boundary**: The repository has a merged probabilistic prediction interface and a contract-smoke runner that materializes native and fail-closed row shapes for multimodal prediction configurations.
-- **Caveat**: This is contract evidence only. The runner uses deterministic fixtures, does not execute a planner campaign, and does not measure prediction quality or compare planning performance.
-- **Claim gap / reason**: Requires executed planner campaign with reactive, single-trajectory, and multimodal rows; matched metrics (success, collision, min-ped-distance, time-to-goal); and fail-closed row handling before any benchmark claim.
+- **Promotion step or reason**: benchmark promotion requires executed transfer-aware closed-loop comparison rows with calibrated ADE/FDE/miss-rate and collision/progress metrics.
+- **Allowed wording / boundary**: The repository now supports forecast-lane infrastructure for typed artifact contracts, observation tiers, probabilistic metric pipelines, deterministic baselines, dataset-level provenance, transfer diagnostics, uncertainty pilots, and a closed-loop coupling gate.
+- **Caveat**: Current evidence is infrastructure and diagnostic in nature: it marks what is implemented and what the next coupling step reports, but it is not yet benchmark- or paper-grade claim support.
+- **Claim gap / reason**: Requires a transfer-aware, same-seed closed-loop campaign that compares forecast-enabled planners to deterministic and baseline modes using calibrated, fail-closed, and same-denominator metrics.
+
+### prediction_unsupported [ledger]
+
+- **Tier/Classification**: diagnostic
+- **Promotion step or reason**: run transfer-focused closed-loop planner campaigns with matched deterministic baselines and explicit safety/progress deltas before promoting this claim.
+- **Allowed wording / boundary**: Forecast artifacts and tooling are in place, but forecast-driven gains in safety, progress, or transfer performance are not established.
+- **Caveat**: Forecast coupling and transfer diagnostics currently show mixed or insufficient evidence (#2843 revise recommendation; mixed baseline-point results in #2781; transferability matrix is not a safety proof).
+- **Claim gap / reason**: Requires transfer-aware transferability campaigns with false-positive accounting, non-regression on success/progress, and statistical uncertainty before any safety/progress claim.
 
 ## Negative / Revise-Only
 

--- a/tests/docs/test_dissertation_evidence_ledger.py
+++ b/tests/docs/test_dissertation_evidence_ledger.py
@@ -194,16 +194,73 @@ class TestDissertationEvidenceLedger:
                     f"Row {i} ({row['area']}) promotion path must mention 'stale artifact refresh'"
                 )
 
-    def test_denominator_repair_promotion_rows(self) -> None:
+    def test_forecast_support_row_present(self) -> None:
+        ledger = _load_ledger()
+        supported = [row for row in ledger["rows"] if row["area"] == "prediction_supported"]
+        unsupported = [row for row in ledger["rows"] if row["area"] == "prediction_unsupported"]
+        assert len(supported) == 1, "Exactly one supported forecast-lane row is required"
+        assert len(unsupported) == 1, "Exactly one unsupported forecast-lane row is required"
+
+    def test_forecast_rows_reference_anchor_issues(self) -> None:
         ledger = _load_ledger()
         for i, row in enumerate(ledger["rows"]):
-            if row["area"] == "prediction":
-                assert row["evidence_promotion_path"] is not None, (
-                    f"Row {i} ({row['area']}) should have a denominator repair path"
+            if row["area"].startswith("prediction_"):
+                assert 2761 in row["source_issues"], (
+                    f"Row {i} ({row.get('area', '?')}) should reference #2761"
                 )
-                assert "denominator repair" in row["evidence_promotion_path"].lower(), (
-                    f"Row {i} ({row['area']}) promotion path must mention 'denominator repair'"
+                assert 2835 in row["source_issues"], (
+                    f"Row {i} ({row.get('area', '?')}) should reference #2835"
                 )
+
+    def test_forecast_supported_row_claim_boundary(self) -> None:
+        ledger = _load_ledger()
+        supported_rows = [row for row in ledger["rows"] if row["area"] == "prediction_supported"]
+        assert supported_rows, "Prediction-supported row missing from ledger"
+        row = supported_rows[0]
+        assert row["artifact_status"] == "current"
+        assert row["evidence_tier"] == "diagnostic"
+        assert row["evidence_promotion_path"] is not None, (
+            "Supported forecast rows need a promotion path"
+        )
+        claim_lower = row["claim"].lower()
+        caveat_lower = row["caveat"].lower()
+        for keyword in [
+            "forecastbatch.v1",
+            "observation-tier",
+            "probabilistic",
+            "baseline",
+            "transferability",
+            "conformal",
+            "closed-loop",
+        ]:
+            assert keyword in claim_lower, (
+                f"Supported forecast claim {row.get('area', '?')} missing '{keyword}'"
+            )
+        assert "not yet benchmark- or paper-grade claim support" in caveat_lower
+
+    def test_forecast_unsupported_row_claim_boundary(self) -> None:
+        ledger = _load_ledger()
+        unsupported_rows = [
+            row for row in ledger["rows"] if row["area"] == "prediction_unsupported"
+        ]
+        assert unsupported_rows, "Prediction-unsupported row missing from ledger"
+        row = unsupported_rows[0]
+        claim_lower = row["claim"].lower()
+        allowed_lower = row["allowed_wording"].lower()
+        caveat_lower = row["caveat"].lower()
+        assert "not support" in claim_lower or "no durable evidence" in claim_lower
+        assert "safety" in allowed_lower, (
+            "Unsupported forecast wording should reference safety boundary"
+        )
+        assert "progress" in allowed_lower, (
+            "Unsupported forecast wording should reference progress boundary"
+        )
+        assert "transfer" in caveat_lower, (
+            "Unsupported forecast caveat should include transfer boundary"
+        )
+        assert row["evidence_promotion_path"] is not None, (
+            "Unsupported forecast row should include a concrete promotion path before claims can be upgraded"
+        )
 
     def test_no_promotion_path_rows(self) -> None:
         ledger = _load_ledger()

--- a/tests/docs/test_dissertation_gap_report.py
+++ b/tests/docs/test_dissertation_gap_report.py
@@ -38,7 +38,7 @@ REQUIRED_GAP_FIELDS = {
     "claim_gap_or_reason",
 }
 VALID_BUCKETS = {"supported", "blocked", "negative_revise_only", "remove_weaken"}
-LEDGER_ROW_COUNT = 6
+LEDGER_ROW_COUNT = 7
 REGISTER_ENTRY_COUNT = 3
 
 
@@ -162,9 +162,10 @@ class TestSourceAccounting:
         assert buckets.get("supported", 0) == 1, (
             f"Expected 1 supported gap, got {buckets.get('supported', 0)}"
         )
-        # blocked: 3 (topology_guidance, signalized_behavior, prediction)
-        assert buckets.get("blocked", 0) == 3, (
-            f"Expected 3 blocked gaps, got {buckets.get('blocked', 0)}"
+        # blocked: 4 (topology_guidance, signalized_behavior, forecast-supported,
+        # forecast-unsupported)
+        assert buckets.get("blocked", 0) == 4, (
+            f"Expected 4 blocked gaps, got {buckets.get('blocked', 0)}"
         )
         # negative_revise_only: 4 (pedestrian_density_stress + NR-001 + NR-002 + NR-003)
         assert buckets.get("negative_revise_only", 0) == 4, (


### PR DESCRIPTION
## Summary

- split the dissertation evidence ledger prediction row into forecast-lane supported and unsupported claim-boundary rows
- update the machine-readable ledger with conservative diagnostic-only forecast boundaries and #2761/#2835 anchors
- add ledger tests that require the supported/unsupported forecast rows and guard against benchmark/paper-grade overclaiming

Closes #2870.

## Validation

- `rtk uv run pytest tests/docs/test_dissertation_evidence_ledger.py -q` (`28 passed`)
- `rtk uv run ruff check tests/docs/test_dissertation_evidence_ledger.py`
- `rtk uv run ruff format --check tests/docs/test_dissertation_evidence_ledger.py`
- `rtk git diff --check`
- `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `BASE_REF=origin/main rtk scripts/dev/check_docs_proof_consistency_diff.sh`

Full PR readiness was not run because this is a docs/ledger/test-only synthesis change with no runtime code, benchmark schema, or metric behavior changes.

## Downstream Propagation

- Parent issue / synthesis surface: links #2761 and #2835 directly from the ledger rows.
- Claim matrix / benchmark report / leaderboard: not updated; this PR does not add new benchmark evidence.
- Registry / config index: not applicable.
- Context index / memory note: existing dissertation ledger and JSON ledger entries remain discoverable through `docs/context/README.md` and `docs/context/catalog.yaml`; docs proof checks passed.

## Research Result Guidance

- Target claim / blocker: forecast-lane dissertation wording needed explicit supported and unsupported boundaries after the fast forecast PR wave.
- Comparator / baseline: existing forecast-lane diagnostic artifacts and issue anchors; no new experiment was run.
- Evidence tier: synthesis / diagnostic boundary only.
- Result classification: claim-boundary update. The repository supports typed forecast artifacts, observation-tier separation, probabilistic metrics/calibration, deterministic baselines, dataset/adapter scaffolding, transferability tooling, conformal pilot support, and coupling gates. It does **not** support claims that forecasts improve local-navigation safety/progress under transfer.
- Decision / stop rule: keep forecast claims in Methods/Outlook/Discussion wording until transfer-aware same-seed closed-loop planner evidence with false-positive and regression accounting exists.
- Synthesis surface: `docs/context/dissertation_evidence_ledger.md` and `docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json`.

## Delegation

- OpenCode Go implementation worker: accepted after main-agent link and wording cleanup.
- OpenCode Go review worker: no blocking findings; low link-semantics note accepted and fixed before commit.
