### PR TITLE
Populate forecast transferability matrix rows

### DIFF
--- a/docs/ai/prediction_lane.md
+++ b/docs/ai/prediction_lane.md
@@ -79,6 +79,7 @@ Follow this order unless a later issue has an explicitly narrower diagnostic pur
 | Issue #2840 | closed | Probabilistic forecast metrics | Metric surface for deterministic/probabilistic forecast comparison. |
 | Issue #2846 | closed | Fast dynamic actor forecast metrics | Separates pedestrian and fast-agent denominators. |
 | Issue #1490 | open, blocked | Predictive planner v2 comparison | Do not repeat the old four-way expansion until revised gate evidence exists. |
+| Issue #2866 | open | Transferability matrix row coverage | Follow-up to make scenario-family/horizon/actor split cells explicit and keep blocked metadata cells visible. |
 | Issue #2837 | open | Horizon and timestep ablation | Analysis-only report for forecast horizon/output-step presets. |
 | Issue #2838 | closed | Observation-level adapters | Required before deployable/oracle observation tiers can be compared safely. |
 | Issue #2839 | closed | Dataset recorder and split manifest | Required before learned predictor training or durable split comparisons. |

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1081,6 +1081,18 @@ entries:
     status: current
     freshness: maintained
     area: predictive_planner
+  - path: docs/context/evidence/issue_2866_transferability_matrix_rows/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/issue_1169_carla_live_replay.md
     status: current
     freshness: maintained

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -388,3 +388,6 @@ Policy caveats:
   false_positive_suppresses_penalty (penalty suppressed, goal retained with zero unnecessary
   slowdown count).
   claim_boundary=diagnostic_only_not_benchmark_evidence. Not a safety or live benchmark claim.
