### PR TITLE
analysis: add forecast risk calibration diagnostic

### DIFF
--- a/docs/ai/prediction_lane.md
+++ b/docs/ai/prediction_lane.md
@@ -75,6 +75,7 @@ Follow this order unless a later issue has an explicitly narrower diagnostic pur
 | Issue #2781 | closed | Interaction-aware baseline | Mixed result: likelihood proxy improved while 1s point accuracy worsened. |
 | Issue #2843 | closed | Closed-loop coupling gate | Latest recommendation: `revise` before learned predictor training. |
 | Issue #2759 | closed | Forecast risk scoring | Opt-in diagnostic risk channel for `PolicyStackV1`; default remains off. |
+| Issue #2869 | closed | Forecast risk calibration filter | Diagnostic comparison of five risk modes; `calibration_filtered`, `actor_class_aware`, and `observation_tier_aware` are blocked by Issue #2865. Recommendation: `wait`. |
 | Issue #2727 | closed | Fast dynamic actor fixture | Enables future actor-class forecast denominator work. |
 | Issue #2840 | closed | Probabilistic forecast metrics | Metric surface for deterministic/probabilistic forecast comparison. |
 | Issue #2846 | closed | Fast dynamic actor forecast metrics | Separates pedestrian and fast-agent denominators. |
@@ -120,6 +121,9 @@ Use the smallest command that matches the changed surface:
 - Forecast-risk scoring diagnostic:
   `uv run pytest tests/planner/test_policy_stack_v1.py tests/validation/test_forecast_risk_policy_stack.py`
   and `uv run python scripts/validation/validate_forecast_risk_policy_stack.py --out-dir <dir>`
+- Forecast-risk calibration-filter diagnostic (issue #2869):
+  `uv run pytest tests/validation/test_forecast_risk_calibration_filter.py`
+  and `uv run python scripts/validation/validate_forecast_risk_calibration_filter.py --out-dir <dir>`
 - Closed-loop coupling gate:
   `uv run pytest tests/validation/test_closed_loop_forecast_coupling_gate.py` and
   `uv run python scripts/validation/validate_closed_loop_forecast_coupling_gate.py --out-dir <dir>`

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1408,6 +1408,22 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2843_closed_loop_forecast_coupling_gate_2026-06-15/gate_report.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -398,6 +398,13 @@ Policy caveats:
   false_positive_suppresses_penalty (penalty suppressed, goal retained with zero unnecessary
   slowdown count).
   claim_boundary=diagnostic_only_not_benchmark_evidence. Not a safety or live benchmark claim.
+- `issue_2869_forecast_risk_calibration_filter_2026-06-15/`: diagnostic-only comparison of
+  five forecast-risk scoring modes (`no_risk`, `raw_risk`, `calibration_filtered`,
+  `actor_class_aware`, `observation_tier_aware`) before trusting planner coupling. Uses the
+  Issue #2865 calibration report to mark `calibration_filtered`, `actor_class_aware`, and
+  `observation_tier_aware` as blocked. Tradeoffs include route-progress reduction and
+  false-positive stopping avoidance. Recommendation: `wait`.
+  claim_boundary=diagnostic_only_not_benchmark_evidence. Not a safety or live benchmark claim.
 - `issue_2866_transferability_matrix_rows/`: tracked bounded-input evidence for the Issue #2866
   transferability matrix follow-up, including generated JSON/Markdown matrix output with explicit
   observation-tier, actor-class, scenario-family, horizon, semantic-metadata, and blocked-cell rows.

--- a/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/README.md
+++ b/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/README.md
@@ -1,0 +1,31 @@
+# Issue #2869 Forecast Risk Calibration Filter Diagnostic
+
+## Scope
+
+This bundle compares five forecast-risk scoring modes before trusting planner coupling:
+`no_risk`, `raw_risk`, `calibration_filtered`, `actor_class_aware`, and `observation_tier_aware`.
+
+## Evidence status
+
+- `schema`: `forecast_risk_calibration_filter.diagnostic_comparison.v1`
+- `calibration_report`: [docs/context/evidence/issue_2865_forecast_calibration_report_2026-06-15/calibration_report.json](../issue_2865_forecast_calibration_report_2026-06-15/calibration_report.json)
+- `report`: [report.json](report.json) and [report.md](report.md)
+- `claim_boundary`: diagnostic_only_not_benchmark_evidence
+- `recommendation`: `wait`
+
+## Reproducible command
+
+```
+uv run python scripts/validation/validate_forecast_risk_calibration_filter.py \
+  --out-dir docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15
+```
+
+## Validation
+
+```
+uv run pytest tests/validation/test_forecast_risk_calibration_filter.py
+```
+
+## Claim boundary
+
+This report is diagnostic-only. It does not establish safety, navigation benefit, human realism, benchmark-strength predictor quality, or paper/dissertation claims. Forecast-risk scoring remains opt-in with `forecast_risk_weight=0.0` by default.

--- a/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.json
+++ b/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.json
@@ -1,0 +1,85 @@
+{
+  "calibration_report": "docs/context/evidence/issue_2865_forecast_calibration_report_2026-06-15/calibration_report.json",
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "diagnostic_weight": 5.0,
+  "issue": 2869,
+  "modes": [
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 0.0,
+      "high_risk": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "mode": "no_risk",
+      "reason": "baseline forecast_risk_weight=0",
+      "status": "available",
+      "uses_calibration_filter": false
+    },
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 5.0,
+      "high_risk": {
+        "forecast_penalty": 5.0,
+        "progress_proxy": 0.2,
+        "selected_proposal": "risk_dwa",
+        "shield_stop_count": 0,
+        "speed": 0.2
+      },
+      "mode": "raw_risk",
+      "reason": "diagnostic unfiltered forecast risk",
+      "status": "available",
+      "uses_calibration_filter": false
+    },
+    {
+      "false_positive": null,
+      "forecast_risk_weight": 5.0,
+      "high_risk": null,
+      "mode": "calibration_filtered",
+      "reason": "no_rows_risk_scoring_eligible",
+      "status": "blocked",
+      "uses_calibration_filter": true
+    },
+    {
+      "false_positive": null,
+      "forecast_risk_weight": 5.0,
+      "high_risk": null,
+      "mode": "actor_class_aware",
+      "reason": "actor_class_unavailable_in_all_rows",
+      "status": "blocked",
+      "uses_calibration_filter": true
+    },
+    {
+      "false_positive": null,
+      "forecast_risk_weight": 5.0,
+      "high_risk": null,
+      "mode": "observation_tier_aware",
+      "reason": "single_observation_tier: deployable_tracked",
+      "status": "blocked",
+      "uses_calibration_filter": true
+    }
+  ],
+  "recommendation": "wait",
+  "recommendation_rationale": "Calibration filtering cannot gate forecast-risk scoring: the Issue #2865 report contains no risk-scoring-eligible rows. Keep forecast-risk scoring opt-in and diagnostic-only until eligible calibration evidence exists.",
+  "schema_version": "forecast_risk_calibration_filter.diagnostic_comparison.v1",
+  "tradeoffs": {
+    "false_positive_stopping_avoided": true,
+    "false_positive_unnecessary_slowdown_count": 0,
+    "route_progress_tradeoff": 0.8
+  }
+}

