### PR TITLE
feat: define ForecastBatch.v1 schema

### DIFF
--- a/docs/ai/prediction_lane.md
+++ b/docs/ai/prediction_lane.md
@@ -38,9 +38,9 @@ Follow this order unless a later issue has an explicitly narrower diagnostic pur
 1. Define and validate the artifact contract.
    `ForecastBatch.v1` is tracked by #2836 and summarized in
    `docs/context/issue_2836_forecast_batch_schema.md`. It records predictor identity,
-   observation tier, coordinate frame, `dt_s`, horizons, scenario id, seed, fallback/degraded
-   status, actor ids, masks, feature schema, optional samples/modes/occupancy, and oracle-state
-   boundaries.
+   observation tier, timestamp, coordinate frame, `dt_s`, horizons, scenario id, seed,
+   fallback/degraded status, actor ids, masks, feature schema, optional deterministic, sampled,
+   Gaussian, occupancy, and reachable/conformal outputs, and oracle-state boundaries.
 2. Build durable motion-rich fixtures and baseline ladder.
    Use #2774 for non-corridor trace fixtures, #2758 for signal/goal-aware baselines, and #2781 for
    interaction-aware comparison. Existing results are diagnostic-only.

--- a/docs/context/issue_2836_forecast_batch_schema.md
+++ b/docs/context/issue_2836_forecast_batch_schema.md
@@ -1,21 +1,109 @@
-# Issue #2836: ForecastBatch.v1 Schema (2026-06-14)
+# Issue #2836 / #2913: ForecastBatch.v1 Schema (2026-06-14)
 
 `ForecastBatch.v1` is a benchmark artifact contract for exchanging pedestrian
 forecast outputs without making prediction-quality, calibration, or planning
 benefit claims. Those claims still require separate benchmark evidence.
 
 The required provenance records predictor identity and family, observation tier,
-coordinate frame, units, axis semantics, `dt_s`, forecast horizons in seconds,
-scenario id, seed, fallback/degraded status, actor ids, actor mask metadata, and
-feature schema. Positions are two-dimensional coordinates in meters. The
-coordinate frame must name the frame and its axes so downstream evaluators do not
-mix world-frame, robot-frame, or map-frame forecasts silently.
+forecast origin `timestamp`, coordinate frame, units, axis semantics, `dt_s`,
+forecast horizons in seconds, scenario id, seed, fallback/degraded status, actor
+ids, actor mask metadata, and feature schema. Positions are two-dimensional
+coordinates in meters. The coordinate frame must name the frame and its axes so
+downstream evaluators do not mix world-frame, robot-frame, or map-frame forecasts
+silently.
 
-The payload is additive. Producers may emit deterministic trajectories, sampled
-trajectories, mode probabilities, occupancy summaries, and uncertainty metadata.
-They do not need to emit every optional field. Missing actor payloads are allowed
-only when the actor mask and mask metadata describe the missingness semantics.
+The payload is additive. Producers may emit deterministic point forecasts,
+sampled trajectories, Gaussian parameters, mode probabilities, occupancy
+summaries, reachable/conformal sets, and uncertainty metadata. They do not need
+to emit every optional field. Missing actor payloads are allowed only when the
+actor mask and mask metadata describe the missingness semantics.
 
 Oracle or deployable-oracle feature fields are rejected unless the artifact is
 explicitly marked with `oracle_state=True`. This keeps deployable-observation
 artifacts separate from diagnostic oracle-state artifacts.
+
+## JSON Schema
+
+The canonical schema lives at
+`robot_sf/benchmark/schemas/forecast_batch.schema.v1.json`. The
+`ForecastBatchSchema` structural validator is in
+`robot_sf/benchmark/schemas/forecast_batch_schema.py`; the domain dataclasses
+and stricter typed loader are in `robot_sf/benchmark/forecast_batch.py`. A CLI
+validator is available at `scripts/validation/validate_forecast_batch.py`.
+
+## Minimal deterministic example
+
+```json
+{
+  "schema_version": "ForecastBatch.v1",
+  "provenance": {
+    "predictor_id": "cv-baseline-v1",
+    "predictor_family": "constant_velocity",
+    "observation_tier": "tracked_agents",
+    "timestamp": "2026-06-15T12:00:00Z",
+    "frame": {"name": "world", "units": "m", "axes": ["x", "y"]},
+    "dt_s": 0.5,
+    "horizons_s": [0.5, 1.0],
+    "scenario_id": "crosswalk_001",
+    "seed": 7,
+    "fallback_status": "native",
+    "degraded_status": "none",
+    "actor_ids": ["ped_1"],
+    "actor_mask": [true],
+    "actor_mask_metadata": {
+      "semantics": "true means forecast payload is available for actor_id",
+      "missing_actor_reasons": {}
+    },
+    "feature_schema": {"name": "socnav_observation_v1", "features": ["position_m"]}
+  },
+  "forecasts": [
+    {"actor_id": "ped_1", "deterministic": [[1.0, 0.0], [1.5, 0.0]]}
+  ]
+}
+```
+
+## Probabilistic example with samples, Gaussian, and reachable set
+
+```json
+{
+  "schema_version": "ForecastBatch.v1",
+  "provenance": {
+    "predictor_id": "gmm-forecast-v1",
+    "predictor_family": "gaussian_mixture",
+    "observation_tier": "tracked_agents",
+    "timestamp": "2026-06-15T12:00:00Z",
+    "frame": {"name": "world", "units": "m", "axes": ["x", "y"]},
+    "dt_s": 0.5,
+    "horizons_s": [0.5, 1.0],
+    "scenario_id": "crosswalk_001",
+    "seed": 7,
+    "fallback_status": "native",
+    "degraded_status": "none",
+    "actor_ids": ["ped_1"],
+    "actor_mask": [true],
+    "actor_mask_metadata": {
+      "semantics": "true means forecast payload is available for actor_id",
+      "missing_actor_reasons": {}
+    },
+    "feature_schema": {"name": "socnav_observation_v1", "features": ["position_m"]}
+  },
+  "forecasts": [
+    {
+      "actor_id": "ped_1",
+      "samples": [
+        [[1.0, 0.0], [1.5, 0.0]],
+        [[1.0, 0.1], [1.4, 0.2]]
+      ],
+      "mode_probabilities": [0.6, 0.4],
+      "gaussian": [
+        {"mean": [1.0, 0.0], "cov": [[0.1, 0.0], [0.0, 0.1]]},
+        {"mean": [1.5, 0.0], "cov": [[0.2, 0.0], [0.0, 0.2]]}
+      ],
+      "reachable_set": [
+        {"center": [1.0, 0.0], "radius_m": 0.5, "set_type": "conformal_tube"},
+        {"center": [1.5, 0.0], "semi_axes_m": [0.6, 0.4], "set_type": "confidence_ellipse"}
+      ]
+    }
+  ]
+}
+```

