### PR TITLE
feat: add manifest lineage graph report

### DIFF
--- a/robot_sf/benchmark/manifest_lineage_graph.py
+++ b/robot_sf/benchmark/manifest_lineage_graph.py
@@ -1,0 +1,675 @@
+# ruff: noqa: DOC201
+"""Build a compact lineage graph report for research manifest inputs.
+
+This module converts per-manifest lineage backfill analysis into a JSON graph
+and Markdown adjacency report.  It is intentionally read-only: it never
+rewrites manifests and marks inferred or ambiguous lineage explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.manifest_lineage import MANDATORY_LINEAGE_FIELDS
+from robot_sf.benchmark.manifest_lineage_backfill import (
+    FieldBackfillEntry,
+    FieldStatus,
+    ManifestBackfillPlan,
+    analyze_manifest,
+)
+from robot_sf.common.artifact_paths import get_repository_root
+
+SCHEMA_VERSION = "manifest_lineage_graph.v1"
+
+
+class LineageStatus:
+    """Canonical statuses for lineage graph edges and traces."""
+
+    CONNECTED = "connected"
+    MISSING = "missing"
+    AMBIGUOUS = "ambiguous"
+    BLOCKED = "blocked"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True, slots=True)
+class LineageNode:
+    """One node in the manifest lineage graph."""
+
+    node_id: str
+    kind: str
+    label: str
+    path: str = ""
+    status: str = LineageStatus.CONNECTED
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping."""
+        return {
+            "id": self.node_id,
+            "kind": self.kind,
+            "label": self.label,
+            "path": self.path,
+            "status": self.status,
+            "payload": self.payload,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LineageEdge:
+    """One directed edge in the manifest lineage graph."""
+
+    source: str
+    target: str
+    kind: str
+    reason: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping."""
+        return {
+            "source": self.source,
+            "target": self.target,
+            "kind": self.kind,
+            "reason": self.reason,
+            "payload": self.payload,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactTrace:
+    """Trace of one artifact candidate back to its source manifest and contract."""
+
+    artifact_id: str
+    artifact_kind: str
+    source_manifest_path: str
+    claim_boundary: str
+    lineage_status: str
+    reason: str
+    field_statuses: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping."""
+        return {
+            "artifact_id": self.artifact_id,
+            "artifact_kind": self.artifact_kind,
+            "source_manifest_path": self.source_manifest_path,
+            "claim_boundary": self.claim_boundary,
+            "lineage_status": self.lineage_status,
+            "reason": self.reason,
+            "field_statuses": self.field_statuses,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestLineageGraph:
+    """Full lineage graph report over a set of manifest inputs."""
+
+    schema_version: str
+    generated_at_utc: str
+    nodes: list[LineageNode]
+    edges: list[LineageEdge]
+    traces: list[ArtifactTrace]
+    summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe mapping."""
+        return {
+            "schema_version": self.schema_version,
+            "generated_at_utc": self.generated_at_utc,
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+            "traces": [t.to_dict() for t in self.traces],
+            "summary": self.summary,
+        }
+
+
+def _repo_relative(path: Path) -> str:
+    """Return a repository-relative path string when possible."""
+    resolved = path.resolve()
+    repo_root = get_repository_root().resolve()
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _sanitize_id(value: str) -> str:
+    """Return a graph-node-safe identifier from an arbitrary string."""
+    return (
+        value.replace("/", "__")
+        .replace("\\", "__")
+        .replace(" ", "_")
+        .replace(":", "_")
+        .replace(".", "_")
+    )
+
+
+def _manifest_node_id(path: str) -> str:
+    """Stable node id for a manifest path."""
+    return f"manifest__{_sanitize_id(path)}"
+
+
+def _field_node_id(manifest_path: str, field_name: str) -> str:
+    """Stable node id for a lineage field inside a manifest."""
+    return f"field__{_sanitize_id(manifest_path)}__{field_name}"
+
+
+def _proxy_node_id(manifest_path: str, proxy_path: str) -> str:
+    """Stable node id for a proxy source path inside a manifest."""
+    return f"proxy__{_sanitize_id(manifest_path)}__{_sanitize_id(proxy_path)}"
+
+
+def _contract_node_id() -> str:
+    """Stable node id for the shared lineage contract."""
+    return "lineage_contract"
+
+
+def _artifact_node_id(artifact_id: str) -> str:
+    """Stable node id for an artifact candidate."""
+    return f"artifact__{_sanitize_id(artifact_id)}"
+
+
+def _now_utc() -> str:
+    """Return the current UTC timestamp as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _load_json(path: Path) -> Any:
+    """Load a JSON file and return the parsed payload."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_candidates(candidates_path: Path | None) -> list[dict[str, Any]]:
+    """Load artifact candidates from a JSON list file.
+
+    Returns:
+        List of candidate dictionaries. Empty when no candidate file is given.
+    """
+    if candidates_path is None or not candidates_path.exists():
+        return []
+    payload = _load_json(candidates_path)
+    if isinstance(payload, dict):
+        payload = payload.get("candidates", [])
+    if not isinstance(payload, list):
+        return []
+    return [dict(item) for item in payload if isinstance(item, Mapping)]
+
+
+def _resolve_manifest_path(
+    manifest_value: str,
+    *,
+    candidate_path: Path | None = None,
+    repo_root: Path | None = None,
+) -> Path:
+    """Resolve a manifest path that may be relative to the candidate file or repo root."""
+    candidate = Path(manifest_value)
+    if candidate.is_absolute():
+        return candidate
+    if candidate_path is not None and candidate_path.is_file():
+        candidate_relative = candidate_path.parent / candidate
+        if candidate_relative.exists():
+            return candidate_relative.resolve()
+    repo_root = repo_root or get_repository_root()
+    repo_relative = repo_root / candidate
+    if repo_relative.exists():
+        return repo_relative.resolve()
+    return candidate.resolve()
+
+
+def _lineage_status_from_entry(entry: FieldBackfillEntry) -> str:
+    """Map a backfill field status to a lineage graph status."""
+    mapping = {
+        FieldStatus.PRESENT: LineageStatus.CONNECTED,
+        FieldStatus.MISSING: LineageStatus.MISSING,
+        FieldStatus.INFERRED: LineageStatus.CONNECTED,
+        FieldStatus.AMBIGUOUS: LineageStatus.AMBIGUOUS,
+        FieldStatus.BLOCKED: LineageStatus.BLOCKED,
+    }
+    return mapping.get(entry.status, LineageStatus.INCONCLUSIVE)
+
+
+def _trace_lineage_status(field_entries: Sequence[FieldBackfillEntry]) -> tuple[str, str]:
+    """Classify an entire manifest trace from its field entries.
+
+    Returns:
+        Tuple of (lineage_status, reason).
+    """
+    statuses = {_lineage_status_from_entry(e) for e in field_entries}
+    if LineageStatus.BLOCKED in statuses:
+        return (
+            LineageStatus.BLOCKED,
+            "one or more lineage fields are blocked by incompatible nearby values",
+        )
+    if LineageStatus.AMBIGUOUS in statuses:
+        return (
+            LineageStatus.AMBIGUOUS,
+            "one or more lineage fields have ambiguous inference candidates",
+        )
+    if LineageStatus.MISSING in statuses:
+        return (
+            LineageStatus.MISSING,
+            "one or more mandatory lineage fields are missing",
+        )
+    if all(s == LineageStatus.CONNECTED for s in statuses):
+        return (
+            LineageStatus.CONNECTED,
+            "all mandatory lineage fields trace to source manifest and validation contract",
+        )
+    return (
+        LineageStatus.INCONCLUSIVE,
+        "lineage state could not be determined conclusively",
+    )
+
+
+def _field_statuses(entries: Sequence[FieldBackfillEntry]) -> dict[str, str]:
+    """Return a mapping from field name to lineage status."""
+    return {e.field_name: _lineage_status_from_entry(e) for e in entries}
+
+
+def _analyze_manifest_at_path(path: Path) -> ManifestBackfillPlan:
+    """Load and analyze a single manifest file."""
+    payload = _load_json(path)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Manifest payload at {path} must be a JSON object")
+    rel_path = _repo_relative(path)
+    return analyze_manifest(dict(payload), path=rel_path)
+
+
+def build_manifest_lineage_graph(  # noqa: C901, PLR0912, PLR0915
+    manifest_paths: Sequence[Path],
+    *,
+    artifact_candidates: Sequence[Mapping[str, Any]] = (),
+    candidate_source_path: Path | None = None,
+) -> ManifestLineageGraph:
+    """Build a lineage graph from manifest paths and optional artifact candidates.
+
+    Args:
+        manifest_paths: Manifest JSON files to analyze.
+        artifact_candidates: Optional artifact/table/figure candidates that trace
+            back to one of the supplied manifest paths.
+        candidate_source_path: Optional path to the candidate file, used to
+            resolve relative manifest references.
+
+    Returns:
+        ManifestLineageGraph with nodes, edges, traces, and summary.
+    """
+    nodes: dict[str, LineageNode] = {}
+    edges: list[LineageEdge] = []
+    traces: list[ArtifactTrace] = []
+
+    contract_node_id = _contract_node_id()
+    nodes[contract_node_id] = LineageNode(
+        node_id=contract_node_id,
+        kind="validation_contract",
+        label="Manifest Lineage Contract",
+        status=LineageStatus.CONNECTED,
+        payload={"mandatory_fields": list(MANDATORY_LINEAGE_FIELDS)},
+    )
+
+    repo_root = get_repository_root()
+    rel_manifest_paths = []
+    plans: list[ManifestBackfillPlan] = []
+
+    for path in manifest_paths:
+        plan = _analyze_manifest_at_path(path)
+        plans.append(plan)
+        rel_path = plan.path or _repo_relative(path)
+        rel_manifest_paths.append(rel_path)
+        manifest_node_id = _manifest_node_id(rel_path)
+        nodes[manifest_node_id] = LineageNode(
+            node_id=manifest_node_id,
+            kind="manifest",
+            label=Path(rel_path).name,
+            path=rel_path,
+            status=LineageStatus.CONNECTED,
+            payload={"validation_errors": plan.validation_errors},
+        )
+        edges.append(
+            LineageEdge(
+                source=manifest_node_id,
+                target=contract_node_id,
+                kind="validates_with",
+                reason="manifest is checked against the shared lineage contract",
+            )
+        )
+
+        for entry in plan.fields:
+            field_id = _field_node_id(rel_path, entry.field_name)
+            field_status = _lineage_status_from_entry(entry)
+            nodes[field_id] = LineageNode(
+                node_id=field_id,
+                kind="lineage_field",
+                label=entry.field_name,
+                path=rel_path,
+                status=field_status,
+                payload={"status": entry.status.value},
+            )
+            edges.append(
+                LineageEdge(
+                    source=manifest_node_id,
+                    target=field_id,
+                    kind="has_field",
+                    reason=f"manifest contains lineage field {entry.field_name}",
+                )
+            )
+
+            if entry.status == FieldStatus.PRESENT:
+                continue
+
+            if entry.status == FieldStatus.INFERRED and entry.inferred_from is not None:
+                proxy_id = _proxy_node_id(rel_path, entry.inferred_from)
+                if proxy_id not in nodes:
+                    nodes[proxy_id] = LineageNode(
+                        node_id=proxy_id,
+                        kind="proxy_source",
+                        label=entry.inferred_from,
+                        path=rel_path,
+                        status=LineageStatus.CONNECTED,
+                    )
+                edges.append(
+                    LineageEdge(
+                        source=field_id,
+                        target=proxy_id,
+                        kind="inferred_from",
+                        reason=entry.reason or f"inferred from {entry.inferred_from}",
+                        payload={"inferred_value": entry.inferred_value},
+                    )
+                )
+                continue
+
+            # Missing, ambiguous, or blocked: derive proxy-related edges from reason.
+            proxy_labels = _parse_proxy_labels(entry.reason)
+            for label in proxy_labels:
+                proxy_id = _proxy_node_id(rel_path, label)
+                if proxy_id not in nodes:
+                    nodes[proxy_id] = LineageNode(
+                        node_id=proxy_id,
+                        kind="proxy_source",
+                        label=label,
+                        path=rel_path,
+                        status=field_status,
+                    )
+                edge_kind = (
+                    "ambiguous_between" if entry.status == FieldStatus.AMBIGUOUS else "blocked_by"
+                )
+                edges.append(
+                    LineageEdge(
+                        source=field_id,
+                        target=proxy_id,
+                        kind=edge_kind,
+                        reason=entry.reason,
+                    )
+                )
+
+    # Trace artifact candidates back to manifests.
+    path_to_plan = {plan.path: plan for plan in plans}
+    for candidate in artifact_candidates:
+        artifact_id = str(candidate.get("artifact_id", "")).strip() or "unnamed_artifact"
+        artifact_kind = str(candidate.get("artifact_kind", "artifact")).strip()
+        claim_boundary = str(candidate.get("claim_boundary", "")).strip()
+        manifest_value = str(candidate.get("source_manifest_path", "")).strip()
+        if not manifest_value:
+            trace_status = LineageStatus.INCONCLUSIVE
+            reason = "candidate has no source_manifest_path"
+            field_statuses: dict[str, str] = {}
+            source_manifest_path = ""
+        else:
+            resolved = _resolve_manifest_path(
+                manifest_value, candidate_path=candidate_source_path, repo_root=repo_root
+            )
+            source_manifest_path = _repo_relative(resolved)
+            matching_plan = path_to_plan.get(source_manifest_path)
+            if matching_plan is None and resolved.exists():
+                matching_plan = _analyze_manifest_at_path(resolved)
+                path_to_plan[matching_plan.path or source_manifest_path] = matching_plan
+            if matching_plan is None:
+                trace_status = LineageStatus.INCONCLUSIVE
+                reason = f"source manifest not found in graph inputs: {source_manifest_path}"
+                field_statuses = {}
+            else:
+                trace_status, reason = _trace_lineage_status(matching_plan.fields)
+                field_statuses = _field_statuses(matching_plan.fields)
+
+        artifact_node_id = _artifact_node_id(artifact_id)
+        if artifact_node_id not in nodes:
+            nodes[artifact_node_id] = LineageNode(
+                node_id=artifact_node_id,
+                kind="artifact_candidate",
+                label=artifact_id,
+                path=source_manifest_path,
+                status=trace_status,
+                payload={
+                    "artifact_kind": artifact_kind,
+                    "claim_boundary": claim_boundary,
+                },
+            )
+        if source_manifest_path:
+            manifest_node_id = _manifest_node_id(source_manifest_path)
+            if manifest_node_id in nodes:
+                edges.append(
+                    LineageEdge(
+                        source=artifact_node_id,
+                        target=manifest_node_id,
+                        kind="traces_to",
+                        reason=f"{artifact_kind} traces to source manifest",
+                    )
+                )
+
+        traces.append(
+            ArtifactTrace(
+                artifact_id=artifact_id,
+                artifact_kind=artifact_kind,
+                source_manifest_path=source_manifest_path,
+                claim_boundary=claim_boundary,
+                lineage_status=trace_status,
+                reason=reason,
+                field_statuses=field_statuses,
+            )
+        )
+
+    summary = _build_summary(nodes.values(), edges, traces)
+    return ManifestLineageGraph(
+        schema_version=SCHEMA_VERSION,
+        generated_at_utc=_now_utc(),
+        nodes=list(nodes.values()),
+        edges=edges,
+        traces=traces,
+        summary=summary,
+    )
+
+
+def _parse_proxy_labels(reason: str) -> list[str]:
+    """Extract dotted proxy labels from a backfill reason string.
+
+    This is a best-effort parser for human-readable reason strings.  It looks
+    for labels like ``metadata.generator_id`` or ``config.validator_version``.
+    """
+    labels: list[str] = []
+    # Split on common separators and punctuation.
+    for raw in reason.replace(":", " ").replace(",", " ").split():
+        label = raw.strip("().")
+        if "." in label and all(part.isidentifier() for part in label.split(".")):
+            labels.append(label)
+    return labels
+
+
+def _build_summary(
+    nodes: Sequence[LineageNode],
+    edges: Sequence[LineageEdge],
+    traces: Sequence[ArtifactTrace],
+) -> dict[str, Any]:
+    """Build aggregate counts for the graph report."""
+    node_counts: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
+    for node in nodes:
+        node_counts[node.kind] = node_counts.get(node.kind, 0) + 1
+        status_counts[node.status] = status_counts.get(node.status, 0) + 1
+
+    edge_counts: dict[str, int] = {}
+    for edge in edges:
+        edge_counts[edge.kind] = edge_counts.get(edge.kind, 0) + 1
+
+    trace_status_counts: dict[str, int] = {}
+    for trace in traces:
+        trace_status_counts[trace.lineage_status] = (
+            trace_status_counts.get(trace.lineage_status, 0) + 1
+        )
+
+    return {
+        "manifest_count": node_counts.get("manifest", 0),
+        "artifact_candidate_count": node_counts.get("artifact_candidate", 0),
+        "lineage_field_count": node_counts.get("lineage_field", 0),
+        "proxy_source_count": node_counts.get("proxy_source", 0),
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+        "trace_count": len(traces),
+        "node_status_counts": status_counts,
+        "edge_kind_counts": edge_counts,
+        "trace_status_counts": trace_status_counts,
+    }
+
+
+def format_lineage_graph_markdown(graph: ManifestLineageGraph) -> str:
+    """Format a lineage graph as a Markdown adjacency report.
+
+    Returns:
+        Markdown string with a summary, adjacency list, and trace table.
+    """
+    lines: list[str] = []
+    lines.append("# Manifest Lineage Graph Report")
+    lines.append("")
+    lines.append(f"- **Schema**: `{graph.schema_version}`")
+    lines.append(f"- **Generated at (UTC)**: {graph.generated_at_utc}")
+    lines.append("")
+
+    summary = graph.summary
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Manifests: {summary.get('manifest_count', 0)}")
+    lines.append(f"- Artifact candidates: {summary.get('artifact_candidate_count', 0)}")
+    lines.append(f"- Lineage fields: {summary.get('lineage_field_count', 0)}")
+    lines.append(f"- Proxy sources: {summary.get('proxy_source_count', 0)}")
+    lines.append(f"- Total nodes: {summary.get('node_count', 0)}")
+    lines.append(f"- Total edges: {summary.get('edge_count', 0)}")
+    lines.append(f"- Traces: {summary.get('trace_count', 0)}")
+    lines.append("")
+
+    status_counts = summary.get("node_status_counts", {})
+    if status_counts:
+        lines.append("### Node status counts")
+        lines.append("")
+        lines.append("| Status | Count |")
+        lines.append("| --- | --- |")
+        for status in sorted(status_counts):
+            lines.append(f"| {status} | {status_counts[status]} |")
+        lines.append("")
+
+    edge_counts = summary.get("edge_kind_counts", {})
+    if edge_counts:
+        lines.append("### Edge kind counts")
+        lines.append("")
+        lines.append("| Kind | Count |")
+        lines.append("| --- | --- |")
+        for kind in sorted(edge_counts):
+            lines.append(f"| {kind} | {edge_counts[kind]} |")
+        lines.append("")
+
+    lines.append("## Artifact traces")
+    lines.append("")
+    if graph.traces:
+        lines.append("| Artifact | Kind | Source manifest | Claim boundary | Status | Reason |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        for trace in graph.traces:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _md_escape(trace.artifact_id),
+                        _md_escape(trace.artifact_kind),
+                        _md_escape(trace.source_manifest_path) or "NA",
+                        _md_escape(trace.claim_boundary) or "NA",
+                        _md_escape(trace.lineage_status),
+                        _md_escape(trace.reason),
+                    ]
+                )
+                + " |"
+            )
+    else:
+        lines.append("No artifact candidates supplied.")
+    lines.append("")
+
+    lines.append("## Adjacency list")
+    lines.append("")
+    adjacency: dict[str, list[tuple[str, str]]] = {}
+    for edge in graph.edges:
+        adjacency.setdefault(edge.source, []).append((edge.target, edge.kind))
+
+    node_by_id = {node.node_id: node for node in graph.nodes}
+    for node_id in sorted(adjacency):
+        node = node_by_id.get(node_id)
+        label = node.label if node else node_id
+        status = f" ({node.status})" if node else ""
+        lines.append(f"- **{label}**{status} ->")
+        for target_id, kind in sorted(adjacency[node_id]):
+            target = node_by_id.get(target_id)
+            target_label = target.label if target else target_id
+            lines.append(f"  - `{kind}` -> **{target_label}**")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _md_escape(text: str) -> str:
+    """Escape Markdown pipe characters in table cells."""
+    return text.replace("|", r"\|").replace("\n", " ")
+
+
+def write_manifest_lineage_graph_report(
+    graph: ManifestLineageGraph,
+    *,
+    json_path: Path,
+    markdown_path: Path | None = None,
+) -> dict[str, Path]:
+    """Write JSON graph and optional Markdown adjacency report to disk.
+
+    Args:
+        graph: The lineage graph to write.
+        json_path: Destination path for the JSON graph.
+        markdown_path: Optional destination path for the Markdown report.
+
+    Returns:
+        Mapping of output kind to written path.
+    """
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(graph.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    written: dict[str, Path] = {"json": json_path}
+    if markdown_path is not None:
+        markdown_path.parent.mkdir(parents=True, exist_ok=True)
+        markdown_path.write_text(
+            format_lineage_graph_markdown(graph),
+            encoding="utf-8",
+        )
+        written["markdown"] = markdown_path
+    return written
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ArtifactTrace",
+    "LineageEdge",
+    "LineageNode",
+    "LineageStatus",
+    "ManifestLineageGraph",
+    "build_manifest_lineage_graph",
+    "format_lineage_graph_markdown",
+    "write_manifest_lineage_graph_report",
+]

--- a/robot_sf/benchmark/manifest_lineage_graph.py
+++ b/robot_sf/benchmark/manifest_lineage_graph.py
@@ -185,22 +185,6 @@ def _load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _load_candidates(candidates_path: Path | None) -> list[dict[str, Any]]:
-    """Load artifact candidates from a JSON list file.
-
-    Returns:
-        List of candidate dictionaries. Empty when no candidate file is given.
-    """
-    if candidates_path is None or not candidates_path.exists():
-        return []
-    payload = _load_json(candidates_path)
-    if isinstance(payload, dict):
-        payload = payload.get("candidates", [])
-    if not isinstance(payload, list):
-        return []
-    return [dict(item) for item in payload if isinstance(item, Mapping)]
-
-
 def _resolve_manifest_path(
     manifest_value: str,
     *,
@@ -213,13 +197,26 @@ def _resolve_manifest_path(
         return candidate
     if candidate_path is not None and candidate_path.is_file():
         candidate_relative = candidate_path.parent / candidate
-        if candidate_relative.exists():
+        if candidate_relative.is_file():
             return candidate_relative.resolve()
     repo_root = repo_root or get_repository_root()
     repo_relative = repo_root / candidate
-    if repo_relative.exists():
+    if repo_relative.is_file():
         return repo_relative.resolve()
     return candidate.resolve()
+
+
+def _dedupe_paths(paths: Sequence[Path]) -> list[Path]:
+    """Return paths with duplicate resolved files removed while preserving order."""
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        deduped.append(resolved)
+        seen.add(resolved)
+    return deduped
 
 
 def _lineage_status_from_entry(entry: FieldBackfillEntry) -> str:
@@ -281,7 +278,7 @@ def _analyze_manifest_at_path(path: Path) -> ManifestBackfillPlan:
     return analyze_manifest(dict(payload), path=rel_path)
 
 
-def build_manifest_lineage_graph(  # noqa: C901, PLR0912, PLR0915
+def build_manifest_lineage_graph(  # noqa: C901, PLR0915
     manifest_paths: Sequence[Path],
     *,
     artifact_candidates: Sequence[Mapping[str, Any]] = (),
@@ -316,7 +313,7 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0912, PLR0915
     rel_manifest_paths = []
     plans: list[ManifestBackfillPlan] = []
 
-    for path in manifest_paths:
+    for path in _dedupe_paths(manifest_paths):
         plan = _analyze_manifest_at_path(path)
         plans.append(plan)
         rel_path = plan.path or _repo_relative(path)
@@ -425,9 +422,6 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0912, PLR0915
             )
             source_manifest_path = _repo_relative(resolved)
             matching_plan = path_to_plan.get(source_manifest_path)
-            if matching_plan is None and resolved.exists():
-                matching_plan = _analyze_manifest_at_path(resolved)
-                path_to_plan[matching_plan.path or source_manifest_path] = matching_plan
             if matching_plan is None:
                 trace_status = LineageStatus.INCONCLUSIVE
                 reason = f"source manifest not found in graph inputs: {source_manifest_path}"

--- a/scripts/benchmark/build_manifest_lineage_graph.py
+++ b/scripts/benchmark/build_manifest_lineage_graph.py
@@ -67,12 +67,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _resolve_manifest_paths(paths: list[Path]) -> list[Path]:
     """Resolve and validate manifest paths from CLI arguments."""
     resolved: list[Path] = []
+    seen: set[Path] = set()
     for path in paths:
         if not path.exists():
             raise FileNotFoundError(f"manifest not found: {path}")
         if not path.is_file():
             raise ValueError(f"manifest path is not a file: {path}")
-        resolved.append(path.resolve())
+        resolved_path = path.resolve()
+        if resolved_path in seen:
+            continue
+        resolved.append(resolved_path)
+        seen.add(resolved_path)
     return resolved
 
 
@@ -80,12 +85,6 @@ def main(argv: list[str] | None = None) -> int:
     """Run the manifest lineage graph report builder."""
     args = _parse_args(argv)
     manifest_paths = _resolve_manifest_paths(args.manifest)
-
-    graph = build_manifest_lineage_graph(
-        manifest_paths,
-        artifact_candidates=(),
-        candidate_source_path=None,
-    )
 
     # Load candidates after resolving manifest paths so the source path is
     # available for relative manifest resolution.

--- a/scripts/benchmark/build_manifest_lineage_graph.py
+++ b/scripts/benchmark/build_manifest_lineage_graph.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Build a compact manifest lineage graph report for local fixture inputs.
+
+Emits a JSON graph and a Markdown adjacency report. The graph traces artifact
+candidates (e.g. dissertation/release tables) back to source manifests and the
+shared validation contract, marking missing or ambiguous lineage as blocked or
+inconclusive.
+
+Example::
+
+    python scripts/benchmark/build_manifest_lineage_graph.py \
+        --manifest tests/benchmark/fixtures/manifest_lineage_graph/connected_manifest.json \
+        --artifact-candidates tests/benchmark/fixtures/manifest_lineage_graph/candidates.json \
+        --out-json output/manifest_lineage_graph.json \
+        --out-md output/manifest_lineage_graph.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from robot_sf.benchmark.manifest_lineage_graph import (  # noqa: E402
+    build_manifest_lineage_graph,
+    write_manifest_lineage_graph_report,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        action="append",
+        type=Path,
+        required=True,
+        help="Manifest JSON files to include in the lineage graph.",
+    )
+    parser.add_argument(
+        "--artifact-candidates",
+        type=Path,
+        default=None,
+        help="Optional JSON file with artifact candidate list or {'candidates': [...]} object.",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        required=True,
+        help="Output path for the JSON graph report.",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=None,
+        help="Optional output path for the Markdown adjacency report.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_manifest_paths(paths: list[Path]) -> list[Path]:
+    """Resolve and validate manifest paths from CLI arguments."""
+    resolved: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            raise FileNotFoundError(f"manifest not found: {path}")
+        if not path.is_file():
+            raise ValueError(f"manifest path is not a file: {path}")
+        resolved.append(path.resolve())
+    return resolved
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the manifest lineage graph report builder."""
+    args = _parse_args(argv)
+    manifest_paths = _resolve_manifest_paths(args.manifest)
+
+    graph = build_manifest_lineage_graph(
+        manifest_paths,
+        artifact_candidates=(),
+        candidate_source_path=None,
+    )
+
+    # Load candidates after resolving manifest paths so the source path is
+    # available for relative manifest resolution.
+    candidates: list[dict[str, Any]] = []
+    if args.artifact_candidates is not None:
+        if not args.artifact_candidates.exists():
+            raise FileNotFoundError(
+                f"artifact candidates file not found: {args.artifact_candidates}"
+            )
+        candidate_payload = json.loads(args.artifact_candidates.read_text(encoding="utf-8"))
+        if isinstance(candidate_payload, dict):
+            candidates = list(candidate_payload.get("candidates", []))
+        elif isinstance(candidate_payload, list):
+            candidates = list(candidate_payload)
+        else:
+            raise ValueError("artifact candidates file must contain a JSON list or object")
+        # Rebuild graph with candidates now that we know the candidate source path.
+        graph = build_manifest_lineage_graph(
+            manifest_paths,
+            artifact_candidates=candidates,
+            candidate_source_path=args.artifact_candidates,
+        )
+
+    written = write_manifest_lineage_graph_report(
+        graph,
+        json_path=args.out_json,
+        markdown_path=args.out_md,
+    )
+
+    summary = {
+        "json_path": str(written["json"]),
+        "markdown_path": str(written.get("markdown", "")),
+        "manifest_count": graph.summary.get("manifest_count", 0),
+        "artifact_candidate_count": graph.summary.get("artifact_candidate_count", 0),
+        "node_count": graph.summary.get("node_count", 0),
+        "edge_count": graph.summary.get("edge_count", 0),
+        "trace_count": graph.summary.get("trace_count", 0),
+    }
+    sys.stdout.write(json.dumps(summary, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/fixtures/manifest_lineage_graph/ambiguous_manifest.json
+++ b/tests/benchmark/fixtures/manifest_lineage_graph/ambiguous_manifest.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "metadata": {
+    "validator_version": "2.0.0",
+    "evidence_tier": "diagnostic"
+  },
+  "config": {
+    "validator_version": "3.0.0"
+  }
+}

--- a/tests/benchmark/fixtures/manifest_lineage_graph/candidates.json
+++ b/tests/benchmark/fixtures/manifest_lineage_graph/candidates.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "artifact_id": "dissertation_table_1",
+      "artifact_kind": "table",
+      "source_manifest_path": "connected_manifest.json",
+      "claim_boundary": "dissertation-chapter-4"
+    },
+    {
+      "artifact_id": "release_table_1",
+      "artifact_kind": "table",
+      "source_manifest_path": "missing_manifest.json",
+      "claim_boundary": "release-v1.0"
+    },
+    {
+      "artifact_id": "release_figure_1",
+      "artifact_kind": "figure",
+      "source_manifest_path": "ambiguous_manifest.json",
+      "claim_boundary": "release-v1.0"
+    },
+    {
+      "artifact_id": "orphan_artifact",
+      "artifact_kind": "table",
+      "source_manifest_path": "nonexistent_manifest.json",
+      "claim_boundary": "unknown"
+    }
+  ]
+}