--- a/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.md
+++ b/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/report.md
@@ -1,0 +1,43 @@
+# Issue #2869 Forecast Risk Calibration Filter Diagnostic
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/2869>
+
+## Boundary
+
+- **schema_version**: `forecast_risk_calibration_filter.diagnostic_comparison.v1`
+- **claim_boundary**: `diagnostic_only_not_benchmark_evidence`
+- **calibration_report**: `docs/context/evidence/issue_2865_forecast_calibration_report_2026-06-15/calibration_report.json`
+- **diagnostic_weight**: 5.0
+- **recommendation**: `wait`
+
+## Risk Mode Comparison
+
+| mode | status | forecast_risk_weight | high_risk selected | high_risk speed | high_risk penalty | false_positive selected | false_positive speed | false_positive penalty |
+|---|---:|---:|---|---:|---:|---|---:|---:|
+| no_risk | available | 0.0 | goal | 1.000000 | 0.000000 | goal | 1.000000 | 0.000000 |
+| raw_risk | available | 5.0 | risk_dwa | 0.200000 | 5.000000 | goal | 1.000000 | 0.000000 |
+| calibration_filtered | blocked | 5.0 | NA | NA | NA | NA | NA | NA |
+| actor_class_aware | blocked | 5.0 | NA | NA | NA | NA | NA | NA |
+| observation_tier_aware | blocked | 5.0 | NA | NA | NA | NA | NA | NA |
+
+### Blocked mode reasons
+
+- **calibration_filtered**: no_rows_risk_scoring_eligible
+- **actor_class_aware**: actor_class_unavailable_in_all_rows
+- **observation_tier_aware**: single_observation_tier: deployable_tracked
+
+## Tradeoffs
+
+| tradeoff | value |
+|---|---|
+| route_progress_tradeoff (no_risk - raw_risk) | 0.800000 |
+| false_positive_stopping_avoided | True |
+| false_positive_unnecessary_slowdown_count | 0 |
+
+## Recommendation
+
+**WAIT**
+
+Calibration filtering cannot gate forecast-risk scoring: the Issue #2865 report contains no risk-scoring-eligible rows. Keep forecast-risk scoring opt-in and diagnostic-only until eligible calibration evidence exists.
+
+> This report is diagnostic-only. It does not establish safety, navigation benefit, human realism, benchmark-strength predictor quality, or paper/dissertation claims.

--- a/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/summary.json
+++ b/docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/summary.json
@@ -1,0 +1,11 @@
+{
+  "blocked_mode_count": 3,
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "false_positive_stopping_avoided": true,
+  "false_positive_unnecessary_slowdown_count": 0,
+  "issue": 2869,
+  "mode_count": 5,
+  "recommendation": "wait",
+  "route_progress_tradeoff": 0.8,
+  "schema_version": "forecast_risk_calibration_filter.diagnostic_comparison.v1"
+}