--- a/robot_sf/benchmark/forecast_batch.py
+++ b/robot_sf/benchmark/forecast_batch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field, fields, is_dataclass
+from datetime import datetime
 from itertools import pairwise
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,20 @@ def _require_non_empty_str(name: str, value: object) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} is required")
     return value.strip()
+
+
+def _require_timestamp(name: str, value: object) -> str:
+    """Return an ISO 8601 timestamp string or raise for invalid values."""
+    text = _require_non_empty_str(name, value)
+    if "T" not in text:
+        raise ValueError(f"{name} must be an ISO 8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO 8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{name} must include timezone information")
+    return text
 
 
 def _require_positive_float(name: str, value: object) -> float:
@@ -158,6 +173,7 @@ class ForecastBatchProvenance:
     actor_mask: list[bool]
     actor_mask_metadata: dict[str, Any]
     feature_schema: dict[str, Any]
+    timestamp: str
     oracle_state: bool = False
     actor_classes: dict[str, str] = field(default_factory=dict)
 
@@ -171,6 +187,7 @@ class ForecastBatchProvenance:
         self.dt_s = _require_positive_float("dt_s", self.dt_s)
         self.horizons_s = _require_float_list("horizons_s", self.horizons_s)
         self.scenario_id = _require_non_empty_str("scenario_id", self.scenario_id)
+        self.timestamp = _require_timestamp("timestamp", self.timestamp)
         if isinstance(self.seed, bool) or not isinstance(self.seed, (int, np.integer)):
             raise ValueError("seed must be an integer")
         self.seed = int(self.seed)
@@ -226,6 +243,7 @@ class ForecastBatchProvenance:
             horizons_s=data.get("horizons_s"),
             scenario_id=data.get("scenario_id", ""),
             seed=data.get("seed", 0),
+            timestamp=data.get("timestamp", ""),
             fallback_status=data.get("fallback_status", ""),
             degraded_status=data.get("degraded_status", ""),
             actor_ids=list(data.get("actor_ids", [])),
@@ -253,6 +271,49 @@ def _array_or_none(name: str, value: object, *, ndim: int) -> np.ndarray | None:
     return array
 
 
+def _normalize_optional_sequence(
+    name: str,
+    value: object,
+    expected_steps: int | None,
+) -> list[dict[str, Any]] | None:
+    """Normalize an optional list of per-horizon metadata objects.
+
+    Returns:
+        List of dicts or None when the optional payload is absent.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)) or len(value) == 0:
+        raise ValueError(f"{name} must be a non-empty list")
+    normalized = [_require_mapping(f"{name}[]", item) for item in value]
+    if expected_steps is not None and len(normalized) != expected_steps:
+        raise ValueError(f"{name} must align with forecast horizons")
+    return normalized
+
+
+def _validate_forecast_payload(forecast: ActorForecast, expected_steps: int) -> None:
+    """Validate that one actor forecast carries a complete aligned payload."""
+    if not any(
+        payload is not None
+        for payload in (
+            forecast.deterministic,
+            forecast.samples,
+            forecast.gaussian,
+            forecast.reachable_set,
+            forecast.occupancy_summary,
+        )
+    ):
+        raise ValueError("forecast payload must include at least one prediction representation")
+    if forecast.deterministic is not None and forecast.deterministic.shape[0] != expected_steps:
+        raise ValueError("deterministic trajectories must align with horizons_s")
+    if forecast.samples is not None and forecast.samples.shape[1] != expected_steps:
+        raise ValueError("sampled trajectories must align with horizons_s")
+    if forecast.gaussian is not None and len(forecast.gaussian) != expected_steps:
+        raise ValueError("gaussian must align with horizons_s")
+    if forecast.reachable_set is not None and len(forecast.reachable_set) != expected_steps:
+        raise ValueError("reachable_set must align with horizons_s")
+
+
 @dataclass
 class ActorForecast:
     """Optional forecast payloads for one actor.
@@ -266,6 +327,8 @@ class ActorForecast:
     deterministic: np.ndarray | None = None
     samples: np.ndarray | None = None
     mode_probabilities: list[float] | None = None
+    gaussian: list[dict[str, Any]] | None = None
+    reachable_set: list[dict[str, Any]] | None = None
     occupancy_summary: dict[str, Any] | None = None
     uncertainty_metadata: dict[str, Any] | None = None
 
@@ -281,8 +344,21 @@ class ActorForecast:
             if np.any(probs < 0.0) or not np.isclose(float(np.sum(probs)), 1.0):
                 raise ValueError("mode_probabilities must be non-negative and sum to 1")
             self.mode_probabilities = [float(value) for value in probs]
-            if self.samples is not None and len(self.mode_probabilities) != self.samples.shape[0]:
+            if self.samples is None:
+                raise ValueError("mode_probabilities require sampled trajectories")
+            if len(self.mode_probabilities) != self.samples.shape[0]:
                 raise ValueError("mode_probabilities must align with samples")
+        expected_steps = None
+        if self.deterministic is not None:
+            expected_steps = self.deterministic.shape[0]
+        elif self.samples is not None:
+            expected_steps = self.samples.shape[1]
+        self.gaussian = _normalize_optional_sequence("gaussian", self.gaussian, expected_steps)
+        self.reachable_set = _normalize_optional_sequence(
+            "reachable_set",
+            self.reachable_set,
+            expected_steps,
+        )
         if self.occupancy_summary is not None:
             self.occupancy_summary = _require_mapping("occupancy_summary", self.occupancy_summary)
         if self.uncertainty_metadata is not None:
@@ -303,6 +379,8 @@ class ActorForecast:
             deterministic=data.get("deterministic"),
             samples=data.get("samples"),
             mode_probabilities=data.get("mode_probabilities"),
+            gaussian=data.get("gaussian"),
+            reachable_set=data.get("reachable_set"),
             occupancy_summary=data.get("occupancy_summary"),
             uncertainty_metadata=data.get("uncertainty_metadata"),
         )
@@ -346,19 +424,15 @@ class ForecastBatch:
             raise ValueError("forecast actor_ids must exactly match actor_mask=True actors")
         expected_steps = len(self.provenance.horizons_s)
         for forecast in self.forecasts:
-            if (
-                forecast.deterministic is not None
-                and forecast.deterministic.shape[0] != expected_steps
-            ):
-                raise ValueError("deterministic trajectories must align with horizons_s")
-            if forecast.samples is not None and forecast.samples.shape[1] != expected_steps:
-                raise ValueError("sampled trajectories must align with horizons_s")
+            _validate_forecast_payload(forecast, expected_steps)
         self.metadata = _require_mapping("metadata", self.metadata)
         if (
             _contains_oracle_key(self.metadata)
             or any(
                 _contains_oracle_key(forecast.occupancy_summary)
                 or _contains_oracle_key(forecast.uncertainty_metadata)
+                or _contains_oracle_key(forecast.gaussian)
+                or _contains_oracle_key(forecast.reachable_set)
                 for forecast in self.forecasts
             )
         ) and not self.provenance.oracle_state:
