### PR TITLE
test: cover bounded CI watcher stops

### DIFF
--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -268,6 +268,43 @@ def _format_human(data: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _terminal_reason(
+    overall: str | None,
+    attempt: int,
+    attempts: int,
+    local_stop: bool,
+) -> str | None:
+    """Classify why a polling loop stopped on this iteration."""
+    if overall is None:
+        return None
+    if overall != "pending":
+        return str(overall)
+    if attempt == attempts:
+        return "attempt_exhausted"
+    if local_stop:
+        return "max_wall_seconds"
+    return None
+
+
+def _guard_head_sha(data: dict[str, Any], expected_head_sha: str) -> bool:
+    """Fail closed when the observed PR head SHA diverges from the expected one.
+
+    Mutates ``data`` in place and returns True if the caller should stop polling.
+    """
+    head_sha = str(data.get("head_sha") or "")
+    if expected_head_sha and not head_sha:
+        data["status"] = "error"
+        data["error"] = "PR head SHA missing while monitoring CI"
+        data["monitor"]["terminal_reason"] = "error"
+        return True
+    if expected_head_sha and head_sha != expected_head_sha:
+        data["status"] = "error"
+        data["error"] = "PR head SHA changed while monitoring CI"
+        data["monitor"]["terminal_reason"] = "error"
+        return True
+    return False
+
+
 def _bounded_sleep_seconds(
     poll_interval: float,
     wall_deadline: float | None,
@@ -323,27 +360,24 @@ def _poll_ci_status(
             deadline_epoch_seconds=deadline_epoch_seconds,
         )
         if data.get("status") == "error":
+            data["monitor"]["terminal_reason"] = "error"
             break
-        head_sha = str(data.get("head_sha") or "")
-        if expected_head_sha and not head_sha:
-            data["status"] = "error"
-            data["error"] = "PR head SHA missing while monitoring CI"
-            break
-        if expected_head_sha and head_sha != expected_head_sha:
-            data["status"] = "error"
-            data["error"] = "PR head SHA changed while monitoring CI"
+        if _guard_head_sha(data, expected_head_sha):
             break
         overall = data.get("checks", {}).get("overall")
         sleep_seconds, local_stop = _bounded_sleep_seconds(poll_interval, wall_deadline)
+        terminal_reason = _terminal_reason(overall, attempt, attempts, local_stop)
         if overall == "pending" and attempt < attempts and local_stop:
             data["monitor"]["local_stop_reason"] = "max_wall_seconds"
+        if terminal_reason:
+            data["monitor"]["terminal_reason"] = terminal_reason
         if attempts > 1:
             if json_output:
                 print(json.dumps(data), flush=True)
             else:
                 print(f"poll attempt {attempt}/{attempts}", flush=True)
                 print(_format_human(data), flush=True)
-        if overall != "pending" or attempt == attempts or local_stop:
+        if terminal_reason:
             break
         time.sleep(sleep_seconds)
     return data

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -736,6 +736,68 @@ def test_negative_max_wall_seconds_is_rejected(
     assert "value must be non-negative" in capsys.readouterr().err
 
 
+def _fake_gh_bin(tmp_path: Path) -> Path:
+    """Write an executable fake ``gh`` binary that serves scripted PR view responses."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_gh = bin_dir / "gh"
+    fake_gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "state_path = os.environ['FAKE_GH_STATE']\n"
+        "with open(state_path, encoding='utf-8') as f:\n"
+        "    state = json.load(f)\n"
+        "idx = state['calls']\n"
+        "if idx >= len(state['responses']):\n"
+        "    print(f'No response for call {idx}', file=sys.stderr)\n"
+        "    sys.exit(1)\n"
+        "resp = state['responses'][idx]\n"
+        "state['calls'] = idx + 1\n"
+        "with open(state_path, 'w', encoding='utf-8') as f:\n"
+        "    json.dump(state, f)\n"
+        "print(json.dumps(resp))\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    fake_gh_bat = bin_dir / "gh.bat"
+    fake_gh_bat.write_text(
+        '@echo off\r\npython "%~dp0gh" %*\r\n',
+        encoding="utf-8",
+    )
+    return bin_dir
+
+
+def _run_script(
+    tmp_path: Path,
+    args: list[str],
+    responses: list[dict[str, object]],
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the CI watcher via subprocess with a fake ``gh`` on PATH."""
+    import os
+
+    script = str(
+        Path(__file__).resolve().parent.parent.parent / "scripts" / "dev" / "check_pr_ci_status.py"
+    )
+    state_path = tmp_path / "fake_gh_state.json"
+    state_path.write_text(
+        json.dumps({"calls": 0, "responses": responses}),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["FAKE_GH_STATE"] = str(state_path)
+    env["PATH"] = str(_fake_gh_bin(tmp_path)) + os.pathsep + env.get("PATH", "")
+    return subprocess.run(
+        [sys.executable, script, *args],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+        env=env,
+    )
+
+
 def test_direct_invocation_help_succeeds_without_pythonpath() -> None:
     """python scripts/dev/check_pr_ci_status.py --help should work without PYTHONPATH."""
     import os
@@ -757,3 +819,87 @@ def test_direct_invocation_help_succeeds_without_pythonpath() -> None:
     assert "run_worktree_shared_venv.sh" in result.stdout
     assert "--expected-head-sha" in result.stdout
     assert "--max-wall-seconds" in result.stdout
+
+
+def test_smoke_completed_ci_exits_cleanly_with_monitor_metadata(
+    tmp_path: Path,
+) -> None:
+    """A completed CI status should exit 0 and include explicit monitor metadata."""
+    response: dict[str, object] = {
+        "number": 21,
+        "title": "smoke success",
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "headRefName": "smoke-success",
+        "headRefOid": "deadbeef",
+        "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+        "reviews": [],
+    }
+
+    result = _run_script(
+        tmp_path,
+        [
+            "21",
+            "--json",
+            "--expected-head-sha",
+            "deadbeef",
+            "--poll-attempts",
+            "3",
+            "--poll-interval",
+            "0.0",
+        ],
+        [response],
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["status"] == "ok"
+    assert payload["checks"]["overall"] == "success"
+    assert payload["monitor"]["expected_head_sha"] == "deadbeef"
+    assert payload["monitor"]["head_sha_matches_expected"] is True
+    assert payload["monitor"]["route_evidence_only"] is True
+    assert payload["monitor"]["terminal_reason"] == "success"
+
+
+def test_smoke_attempt_exhaustion_reports_bounded_pending_reason(
+    tmp_path: Path,
+) -> None:
+    """Exhausting bounded poll attempts while pending should report a terminal reason."""
+    response: dict[str, object] = {
+        "number": 22,
+        "title": "smoke pending",
+        "state": "OPEN",
+        "mergeable": "UNKNOWN",
+        "headRefName": "smoke-pending",
+        "headRefOid": "cafebabe",
+        "statusCheckRollup": [{"name": "ci", "status": "queued", "conclusion": ""}],
+        "reviews": [],
+    }
+
+    result = _run_script(
+        tmp_path,
+        [
+            "22",
+            "--json",
+            "--expected-head-sha",
+            "cafebabe",
+            "--poll-attempts",
+            "3",
+            "--poll-interval",
+            "0.0",
+        ],
+        [response, response, response],
+    )
+
+    assert result.returncode == 2, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    lines = result.stdout.strip().splitlines()
+    assert len(lines) == 3
+    final = json.loads(lines[-1])
+    assert final["status"] == "ok"
+    assert final["checks"]["overall"] == "pending"
+    assert final["monitor"]["expected_head_sha"] == "cafebabe"
+    assert final["monitor"]["head_sha_matches_expected"] is True
+    assert final["monitor"]["route_evidence_only"] is True
+    assert final["monitor"]["terminal_reason"] == "attempt_exhausted"
+    assert final["monitor"]["poll_attempt"] == 3
+    assert final["monitor"]["poll_attempts"] == 3


### PR DESCRIPTION
## Summary

Closes #2908 by adding bounded CI watcher smoke coverage and explicit terminal metadata for monitor handoffs. The CI polling helper now reports why the polling loop stopped (`success`, `failure`, `attempt_exhausted`, `max_wall_seconds`, or `error`) in `monitor.terminal_reason`.

## Changes

- Add `monitor.terminal_reason` to `scripts/dev/check_pr_ci_status.py` for completed, exhausted, max-wall, and error stop paths.
- Keep head-SHA mismatch checks fail-closed while extracting helper logic to keep lint complexity under control.
- Add subprocess smoke tests with a fake `gh` binary so completed and attempt-exhausted polling paths are covered without live GitHub polling.
- Add a Windows `gh.bat` companion for the fake `gh` fixture.
- Assert `route_evidence_only` remains true in both new smoke paths.

## Validation

- `uv run ruff check scripts/dev/check_pr_ci_status.py tests/dev/test_check_pr_ci_status.py` - PASS.
- `uv run pytest tests/dev/test_check_pr_ci_status.py -q` - PASS, 38 passed.
- `git diff --check` - PASS.
- `uv sync --all-extras` - PASS before final readiness.
- Initial full readiness on pre-review-fix head `d60f1b0e9a3b360b7283e79938ab8a765a92f8d9`: PASS, 6746 passed, 9 skipped, 9 warnings.
- Final readiness after Gemini review fix on amended head `3912ad4cb6b214957715add47a195765e781040e`: PASS, 6746 passed, 9 skipped, 8 warnings.

## Research Result Guidance

NA - workflow/test coverage. This protects agent CI-wait reproducibility and handoff quality, but does not create benchmark evidence or move a research claim boundary.

## Downstream Propagation

- Parent issue: closes #2908.
- Claim map / benchmark report / leaderboard: NA, no benchmark result changes.
- Registry / config index: NA, no config or artifact contract change.
- Context or memory note: NA, behavior is covered by tests and PR validation evidence.
