### PR TITLE
feat: gate learned prediction readiness

### DIFF
--- a/docs/ai/prediction_lane.md
+++ b/docs/ai/prediction_lane.md
@@ -50,7 +50,7 @@ Follow this order unless a later issue has an explicitly narrower diagnostic pur
 4. Add metric and calibration reports.
    Issues #2840 and #2846 generalize probabilistic forecast metrics and separate actor-class
    denominators. Issue #2837 compares horizon and output timestep tradeoffs, #2841 handles
-   reliability/calibration, and #2842 explores conformal or reachable-set uncertainty.
+   reliability/calibration, and #2842 recorded a conformal/reachable-set uncertainty smoke pilot.
 5. Test planner coupling before training-heavy expansion.
    Issue #2843 defines the closed-loop coupling gate. The latest gate recommendation is `revise`,
    not `continue`, because diagnostic forecast improvement did not translate into a passing
@@ -68,26 +68,26 @@ Follow this order unless a later issue has an explicitly narrower diagnostic pur
 
 | Issue | State on 2026-06-15 | Role | Routing note |
 | --- | --- | --- | --- |
-| #2835 | open | Epic | Parent coordination surface for the lane. |
-| #2836 | closed | Forecast artifact schema | `ForecastBatch.v1`; prerequisite for durable forecast artifacts. |
-| #2774 | closed | Motion-rich fixtures | Diagnostic trace-family expansion beyond corridor fixtures. |
-| #2758 | closed | Semantic baselines | Signal/goal-aware CV variants; diagnostic-only. |
-| #2781 | closed | Interaction-aware baseline | Mixed result: likelihood proxy improved while 1s point accuracy worsened. |
-| #2843 | closed | Closed-loop coupling gate | Latest recommendation: `revise` before learned predictor training. |
-| #2759 | closed | Forecast risk scoring | Opt-in diagnostic risk channel for `PolicyStackV1`; default remains off. |
-| #2727 | closed | Fast dynamic actor fixture | Enables future actor-class forecast denominator work. |
-| #2840 | closed | Probabilistic forecast metrics | Metric surface for deterministic/probabilistic forecast comparison. |
-| #2846 | closed | Fast dynamic actor forecast metrics | Separates pedestrian and fast-agent denominators. |
-| #1490 | open, blocked | Predictive planner v2 comparison | Do not repeat the old four-way expansion until revised gate evidence exists. |
-| #2837 | open | Horizon and timestep ablation | Analysis-only report for forecast horizon/output-step presets. |
-| #2838 | closed | Observation-level adapters | Required before deployable/oracle observation tiers can be compared safely. |
-| #2839 | closed | Dataset recorder and split manifest | Required before learned predictor training or durable split comparisons. |
-| #2841 | closed | Calibration and reliability | Metric/report surface for probabilistic forecast quality. |
-| #2842 | open, running | Conformal/reachable-set pilot | Diagnostic uncertainty pilot; no planner/safety claim by itself. |
-| #2844 | open, blocked | Learned probabilistic graph predictor | Blocked until schema/data/metrics/coupling prerequisites unblock. |
-| #2845 | open, blocked | Transformer/diffusion study | Blocked analysis until lighter prerequisites and bounded data exist. |
-| #2847 | closed | Transferability stress matrix | Should run after observation tier, metrics, and fixture/split surfaces are usable. |
-| #2848 | closed | This routing doc | Keep this map current when lane gates or issue states change materially. |
+| Issue #2835 | open | Epic | Parent coordination surface for the lane. |
+| Issue #2836 | closed | Forecast artifact schema | `ForecastBatch.v1`; prerequisite for durable forecast artifacts. |
+| Issue #2774 | closed | Motion-rich fixtures | Diagnostic trace-family expansion beyond corridor fixtures. |
+| Issue #2758 | closed | Semantic baselines | Signal/goal-aware CV variants; diagnostic-only. |
+| Issue #2781 | closed | Interaction-aware baseline | Mixed result: likelihood proxy improved while 1s point accuracy worsened. |
+| Issue #2843 | closed | Closed-loop coupling gate | Latest recommendation: `revise` before learned predictor training. |
+| Issue #2759 | closed | Forecast risk scoring | Opt-in diagnostic risk channel for `PolicyStackV1`; default remains off. |
+| Issue #2727 | closed | Fast dynamic actor fixture | Enables future actor-class forecast denominator work. |
+| Issue #2840 | closed | Probabilistic forecast metrics | Metric surface for deterministic/probabilistic forecast comparison. |
+| Issue #2846 | closed | Fast dynamic actor forecast metrics | Separates pedestrian and fast-agent denominators. |
+| Issue #1490 | open, blocked | Predictive planner v2 comparison | Do not repeat the old four-way expansion until revised gate evidence exists. |
+| Issue #2837 | open | Horizon and timestep ablation | Analysis-only report for forecast horizon/output-step presets. |
+| Issue #2838 | closed | Observation-level adapters | Required before deployable/oracle observation tiers can be compared safely. |
+| Issue #2839 | closed | Dataset recorder and split manifest | Required before learned predictor training or durable split comparisons. |
+| Issue #2841 | closed | Calibration and reliability | Metric/report surface for probabilistic forecast quality. |
+| Issue #2842 | closed | Conformal/reachable-set pilot | Diagnostic uncertainty smoke input; no planner/safety claim by itself. |
+| Issue #2844 | open, blocked | Learned probabilistic graph predictor | Blocked until schema/data/metrics/coupling prerequisites unblock. |
+| Issue #2845 | open, blocked | Transformer/diffusion study | Blocked analysis until lighter prerequisites and bounded data exist. |
+| Issue #2847 | closed | Transferability stress matrix | Should run after observation tier, metrics, and fixture/split surfaces are usable. |
+| Issue #2848 | closed | This routing doc | Keep this map current when lane gates or issue states change materially. |
 
 ## Gate Conditions
 
@@ -102,6 +102,8 @@ Do not start learned predictor training or heavy-model evaluation unless all of 
   calibration or uncertainty fields when applicable.
 - Closed-loop coupling gate reports `continue` on same-seed evidence with mechanism activation,
   success/progress non-regression, false-positive accounting, and runtime caveats.
+- Calibration report decision is `continue` and transferability matrix includes oracle + deployable rows
+  before learned predictor training.
 
 If any condition is missing, route the follow-up as `blocked`, `diagnostic-only`, or `revise`
 instead of treating it as benchmark evidence.

--- a/docs/context/issue_2768_learned_prediction_readiness.md
+++ b/docs/context/issue_2768_learned_prediction_readiness.md
@@ -29,7 +29,7 @@ linked_policy:
 ## Status: NOT-TRAINING-READY
 
 Learned pedestrian prediction training is **blocked** until every prerequisite in this contract
-is satisfied. The validator stub at
+is satisfied. The validator at
 `scripts/validation/validate_learned_prediction_readiness.py` fails closed when split metadata
 or baseline evidence is missing.
 
@@ -83,6 +83,8 @@ Every trace source used for training must declare an explicit, leakage-free spli
   and how the split prevents it.
 - **split_manifest_path**: path to a committed YAML or JSON manifest that records which
   episode IDs or seed values belong to each split.
+  `ForecastDataset.v1` manifests are valid when `split_policy.leakage_prevention` is
+  explicitly populated as a list.
 
 Splits must sum to 1.0. The test split must never be used for model selection, hyperparameter
 tuning, or early stopping.
@@ -96,6 +98,14 @@ The prediction target horizon must be explicitly defined:
 - **dt_seconds**: time step between predicted positions.
 - **multi_horizon**: whether multiple horizons are trained simultaneously. If true, list each
   horizon.