--- a/tests/benchmark/fixtures/manifest_lineage_graph/connected_manifest.json
+++ b/tests/benchmark/fixtures/manifest_lineage_graph/connected_manifest.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "benchmark_claim.v1",
+  "generator_id": "connected-generator",
+  "validator_version": "1.0.0",
+  "claim_boundary": "dissertation-chapter-4",
+  "evidence_tier": "benchmark",
+  "denominator_policy": "all-attempts",
+  "execution_gate": "pass",
+  "source": {"type": "benchmark_run", "path": "output/benchmarks/run_001"}
+}

--- a/tests/benchmark/fixtures/manifest_lineage_graph/missing_manifest.json
+++ b/tests/benchmark/fixtures/manifest_lineage_graph/missing_manifest.json
@@ -1,0 +1,3 @@
+{
+  "schema_version": "benchmark_claim.v1"
+}

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -224,6 +224,16 @@ def test_repo_relative_paths_in_graph(tmp_path: Path) -> None:
     assert manifest_node.path.startswith("tests/benchmark/fixtures/manifest_lineage_graph/")
 
 
+def test_duplicate_manifest_paths_are_deduplicated() -> None:
+    """Duplicate manifest inputs should not duplicate nodes or edges."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+
+    graph = build_manifest_lineage_graph([manifest_path, manifest_path])
+
+    assert graph.summary["manifest_count"] == 1
+    assert graph.summary["edge_kind_counts"]["validates_with"] == 1
+
+
 def test_missing_field_produces_missing_edges() -> None:
     """Missing lineage fields produce missing field nodes and no proxy edges."""
     manifest_path = FIXTURE_DIR / "missing_manifest.json"

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -1,0 +1,250 @@
+"""Tests for the manifest lineage graph report builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.manifest_lineage_graph import (
+    LineageStatus,
+    build_manifest_lineage_graph,
+    format_lineage_graph_markdown,
+    write_manifest_lineage_graph_report,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[0] / "fixtures" / "manifest_lineage_graph"
+
+
+def _load_fixture(name: str) -> dict:
+    """Load a JSON fixture by name."""
+    path = FIXTURE_DIR / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_connected_manifest_trace_is_connected() -> None:
+    """A complete manifest yields a connected trace."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    candidates = [
+        {
+            "artifact_id": "dissertation_table_1",
+            "artifact_kind": "table",
+            "source_manifest_path": str(manifest_path),
+            "claim_boundary": "dissertation-chapter-4",
+        }
+    ]
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        artifact_candidates=candidates,
+    )
+
+    assert graph.schema_version == "manifest_lineage_graph.v1"
+    trace = next(t for t in graph.traces if t.artifact_id == "dissertation_table_1")
+    assert trace.lineage_status == LineageStatus.CONNECTED
+    assert "all mandatory lineage fields" in trace.reason
+    assert all(s == LineageStatus.CONNECTED for s in trace.field_statuses.values())
+
+
+def test_missing_manifest_trace_is_missing() -> None:
+    """A manifest missing all lineage fields yields a missing trace."""
+    manifest_path = FIXTURE_DIR / "missing_manifest.json"
+    candidates = [
+        {
+            "artifact_id": "release_table_1",
+            "artifact_kind": "table",
+            "source_manifest_path": str(manifest_path),
+            "claim_boundary": "release-v1.0",
+        }
+    ]
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        artifact_candidates=candidates,
+    )
+
+    trace = next(t for t in graph.traces if t.artifact_id == "release_table_1")
+    assert trace.lineage_status == LineageStatus.MISSING
+    assert any(s == LineageStatus.MISSING for s in trace.field_statuses.values())
+
+
+def test_ambiguous_manifest_trace_is_ambiguous() -> None:
+    """A manifest with conflicting proxy values yields an ambiguous trace."""
+    manifest_path = FIXTURE_DIR / "ambiguous_manifest.json"
+    candidates = [
+        {
+            "artifact_id": "release_figure_1",
+            "artifact_kind": "figure",
+            "source_manifest_path": str(manifest_path),
+            "claim_boundary": "release-v1.0",
+        }
+    ]
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        artifact_candidates=candidates,
+    )
+
+    trace = next(t for t in graph.traces if t.artifact_id == "release_figure_1")
+    assert trace.lineage_status == LineageStatus.AMBIGUOUS
+    assert any(s == LineageStatus.AMBIGUOUS for s in trace.field_statuses.values())
+
+
+def test_orphan_candidate_is_inconclusive() -> None:
+    """A candidate pointing at a manifest not in the input set is inconclusive."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    candidates = [
+        {
+            "artifact_id": "orphan_artifact",
+            "artifact_kind": "table",
+            "source_manifest_path": "nonexistent_manifest.json",
+            "claim_boundary": "unknown",
+        }
+    ]
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        artifact_candidates=candidates,
+    )
+
+    trace = next(t for t in graph.traces if t.artifact_id == "orphan_artifact")
+    assert trace.lineage_status == LineageStatus.INCONCLUSIVE
+
+
+def test_graph_nodes_include_contract_manifest_and_fields() -> None:
+    """The graph contains the validation contract, manifest, and field nodes."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    node_kinds = {node.kind for node in graph.nodes}
+    assert "validation_contract" in node_kinds
+    assert "manifest" in node_kinds
+    assert "lineage_field" in node_kinds
+
+    assert any(edge.kind == "validates_with" for edge in graph.edges)
+    assert any(edge.kind == "has_field" for edge in graph.edges)
+
+
+def test_markdown_report_contains_summary_and_traces() -> None:
+    """Markdown report includes the summary and artifact trace table."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    candidates = [
+        {
+            "artifact_id": "dissertation_table_1",
+            "artifact_kind": "table",
+            "source_manifest_path": str(manifest_path),
+            "claim_boundary": "dissertation-chapter-4",
+        }
+    ]
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        artifact_candidates=candidates,
+    )
+    markdown = format_lineage_graph_markdown(graph)
+
+    assert "# Manifest Lineage Graph Report" in markdown
+    assert "## Summary" in markdown
+    assert "## Artifact traces" in markdown
+    assert "dissertation_table_1" in markdown
+    assert "connected" in markdown
+
+
+def test_write_report_creates_json_and_markdown(tmp_path: Path) -> None:
+    """write_manifest_lineage_graph_report emits both output files."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    json_path = tmp_path / "lineage.json"
+    md_path = tmp_path / "lineage.md"
+    written = write_manifest_lineage_graph_report(
+        graph,
+        json_path=json_path,
+        markdown_path=md_path,
+    )
+
+    assert written["json"] == json_path
+    assert written["markdown"] == md_path
+    assert json_path.exists()
+    assert md_path.exists()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "manifest_lineage_graph.v1"
+    assert "nodes" in payload
+    assert "edges" in payload
+
+
+def test_cli_runs_and_writes_outputs(tmp_path: Path) -> None:
+    """The CLI script emits JSON and Markdown reports."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "build_manifest_lineage_graph.py"
+    )
+    json_path = tmp_path / "out.json"
+    md_path = tmp_path / "out.md"
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            "python",
+            str(script),
+            "--manifest",
+            str(FIXTURE_DIR / "connected_manifest.json"),
+            "--manifest",
+            str(FIXTURE_DIR / "ambiguous_manifest.json"),
+            "--artifact-candidates",
+            str(FIXTURE_DIR / "candidates.json"),
+            "--out-json",
+            str(json_path),
+            "--out-md",
+            str(md_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["manifest_count"] == 2
+    assert summary["artifact_candidate_count"] == 4
+    assert json_path.exists()
+    assert md_path.exists()
+
+
+def test_repo_relative_paths_in_graph(tmp_path: Path) -> None:
+    """Manifest paths in the graph are repository-relative."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    manifest_node = next(node for node in graph.nodes if node.kind == "manifest")
+    assert not Path(manifest_node.path).is_absolute()
+    assert manifest_node.path.startswith("tests/benchmark/fixtures/manifest_lineage_graph/")
+
+
+def test_missing_field_produces_missing_edges() -> None:
+    """Missing lineage fields produce missing field nodes and no proxy edges."""
+    manifest_path = FIXTURE_DIR / "missing_manifest.json"
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    field_nodes = [node for node in graph.nodes if node.kind == "lineage_field"]
+    assert len(field_nodes) == 8
+    missing_field = next(
+        node
+        for node in field_nodes
+        if node.label == "source" and node.status == LineageStatus.MISSING
+    )
+    assert missing_field.status == LineageStatus.MISSING
+
+
+def test_ambiguous_field_produces_ambiguous_edges() -> None:
+    """Ambiguous lineage fields produce ambiguous_between edges."""
+    manifest_path = FIXTURE_DIR / "ambiguous_manifest.json"
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    ambiguous_edges = [edge for edge in graph.edges if edge.kind == "ambiguous_between"]
+    assert len(ambiguous_edges) >= 1
+    labels = {edge.source.split("__")[-1] for edge in ambiguous_edges}
+    assert "validator_version" in labels


### PR DESCRIPTION
## Summary
- Add `robot_sf.benchmark.manifest_lineage_graph` for compact JSON graph and Markdown adjacency reports over manifest lineage inputs.
- Add `scripts/benchmark/build_manifest_lineage_graph.py` as the fixture/report CLI.
- Add connected, missing, ambiguous, and candidate fixtures with focused tests for connected/missing/ambiguous/inconclusive traces and repo-relative paths.

Closes #2722.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_graph.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/manifest_lineage_graph.py scripts/benchmark/build_manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/manifest_lineage_graph.py scripts/benchmark/build_manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_manifest_lineage_graph.py --manifest tests/benchmark/fixtures/manifest_lineage_graph/connected_manifest.json --manifest tests/benchmark/fixtures/manifest_lineage_graph/ambiguous_manifest.json --artifact-candidates tests/benchmark/fixtures/manifest_lineage_graph/candidates.json --out-json output/manifest_lineage_graph/lineage.json --out-md output/manifest_lineage_graph/lineage.md`
- `git diff --check`

## Research Result Guidance
- Target claim/hypothesis/blocker: make existing mandatory lineage fields auditable as a graph/report surface.
- Comparator/baseline: previously no compact lineage graph report existed.
- Evidence tier: nominal workflow evidence from compact fixtures.
- Result classification: support/tooling evidence only; not benchmark or manuscript evidence.
- Decision/stop rule: fixture report must show connected, missing, ambiguous, and inconclusive traces with repo-relative paths.
- Synthesis surface/update target: script/tests are the durable surface; disposable `output/manifest_lineage_graph/*` validation files were not committed.

## Downstream Propagation
- Parent issue #2722 closes with this tool and fixture proof.
- No benchmark leaderboard, model registry, or paper claim update needed; the report is an audit helper.
