### PR TITLE
fix: structure lineage proxy metadata

### DIFF
--- a/docs/context/issue_2659_lineage_schema_unification.md
+++ b/docs/context/issue_2659_lineage_schema_unification.md
@@ -52,3 +52,14 @@ older consumers can continue reading `source`, `generator`, `claim_boundary`, `e
 The shared helper validates field presence and basic types; it does not prove a manifest is
 executable, benchmark-valid, or complete for paper-facing claims. Downstream benchmark claims still
 need executable evidence, denominator review, and fail-closed handling.
+
+## Issue #2906 Backfill Proxy Metadata Update 2026-06-16
+
+Issue #2906 extends manifest-lineage backfill entries with structured proxy metadata:
+`candidate_sources`, `conflicting_sources`, and `blocked_by`. The graph builder uses these fields
+for proxy-source edges instead of parsing human-readable `reason` text, while retaining the reason
+string for reader context and legacy fallback.
+
+This remains reviewability and artifact-quality work only. It hardens graph topology against wording
+changes, but it does not upgrade any manifest, graph row, or artifact candidate into benchmark or
+paper-facing evidence.

--- a/robot_sf/benchmark/manifest_lineage_backfill.py
+++ b/robot_sf/benchmark/manifest_lineage_backfill.py
@@ -157,6 +157,9 @@ class FieldBackfillEntry:
     inferred_value: str | dict[str, Any] | None = None
     inferred_from: str | None = None
     reason: str = ""
+    candidate_sources: tuple[str, ...] = ()
+    conflicting_sources: tuple[str, ...] = ()
+    blocked_by: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -247,6 +250,7 @@ def _classify_field(
             return FieldBackfillEntry(
                 field_name=field_name,
                 status=FieldStatus.BLOCKED,
+                blocked_by=tuple(invalid_labels),
                 reason=(
                     f"nearby field has incompatible value for {field_name}: "
                     f"{', '.join(invalid_labels)}"
@@ -258,13 +262,15 @@ def _classify_field(
             reason=f"no nearby field available to infer {field_name}",
         )
     if invalid_labels:
-        source_labels = [label for label, _ in values] + invalid_labels
+        source_labels = [label for label, _ in values]
         return FieldBackfillEntry(
             field_name=field_name,
             status=FieldStatus.AMBIGUOUS,
+            candidate_sources=tuple(source_labels),
+            blocked_by=tuple(invalid_labels),
             reason=(
                 f"valid and invalid inference candidates for {field_name}: "
-                f"{', '.join(source_labels)}"
+                f"{', '.join(source_labels + invalid_labels)}"
             ),
         )
     if len(values) == 1:
@@ -274,24 +280,27 @@ def _classify_field(
             status=FieldStatus.INFERRED,
             inferred_value=val,
             inferred_from=source_label,
+            candidate_sources=(source_label,),
             reason=f"inferred from {source_label}",
         )
     first_label, first_value = values[0]
+    labels = tuple(label for label, _ in values)
     if all(value == first_value for _, value in values[1:]):
         return FieldBackfillEntry(
             field_name=field_name,
             status=FieldStatus.INFERRED,
             inferred_value=first_value,
             inferred_from=first_label,
-            reason=f"inferred from matching candidates: {', '.join(label for label, _ in values)}",
+            candidate_sources=labels,
+            reason=f"inferred from matching candidates: {', '.join(labels)}",
         )
 
     # Multiple conflicting candidates: ambiguous.
-    source_labels = ", ".join(label for label, _ in values)
     return FieldBackfillEntry(
         field_name=field_name,
         status=FieldStatus.AMBIGUOUS,
-        reason=f"multiple inference candidates: {source_labels}",
+        conflicting_sources=labels,
+        reason=f"multiple inference candidates: {', '.join(labels)}",
     )
 
 

--- a/robot_sf/benchmark/manifest_lineage_graph.py
+++ b/robot_sf/benchmark/manifest_lineage_graph.py
@@ -385,28 +385,15 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
                 continue
 
             if entry.status == FieldStatus.INFERRED and entry.inferred_from is not None:
-                proxy_id = _proxy_node_id(rel_path, entry.inferred_from)
-                if proxy_id not in nodes:
-                    nodes[proxy_id] = LineageNode(
-                        node_id=proxy_id,
-                        kind="proxy_source",
-                        label=entry.inferred_from,
-                        path=rel_path,
-                        status=LineageStatus.CONNECTED,
-                    )
-                edges.append(
-                    LineageEdge(
-                        source=field_id,
-                        target=proxy_id,
-                        kind="inferred_from",
-                        reason=entry.reason or f"inferred from {entry.inferred_from}",
-                        payload={"inferred_value": entry.inferred_value},
-                    )
-                )
+                _add_inferred_proxy_edge(nodes, edges, rel_path, field_id, entry)
                 continue
 
-            # Missing, ambiguous, or blocked: derive proxy-related edges from reason.
-            proxy_labels = _parse_proxy_labels(entry.reason)
+            # Derive proxy-related edges from structured metadata.  Older plans
+            # that only stored a reason string fall back to parsing the reason.
+            edge_kind, proxy_labels = _proxy_edge_kind_and_labels(entry)
+            if not edge_kind:
+                continue
+
             for label in proxy_labels:
                 proxy_id = _proxy_node_id(rel_path, label)
                 if proxy_id not in nodes:
@@ -417,9 +404,6 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
                         path=rel_path,
                         status=field_status,
                     )
-                edge_kind = (
-                    "ambiguous_between" if entry.status == FieldStatus.AMBIGUOUS else "blocked_by"
-                )
                 edges.append(
                     LineageEdge(
                         source=field_id,
@@ -506,11 +490,64 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
     )
 
 
+def _add_inferred_proxy_edge(
+    nodes: dict[str, LineageNode],
+    edges: list[LineageEdge],
+    rel_path: str,
+    field_id: str,
+    entry: FieldBackfillEntry,
+) -> None:
+    """Add an inferred_from edge between a field and its proxy source."""
+    assert entry.inferred_from is not None
+    proxy_id = _proxy_node_id(rel_path, entry.inferred_from)
+    if proxy_id not in nodes:
+        nodes[proxy_id] = LineageNode(
+            node_id=proxy_id,
+            kind="proxy_source",
+            label=entry.inferred_from,
+            path=rel_path,
+            status=LineageStatus.CONNECTED,
+        )
+    edges.append(
+        LineageEdge(
+            source=field_id,
+            target=proxy_id,
+            kind="inferred_from",
+            reason=entry.reason or f"inferred from {entry.inferred_from}",
+            payload={"inferred_value": entry.inferred_value},
+        )
+    )
+
+
+def _proxy_edge_kind_and_labels(entry: FieldBackfillEntry) -> tuple[str, list[str]]:
+    """Return the edge kind and proxy labels for a non-present field entry.
+
+    Uses structured metadata first, and falls back to parsing the reason
+    string only for legacy plans that did not store structured metadata.
+    """
+    if entry.status == FieldStatus.AMBIGUOUS:
+        labels = list(entry.candidate_sources + entry.conflicting_sources + entry.blocked_by)
+        edge_kind = "ambiguous_between"
+    elif entry.status == FieldStatus.BLOCKED:
+        labels = list(entry.blocked_by)
+        edge_kind = "blocked_by"
+    else:
+        return "", []
+
+    if not labels and entry.reason:
+        labels = _parse_proxy_labels(entry.reason)
+    return edge_kind, labels
+
+
 def _parse_proxy_labels(reason: str) -> list[str]:
     """Extract dotted proxy labels from a backfill reason string.
 
-    This is a best-effort parser for human-readable reason strings.  It looks
-    for labels like ``metadata.generator_id`` or ``config.validator_version``.
+    This is a best-effort parser kept only for backward compatibility with
+    older serialized plans that did not store structured proxy metadata.
+    Newly produced ``FieldBackfillEntry`` objects should rely on
+    ``candidate_sources``, ``conflicting_sources``, and ``blocked_by`` instead.
+    It looks for labels like ``metadata.generator_id`` or
+    ``config.validator_version``.
     """
     labels: list[str] = []
     # Split on common separators and punctuation.

--- a/tests/benchmark/test_manifest_lineage_backfill.py
+++ b/tests/benchmark/test_manifest_lineage_backfill.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from robot_sf.benchmark.manifest_lineage_backfill import (
+    FieldBackfillEntry,
     FieldStatus,
     ManifestBackfillPlan,
     analyze_manifest,
@@ -442,3 +443,123 @@ def test_human_readable_output_includes_status_markers(
     )
     captured = capsys.readouterr()
     assert "INFERRED" in captured.out
+
+
+# Structured proxy metadata tests
+
+
+def test_inferred_entry_has_candidate_sources() -> None:
+    """INFERRED entries record the proxy source label in candidate_sources."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": "gen-a"},
+    }
+    plan = analyze_manifest(manifest, path="inferred.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.INFERRED
+    assert gid.candidate_sources == ("metadata.generator_id",)
+    assert gid.conflicting_sources == ()
+    assert gid.blocked_by == ()
+
+
+def test_matching_inferred_entry_records_all_candidate_sources() -> None:
+    """INFERRED entries from matching candidates record every source label."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": "gen-a"},
+        "config": {"generator_id": "gen-a"},
+    }
+    plan = analyze_manifest(manifest, path="matching.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.INFERRED
+    assert set(gid.candidate_sources) == {"metadata.generator_id", "config.generator_id"}
+    assert gid.conflicting_sources == ()
+    assert gid.blocked_by == ()
+
+
+def test_ambiguous_entry_has_conflicting_sources() -> None:
+    """AMBIGUOUS entries from conflicting values record conflicting_sources."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"validator_version": "1.0"},
+        "config": {"validator_version": "2.0"},
+    }
+    plan = analyze_manifest(manifest, path="ambiguous.json")
+
+    vv = next(f for f in plan.fields if f.field_name == "validator_version")
+    assert vv.status == FieldStatus.AMBIGUOUS
+    assert set(vv.conflicting_sources) == {"metadata.validator_version", "config.validator_version"}
+    assert vv.blocked_by == ()
+
+
+def test_ambiguous_valid_and_invalid_entry_has_candidate_and_blocked_sources() -> None:
+    """AMBIGUOUS entries with valid and invalid candidates keep both groups."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": "gen-a"},
+        "config": {"generator_id": ""},
+    }
+    plan = analyze_manifest(manifest, path="valid_and_invalid.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.AMBIGUOUS
+    assert gid.candidate_sources == ("metadata.generator_id",)
+    assert gid.blocked_by == ("config.generator_id",)
+    assert gid.conflicting_sources == ()
+
+
+def test_blocked_entry_has_blocked_by_sources() -> None:
+    """BLOCKED entries record invalid nearby source labels in blocked_by."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": ""},
+    }
+    plan = analyze_manifest(manifest, path="blocked.json")
+
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    assert gid.status == FieldStatus.BLOCKED
+    assert gid.blocked_by == ("metadata.generator_id",)
+    assert gid.candidate_sources == ()
+    assert gid.conflicting_sources == ()
+
+
+def test_missing_entry_has_empty_structured_metadata() -> None:
+    """MISSING entries carry no structured proxy metadata."""
+    plan = analyze_manifest({"schema_version": "benchmark_claim.v1"}, path="missing.json")
+
+    src = next(f for f in plan.fields if f.field_name == "source")
+    assert src.status == FieldStatus.MISSING
+    assert src.candidate_sources == ()
+    assert src.conflicting_sources == ()
+    assert src.blocked_by == ()
+
+
+def test_plan_to_dict_serializes_structured_metadata() -> None:
+    """ManifestBackfillPlan.to_dict() includes structured proxy metadata."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": "gen-a"},
+        "config": {"generator_id": ""},
+    }
+    plan = analyze_manifest(manifest, path="serial.json")
+    d = plan.to_dict()
+
+    gid = next(f for f in d["fields"] if f["field_name"] == "generator_id")
+    assert gid["candidate_sources"] == ("metadata.generator_id",)
+    assert gid["blocked_by"] == ("config.generator_id",)
+    assert gid["conflicting_sources"] == ()
+
+
+def test_field_backfill_entry_defaults_keep_backward_compatibility() -> None:
+    """FieldBackfillEntry can still be constructed without structured fields."""
+    entry = FieldBackfillEntry(
+        field_name="generator_id",
+        status=FieldStatus.MISSING,
+        reason="legacy reason",
+    )
+    assert entry.candidate_sources == ()
+    assert entry.conflicting_sources == ()
+    assert entry.blocked_by == ()
+    assert entry.reason == "legacy reason"

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 import pytest
 
+from robot_sf.benchmark.manifest_lineage_backfill import (
+    FieldBackfillEntry,
+    ManifestBackfillPlan,
+    analyze_manifest,
+)
 from robot_sf.benchmark.manifest_lineage_graph import (
     LineageStatus,
     build_manifest_lineage_graph,
@@ -451,3 +456,163 @@ def test_ambiguous_field_produces_ambiguous_edges() -> None:
     assert len(ambiguous_edges) >= 1
     labels = {edge.source.split("__")[-1] for edge in ambiguous_edges}
     assert "validator_version" in labels
+
+
+def test_graph_edges_derive_from_structured_metadata() -> None:
+    """Proxy edges are driven by structured metadata, not the reason string."""
+    manifest_path = FIXTURE_DIR / "ambiguous_manifest.json"
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    ambiguous_edges = [edge for edge in graph.edges if edge.kind == "ambiguous_between"]
+    assert ambiguous_edges
+    for edge in ambiguous_edges:
+        assert edge.source.startswith("field__")
+        assert edge.target.startswith("proxy__")
+
+
+def test_reason_wording_change_does_not_change_topology(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wording-only reason change leaves graph topology unchanged."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"validator_version": "1.0"},
+        "config": {"validator_version": "2.0"},
+    }
+    plan_original = analyze_manifest(manifest, path="reason_test.json")
+
+    # Build a plan with the same structured metadata but a custom reason.
+    original_vv = next(f for f in plan_original.fields if f.field_name == "validator_version")
+    custom_entry = FieldBackfillEntry(
+        field_name=original_vv.field_name,
+        status=original_vv.status,
+        reason="completely different wording",
+        candidate_sources=original_vv.candidate_sources,
+        conflicting_sources=original_vv.conflicting_sources,
+        blocked_by=original_vv.blocked_by,
+    )
+    custom_plan = ManifestBackfillPlan(
+        path=plan_original.path,
+        validation_errors=plan_original.validation_errors,
+        fields=[
+            custom_entry if f.field_name == "validator_version" else f for f in plan_original.fields
+        ],
+        has_inferred=plan_original.has_inferred,
+        has_ambiguous=plan_original.has_ambiguous,
+        has_blocked=plan_original.has_blocked,
+    )
+
+    manifest_path = tmp_path / "reason_test.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    graph_original = build_manifest_lineage_graph([manifest_path])
+
+    # Align the custom plan path with the real file so node ids match.
+    custom_plan_aligned = ManifestBackfillPlan(
+        path=str(manifest_path),
+        validation_errors=custom_plan.validation_errors,
+        fields=custom_plan.fields,
+        has_inferred=custom_plan.has_inferred,
+        has_ambiguous=custom_plan.has_ambiguous,
+        has_blocked=custom_plan.has_blocked,
+    )
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.manifest_lineage_graph._analyze_manifest_at_path",
+        lambda _path: custom_plan_aligned,
+    )
+    graph_custom = build_manifest_lineage_graph([manifest_path])
+
+    original_edges = _sorted_edge_tuples(graph_original.edges)
+    custom_edges = _sorted_edge_tuples(graph_custom.edges)
+    assert original_edges == custom_edges
+
+
+def test_ambiguous_valid_and_invalid_sources_are_structured_edges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AMBIGUOUS valid+invalid sources keep both groups in graph edges."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"generator_id": "gen-a"},
+        "config": {"generator_id": ""},
+    }
+    plan = analyze_manifest(manifest, path="valid_invalid_graph.json")
+    gid = next(f for f in plan.fields if f.field_name == "generator_id")
+    custom_entry = FieldBackfillEntry(
+        field_name=gid.field_name,
+        status=gid.status,
+        reason="wording without dotted labels",
+        candidate_sources=gid.candidate_sources,
+        blocked_by=gid.blocked_by,
+    )
+    manifest_path = tmp_path / "valid_invalid_graph.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    custom_plan = ManifestBackfillPlan(
+        path=str(manifest_path),
+        validation_errors=plan.validation_errors,
+        fields=[custom_entry if f.field_name == "generator_id" else f for f in plan.fields],
+        has_inferred=plan.has_inferred,
+        has_ambiguous=plan.has_ambiguous,
+        has_blocked=plan.has_blocked,
+    )
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.manifest_lineage_graph._analyze_manifest_at_path",
+        lambda _path: custom_plan,
+    )
+    graph = build_manifest_lineage_graph([manifest_path])
+
+    ambiguous_edges = [
+        edge
+        for edge in graph.edges
+        if edge.kind == "ambiguous_between" and edge.source.endswith("__generator_id")
+    ]
+    targets = {edge.target for edge in ambiguous_edges}
+    assert any("metadata_generator_id" in target for target in targets)
+    assert any("config_generator_id" in target for target in targets)
+
+
+def test_legacy_reason_fallback_still_produces_edges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Entries with only a reason string still produce proxy edges via fallback."""
+    manifest = {
+        "schema_version": "benchmark_claim.v1",
+        "metadata": {"validator_version": "1.0"},
+        "config": {"validator_version": "2.0"},
+    }
+    plan = analyze_manifest(manifest, path="legacy_fallback.json")
+    original_vv = next(f for f in plan.fields if f.field_name == "validator_version")
+
+    legacy_entry = FieldBackfillEntry(
+        field_name=original_vv.field_name,
+        status=original_vv.status,
+        reason="multiple inference candidates: metadata.validator_version, config.validator_version",
+    )
+    legacy_plan = ManifestBackfillPlan(
+        path=plan.path,
+        validation_errors=plan.validation_errors,
+        fields=[legacy_entry if f.field_name == "validator_version" else f for f in plan.fields],
+        has_inferred=plan.has_inferred,
+        has_ambiguous=plan.has_ambiguous,
+        has_blocked=plan.has_blocked,
+    )
+
+    manifest_path = tmp_path / "legacy_fallback.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.manifest_lineage_graph._analyze_manifest_at_path",
+        lambda _path: legacy_plan,
+    )
+    graph = build_manifest_lineage_graph([manifest_path])
+    ambiguous_edges = [edge for edge in graph.edges if edge.kind == "ambiguous_between"]
+    targets = {edge.target for edge in ambiguous_edges}
+    assert any("metadata_validator_version" in target for target in targets)
+    assert any("config_validator_version" in target for target in targets)
+
+
+def _sorted_edge_tuples(edges):
+    """Return a sorted tuple representation of edges for comparison."""
+    return tuple(sorted((edge.source, edge.target, edge.kind) for edge in edges))


### PR DESCRIPTION
## Summary
Replaces manifest-lineage proxy edge construction from reason-string parsing with structured backfill metadata. The change keeps human-readable reasons and legacy fallback, but new graph topology now depends on typed source fields.

## Linked Issues
- Closes `#2906`
- Relates to `#2659`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#2905` remains separate for the broader graph-builder refactor
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `candidate_sources`, `conflicting_sources`, and `blocked_by` to `FieldBackfillEntry`.
- Populated those fields during manifest-lineage backfill classification.
- Updated manifest-lineage graph edge construction to consume structured metadata first, with reason parsing retained only as legacy fallback.
- Added regression tests for serialization, wording-stable graph topology, mixed valid/invalid ambiguous sources, and legacy reason-only entries.
- Documented the additive compatibility contract in `docs/context/issue_2659_lineage_schema_unification.md`.

