### PR TITLE
docs: document worktree-safe CI watcher

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -279,7 +279,7 @@ timings from `gh run view` data.
 For routine autopilot CI waits, prefer the compact monitor helper instead of leaving the parent
 thread idle on raw GitHub output. In a fresh linked worktree, run it through the shared-venv
 wrapper so uv reuses the owning checkout's environment and does not create or prompt for a local
-``.venv``:
+`.venv`:
 
 ```bash
 scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py \
@@ -290,9 +290,9 @@ scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci
   --json
 ```
 
-The wrapper sets ``UV_PROJECT_ENVIRONMENT`` to the owning checkout's ``.venv`` and ``UV_NO_SYNC=1``,
-so the command works from a worktree that has not run ``uv sync``. The ``--help`` output of
-``scripts/dev/check_pr_ci_status.py`` also prints this invocation for quick agent copy/paste.
+The wrapper sets `UV_PROJECT_ENVIRONMENT` to the owning checkout's `.venv` and `UV_NO_SYNC=1`,
+so the command works from a worktree that has not run `uv sync`. The `--help` output of
+`scripts/dev/check_pr_ci_status.py` also prints this invocation for quick agent copy/paste.
 
 Each JSON payload includes `monitor` metadata for the active delegation ledger: expected head SHA,
 SHA-match result, poll attempt, wait budget, deadline, and `route_evidence_only: true`. Monitor

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -277,15 +277,22 @@ when GitHub CI wall time drifts from local readiness and you need queue, job, an
 timings from `gh run view` data.
 
 For routine autopilot CI waits, prefer the compact monitor helper instead of leaving the parent
-thread idle on raw GitHub output:
+thread idle on raw GitHub output. In a fresh linked worktree, run it through the shared-venv
+wrapper so uv reuses the owning checkout's environment and does not create or prompt for a local
+``.venv``:
 
 ```bash
-uv run python scripts/dev/check_pr_ci_status.py <pr-number> \
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py \
+  <pr-number> \
   --expected-head-sha <head-sha> \
   --poll-attempts 40 \
   --poll-interval 30 \
   --json
 ```
+
+The wrapper sets ``UV_PROJECT_ENVIRONMENT`` to the owning checkout's ``.venv`` and ``UV_NO_SYNC=1``,
+so the command works from a worktree that has not run ``uv sync``. The ``--help`` output of
+``scripts/dev/check_pr_ci_status.py`` also prints this invocation for quick agent copy/paste.
 
 Each JSON payload includes `monitor` metadata for the active delegation ledger: expected head SHA,
 SHA-match result, poll attempt, wait budget, deadline, and `route_evidence_only: true`. Monitor

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -2,7 +2,7 @@
 """Check CI status for a GitHub PR using the gh CLI.
 
 Output is compact and cache-friendly.  Use --json for machine-readable output.
-Run ``--help`` for the worktree-safe invocation used by agent workflows.
+Run `--help` for the worktree-safe invocation used by agent workflows.
 """
 
 from __future__ import annotations

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -2,6 +2,7 @@
 """Check CI status for a GitHub PR using the gh CLI.
 
 Output is compact and cache-friendly.  Use --json for machine-readable output.
+Run ``--help`` for the worktree-safe invocation used by agent workflows.
 """
 
 from __future__ import annotations
@@ -315,7 +316,21 @@ def _poll_ci_status(
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point: check CI status and print results."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    epilog = """\
+Recommended agent workflow (fresh linked worktree, no local .venv):
+
+  scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py \\
+      <pr-number> --expected-head-sha <head-sha> --poll-attempts 40 \\
+      --poll-interval 30 --json
+
+The wrapper reuses the owning checkout's shared virtualenv and sets UV_NO_SYNC=1
+so uv will not create or prompt for a per-worktree .venv.
+"""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=epilog,
+    )
     parser.add_argument(
         "pr_number",
         nargs="?",

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -651,3 +653,40 @@ def test_main_gh_timeout() -> None:
     ):
         rc = main(["42"])
     assert rc == 1
+
+
+def test_help_includes_worktree_safe_invocation(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--help should document the wrapper invocation used by agent workflows."""
+    with pytest.raises(SystemExit):
+        main(["--help"])
+
+    captured = capsys.readouterr()
+    assert "run_worktree_shared_venv.sh" in captured.out
+    assert "uv run python scripts/dev/check_pr_ci_status.py" in captured.out
+    assert "--expected-head-sha" in captured.out
+    assert "no local .venv" in captured.out
+    assert "UV_NO_SYNC" in captured.out
+
+
+def test_direct_invocation_help_succeeds_without_pythonpath() -> None:
+    """python scripts/dev/check_pr_ci_status.py --help should work without PYTHONPATH."""
+    import os
+
+    script = str(
+        Path(__file__).resolve().parent.parent.parent / "scripts" / "dev" / "check_pr_ci_status.py"
+    )
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, script, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "run_worktree_shared_venv.sh" in result.stdout
+    assert "--expected-head-sha" in result.stdout


### PR DESCRIPTION
## Summary
Documents the worktree-safe `check_pr_ci_status.py` invocation for agent workflows and adds focused tests so the helper remains usable from fresh linked worktrees without creating a local `.venv`.

## Linked Issues
- Closes `#2889`

## Stack / Dependency
- Base dependency: `origin/main` at `e75f59d7e8fcdfc8e0781cd623310e6f9d7fd1b7`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a `--help` epilog to `scripts/dev/check_pr_ci_status.py` showing the recommended shared-venv wrapper invocation.
- Updated `docs/dev_guide.md` to use `scripts/dev/run_worktree_shared_venv.sh -- uv run python ...` for routine autopilot CI waits.
- Added tests proving help output includes the wrapper command and direct `python ... --help` works without `PYTHONPATH`.

## Why It Matters
- Added value: avoids permission fallback and accidental per-worktree `.venv` creation during CI monitoring.
- Expected impact: cheaper, cleaner agent PR validation loops.
- Why this is worth merging now: this fixes friction observed while validating PR #2888.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support only.
- Comparator or baseline, if applicable: previous bare `uv run python` watcher command.
- Evidence tier: targeted smoke / docs-only support helper.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: recommended command must work in a linked worktree and not leave local `.venv`.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#2889`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, help/docs now point to the wrapper invocation.
- Did the intervention change command source, selected command, trajectory, or route progress? yes, selected watcher command changes to shared-venv wrapper.
- Did the scenario actually contain the targeted failure mode? yes, issue #2889 records the fresh-worktree fallback.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: stop for #2889.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_ci_status.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_watch_pr_ci_status.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_script_contract.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py --help`
  - `python3 scripts/dev/check_pr_ci_status.py --help`
  - `git diff --check`
- Evidence that the change works here: 34 watcher tests, 24 sibling watcher tests, and 45 CI-script contract tests passed; wrapper help succeeded and no local `.venv` remained.
- Benchmarks or smoke tests, if applicable: targeted workflow smoke only.

## Risks / Rollout
- Compatibility risks: none expected; runtime CI JSON logic is unchanged.
- Failure modes: wrapper still requires the owning checkout `.venv`; existing contract test covers the actionable failure.
- Rollback or fallback plan: revert docs/help/tests to the bare command.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`
- Relevant design or provenance notes: issue `#2889`.
- Any assumptions that need to be preserved: fresh linked worktrees should use the shared-venv wrapper for agent CI monitoring.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via `Closes #2889`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: workflow helper/docs change only.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the help epilog and dev-guide command both use the shared-venv wrapper.
- Any known limitations: this does not solve interactive watcher stopping; that is tracked separately in issue `#2890`.