@@ -387,14 +461,19 @@ def as_dict(value: Any) -> Any:
     """Convert dataclasses and numpy arrays to JSON-compatible values.
 
     Returns:
-        JSON-compatible value.
+        JSON-compatible value. Optional fields that are ``None`` are omitted
+        so that serialized artifacts do not carry explicit null payloads.
     """
     if isinstance(value, np.ndarray):
         return value.tolist()
     if isinstance(value, np.generic):
         return value.item()
     if is_dataclass(value):
-        return {item.name: as_dict(getattr(value, item.name)) for item in fields(value)}
+        return {
+            item.name: as_dict(getattr(value, item.name))
+            for item in fields(value)
+            if getattr(value, item.name) is not None
+        }
     if isinstance(value, dict):
         return {str(key): as_dict(item) for key, item in value.items()}
     if isinstance(value, list | tuple):

--- a/robot_sf/benchmark/forecast_observation_adapters.py
+++ b/robot_sf/benchmark/forecast_observation_adapters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import numpy as np
@@ -58,6 +59,27 @@ def _default_dt_s(trace: dict[str, Any]) -> float:
     except (AttributeError, TypeError, ValueError):
         return 0.1
     return dt_s if dt_s > 0.0 else 0.1
+
+
+def _forecast_timestamp(frame_payload: dict[str, Any]) -> str:
+    """Build an ISO 8601 timestamp from frame timing metadata.
+
+    Returns:
+        ISO timestamp string. Falls back to ``1970-01-01T00:00:00Z`` when no
+        timing metadata is present so that artifacts always carry a timestamp.
+    """
+    time_s = frame_payload.get("time_s")
+    if (
+        isinstance(time_s, (int, float))
+        and not isinstance(time_s, bool)
+        and np.isfinite(float(time_s))
+        and time_s >= 0
+    ):
+        return datetime.fromtimestamp(float(time_s), tz=UTC).isoformat()
+    timestamp = frame_payload.get("timestamp") or frame_payload.get("time")
+    if isinstance(timestamp, str) and timestamp.strip():
+        return timestamp.strip()
+    return "1970-01-01T00:00:00Z"
 
 
 def _stable_state_id(actor_id: object) -> int:
@@ -183,6 +205,7 @@ class ForecastObservationAdapter:
                 or "unknown"
             ),
             seed=int(trace.get("seed", trace.get("metadata", {}).get("seed", 0))),
+            timestamp=_forecast_timestamp(frame_payload),
             fallback_status="native",
             degraded_status="degraded_observation" if missing_actor_reasons else "none",
             actor_ids=actor_ids,

--- a/robot_sf/benchmark/schemas/forecast_batch.schema.v1.json
+++ b/robot_sf/benchmark/schemas/forecast_batch.schema.v1.json
@@ -1,0 +1,382 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/robot-sf/forecast_batch.schema.v1.json",
+    "title": "RobotSF ForecastBatch (v1)",
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+        "schema_version",
+        "provenance",
+        "forecasts"
+    ],
+    "properties": {
+        "schema_version": {
+            "const": "ForecastBatch.v1"
+        },
+        "provenance": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "predictor_id",
+                "predictor_family",
+                "observation_tier",
+                "timestamp",
+                "frame",
+                "dt_s",
+                "horizons_s",
+                "scenario_id",
+                "seed",
+                "fallback_status",
+                "degraded_status",
+                "actor_ids",
+                "actor_mask",
+                "actor_mask_metadata",
+                "feature_schema"
+            ],
+            "properties": {
+                "predictor_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Stable identifier for the predictor that produced this batch."
+                },
+                "predictor_family": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Predictor family such as constant_velocity, learned, or occupancy."
+                },
+                "observation_tier": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Observation level used as predictor input, e.g. tracked_agents or oracle_full_state."
+                },
+                "timestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "ISO 8601 timestamp for the forecast origin."
+                },
+                "frame": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "units",
+                        "axes"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Stable frame label such as world or robot."
+                        },
+                        "units": {
+                            "const": "m",
+                            "description": "Position units; ForecastBatch.v1 expects meters."
+                        },
+                        "axes": {
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "description": "Ordered axis names for each point coordinate."
+                        },
+                        "origin": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Optional human-readable origin description."
+                        }
+                    }
+                },
+                "dt_s": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "Forecast sampling interval in seconds."
+                },
+                "horizons_s": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "number",
+                        "exclusiveMinimum": 0
+                    },
+                    "description": "Strictly increasing forecast horizons in seconds."
+                },
+                "scenario_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Scenario identifier for grouping comparable forecasts."
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": "Random seed used to generate the scenario or predictor state."
+                },
+                "fallback_status": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Fallback mode for this forecast, e.g. native or fallback."
+                },
+                "degraded_status": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Degraded mode for this forecast, e.g. none or degraded_observation."
+                },
+                "actor_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "description": "Ordered list of actor identifiers in the forecast denominator."
+                },
+                "actor_mask": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "boolean"
+                    },
+                    "description": "Boolean mask aligned with actor_ids; true means a payload is expected."
+                },
+                "actor_mask_metadata": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "Semantics and reasons for missing actor payloads."
+                },
+                "feature_schema": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "Input feature schema consumed by the predictor."
+                },
+                "oracle_state": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True only when the artifact explicitly carries oracle-state fields."
+                },
+                "actor_classes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "description": "Optional actor-class labels keyed by actor id."
+                }
+            }
+        },
+        "forecasts": {
+            "type": "array",
+            "description": "Per-actor forecast payloads. Must match actor_mask=true actors exactly.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "actor_id"
+                ],
+                "anyOf": [
+                    {
+                        "required": [
+                            "deterministic"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "samples"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "gaussian"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "reachable_set"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "occupancy_summary"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "actor_id": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "deterministic": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        "description": "Deterministic point forecast with shape (T, 2).",
+                        "minItems": 1
+                    },
+                    "samples": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": {
+                                    "type": "number"
+                                }
+                            }
+                        },
+                        "description": "Sampled trajectories with shape (K, T, 2).",
+                        "minItems": 1
+                    },
+                    "mode_probabilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        },
+                        "description": "Mode probabilities aligned with samples; must sum to 1.",
+                        "minItems": 1
+                    },
+                    "gaussian": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "mean",
+                                "cov"
+                            ],
+                            "properties": {
+                                "mean": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": {
+                                        "type": "number"
+                                    },
+                                    "description": "Gaussian mean [x, y] for this horizon."
+                                },
+                                "cov": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                        "items": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "description": "2x2 Gaussian covariance matrix."
+                                }
+                            }
+                        },
+                        "description": "Per-horizon Gaussian parameter forecast.",
+                        "minItems": 1
+                    },
+                    "reachable_set": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "center",
+                                "set_type"
+                            ],
+                            "properties": {
+                                "center": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": {
+                                        "type": "number"
+                                    },
+                                    "description": "Set center [x, y] for this horizon."
+                                },
+                                "radius_m": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "description": "Circular set radius in meters."
+                                },
+                                "semi_axes_m": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": {
+                                        "type": "number",
+                                        "minimum": 0
+                                    },
+                                    "description": "Ellipse semi-axis lengths in meters."
+                                },
+                                "set_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "conformal_tube",
+                                        "reachable_set",
+                                        "confidence_ellipse"
+                                    ],
+                                    "description": "Kind of geometric uncertainty set."
+                                }
+                            },
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "set_type": {
+                                                "const": "conformal_tube"
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "required": [
+                                            "radius_m"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "set_type": {
+                                                "const": "confidence_ellipse"
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "required": [
+                                            "semi_axes_m"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "description": "Per-horizon reachable or conformal set forecast.",
+                        "minItems": 1
+                    },
+                    "occupancy_summary": {
+                        "type": "object",
+                        "description": "Occupancy grid or aggregated occupancy metadata.",
+                        "minProperties": 1
+                    },
+                    "uncertainty_metadata": {
+                        "type": "object",
+                        "description": "Predictor-specific uncertainty metadata."
+                    }
+                }
+            }
+        },
+        "metadata": {
+            "type": "object",
+            "description": "Optional batch-level metadata."
+        }
+    }
+}

