### PR TITLE
fix: allow manifest lineage graph without candidates

### DIFF
--- a/scripts/benchmark/build_manifest_lineage_graph.py
+++ b/scripts/benchmark/build_manifest_lineage_graph.py
@@ -89,6 +89,7 @@ def main(argv: list[str] | None = None) -> int:
     # Load candidates after resolving manifest paths so the source path is
     # available for relative manifest resolution.
     candidates: list[dict[str, Any]] = []
+    candidate_source_path: Path | None = None
     if args.artifact_candidates is not None:
         if not args.artifact_candidates.exists():
             raise FileNotFoundError(
@@ -101,12 +102,13 @@ def main(argv: list[str] | None = None) -> int:
             candidates = list(candidate_payload)
         else:
             raise ValueError("artifact candidates file must contain a JSON list or object")
-        # Rebuild graph with candidates now that we know the candidate source path.
-        graph = build_manifest_lineage_graph(
-            manifest_paths,
-            artifact_candidates=candidates,
-            candidate_source_path=args.artifact_candidates,
-        )
+        candidate_source_path = args.artifact_candidates
+
+    graph = build_manifest_lineage_graph(
+        manifest_paths,
+        artifact_candidates=candidates,
+        candidate_source_path=candidate_source_path,
+    )
 
     written = write_manifest_lineage_graph_report(
         graph,

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from robot_sf.benchmark.manifest_lineage_graph import (
@@ -189,7 +190,7 @@ def test_cli_runs_and_writes_outputs(tmp_path: Path) -> None:
 
     result = subprocess.run(
         [
-            "python",
+            sys.executable,
             str(script),
             "--manifest",
             str(FIXTURE_DIR / "connected_manifest.json"),
@@ -212,6 +213,78 @@ def test_cli_runs_and_writes_outputs(tmp_path: Path) -> None:
     assert summary["artifact_candidate_count"] == 4
     assert json_path.exists()
     assert md_path.exists()
+
+
+def test_cli_runs_without_artifact_candidates(tmp_path: Path) -> None:
+    """The CLI script works when --artifact-candidates is omitted."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "build_manifest_lineage_graph.py"
+    )
+    json_path = tmp_path / "out.json"
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--manifest",
+            str(FIXTURE_DIR / "connected_manifest.json"),
+            "--out-json",
+            str(json_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["manifest_count"] == 1
+    assert summary["artifact_candidate_count"] == 0
+    assert summary["trace_count"] == 0
+    assert json_path.exists()
+    assert summary["markdown_path"] == ""
+
+
+def test_cli_runs_without_artifact_candidates_and_with_markdown(tmp_path: Path) -> None:
+    """The CLI script emits Markdown even without artifact candidates."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "build_manifest_lineage_graph.py"
+    )
+    json_path = tmp_path / "out.json"
+    md_path = tmp_path / "out.md"
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--manifest",
+            str(FIXTURE_DIR / "connected_manifest.json"),
+            "--out-json",
+            str(json_path),
+            "--out-md",
+            str(md_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["manifest_count"] == 1
+    assert summary["artifact_candidate_count"] == 0
+    assert summary["trace_count"] == 0
+    assert json_path.exists()
+    assert md_path.exists()
+    assert "No artifact candidates supplied" in md_path.read_text(encoding="utf-8")
 
 
 def test_repo_relative_paths_in_graph(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #2901 by building the manifest lineage graph regardless of whether `--artifact-candidates` is supplied. The CLI now supports documented manifest-only JSON output and manifest-only JSON+Markdown output while preserving candidate-backed behavior.

## Changes

- Move graph construction outside the optional artifact-candidate branch in `scripts/benchmark/build_manifest_lineage_graph.py`.
- Add CLI regression tests for:
  - `--manifest` + `--out-json` without candidates;
  - `--manifest` + `--out-json` + `--out-md` without candidates;
  - existing candidate-backed CLI behavior remains covered.
- Use `sys.executable` in the CLI subprocess tests so they run under the active test interpreter.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_graph.py -q` - PASS, 14 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/build_manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py` - PASS.
- `git diff --check` - PASS.
- `uv sync --all-extras` - PASS before final readiness.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh` - PASS on head `67d10de0722e7dfa84a6f5e905773fb8d3c03d10`, 6739 passed, 9 skipped, 8 warnings.

## Research Result Guidance

NA - support/tooling bug fix. This improves evidence-tool reliability but does not create benchmark evidence or move a research claim boundary.

## Downstream Propagation

- Parent issue: closes #2901.
- Claim map / benchmark report / leaderboard: NA, no benchmark result changes.
- Registry / config index: NA, no artifact contract or config index change.
- Context or memory note: NA, regression is covered by tests and PR validation evidence.

## Notes

The issue body referenced `scripts/analysis/build_manifest_lineage_graph.py`; the actual script in the current tree is `scripts/benchmark/build_manifest_lineage_graph.py`.