+
+Machine-checkable readiness fields use this key form:
+
+- horizon_seconds: blocked until a bounded Issue #2837 recommendation is selected.
+- horizon_steps: blocked until a bounded Issue #2837 recommendation is selected.
+- dt_seconds: blocked until a bounded Issue #2837 recommendation is selected.
+- horizon_recommendation: blocked pending Issue #2837.
+- timestep_recommendation: blocked pending Issue #2837.
 
 The horizon definition must be compatible with the downstream planner's
 `predictive_horizon_steps` and `predictive_rollout_dt` configuration.
@@ -183,13 +193,17 @@ Learned prediction training **must not** begin until:
 
 1. At least one trace source exists in the registry with `episode_count > 0` and
    `actor_types` covering the target prediction family.
-2. A committed split manifest exists with explicit `split_strategy`, fractions summing to 1.0,
-   and a named `leakage_prevention` statement.
-3. Deterministic baseline metrics (constant_velocity at minimum) exist on the test split
-   for ADE, FDE, and at least one collision-relevance metric.
-4. The target horizon definition is compatible with the downstream planner configuration.
-5. The validator stub at `scripts/validation/validate_learned_prediction_readiness.py`
-   exits with code 0.
+2. A committed split manifest exists with explicit `split_strategy`, leakage metadata, and
+   no leakage across splits.
+3. Baseline metrics exist for the required target (default: `constant_velocity`) with ADE/FDE on
+   the test split.
+4. Calibration report recommendation is `continue`.
+5. Transferability report contains both oracle and deployable observation tiers.
+6. Closed-loop coupling gate recommendation is `continue`.
+7. Horizon and timestep recommendations are documented with `horizon_seconds`,
+   `horizon_steps`, and `dt_seconds`.
+8. The validator at `scripts/validation/validate_learned_prediction_readiness.py`
+   exits with code 0 and all prerequisite statuses are `passed`.
 
 If any condition is not met, the training block remains active and any attempt to train
 a learned predictor should be classified as `blocked` or `not_benchmark_evidence`.