--- a/robot_sf/benchmark/schemas/forecast_batch_schema.py
+++ b/robot_sf/benchmark/schemas/forecast_batch_schema.py
@@ -1,0 +1,221 @@
+"""
+ForecastBatchSchema entity for the ForecastBatch.v1 artifact contract.
+
+This module provides the ForecastBatchSchema entity that encapsulates the JSON
+schema definition for forecast batch artifacts, providing a programmatic
+interface for schema validation and metadata extraction.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from jsonschema import Draft202012Validator
+
+logger = logging.getLogger(__name__)
+
+
+class ForecastBatchSchema:
+    """
+    Entity representing a JSON schema definition for ForecastBatch.v1 data.
+
+    This class encapsulates the schema structure and provides methods for
+    validation, metadata extraction, and schema evolution tracking.
+    """
+
+    def __init__(self, schema_path: Path) -> None:
+        """
+        Initialize ForecastBatchSchema from a JSON schema file.
+
+        Args:
+            schema_path: Path to the JSON schema file
+
+        Raises:
+            FileNotFoundError: If schema file doesn't exist
+            json.JSONDecodeError: If schema file contains invalid JSON
+            ValueError: If schema is not a valid JSON Schema
+        """
+        self.schema_path = schema_path
+        self._schema_data: dict[str, Any] | None = None
+        self._version: str | None = None
+
+        self._load_schema()
+
+    def _load_schema(self) -> None:
+        """Load and validate the schema from file."""
+        if not self.schema_path.exists():
+            raise FileNotFoundError(f"Schema file not found: {self.schema_path}")
+
+        try:
+            with open(self.schema_path, encoding="utf-8") as f:
+                self._schema_data = json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in schema file {self.schema_path}: {e}") from e
+
+        self._validate_schema_structure()
+        self._extract_version()
+
+    def _validate_schema_structure(self) -> None:
+        """Validate that the loaded schema has required structure."""
+        if not isinstance(self._schema_data, dict):
+            raise ValueError("Schema must be a JSON object")
+
+        required_fields = ["$schema", "$id", "title", "type", "properties", "required"]
+        for field in required_fields:
+            if field not in self._schema_data:
+                raise ValueError(f"Schema missing required field: {field}")
+
+        if self._schema_data["$schema"] != "https://json-schema.org/draft/2020-12/schema":
+            raise ValueError("Schema must use JSON Schema draft 2020-12")
+
+        if self._schema_data["type"] != "object":
+            raise ValueError("Schema root type must be 'object'")
+
+        required_props = ["schema_version", "provenance", "forecasts"]
+        if not all(prop in self._schema_data["required"] for prop in required_props):
+            raise ValueError(f"Schema must require properties: {required_props}")
+
+    def _extract_version(self) -> None:
+        """Extract version information from schema."""
+        assert self._schema_data is not None, "Schema data must be loaded"
+        properties = self._schema_data.get("properties", {})
+        version_prop = properties.get("schema_version", {})
+
+        if "const" in version_prop:
+            self._version = version_prop["const"]
+        elif "enum" in version_prop and len(version_prop["enum"]) == 1:
+            self._version = version_prop["enum"][0]
+        else:
+            title = self._schema_data.get("title", "")
+            id_field = self._schema_data.get("$id", "")
+
+            version_match = re.search(r"v(\d+)", title) or re.search(r"v(\d+)", id_field)
+            if version_match:
+                self._version = f"v{version_match.group(1)}"
+            else:
+                self._version = "unknown"
+
+    @property
+    def schema_data(self) -> dict[str, Any]:
+        """Get the raw schema data."""
+        if self._schema_data is None:
+            raise RuntimeError("Schema not loaded")
+        return self._schema_data
+
+    @property
+    def version(self) -> str:
+        """Get the schema version."""
+        if self._version is None:
+            raise RuntimeError("Version not extracted")
+        return self._version
+
+    @property
+    def title(self) -> str:
+        """Get the schema title."""
+        return self._schema_data["title"]
+
+    @property
+    def schema_id(self) -> str:
+        """Get the schema $id."""
+        return self._schema_data["$id"]
+
+    @property
+    def required_properties(self) -> list[str]:
+        """Get the list of required properties."""
+        return self._schema_data["required"]
+
+    def get_property_schema(self, property_name: str) -> dict[str, Any]:
+        """
+        Get the schema definition for a specific property.
+
+        Args:
+            property_name: Name of the property
+
+        Returns:
+            Schema definition for the property
+
+        Raises:
+            KeyError: If property doesn't exist in schema
+        """
+        properties = self._schema_data.get("properties", {})
+        if property_name not in properties:
+            raise KeyError(f"Property '{property_name}' not defined in schema")
+        return properties[property_name]
+
+    def validate_forecast_batch_data(self, batch_data: dict[str, Any]) -> None:
+        """
+        Validate forecast batch data against this schema.
+
+        Args:
+            batch_data: Forecast batch data to validate
+
+        Raises:
+            ValueError: If data doesn't conform to schema
+        """
+        try:
+            jsonschema.validate(
+                instance=batch_data,
+                schema=self._schema_data,
+                format_checker=Draft202012Validator.FORMAT_CHECKER,
+            )
+        except jsonschema.ValidationError as e:
+            path = "/".join(str(part) for part in e.absolute_path) if e.absolute_path else "root"
+            raise ValueError(f"ForecastBatch data validation failed at {path}: {e.message}") from e
+
+    def is_backward_compatible_with(self, other_schema: "ForecastBatchSchema") -> bool:
+        """
+        Check if this schema is backward compatible with another schema.
+
+        Args:
+            other_schema: Schema to check compatibility against
+
+        Returns:
+            True if this schema is backward compatible with other_schema
+        """
+        try:
+            if self.version == other_schema.version:
+                return True
+            this_match = re.search(r"v(\d+)", self.version)
+            other_match = re.search(r"v(\d+)", other_schema.version)
+            if this_match is None or other_match is None:
+                return False
+            return int(this_match.group(1)) >= int(other_match.group(1))
+        except (ValueError, AttributeError):
+            return False
+
+    def __str__(self) -> str:
+        """String representation of the schema.
+
+        Returns:
+            Human-readable string showing version and title.
+        """
+        return f"ForecastBatchSchema(version={self.version}, title={self.title})"
+
+    def __repr__(self) -> str:
+        """Detailed string representation.
+
+        Returns:
+            Constructor-style representation showing schema path and version.
+        """
+        return f"ForecastBatchSchema(schema_path={self.schema_path}, version={self.version})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality based on schema content.
+
+        Returns:
+            True if both schemas have identical content.
+        """
+        if not isinstance(other, ForecastBatchSchema):
+            return False
+        return self._schema_data == other._schema_data
+
+    def __hash__(self) -> int:
+        """Hash based on schema content.
+
+        Returns:
+            Hash value computed from JSON-serialized schema data.
+        """
+        return hash(json.dumps(self._schema_data, sort_keys=True))

