### PR TITLE
feat: add deterministic lineage graph timestamp

### DIFF
--- a/robot_sf/benchmark/manifest_lineage_graph.py
+++ b/robot_sf/benchmark/manifest_lineage_graph.py
@@ -180,6 +180,28 @@ def _now_utc() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _parse_generated_at_utc(value: str) -> str:
+    """Validate a user-supplied ISO-8601 UTC timestamp.
+
+    Returns the original string on success so the report keeps the caller's
+    exact formatting. Raises ValueError with an actionable message on failure.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid --generated-at-utc timestamp '{value}'; "
+            "expected an ISO-8601 datetime such as 2026-06-15T00:00:00+00:00"
+        ) from exc
+    if parsed.tzinfo != UTC:
+        raise ValueError(
+            f"invalid --generated-at-utc timestamp '{value}'; "
+            "expected a timezone-aware UTC ISO-8601 datetime such as "
+            "2026-06-15T00:00:00+00:00"
+        )
+    return value
+
+
 def _load_json(path: Path) -> Any:
     """Load a JSON file and return the parsed payload."""
     return json.loads(path.read_text(encoding="utf-8"))
@@ -283,6 +305,7 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
     *,
     artifact_candidates: Sequence[Mapping[str, Any]] = (),
     candidate_source_path: Path | None = None,
+    generated_at_utc: str | None = None,
 ) -> ManifestLineageGraph:
     """Build a lineage graph from manifest paths and optional artifact candidates.
 
@@ -292,6 +315,8 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
             back to one of the supplied manifest paths.
         candidate_source_path: Optional path to the candidate file, used to
             resolve relative manifest references.
+        generated_at_utc: Optional ISO-8601 UTC timestamp for the report. When
+            omitted, the current wall-clock UTC time is used.
 
     Returns:
         ManifestLineageGraph with nodes, edges, traces, and summary.
@@ -468,9 +493,12 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
         )
 
     summary = _build_summary(nodes.values(), edges, traces)
