### PR TITLE
feat: add claim matrix chapter targets

### DIFF
--- a/docs/benchmark_artifact_publication.md
+++ b/docs/benchmark_artifact_publication.md
@@ -125,8 +125,9 @@ artifacts into a disposable bundle and writes:
 - `checksums.sha256`: checksums for files under `payload/artifacts/`;
 - per-artifact rows with `artifact_id`, `source_path`, `source_artifact`,
   `output_path`, `sha256`, `source_commit`, `generation_command`,
-  `caption_draft`, `claim_boundary`, `recommended_manuscript_use`, and
-  `fallback_degraded_summary`.
+  `caption_draft`, `claim_boundary`, `recommended_manuscript_use`,
+  `fallback_degraded_summary`, and optionally `chapter_target` and
+  `chapter_target_justification`.
 
 The artifact spec is a compact JSON file so reviewers can see exactly which
 figure/table candidates are being handed off:
@@ -141,7 +142,8 @@ figure/table candidates are being handed off:
       "caption_draft": "Campaign table preserving fallback and degraded rows.",
       "claim_boundary": "Formatted table only; not new benchmark evidence.",
       "recommended_manuscript_use": "discussion",
-      "fallback_degraded_summary": "Fallback and degraded rows remain visible."
+      "fallback_degraded_summary": "Fallback and degraded rows remain visible.",
+      "chapter_target": "Results, Section 4.2"
     }
   ]
 }
@@ -149,6 +151,12 @@ figure/table candidates are being handed off:
 
 Allowed `recommended_manuscript_use` values are `results`, `methodology`,
 `discussion`, `outlook`, and `do-not-use`; unsupported values fail closed.
+
+Optional `chapter_target` is a free-form dissertation chapter/section label
+(e.g. `Results, Section 4.2` or `Limitations, Section 5.1`). Diagnostic-only
+rows should target limitations, methodology, or future-work style sections
+unless `chapter_target_justification` explicitly explains why another target
+is appropriate.
 
 Example command:
 

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -91,6 +91,8 @@ class DissertationArtifactSpec:
     recommended_manuscript_use: str
     fallback_degraded_summary: str
     metadata: dict[str, Any] | None = None
+    chapter_target: str | None = None
+    chapter_target_justification: str | None = None
 
 
 @dataclass(frozen=True)