--- a/scripts/validation/validate_forecast_batch.py
+++ b/scripts/validation/validate_forecast_batch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Validate a ForecastBatch.v1 JSON artifact and emit a JSON report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.forecast_batch import validate_forecast_batch
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Validate a ForecastBatch.v1 JSON artifact against the typed contract."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to the ForecastBatch.v1 JSON file to validate.",
+    )
+    parser.add_argument(
+        "--schema-only",
+        action="store_true",
+        help=(
+            "Perform only JSON Schema structural validation; skip the stricter "
+            "dataclass contract checks (shape alignment, oracle gating, etc.)."
+        ),
+    )
+    return parser
+
+
+def _load_batch(path: Path) -> dict[str, Any]:
+    """Load and minimally check the input JSON object."""
+    if not path.exists():
+        raise ValueError(f"input file not found: {path}")
+    with path.open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    if not isinstance(data, dict):
+        raise ValueError("forecast batch JSON must be an object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate a ForecastBatch artifact and return a shell-friendly exit code."""
+    args = build_arg_parser().parse_args(argv)
+    try:
+        data = _load_batch(args.input)
+        if args.schema_only:
+            from robot_sf.benchmark.schemas.forecast_batch_schema import ForecastBatchSchema
+
+            schema_path = (
+                Path(__file__).resolve().parents[2]
+                / "robot_sf"
+                / "benchmark"
+                / "schemas"
+                / "forecast_batch.schema.v1.json"
+            )
+            schema = ForecastBatchSchema(schema_path)
+            schema.validate_forecast_batch_data(data)
+        else:
+            validate_forecast_batch(data)
+    except Exception as exc:
+        print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "valid",
+                "schema_version": data.get("schema_version"),
+                "predictor_id": data.get("provenance", {}).get("predictor_id"),
+                "scenario_id": data.get("provenance", {}).get("scenario_id"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/benchmark/test_forecast_batch.py
+++ b/tests/benchmark/test_forecast_batch.py
@@ -34,6 +34,7 @@ def _provenance(**overrides: object) -> ForecastBatchProvenance:
         "horizons_s": [0.5, 1.0],
         "scenario_id": "crosswalk_001",
         "seed": 7,
+        "timestamp": "2026-06-15T12:00:00Z",
         "fallback_status": "native",
         "degraded_status": "none",
         "actor_ids": ["ped_1", "ped_2"],
@@ -144,6 +145,7 @@ def test_forecast_batch_preserves_positional_oracle_state_argument_order() -> No
             "missing_actor_reasons": {},
         },
         {"name": "socnav_observation_v1", "features": ["position_m", "velocity_mps"]},
+        "2026-06-15T12:00:00Z",
         True,
     )
 

--- a/tests/benchmark/test_forecast_conformal_pilot.py
+++ b/tests/benchmark/test_forecast_conformal_pilot.py
@@ -39,6 +39,7 @@ def _batch(
             horizons_s=[0.5, 1.0],
             scenario_id=scenario_id,
             seed=1,
+            timestamp="2026-06-15T12:00:00Z",
             fallback_status="native",
             degraded_status="none",
             actor_ids=["actor-1"],
@@ -134,6 +135,7 @@ def test_conformal_pilot_marks_missing_deterministic_scores_as_limitation() -> N
     """Forecasts without deterministic trajectories cannot fit deterministic tubes."""
     no_deterministic = _batch(deterministic=None)
     no_deterministic.forecasts[0].deterministic = None
+    no_deterministic.forecasts[0].occupancy_summary = {"representation": "occupancy_only"}
 
     report = build_forecast_conformal_pilot_report(
         [_case(batch=no_deterministic)],

--- a/tests/benchmark/test_forecast_metrics.py
+++ b/tests/benchmark/test_forecast_metrics.py
@@ -29,6 +29,7 @@ def _provenance(**overrides: object) -> ForecastBatchProvenance:
         "horizons_s": [0.5, 1.0],
         "scenario_id": "scenario_a",
         "seed": 11,
+        "timestamp": "2026-06-15T12:00:00Z",
         "fallback_status": "native",
         "degraded_status": "none",
         "actor_ids": ["ped_1", "ped_2"],
@@ -216,7 +217,14 @@ def test_forecast_metrics_explain_missing_final_horizon_payloads() -> None:
     """Unavailable final-horizon metrics should carry a specific reason."""
     batch = ForecastBatch(
         provenance=_provenance(actor_mask=[True, False]),
-        forecasts=[ActorForecast(actor_id="ped_1", deterministic=None, samples=None)],
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=None,
+                samples=None,
+                occupancy_summary={"representation": "occupancy_only"},
+            )
+        ],
     )
     truth = {"ped_1": [[0.0, 0.0], [1.0, 0.0]]}
 

--- a/tests/benchmark/test_forecast_observation_adapters.py
+++ b/tests/benchmark/test_forecast_observation_adapters.py
@@ -82,6 +82,23 @@ def test_same_trace_adapts_to_oracle_and_tracked_tiers() -> None:
     assert len(tracked.actors) == 2
 
 