+- `issue_2866_transferability_matrix_rows/`: tracked bounded-input evidence for the Issue #2866
+  transferability matrix follow-up, including generated JSON/Markdown matrix output with explicit
+  observation-tier, actor-class, scenario-family, horizon, semantic-metadata, and blocked-cell rows.

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/README.md
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/README.md
@@ -1,0 +1,42 @@
+# Issue #2866 Transferability Matrix Rows
+
+## Scope
+
+This diagnostic bundle records the Issue #2866 follow-up for `ForecastTransferabilityStressMatrix.v1`
+row construction.
+
+## Evidence status
+
+- `schema`: `ForecastTransferabilityStressMatrix.v1`
+- `matrix`: [transferability_matrix.json](transferability_matrix.json) and
+  [transferability_matrix.md](transferability_matrix.md)
+- `claim_boundary`: blocked / diagnostic-only
+- `reason`: the tracked bounded inputs expose observation-tier, actor-class, scenario-family,
+  horizon, and semantic-metadata splits, but one deployable cell intentionally lacks actor and
+  scenario-family metadata. The matrix therefore emits explicit blocked cells and returns
+  `decision: stop`.
+
+## Reproducible command
+
+```
+uv run python scripts/benchmark/build_forecast_transferability_matrix.py \
+  docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json \
+  docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json \
+  docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json \
+  --report-id issue_2866_transferability_matrix_rows \
+  --generated-at-utc 2026-06-15T00:00:00+00:00 \
+  --out-json docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.json \
+  --out-md docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.md
+```
+
+## Validation
+
+```
+uv run pytest tests/benchmark/test_forecast_transferability_stress_matrix.py
+```
+
+## Claim boundary
+
+The complete deployable fixture cells show that the matrix can preserve row-level metadata, not that
+forecast transfer is benchmark-proven. Oracle rows remain diagnostic-only, and blocked cells prevent
+any transferability, safety, progress, paper-facing, or dissertation claim.

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json
@@ -1,0 +1,51 @@
+{
+  "aggregate_rows": [
+    {
+      "actor_class": "bicycle",
+      "denominator": 8,
+      "horizon_s": 0.5,
+      "metric": "mean_ade",
+      "scenario_family": "motion_rich_occluded_emergence",
+      "status": "ok",
+      "value": 0.42
+    },
+    {
+      "actor_class": "bicycle",
+      "denominator": 8,
+      "horizon_s": 1.0,
+      "metric": "mean_ade",
+      "scenario_family": "motion_rich_occluded_emergence",
+      "status": "ok",
+      "value": 0.91
+    }
+  ],
+  "artifact_input": {
+    "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+    "generated_at_utc": "2026-06-15T00:00:00+00:00",
+    "issue": 2866,
+    "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json"
+  },
+  "provenance": {
+    "dt_s": 0.5,
+    "horizons_s": [
+      0.5,
+      1.0
+    ],
+    "observation_tier": "deployable_tracked",
+    "predictor_family": "constant_velocity",
+    "predictor_id": "cv-deployable-motion-rich-bicycle-fixture",
+    "scenario_id": "motion_rich_occluded_emergence_fixture",
+    "scenario_family": "motion_rich_occluded_emergence"
+  },
+  "schema_version": "ForecastMetrics.v1",
+  "transfer_dimensions": {
+    "density": "medium",
+    "dropout": "synthetic_dropout_0.1",
+    "latency": "1_step",
+    "map_family": "motion_rich_fixture",
+    "observation_noise": "tracked_noise_low",
+    "occlusion": "occluded_emergence",
+    "pedestrian_model_family": "fast_actor_fixture",
+    "semantic_metadata_present": true
+  }
+}

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json
@@ -1,0 +1,37 @@
+{
+  "aggregate_rows": [
+    {
+      "denominator": 0,
+      "horizon_s": 1.0,
+      "metric": "mean_ade",
+      "status": "unavailable",
+      "value": null
+    }
+  ],
+  "artifact_input": {
+    "command": "tracked unavailable-cell fixture for issue #2866 transferability matrix rows",
+    "generated_at_utc": "2026-06-15T00:00:00+00:00",
+    "issue": 2866,
+    "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json"
+  },
+  "provenance": {
+    "dt_s": 0.5,
+    "horizons_s": [
+      1.0
+    ],
+    "observation_tier": "deployable_tracked",
+    "predictor_family": "constant_velocity",
+    "predictor_id": "cv-deployable-unavailable-cell-fixture",
+    "scenario_id": "missing_metadata_fixture"
+  },
+  "schema_version": "ForecastMetrics.v1",
+  "transfer_dimensions": {
+    "density": "unknown",
+    "dropout": "unknown",
+    "latency": "unknown",
+    "observation_noise": "tracked_noise_unknown",
+    "occlusion": "unknown",
+    "pedestrian_model_family": "unknown",
+    "semantic_metadata_present": "unknown"
+  }
+}

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json
@@ -1,0 +1,51 @@
+{
+  "aggregate_rows": [
+    {
+      "actor_class": "pedestrian",
+      "denominator": 20,
+      "horizon_s": 0.5,
+      "metric": "mean_ade",
+      "scenario_family": "corridor_fixture",
+      "status": "ok",
+      "value": 0.18
+    },
+    {
+      "actor_class": "pedestrian",
+      "denominator": 20,
+      "horizon_s": 1.0,
+      "metric": "mean_ade",
+      "scenario_family": "corridor_fixture",
+      "status": "ok",
+      "value": 0.34
+    }
+  ],
+  "artifact_input": {
+    "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+    "generated_at_utc": "2026-06-15T00:00:00+00:00",
+    "issue": 2866,
+    "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json"
+  },
+  "provenance": {
+    "dt_s": 0.5,
+    "horizons_s": [
+      0.5,
+      1.0
+    ],
+    "observation_tier": "oracle_full_state",
+    "predictor_family": "constant_velocity",
+    "predictor_id": "cv-oracle-corridor-fixture",
+    "scenario_id": "classic_corridor_fixture",
+    "scenario_family": "corridor_fixture"
+  },
+  "schema_version": "ForecastMetrics.v1",
+  "transfer_dimensions": {
+    "density": "low",
+    "dropout": "none",
+    "latency": "0_steps",
+    "map_family": "corridor_fixture",
+    "observation_noise": "none",
+    "occlusion": "clear",
+    "pedestrian_model_family": "social_force",
+    "semantic_metadata_present": false
+  }
+}

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/summary.json
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/summary.json
@@ -1,0 +1,36 @@
+{
+  "issue": 2866,
+  "schema_version": "ForecastTransferabilityEvidence.v1",
+  "status": "blocked",
+  "claim_boundary": "Transferability rows are preserved with explicit blocked cells; no transferability, safety, progress, paper-facing, or dissertation claim is supported.",
+  "generated_at_utc": "2026-06-15T13:27:08.661985+00:00",
+  "provenance": {
+    "command": "uv run python scripts/benchmark/build_forecast_transferability_matrix.py docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json --report-id issue_2866_transferability_matrix_rows --generated-at-utc 2026-06-15T00:00:00+00:00 --out-json docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.json --out-md docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.md",
+    "commit": "3f9504e32d3fab87ed3cb9304fea4b8371d84b13",
+    "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/*.json"
+  },
+  "coverage": {
+    "matrix_rows": 5,
+    "limitation_rows": 2,
+    "recommendation": {
+      "decision": "stop",
+      "claim_status": "blocked"
+    },
+    "tracked_rows": [
+      "observation_tier",
+      "scenario_family",
+      "actor_type",
+      "horizon_s",
+      "semantic_metadata_present"
+    ],
+    "blocked_cells": [
+      "scenario_family",
+      "map_family",
+      "actor_type"
+    ],
+    "notes": [
+      "The tracked metric inputs are bounded schema-compatible fixtures, not benchmark campaign outputs.",
+      "Complete deployable fixture rows demonstrate metadata preservation only; blocked cells prevent transfer claims."
+    ]
+  }
+}

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.json
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.json
@@ -1,0 +1,318 @@
+{
+  "claim_boundary": "Forecast transferability stress rows are benchmark-eligible only when each cell has all required dimensions, non-empty deployable metric denominators, and non-oracle observation tiers.",
+  "dimension_coverage": {
+    "actor_type": {
+      "coverage_status": "partial",
+      "observed_values": [
+        "bicycle",
+        "pedestrian"
+      ],
+      "unavailable_report_count": 1
+    },
+    "density": {
+      "coverage_status": "full",
+      "observed_values": [
+        "low",
+        "medium",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "dropout": {
+      "coverage_status": "full",
+      "observed_values": [
+        "none",
+        "synthetic_dropout_0.1",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "latency": {
+      "coverage_status": "full",
+      "observed_values": [
+        "0_steps",
+        "1_step",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "map_family": {
+      "coverage_status": "partial",
+      "observed_values": [
+        "corridor_fixture",
+        "motion_rich_occluded_emergence"
+      ],
+      "unavailable_report_count": 1
+    },
+    "observation_noise": {
+      "coverage_status": "full",
+      "observed_values": [
+        "none",
+        "tracked_noise_low",
+        "tracked_noise_unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "observation_tier": {
+      "coverage_status": "full",
+      "observed_values": [
+        "deployable_tracked",
+        "oracle_full_state"
+      ],
+      "unavailable_report_count": 0
+    },
+    "occlusion": {
+      "coverage_status": "full",
+      "observed_values": [
+        "clear",
+        "occluded_emergence",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "pedestrian_model_family": {
+      "coverage_status": "full",
+      "observed_values": [
+        "fast_actor_fixture",
+        "social_force",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    },
+    "scenario_family": {
+      "coverage_status": "partial",
+      "observed_values": [
+        "corridor_fixture",
+        "motion_rich_occluded_emergence"
+      ],
+      "unavailable_report_count": 1
+    },
+    "semantic_metadata_present": {
+      "coverage_status": "full",
+      "observed_values": [
+        "absent",
+        "present",
+        "unknown"
+      ],
+      "unavailable_report_count": 0
+    }
+  },
+  "generated_at_utc": "2026-06-15T00:00:00+00:00",
+  "limitation_rows": [
+    {
+      "availability_status": "blocked",
+      "dimension": "scenario_family",
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-deployable-unavailable-cell-fixture",
+      "reason": "dimension metadata unavailable in ForecastMetrics.v1 report",
+      "scenario_id": "missing_metadata_fixture"
+    },
+    {
+      "availability_status": "blocked",
+      "dimension": "map_family",
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-deployable-unavailable-cell-fixture",
+      "reason": "dimension metadata unavailable in ForecastMetrics.v1 report",
+      "scenario_id": "missing_metadata_fixture"
+    }
+  ],
+  "matrix_rows": [
+    {
+      "actor_type": "pedestrian",
+      "artifact_input": {
+        "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+        "generated_at_utc": "2026-06-15T00:00:00+00:00",
+        "issue": 2866,
+        "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json"
+      },
+      "claim_boundary": "oracle-state row; not deployable transfer evidence",
+      "denominator": 20,
+      "evidence_status": "diagnostic-only",
+      "horizon_s": 0.5,
+      "mean_value": 0.18,
+      "metric": "mean_ade",
+      "metric_status": "ok",
+      "observation_tier": "oracle_full_state",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-oracle-corridor-fixture",
+      "scenario_id": "classic_corridor_fixture",
+      "transfer_dimensions": {
+        "actor_type": "pedestrian",
+        "density": "low",
+        "dropout": "none",
+        "latency": "0_steps",
+        "map_family": "corridor_fixture",
+        "observation_noise": "none",
+        "observation_tier": "oracle_full_state",
+        "occlusion": "clear",
+        "pedestrian_model_family": "social_force",
+        "scenario_family": "corridor_fixture",
+        "semantic_metadata_present": "absent"
+      },
+      "unavailable_dimensions": []
+    },
+    {
+      "actor_type": "pedestrian",
+      "artifact_input": {
+        "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+        "generated_at_utc": "2026-06-15T00:00:00+00:00",
+        "issue": 2866,
+        "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_oracle_corridor.json"
+      },
+      "claim_boundary": "oracle-state row; not deployable transfer evidence",
+      "denominator": 20,
+      "evidence_status": "diagnostic-only",
+      "horizon_s": 1.0,
+      "mean_value": 0.34,
+      "metric": "mean_ade",
+      "metric_status": "ok",
+      "observation_tier": "oracle_full_state",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-oracle-corridor-fixture",
+      "scenario_id": "classic_corridor_fixture",
+      "transfer_dimensions": {
+        "actor_type": "pedestrian",
+        "density": "low",
+        "dropout": "none",
+        "latency": "0_steps",
+        "map_family": "corridor_fixture",
+        "observation_noise": "none",
+        "observation_tier": "oracle_full_state",
+        "occlusion": "clear",
+        "pedestrian_model_family": "social_force",
+        "scenario_family": "corridor_fixture",
+        "semantic_metadata_present": "absent"
+      },
+      "unavailable_dimensions": []
+    },
+    {
+      "actor_type": "bicycle",
+      "artifact_input": {
+        "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+        "generated_at_utc": "2026-06-15T00:00:00+00:00",
+        "issue": 2866,
+        "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json"
+      },
+      "claim_boundary": "deployable observation row; still simulation-only transfer evidence",
+      "denominator": 8,
+      "evidence_status": "benchmark-eligible",
+      "horizon_s": 0.5,
+      "mean_value": 0.42,
+      "metric": "mean_ade",
+      "metric_status": "ok",
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-deployable-motion-rich-bicycle-fixture",
+      "scenario_id": "motion_rich_occluded_emergence_fixture",
+      "transfer_dimensions": {
+        "actor_type": "bicycle",
+        "density": "medium",
+        "dropout": "synthetic_dropout_0.1",
+        "latency": "1_step",
+        "map_family": "motion_rich_occluded_emergence",
+        "observation_noise": "tracked_noise_low",
+        "observation_tier": "deployable_tracked",
+        "occlusion": "occluded_emergence",
+        "pedestrian_model_family": "fast_actor_fixture",
+        "scenario_family": "motion_rich_occluded_emergence",
+        "semantic_metadata_present": "present"
+      },
+      "unavailable_dimensions": []
+    },
+    {
+      "actor_type": "bicycle",
+      "artifact_input": {
+        "command": "tracked metric fixture for issue #2866 transferability matrix rows",
+        "generated_at_utc": "2026-06-15T00:00:00+00:00",
+        "issue": 2866,
+        "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_motion_rich_bicycle.json"
+      },
+      "claim_boundary": "deployable observation row; still simulation-only transfer evidence",
+      "denominator": 8,
+      "evidence_status": "benchmark-eligible",
+      "horizon_s": 1.0,
+      "mean_value": 0.91,
+      "metric": "mean_ade",
+      "metric_status": "ok",
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-deployable-motion-rich-bicycle-fixture",
+      "scenario_id": "motion_rich_occluded_emergence_fixture",
+      "transfer_dimensions": {
+        "actor_type": "bicycle",
+        "density": "medium",
+        "dropout": "synthetic_dropout_0.1",
+        "latency": "1_step",
+        "map_family": "motion_rich_occluded_emergence",
+        "observation_noise": "tracked_noise_low",
+        "observation_tier": "deployable_tracked",
+        "occlusion": "occluded_emergence",
+        "pedestrian_model_family": "fast_actor_fixture",
+        "scenario_family": "motion_rich_occluded_emergence",
+        "semantic_metadata_present": "present"
+      },
+      "unavailable_dimensions": []
+    },
+    {
+      "actor_type": null,
+      "artifact_input": {
+        "command": "tracked unavailable-cell fixture for issue #2866 transferability matrix rows",
+        "generated_at_utc": "2026-06-15T00:00:00+00:00",
+        "issue": 2866,
+        "source": "docs/context/evidence/issue_2866_transferability_matrix_rows/metric_deployable_unavailable_cells.json"
+      },
+      "claim_boundary": "blocked transfer dimensions prevent benchmark-strength transfer claims",
+      "denominator": 0,
+      "evidence_status": "blocked",
+      "horizon_s": 1.0,
+      "mean_value": null,
+      "metric": "mean_ade",
+      "metric_status": "unavailable",
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "constant_velocity",
+      "predictor_id": "cv-deployable-unavailable-cell-fixture",
+      "scenario_id": "missing_metadata_fixture",
+      "transfer_dimensions": {
+        "actor_type": null,
+        "density": "unknown",
+        "dropout": "unknown",
+        "latency": "unknown",
+        "map_family": null,
+        "observation_noise": "tracked_noise_unknown",
+        "observation_tier": "deployable_tracked",
+        "occlusion": "unknown",
+        "pedestrian_model_family": "unknown",
+        "scenario_family": null,
+        "semantic_metadata_present": "unknown"
+      },
+      "unavailable_dimensions": [
+        "scenario_family",
+        "map_family",
+        "actor_type"
+      ]
+    }
+  ],
+  "recommendation": {
+    "claim_status": "blocked",
+    "decision": "stop",
+    "reason": "one or more transfer cells are blocked by unavailable required metadata"
+  },
+  "report_id": "issue_2866_transferability_matrix_rows",
+  "required_dimensions": [
+    "observation_tier",
+    "observation_noise",
+    "latency",
+    "dropout",
+    "occlusion",
+    "scenario_family",
+    "map_family",
+    "density",
+    "pedestrian_model_family",
+    "actor_type",
+    "semantic_metadata_present"
+  ],
+  "schema_version": "ForecastTransferabilityStressMatrix.v1",
+  "source_schema_version": "ForecastMetrics.v1"
+}

--- a/docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.md
+++ b/docs/context/evidence/issue_2866_transferability_matrix_rows/transferability_matrix.md
@@ -1,0 +1,36 @@
+# Forecast Transferability Stress Matrix
+
+- Report id: issue_2866_transferability_matrix_rows
+- Decision: stop
+- Claim status: blocked
+- Matrix rows: 5
+- Limitation rows: 2
+
+| dimension | coverage_status | observed_values | unavailable_reports |
+| --- | --- | --- | ---: |
+| observation_tier | full | deployable_tracked, oracle_full_state | 0 |
+| observation_noise | full | none, tracked_noise_low, tracked_noise_unknown | 0 |
+| latency | full | 0_steps, 1_step, unknown | 0 |
+| dropout | full | none, synthetic_dropout_0.1, unknown | 0 |
+| occlusion | full | clear, occluded_emergence, unknown | 0 |
+| scenario_family | partial | corridor_fixture, motion_rich_occluded_emergence | 1 |
+| map_family | partial | corridor_fixture, motion_rich_occluded_emergence | 1 |
+| density | full | low, medium, unknown | 0 |
+| pedestrian_model_family | full | fast_actor_fixture, social_force, unknown | 0 |
+| actor_type | partial | bicycle, pedestrian | 1 |
+| semantic_metadata_present | full | absent, present, unknown | 0 |
+
+| metric | horizon_s | observation_tier | actor_type | denominator | status | value | evidence |
+| --- | ---: | --- | --- | ---: | --- | ---: | --- |
+| mean_ade | 0.5 | oracle_full_state | pedestrian | 20 | ok | 0.18 | diagnostic-only |
+| mean_ade | 1 | oracle_full_state | pedestrian | 20 | ok | 0.34 | diagnostic-only |
+| mean_ade | 0.5 | deployable_tracked | bicycle | 8 | ok | 0.42 | benchmark-eligible |
+| mean_ade | 1 | deployable_tracked | bicycle | 8 | ok | 0.91 | benchmark-eligible |
+| mean_ade | 1 | deployable_tracked | None | 0 | unavailable | NA | blocked |
+
+## Limitations
+
+- scenario_family: dimension metadata unavailable in ForecastMetrics.v1 report (cv-deployable-unavailable-cell-fixture, missing_metadata_fixture, deployable_tracked)
+- map_family: dimension metadata unavailable in ForecastMetrics.v1 report (cv-deployable-unavailable-cell-fixture, missing_metadata_fixture, deployable_tracked)
+
+Forecast transferability stress rows are benchmark-eligible only when each cell has all required dimensions, non-empty deployable metric denominators, and non-oracle observation tiers.

--- a/robot_sf/benchmark/forecast_transferability_stress_matrix.py
+++ b/robot_sf/benchmark/forecast_transferability_stress_matrix.py
@@ -18,10 +18,12 @@ DEFAULT_TRANSFER_DIMENSIONS = (
     "latency",
     "dropout",
     "occlusion",
+    "scenario_family",
     "map_family",
     "density",
     "pedestrian_model_family",
     "actor_type",
+    "semantic_metadata_present",
 )
 
 _METRIC_PROVENANCE_KEYS = {
@@ -30,6 +32,13 @@ _METRIC_PROVENANCE_KEYS = {
     "latency": ("latency", "latency_s", "latency_steps"),
     "dropout": ("dropout", "dropout_rate", "missed_detection_probability"),
     "occlusion": ("occlusion", "occlusion_level", "occlusion_status"),
+    "scenario_family": ("scenario_family", "map_family", "scenario_family_id"),
+    "semantic_metadata_present": (
+        "semantic_metadata_present",
+        "semantic_metadata",
+        "intent_metadata_present",
+        "signal_metadata_present",
+    ),
     "map_family": ("map_family", "scenario_family"),
     "density": ("density", "density_label", "ped_density_bucket"),
     "pedestrian_model_family": ("pedestrian_model_family", "ped_model_family"),
@@ -79,14 +88,14 @@ def build_forecast_transferability_stress_matrix(
                 {
                     **report_key,
                     "dimension": dimension,
-                    "availability_status": "not_available",
+                    "availability_status": "blocked",
                     "reason": "dimension metadata unavailable in ForecastMetrics.v1 report",
                 }
             )
         for aggregate_row in report["aggregate_rows"]:
             actor_type_value = aggregate_row.get("actor_class")
-            actor_type = "unknown" if actor_type_value is None else str(actor_type_value)
-            row_dimensions = dict(transfer_dimensions)
+            actor_type = None if actor_type_value is None else str(actor_type_value)
+            row_dimensions = _transfer_dimensions(report, aggregate_row=aggregate_row)
             row_dimensions["actor_type"] = actor_type
             row_missing_dimensions = [
                 dimension
@@ -102,6 +111,7 @@ def build_forecast_transferability_stress_matrix(
                     "mean_value": aggregate_row.get("value"),
                     "metric_status": str(_required_value(aggregate_row, "status")),
                     "denominator": int(_required_value(aggregate_row, "denominator")),
+                    "artifact_input": _artifact_input(report),
                     "transfer_dimensions": {
                         dimension: row_dimensions.get(dimension)
                         for dimension in required_dimensions
@@ -111,10 +121,12 @@ def build_forecast_transferability_stress_matrix(
                         observation_tier=report_key["observation_tier"],
                         unavailable_dimensions=row_missing_dimensions,
                         metric_status=str(_required_value(aggregate_row, "status")),
+                        denominator=int(_required_value(aggregate_row, "denominator")),
                     ),
                     "claim_boundary": _row_claim_boundary(
                         observation_tier=report_key["observation_tier"],
                         unavailable_dimensions=row_missing_dimensions,
+                        denominator=int(_required_value(aggregate_row, "denominator")),
                     ),
                 }
             )
@@ -131,9 +143,9 @@ def build_forecast_transferability_stress_matrix(
         "dimension_coverage": dimension_coverage,
         "recommendation": recommendation,
         "claim_boundary": (
-            "Forecast transferability stress rows are diagnostic unless every required "
-            "dimension is available, denominators are non-empty, and observation tiers are "
-            "deployable or explicitly separated from oracle-only rows."
+            "Forecast transferability stress rows are benchmark-eligible only when each cell has "
+            "all required dimensions, non-empty deployable metric denominators, and "
+            "non-oracle observation tiers."
         ),
     }
 
@@ -245,7 +257,7 @@ def _empty_report(
         "limitation_rows": [
             {
                 "dimension": "all",
-                "availability_status": "not_available",
+                "availability_status": "blocked",
                 "reason": "no ForecastMetrics.v1 reports supplied",
             }
         ],
@@ -293,7 +305,11 @@ def _require_transferability_report(report: dict[str, Any]) -> None:
         raise ValueError("report must use ForecastTransferabilityStressMatrix.v1")
 
 
-def _transfer_dimensions(report: dict[str, Any]) -> dict[str, str | None]:
+def _transfer_dimensions(
+    report: dict[str, Any],
+    *,
+    aggregate_row: dict[str, Any] | None = None,
+) -> dict[str, str | None]:
     provenance = report.get("provenance", {})
     if not isinstance(provenance, dict):
         provenance = {}
@@ -302,13 +318,50 @@ def _transfer_dimensions(report: dict[str, Any]) -> dict[str, str | None]:
         metadata = report.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
+    row_payload = aggregate_row if isinstance(aggregate_row, dict) else {}
     dimensions: dict[str, str | None] = {}
     for dimension, keys in _METRIC_PROVENANCE_KEYS.items():
-        value = _first_present(metadata, keys)
+        value = _first_present(row_payload, keys)
+        if value is None:
+            value = _first_present(metadata, keys)
         if value is None:
             value = _first_present(provenance, keys)
+        if dimension == "semantic_metadata_present":
+            value = _normalize_semantic_metadata_present(value)
         dimensions[dimension] = None if value is None else str(value)
     return dimensions
+
+
+def _normalize_semantic_metadata_present(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "present" if value else "absent"
+    if isinstance(value, (int, float)):
+        return "present" if int(value) != 0 else "absent"
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "present", "yes"}:
+            return "present"
+        if normalized in {"0", "false", "absent", "no"}:
+            return "absent"
+        return normalized
+    return str(value)
+
+
+def _artifact_input(report: dict[str, Any]) -> dict[str, Any] | None:
+    """Return optional provenance for matrix cells."""
+    artifact = report.get("artifact_input")
+    if isinstance(artifact, dict) and artifact:
+        return {
+            "source": str(artifact.get("source")) if artifact.get("source") is not None else "",
+            "issue": artifact.get("issue"),
+            "command": artifact.get("command"),
+            "generated_at_utc": artifact.get("generated_at_utc"),
+        }
+    if isinstance(report.get("artifact_source"), str):
+        return {"source": report["artifact_source"]}
+    return None
 
 
 def _first_present(payload: dict[str, Any], keys: tuple[str, ...]) -> Any:
@@ -335,8 +388,8 @@ def _dimension_coverage(
         for dimension, value in row["transfer_dimensions"].items():
             if value is not None:
                 values_by_dimension[dimension].add(str(value))
-    for row in limitation_rows:
-        unavailable_counts[str(row["dimension"])] += 1
+        for dimension in row.get("unavailable_dimensions", []):
+            unavailable_counts[dimension] += 1
     coverage = {}
     for dimension in required_dimensions:
         observed_values = sorted(values_by_dimension[dimension])
@@ -363,17 +416,29 @@ def _recommendation(
             "claim_status": "blocked",
             "reason": "no matrix rows were produced",
         }
-    if limitation_rows:
+    if any(row["evidence_status"] == "blocked" for row in rows):
+        return {
+            "decision": "stop",
+            "claim_status": "blocked",
+            "reason": "one or more transfer cells are blocked by unavailable required metadata",
+        }
+    if any(row["evidence_status"] == "unavailable" for row in rows):
         return {
             "decision": "revise",
             "claim_status": "diagnostic-only",
-            "reason": "one or more transfer dimensions are unavailable",
+            "reason": "one or more transfer cells have unavailable metrics",
         }
     if any(_is_oracle_tier(row["observation_tier"]) for row in rows):
         return {
             "decision": "revise",
             "claim_status": "diagnostic-only",
             "reason": "oracle-state rows must not be promoted as deployable transfer evidence",
+        }
+    if limitation_rows:
+        return {
+            "decision": "revise",
+            "claim_status": "diagnostic-only",
+            "reason": "one or more transfer dimensions are unavailable",
         }
     if any(row["denominator"] == 0 or row["metric_status"] != "ok" for row in rows):
         return {
@@ -393,11 +458,14 @@ def _row_evidence_status(
     observation_tier: str,
     unavailable_dimensions: list[str],
     metric_status: str,
+    denominator: int,
 ) -> str:
-    if unavailable_dimensions or metric_status != "ok":
-        return "diagnostic-only"
+    if unavailable_dimensions:
+        return "blocked"
+    if metric_status != "ok" or denominator <= 0:
+        return "unavailable"
     if _is_oracle_tier(observation_tier):
-        return "oracle-only"
+        return "diagnostic-only"
     return "benchmark-eligible"
 
 
@@ -405,9 +473,12 @@ def _row_claim_boundary(
     *,
     observation_tier: str,
     unavailable_dimensions: list[str],
+    denominator: int,
 ) -> str:
     if unavailable_dimensions:
-        return "unavailable transfer dimensions prevent benchmark-strength transfer claims"
+        return "blocked transfer dimensions prevent benchmark-strength transfer claims"
+    if denominator <= 0:
+        return "unavailable metric cell prevents benchmark-strength transfer claims"
     if _is_oracle_tier(observation_tier):
         return "oracle-state row; not deployable transfer evidence"
     return "deployable observation row; still simulation-only transfer evidence"

--- a/scripts/benchmark/build_forecast_transferability_matrix.py
+++ b/scripts/benchmark/build_forecast_transferability_matrix.py
@@ -20,6 +20,10 @@ def main() -> None:
     parser.add_argument("--report-id", required=True)
     parser.add_argument("--out-json", type=Path, required=True)
     parser.add_argument("--out-md", type=Path)
+    parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic ISO-8601 generation timestamp for reviewable artifacts.",
+    )
     args = parser.parse_args()
 
     metric_reports = []
@@ -33,6 +37,7 @@ def main() -> None:
     report = build_forecast_transferability_stress_matrix(
         metric_reports,
         report_id=args.report_id,
+        generated_at_utc=args.generated_at_utc,
     )
     paths = write_forecast_transferability_stress_matrix(
         report,

--- a/tests/benchmark/test_forecast_transferability_stress_matrix.py
+++ b/tests/benchmark/test_forecast_transferability_stress_matrix.py
@@ -16,41 +16,57 @@ from robot_sf.benchmark.forecast_transferability_stress_matrix import (
 )
 
 
-def _metric_report(
+def _metric_report(  # noqa: PLR0913
     *,
     observation_tier: str = "deployable_observation",
     transfer_dimensions: dict[str, object] | None = None,
-    actor_class: str = "pedestrian",
+    horizon_s: float | list[float] = 1.0,
+    actor_class: str | None = "pedestrian",
+    aggregate_row_fields: dict[str, object] | None = None,
+    provenance_fields: dict[str, object] | None = None,
     metric_status: str = "ok",
     denominator: int = 3,
     value: float | None = 0.42,
+    report_fields: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    return {
-        "schema_version": "ForecastMetrics.v1",
-        "provenance": {
-            "predictor_id": "cv-baseline",
-            "predictor_family": "constant_velocity",
+    horizons = [horizon_s] if isinstance(horizon_s, float) else list(horizon_s)
+    aggregate_rows = [
+        {
+            "metric": "mean_ade",
+            "horizon_s": horizon,
+            "value": value,
+            "status": metric_status,
+            "denominator": denominator,
+            "actor_class": actor_class,
             "scenario_id": "classic_crossing_low",
-            "scenario_family": "classic_crossing",
             "observation_tier": observation_tier,
             "dt_s": 0.5,
-            "horizons_s": [1.0],
-        },
-        "transfer_dimensions": transfer_dimensions or {},
-        "aggregate_rows": [
-            {
-                "metric": "mean_ade",
-                "horizon_s": 1.0,
-                "value": value,
-                "status": metric_status,
-                "denominator": denominator,
-                "actor_class": actor_class,
-                "scenario_id": "classic_crossing_low",
-                "observation_tier": observation_tier,
-                "dt_s": 0.5,
-            }
-        ],
+        }
+        for horizon in horizons
+    ]
+    if aggregate_row_fields:
+        for row in aggregate_rows:
+            row.update(aggregate_row_fields)
+    provenance = {
+        "predictor_id": "cv-baseline",
+        "predictor_family": "constant_velocity",
+        "scenario_id": "classic_crossing_low",
+        "scenario_family": "classic_crossing",
+        "observation_tier": observation_tier,
+        "dt_s": 0.5,
+        "horizons_s": [0.5, 1.0, 2.0],
     }
+    if provenance_fields:
+        provenance.update(provenance_fields)
+    report: dict[str, object] = {
+        "schema_version": "ForecastMetrics.v1",
+        "provenance": provenance,
+        "transfer_dimensions": transfer_dimensions or {},
+        "aggregate_rows": aggregate_rows,
+    }
+    if report_fields:
+        report.update(report_fields)
+    return report
 
 
 def _complete_transfer_dimensions() -> dict[str, object]:
@@ -62,6 +78,7 @@ def _complete_transfer_dimensions() -> dict[str, object]:
         "map_family": "classic_crossing",
         "density": "low",
         "pedestrian_model_family": "social_force",
+        "semantic_metadata_present": "present",
     }
 
 
@@ -81,10 +98,10 @@ def test_transferability_matrix_can_be_benchmark_eligible() -> None:
     assert report["dimension_coverage"]["latency"]["observed_values"] == ["0_steps"]
 
 
-def test_transferability_matrix_reports_unavailable_dimensions() -> None:
+def test_transferability_matrix_reports_blocked_dimensions() -> None:
     """Missing transfer axes should become explicit limitation rows."""
     report = build_forecast_transferability_stress_matrix(
-        [_metric_report(observation_tier="oracle_full_state")],
+        [_metric_report(observation_tier="deployable_vision")],
         report_id="missing-transfer",
         generated_at_utc="2026-06-15T00:00:00+00:00",
     )
@@ -92,9 +109,9 @@ def test_transferability_matrix_reports_unavailable_dimensions() -> None:
     missing_dimensions = {row["dimension"] for row in report["limitation_rows"]}
     assert "latency" in missing_dimensions
     assert "dropout" in missing_dimensions
-    assert report["matrix_rows"][0]["evidence_status"] == "diagnostic-only"
-    assert report["recommendation"]["decision"] == "revise"
-    assert report["recommendation"]["claim_status"] == "diagnostic-only"
+    assert report["matrix_rows"][0]["evidence_status"] == "blocked"
+    assert report["recommendation"]["decision"] == "stop"
+    assert report["recommendation"]["claim_status"] == "blocked"
 
 
 def test_transferability_matrix_treats_mixed_case_oracle_as_diagnostic() -> None:
@@ -110,8 +127,163 @@ def test_transferability_matrix_treats_mixed_case_oracle_as_diagnostic() -> None
         generated_at_utc="2026-06-15T00:00:00+00:00",
     )
 
-    assert report["matrix_rows"][0]["evidence_status"] == "oracle-only"
+    assert report["matrix_rows"][0]["evidence_status"] == "diagnostic-only"
     assert report["recommendation"]["claim_status"] == "diagnostic-only"
+
+
+def test_transferability_matrix_tracks_actor_type_and_horizons() -> None:
+    """Different actor classes and horizons should survive as separate matrix rows."""
+    report = build_forecast_transferability_stress_matrix(
+        [
+            _metric_report(
+                actor_class="pedestrian",
+                transfer_dimensions=_complete_transfer_dimensions(),
+                horizon_s=[0.5, 1.0],
+            ),
+            _metric_report(
+                actor_class="bicycle",
+                transfer_dimensions=_complete_transfer_dimensions(),
+                horizon_s=[0.5, 1.0],
+            ),
+        ],
+        report_id="actor-horizon-transfer",
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    rows = report["matrix_rows"]
+    assert len(rows) == 4
+    assert {row["actor_type"] for row in rows} == {"pedestrian", "bicycle"}
+    assert {float(row["horizon_s"]) for row in rows} == {0.5, 1.0}
+
+
+def test_transferability_matrix_preserves_row_level_scenario_family_and_actor_cells() -> None:
+    """Scenario family and actor class should be carried from durable aggregate rows."""
+    transfer_dimensions = {
+        "observation_noise": "none",
+        "latency": "0_steps",
+        "dropout": "none",
+        "occlusion": "clear",
+        "density": "low",
+        "pedestrian_model_family": "social_force",
+        "semantic_metadata_present": "present",
+    }
+    report = build_forecast_transferability_stress_matrix(
+        [
+            _metric_report(
+                transfer_dimensions=transfer_dimensions,
+                aggregate_row_fields={"scenario_family": "crossing_split_a"},
+                actor_class="pedestrian",
+            ),
+            _metric_report(
+                transfer_dimensions=transfer_dimensions,
+                aggregate_row_fields={"scenario_family": "crossing_split_b"},
+                actor_class="bicycle",
+            ),
+        ],
+        report_id="scenario-family-transfer",
+        required_dimensions=(
+            "observation_tier",
+            "scenario_family",
+            "actor_type",
+            "semantic_metadata_present",
+        ),
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    rows = report["matrix_rows"]
+    assert len(rows) == 2
+    assert {row["transfer_dimensions"]["scenario_family"] for row in rows} == {
+        "crossing_split_a",
+        "crossing_split_b",
+    }
+    assert {row["actor_type"] for row in rows} == {"pedestrian", "bicycle"}
+    assert report["recommendation"]["claim_status"] == "benchmark-eligible"
+
+
+def test_transferability_matrix_marks_unavailable_actor_and_scenario_family_cells() -> None:
+    """Missing actor class or scenario family must stay as explicit blocked cells."""
+    complete = _complete_transfer_dimensions()
+    complete.pop("semantic_metadata_present", None)
+    complete.pop("map_family", None)
+    report = build_forecast_transferability_stress_matrix(
+        [
+            _metric_report(
+                transfer_dimensions=_complete_transfer_dimensions(),
+                actor_class="pedestrian",
+            ),
+            _metric_report(
+                transfer_dimensions=complete,
+                actor_class=None,
+                aggregate_row_fields={"scenario_family": None},
+                provenance_fields={"scenario_family": None},
+            ),
+        ],
+        report_id="unavailable-cells-transfer",
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    rows = report["matrix_rows"]
+    assert len(rows) == 2
+    blocked_rows = [row for row in rows if row["evidence_status"] == "blocked"]
+    assert len(blocked_rows) == 1
+    assert None in {row["actor_type"] for row in blocked_rows}
+    assert "scenario_family" in blocked_rows[0]["unavailable_dimensions"]
+    assert "map_family" in blocked_rows[0]["unavailable_dimensions"]
+    assert "actor_type" in blocked_rows[0]["unavailable_dimensions"]
+    assert report["limitation_rows"]
+    assert report["dimension_coverage"]["actor_type"]["unavailable_report_count"] == 1
+
+
+def test_transferability_matrix_tracks_semantic_metadata_present_and_absent() -> None:
+    """Missing semantic metadata should remain explicit when present and absent differ."""
+    transfer_dimensions = _complete_transfer_dimensions()
+    report = build_forecast_transferability_stress_matrix(
+        [
+            _metric_report(
+                transfer_dimensions={
+                    **transfer_dimensions,
+                    "semantic_metadata_present": True,
+                },
+            ),
+            _metric_report(
+                transfer_dimensions={
+                    **transfer_dimensions,
+                    "semantic_metadata_present": False,
+                },
+            ),
+        ],
+        report_id="semantic-meta-transfer",
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    assert {
+        row["transfer_dimensions"]["semantic_metadata_present"] for row in report["matrix_rows"]
+    } == {"present", "absent"}
+
+
+def test_transferability_matrix_captures_row_provenance() -> None:
+    """Matrix rows should carry artifact provenance for traceability."""
+    report = build_forecast_transferability_stress_matrix(
+        [
+            _metric_report(
+                transfer_dimensions=_complete_transfer_dimensions(),
+                report_fields={
+                    "artifact_input": {
+                        "issue": 2866,
+                        "source": "fixture://forecast-metrics",
+                        "command": "unit-test",
+                    }
+                },
+            )
+        ],
+        report_id="provenance-transfer",
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    artifact_input = report["matrix_rows"][0]["artifact_input"]
+    assert artifact_input is not None
+    assert artifact_input["issue"] == 2866
+    assert artifact_input["source"] == "fixture://forecast-metrics"
 
 
 def test_transferability_matrix_rejects_malformed_aggregate_rows() -> None:
@@ -149,9 +321,21 @@ def test_transferability_markdown_includes_limitations() -> None:
     markdown = format_forecast_transferability_stress_markdown(report)
 
     assert "# Forecast Transferability Stress Matrix" in markdown
-    assert "Claim status: diagnostic-only" in markdown
+    assert "Claim status: blocked" in markdown
     assert "## Limitations" in markdown
     assert "observation_noise" in markdown
+
+
+def test_transferability_matrix_marks_unavailable_metrics() -> None:
+    """Rows with empty denominators should be marked unavailable."""
+    report = build_forecast_transferability_stress_matrix(
+        [_metric_report(denominator=0, transfer_dimensions=_complete_transfer_dimensions())],
+        report_id="unavailable-metrics",
+        generated_at_utc="2026-06-15T00:00:00+00:00",
+    )
+
+    assert report["matrix_rows"][0]["evidence_status"] == "unavailable"
+    assert report["recommendation"]["claim_status"] == "diagnostic-only"
 
 
 def test_transferability_cli_writes_json_and_markdown(
@@ -163,7 +347,9 @@ def test_transferability_cli_writes_json_and_markdown(
     out_json = tmp_path / "transfer.json"
     out_md = tmp_path / "transfer.md"
     metric_path.write_text(
-        json.dumps(_metric_report(transfer_dimensions=_complete_transfer_dimensions())),
+        json.dumps(
+            _metric_report(transfer_dimensions=_complete_transfer_dimensions()),
+        ),
         encoding="utf-8",
     )
 
@@ -179,6 +365,8 @@ def test_transferability_cli_writes_json_and_markdown(
             str(out_json),
             "--out-md",
             str(out_md),
+            "--generated-at-utc",
+            "2026-06-15T00:00:00+00:00",
         ],
         check=True,
         capture_output=True,
@@ -189,7 +377,9 @@ def test_transferability_cli_writes_json_and_markdown(
     assert summary["decision"] == "continue"
     assert out_json.exists()
     assert out_md.exists()
-    assert json.loads(out_json.read_text(encoding="utf-8"))["report_id"] == "cli-transfer"
+    output = json.loads(out_json.read_text(encoding="utf-8"))
+    assert output["report_id"] == "cli-transfer"
+    assert output["generated_at_utc"] == "2026-06-15T00:00:00+00:00"
 
 
 def test_transferability_cli_reports_malformed_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #2866.

## Summary

- Extend the forecast transferability stress matrix with row-level scenario-family, actor-class, horizon, semantic-metadata, artifact-input, and unavailable-dimension handling.
- Add deterministic `--generated-at-utc` support to the matrix CLI so tracked evidence artifacts are reproducible.
- Add bounded Issue #2866 evidence inputs plus generated JSON/Markdown matrix outputs under `docs/context/evidence/issue_2866_transferability_matrix_rows/`, registered in the evidence README/catalog and prediction-lane map.

## Validation

- `uv run pytest tests/benchmark/test_forecast_transferability_stress_matrix.py` - 14 passed
- `uv run ruff check robot_sf/benchmark/forecast_transferability_stress_matrix.py scripts/benchmark/build_forecast_transferability_matrix.py tests/benchmark/test_forecast_transferability_stress_matrix.py`
- `uv run ruff format --check robot_sf/benchmark/forecast_transferability_stress_matrix.py scripts/benchmark/build_forecast_transferability_matrix.py tests/benchmark/test_forecast_transferability_stress_matrix.py`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- Generated matrix command recorded in `docs/context/evidence/issue_2866_transferability_matrix_rows/README.md`.

## Downstream Propagation

- Parent issue / claim map: supports the prediction-lane readiness chain by making transferability matrix coverage and blocked cells explicit.
- Benchmark report / leaderboard: not updated; this is bounded fixture-backed matrix evidence, not a benchmark campaign result.
- Registry / config index: not applicable.
- Context index / memory: evidence README/catalog and `docs/ai/prediction_lane.md` updated.
- Deferred follow-up: blocked transfer claims remain for future durable campaign outputs; the generated matrix returns `decision: stop` and `claim_status: blocked`.

## Research Result Guidance

- Target claim / blocker: transferability matrix rows need explicit observation-tier, actor-class, scenario-family, horizon, semantic-metadata, and unavailable-cell coverage before downstream gates can reason about forecast transfer.
- Comparator / baseline: previous matrix did not preserve these split rows or artifact provenance strongly enough for the Issue #2866 contract.
- Evidence tier: analysis-tool and bounded fixture evidence only.
- Result classification: blocked / diagnostic-only. Complete deployable fixture cells demonstrate metadata preservation only; oracle rows remain diagnostic-only; missing deployable metadata cells force `stop`.
- Decision / stop rule: do not promote any transferability, safety, progress, paper-facing, or dissertation claim from this PR.
- Synthesis surface / update target: `docs/context/evidence/issue_2866_transferability_matrix_rows/` and `docs/ai/prediction_lane.md`.

## Delegation

- OpenCode Go attempt 1 was silent/timeout and discarded.
- OpenCode Go attempt 2 produced the core implementation; accepted after local diff review, deterministic artifact generation, tracked matrix evidence, and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation and evidence artifacts for forecast transferability matrix validation and assessment, including coverage analysis, dimension tracking, and benchmark eligibility criteria.

* **New Features**
  * Matrix generation enhanced with additional transfer dimensions and improved handling of missing metadata scenarios for broader diagnostic coverage.
  * CLI now supports optional timestamp parameters for deterministic and reproducible artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->