@@ -543,6 +545,48 @@ def _validate_dissertation_artifacts(
     return resolved
 
 
+def _build_dissertation_manifest_entry(
+    artifact: DissertationArtifactSpec,
+    rel_source: Path,
+    payload_path: Path,
+    digest: str,
+    size_bytes: int,
+    commit: str,
+    command: str,
+) -> dict[str, Any]:
+    """Build one artifact manifest entry for a dissertation bundle.
+
+    Returns:
+        JSON-serializable manifest entry for the artifact.
+    """
+    entry: dict[str, Any] = {
+        "artifact_id": artifact.artifact_id,
+        "source_path": rel_source.as_posix(),
+        "source_artifact": artifact.source_artifact,
+        "output_path": payload_path.as_posix(),
+        "size_bytes": size_bytes,
+        "sha256": digest,
+        "source_commit": commit.strip(),
+        "generation_command": command.strip(),
+        "caption_draft": artifact.caption_draft.strip(),
+        "claim_boundary": artifact.claim_boundary.strip(),
+        "recommended_manuscript_use": artifact.recommended_manuscript_use,
+        "fallback_degraded_summary": artifact.fallback_degraded_summary.strip(),
+        "metadata": artifact.metadata or {},
+    }
+    chapter_target = artifact.chapter_target.strip() if artifact.chapter_target is not None else ""
+    if chapter_target:
+        entry["chapter_target"] = chapter_target
+    chapter_target_justification = (
+        artifact.chapter_target_justification.strip()
+        if artifact.chapter_target_justification is not None
+        else ""
+    )
+    if chapter_target_justification:
+        entry["chapter_target_justification"] = chapter_target_justification
+    return entry
+
+
 def export_dissertation_artifact_bundle(
     source_root: Path,
     out_dir: Path,
@@ -605,21 +649,9 @@ def export_dissertation_artifact_bundle(
         total_bytes += size_bytes
         checksums.append(f"{digest}  {payload_path.as_posix()}\n")
         manifest_entries.append(
-            {
-                "artifact_id": artifact.artifact_id,
-                "source_path": rel_source.as_posix(),
-                "source_artifact": artifact.source_artifact,
-                "output_path": payload_path.as_posix(),
-                "size_bytes": size_bytes,
-                "sha256": digest,
-                "source_commit": commit.strip(),
-                "generation_command": command.strip(),
-                "caption_draft": artifact.caption_draft.strip(),
-                "claim_boundary": artifact.claim_boundary.strip(),
-                "recommended_manuscript_use": artifact.recommended_manuscript_use,
-                "fallback_degraded_summary": artifact.fallback_degraded_summary.strip(),
-                "metadata": artifact.metadata or {},
-            }
+            _build_dissertation_manifest_entry(
+                artifact, rel_source, payload_path, digest, size_bytes, commit, command
+            )
         )
 
     manifest_entries = sorted(manifest_entries, key=lambda entry: str(entry["artifact_id"]))

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -582,6 +582,11 @@ def _build_dissertation_manifest_entry(
         if artifact.chapter_target_justification is not None
         else ""
     )
+    if chapter_target_justification and not chapter_target:
+        raise ValueError(
+            f"Artifact {artifact.artifact_id!r} sets chapter_target_justification "
+            "without chapter_target"
+        )
     if chapter_target_justification:
         entry["chapter_target_justification"] = chapter_target_justification
     return entry

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -57,6 +57,18 @@ _STRONG_BOUNDARY_HINTS = {
     "verified",
     "reproducible",
 }
+_DIAGNOSTIC_CHAPTER_TARGET_STYLES = {
+    "limitations",
+    "limitation",
+    "methodology",
+    "methods",
+    "future work",
+    "future-work",
+    "future_work",
+    "discussion",
+    "outlook",
+    "n/a",
+}
 
 
 class ClaimMatrixRow(TypedDict):
@@ -71,6 +83,8 @@ class ClaimMatrixRow(TypedDict):
     figure_table_candidate: str
     caveat: str
     validation_status: str
+    chapter_target: str | None
+    chapter_target_status: str | None
 
 
 class ClaimMatrix(TypedDict):
@@ -434,6 +448,14 @@ def _load_dissertation_artifacts(spec_path: Path) -> list[DissertationArtifactSp
                     raise ValueError(f"Artifact spec row {index} field {key!r} cannot be null")
                 return str(value)
 
+            def get_optional_str(key: str) -> str | None:
+                """Return an optional artifact spec value, treating JSON null as None."""
+                value = row.get(key)
+                if value is None:
+                    return None
+                stripped = str(value).strip()
+                return stripped if stripped else None
+
             artifacts.append(
                 DissertationArtifactSpec(
                     artifact_id=get_str("artifact_id"),
@@ -444,6 +466,8 @@ def _load_dissertation_artifacts(spec_path: Path) -> list[DissertationArtifactSp
                     recommended_manuscript_use=get_str("recommended_manuscript_use"),
                     fallback_degraded_summary=get_str("fallback_degraded_summary"),
                     metadata=row.get("metadata") if isinstance(row.get("metadata"), dict) else None,
+                    chapter_target=get_optional_str("chapter_target"),
+                    chapter_target_justification=get_optional_str("chapter_target_justification"),
                 )
             )
         except KeyError as exc:
@@ -912,6 +936,63 @@ def _run_dissertation_bundle(args: argparse.Namespace) -> int:
     return 0
 
 
+def _extract_chapter_target(artifact: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract optional chapter target and justification from an artifact.
+
+    Supports the canonical ``chapter_target`` field, the
+    ``dissertation_chapter`` alias used by the dissertation evidence ledger,
+    and an optional nested ``metadata.chapter_target`` fallback.
+
+    Returns:
+        A tuple of (chapter_target, chapter_target_justification).
+    """
+    metadata = artifact.get("metadata") if isinstance(artifact.get("metadata"), dict) else None
+
+    raw_target = artifact.get("chapter_target")
+    if raw_target is None:
+        raw_target = artifact.get("dissertation_chapter")
+    if raw_target is None and metadata is not None:
+        raw_target = metadata.get("chapter_target")
+    chapter_target = str(raw_target).strip() if raw_target is not None else None
+    if chapter_target == "":
+        chapter_target = None
+
+    raw_justification = artifact.get("chapter_target_justification")
+    if raw_justification is None and metadata is not None:
+        raw_justification = metadata.get("chapter_target_justification")
+    justification = str(raw_justification).strip() if raw_justification is not None else None
+    if justification == "":
+        justification = None
+
+    return chapter_target, justification
+
+
+def _validate_chapter_target(
+    evidence_tier: str,
+    chapter_target: str | None,
+    justification: str | None,
+) -> str | None:
+    """Validate that a chapter target is appropriate for the evidence tier.
+
+    Diagnostic-only rows should map primarily to limitations, methodology, or
+    future-work style targets unless explicitly justified.
+
+    Returns:
+        ``None`` when no target is present, ``"ok"`` when the target is
+        acceptable, or a short warning string when the target looks mismatched.
+    """
+    if chapter_target is None:
+        return None
+    normalized = chapter_target.lower()
+    has_allowed_style = any(style in normalized for style in _DIAGNOSTIC_CHAPTER_TARGET_STYLES)
+    if evidence_tier == "diagnostic-only" and not has_allowed_style and not justification:
+        return (
+            f"warning: diagnostic-only row targets '{chapter_target}'; "
+            "expected limitations/methodology/future-work style or explicit justification"
+        )
+    return "ok"
+
+
 def _get_validation_status(
     artifact_id: str,
     source_path: str,
@@ -1013,6 +1094,11 @@ def _process_dissertation_artifact(
         evidence_claim_boundaries=evidence_claim_boundaries,
     )
 
+    chapter_target, chapter_target_justification = _extract_chapter_target(artifact)
+    chapter_target_status = _validate_chapter_target(
+        evidence_tier, chapter_target, chapter_target_justification
+    )
+
     return ClaimMatrixRow(
         artifact_id=artifact_id,
         source_artifact_path=f"{source_artifact} ({source_path})",
@@ -1023,6 +1109,8 @@ def _process_dissertation_artifact(
         figure_table_candidate=str(artifact.get("caption_draft", "N/A")),
         caveat=caveat,
         validation_status=validation_status,
+        chapter_target=chapter_target,
+        chapter_target_status=chapter_target_status,
     )
 
 
@@ -1057,6 +1145,17 @@ def _collect_claim_matrix_inputs(
     return all_dissertation_artifacts, evidence_claim_boundaries
 
 
+def _format_claim_matrix_cell(value: object) -> str:
+    """Format a claim-matrix value for Markdown.
+
+    Returns:
+        Empty string for missing values, otherwise the string value.
+    """
+    if value is None:
+        return ""
+    return str(value)
+
+
 def _write_claim_matrix_outputs(
     *,
     claims_rows: list[ClaimMatrixRow],
@@ -1076,12 +1175,21 @@ def _write_claim_matrix_outputs(
     if not claims_rows:
         markdown_lines.append("No claims found to display.")
     else:
-        headers = list(ClaimMatrixRow.__annotations__.keys())
+        all_headers = list(ClaimMatrixRow.__annotations__.keys())
+        has_chapter_target = any(row.get("chapter_target") is not None for row in claims_rows)
+        if not has_chapter_target:
+            headers = [
+                h for h in all_headers if h not in ("chapter_target", "chapter_target_status")
+            ]
+        else:
+            headers = all_headers
         readable_headers = [header.replace("_", " ").title() for header in headers]
         markdown_lines.append("| " + " | ".join(readable_headers) + " |")
         markdown_lines.append("|" + "---|".join(["-" * len(h) for h in readable_headers]) + "|")
         for row in claims_rows:
-            markdown_lines.append("| " + " | ".join([str(row[key]) for key in headers]) + " |")
+            markdown_lines.append(
+                "| " + " | ".join([_format_claim_matrix_cell(row[key]) for key in headers]) + " |"
+            )
 
     markdown_output.parent.mkdir(parents=True, exist_ok=True)
     markdown_output.write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -441,16 +441,21 @@ def _load_dissertation_artifacts(spec_path: Path) -> list[DissertationArtifactSp
             raise ValueError(f"Artifact spec row {index} must be an object")
         try:
 
-            def get_str(key: str) -> str:
+            def get_str(
+                key: str,
+                *,
+                _row: dict[str, Any] = row,
+                _index: int = index,
+            ) -> str:
                 """Return a required artifact spec value without accepting JSON null."""
-                value = row[key]
+                value = _row[key]
                 if value is None:
-                    raise ValueError(f"Artifact spec row {index} field {key!r} cannot be null")
+                    raise ValueError(f"Artifact spec row {_index} field {key!r} cannot be null")
                 return str(value)
 
-            def get_optional_str(key: str) -> str | None:
+            def get_optional_str(key: str, *, _row: dict[str, Any] = row) -> str | None:
                 """Return an optional artifact spec value, treating JSON null as None."""
-                value = row.get(key)
+                value = _row.get(key)
                 if value is None:
                     return None
                 stripped = str(value).strip()
@@ -982,12 +987,16 @@ def _validate_chapter_target(
         acceptable, or a short warning string when the target looks mismatched.
     """
     if chapter_target is None:
+        if justification:
+            return "warning: justification provided but no chapter target is specified"
         return None
     normalized = chapter_target.lower()
     has_allowed_style = any(style in normalized for style in _DIAGNOSTIC_CHAPTER_TARGET_STYLES)
-    if evidence_tier == "diagnostic-only" and not has_allowed_style and not justification:
+    if evidence_tier in {"diagnostic-only", "non-claimable"} and not (
+        has_allowed_style or justification
+    ):
         return (
-            f"warning: diagnostic-only row targets '{chapter_target}'; "
+            f"warning: {evidence_tier} row targets '{chapter_target}'; "
             "expected limitations/methodology/future-work style or explicit justification"
         )
     return "ok"
@@ -1153,7 +1162,7 @@ def _format_claim_matrix_cell(value: object) -> str:
     """
     if value is None:
         return ""
-    return str(value)
+    return str(value).replace("|", r"\|")
 
 
 def _write_claim_matrix_outputs(

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -125,6 +125,7 @@ def _make_dissertation_source(source_root: Path) -> Path:
                 "recommended_manuscript_use": "do-not-use",
                 "fallback_degraded_summary": "Do not use as performance evidence.",
                 "chapter_target": "Limitations, Section 5.1",
+                "chapter_target_justification": "Used to contextualize diagnostic limits.",
             },
         ]
     }
@@ -409,6 +410,10 @@ def test_dissertation_bundle_command_creates_artifact_manifest(tmp_path: Path, c
     }
     assert table_row["chapter_target"] == "Results, Section 4.2"
     assert rows["fig_planner_status"]["chapter_target"] == "Limitations, Section 5.1"
+    assert (
+        rows["fig_planner_status"]["chapter_target_justification"]
+        == "Used to contextualize diagnostic limits."
+    )
     assert table_row["sha256"] in checksums_path.read_text(encoding="utf-8")
 
 
@@ -430,6 +435,37 @@ def test_dissertation_bundle_command_rejects_invalid_manuscript_use(tmp_path: Pa
                 str(tmp_path / "dissertation_export"),
                 "--bundle-name",
                 "bad_use",
+                "--artifact-spec",
+                str(spec_path),
+                "--command",
+                "uv run python scripts/tools/compile_benchmark_artifacts.py",
+                "--commit",
+                "abc123",
+            ]
+        )
+
+
+def test_dissertation_bundle_command_rejects_justification_without_chapter_target(
+    tmp_path: Path,
+) -> None:
+    """Chapter-target justifications require a chapter target to justify."""
+    source_root = tmp_path / "publication_candidates"
+    spec_path = _make_dissertation_source(source_root)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["artifacts"][0].pop("chapter_target")
+    spec["artifacts"][0]["chapter_target_justification"] = "No target is present."
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="without chapter_target"):
+        benchmark_publication_bundle.main(
+            [
+                "dissertation-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "dissertation_export"),
+                "--bundle-name",
+                "missing_target",
                 "--artifact-spec",
                 str(spec_path),
                 "--command",
@@ -1250,6 +1286,8 @@ def _make_chapter_target_claims_matrix_fixtures(tmp_path: Path) -> Path:
     _write(payload_dir / "fig_limitations.png", "fake png bytes for limitations\n")
     _write(payload_dir / "fig_results_unjustified.png", "fake png bytes for unjustified\n")
     _write(payload_dir / "fig_results_justified.png", "fake png bytes for justified\n")
+    _write(payload_dir / "fig_alias_target.png", "fake png bytes for alias target\n")
+    _write(payload_dir / "fig_metadata_target.png", "fake png bytes for metadata target\n")
     _write(payload_dir / "tab_no_target.md", "| diagnostic | value |\n| --- | --- |\n")
 
     table_hash = benchmark_publication_bundle._sha256_file(payload_dir / "tab_results.md")
@@ -1261,6 +1299,10 @@ def _make_chapter_target_claims_matrix_fixtures(tmp_path: Path) -> Path:
     )
     justified_hash = benchmark_publication_bundle._sha256_file(
         payload_dir / "fig_results_justified.png"
+    )
+    alias_hash = benchmark_publication_bundle._sha256_file(payload_dir / "fig_alias_target.png")
+    metadata_hash = benchmark_publication_bundle._sha256_file(
+        payload_dir / "fig_metadata_target.png"
     )
     no_target_hash = benchmark_publication_bundle._sha256_file(payload_dir / "tab_no_target.md")
 
@@ -1319,6 +1361,33 @@ def _make_chapter_target_claims_matrix_fixtures(tmp_path: Path) -> Path:
                 "chapter_target_justification": "Required to illustrate a diagnostic contrast in the Results section.",
             },
             {
+                "artifact_id": "fig_alias_chapter_target",
+                "source_path": "src/figures/alias_target.png",
+                "source_artifact": "Alias Target Figure",
+                "caption_draft": "Diagnostic figure using the dissertation_chapter alias.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": alias_hash,
+                "output_path": "artifacts/fig_alias_target.png",
+                "dissertation_chapter": "Methodology, Section 3.2",
+            },
+            {
+                "artifact_id": "fig_metadata_chapter_target",
+                "source_path": "src/figures/metadata_target.png",
+                "source_artifact": "Metadata Target Figure",
+                "caption_draft": "Diagnostic figure using metadata chapter target.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": metadata_hash,
+                "output_path": "artifacts/fig_metadata_target.png",
+                "metadata": {
+                    "chapter_target": "Future Work, Section 6.1",
+                    "chapter_target_justification": "Future-work placement for diagnostic limits.",
+                },
+            },
+            {
                 "artifact_id": "tab_no_chapter_target",
                 "source_path": "src/tables/no_target.md",
                 "source_artifact": "No Target Table",
@@ -1338,6 +1407,8 @@ def _make_chapter_target_claims_matrix_fixtures(tmp_path: Path) -> Path:
         f"{limitations_hash}  artifacts/fig_limitations.png\n"
         f"{unjustified_hash}  artifacts/fig_results_unjustified.png\n"
         f"{justified_hash}  artifacts/fig_results_justified.png\n"
+        f"{alias_hash}  artifacts/fig_alias_target.png\n"
+        f"{metadata_hash}  artifacts/fig_metadata_target.png\n"
         f"{no_target_hash}  artifacts/tab_no_target.md\n",
     )
     return bundle_root
@@ -1367,7 +1438,7 @@ def test_claim_matrix_chapter_target_surfaces(
 
     json_content = json.loads(json_output_path.read_text(encoding="utf-8"))
     assert json_content["schema_version"] == "claim_matrix.v1"
-    assert len(json_content["claims"]) == 5
+    assert len(json_content["claims"]) == 7
 
     by_id = {c["artifact_id"]: c for c in json_content["claims"]}
     results_row = by_id["tab_results_chapter_target"]
@@ -1384,12 +1455,23 @@ def test_claim_matrix_chapter_target_surfaces(
     assert no_target_row["chapter_target"] is None
     assert no_target_row["chapter_target_status"] is None
 
+    alias_row = by_id["fig_alias_chapter_target"]
+    assert alias_row["chapter_target"] == "Methodology, Section 3.2"
+    assert alias_row["chapter_target_status"] == "ok"
+
+    metadata_row = by_id["fig_metadata_chapter_target"]
+    assert metadata_row["chapter_target"] == "Future Work, Section 6.1"
+    assert metadata_row["chapter_target_status"] == "ok"
+
     markdown_content = markdown_output_path.read_text(encoding="utf-8")
     assert "# Dissertation Claim Matrix" in markdown_content
     assert "Chapter Target" in markdown_content
     assert "Results, Section 4.2" in markdown_content
     assert "Limitations, Section 5.1" in markdown_content
-    assert "None" not in markdown_content
+    no_target_markdown_row = next(
+        line for line in markdown_content.splitlines() if "tab_no_chapter_target" in line
+    )
+    assert no_target_markdown_row.endswith(" |  |  |")
 
 
 def test_claim_matrix_diagnostic_chapter_target_requires_justification(
@@ -1427,6 +1509,24 @@ def test_claim_matrix_diagnostic_chapter_target_requires_justification(
     assert justified_row["evidence_tier"] == "diagnostic-only"
     assert justified_row["chapter_target"] == "Results, Section 4.4"
     assert justified_row["chapter_target_status"] == "ok"
+
+
+def test_claim_matrix_chapter_target_validation_edge_cases() -> None:
+    """Chapter-target validation should flag inconsistent weak rows."""
+    assert (
+        benchmark_publication_bundle._validate_chapter_target(
+            "diagnostic-only",
+            None,
+            "Justification without a target.",
+        )
+        == "warning: justification provided but no chapter target is specified"
+    )
+    assert benchmark_publication_bundle._validate_chapter_target(
+        "non-claimable",
+        "Results, Section 4.5",
+        None,
+    ).startswith("warning: non-claimable row targets")
+    assert benchmark_publication_bundle._format_claim_matrix_cell("a | b") == r"a \| b"
 
 
 def test_claim_matrix_no_chapter_target_remains_stable(

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -110,6 +110,7 @@ def _make_dissertation_source(source_root: Path) -> Path:
                 "claim_boundary": "Formatted table only; not new benchmark evidence.",
                 "recommended_manuscript_use": "discussion",
                 "fallback_degraded_summary": "Fallback and degraded rows remain visible.",
+                "chapter_target": "Results, Section 4.2",
                 "metadata": {
                     "table_label": "tab:campaign-table",
                     "source_release_tag": "0.0.2",
@@ -123,6 +124,7 @@ def _make_dissertation_source(source_root: Path) -> Path:
                 "claim_boundary": "Diagnostic status distribution only.",
                 "recommended_manuscript_use": "do-not-use",
                 "fallback_degraded_summary": "Do not use as performance evidence.",
+                "chapter_target": "Limitations, Section 5.1",
             },
         ]
     }
@@ -405,6 +407,8 @@ def test_dissertation_bundle_command_creates_artifact_manifest(tmp_path: Path, c
         "table_label": "tab:campaign-table",
         "source_release_tag": "0.0.2",
     }
+    assert table_row["chapter_target"] == "Results, Section 4.2"
+    assert rows["fig_planner_status"]["chapter_target"] == "Limitations, Section 5.1"
     assert table_row["sha256"] in checksums_path.read_text(encoding="utf-8")
 
 
@@ -1233,3 +1237,228 @@ def test_claim_matrix_missing_checksum_or_source(
     # This test should ideally be in its own fixture setup for clarity.
     # For now, relying on the fixture setup where fig_missing_checksum_bundle1 payload exists.
     # A dedicated test for 'missing payload file' would involve deleting the created payload file.
+
+
+def _make_chapter_target_claims_matrix_fixtures(tmp_path: Path) -> Path:
+    """Create a dissertation bundle with chapter-target metadata for claim-matrix tests."""
+    bundle_root = tmp_path / "diss_bundle_chapter_targets"
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    payload_dir = bundle_root / "payload" / "artifacts"
+    payload_dir.mkdir(parents=True, exist_ok=True)
+
+    _write(payload_dir / "tab_results.md", "| metric | value |\n| --- | --- |\n")
+    _write(payload_dir / "fig_limitations.png", "fake png bytes for limitations\n")
+    _write(payload_dir / "fig_results_unjustified.png", "fake png bytes for unjustified\n")
+    _write(payload_dir / "fig_results_justified.png", "fake png bytes for justified\n")
+    _write(payload_dir / "tab_no_target.md", "| diagnostic | value |\n| --- | --- |\n")
+
+    table_hash = benchmark_publication_bundle._sha256_file(payload_dir / "tab_results.md")
+    limitations_hash = benchmark_publication_bundle._sha256_file(
+        payload_dir / "fig_limitations.png"
+    )
+    unjustified_hash = benchmark_publication_bundle._sha256_file(
+        payload_dir / "fig_results_unjustified.png"
+    )
+    justified_hash = benchmark_publication_bundle._sha256_file(
+        payload_dir / "fig_results_justified.png"
+    )
+    no_target_hash = benchmark_publication_bundle._sha256_file(payload_dir / "tab_no_target.md")
+
+    spec = {
+        "schema_version": "dissertation_artifact_bundle.v1",
+        "source_commit": "abc123",
+        "generation_command": "test-command-chapter-targets",
+        "artifacts": [
+            {
+                "artifact_id": "tab_results_chapter_target",
+                "source_path": "src/tables/results.md",
+                "source_artifact": "Results Table",
+                "caption_draft": "Benchmark results table.",
+                "claim_boundary": "benchmark-facing, strong claim",
+                "recommended_manuscript_use": "results",
+                "fallback_degraded_summary": "No degradation.",
+                "sha256": table_hash,
+                "output_path": "artifacts/tab_results.md",
+                "chapter_target": "Results, Section 4.2",
+            },
+            {
+                "artifact_id": "fig_limitations_chapter_target",
+                "source_path": "src/figures/limitations.png",
+                "source_artifact": "Limitations Figure",
+                "caption_draft": "Limitations figure.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": limitations_hash,
+                "output_path": "artifacts/fig_limitations.png",
+                "chapter_target": "Limitations, Section 5.1",
+            },
+            {
+                "artifact_id": "fig_results_unjustified_chapter_target",
+                "source_path": "src/figures/results_unjustified.png",
+                "source_artifact": "Unjustified Results Figure",
+                "caption_draft": "Diagnostic figure wrongly targeted at Results.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": unjustified_hash,
+                "output_path": "artifacts/fig_results_unjustified.png",
+                "chapter_target": "Results, Section 4.3",
+            },
+            {
+                "artifact_id": "fig_results_justified_chapter_target",
+                "source_path": "src/figures/results_justified.png",
+                "source_artifact": "Justified Results Figure",
+                "caption_draft": "Diagnostic figure with explicit Results justification.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": justified_hash,
+                "output_path": "artifacts/fig_results_justified.png",
+                "chapter_target": "Results, Section 4.4",
+                "chapter_target_justification": "Required to illustrate a diagnostic contrast in the Results section.",
+            },
+            {
+                "artifact_id": "tab_no_chapter_target",
+                "source_path": "src/tables/no_target.md",
+                "source_artifact": "No Target Table",
+                "caption_draft": "Diagnostic table without chapter target.",
+                "claim_boundary": "diagnostic-only",
+                "recommended_manuscript_use": "discussion",
+                "fallback_degraded_summary": "Diagnostic only.",
+                "sha256": no_target_hash,
+                "output_path": "artifacts/tab_no_target.md",
+            },
+        ],
+    }
+    _write(bundle_root / "artifact_manifest.json", json.dumps(spec, indent=2) + "\n")
+    _write(
+        bundle_root / "checksums.sha256",
+        f"{table_hash}  artifacts/tab_results.md\n"
+        f"{limitations_hash}  artifacts/fig_limitations.png\n"
+        f"{unjustified_hash}  artifacts/fig_results_unjustified.png\n"
+        f"{justified_hash}  artifacts/fig_results_justified.png\n"
+        f"{no_target_hash}  artifacts/tab_no_target.md\n",
+    )
+    return bundle_root
+
+
+def test_claim_matrix_chapter_target_surfaces(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Chapter targets should appear in JSON and Markdown when present and be absent otherwise."""
+    diss_bundle = _make_chapter_target_claims_matrix_fixtures(tmp_path)
+    json_output_path = tmp_path / "claims_matrix_chapter_targets.json"
+    markdown_output_path = tmp_path / "claims_matrix_chapter_targets.md"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "claim-matrix",
+            "--bundle-dir",
+            str(diss_bundle),
+            "--json-output",
+            str(json_output_path),
+            "--markdown-output",
+            str(markdown_output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+
+    json_content = json.loads(json_output_path.read_text(encoding="utf-8"))
+    assert json_content["schema_version"] == "claim_matrix.v1"
+    assert len(json_content["claims"]) == 5
+
+    by_id = {c["artifact_id"]: c for c in json_content["claims"]}
+    results_row = by_id["tab_results_chapter_target"]
+    assert results_row["evidence_tier"] == "paper-grade"
+    assert results_row["chapter_target"] == "Results, Section 4.2"
+    assert results_row["chapter_target_status"] == "ok"
+
+    limitations_row = by_id["fig_limitations_chapter_target"]
+    assert limitations_row["evidence_tier"] == "diagnostic-only"
+    assert limitations_row["chapter_target"] == "Limitations, Section 5.1"
+    assert limitations_row["chapter_target_status"] == "ok"
+
+    no_target_row = by_id["tab_no_chapter_target"]
+    assert no_target_row["chapter_target"] is None
+    assert no_target_row["chapter_target_status"] is None
+
+    markdown_content = markdown_output_path.read_text(encoding="utf-8")
+    assert "# Dissertation Claim Matrix" in markdown_content
+    assert "Chapter Target" in markdown_content
+    assert "Results, Section 4.2" in markdown_content
+    assert "Limitations, Section 5.1" in markdown_content
+    assert "None" not in markdown_content
+
+
+def test_claim_matrix_diagnostic_chapter_target_requires_justification(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Diagnostic-only rows targeting Results should warn unless explicitly justified."""
+    diss_bundle = _make_chapter_target_claims_matrix_fixtures(tmp_path)
+    json_output_path = tmp_path / "claims_matrix_chapter_targets.json"
+    markdown_output_path = tmp_path / "claims_matrix_chapter_targets.md"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "claim-matrix",
+            "--bundle-dir",
+            str(diss_bundle),
+            "--json-output",
+            str(json_output_path),
+            "--markdown-output",
+            str(markdown_output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+
+    json_content = json.loads(json_output_path.read_text(encoding="utf-8"))
+    by_id = {c["artifact_id"]: c for c in json_content["claims"]}
+
+    unjustified_row = by_id["fig_results_unjustified_chapter_target"]
+    assert unjustified_row["evidence_tier"] == "diagnostic-only"
+    assert unjustified_row["chapter_target"] == "Results, Section 4.3"
+    assert unjustified_row["chapter_target_status"].startswith("warning:")
+    assert "limitations/methodology/future-work" in unjustified_row["chapter_target_status"]
+
+    justified_row = by_id["fig_results_justified_chapter_target"]
+    assert justified_row["evidence_tier"] == "diagnostic-only"
+    assert justified_row["chapter_target"] == "Results, Section 4.4"
+    assert justified_row["chapter_target_status"] == "ok"
+
+
+def test_claim_matrix_no_chapter_target_remains_stable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Rows without chapter targets should omit chapter-target columns from Markdown."""
+    diss_bundle_1, _ = _make_claims_matrix_fixtures(tmp_path)
+    json_output_path = tmp_path / "claims_matrix_stable.json"
+    markdown_output_path = tmp_path / "claims_matrix_stable.md"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "claim-matrix",
+            "--bundle-dir",
+            str(diss_bundle_1),
+            "--json-output",
+            str(json_output_path),
+            "--markdown-output",
+            str(markdown_output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+
+    json_content = json.loads(json_output_path.read_text(encoding="utf-8"))
+    for claim in json_content["claims"]:
+        assert claim["chapter_target"] is None
+        assert claim["chapter_target_status"] is None
+
+    markdown_content = markdown_output_path.read_text(encoding="utf-8")
+    assert "Chapter Target" not in markdown_content
+    assert (
+        "| Artifact Id | Source Artifact Path | Checksum | Evidence Tier | Allowed Wording | Not Claimed Boundary | Figure Table Candidate | Caveat | Validation Status |"
+        in markdown_content
+    )


### PR DESCRIPTION
## Summary
Adds optional dissertation chapter/section targets to publication artifact manifests and claim-matrix outputs, with diagnostic-only guardrails for rows that point outside limitations/methodology/future-work style sections.

## Linked Issues
- Closes `#2761`

## Stack / Dependency
- Base dependency: `origin/main` at `79eebc26e9f09b38fd533d932ff1cb709bb44612`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added optional `chapter_target` and `chapter_target_justification` fields to dissertation artifact specs and exported manifests.
- Extended claim-matrix JSON rows with nullable chapter-target fields and Markdown output with chapter columns only when at least one row has a target.
- Added diagnostic-only chapter-target status warnings unless the target is limitations/methodology/future-work style or explicitly justified.
- Added focused publication-bundle tests for benchmark-eligible targets, diagnostic targets, warnings, justified overrides, and no-target backwards-compatible Markdown.
- Documented the optional fields in `docs/benchmark_artifact_publication.md`.

## Why It Matters
- Added value: dissertation publication planning can now map each candidate figure/table to a chapter or section without changing evidence tiers.
- Expected impact: makes claim-matrix artifacts easier to use for paper/dissertation synthesis while keeping diagnostic-only rows visibly caveated.
- Why this is worth merging now: it is a bounded publication-quality improvement with focused tests and no external dissertation checkout dependency.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - publication-support metadata only; no research claim changes.
- Comparator or baseline, if applicable: existing claim matrix without chapter-target fields.
- Evidence tier: targeted smoke / docs-only support helper.
- Result classification: NA - support/tooling improvement, not empirical evidence.
- Decision or stop rule, if applicable: optional metadata must remain backwards-compatible and must not promote diagnostic-only rows.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#2761`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it formats existing artifact metadata and does not interpret new research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no empirical mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: stop for this support scope.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_benchmark_publication_bundle.py -v --tb=short`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_hybrid_evidence_matrix.py tests/tools/test_benchmark_publication_bundle.py tests/benchmark/test_benchmark_claim.py -v --tb=short`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
  - `git diff --check`
- Evidence that the change works here: focused publication tests passed 27/27; related benchmark/publication/claim slice passed 40/40; lint, format, and whitespace checks passed.
- Benchmarks or smoke tests, if applicable: targeted publication-tooling smoke via committed pytest fixtures; no benchmark run because this does not change benchmark semantics.

## Risks / Rollout
- Compatibility risks: JSON claim rows gain two nullable fields; Markdown omits the chapter columns when no rows have chapter targets to preserve the legacy surface.
- Failure modes: diagnostic section-name heuristic is intentionally conservative and may need future wording adjustments.
- Rollback or fallback plan: remove the optional metadata fields and claim-matrix columns; existing manifests without these fields still work.

## Docs / Provenance
- Updated docs: `docs/benchmark_artifact_publication.md`
- Relevant design or provenance notes: issue `#2761` contract.
- Any assumptions that need to be preserved: diagnostic-only rows should primarily target limitations, methodology, or future-work style sections unless justified.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via `Closes #2761`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this adds optional publication metadata support, not a new empirical result or durable artifact bundle.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: diagnostic-only `Results` target warnings in `tests/tools/test_benchmark_publication_bundle.py`.
- Any known limitations: chapter target labels are free-form; the warning check is a lightweight style guard, not a dissertation schema validator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying chapter targets on dissertation artifacts with optional justification text.
  * Chapter target metadata now displays in generated claim matrices with validation status.

* **Documentation**
  * Updated guidance on using chapter targets for dissertation artifacts, including when and how to apply them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->