### PR TITLE
feat: add bounded CI watcher wall timeout

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -287,17 +287,21 @@ scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci
   --expected-head-sha <head-sha> \
   --poll-attempts 40 \
   --poll-interval 30 \
+  --max-wall-seconds 1200 \
   --json
 ```
 
 The wrapper sets `UV_PROJECT_ENVIRONMENT` to the owning checkout's `.venv` and `UV_NO_SYNC=1`,
 so the command works from a worktree that has not run `uv sync`. The `--help` output of
 `scripts/dev/check_pr_ci_status.py` also prints this invocation for quick agent copy/paste.
+Use `--max-wall-seconds` to give long-running monitors a clean local stop path before patching or
+pushing a branch; exit code 2 means checks were still pending when the local cap expired, not that
+remote GitHub checks were cancelled or failed.
 
 Each JSON payload includes `monitor` metadata for the active delegation ledger: expected head SHA,
-SHA-match result, poll attempt, wait budget, deadline, and `route_evidence_only: true`. Monitor
-success is route evidence only; reassess the current PR head SHA and normal readiness proof before
-labeling or merging.
+SHA-match result, poll attempt, wait budget, optional wall-clock cap, deadline, and
+`route_evidence_only: true`. Monitor success is route evidence only; reassess the current PR head
+SHA and normal readiness proof before labeling or merging.
 
 For routine goal-autopilot orientation, prefer the compact state snapshot helper before broad parent
 thread reads:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -300,8 +300,10 @@ remote GitHub checks were cancelled or failed.
 
 Each JSON payload includes `monitor` metadata for the active delegation ledger: expected head SHA,
 SHA-match result, poll attempt, wait budget, optional wall-clock cap, deadline, and
-`route_evidence_only: true`. Monitor success is route evidence only; reassess the current PR head
-SHA and normal readiness proof before labeling or merging.
+`route_evidence_only: true`. When the local wall cap expires while checks are still pending, the
+payload also includes `monitor.local_stop_reason: "max_wall_seconds"`. Monitor success is route
+evidence only; reassess the current PR head SHA and normal readiness proof before labeling or
+merging.
 
 For routine goal-autopilot orientation, prefer the compact state snapshot helper before broad parent
 thread reads:

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -204,6 +204,7 @@ def _add_monitor_metadata(
     attempts: int,
     poll_interval: float,
     wait_budget_seconds: float,
+    max_wall_seconds: float | None,
     deadline_epoch_seconds: int | None,
 ) -> None:
     """Attach compact CI monitor resume metadata to a status payload."""
@@ -220,6 +221,7 @@ def _add_monitor_metadata(
         "poll_attempts": attempts,
         "poll_interval_seconds": poll_interval,
         "wait_budget_seconds": wait_budget_seconds,
+        "max_wall_seconds": max_wall_seconds,
         "deadline_epoch_seconds": deadline_epoch_seconds,
         "route_evidence_only": True,
     }
@@ -266,6 +268,20 @@ def _format_human(data: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _bounded_sleep_seconds(
+    poll_interval: float,
+    wall_deadline: float | None,
+) -> tuple[float, bool]:
+    """Return the next sleep duration and whether the local wall cap is exhausted."""
+    sleep_seconds = max(0.0, poll_interval)
+    if wall_deadline is None:
+        return sleep_seconds, False
+    remaining_seconds = wall_deadline - time.monotonic()
+    if remaining_seconds <= 0:
+        return 0.0, True
+    return min(sleep_seconds, remaining_seconds), False
+
+
 def _poll_ci_status(
     pr: str,
     *,
@@ -274,11 +290,18 @@ def _poll_ci_status(
     backoff: float,
     json_output: bool,
     expected_head_sha: str = "",
+    max_wall_seconds: float | None = None,
 ) -> dict[str, Any]:
     """Fetch CI status once or poll until checks settle or the budget expires."""
     data: dict[str, Any] = {}
     wait_budget_seconds = max(0.0, float(attempts - 1) * max(0.0, poll_interval))
-    deadline_epoch_seconds = int(time.time() + wait_budget_seconds) if attempts > 1 else None
+    effective_wait_budget = wait_budget_seconds
+    if max_wall_seconds is not None:
+        effective_wait_budget = min(wait_budget_seconds, max(0.0, max_wall_seconds))
+    deadline_epoch_seconds = int(time.time() + effective_wait_budget) if attempts > 1 else None
+    wall_deadline = (
+        time.monotonic() + max(0.0, max_wall_seconds) if max_wall_seconds is not None else None
+    )
     for attempt in range(1, attempts + 1):
         data = _fetch_ci_status(pr, backoff=backoff if attempt == 1 else 0.0)
         _add_monitor_metadata(
@@ -288,6 +311,7 @@ def _poll_ci_status(
             attempts=attempts,
             poll_interval=poll_interval,
             wait_budget_seconds=wait_budget_seconds,
+            max_wall_seconds=max_wall_seconds,
             deadline_epoch_seconds=deadline_epoch_seconds,
         )
         if data.get("status") == "error":
@@ -302,15 +326,18 @@ def _poll_ci_status(
             data["error"] = "PR head SHA changed while monitoring CI"
             break
         overall = data.get("checks", {}).get("overall")
+        sleep_seconds, local_stop = _bounded_sleep_seconds(poll_interval, wall_deadline)
+        if overall == "pending" and attempt < attempts and local_stop:
+            data["monitor"]["local_stop_reason"] = "max_wall_seconds"
         if attempts > 1:
             if json_output:
                 print(json.dumps(data), flush=True)
             else:
                 print(f"poll attempt {attempt}/{attempts}", flush=True)
                 print(_format_human(data), flush=True)
-        if overall != "pending" or attempt == attempts:
+        if overall != "pending" or attempt == attempts or local_stop:
             break
-        time.sleep(max(0.0, poll_interval))
+        time.sleep(sleep_seconds)
     return data
 
 
@@ -321,10 +348,13 @@ Recommended agent workflow (fresh linked worktree, no local .venv):
 
   scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_ci_status.py \\
       <pr-number> --expected-head-sha <head-sha> --poll-attempts 40 \\
-      --poll-interval 30 --json
+      --poll-interval 30 --max-wall-seconds 1200 --json
 
 The wrapper reuses the owning checkout's shared virtualenv and sets UV_NO_SYNC=1
 so uv will not create or prompt for a per-worktree .venv.
+`--max-wall-seconds` gives long-running agents a non-interactive local stop path;
+exit code 2 means checks were still pending locally, not that remote GitHub checks
+were cancelled or failed.
 """
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -365,6 +395,15 @@ so uv will not create or prompt for a per-worktree .venv.
         default="",
         help="optional PR head SHA guard; stale heads return error without claiming readiness",
     )
+    parser.add_argument(
+        "--max-wall-seconds",
+        type=float,
+        default=None,
+        help=(
+            "optional local wall-clock cap for bounded polling; pending checks return exit code 2 "
+            "without affecting remote GitHub checks"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -377,6 +416,7 @@ so uv will not create or prompt for a per-worktree .venv.
             backoff=args.backoff,
             json_output=args.json,
             expected_head_sha=args.expected_head_sha,
+            max_wall_seconds=args.max_wall_seconds,
         )
     except FileNotFoundError:
         print("gh CLI not found. Install GitHub CLI: https://cli.github.com/", file=sys.stderr)

--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -282,6 +282,14 @@ def _bounded_sleep_seconds(
     return min(sleep_seconds, remaining_seconds), False
 
 
+def _non_negative_float(value: str) -> float:
+    """Parse a non-negative float for local duration limits."""
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
+
+
 def _poll_ci_status(
     pr: str,
     *,
@@ -397,7 +405,7 @@ were cancelled or failed.
     )
     parser.add_argument(
         "--max-wall-seconds",
-        type=float,
+        type=_non_negative_float,
         default=None,
         help=(
             "optional local wall-clock cap for bounded polling; pending checks return exit code 2 "

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -725,6 +725,17 @@ def test_help_includes_worktree_safe_invocation(
     assert "UV_NO_SYNC" in captured.out
 
 
+def test_negative_max_wall_seconds_is_rejected(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--max-wall-seconds should reject negative local duration caps."""
+    with pytest.raises(SystemExit) as excinfo:
+        main(["42", "--max-wall-seconds", "-1"])
+
+    assert excinfo.value.code == 2
+    assert "value must be non-negative" in capsys.readouterr().err
+
+
 def test_direct_invocation_help_succeeds_without_pythonpath() -> None:
     """python scripts/dev/check_pr_ci_status.py --help should work without PYTHONPATH."""
     import os

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -597,6 +597,7 @@ def test_main_bounded_polling_json_includes_monitor_metadata(
         "poll_attempts": 5,
         "poll_interval_seconds": 2.0,
         "wait_budget_seconds": 8.0,
+        "max_wall_seconds": None,
         "deadline_epoch_seconds": 1008,
         "route_evidence_only": True,
     }
@@ -635,6 +636,59 @@ def test_main_expected_head_sha_mismatch_returns_json_error(
     assert payload["monitor"]["route_evidence_only"] is True
 
 
+def test_main_bounded_polling_json_respects_max_wall_seconds(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A local wall cap should stop pending monitors without cancelling remote checks."""
+    pending_data = json.dumps(
+        {
+            "number": 11,
+            "title": "wall cap",
+            "state": "OPEN",
+            "mergeable": "UNKNOWN",
+            "headRefName": "wall-cap",
+            "headRefOid": "abc123",
+            "statusCheckRollup": [{"name": "ci", "status": "queued", "conclusion": ""}],
+            "reviews": [],
+        }
+    )
+
+    with (
+        patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run,
+        patch("scripts.dev.check_pr_ci_status.time.sleep") as mock_sleep,
+        patch("scripts.dev.check_pr_ci_status.time.time", return_value=1000.0),
+        patch("scripts.dev.check_pr_ci_status.time.monotonic", side_effect=[0.0, 0.0, 1.0]),
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=pending_data, stderr=""),
+            MagicMock(returncode=0, stdout=pending_data, stderr=""),
+        ]
+        rc = main(
+            [
+                "11",
+                "--json",
+                "--expected-head-sha",
+                "abc123",
+                "--poll-attempts",
+                "40",
+                "--poll-interval",
+                "30",
+                "--max-wall-seconds",
+                "1",
+            ]
+        )
+
+    assert rc == 2
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once_with(1.0)
+    payloads = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+    assert len(payloads) == 2
+    assert payloads[-1]["checks"]["overall"] == "pending"
+    assert payloads[-1]["monitor"]["max_wall_seconds"] == 1.0
+    assert payloads[-1]["monitor"]["deadline_epoch_seconds"] == 1001
+    assert payloads[-1]["monitor"]["local_stop_reason"] == "max_wall_seconds"
+
+
 def test_main_gh_not_installed() -> None:
     """main() should exit non-zero when gh is not on PATH."""
     with patch(
@@ -666,6 +720,7 @@ def test_help_includes_worktree_safe_invocation(
     assert "run_worktree_shared_venv.sh" in captured.out
     assert "uv run python scripts/dev/check_pr_ci_status.py" in captured.out
     assert "--expected-head-sha" in captured.out
+    assert "--max-wall-seconds" in captured.out
     assert "no local .venv" in captured.out
     assert "UV_NO_SYNC" in captured.out
 
@@ -690,3 +745,4 @@ def test_direct_invocation_help_succeeds_without_pythonpath() -> None:
     assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
     assert "run_worktree_shared_venv.sh" in result.stdout
     assert "--expected-head-sha" in result.stdout
+    assert "--max-wall-seconds" in result.stdout


### PR DESCRIPTION
## Summary
- Add `--max-wall-seconds` to `scripts/dev/check_pr_ci_status.py` so long polling has a non-interactive local stop path.
- Include the wall cap and local stop reason in monitor metadata.
- Update the routine autopilot CI wait docs and focused watcher tests.

Closes #2890.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_ci_status.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_watch_pr_ci_status.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py`
- `python3 scripts/dev/check_pr_ci_status.py --help`
- `git diff --check`

## Research Result Guidance
NA - workflow/tooling support only; no benchmark, metric, schema, model-provenance, or paper-facing claim.

## Downstream Propagation
NA - updates developer workflow documentation and script help for future agent CI monitoring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-wall-seconds` option to enable local wall-clock timeout control during CI polling operations.

* **Documentation**
  * Updated development guide with revised instructions and clarified exit code meanings for CI monitoring workflows.

* **Tests**
  * Added test coverage for wall-time limiting functionality in CI polling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->