--- a/scripts/validation/validate_forecast_risk_calibration_filter.py
+++ b/scripts/validation/validate_forecast_risk_calibration_filter.py
@@ -1,0 +1,528 @@
+"""Diagnostic comparison of forecast-risk scoring modes before planner coupling.
+
+Compares five risk-channel modes on identical deterministic observations:
+
+- ``no_risk``: baseline with ``forecast_risk_weight=0``
+- ``raw_risk``: unfiltered forecast-risk penalty
+- ``calibration_filtered``: gated by Issue #2865 calibration eligibility
+- ``actor_class_aware``: gated by per-actor-class calibration rows
+- ``observation_tier_aware``: gated by cross-observation-tier calibration rows
+
+The tool reads the Issue #2865 calibration report and marks unavailable/blocked
+modes explicitly. It does NOT run a live benchmark and makes no safety,
+navigation, paper, or dissertation claim.
+
+Usage::
+
+    uv run python scripts/validation/validate_forecast_risk_calibration_filter.py
+    uv run python scripts/validation/validate_forecast_risk_calibration_filter.py \
+        --out-dir docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.planner.policy_stack_v1 import (
+    PolicyStackV1Adapter,
+    PolicyStackV1Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SCHEMA_VERSION = "forecast_risk_calibration_filter.diagnostic_comparison.v1"
+CLAIM_BOUNDARY = "diagnostic_only_not_benchmark_evidence"
+_DIAGNOSTIC_WEIGHT = 5.0
+_DEFAULT_CALIBRATION_PATH = (
+    "docs/context/evidence/issue_2865_forecast_calibration_report_2026-06-15/"
+    "calibration_report.json"
+)
+_RISK_MODES = (
+    "no_risk",
+    "raw_risk",
+    "calibration_filtered",
+    "actor_class_aware",
+    "observation_tier_aware",
+)
+
+
+class _FixedRiskDWA:
+    """Deterministic risk_dwa test double returning a fixed command."""
+
+    def __init__(self, command: tuple[float, float] = (0.2, 0.0)) -> None:
+        self.command = command
+        self.calls = 0
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        _ = observation
+        self.calls += 1
+        return self.command
+
+    def reset(self) -> None:
+        self.calls = 0
+
+
+def _base_observation() -> dict[str, Any]:
+    """Return the canonical deterministic observation fixture."""
+    return {
+        "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+        "goal": {"current": [1.0, 0.0]},
+        "pedestrians": {"positions": [[2.0, 0.5]]},
+    }
+
+
+def _case_high_risk() -> dict[str, Any]:
+    """High-risk scenario: raw risk should slow/stop the goal proposal."""
+    obs = _base_observation()
+    obs["forecast_risk_channel"] = {
+        "status": "available",
+        "risk": 1.0,
+        "occupancy_risk": 0.9,
+        "collision_relevance": 0.8,
+    }
+    return obs
+
+
+def _case_false_positive_suppress() -> dict[str, Any]:
+    """False-positive scenario: penalty suppressed, unnecessary stop avoided."""
+    obs = _base_observation()
+    obs["forecast_risk_channel"] = {
+        "status": "available",
+        "risk": 1.0,
+        "false_positive_risk": 1.0,
+        "unnecessary_stop_risk": 1.0,
+    }
+    return obs
+
+
+_CASES: list[dict[str, Any]] = [
+    {"name": "high_risk_diagnostic_slows_goal", "observation": _case_high_risk()},
+    {"name": "false_positive_suppresses_penalty", "observation": _case_false_positive_suppress()},
+]
+
+
+def _load_calibration_report(path: Path) -> dict[str, Any]:
+    """Load and basic-validate the Issue #2865 calibration report."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data.get("reliability_rows"), list):
+        raise ValueError("calibration report missing reliability_rows")
+    return data
+
+
+def _any_eligible_for_risk_scoring(rows: list[dict[str, Any]]) -> bool:
+    """Return True if at least one row is eligible for forecast-risk scoring."""
+    eligible = {"eligible", "calibrated"}
+    return any(str(row.get("risk_scoring_eligibility", "")) in eligible for row in rows)
+
+
+def _actor_class_available(rows: list[dict[str, Any]]) -> bool:
+    """Return True if any row carries a usable actor class."""
+    return any(str(row.get("actor_class", "unavailable")).lower() != "unavailable" for row in rows)
+
+
+def _observation_tier_variation(rows: list[dict[str, Any]]) -> set[str]:
+    """Return the set of observation tiers present in calibration rows."""
+    return {str(row.get("observation_tier", "unknown")) for row in rows}
+
+
+def _mode_availability(mode: str, rows: list[dict[str, Any]]) -> tuple[str, str]:
+    """Resolve (status, reason) for a risk mode from calibration rows.
+
+    Returns:
+        tuple[str, str]: ``("available", "")`` or ``("blocked", "reason")``.
+    """
+    if mode == "no_risk":
+        return "available", "baseline forecast_risk_weight=0"
+    if mode == "raw_risk":
+        return "available", "diagnostic unfiltered forecast risk"
+    if mode == "calibration_filtered":
+        if _any_eligible_for_risk_scoring(rows):
+            return "available", "calibration report contains risk-scoring-eligible rows"
+        return "blocked", "no_rows_risk_scoring_eligible"
+    if mode == "actor_class_aware":
+        if _actor_class_available(rows):
+            return "available", "per-actor-class calibration rows available"
+        return "blocked", "actor_class_unavailable_in_all_rows"
+    if mode == "observation_tier_aware":
+        tiers = _observation_tier_variation(rows)
+        if len(tiers) > 1:
+            return "available", f"cross-tier calibration rows available: {sorted(tiers)}"
+        return "blocked", f"single_observation_tier: {sorted(tiers)[0] if tiers else 'unknown'}"
+    return "blocked", f"unknown_mode: {mode}"
+
+
+def _run_single(
+    *,
+    mode: str,
+    case: dict[str, Any],
+    calibration_rows: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Run one mode/case combination and return metrics, or None if blocked."""
+    status, _reason = _mode_availability(mode, calibration_rows)
+    if status != "available":
+        return None
+
+    if mode == "raw_risk":
+        config = PolicyStackV1Config(
+            proposal_sources=("goal", "risk_dwa"),
+            forecast_risk_weight=_DIAGNOSTIC_WEIGHT,
+        )
+    else:
+        config = PolicyStackV1Config(
+            proposal_sources=("goal", "risk_dwa"),
+            forecast_risk_weight=0.0,
+        )
+
+    stack = PolicyStackV1Adapter(config=config, risk_dwa=_FixedRiskDWA())
+    stack.plan(case["observation"])
+    last = stack.diagnostics()["last_step"]
+    if last is None:
+        raise AssertionError("diagnostics last_step must exist after plan()")
+
+    goal_components = last.get("risk_score_components", {}).get("goal", {})
+    command = last.get("selected_command", [0.0, 0.0])
+    speed = abs(float(command[0]))
+    return {
+        "selected_proposal": str(last.get("selected_proposal_key", "")),
+        "speed": round(speed, 6),
+        "progress_proxy": round(speed, 6),
+        "forecast_penalty": round(float(goal_components.get("forecast_risk_penalty", 0.0)), 6),
+        "shield_stop_count": 1 if last.get("selected_proposal_key") == "shield_stop" else 0,
+    }
+
+
+def _build_mode_rows(calibration_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build one table row per risk mode with per-case metrics."""
+    case_metrics: dict[str, dict[str, dict[str, Any] | None]] = {mode: {} for mode in _RISK_MODES}
+    for mode in _RISK_MODES:
+        for case in _CASES:
+            metrics = _run_single(
+                mode=mode,
+                case=case,
+                calibration_rows=calibration_rows,
+            )
+            case_metrics[mode][case["name"]] = metrics
+
+    rows: list[dict[str, Any]] = []
+    for mode in _RISK_MODES:
+        status, reason = _mode_availability(mode, calibration_rows)
+        high = case_metrics[mode].get("high_risk_diagnostic_slows_goal")
+        fp = case_metrics[mode].get("false_positive_suppresses_penalty")
+        row: dict[str, Any] = {
+            "mode": mode,
+            "status": status,
+            "reason": reason,
+            "forecast_risk_weight": 0.0 if mode == "no_risk" else _DIAGNOSTIC_WEIGHT,
+            "uses_calibration_filter": mode
+            in {"calibration_filtered", "actor_class_aware", "observation_tier_aware"},
+            "high_risk": high,
+            "false_positive": fp,
+        }
+        rows.append(row)
+    return rows
+
+
+def _compute_tradeoffs(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute cross-mode tradeoffs for progress and false-positive stopping."""
+    by_mode = {row["mode"]: row for row in rows}
+    no_risk_high = by_mode.get("no_risk", {}).get("high_risk")
+    raw_risk_high = by_mode.get("raw_risk", {}).get("high_risk")
+    no_risk_fp = by_mode.get("no_risk", {}).get("false_positive")
+    raw_risk_fp = by_mode.get("raw_risk", {}).get("false_positive")
+
+    route_progress_tradeoff: float | None = None
+    if (
+        no_risk_high is not None
+        and raw_risk_high is not None
+        and isinstance(no_risk_high, dict)
+        and isinstance(raw_risk_high, dict)
+    ):
+        route_progress_tradeoff = round(
+            float(no_risk_high["progress_proxy"]) - float(raw_risk_high["progress_proxy"]),
+            6,
+        )
+
+    false_positive_stopping: bool | None = None
+    false_positive_unnecessary_slowdown_count: int | None = None
+    if (
+        no_risk_fp is not None
+        and raw_risk_fp is not None
+        and isinstance(no_risk_fp, dict)
+        and isinstance(raw_risk_fp, dict)
+    ):
+        false_positive_stopping = (
+            raw_risk_fp["selected_proposal"] == "goal" and raw_risk_fp["forecast_penalty"] == 0.0
+        )
+        false_positive_unnecessary_slowdown_count = int(raw_risk_fp["speed"] < no_risk_fp["speed"])
+
+    return {
+        "route_progress_tradeoff": route_progress_tradeoff,
+        "false_positive_stopping_avoided": false_positive_stopping,
+        "false_positive_unnecessary_slowdown_count": false_positive_unnecessary_slowdown_count,
+    }
+
+
+def _decide_recommendation(rows: list[dict[str, Any]], tradeoffs: dict[str, Any]) -> str:
+    """Return a bounded recommendation for calibration-filter gating."""
+    by_mode = {row["mode"]: row for row in rows}
+    calibration_filtered = by_mode.get("calibration_filtered", {})
+    if calibration_filtered.get("status") == "blocked":
+        return "wait"
+    # If calibration filtering were ever available, require raw_risk consistency too.
+    raw_risk = by_mode.get("raw_risk", {})
+    raw_high = raw_risk.get("high_risk") if isinstance(raw_risk.get("high_risk"), dict) else None
+    if raw_high is None or raw_high.get("forecast_penalty", 0.0) <= 0.0:
+        return "wait"
+    if tradeoffs.get("false_positive_stopping_avoided") is False:
+        return "wait"
+    return "diagnostic_only"
+
+
+def _recommendation_rationale(recommendation: str) -> str:
+    """Return a rationale matching the current recommendation."""
+    if recommendation == "wait":
+        return (
+            "Calibration filtering cannot gate forecast-risk scoring: the Issue #2865 report "
+            "contains no risk-scoring-eligible rows. Keep forecast-risk scoring opt-in and "
+            "diagnostic-only until eligible calibration evidence exists."
+        )
+    return (
+        "Calibration-filtered rows are available in the input report, but this tool remains a "
+        "deterministic diagnostic comparison rather than benchmark evidence. Use it only to "
+        "decide whether a same-seed benchmark comparison is now warranted."
+    )
+
+
+def build_report(calibration_path: Path | None = None) -> dict[str, Any]:
+    """Build the full diagnostic comparison report.
+
+    Args:
+        calibration_path: Path to Issue #2865 calibration report JSON.
+            Defaults to the tracked evidence location.
+
+    Returns:
+        dict with claim_boundary, mode table, tradeoffs, and recommendation.
+    """
+    path = calibration_path or Path(_DEFAULT_CALIBRATION_PATH)
+    report_data = _load_calibration_report(path)
+    rows = report_data.get("reliability_rows", [])
+
+    mode_rows = _build_mode_rows(rows)
+    tradeoffs = _compute_tradeoffs(mode_rows)
+    recommendation = _decide_recommendation(mode_rows, tradeoffs)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 2869,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "calibration_report": str(path),
+        "diagnostic_weight": _DIAGNOSTIC_WEIGHT,
+        "modes": mode_rows,
+        "tradeoffs": tradeoffs,
+        "recommendation": recommendation,
+        "recommendation_rationale": _recommendation_rationale(recommendation),
+    }
+
+
+def _format_optional_float(value: Any) -> str:
+    """Format optional metric values for Markdown tables."""
+    if value is None:
+        return "NA"
+    return f"{float(value):.6f}"
+
+
+def _format_optional_int(value: Any) -> str:
+    """Format optional integer values for Markdown tables."""
+    if value is None:
+        return "NA"
+    return str(int(value))
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    """Render the report as a human-readable Markdown string."""
+    lines = [
+        "# Issue #2869 Forecast Risk Calibration Filter Diagnostic",
+        "",
+        "Related issue: <https://github.com/ll7/robot_sf_ll7/issues/2869>",
+        "",
+        "## Boundary",
+        "",
+        f"- **schema_version**: `{report['schema_version']}`",
+        f"- **claim_boundary**: `{report['claim_boundary']}`",
+        f"- **calibration_report**: `{report['calibration_report']}`",
+        f"- **diagnostic_weight**: {report['diagnostic_weight']}",
+        f"- **recommendation**: `{report['recommendation']}`",
+        "",
+        "## Risk Mode Comparison",
+        "",
+        "| mode | status | forecast_risk_weight | high_risk selected | high_risk speed | "
+        "high_risk penalty | false_positive selected | false_positive speed | "
+        "false_positive penalty |",
+        "|---|---:|---:|---|---:|---:|---|---:|---:|",
+    ]
+    for row in report["modes"]:
+        high = row["high_risk"] if isinstance(row["high_risk"], dict) else {}
+        fp = row["false_positive"] if isinstance(row["false_positive"], dict) else {}
+        lines.append(
+            f"| {row['mode']} | {row['status']} | "
+            f"{row['forecast_risk_weight']:.1f} | "
+            f"{high.get('selected_proposal', 'NA')} | "
+            f"{_format_optional_float(high.get('speed'))} | "
+            f"{_format_optional_float(high.get('forecast_penalty'))} | "
+            f"{fp.get('selected_proposal', 'NA')} | "
+            f"{_format_optional_float(fp.get('speed'))} | "
+            f"{_format_optional_float(fp.get('forecast_penalty'))} |"
+        )
+    lines.append("")
+    lines.append("### Blocked mode reasons")
+    lines.append("")
+    for row in report["modes"]:
+        if row["status"] == "blocked":
+            lines.append(f"- **{row['mode']}**: {row['reason']}")
+    lines.append("")
+    lines.append("## Tradeoffs")
+    lines.append("")
+    lines.append("| tradeoff | value |")
+    lines.append("|---|---|")
+    tradeoffs = report["tradeoffs"]
+    lines.append(
+        f"| route_progress_tradeoff (no_risk - raw_risk) | "
+        f"{_format_optional_float(tradeoffs.get('route_progress_tradeoff'))} |"
+    )
+    lines.append(
+        f"| false_positive_stopping_avoided | "
+        f"{tradeoffs.get('false_positive_stopping_avoided', 'NA')} |"
+    )
+    lines.append(
+        f"| false_positive_unnecessary_slowdown_count | "
+        f"{_format_optional_int(tradeoffs.get('false_positive_unnecessary_slowdown_count'))} |"
+    )
+    lines.append("")
+    lines.append("## Recommendation")
+    lines.append("")
+    lines.append(f"**{report['recommendation'].upper()}**")
+    lines.append("")
+    lines.append(report["recommendation_rationale"])
+    lines.append("")
+    lines.append(
+        "> This report is diagnostic-only. It does not establish safety, navigation benefit, "
+        "human realism, benchmark-strength predictor quality, or paper/dissertation claims."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--calibration-report",
+        type=Path,
+        default=Path(_DEFAULT_CALIBRATION_PATH),
+        help="Path to Issue #2865 calibration report JSON.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Directory for report.json, report.md, summary.json, README.md (default: stdout only).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the diagnostic comparison and optionally write artifacts.
+
+    Returns:
+        Exit code 0 on success.
+    """
+    args = build_arg_parser().parse_args(argv)
+    if not args.calibration_report.exists():
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "error": f"calibration report not found: {args.calibration_report}",
+                }
+            )
+        )
+        return 1
+
+    try:
+        report = build_report(args.calibration_report)
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}))
+        return 1
+
+    summary = {
+        "issue": report["issue"],
+        "schema_version": report["schema_version"],
+        "claim_boundary": report["claim_boundary"],
+        "recommendation": report["recommendation"],
+        "mode_count": len(report["modes"]),
+        "blocked_mode_count": sum(1 for row in report["modes"] if row["status"] == "blocked"),
+        "route_progress_tradeoff": report["tradeoffs"].get("route_progress_tradeoff"),
+        "false_positive_stopping_avoided": report["tradeoffs"].get(
+            "false_positive_stopping_avoided"
+        ),
+        "false_positive_unnecessary_slowdown_count": report["tradeoffs"].get(
+            "false_positive_unnecessary_slowdown_count"
+        ),
+    }
+    print(json.dumps({"summary": summary, "report": report}, indent=2, sort_keys=True))
+
+    if args.out_dir is not None:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "report.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        (args.out_dir / "report.md").write_text(_render_markdown(report), encoding="utf-8")
+        (args.out_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        readme = _render_readme(report)
+        (args.out_dir / "README.md").write_text(readme, encoding="utf-8")
+    return 0
+
+
+def _render_readme(report: dict[str, Any]) -> str:
+    """Render the evidence-bundle README."""
+    calibration_report = str(report["calibration_report"])
+    calibration_link = (
+        "../issue_2865_forecast_calibration_report_2026-06-15/calibration_report.json"
+    )
+    return (
+        "# Issue #2869 Forecast Risk Calibration Filter Diagnostic\n\n"
+        "## Scope\n\n"
+        "This bundle compares five forecast-risk scoring modes before trusting planner coupling:\n"
+        "`no_risk`, `raw_risk`, `calibration_filtered`, `actor_class_aware`, and "
+        "`observation_tier_aware`.\n\n"
+        "## Evidence status\n\n"
+        f"- `schema`: `{report['schema_version']}`\n"
+        f"- `calibration_report`: [{calibration_report}]({calibration_link})\n"
+        "- `report`: [report.json](report.json) and [report.md](report.md)\n"
+        f"- `claim_boundary`: {report['claim_boundary']}\n"
+        f"- `recommendation`: `{report['recommendation']}`\n\n"
+        "## Reproducible command\n\n"
+        "```\n"
+        "uv run python scripts/validation/validate_forecast_risk_calibration_filter.py \\\n"
+        "  --out-dir docs/context/evidence/"
+        "issue_2869_forecast_risk_calibration_filter_2026-06-15\n"
+        "```\n\n"
+        "## Validation\n\n"
+        "```\n"
+        "uv run pytest tests/validation/test_forecast_risk_calibration_filter.py\n"
+        "```\n\n"
+        "## Claim boundary\n\n"
+        "This report is diagnostic-only. It does not establish safety, navigation benefit, "
+        "human realism, benchmark-strength predictor quality, or paper/dissertation claims. "
+        "Forecast-risk scoring remains opt-in with `forecast_risk_weight=0.0` by default.\n"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/validation/test_forecast_risk_calibration_filter.py
+++ b/tests/validation/test_forecast_risk_calibration_filter.py
@@ -1,0 +1,280 @@
+"""Tests for the forecast risk calibration filter diagnostic (issue #2869)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.validation import validate_forecast_risk_calibration_filter as validator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+def _write_calibration_report(
+    tmp_path: Path,
+    *,
+    eligible: bool = False,
+    actor_class_available: bool = False,
+    tiers: list[str] | None = None,
+) -> Path:
+    """Write a synthetic Issue #2865-style calibration report and return its path."""
+    if tiers is None:
+        tiers = ["deployable_tracked"]
+    rows: list[dict[str, object]] = []
+    for tier in tiers:
+        risk_eligibility = "eligible" if eligible else "blocked_no_denominator"
+        actor_class = "pedestrian" if actor_class_available else "unavailable"
+        rows.append(
+            {
+                "scenario_family": "corridor_interaction",
+                "predictor_family": "cv",
+                "observation_tier": tier,
+                "horizon_s": 1.0,
+                "actor_class": actor_class,
+                "risk_scoring_eligibility": risk_eligibility,
+                "calibration_status": "calibrated" if eligible else "unavailable",
+            }
+        )
+    data = {
+        "schema_version": "ForecastCalibrationReport.v1",
+        "report_id": "synthetic",
+        "reliability_rows": rows,
+        "limitation_rows": [],
+    }
+    p = tmp_path / "calibration_report.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+# -- Unit tests for availability logic ----------------------------------------
+
+
+class TestModeAvailability:
+    """Tests for _mode_availability classification."""
+
+    def test_no_risk_always_available(self) -> None:
+        """no_risk mode is always available."""
+        status, reason = validator._mode_availability("no_risk", [])
+        assert status == "available"
+        assert "baseline" in reason
+
+    def test_raw_risk_always_available(self) -> None:
+        """raw_risk mode is always available as a diagnostic."""
+        status, reason = validator._mode_availability("raw_risk", [])
+        assert status == "available"
+        assert "diagnostic" in reason
+
+    def test_calibration_filtered_blocked_without_eligible_rows(self) -> None:
+        """calibration_filtered is blocked when no rows are risk-scoring eligible."""
+        rows = [{"risk_scoring_eligibility": "blocked_no_denominator"}]
+        status, reason = validator._mode_availability("calibration_filtered", rows)
+        assert status == "blocked"
+        assert "no_rows_risk_scoring_eligible" in reason
+
+    def test_calibration_filtered_available_with_eligible_rows(self) -> None:
+        """calibration_filtered is available when at least one row is eligible."""
+        rows = [{"risk_scoring_eligibility": "eligible"}]
+        status, reason = validator._mode_availability("calibration_filtered", rows)
+        assert status == "available"
+        assert "eligible" in reason
+
+    def test_actor_class_aware_blocked_when_unavailable(self) -> None:
+        """actor_class_aware is blocked when all rows have actor_class unavailable."""
+        rows = [{"actor_class": "unavailable"}]
+        status, reason = validator._mode_availability("actor_class_aware", rows)
+        assert status == "blocked"
+        assert "actor_class_unavailable" in reason
+
+    def test_actor_class_aware_available_with_actor_class(self) -> None:
+        """actor_class_aware is available when rows carry a real actor class."""
+        rows = [{"actor_class": "pedestrian"}]
+        status, _reason = validator._mode_availability("actor_class_aware", rows)
+        assert status == "available"
+
+    def test_observation_tier_aware_blocked_with_single_tier(self) -> None:
+        """observation_tier_aware is blocked with only one observation tier."""
+        rows = [{"observation_tier": "deployable_tracked"}]
+        status, reason = validator._mode_availability("observation_tier_aware", rows)
+        assert status == "blocked"
+        assert "single_observation_tier" in reason
+
+    def test_observation_tier_aware_available_with_multiple_tiers(self) -> None:
+        """observation_tier_aware is available with multiple observation tiers."""
+        rows = [
+            {"observation_tier": "deployable_tracked"},
+            {"observation_tier": "oracle"},
+        ]
+        status, _reason = validator._mode_availability("observation_tier_aware", rows)
+        assert status == "available"
+
+
+# -- Report structure tests ---------------------------------------------------
+
+
+class TestBuildReport:
+    """Structural assertions on the diagnostic report."""
+
+    def test_report_schema_version(self, tmp_path: Path) -> None:
+        """Report schema version should match the module constant."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        assert report["schema_version"] == validator.SCHEMA_VERSION
+
+    def test_claim_boundary_is_diagnostic_only(self, tmp_path: Path) -> None:
+        """Claim boundary must be diagnostic-only, not benchmark evidence."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        assert report["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+
+    def test_five_modes_present(self, tmp_path: Path) -> None:
+        """Report should cover exactly the five required risk modes."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        modes = [row["mode"] for row in report["modes"]]
+        assert modes == list(validator._RISK_MODES)
+
+    def test_current_evidence_blocks_three_modes(self, tmp_path: Path) -> None:
+        """Synthetic report mirroring #2865 blocks calibration, actor-class, and tier-aware."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        blocked = {row["mode"] for row in report["modes"] if row["status"] == "blocked"}
+        assert blocked == {
+            "calibration_filtered",
+            "actor_class_aware",
+            "observation_tier_aware",
+        }
+
+    def test_recommendation_wait_with_blocked_calibration_filter(self, tmp_path: Path) -> None:
+        """When calibration filtering is blocked, recommendation must be wait."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        assert report["recommendation"] == "wait"
+
+
+# -- Metric/tradeoff tests ----------------------------------------------------
+
+
+class TestModeMetrics:
+    """Tests for per-mode metric extraction."""
+
+    def test_no_risk_zero_forecast_penalty(self, tmp_path: Path) -> None:
+        """no_risk should apply zero forecast penalty on the high-risk case."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        no_risk_row = next(row for row in report["modes"] if row["mode"] == "no_risk")
+        high = no_risk_row["high_risk"]
+        assert isinstance(high, dict)
+        assert high["forecast_penalty"] == 0.0
+        assert high["selected_proposal"] == "goal"
+
+    def test_raw_risk_penalizes_goal(self, tmp_path: Path) -> None:
+        """raw_risk should apply a positive forecast penalty on the high-risk case."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        raw_row = next(row for row in report["modes"] if row["mode"] == "raw_risk")
+        high = raw_row["high_risk"]
+        assert isinstance(high, dict)
+        assert high["forecast_penalty"] > 0.0
+
+    def test_raw_risk_false_positive_suppresses_penalty(self, tmp_path: Path) -> None:
+        """raw_risk should suppress penalty when false_positive risk is 1."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        raw_row = next(row for row in report["modes"] if row["mode"] == "raw_risk")
+        fp = raw_row["false_positive"]
+        assert isinstance(fp, dict)
+        assert fp["forecast_penalty"] == 0.0
+        assert fp["selected_proposal"] == "goal"
+
+    def test_blocked_modes_have_null_metrics(self, tmp_path: Path) -> None:
+        """Blocked modes should not produce per-case metrics."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        for row in report["modes"]:
+            if row["status"] == "blocked":
+                assert row["high_risk"] is None
+                assert row["false_positive"] is None
+
+
+class TestTradeoffs:
+    """Tests for cross-mode tradeoff computation."""
+
+    def test_route_progress_tradeoff_positive(self, tmp_path: Path) -> None:
+        """raw_risk should slow the high-risk case relative to no_risk."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        tradeoff = report["tradeoffs"]["route_progress_tradeoff"]
+        assert tradeoff is not None
+        assert tradeoff > 0.0
+
+    def test_false_positive_stopping_avoided(self, tmp_path: Path) -> None:
+        """False-positive suppression should avoid unnecessary stopping."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        assert report["tradeoffs"]["false_positive_stopping_avoided"] is True
+
+    def test_false_positive_unnecessary_slowdown_zero(self, tmp_path: Path) -> None:
+        """False-positive case should not slow relative to no_risk."""
+        report_path = _write_calibration_report(tmp_path)
+        report = validator.build_report(report_path)
+        assert report["tradeoffs"]["false_positive_unnecessary_slowdown_count"] == 0
+
+
+# -- CLI tests ----------------------------------------------------------------
+
+
+class TestMainCLI:
+    """Tests for the main() CLI entry point."""
+
+    def test_main_returns_zero(self, tmp_path: Path) -> None:
+        """CLI should exit with code 0 on success."""
+        report_path = _write_calibration_report(tmp_path)
+        assert validator.main(["--calibration-report", str(report_path)]) == 0
+
+    def test_main_json_output(self, tmp_path: Path, capsys) -> None:
+        """CLI should print JSON with summary and report keys."""
+        report_path = _write_calibration_report(tmp_path)
+        validator.main(["--calibration-report", str(report_path)])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "summary" in data
+        assert "report" in data
+        assert data["summary"]["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+
+    def test_main_writes_artifacts(self, tmp_path: Path) -> None:
+        """--out-dir should produce report.json, report.md, summary.json, and README.md."""
+        report_path = _write_calibration_report(tmp_path)
+        out = tmp_path / "out"
+        exit_code = validator.main(
+            ["--calibration-report", str(report_path), "--out-dir", str(out)]
+        )
+        assert exit_code == 0
+        assert (out / "report.json").exists()
+        assert (out / "report.md").exists()
+        assert (out / "summary.json").exists()
+        assert (out / "README.md").exists()
+
+    def test_main_summary_json_content(self, tmp_path: Path) -> None:
+        """summary.json should carry the diagnostic claim boundary and recommendation."""
+        report_path = _write_calibration_report(tmp_path)
+        out = tmp_path / "out"
+        validator.main(["--calibration-report", str(report_path), "--out-dir", str(out)])
+        summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
+        assert summary["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+        assert summary["recommendation"] == "wait"
+        assert summary["blocked_mode_count"] == 3
+
+    def test_main_missing_report_returns_1(self, tmp_path: Path) -> None:
+        """Missing calibration report returns exit code 1."""
+        rc = validator.main(["--calibration-report", str(tmp_path / "missing.json")])
+        assert rc == 1
+
+    def test_main_malformed_report_returns_1(self, tmp_path: Path) -> None:
+        """Malformed calibration report returns exit code 1."""
+        p = tmp_path / "bad.json"
+        p.write_text(json.dumps({"no_reliability_rows": []}), encoding="utf-8")
+        rc = validator.main(["--calibration-report", str(p)])
+        assert rc == 1


### PR DESCRIPTION
## Summary

- Adds a deterministic diagnostic tool for Issue #2869 that compares `no_risk`, `raw_risk`, `calibration_filtered`, `actor_class_aware`, and `observation_tier_aware` forecast-risk scoring modes.
- Publishes a tracked evidence bundle under `docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/`.
- Updates the prediction-lane docs, evidence README, and context catalog so the diagnostic result remains discoverable.

Closes #2869.

## Result

Recommendation: `wait`.

The current Issue #2865 calibration report has no risk-scoring-eligible rows, actor class is unavailable in all rows, and only the `deployable_tracked` observation tier is present. The filtered modes are therefore explicitly blocked. Raw risk remains diagnostic-only: it penalizes the high-risk fixture and preserves the false-positive suppression behavior, but this is not benchmark evidence.

## Validation

- `uv run pytest tests/validation/test_forecast_risk_calibration_filter.py -q`
- `uv run pytest tests/planner/test_policy_stack_v1.py tests/validation/test_forecast_risk_policy_stack.py -v`
- `uv run ruff check scripts/validation/validate_forecast_risk_calibration_filter.py tests/validation/test_forecast_risk_calibration_filter.py`
- `uv run ruff format --check scripts/validation/validate_forecast_risk_calibration_filter.py tests/validation/test_forecast_risk_calibration_filter.py`
- `uv run python scripts/validation/validate_forecast_risk_calibration_filter.py --out-dir docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `git diff --check`

## Downstream Propagation

- Parent issue: #2869 closes with a diagnostic-only `wait` recommendation.
- Prediction lane: updated `docs/ai/prediction_lane.md`.
- Evidence catalog: updated `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.
- Durable artifact: small tracked JSON/Markdown evidence bundle under `docs/context/evidence/issue_2869_forecast_risk_calibration_filter_2026-06-15/`.

## Research Result Guidance

- Target blocker: whether calibration filtering can gate forecast-risk scoring before planner coupling.
- Comparator/baseline: deterministic `no_risk` and `raw_risk` PolicyStackV1 fixtures with identical observations.
- Evidence tier: diagnostic-only, not benchmark evidence.
- Result classification: `wait`; calibration-filtered, actor-class-aware, and observation-tier-aware modes are unavailable on the current #2865 calibration evidence.
- Decision/stop rule: keep forecast-risk scoring opt-in and do not run same-seed planner stress as benchmark-strength evidence until eligible calibration rows exist.
- Synthesis surface: `docs/ai/prediction_lane.md` and the tracked #2869 evidence bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive evidence documentation for Issue `#2869` Forecast Risk Calibration Filter diagnostic analysis, including validation methodology and results.

* **New Features**
  * Introduced a diagnostic validation tool for comparing multiple forecast-risk scoring modes with structured reporting capabilities.

* **Tests**
  * Added test coverage for forecast risk calibration filter validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->