+    timestamp = (
+        _parse_generated_at_utc(generated_at_utc) if generated_at_utc is not None else _now_utc()
+    )
     return ManifestLineageGraph(
         schema_version=SCHEMA_VERSION,
-        generated_at_utc=_now_utc(),
+        generated_at_utc=timestamp,
         nodes=list(nodes.values()),
         edges=edges,
         traces=traces,

--- a/scripts/benchmark/build_manifest_lineage_graph.py
+++ b/scripts/benchmark/build_manifest_lineage_graph.py
@@ -28,9 +28,18 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from robot_sf.benchmark.manifest_lineage_graph import (  # noqa: E402
+    _parse_generated_at_utc,
     build_manifest_lineage_graph,
     write_manifest_lineage_graph_report,
 )
+
+
+def _cli_generated_at_utc(value: str) -> str:
+    """CLI type wrapper that turns ValueError into argparse-friendly output."""
+    try:
+        return _parse_generated_at_utc(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -60,6 +69,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=None,
         help="Optional output path for the Markdown adjacency report.",
+    )
+    parser.add_argument(
+        "--generated-at-utc",
+        type=_cli_generated_at_utc,
+        default=None,
+        metavar="TIMESTAMP",
+        help=(
+            "Optional ISO-8601 UTC timestamp for the report "
+            "(e.g. 2026-06-15T00:00:00+00:00). Defaults to current UTC time."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -108,6 +127,7 @@ def main(argv: list[str] | None = None) -> int:
         manifest_paths,
         artifact_candidates=candidates,
         candidate_source_path=candidate_source_path,
+        generated_at_utc=args.generated_at_utc,
     )
 
     written = write_manifest_lineage_graph_report(

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from robot_sf.benchmark.manifest_lineage_graph import (
     LineageStatus,
     build_manifest_lineage_graph,
@@ -287,6 +289,49 @@ def test_cli_runs_without_artifact_candidates_and_with_markdown(tmp_path: Path) 
     assert "No artifact candidates supplied" in md_path.read_text(encoding="utf-8")
 
 
+def test_generated_at_utc_override_in_graph() -> None:
+    """A supplied timestamp is used instead of the current wall-clock time."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    fixed_timestamp = "2026-06-15T00:00:00+00:00"
+
+    graph = build_manifest_lineage_graph(
+        [manifest_path],
+        generated_at_utc=fixed_timestamp,
+    )
+
+    assert graph.generated_at_utc == fixed_timestamp
+
+
+def test_generated_at_utc_invalid_raises_actionable_error() -> None:
+    """An invalid timestamp raises a clear, actionable ValueError."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+
+    invalid_values = [
+        "not-a-timestamp",
+        "2026-06-15T00:00:00",
+        "2026-06-15T02:00:00+02:00",
+    ]
+    for invalid_value in invalid_values:
+        with pytest.raises(ValueError, match="invalid --generated-at-utc timestamp"):
+            build_manifest_lineage_graph(
+                [manifest_path],
+                generated_at_utc=invalid_value,
+            )
+
+
+def test_generated_at_utc_defaults_to_current_utc() -> None:
+    """Omitting the timestamp uses the current wall-clock UTC time."""
+    from datetime import UTC, datetime
+
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    before = datetime.now(UTC)
+    graph = build_manifest_lineage_graph([manifest_path])
+    after = datetime.now(UTC)
+
+    parsed = datetime.fromisoformat(graph.generated_at_utc)
+    assert before <= parsed <= after
+
+
 def test_repo_relative_paths_in_graph(tmp_path: Path) -> None:
     """Manifest paths in the graph are repository-relative."""
     manifest_path = FIXTURE_DIR / "connected_manifest.json"
@@ -295,6 +340,81 @@ def test_repo_relative_paths_in_graph(tmp_path: Path) -> None:
     manifest_node = next(node for node in graph.nodes if node.kind == "manifest")
     assert not Path(manifest_node.path).is_absolute()
     assert manifest_node.path.startswith("tests/benchmark/fixtures/manifest_lineage_graph/")
+
+
+def test_cli_generated_at_utc_override(tmp_path: Path) -> None:
+    """The CLI uses --generated-at-utc in both JSON and Markdown outputs."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "build_manifest_lineage_graph.py"
+    )
+    json_path = tmp_path / "out.json"
+    md_path = tmp_path / "out.md"
+    fixed_timestamp = "2026-06-15T00:00:00+00:00"
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--manifest",
+            str(FIXTURE_DIR / "connected_manifest.json"),
+            "--out-json",
+            str(json_path),
+            "--out-md",
+            str(md_path),
+            "--generated-at-utc",
+            fixed_timestamp,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["json_path"] == str(json_path)
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["generated_at_utc"] == fixed_timestamp
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert f"**Generated at (UTC)**: {fixed_timestamp}" in markdown
+
+
+def test_cli_generated_at_utc_invalid_fails(tmp_path: Path) -> None:
+    """The CLI rejects an invalid --generated-at-utc with an actionable error."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "build_manifest_lineage_graph.py"
+    )
+    json_path = tmp_path / "out.json"
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--manifest",
+            str(FIXTURE_DIR / "connected_manifest.json"),
+            "--out-json",
+            str(json_path),
+            "--generated-at-utc",
+            "not-a-timestamp",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "invalid --generated-at-utc timestamp" in result.stderr
+    assert "ISO-8601" in result.stderr
 
 
 def test_duplicate_manifest_paths_are_deduplicated() -> None:


### PR DESCRIPTION
## Summary

Fixes #2907 by adding deterministic `generated_at_utc` control to manifest lineage graph reports. The CLI now accepts `--generated-at-utc <ISO-8601 UTC timestamp>` and threads it through JSON and Markdown report generation while preserving the existing wall-clock default when omitted.

## Changes

- Add `generated_at_utc` override plumbing to `robot_sf/benchmark/manifest_lineage_graph.py`.
- Add `--generated-at-utc` to `scripts/benchmark/build_manifest_lineage_graph.py`.
- Validate supplied timestamps as timezone-aware UTC values; naive and non-UTC offsets are rejected with actionable guidance.
- Add API and CLI tests for override, invalid input, and default behavior.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_graph.py -q` - PASS, 19 passed on amended head `df1fa4c11d8c6f01a9d59549ae060cffe683bd98`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/build_manifest_lineage_graph.py robot_sf/benchmark/manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py` - PASS.
- `git diff --check` - PASS.
- `uv sync --all-extras` - PASS before final readiness.
- Initial full readiness on pre-review-fix head `aea67ed506a8070c26b9261bf17c960110d98161`: PASS, 6744 passed, 9 skipped, 9 warnings.
- Amended-head full readiness local rerun on `df1fa4c11d8c6f01a9d59549ae060cffe683bd98`: FAILED after 35:44 due two unrelated timeout/perf failures under saturated local xdist: `tests/benchmark_full/test_integration_reproducibility.py::test_reproducibility_same_seed` exceeded the 10s local budget, and `tests/examples/test_examples_run.py::test_example_runs_without_error[plotting/coverage_example.py]` timed out at 60s.
- The same two timeout cases PASS in isolation without relax mode on the amended head: reproducibility 1 passed in 12.23s with 2.10s call time; coverage example 1 passed/26 deselected in 14.00s with 3.44s call time.
- Changed-file coverage on the initial readiness run: `robot_sf/benchmark/manifest_lineage_graph.py` 95.3%, above the 80% minimum; below the 100% goal as a warning only.

## Research Result Guidance

NA - support/tooling artifact-quality feature. This improves reproducible evidence generation but does not create benchmark evidence or move a research claim boundary.

## Downstream Propagation

- Parent issue: closes #2907.
- Claim map / benchmark report / leaderboard: NA, no benchmark result changes.
- Registry / config index: NA, no artifact contract or config index change beyond CLI behavior.
- Context or memory note: NA, behavior is covered by tests and PR validation evidence.

## Notes

The issue body referenced `scripts/analysis/build_manifest_lineage_graph.py`; the actual script in the current tree is `scripts/benchmark/build_manifest_lineage_graph.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify a custom ISO-8601 UTC timestamp via `--generated-at-utc` flag when generating manifest lineage graphs. Invalid timestamps are rejected with clear error messages; defaults to current UTC time if omitted.

* **Tests**
  * Added comprehensive test coverage for timestamp validation and CLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