@@ -212,9 +226,15 @@ The readiness validator at `scripts/validation/validate_learned_prediction_readi
 checks the following fail-closed conditions:
 
 - Trace registry file exists and contains at least one source entry with `episode_count > 0`.
-- Split manifest file exists and contains valid train/validation/test fractions summing to 1.0.
-- Baseline evidence file exists and contains constant_velocity baseline metrics for ADE and FDE.
-- Horizon definition is present and compatible.
+- Split manifest file exists and contains valid train/validation/test fractions or dataset schema
+  leakage metadata.
+- Baseline evidence file exists and contains the named target metrics for ADE and FDE.
+- Calibration report is present and recommends `continue`.
+- Transferability report is present and includes oracle + deployable observation tiers.
+- Closed-loop coupling gate is present and recommends `continue`.
+- Horizon/recommendation fields are present in the readiness doc.
+
+Each prerequisite reports pass/fail/blocked in the validator output.
 
 If any check fails, the validator exits with code 2 and a structured error message.
 

--- a/scripts/validation/validate_learned_prediction_readiness.py
+++ b/scripts/validation/validate_learned_prediction_readiness.py
@@ -8,38 +8,59 @@ message.
 Checks performed:
   1. Readiness doc exists and contains the required section headers.
   2. Trace registry file exists (if referenced) with at least one source entry.
-  3. Split manifest exists with valid fractions summing to 1.0.
-  4. Baseline evidence exists with constant_velocity ADE and FDE metrics.
-  5. Horizon definition is present in the readiness doc.
+  3. Split manifest exists and prevents leakage.
+  4. Baseline evidence exists for a named target and has ADE/FDE metrics.
+  5. Calibration and transferability evidence are present.
+  6. Closed-loop coupling gate is continue.
+  7. Horizon and timestep recommendations are documented in the readiness contract.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
+
+STATUS_PASSED = "passed"
+STATUS_FAILED = "failed"
+STATUS_BLOCKED = "blocked"
+DEFAULT_BASELINE_TARGET = "constant_velocity"
+FORECAST_CALIBRATION_REPORT_SCHEMA_VERSION = "ForecastCalibrationReport.v1"
+FORECAST_DATASET_SCHEMA_VERSION = "forecast_dataset.v1"
+FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION = "ForecastTransferabilityStressMatrix.v1"
+
+
+def _load_json(path: Path) -> dict | list | None:
+    """Load a JSON file, returning None on read/parse failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 def _load_yaml(path: Path) -> dict | list | None:
-    """Load a YAML file, returning None if the file does not exist."""
+    """Load a YAML file, returning None if unavailable."""
     try:
         import yaml
     except ImportError:
         return None
     if not path.exists():
         return None
-    with open(path, encoding="utf-8") as fh:
-        return yaml.safe_load(fh)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except OSError:
+        return None
 
 
-def _check_readiness_doc(doc_path: Path) -> list[str]:
+def _check_readiness_doc(doc_path: Path) -> tuple[str, list[str]]:
     """Verify the readiness document exists and contains required sections."""
-    errors: list[str] = []
     if not doc_path.exists():
-        errors.append(f"readiness doc not found: {doc_path}")
-        return errors
+        return STATUS_BLOCKED, [f"readiness doc not found: {doc_path}"]
 
     content = doc_path.read_text(encoding="utf-8")
+    errors: list[str] = []
     required_sections = [
         "Trace Dataset Registry",
         "Train / Validation / Test Split Metadata",
@@ -55,153 +76,348 @@ def _check_readiness_doc(doc_path: Path) -> list[str]:
     for section in required_sections:
         if section not in content:
             errors.append(f"missing required section: {section}")
-    return errors
+
+    required_fields = {
+        "horizon_seconds",
+        "horizon_steps",
+        "dt_seconds",
+        "horizon_recommendation",
+        "timestep_recommendation",
+    }
+    for field in required_fields:
+        if not re.search(rf"(?im)^\s*-?\s*{re.escape(field)}\s*:", content):
+            errors.append(f"readiness doc missing required field: {field}")
+
+    if errors:
+        return STATUS_FAILED, errors
+    return STATUS_PASSED, []
 
 
-def _check_trace_registry(registry_path: Path) -> list[str]:  # noqa: C901
+def _check_trace_registry(registry_path: Path) -> tuple[str, list[str]]:  # noqa: C901
     """Verify trace registry exists and has at least one viable source entry."""
-    errors: list[str] = []
     if not registry_path.exists():
-        errors.append(f"trace registry not found: {registry_path}")
-        return errors
+        return STATUS_BLOCKED, [f"trace registry not found: {registry_path}"]
 
     data = _load_yaml(registry_path)
     if data is None:
-        errors.append(f"trace registry could not be loaded: {registry_path}")
-        return errors
+        return STATUS_FAILED, [f"trace registry could not be loaded: {registry_path}"]
 
     if isinstance(data, list):
         sources = data
     elif isinstance(data, dict):
         sources = data.get("sources", [])
     else:
-        errors.append("trace registry must be a dictionary or a list")
-        return errors
+        return STATUS_FAILED, ["trace registry must be a dictionary or a list"]
 
     if not sources:
-        errors.append("trace registry has no source entries")
-        return errors
+        return STATUS_FAILED, ["trace registry has no source entries"]
 
     viable = 0
     for src in sources:
         if not isinstance(src, dict):
-            errors.append("trace registry source entries must be dictionaries")
-            continue
+            return STATUS_FAILED, ["trace registry source entries must be dictionaries"]
         count = src.get("episode_count", 0)
         actors = src.get("actor_types", [])
         if not isinstance(count, (int, float)):
-            errors.append("trace registry source episode_count must be numeric")
-            continue
+            return STATUS_FAILED, ["trace registry source episode_count must be numeric"]
         if count > 0 and actors:
             viable += 1
 
     if viable == 0:
-        errors.append(
-            "trace registry has no source with episode_count > 0 and non-empty actor_types"
+        return (
+            STATUS_FAILED,
+            ["trace registry has no source with episode_count > 0 and non-empty actor_types"],
         )
-    return errors
+    return STATUS_PASSED, []
 
 
-def _check_split_manifest(manifest_path: Path) -> list[str]:
-    """Verify split manifest has valid fractions summing to 1.0."""
+def _check_split_manifest_legacy(manifest: dict) -> tuple[str, list[str]]:
+    """Validate a legacy split manifest using explicit fractions."""
     errors: list[str] = []
-    if not manifest_path.exists():
-        errors.append(f"split manifest not found: {manifest_path}")
-        return errors
-
-    data = _load_yaml(manifest_path)
-    if data is None:
-        errors.append(f"split manifest could not be loaded: {manifest_path}")
-        return errors
-
-    if not isinstance(data, dict):
-        errors.append("split manifest must be a dictionary")
-        return errors
-
-    train_frac = data.get("train_fraction")
-    val_frac = data.get("validation_fraction")
-    test_frac = data.get("test_fraction")
+    train_frac = manifest.get("train_fraction")
+    val_frac = manifest.get("validation_fraction")
+    test_frac = manifest.get("test_fraction")
 
     if train_frac is None or val_frac is None or test_frac is None:
-        errors.append(
-            "split manifest missing train_fraction, validation_fraction, or test_fraction"
+        return (
+            STATUS_FAILED,
+            ["split manifest missing train_fraction, validation_fraction, or test_fraction"],
         )
-        return errors
 
     if not all(isinstance(value, (int, float)) for value in (train_frac, val_frac, test_frac)):
-        errors.append("split fractions must be numeric")
-        return errors
+        return STATUS_FAILED, ["split fractions must be numeric"]
+
+    if any(value < 0 for value in (train_frac, val_frac, test_frac)):
+        return STATUS_FAILED, ["split fractions must be non-negative"]
 
     total = train_frac + val_frac + test_frac
     if abs(total - 1.0) > 1e-6:
         errors.append(f"split fractions sum to {total}, expected 1.0")
 
-    strategy = data.get("split_strategy")
-    if not strategy:
+    if not manifest.get("split_strategy"):
         errors.append("split manifest missing split_strategy")
 
-    leakage = data.get("leakage_prevention")
-    if not leakage:
+    if not manifest.get("leakage_prevention"):
         errors.append("split manifest missing leakage_prevention statement")
 
-    return errors
+    return (STATUS_FAILED, errors) if errors else (STATUS_PASSED, [])
 
 
-def _check_baseline_evidence(baseline_path: Path) -> list[str]:  # noqa: C901
-    """Verify baseline evidence has constant_velocity ADE and FDE."""
+def _validate_forecast_dataset_manifest(payload: dict) -> None:
+    """Validate the ForecastDataset.v1 split fields needed by the readiness gate."""
+    if payload.get("schema_version") != FORECAST_DATASET_SCHEMA_VERSION:
+        raise ValueError("schema_version must be forecast_dataset.v1")
+    if not str(payload.get("dataset_id", "")).strip():
+        raise ValueError("dataset_id is required")
+    if int(payload.get("example_count", 0)) <= 0:
+        raise ValueError("example_count must be positive")
+    splits = payload.get("splits")
+    if not isinstance(splits, dict):
+        raise ValueError("splits must be a mapping")
+    missing_splits = {"train", "validation", "test"} - set(splits)
+    if missing_splits:
+        raise ValueError(f"splits missing required keys: {sorted(missing_splits)}")
+    examples_path = payload.get("examples_path")
+    if not isinstance(examples_path, str) or not examples_path.strip():
+        raise ValueError("examples_path is required")
+    feature_schema = payload.get("feature_schema")
+    if not isinstance(feature_schema, dict) or not feature_schema:
+        raise ValueError("feature_schema is required")
+
+
+def _check_split_manifest_dataset(manifest: dict) -> tuple[str, list[str]]:
+    """Validate ForecastDataset.v1 split manifests with explicit leak checks."""
+    try:
+        _validate_forecast_dataset_manifest(manifest)
+    except (TypeError, ValueError) as exc:
+        return STATUS_FAILED, [f"forecast dataset manifest invalid: {exc}"]
+
     errors: list[str] = []
+    split_policy = manifest.get("split_policy")
+    if not isinstance(split_policy, dict):
+        return STATUS_FAILED, ["forecast dataset manifest missing split_policy"]
+
+    leakage_prevention = split_policy.get("leakage_prevention")
+    if not leakage_prevention:
+        errors.append("forecast dataset manifest missing split_policy.leakage_prevention")
+    if not isinstance(leakage_prevention, list):
+        errors.append("forecast dataset manifest split_policy.leakage_prevention must be a list")
+
+    if errors:
+        return STATUS_FAILED, errors
+    return STATUS_PASSED, []
+
+
+def _check_split_manifest(manifest_path: Path) -> tuple[str, list[str]]:
+    """Verify split manifest has no leak and explicit split strategy metadata."""
+    if not manifest_path.exists():
+        return STATUS_BLOCKED, [f"split manifest not found: {manifest_path}"]
+
+    data = _load_yaml(manifest_path)
+    if data is None:
+        return STATUS_FAILED, [f"split manifest could not be loaded: {manifest_path}"]
+
+    if not isinstance(data, dict):
+        return STATUS_FAILED, ["split manifest must be a dictionary"]
+
+    if data.get("schema_version") == FORECAST_DATASET_SCHEMA_VERSION:
+        return _check_split_manifest_dataset(data)
+    return _check_split_manifest_legacy(data)
+
+
+def _check_baseline_evidence(  # noqa: C901, PLR0912
+    baseline_path: Path,
+    baseline_target: str,
+) -> tuple[str, list[str]]:
+    """Verify baseline evidence has named target ADE and FDE."""
     if not baseline_path.exists():
-        errors.append(f"baseline evidence not found: {baseline_path}")
-        return errors
+        return STATUS_BLOCKED, [f"baseline evidence not found: {baseline_path}"]
 
     data = _load_yaml(baseline_path)
     if data is None:
-        errors.append(f"baseline evidence could not be loaded: {baseline_path}")
-        return errors
+        return STATUS_FAILED, [f"baseline evidence could not be loaded: {baseline_path}"]
 
     if not isinstance(data, (dict, list)):
-        errors.append("baseline evidence must be a dictionary or a list")
-        return errors
+        return STATUS_FAILED, ["baseline evidence must be a dictionary or a list"]
 
+    target = baseline_target.strip().lower() or DEFAULT_BASELINE_TARGET
     baselines = data if isinstance(data, list) else data.get("baselines", {})
-    cv = None
+    selected = None
     if isinstance(baselines, list):
-        for b in baselines:
-            if isinstance(b, dict) and b.get("name") == "constant_velocity":
-                cv = b
+        for baseline in baselines:
+            if not isinstance(baseline, dict):
+                return STATUS_FAILED, ["baseline entries must be mappings"]
+            name = baseline.get("name")
+            if isinstance(name, str) and name.lower() == target:
+                selected = baseline
                 break
     elif isinstance(baselines, dict):
-        cv = baselines.get("constant_velocity")
+        for key, value in baselines.items():
+            if str(key).lower() == target:
+                if isinstance(value, dict):
+                    selected = value
+                else:
+                    return STATUS_FAILED, [f"{target} baseline entry must be a mapping"]
+                break
 
-    if cv is None:
-        errors.append("baseline evidence missing constant_velocity entry")
-        return errors
+    if selected is None:
+        return STATUS_FAILED, [f"baseline evidence missing {target} entry"]
 
-    if not isinstance(cv, dict):
-        errors.append("constant_velocity baseline entry must be a dictionary")
-        return errors
-
-    cv_keys = {str(key).lower() for key in cv}
-    if "ade" not in cv_keys:
-        errors.append("constant_velocity baseline missing ADE metric")
-    if "fde" not in cv_keys:
-        errors.append("constant_velocity baseline missing FDE metric")
-
-    return errors
+    selected_keys = {str(key).lower() for key in selected}
+    missing = []
+    if "ade" not in selected_keys:
+        missing.append(f"{target} baseline missing ADE metric")
+    if "fde" not in selected_keys:
+        missing.append(f"{target} baseline missing FDE metric")
+    if missing:
+        return STATUS_FAILED, missing
+    return STATUS_PASSED, []
 
 
-def _check_horizon_definition(doc_path: Path) -> list[str]:
-    """Verify horizon definition section contains horizon_seconds and horizon_steps."""
-    errors: list[str] = []
+def _check_horizon_definition(doc_path: Path) -> tuple[str, list[str]]:
+    """Verify horizon and timestep recommendations are documented."""
     if not doc_path.exists():
-        return errors
-
+        return STATUS_BLOCKED, [f"horizon definition doc not found: {doc_path}"]
     content = doc_path.read_text(encoding="utf-8")
-    if "horizon_seconds" not in content:
-        errors.append("readiness doc missing horizon_seconds definition")
-    if "horizon_steps" not in content:
-        errors.append("readiness doc missing horizon_steps definition")
-    return errors
+    errors: list[str] = []
+    required = ["horizon_seconds", "horizon_steps", "dt_seconds"]
+    for field in required:
+        if field not in content:
+            errors.append(f"readiness doc missing {field} definition")
+
+    if "horizon_recommendation" not in content:
+        errors.append("readiness doc missing horizon_recommendation")
+    if "timestep_recommendation" not in content:
+        errors.append("readiness doc missing timestep_recommendation")
+
+    if errors:
+        return STATUS_FAILED, errors
+    return STATUS_PASSED, []
+
+
+def _is_oracle_tier(observation_tier: object) -> bool:
+    """Return whether the tier label is oracle-like."""
+    return str(observation_tier).strip().lower().startswith("oracle")
+
+
+def _check_calibration_report(calibration_report_path: Path) -> tuple[str, list[str]]:
+    """Require a calibration report recommendation of continue."""
+    if not calibration_report_path.exists():
+        return STATUS_BLOCKED, [f"calibration report not found: {calibration_report_path}"]
+
+    payload = _load_json(calibration_report_path)
+    if not isinstance(payload, dict):
+        return STATUS_FAILED, ["calibration report must be JSON"]
+
+    if payload.get("schema_version") != FORECAST_CALIBRATION_REPORT_SCHEMA_VERSION:
+        return STATUS_FAILED, ["calibration report must use ForecastCalibrationReport.v1"]
+
+    recommendation = payload.get("recommendation")
+    if not isinstance(recommendation, dict):
+        return STATUS_FAILED, ["calibration report missing recommendation block"]
+
+    decision = str(recommendation.get("decision", "")).strip().lower()
+    claim_status = str(recommendation.get("claim_status", "")).strip().lower()
+    if decision == "":
+        return STATUS_FAILED, ["calibration report missing recommendation.decision"]
+    if decision != "continue":
+        return STATUS_FAILED, [
+            f"calibration report recommendation is {decision}, expected continue"
+        ]
+    if claim_status == "blocked":
+        return STATUS_FAILED, ["calibration report claim_status is blocked"]
+    return STATUS_PASSED, []
+
+
+def _check_transferability_report(transferability_report_path: Path) -> tuple[str, list[str]]:
+    """Require observation-tier split and non-blocked transferability evidence."""
+    if not transferability_report_path.exists():
+        return STATUS_BLOCKED, [f"transferability report not found: {transferability_report_path}"]
+
+    payload = _load_json(transferability_report_path)
+    if not isinstance(payload, dict):
+        return STATUS_FAILED, ["transferability report must be JSON"]
+
+    if payload.get("schema_version") != (FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION):
+        return STATUS_FAILED, [
+            "transferability report must use ForecastTransferabilityStressMatrix.v1"
+        ]
+
+    matrix_rows = payload.get("matrix_rows")
+    if not isinstance(matrix_rows, list) or not matrix_rows:
+        return STATUS_FAILED, ["transferability report has no matrix_rows"]
+
+    tiers = {row.get("observation_tier") for row in matrix_rows if isinstance(row, dict)}
+    has_oracle = any(_is_oracle_tier(tier) for tier in tiers)
+    has_deployable = any(not _is_oracle_tier(tier) for tier in tiers)
+    if not has_oracle or not has_deployable:
+        return STATUS_FAILED, [
+            "transferability report missing observation-tier split (oracle + deployable)",
+        ]
+
+    recommendation = payload.get("recommendation")
+    if not isinstance(recommendation, dict):
+        return STATUS_FAILED, ["transferability report missing recommendation block"]
+
+    decision = str(recommendation.get("decision", "")).strip().lower()
+    claim_status = str(recommendation.get("claim_status", "")).strip().lower()
+    if not decision:
+        return STATUS_FAILED, ["transferability report missing recommendation.decision"]
+    if decision != "continue":
+        return STATUS_FAILED, [
+            f"transferability report recommendation is {decision}, expected continue"
+        ]
+    if claim_status == "blocked":
+        return STATUS_FAILED, ["transferability report claim_status is blocked"]
+    return STATUS_PASSED, []
+
+
+def _check_closed_loop_gate(path: Path) -> tuple[str, list[str]]:
+    """Require a coupling-gate recommendation of continue."""
+    if not path.exists():
+        return STATUS_BLOCKED, [f"closed-loop coupling gate artifact not found: {path}"]
+
+    if path.suffix.lower() == ".json":
+        payload = _load_json(path)
+        if not isinstance(payload, dict):
+            return STATUS_FAILED, ["closed-loop gate artifact is malformed JSON"]
+
+        recommendation = payload.get("recommendation")
+        if isinstance(recommendation, str):
+            if recommendation.lower() == "continue":
+                return STATUS_PASSED, []
+            return STATUS_FAILED, [
+                f"closed-loop gate recommendation is {recommendation}, expected continue"
+            ]
+
+        gate_status = payload.get("closed_loop_gate", {}).get("status")
+        if gate_status is not None:
+            return STATUS_FAILED, [
+                f"closed-loop gate status is {gate_status}; expected explicit recommendation continue"
+            ]
+        return STATUS_FAILED, ["closed-loop gate recommendation missing"]
+
+    if path.suffix.lower() == ".md":
+        content = path.read_text(encoding="utf-8")
+        status_match = re.search(r"^-\s*status:\s*`?([A-Za-z_]+)`?", content, re.MULTILINE)
+        if status_match is None:
+            return STATUS_FAILED, ["closed-loop gate status line not found"]
+        status = status_match.group(1).strip().lower()
+        return STATUS_FAILED, [
+            f"closed-loop gate status is {status}; expected explicit recommendation continue"
+        ]
+
+    return STATUS_FAILED, ["closed-loop gate artifact must be JSON or Markdown"]
+
+
+def _register_prerequisite(
+    prerequisites: dict[str, dict[str, list[str] | str]],
+    name: str,
+    status: str,
+    messages: list[str],
+) -> None:
+    """Record a prerequisite result."""
+    prerequisites[name] = {"status": status, "messages": messages}
 
 
 def validate_readiness(
@@ -209,39 +425,77 @@ def validate_readiness(
     registry_path: Path | None = None,
     split_manifest_path: Path | None = None,
     baseline_path: Path | None = None,
+    calibration_report_path: Path | None = None,
+    transferability_report_path: Path | None = None,
+    closed_loop_gate_path: Path | None = None,
+    baseline_target: str = DEFAULT_BASELINE_TARGET,
 ) -> dict:
     """Run all readiness checks and return a structured report."""
-    all_errors: list[str] = []
+    checks: dict[str, tuple[str, list[str]]] = {
+        "readiness_doc": _check_readiness_doc(doc_path),
+        "trace_registry": (
+            STATUS_BLOCKED,
+            ["trace registry path not provided"],
+        )
+        if registry_path is None
+        else _check_trace_registry(registry_path),
+        "split_manifest": (
+            STATUS_BLOCKED,
+            ["split manifest path not provided"],
+        )
+        if split_manifest_path is None
+        else _check_split_manifest(split_manifest_path),
+        "baseline_evidence": (
+            STATUS_BLOCKED,
+            ["baseline evidence path not provided"],
+        )
+        if baseline_path is None
+        else _check_baseline_evidence(baseline_path, baseline_target),
+        "calibration_report": (
+            STATUS_BLOCKED,
+            ["calibration report path not provided"],
+        )
+        if calibration_report_path is None
+        else _check_calibration_report(calibration_report_path),
+        "transferability_split": (
+            STATUS_BLOCKED,
+            ["transferability report path not provided"],
+        )
+        if transferability_report_path is None
+        else _check_transferability_report(transferability_report_path),
+        "closed_loop_gate": (
+            STATUS_BLOCKED,
+            ["closed-loop gate path not provided"],
+        )
+        if closed_loop_gate_path is None
+        else _check_closed_loop_gate(closed_loop_gate_path),
+        "horizon_timestep": _check_horizon_definition(doc_path),
+    }
 
-    all_errors.extend(_check_readiness_doc(doc_path))
+    prerequisites: dict[str, dict[str, list[str] | str]] = {}
+    errors: list[str] = []
+    for name, (status, messages) in checks.items():
+        _register_prerequisite(prerequisites, name, status, messages)
+        if status != STATUS_PASSED:
+            errors.extend(messages)
 
-    if registry_path is None:
-        all_errors.append("trace registry path not provided")
-    else:
-        all_errors.extend(_check_trace_registry(registry_path))
-
-    if split_manifest_path is None:
-        all_errors.append("split manifest path not provided")
-    else:
-        all_errors.extend(_check_split_manifest(split_manifest_path))
-
-    if baseline_path is None:
-        all_errors.append("baseline evidence path not provided")
-    else:
-        all_errors.extend(_check_baseline_evidence(baseline_path))
-
-    all_errors.extend(_check_horizon_definition(doc_path))
-
-    status = "ready" if not all_errors else "blocked"
+    status = "ready" if not errors else "blocked"
     return {
         "status": status,
-        "errors": all_errors,
+        "errors": errors,
         "checked": {
             "readiness_doc": str(doc_path),
             "trace_registry": str(registry_path) if registry_path else None,
             "split_manifest": str(split_manifest_path) if split_manifest_path else None,
             "baseline_evidence": str(baseline_path) if baseline_path else None,
+            "calibration_report": str(calibration_report_path) if calibration_report_path else None,
+            "transferability_report": str(transferability_report_path)
+            if transferability_report_path
+            else None,
+            "closed_loop_gate": str(closed_loop_gate_path) if closed_loop_gate_path else None,
+            "required_baseline_target": baseline_target,
         },
+        "prerequisites": prerequisites,
     }
 
 
@@ -264,12 +518,33 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--split-manifest",
         type=Path,
-        help="Path to the train/validation/test split manifest YAML.",
+        help="Path to the split manifest YAML.",
     )
     parser.add_argument(
         "--baseline-evidence",
         type=Path,
         help="Path to the deterministic baseline evidence YAML.",
+    )
+    parser.add_argument(
+        "--calibration-report",
+        type=Path,
+        help="Path to the forecast calibration report JSON.",
+    )
+    parser.add_argument(
+        "--transferability-report",
+        type=Path,
+        help="Path to the transferability stress-matrix JSON.",
+    )
+    parser.add_argument(
+        "--closed-loop-gate",
+        type=Path,
+        help="Path to the closed-loop coupling gate artifact (JSON or Markdown).",
+    )
+    parser.add_argument(
+        "--baseline-target",
+        type=str,
+        default=DEFAULT_BASELINE_TARGET,
+        help="Named baseline target that must exist in baseline evidence.",
     )
     parser.add_argument(
         "--repo-root",
@@ -297,16 +572,26 @@ def main(argv: list[str] | None = None) -> int:
         registry_path=_resolve(args.trace_registry),
         split_manifest_path=_resolve(args.split_manifest),
         baseline_path=_resolve(args.baseline_evidence),
+        calibration_report_path=_resolve(args.calibration_report),
+        transferability_report_path=_resolve(args.transferability_report),
+        closed_loop_gate_path=_resolve(args.closed_loop_gate),
+        baseline_target=args.baseline_target,
     )
 
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     elif report["status"] == "ready":
         print("learned-prediction readiness: READY")
+        for key, payload in report["prerequisites"].items():
+            status = payload["status"]
+            print(f" - {key}: {status}")
     else:
         print("learned-prediction readiness: BLOCKED")
-        for err in report["errors"]:
-            print(f"  - {err}")
+        for key, payload in report["prerequisites"].items():
+            status = payload["status"]
+            print(f" - {key}: {status}")
+            for err in payload["messages"]:
+                print(f"   * {err}")
 
     return 0 if report["status"] == "ready" else 2
 

--- a/tests/validation/test_validate_learned_prediction_readiness.py
+++ b/tests/validation/test_validate_learned_prediction_readiness.py
@@ -1,4 +1,4 @@
-"""Tests for the learned-prediction readiness validator stub."""
+"""Tests for the learned-prediction readiness validator."""
 
 from __future__ import annotations
 
@@ -9,6 +9,10 @@ import pytest
 import yaml
 
 from scripts.validation.validate_learned_prediction_readiness import (
+    DEFAULT_BASELINE_TARGET,
+    FORECAST_CALIBRATION_REPORT_SCHEMA_VERSION,
+    FORECAST_DATASET_SCHEMA_VERSION,
+    FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION,
     main,
     validate_readiness,
 )
@@ -18,51 +22,35 @@ if TYPE_CHECKING:
 
 
 def _readiness_doc_content() -> str:
-    """Return a minimal readiness document with all required sections."""
+    """Return a minimal readiness document with required sections and keys."""
     return """\
 # Learned Prediction Readiness Contract
 
 ## Trace Dataset Registry
 
-Required dataset registry with source metadata.
-
 ## Train / Validation / Test Split Metadata
-
-Split strategy and leakage prevention.
 
 ## Target Horizon Definition
 
 - horizon_seconds: 3.0
 - horizon_steps: 30
 - dt_seconds: 0.1
+- horizon_recommendation: 3s for planner experiments
+- timestep_recommendation: 0.1s for prediction rollout
 
 ## Dynamic Actor Types
 
-Supported actor types for prediction.
-
 ## Semantic Input Contract
-
-Required and optional semantic fields.
 
 ## Calibration Metrics
 
-ADE, FDE, MR, ECE metrics.
-
 ## Collision-Relevance Metrics
-
-Collision proxy rate and TTC error.
 
 ## Deterministic / Semantic Baselines
 
-Constant velocity and semantic baselines.
-
 ## Comparison Protocol
 
-Same test split, seeds, and horizon.
-
 ## Training Block Conditions
-
-Conditions that must be satisfied before training.
 """
 
 
@@ -86,15 +74,39 @@ def _trace_registry_content() -> str:
 
 
 def _split_manifest_content() -> str:
-    """Return a valid split manifest."""
+    """Return a valid legacy-style split manifest."""
     return yaml.safe_dump(
         {
             "split_strategy": "episode_partition",
             "train_fraction": 0.7,
             "validation_fraction": 0.15,
             "test_fraction": 0.15,
-            "leakage_prevention": "Episodes are partitioned by seed hash; no seed appears in multiple splits.",
+            "leakage_prevention": "Episode-level partition by seed hash.",
         }
+    )
+
+
+def _dataset_manifest_content() -> str:
+    """Return a minimal forecast_dataset.v1-style manifest."""
+    return json.dumps(
+        {
+            "schema_version": FORECAST_DATASET_SCHEMA_VERSION,
+            "dataset_id": "unit_test_dataset",
+            "example_count": 10,
+            "examples_path": "examples.jsonl",
+            "splits": {
+                "train": {"example_count": 6},
+                "validation": {"example_count": 2},
+                "test": {"example_count": 2},
+            },
+            "split_policy": {
+                "strategy": "trace_partition",
+                "leakage_prevention": ["scenario_seed_keys"],
+                "split_names": ["train", "validation", "test"],
+            },
+            "feature_schema": {"position": {"type": "float"}},
+        },
+        sort_keys=True,
     )
 
 
@@ -113,10 +125,82 @@ def _baseline_evidence_content() -> str:
     )
 
 
+def _calibration_report_content(
+    decision: str = "continue", claim_status: str = "analysis-only"
+) -> str:
+    """Build a minimal calibration report payload."""
+    return json.dumps(
+        {
+            "schema_version": FORECAST_CALIBRATION_REPORT_SCHEMA_VERSION,
+            "recommendation": {
+                "decision": decision,
+                "claim_status": claim_status,
+            },
+        },
+        sort_keys=True,
+    )
+
+
+def _transferability_report_content(
+    decision: str = "continue",
+    claim_status: str = "benchmark-eligible",
+) -> str:
+    """Build a minimal transferability matrix with oracle + deployable rows."""
+    return json.dumps(
+        {
+            "schema_version": FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION,
+            "matrix_rows": [
+                {"observation_tier": "oracle_full_state"},
+                {"observation_tier": "deployable_vision"},
+            ],
+            "recommendation": {
+                "decision": decision,
+                "claim_status": claim_status,
+            },
+        },
+        sort_keys=True,
+    )
+
+
+def _closed_loop_gate_content(decision: str = "continue") -> str:
+    """Build a minimal closed-loop gate artifact."""
+    return json.dumps({"recommendation": decision}, sort_keys=True)
+
+
+def _write_validation_bundle(tmp_path: Path) -> dict[str, Path]:
+    """Write full pass-set artifacts for validator success."""
+    doc = tmp_path / "readiness.md"
+    registry = tmp_path / "registry.yaml"
+    split = tmp_path / "split.yaml"
+    baseline = tmp_path / "baseline.yaml"
+    calibration = tmp_path / "calibration.json"
+    transferability = tmp_path / "transferability.json"
+    closed_loop = tmp_path / "closed_loop_gate.json"
+
+    doc.write_text(_readiness_doc_content(), encoding="utf-8")
+    registry.write_text(_trace_registry_content(), encoding="utf-8")
+    split.write_text(_split_manifest_content(), encoding="utf-8")
+    baseline.write_text(_baseline_evidence_content(), encoding="utf-8")
+    calibration.write_text(_calibration_report_content(), encoding="utf-8")
+    transferability.write_text(_transferability_report_content(), encoding="utf-8")
+    closed_loop.write_text(_closed_loop_gate_content(), encoding="utf-8")
+
+    return {
+        "doc": doc,
+        "registry": registry,
+        "split": split,
+        "baseline": baseline,
+        "calibration": calibration,
+        "transferability": transferability,
+        "closed_loop": closed_loop,
+    }
+
+
 def test_blocked_when_readiness_doc_missing(tmp_path: Path) -> None:
     """Validator should fail when the readiness doc does not exist."""
     report = validate_readiness(doc_path=tmp_path / "missing.md")
     assert report["status"] == "blocked"
+    assert report["prerequisites"]["readiness_doc"]["status"] == "blocked"
     assert any("readiness doc not found" in e for e in report["errors"])
 
 
@@ -126,117 +210,119 @@ def test_blocked_when_sections_missing(tmp_path: Path) -> None:
     doc.write_text("# Incomplete\n", encoding="utf-8")
     report = validate_readiness(doc_path=doc)
     assert report["status"] == "blocked"
+    assert report["prerequisites"]["readiness_doc"]["status"] == "failed"
     assert any("missing required section" in e for e in report["errors"])
 
 
-def test_blocked_when_trace_registry_missing(tmp_path: Path) -> None:
-    """Validator should fail when trace registry is referenced but absent."""
+def test_blocked_when_prerequisite_paths_not_provided(tmp_path: Path) -> None:
+    """Validator should fail closed when prereq artifact paths are omitted."""
     doc = tmp_path / "readiness.md"
     doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    report = validate_readiness(
-        doc_path=doc,
-        registry_path=tmp_path / "missing_registry.yaml",
-    )
+    report = validate_readiness(doc_path=doc)
     assert report["status"] == "blocked"
-    assert any("trace registry not found" in e for e in report["errors"])
+    assert report["prerequisites"]["trace_registry"]["status"] == "blocked"
+    assert report["prerequisites"]["split_manifest"]["status"] == "blocked"
+    assert report["prerequisites"]["baseline_evidence"]["status"] == "blocked"
+    assert report["prerequisites"]["calibration_report"]["status"] == "blocked"
+    assert report["prerequisites"]["transferability_split"]["status"] == "blocked"
+    assert report["prerequisites"]["closed_loop_gate"]["status"] == "blocked"
+    for key in (
+        "trace registry path not provided",
+        "split manifest path not provided",
+        "baseline evidence path not provided",
+        "calibration report path not provided",
+        "transferability report path not provided",
+        "closed-loop gate path not provided",
+    ):
+        assert key in report["errors"]
 
 
 def test_blocked_when_trace_registry_has_no_sources(tmp_path: Path) -> None:
     """Validator should report an empty registry instead of failing open."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(yaml.safe_dump({"sources": []}), encoding="utf-8")
-    report = validate_readiness(doc_path=doc, registry_path=registry)
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["registry"].write_text(yaml.safe_dump({"sources": []}), encoding="utf-8")
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
     assert report["status"] == "blocked"
+    assert report["prerequisites"]["trace_registry"]["status"] == "failed"
     assert "trace registry has no source entries" in report["errors"]
 
 
 def test_blocked_when_trace_registry_shape_invalid(tmp_path: Path) -> None:
     """Validator should fail closed on malformed trace registry YAML."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(yaml.safe_dump("not-a-registry"), encoding="utf-8")
-    report = validate_readiness(doc_path=doc, registry_path=registry)
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["registry"].write_text(yaml.safe_dump("not-a-registry"), encoding="utf-8")
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
     assert report["status"] == "blocked"
     assert "trace registry must be a dictionary or a list" in report["errors"]
 
 
-def test_blocked_when_prerequisite_paths_not_provided(tmp_path: Path) -> None:
-    """Validator should fail closed when prerequisite artifact paths are omitted."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    report = validate_readiness(doc_path=doc)
-    assert report["status"] == "blocked"
-    assert "trace registry path not provided" in report["errors"]
-    assert "split manifest path not provided" in report["errors"]
-    assert "baseline evidence path not provided" in report["errors"]
-
-
 def test_blocked_when_split_manifest_missing(tmp_path: Path) -> None:
     """Validator should fail when split manifest is referenced but absent."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
+    bundle = _write_validation_bundle(tmp_path)
     report = validate_readiness(
-        doc_path=doc,
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
         split_manifest_path=tmp_path / "missing_split.yaml",
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
     )
     assert report["status"] == "blocked"
+    assert report["prerequisites"]["split_manifest"]["status"] == "blocked"
     assert any("split manifest not found" in e for e in report["errors"])
 
 
-def test_blocked_when_baseline_evidence_missing(tmp_path: Path) -> None:
-    """Validator should fail when baseline evidence is referenced but absent."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
+def test_blocked_when_split_manifest_fails_forecast_schema(tmp_path: Path) -> None:
+    """Validator should reject ForecastDataset manifests missing leakage prevention."""
+    bundle = _write_validation_bundle(tmp_path)
+    manifest = {
+        "schema_version": FORECAST_DATASET_SCHEMA_VERSION,
+        "dataset_id": "unit",
+        "example_count": 1,
+        "examples_path": "examples.jsonl",
+        "splits": {"train": {}, "validation": {}, "test": {}},
+        "split_policy": {
+            "strategy": "trace_partition",
+            "split_names": ["train", "validation", "test"],
+        },
+        "feature_schema": {"position": {"type": "float"}},
+    }
+    bundle["split"].write_text(json.dumps(manifest), encoding="utf-8")
     report = validate_readiness(
-        doc_path=doc,
-        baseline_path=tmp_path / "missing_baseline.yaml",
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
     )
     assert report["status"] == "blocked"
-    assert any("baseline evidence not found" in e for e in report["errors"])
-
-
-def test_blocked_when_split_fractions_do_not_sum_to_one(tmp_path: Path) -> None:
-    """Validator should fail when split fractions do not sum to 1.0."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(
-        yaml.safe_dump(
-            {
-                "split_strategy": "episode_partition",
-                "train_fraction": 0.5,
-                "validation_fraction": 0.2,
-                "test_fraction": 0.1,
-                "leakage_prevention": "none",
-            }
-        ),
-        encoding="utf-8",
-    )
-    report = validate_readiness(doc_path=doc, split_manifest_path=split)
-    assert report["status"] == "blocked"
-    assert any("sum to" in e for e in report["errors"])
-
-
-def test_blocked_when_split_manifest_shape_invalid(tmp_path: Path) -> None:
-    """Validator should fail closed on malformed split manifest YAML."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(yaml.safe_dump(["not", "a", "mapping"]), encoding="utf-8")
-    report = validate_readiness(doc_path=doc, split_manifest_path=split)
-    assert report["status"] == "blocked"
-    assert "split manifest must be a dictionary" in report["errors"]
+    assert report["prerequisites"]["split_manifest"]["status"] == "failed"
+    assert any("leakage_prevention" in e for e in report["errors"])
 
 
 def test_blocked_when_split_fractions_are_not_numeric(tmp_path: Path) -> None:
     """Validator should fail closed before adding nonnumeric split fractions."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["split"].write_text(
         yaml.safe_dump(
             {
                 "split_strategy": "episode_partition",
@@ -248,92 +334,214 @@ def test_blocked_when_split_fractions_are_not_numeric(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
-    report = validate_readiness(doc_path=doc, split_manifest_path=split)
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
     assert report["status"] == "blocked"
+    assert report["prerequisites"]["split_manifest"]["status"] == "failed"
     assert "split fractions must be numeric" in report["errors"]
 
 
 def test_blocked_when_baseline_missing_cv_entry(tmp_path: Path) -> None:
     """Validator should fail when constant_velocity baseline is absent."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["baseline"].write_text(
         yaml.safe_dump({"baselines": {"zero_velocity": {"ade": 1.0, "fde": 1.0}}}),
         encoding="utf-8",
     )
-    report = validate_readiness(doc_path=doc, baseline_path=baseline)
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
     assert report["status"] == "blocked"
     assert any("missing constant_velocity" in e for e in report["errors"])
 
 
-def test_blocked_when_baseline_shape_invalid(tmp_path: Path) -> None:
-    """Validator should fail closed on malformed baseline evidence YAML."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(yaml.safe_dump("not-a-baseline"), encoding="utf-8")
-    report = validate_readiness(doc_path=doc, baseline_path=baseline)
-    assert report["status"] == "blocked"
-    assert "baseline evidence must be a dictionary or a list" in report["errors"]
-
-
-def test_blocked_when_baseline_missing_ade(tmp_path: Path) -> None:
-    """Validator should fail when constant_velocity baseline lacks ADE."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(
-        yaml.safe_dump({"baselines": {"constant_velocity": {"fde": 0.82}}}),
+def test_ready_when_named_baseline_target_present(tmp_path: Path) -> None:
+    """Validator should accept a requested non-default baseline target."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["baseline"].write_text(
+        yaml.safe_dump({"baselines": {"semantic_baseline": {"ade": 0.99, "fde": 1.2}}}),
         encoding="utf-8",
     )
-    report = validate_readiness(doc_path=doc, baseline_path=baseline)
-    assert report["status"] == "blocked"
-    assert any("missing ADE" in e for e in report["errors"])
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+        baseline_target="semantic_baseline",
+    )
+    assert report["status"] == "ready"
 
 
 def test_ready_accepts_uppercase_baseline_metric_keys(tmp_path: Path) -> None:
     """Validator should accept ADE/FDE metric keys case-insensitively."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(_trace_registry_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(_split_manifest_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["baseline"].write_text(
         yaml.safe_dump({"baselines": {"constant_velocity": {"ADE": 0.45, "FDE": 0.82}}}),
+        encoding="utf-8",
+    )
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "ready"
+    assert report["checked"]["required_baseline_target"] == DEFAULT_BASELINE_TARGET
+
+
+def test_blocked_when_calibration_recommendation_is_not_continue(tmp_path: Path) -> None:
+    """Calibration report must return a continue decision."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["calibration"].write_text(
+        _calibration_report_content("revise", "analysis-only"),
+        encoding="utf-8",
+    )
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "blocked"
+    assert any("recommendation is revise, expected continue" in e for e in report["errors"])
+
+
+def test_blocked_when_transferability_lacks_oracle_and_deployable_tiers(
+    tmp_path: Path,
+) -> None:
+    """Transferability matrix must include oracle and deployable observation tiers."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["transferability"].write_text(
+        json.dumps(
+            {
+                "schema_version": FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION,
+                "matrix_rows": [{"observation_tier": "deployable_vision"}],
+                "recommendation": {"decision": "continue", "claim_status": "benchmark-eligible"},
+            },
+            sort_keys=True,
+        ),
         encoding="utf-8",
     )
 
     report = validate_readiness(
-        doc_path=doc,
-        registry_path=registry,
-        split_manifest_path=split,
-        baseline_path=baseline,
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
     )
-    assert report["status"] == "ready"
+    assert report["status"] == "blocked"
+    assert any("missing observation-tier split" in e for e in report["errors"])
+
+
+def test_blocked_when_transferability_recommendation_is_revise(tmp_path: Path) -> None:
+    """Transferability matrix must recommend continue."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["transferability"].write_text(
+        _transferability_report_content("revise", "analysis-only"),
+        encoding="utf-8",
+    )
+
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "blocked"
+    assert any("recommendation is revise, expected continue" in e for e in report["errors"])
+
+
+def test_blocked_when_closed_loop_gate_is_revise(tmp_path: Path) -> None:
+    """Closed-loop gate recommendation must be continue."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["closed_loop"].write_text(_closed_loop_gate_content("revise"), encoding="utf-8")
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "blocked"
+    assert report["prerequisites"]["closed_loop_gate"]["status"] == "failed"
+    assert any("expected continue" in e for e in report["errors"])
+
+
+def test_blocked_when_closed_loop_gate_uses_legacy_passed_status(tmp_path: Path) -> None:
+    """Closed-loop gate must not pass without an explicit continue recommendation."""
+    bundle = _write_validation_bundle(tmp_path)
+    bundle["closed_loop"].write_text(
+        json.dumps({"closed_loop_gate": {"status": "passed"}}, sort_keys=True),
+        encoding="utf-8",
+    )
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "blocked"
+    assert any("expected explicit recommendation continue" in e for e in report["errors"])
 
 
 def test_ready_when_all_checks_pass(tmp_path: Path) -> None:
     """Validator should pass when all prerequisites are satisfied."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(_trace_registry_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(_split_manifest_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(_baseline_evidence_content(), encoding="utf-8")
-
+    bundle = _write_validation_bundle(tmp_path)
     report = validate_readiness(
-        doc_path=doc,
-        registry_path=registry,
-        split_manifest_path=split,
-        baseline_path=baseline,
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
     )
     assert report["status"] == "ready"
     assert report["errors"] == []
+
+
+def test_prerequisite_status_shape_when_blocked(tmp_path: Path) -> None:
+    """Each prerequisite should report a status and message list."""
+    doc = tmp_path / "readiness.md"
+    doc.write_text(_readiness_doc_content(), encoding="utf-8")
+    report = validate_readiness(doc_path=doc)
+    for payload in report["prerequisites"].values():
+        assert sorted(payload.keys()) == ["messages", "status"]
+        assert payload["status"] in {"blocked", "failed", "passed"}
+        assert isinstance(payload["messages"], list)
 
 
 def test_cli_exits_zero_when_ready(
@@ -342,34 +550,33 @@ def test_cli_exits_zero_when_ready(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """CLI should exit 0 when all checks pass."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(_trace_registry_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(_split_manifest_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(_baseline_evidence_content(), encoding="utf-8")
-
+    bundle = _write_validation_bundle(tmp_path)
     monkeypatch.setattr(
         "sys.argv",
         [
             "validate_learned_prediction_readiness.py",
             "--readiness-doc",
-            str(doc),
+            str(bundle["doc"]),
             "--trace-registry",
-            str(registry),
+            str(bundle["registry"]),
             "--split-manifest",
-            str(split),
+            str(bundle["split"]),
             "--baseline-evidence",
-            str(baseline),
+            str(bundle["baseline"]),
+            "--calibration-report",
+            str(bundle["calibration"]),
+            "--transferability-report",
+            str(bundle["transferability"]),
+            "--closed-loop-gate",
+            str(bundle["closed_loop"]),
             "--json",
         ],
     )
     exit_code = main()
-    assert exit_code == 0
     output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
     assert output["status"] == "ready"
+    assert output["prerequisites"]["transferability_split"]["status"] == "passed"
 
 
 def test_cli_resolves_relative_paths_against_repo_root(
@@ -378,16 +585,8 @@ def test_cli_resolves_relative_paths_against_repo_root(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """CLI should resolve relative input paths against --repo-root."""
-    doc = tmp_path / "readiness.md"
-    doc.write_text(_readiness_doc_content(), encoding="utf-8")
-    registry = tmp_path / "registry.yaml"
-    registry.write_text(_trace_registry_content(), encoding="utf-8")
-    split = tmp_path / "split.yaml"
-    split.write_text(_split_manifest_content(), encoding="utf-8")
-    baseline = tmp_path / "baseline.yaml"
-    baseline.write_text(_baseline_evidence_content(), encoding="utf-8")
+    _write_validation_bundle(tmp_path)
     monkeypatch.chdir(tmp_path.parent)
-
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -402,12 +601,18 @@ def test_cli_resolves_relative_paths_against_repo_root(
             "split.yaml",
             "--baseline-evidence",
             "baseline.yaml",
+            "--calibration-report",
+            "calibration.json",
+            "--transferability-report",
+            "transferability.json",
+            "--closed-loop-gate",
+            "closed_loop_gate.json",
             "--json",
         ],
     )
     exit_code = main()
-    assert exit_code == 0
     output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
     assert output["status"] == "ready"
 
 
@@ -419,7 +624,6 @@ def test_cli_exits_two_when_blocked(
     """CLI should exit 2 when prerequisites are missing."""
     doc = tmp_path / "readiness.md"
     doc.write_text("# Incomplete\n", encoding="utf-8")
-
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -430,9 +634,10 @@ def test_cli_exits_two_when_blocked(
         ],
     )
     exit_code = main()
-    assert exit_code == 2
     output = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
     assert output["status"] == "blocked"
+    assert output["prerequisites"]["readiness_doc"]["status"] == "failed"
 
 
 def test_cli_text_output_when_blocked(
@@ -440,20 +645,15 @@ def test_cli_text_output_when_blocked(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """CLI should print BLOCKED with error lines in text mode."""
+    """CLI should print BLOCKED with per-prereq messages in text mode."""
     doc = tmp_path / "readiness.md"
     doc.write_text("# Incomplete\n", encoding="utf-8")
-
     monkeypatch.setattr(
         "sys.argv",
-        [
-            "validate_learned_prediction_readiness.py",
-            "--readiness-doc",
-            str(doc),
-        ],
+        ["validate_learned_prediction_readiness.py", "--readiness-doc", str(doc)],
     )
     exit_code = main()
-    assert exit_code == 2
     text = capsys.readouterr().out
+    assert exit_code == 2
     assert "BLOCKED" in text
-    assert "missing required section" in text
+    assert "horizon_timestep" in text


### PR DESCRIPTION
## Summary

- Extends the learned-prediction readiness validator into a fail-closed per-prerequisite gate.
- Requires explicit `passed`/`failed`/`blocked` status for dataset/split provenance, baseline target, calibration, transferability, closed-loop gate, and horizon/timestep readiness.
- Tightens learned-predictor unblocking so calibration, transferability, and closed-loop coupling must explicitly recommend `continue`; legacy `passed` closed-loop statuses no longer unblock training.
- Updates the readiness contract and prediction-lane routing doc, including the now-closed Issue #2842 state.

Closes #2867.

## Validation

- `rtk uv run pytest tests/validation/test_validate_learned_prediction_readiness.py` (22 passed)
- `rtk uv run ruff check scripts/validation/validate_learned_prediction_readiness.py tests/validation/test_validate_learned_prediction_readiness.py`
- `rtk uv run ruff format --check scripts/validation/validate_learned_prediction_readiness.py tests/validation/test_validate_learned_prediction_readiness.py`
- `BASE_REF=origin/main rtk scripts/dev/check_docs_proof_consistency_diff.sh`
- `rtk git diff --check`
- Direct script smoke: `python scripts/validation/validate_learned_prediction_readiness.py --json` returned exit 2 with clean JSON and per-prerequisite blocked statuses.

## Downstream Propagation

- Issue #2844 should link this validator/readiness contract as its unblocking contract after this PR is available.
- No benchmark report, leaderboard, model registry, or artifact catalog update is required; this PR adds a readiness gate, not new benchmark evidence.
- Disposable local coverage output from focused pytest was pruned before commit.

## Research Result Guidance

- Target claim/blocker: make learned probabilistic predictor readiness machine-checkable before Issue #2844 can start.
- Comparator/baseline: readiness is measured against explicit prerequisite artifacts and a named baseline target, defaulting to `constant_velocity`.
- Evidence tier: workflow/validator nominal evidence.
- Result classification: readiness gate only; learned prediction training remains blocked by default until all prerequisites pass.
- Decision/stop rule: missing, stale, revise, stop, blocked, or non-`continue` gate artifacts keep learned predictor work blocked.
- Synthesis surface/update target: `docs/context/issue_2768_learned_prediction_readiness.md`, `docs/ai/prediction_lane.md`, and Issue #2844 link/comment.

## Delegation

- OpenCode Go selected Issue #2867 as the next compact high-value target.
- OpenCode Go implemented the first validator expansion.
- OpenCode Go review found a blocking legacy closed-loop pass bug and transferability strictness gap; both were fixed and covered with tests before this PR.