## Why It Matters
- Added value: prevents wording-only reason changes from silently changing lineage graph topology.
- Expected impact: stronger artifact audit reliability for lineage reports.
- Why this is worth merging now: lineage tooling is still new, so hardening the schema before more downstream reports depend on it is cheaper and safer.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling artifact-quality fix; no research claim.
- Comparator or baseline, if applicable: previous graph builder parsed proxy labels from prose `reason` strings.
- Evidence tier: NA - support helper.
- Result classification: blocker-resolution for audit brittleness.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2659_lineage_schema_unification.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this hardens an existing support tool and does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue using structured lineage metadata for graph audit surfaces.
- Proposed child issue or existing follow-up: `#2905` for the broader typed-stage graph-builder refactor.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_backfill.py tests/benchmark/test_manifest_lineage_graph.py -q` -> `55 passed`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/manifest_lineage_backfill.py robot_sf/benchmark/manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_backfill.py tests/benchmark/test_manifest_lineage_graph.py` -> pass
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/manifest_lineage_backfill.py robot_sf/benchmark/manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_backfill.py tests/benchmark/test_manifest_lineage_graph.py` -> pass
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_2659_lineage_schema_unification.md` -> pass
  - `git diff --check` -> pass
  - `git fetch origin main && git merge --ff-only origin/main && uv sync --all-extras && PYTEST_NUM_WORKERS=8 BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh` -> pass on initial head `5f719ccda8c83016976fe353ee5b431c996415f6`; after review fixes, targeted lineage pytest/ruff/format/docs checks passed on amended head `7fa211e35a74a9587a16a03055471943613f25f4`