+@pytest.mark.parametrize("time_s", [True, float("inf")])
+def test_invalid_time_s_does_not_become_epoch_seconds(time_s: object) -> None:
+    """Invalid frame timing metadata should not be treated as numeric seconds."""
+    trace = _trace()
+    trace["frames"][0]["time_s"] = time_s
+    trace["frames"][0]["timestamp"] = "2026-06-15T12:00:00Z"
+
+    batch = TrackedAgentsForecastAdapter().adapt_trace(
+        trace,
+        feature_schema=_feature_schema(),
+        horizons_s=[0.5, 1.0],
+        expected_actor_ids=["1", "2"],
+    )
+
+    assert batch.provenance.timestamp == "2026-06-15T12:00:00Z"
+
+
 def test_one_pedestrian_happy_path_records_single_actor_denominator() -> None:
     """A single visible actor should remain a valid one-actor forecast denominator."""
     trace = {

--- a/tests/contract/test_forecast_batch_schema.py
+++ b/tests/contract/test_forecast_batch_schema.py
@@ -1,0 +1,502 @@
+"""Contract tests for the ForecastBatch.v1 JSON schema and typed validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.forecast_batch import (
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+    validate_forecast_batch,
+)
+from robot_sf.benchmark.schemas.forecast_batch_schema import ForecastBatchSchema
+
+try:
+    import jsonschema  # type: ignore
+except Exception as e:  # pragma: no cover
+    raise RuntimeError("jsonschema dependency required for contract tests") from e
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "forecast_batch.schema.v1.json"
+)
+
+CLI_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "validation" / "validate_forecast_batch.py"
+)
+
+
+def _load_schema() -> dict:
+    """Load the canonical ForecastBatch schema from the repository."""
+    text = SCHEMA_PATH.read_text()
+    return json.loads(text)
+
+
+def _valid_batch_dict() -> dict[str, object]:
+    """Return a JSON-compatible valid ForecastBatch fixture."""
+    return ForecastBatch(
+        provenance=ForecastBatchProvenance(
+            predictor_id="cv-baseline-v1",
+            predictor_family="constant_velocity",
+            observation_tier="deployable_observation",
+            frame=CoordinateFrame(name="world", units="m", axes=("x", "y")),
+            dt_s=0.5,
+            horizons_s=[0.5, 1.0],
+            scenario_id="crosswalk_001",
+            seed=7,
+            timestamp="2026-06-15T12:00:00Z",
+            fallback_status="native",
+            degraded_status="none",
+            actor_ids=["ped_1", "ped_2"],
+            actor_mask=[True, True],
+            actor_mask_metadata={
+                "semantics": "true means forecast payload is available for actor_id",
+                "missing_actor_reasons": {},
+            },
+            feature_schema={"name": "socnav_observation_v1", "features": ["position_m"]},
+        ),
+        forecasts=[
+            ActorForecast(actor_id="ped_1", deterministic=[[1.0, 0.0], [1.5, 0.0]]),
+            ActorForecast(actor_id="ped_2", deterministic=[[0.0, 1.0], [0.0, 1.5]]),
+        ],
+    ).to_dict()
+
+
+def test_forecast_batch_schema_entity_loads_and_reports_version() -> None:
+    """The ForecastBatchSchema entity should load the canonical JSON schema."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+
+    assert schema.version == "ForecastBatch.v1"
+    assert schema.title == "RobotSF ForecastBatch (v1)"
+    assert schema.schema_id.endswith("forecast_batch.schema.v1.json")
+    assert schema.schema_data["type"] == "object"
+    assert "schema_version" in schema.required_properties
+    assert "provenance" in schema.required_properties
+    assert "forecasts" in schema.required_properties
+    assert schema.get_property_schema("schema_version")["const"] == "ForecastBatch.v1"
+    assert "ForecastBatch.v1" in str(schema)
+    assert schema == ForecastBatchSchema(SCHEMA_PATH)
+    assert schema != object()
+    assert hash(schema) == hash(ForecastBatchSchema(SCHEMA_PATH))
+
+
+def test_forecast_batch_schema_entity_reports_missing_property() -> None:
+    """Property lookup should fail closed for unknown schema keys."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+
+    with pytest.raises(KeyError, match="not defined"):
+        schema.get_property_schema("not_a_property")
+
+
+def test_forecast_batch_schema_entity_rejects_missing_file(tmp_path: Path) -> None:
+    """A missing schema file should raise a useful error."""
+    with pytest.raises(FileNotFoundError, match="Schema file not found"):
+        ForecastBatchSchema(tmp_path / "missing.schema.json")
+
+
+def test_forecast_batch_schema_entity_rejects_malformed_json(tmp_path: Path) -> None:
+    """Malformed schema JSON should fail before validation."""
+    schema_path = tmp_path / "bad.schema.json"
+    schema_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        ForecastBatchSchema(schema_path)
+
+
+@pytest.mark.parametrize(
+    ("schema_update", "message"),
+    [
+        (lambda schema: schema.pop("$id"), "missing required field"),
+        (
+            lambda schema: schema.__setitem__("$schema", "https://json-schema.org/draft-07/schema"),
+            "draft 2020-12",
+        ),
+        (lambda schema: schema.__setitem__("type", "array"), "root type"),
+        (
+            lambda schema: schema.__setitem__("required", ["schema_version"]),
+            "must require properties",
+        ),
+    ],
+)
+def test_forecast_batch_schema_entity_rejects_invalid_schema_structure(
+    tmp_path: Path,
+    schema_update,
+    message: str,
+) -> None:
+    """Schema loader should reject structures that cannot describe ForecastBatch.v1."""
+    schema_data = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_update(schema_data)
+    schema_path = tmp_path / "invalid.schema.json"
+    schema_path.write_text(json.dumps(schema_data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        ForecastBatchSchema(schema_path)
+
+
+@pytest.mark.parametrize(
+    ("version_property", "expected_version"),
+    [
+        ({"enum": ["ForecastBatch.v1"]}, "ForecastBatch.v1"),
+        ({}, "v1"),
+    ],
+)
+def test_forecast_batch_schema_entity_extracts_version_fallbacks(
+    tmp_path: Path,
+    version_property: dict[str, object],
+    expected_version: str,
+) -> None:
+    """Version extraction should handle enum and title/id fallback schemas."""
+    schema_data = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_data["properties"]["schema_version"] = version_property
+    schema_path = tmp_path / "fallback.schema.json"
+    schema_path.write_text(json.dumps(schema_data), encoding="utf-8")
+
+    assert ForecastBatchSchema(schema_path).version == expected_version
+
+
+def test_forecast_batch_schema_entity_extracts_unknown_version(tmp_path: Path) -> None:
+    """A schema without version clues should report unknown rather than guessing."""
+    schema_data = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_data["title"] = "ForecastBatch schema"
+    schema_data["$id"] = "https://example.com/robot-sf/forecast_batch.schema.json"
+    schema_data["properties"]["schema_version"] = {}
+    schema_path = tmp_path / "unknown.schema.json"
+    schema_path.write_text(json.dumps(schema_data), encoding="utf-8")
+
+    assert ForecastBatchSchema(schema_path).version == "unknown"
+
+
+def test_forecast_batch_schema_entity_backward_compatibility_is_conservative() -> None:
+    """Matching ForecastBatch versions are compatible; unknown versions are not."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+
+    assert schema.is_backward_compatible_with(ForecastBatchSchema(SCHEMA_PATH)) is True
+    assert schema.is_backward_compatible_with(object()) is False
+
+
+def test_forecast_batch_schema_valid_minimal_passes() -> None:
+    """A minimal valid ForecastBatch should pass JSON Schema validation."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    jsonschema.validate(instance=batch, schema=schema)
+
+
+def test_forecast_batch_schema_rejects_missing_frame() -> None:
+    """A missing top-level frame should fail JSON Schema validation."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    provenance = dict(batch["provenance"])  # type: ignore[arg-type]
+    provenance.pop("frame")
+    batch["provenance"] = provenance
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=batch, schema=schema)
+
+
+def test_forecast_batch_schema_rejects_wrong_horizon_shape() -> None:
+    """A deterministic trajectory with the wrong horizon count should fail the contract."""
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [{"actor_id": "ped_1", "deterministic": [[1.0, 0.0]]}]
+    batch["provenance"]["actor_mask"] = [True, False]
+    batch["provenance"]["actor_mask_metadata"]["missing_actor_reasons"] = {"ped_2": "not visible"}
+
+    with pytest.raises(ValueError, match="horizons_s"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_missing_timestamp() -> None:
+    """A missing provenance timestamp should fail the typed validator."""
+    batch = _valid_batch_dict()
+    provenance = dict(batch["provenance"])  # type: ignore[arg-type]
+    provenance.pop("timestamp")
+    batch["provenance"] = provenance
+
+    with pytest.raises(ValueError, match="timestamp"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_invalid_timestamp() -> None:
+    """A non-ISO timestamp should fail the typed validator."""
+    batch = _valid_batch_dict()
+    batch["provenance"]["timestamp"] = "2026-06-15"
+
+    with pytest.raises(ValueError, match="timestamp"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_entity_rejects_non_datetime_timestamp() -> None:
+    """The structural schema validator should enforce JSON Schema date-time format."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+    batch = _valid_batch_dict()
+    batch["provenance"]["timestamp"] = "not-a-date-time"
+
+    with pytest.raises(ValueError, match="timestamp"):
+        schema.validate_forecast_batch_data(batch)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "2026-06-15T99:99:99Z",
+        "2026-06-15T12:00:00",
+    ],
+)
+def test_forecast_batch_schema_rejects_malformed_or_naive_timestamp(timestamp: str) -> None:
+    """Forecast timestamps should be parseable and timezone-qualified."""
+    batch = _valid_batch_dict()
+    batch["provenance"]["timestamp"] = timestamp
+
+    with pytest.raises(ValueError, match="timestamp"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_stale_provenance() -> None:
+    """Empty required provenance strings should fail the typed validator."""
+    batch = _valid_batch_dict()
+    batch["provenance"]["predictor_id"] = ""
+
+    with pytest.raises(ValueError, match="predictor_id"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_tracks_fallback_and_degraded_status() -> None:
+    """Fallback and degraded status should survive validation and be discoverable."""
+    batch = _valid_batch_dict()
+    batch["provenance"]["fallback_status"] = "fallback"
+    batch["provenance"]["degraded_status"] = "degraded_observation"
+
+    loaded = validate_forecast_batch(batch)
+
+    assert loaded.provenance.fallback_status == "fallback"
+    assert loaded.provenance.degraded_status == "degraded_observation"
+
+
+def test_forecast_batch_schema_probabilistic_example_passes() -> None:
+    """A probabilistic forecast with samples, modes, Gaussian, and reachable sets passes."""
+    batch = _valid_batch_dict()
+    batch["provenance"]["actor_mask"] = [True, False]
+    batch["provenance"]["actor_mask_metadata"]["missing_actor_reasons"] = {"ped_2": "occluded"}
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "samples": [
+                [[1.0, 0.0], [1.5, 0.0]],
+                [[1.0, 0.1], [1.4, 0.2]],
+            ],
+            "mode_probabilities": [0.6, 0.4],
+            "gaussian": [
+                {"mean": [1.0, 0.0], "cov": [[0.1, 0.0], [0.0, 0.1]]},
+                {"mean": [1.5, 0.0], "cov": [[0.2, 0.0], [0.0, 0.2]]},
+            ],
+            "reachable_set": [
+                {
+                    "center": [1.0, 0.0],
+                    "radius_m": 0.5,
+                    "set_type": "conformal_tube",
+                },
+                {
+                    "center": [1.5, 0.0],
+                    "semi_axes_m": [0.6, 0.4],
+                    "set_type": "confidence_ellipse",
+                },
+            ],
+        }
+    ]
+
+    loaded = validate_forecast_batch(batch)
+
+    assert loaded.forecasts[0].gaussian is not None
+    assert len(loaded.forecasts[0].gaussian) == 2
+    assert loaded.forecasts[0].reachable_set is not None
+    assert loaded.forecasts[0].reachable_set[1]["set_type"] == "confidence_ellipse"
+
+
+def test_forecast_batch_schema_gaussian_must_align_with_horizons() -> None:
+    """Gaussian parameter lists must have one entry per horizon."""
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "deterministic": [[1.0, 0.0], [1.5, 0.0]],
+            "gaussian": [{"mean": [1.0, 0.0], "cov": [[0.1, 0.0], [0.0, 0.1]]}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="gaussian"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_empty_actor_forecast_payload() -> None:
+    """A forecast item with only actor_id is incomplete and should fail closed."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [{"actor_id": "ped_1"}, {"actor_id": "ped_2"}]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=batch, schema=schema)
+    with pytest.raises(ValueError, match="prediction representation"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_mode_probabilities_without_samples() -> None:
+    """Mode probabilities are only meaningful when aligned with sample trajectories."""
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "deterministic": [[1.0, 0.0], [1.5, 0.0]],
+            "mode_probabilities": [1.0],
+        },
+        {
+            "actor_id": "ped_2",
+            "deterministic": [[0.0, 1.0], [0.0, 1.5]],
+        },
+    ]
+
+    with pytest.raises(ValueError, match="sampled trajectories"):
+        validate_forecast_batch(batch)
+
+
+@pytest.mark.parametrize(
+    "forecast",
+    [
+        {"actor_id": "ped_1", "deterministic": []},
+        {"actor_id": "ped_1", "samples": []},
+        {"actor_id": "ped_1", "gaussian": []},
+        {"actor_id": "ped_1", "reachable_set": []},
+        {"actor_id": "ped_1", "occupancy_summary": {}},
+        {
+            "actor_id": "ped_1",
+            "samples": [[[1.0, 0.0], [1.5, 0.0]]],
+            "mode_probabilities": [1.2],
+        },
+    ],
+)
+def test_forecast_batch_schema_rejects_structurally_empty_payloads(
+    forecast: dict[str, object],
+) -> None:
+    """A present forecast representation must contain useful payload content."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [forecast, {"actor_id": "ped_2", "occupancy_summary": {"kind": "grid"}}]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=batch, schema=schema)
+
+
+def test_forecast_batch_schema_reachable_set_must_align_with_horizons() -> None:
+    """Reachable or conformal sets must have one entry per horizon."""
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "reachable_set": [
+                {"center": [1.0, 0.0], "radius_m": 0.5, "set_type": "conformal_tube"}
+            ],
+        },
+        {
+            "actor_id": "ped_2",
+            "deterministic": [[0.0, 1.0], [0.0, 1.5]],
+        },
+    ]
+
+    with pytest.raises(ValueError, match="reachable_set"):
+        validate_forecast_batch(batch)
+
+
+def test_forecast_batch_schema_rejects_unknown_reachable_set_type() -> None:
+    """The JSON schema should reject unsupported reachable-set types."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "deterministic": [[1.0, 0.0], [1.5, 0.0]],
+            "reachable_set": [{"center": [1.0, 0.0], "set_type": "unknown_kind"}],
+        }
+    ]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=batch, schema=schema)
+
+
+@pytest.mark.parametrize(
+    "reachable_set",
+    [
+        [{"center": [1.0, 0.0], "set_type": "conformal_tube"}],
+        [{"center": [1.0, 0.0], "set_type": "confidence_ellipse"}],
+    ],
+)
+def test_forecast_batch_schema_requires_reachable_set_shape_fields(
+    reachable_set: list[dict[str, object]],
+) -> None:
+    """Reachable-set variants should declare their required geometry parameters."""
+    schema = _load_schema()
+    batch = _valid_batch_dict()
+    batch["forecasts"] = [
+        {
+            "actor_id": "ped_1",
+            "deterministic": [[1.0, 0.0], [1.5, 0.0]],
+            "reachable_set": reachable_set,
+        }
+    ]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=batch, schema=schema)
+
+
+def test_forecast_batch_schema_entity_validates_batch_data() -> None:
+    """ForecastBatchSchema.validate_forecast_batch_data should fail closed."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+    batch = _valid_batch_dict()
+    schema.validate_forecast_batch_data(batch)
+
+    batch["schema_version"] = "wrong"
+    with pytest.raises(ValueError, match="schema_version"):
+        schema.validate_forecast_batch_data(batch)
+
+
+def test_forecast_batch_cli_validates_valid_batch(tmp_path: Path) -> None:
+    """The CLI validator should accept a valid ForecastBatch artifact."""
+    batch_path = tmp_path / "batch.json"
+    batch_path.write_text(json.dumps(_valid_batch_dict()), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(CLI_PATH), "--input", str(batch_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert summary["status"] == "valid"
+    assert summary["schema_version"] == "ForecastBatch.v1"
+
+
+def test_forecast_batch_cli_rejects_invalid_batch(tmp_path: Path) -> None:
+    """The CLI validator should reject an artifact with missing timestamp."""
+    batch_path = tmp_path / "batch.json"
+    batch = _valid_batch_dict()
+    batch["provenance"].pop("timestamp")
+    batch_path.write_text(json.dumps(batch), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(CLI_PATH), "--input", str(batch_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "timestamp" in result.stdout


### PR DESCRIPTION
## Summary

- Define the canonical `ForecastBatch.v1` JSON Schema plus a `ForecastBatchSchema` loader/validator.
- Tighten the typed ForecastBatch contract with required timezone-qualified timestamps, Gaussian and reachable/conformal payloads, fail-closed empty-payload checks, and stricter mode-probability alignment.
- Address review feedback by making schema-version compatibility parsing robust, excluding invalid `time_s` values from numeric timestamp conversion, enforcing JSON Schema date-time format checks, requiring non-empty structural payloads, and requiring reachable-set geometry fields by `set_type`.
- Add a ForecastBatch CLI validator, contract tests, validated docs examples, and prediction-lane documentation updates.

Closes #2913.

## Validation

- `uv run pytest tests/contract/test_forecast_batch_schema.py tests/benchmark/test_forecast_batch.py tests/benchmark/test_forecast_metrics.py tests/benchmark/test_forecast_conformal_pilot.py tests/benchmark/test_forecast_observation_adapters.py -q` — 86 passed.
- `uv run pytest tests/contract/test_forecast_batch_schema.py tests/benchmark/test_forecast_observation_adapters.py -q` — 54 passed after review fixes.
- `uv run pytest tests/benchmark tests/contract -q --ignore=tests/benchmark/test_parquet_export.py` — 1242 passed, 1 skipped before full extras bootstrap.
- `uv run python <docs example validator>` — validated 2 JSON examples against both `ForecastBatchSchema` and the typed ForecastBatch loader.
- `uv run ruff check ... && uv run ruff format --check ... && git diff --check` — passed.
- `uv sync --all-extras`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on `f554be2e5924e6e05d0dc325ac216ea80a8282d7`: 6787 passed, 9 skipped, 8 warnings; readiness stamp `output/validation/pr_ready/issue-2913-forecast-batch-schema.json` recorded `status: passed`, `tree_state: clean`.

## Downstream Propagation

- Parent issue: #2913.
- Parent forecast lane context: updated `docs/context/issue_2836_forecast_batch_schema.md`.
- AI-facing forecast lane map: updated `docs/ai/prediction_lane.md`.
- No leaderboard, benchmark result, model registry, or artifact catalog update is needed; this PR defines a schema/validation contract and does not promote benchmark results.

## Research Result Guidance

- Target claim/hypothesis/blocker: prediction artifacts need a fail-closed comparable contract before forecast-aware planning and learned predictor evidence can be interpreted.
- Comparator/baseline: existing typed ForecastBatch contract without canonical JSON Schema, CLI validation, required timestamp, Gaussian/reachable-set fields, or empty-payload fail-closed tests.
- Evidence tier: schema/contract validation, not benchmark evidence.
- Result classification: support/tooling contract accepted if CI remains green.
- Decision/stop rule: invalid/incomplete artifacts fail closed; docs examples validate through both structural and typed validators.
- Synthesis surface/update target: #2913 plus the forecast schema context note.