- Evidence that the change works here: full readiness on the initial implementation head reported `6830 passed, 9 skipped, 9 warnings`; amended-head targeted checks reported `55 passed` plus ruff/format/docs consistency; changed-file coverage was `94.8%` for `manifest_lineage_backfill.py` and `95.5%` for `manifest_lineage_graph.py` (goal warning only, above the 80% minimum).
- Benchmarks or smoke tests, if applicable: NA - support/tooling change, no benchmark evidence claim.

## Risks / Rollout
- Compatibility risks: additive dataclass fields change serialized Python dict shape; defaults preserve older construction paths, and legacy reason parsing remains as fallback when structured fields are absent.
- Failure modes: downstream consumers that depended on exact reason-derived topology should now rely on typed metadata; tests cover the intended stable topology behavior.
- Rollback or fallback plan: revert this PR to restore reason parsing as the primary graph edge source.

## Docs / Provenance
- Updated docs: `docs/context/issue_2659_lineage_schema_unification.md`
- Relevant design or provenance notes: self-review note recorded in common Git-dir inbox for the delegated Kimi route.
- Any assumptions that need to be preserved: this remains reviewability/artifact-quality work only, not benchmark or paper-facing evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes `#2906`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): context note updated; no index change needed because the note was already indexed.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; existing `#2905` covers the broader refactor.
- Not applicable because: this is a support/tooling schema-hardening change without a new research claim.

## Follow-Up Issues
- Deferred work: graph builder stage refactor and collision-safe node IDs remain in `#2905`.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify `_proxy_edge_kind_and_labels()` includes `blocked_by` labels for ambiguous valid+invalid entries; this was a parent-review fix after the delegated worker output.
- Known limitation: no global audit of external consumers of reason strings was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation describing structured proxy metadata fields for manifest lineage backfill entries, clarifying how lineage information sources are tracked.

* **Refactor**
  * Enhanced internal tracking of lineage sources through structured metadata, improving artifact quality and traceability while maintaining backward compatibility with legacy approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->