### PR TITLE
refactor: split lineage graph construction stages

### DIFF
--- a/docs/context/issue_2659_lineage_schema_unification.md
+++ b/docs/context/issue_2659_lineage_schema_unification.md
@@ -63,3 +63,13 @@ string for reader context and legacy fallback.
 This remains reviewability and artifact-quality work only. It hardens graph topology against wording
 changes, but it does not upgrade any manifest, graph row, or artifact candidate into benchmark or
 paper-facing evidence.
+
+## Issue #2905 Node ID Collision Safety 2026-06-16
+
+Issue #2905 refactors the lineage graph builder into smaller typed construction stages and makes
+manifest, lineage-field, proxy-source, and artifact-candidate node IDs collision-safe. Distinct
+inputs that previously sanitized to the same base string (for example ``a/b`` and ``a__b``) now
+receive distinct node IDs through a compact deterministic hash suffix.
+
+The public graph schema is unchanged; only internal ``id`` values differ. Lineage-field node IDs
+keep the field name as the final segment so that adjacency and label lookups remain readable.

--- a/robot_sf/benchmark/manifest_lineage_graph.py
+++ b/robot_sf/benchmark/manifest_lineage_graph.py
@@ -8,6 +8,7 @@ rewrites manifests and marks inferred or ambiguous lineage explicitly.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -25,6 +26,7 @@ from robot_sf.benchmark.manifest_lineage_backfill import (
 from robot_sf.common.artifact_paths import get_repository_root
 
 SCHEMA_VERSION = "manifest_lineage_graph.v1"
+ID_HASH_HEX_LENGTH = 12
 
 
 class LineageStatus:
@@ -150,19 +152,31 @@ def _sanitize_id(value: str) -> str:
     )
 
 
+def _collision_safe_id(value: str) -> str:
+    """Return a sanitized identifier with a deterministic disambiguation suffix.
+
+    Distinct inputs that sanitize to the same base string (for example
+    ``a/b`` and ``a__b``) still receive distinct node IDs because the suffix
+    is computed from the original, unsanitized value.
+    """
+    sanitized = _sanitize_id(value)
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:ID_HASH_HEX_LENGTH]
+    return f"{sanitized}__{digest}"
+
+
 def _manifest_node_id(path: str) -> str:
     """Stable node id for a manifest path."""
-    return f"manifest__{_sanitize_id(path)}"
+    return f"manifest__{_collision_safe_id(path)}"
 
 
 def _field_node_id(manifest_path: str, field_name: str) -> str:
     """Stable node id for a lineage field inside a manifest."""
-    return f"field__{_sanitize_id(manifest_path)}__{field_name}"
+    return f"field__{_collision_safe_id(manifest_path)}__{field_name}"
 
 
 def _proxy_node_id(manifest_path: str, proxy_path: str) -> str:
     """Stable node id for a proxy source path inside a manifest."""
-    return f"proxy__{_sanitize_id(manifest_path)}__{_sanitize_id(proxy_path)}"
+    return f"proxy__{_collision_safe_id(manifest_path)}__{_collision_safe_id(proxy_path)}"
 
 
 def _contract_node_id() -> str:
@@ -172,7 +186,7 @@ def _contract_node_id() -> str:
 
 def _artifact_node_id(artifact_id: str) -> str:
     """Stable node id for an artifact candidate."""
-    return f"artifact__{_sanitize_id(artifact_id)}"
+    return f"artifact__{_collision_safe_id(artifact_id)}"
 
 
 def _now_utc() -> str:
@@ -300,7 +314,189 @@ def _analyze_manifest_at_path(path: Path) -> ManifestBackfillPlan:
     return analyze_manifest(dict(payload), path=rel_path)
 
 
-def build_manifest_lineage_graph(  # noqa: C901, PLR0915
+def _build_contract_node() -> tuple[str, LineageNode]:
+    """Build the shared lineage contract node and return its id plus node."""
+    contract_node_id = _contract_node_id()
+    return contract_node_id, LineageNode(
+        node_id=contract_node_id,
+        kind="validation_contract",
+        label="Manifest Lineage Contract",
+        status=LineageStatus.CONNECTED,
+        payload={"mandatory_fields": list(MANDATORY_LINEAGE_FIELDS)},
+    )
+
+
+def _build_manifest_subgraph(
+    plan: ManifestBackfillPlan,
+    contract_node_id: str,
+    nodes: dict[str, LineageNode],
+    edges: list[LineageEdge],
+) -> None:
+    """Add a manifest node, its field nodes, and proxy edges to the graph."""
+    rel_path = plan.path
+    manifest_node_id = _manifest_node_id(rel_path)
+    nodes[manifest_node_id] = LineageNode(
+        node_id=manifest_node_id,
+        kind="manifest",
+        label=Path(rel_path).name,
+        path=rel_path,
+        status=LineageStatus.CONNECTED,
+        payload={"validation_errors": plan.validation_errors},
+    )
+    edges.append(
+        LineageEdge(
+            source=manifest_node_id,
+            target=contract_node_id,
+            kind="validates_with",
+            reason="manifest is checked against the shared lineage contract",
+        )
+    )
+
+    for entry in plan.fields:
+        field_id = _field_node_id(rel_path, entry.field_name)
+        field_status = _lineage_status_from_entry(entry)
+        nodes[field_id] = LineageNode(
+            node_id=field_id,
+            kind="lineage_field",
+            label=entry.field_name,
+            path=rel_path,
+            status=field_status,
+            payload={"status": entry.status.value},
+        )
+        edges.append(
+            LineageEdge(
+                source=manifest_node_id,
+                target=field_id,
+                kind="has_field",
+                reason=f"manifest contains lineage field {entry.field_name}",
+            )
+        )
+
+        if entry.status == FieldStatus.PRESENT:
+            continue
+
+        if entry.status == FieldStatus.INFERRED and entry.inferred_from is not None:
+            _add_inferred_proxy_edge(nodes, edges, rel_path, field_id, entry)
+            continue
+
+        # Derive proxy-related edges from structured metadata.  Older plans
+        # that only stored a reason string fall back to parsing the reason.
+        edge_kind, proxy_labels = _proxy_edge_kind_and_labels(entry)
+        if not edge_kind:
+            continue
+
+        for label in proxy_labels:
+            proxy_id = _proxy_node_id(rel_path, label)
+            if proxy_id not in nodes:
+                nodes[proxy_id] = LineageNode(
+                    node_id=proxy_id,
+                    kind="proxy_source",
+                    label=label,
+                    path=rel_path,
+                    status=field_status,
+                )
+            edges.append(
+                LineageEdge(
+                    source=field_id,
+                    target=proxy_id,
+                    kind=edge_kind,
+                    reason=entry.reason,
+                )
+            )
+
+
+def _candidate_text(
+    candidate: Mapping[str, Any],
+    key: str,
+    *,
+    default: str = "",
+    fallback_on_blank: bool = False,
+) -> str:
+    """Return stripped candidate text while treating explicit None as missing."""
+    value = candidate.get(key)
+    if value is None:
+        return default
+    text = str(value).strip()
+    if fallback_on_blank and not text:
+        return default
+    return text
+
+
+def _build_artifact_trace(
+    candidate: Mapping[str, Any],
+    path_to_plan: dict[str, ManifestBackfillPlan],
+    repo_root: Path,
+    candidate_source_path: Path | None,
+    nodes: dict[str, LineageNode],
+    edges: list[LineageEdge],
+) -> ArtifactTrace:
+    """Add an artifact candidate node/edge and return its trace record."""
+    artifact_id = _candidate_text(
+        candidate,
+        "artifact_id",
+        default="unnamed_artifact",
+        fallback_on_blank=True,
+    )
+    artifact_kind = _candidate_text(candidate, "artifact_kind", default="artifact")
+    claim_boundary = _candidate_text(candidate, "claim_boundary")
+    manifest_value = _candidate_text(candidate, "source_manifest_path")
+
+    if not manifest_value:
+        trace_status = LineageStatus.INCONCLUSIVE
+        reason = "candidate has no source_manifest_path"
+        field_statuses: dict[str, str] = {}
+        source_manifest_path = ""
+    else:
+        resolved = _resolve_manifest_path(
+            manifest_value, candidate_path=candidate_source_path, repo_root=repo_root
+        )
+        source_manifest_path = _repo_relative(resolved)
+        matching_plan = path_to_plan.get(source_manifest_path)
+        if matching_plan is None:
+            trace_status = LineageStatus.INCONCLUSIVE
+            reason = f"source manifest not found in graph inputs: {source_manifest_path}"
+            field_statuses = {}
+        else:
+            trace_status, reason = _trace_lineage_status(matching_plan.fields)
+            field_statuses = _field_statuses(matching_plan.fields)
+
+    artifact_node_id = _artifact_node_id(artifact_id)
+    if artifact_node_id not in nodes:
+        nodes[artifact_node_id] = LineageNode(
+            node_id=artifact_node_id,
+            kind="artifact_candidate",
+            label=artifact_id,
+            path=source_manifest_path,
+            status=trace_status,
+            payload={
+                "artifact_kind": artifact_kind,
+                "claim_boundary": claim_boundary,
+            },
+        )
+    if source_manifest_path:
+        manifest_node_id = _manifest_node_id(source_manifest_path)
+        if manifest_node_id in nodes:
+            edges.append(
+                LineageEdge(
+                    source=artifact_node_id,
+                    target=manifest_node_id,
+                    kind="traces_to",
+                    reason=f"{artifact_kind} traces to source manifest",
+                )
+            )
+
+    return ArtifactTrace(
+        artifact_id=artifact_id,
+        artifact_kind=artifact_kind,
+        source_manifest_path=source_manifest_path,
+        claim_boundary=claim_boundary,
+        lineage_status=trace_status,
+        reason=reason,
+        field_statuses=field_statuses,
+    )
+
+
+def build_manifest_lineage_graph(
     manifest_paths: Sequence[Path],
     *,
     artifact_candidates: Sequence[Mapping[str, Any]] = (),
@@ -325,154 +521,24 @@ def build_manifest_lineage_graph(  # noqa: C901, PLR0915
     edges: list[LineageEdge] = []
     traces: list[ArtifactTrace] = []
 
-    contract_node_id = _contract_node_id()
-    nodes[contract_node_id] = LineageNode(
-        node_id=contract_node_id,
-        kind="validation_contract",
-        label="Manifest Lineage Contract",
-        status=LineageStatus.CONNECTED,
-        payload={"mandatory_fields": list(MANDATORY_LINEAGE_FIELDS)},
-    )
+    contract_node_id, contract_node = _build_contract_node()
+    nodes[contract_node_id] = contract_node
+
+    plans = [_analyze_manifest_at_path(path) for path in _dedupe_paths(manifest_paths)]
+    for plan in plans:
+        _build_manifest_subgraph(plan, contract_node_id, nodes, edges)
 
     repo_root = get_repository_root()
-    rel_manifest_paths = []
-    plans: list[ManifestBackfillPlan] = []
-
-    for path in _dedupe_paths(manifest_paths):
-        plan = _analyze_manifest_at_path(path)
-        plans.append(plan)
-        rel_path = plan.path or _repo_relative(path)
-        rel_manifest_paths.append(rel_path)
-        manifest_node_id = _manifest_node_id(rel_path)
-        nodes[manifest_node_id] = LineageNode(
-            node_id=manifest_node_id,
-            kind="manifest",
-            label=Path(rel_path).name,
-            path=rel_path,
-            status=LineageStatus.CONNECTED,
-            payload={"validation_errors": plan.validation_errors},
-        )
-        edges.append(
-            LineageEdge(
-                source=manifest_node_id,
-                target=contract_node_id,
-                kind="validates_with",
-                reason="manifest is checked against the shared lineage contract",
-            )
-        )
-
-        for entry in plan.fields:
-            field_id = _field_node_id(rel_path, entry.field_name)
-            field_status = _lineage_status_from_entry(entry)
-            nodes[field_id] = LineageNode(
-                node_id=field_id,
-                kind="lineage_field",
-                label=entry.field_name,
-                path=rel_path,
-                status=field_status,
-                payload={"status": entry.status.value},
-            )
-            edges.append(
-                LineageEdge(
-                    source=manifest_node_id,
-                    target=field_id,
-                    kind="has_field",
-                    reason=f"manifest contains lineage field {entry.field_name}",
-                )
-            )
-
-            if entry.status == FieldStatus.PRESENT:
-                continue
-
-            if entry.status == FieldStatus.INFERRED and entry.inferred_from is not None:
-                _add_inferred_proxy_edge(nodes, edges, rel_path, field_id, entry)
-                continue
-
-            # Derive proxy-related edges from structured metadata.  Older plans
-            # that only stored a reason string fall back to parsing the reason.
-            edge_kind, proxy_labels = _proxy_edge_kind_and_labels(entry)
-            if not edge_kind:
-                continue
-
-            for label in proxy_labels:
-                proxy_id = _proxy_node_id(rel_path, label)
-                if proxy_id not in nodes:
-                    nodes[proxy_id] = LineageNode(
-                        node_id=proxy_id,
-                        kind="proxy_source",
-                        label=label,
-                        path=rel_path,
-                        status=field_status,
-                    )
-                edges.append(
-                    LineageEdge(
-                        source=field_id,
-                        target=proxy_id,
-                        kind=edge_kind,
-                        reason=entry.reason,
-                    )
-                )
-
-    # Trace artifact candidates back to manifests.
     path_to_plan = {plan.path: plan for plan in plans}
     for candidate in artifact_candidates:
-        artifact_id = str(candidate.get("artifact_id", "")).strip() or "unnamed_artifact"
-        artifact_kind = str(candidate.get("artifact_kind", "artifact")).strip()
-        claim_boundary = str(candidate.get("claim_boundary", "")).strip()
-        manifest_value = str(candidate.get("source_manifest_path", "")).strip()
-        if not manifest_value:
-            trace_status = LineageStatus.INCONCLUSIVE
-            reason = "candidate has no source_manifest_path"
-            field_statuses: dict[str, str] = {}
-            source_manifest_path = ""
-        else:
-            resolved = _resolve_manifest_path(
-                manifest_value, candidate_path=candidate_source_path, repo_root=repo_root
-            )
-            source_manifest_path = _repo_relative(resolved)
-            matching_plan = path_to_plan.get(source_manifest_path)
-            if matching_plan is None:
-                trace_status = LineageStatus.INCONCLUSIVE
-                reason = f"source manifest not found in graph inputs: {source_manifest_path}"
-                field_statuses = {}
-            else:
-                trace_status, reason = _trace_lineage_status(matching_plan.fields)
-                field_statuses = _field_statuses(matching_plan.fields)
-
-        artifact_node_id = _artifact_node_id(artifact_id)
-        if artifact_node_id not in nodes:
-            nodes[artifact_node_id] = LineageNode(
-                node_id=artifact_node_id,
-                kind="artifact_candidate",
-                label=artifact_id,
-                path=source_manifest_path,
-                status=trace_status,
-                payload={
-                    "artifact_kind": artifact_kind,
-                    "claim_boundary": claim_boundary,
-                },
-            )
-        if source_manifest_path:
-            manifest_node_id = _manifest_node_id(source_manifest_path)
-            if manifest_node_id in nodes:
-                edges.append(
-                    LineageEdge(
-                        source=artifact_node_id,
-                        target=manifest_node_id,
-                        kind="traces_to",
-                        reason=f"{artifact_kind} traces to source manifest",
-                    )
-                )
-
         traces.append(
-            ArtifactTrace(
-                artifact_id=artifact_id,
-                artifact_kind=artifact_kind,
-                source_manifest_path=source_manifest_path,
-                claim_boundary=claim_boundary,
-                lineage_status=trace_status,
-                reason=reason,
-                field_statuses=field_statuses,
+            _build_artifact_trace(
+                candidate,
+                path_to_plan,
+                repo_root,
+                candidate_source_path,
+                nodes,
+                edges,
             )
         )
 

--- a/tests/benchmark/test_manifest_lineage_graph.py
+++ b/tests/benchmark/test_manifest_lineage_graph.py
@@ -118,6 +118,42 @@ def test_orphan_candidate_is_inconclusive() -> None:
     assert trace.lineage_status == LineageStatus.INCONCLUSIVE
 
 
+def test_artifact_candidates_handle_none_and_falsy_values() -> None:
+    """Explicit null values use fallbacks while numeric identifiers stay distinct."""
+    manifest_path = FIXTURE_DIR / "connected_manifest.json"
+    candidates = [
+        {
+            "artifact_id": None,
+            "artifact_kind": None,
+            "source_manifest_path": None,
+            "claim_boundary": None,
+        },
+        {
+            "artifact_id": 0,
+            "artifact_kind": 0,
+            "source_manifest_path": None,
+            "claim_boundary": 0,
+        },
+    ]
+
+    graph = build_manifest_lineage_graph([manifest_path], artifact_candidates=candidates)
+
+    fallback_trace = next(t for t in graph.traces if t.artifact_id == "unnamed_artifact")
+    assert fallback_trace.artifact_kind == "artifact"
+    assert fallback_trace.claim_boundary == ""
+    assert fallback_trace.source_manifest_path == ""
+    assert fallback_trace.lineage_status == LineageStatus.INCONCLUSIVE
+
+    zero_trace = next(t for t in graph.traces if t.artifact_id == "0")
+    assert zero_trace.artifact_kind == "0"
+    assert zero_trace.claim_boundary == "0"
+    assert zero_trace.source_manifest_path == ""
+
+    artifact_labels = {node.label for node in graph.nodes if node.kind == "artifact_candidate"}
+    assert "None" not in artifact_labels
+    assert {"unnamed_artifact", "0"}.issubset(artifact_labels)
+
+
 def test_graph_nodes_include_contract_manifest_and_fields() -> None:
     """The graph contains the validation contract, manifest, and field nodes."""
     manifest_path = FIXTURE_DIR / "connected_manifest.json"
@@ -131,6 +167,38 @@ def test_graph_nodes_include_contract_manifest_and_fields() -> None:
 
     assert any(edge.kind == "validates_with" for edge in graph.edges)
     assert any(edge.kind == "has_field" for edge in graph.edges)
+
+
+def test_graph_keeps_sanitized_path_collisions_distinct(tmp_path: Path) -> None:
+    """Graph construction keeps distinct manifests with colliding sanitized paths separate."""
+    manifest = _load_fixture("connected_manifest.json")
+    nested_path = tmp_path / "x" / "a" / "b.json"
+    flat_path = tmp_path / "x" / "a__b.json"
+    nested_path.parent.mkdir(parents=True)
+    nested_path.write_text(json.dumps(manifest), encoding="utf-8")
+    flat_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    graph = build_manifest_lineage_graph([nested_path, flat_path])
+
+    manifest_ids = sorted(node.node_id for node in graph.nodes if node.kind == "manifest")
+    assert len(manifest_ids) == 2
+    assert manifest_ids[0] != manifest_ids[1]
+    assert all("a__b_json" in node_id for node_id in manifest_ids)
+
+    source_field_ids = sorted(
+        node.node_id
+        for node in graph.nodes
+        if node.kind == "lineage_field" and node.label == "source"
+    )
+    assert len(source_field_ids) == 2
+    assert source_field_ids[0] != source_field_ids[1]
+    assert all(node_id.endswith("__source") for node_id in source_field_ids)
+
+    manifest_to_source_edges = [
+        edge for edge in graph.edges if edge.kind == "has_field" and edge.target in source_field_ids
+    ]
+    assert len(manifest_to_source_edges) == 2
+    assert {edge.source for edge in manifest_to_source_edges} == set(manifest_ids)
 
 
 def test_markdown_report_contains_summary_and_traces() -> None:
@@ -616,3 +684,39 @@ def test_legacy_reason_fallback_still_produces_edges(
 def _sorted_edge_tuples(edges):
     """Return a sorted tuple representation of edges for comparison."""
     return tuple(sorted((edge.source, edge.target, edge.kind) for edge in edges))
+
+
+def test_collision_safe_node_ids_for_distinct_inputs() -> None:
+    """Distinct inputs that sanitize to the same base string get distinct node IDs."""
+    from robot_sf.benchmark.manifest_lineage_graph import (
+        _artifact_node_id,
+        _field_node_id,
+        _manifest_node_id,
+        _proxy_node_id,
+    )
+
+    # These pairs sanitized to the same identifier before the collision-safe
+    # suffix was added (e.g. "a/b" and "a__b" both became "a__b").
+    manifest_a = _manifest_node_id("x/a/b.json")
+    manifest_b = _manifest_node_id("x/a__b.json")
+    assert manifest_a != manifest_b
+    assert "a__b" in manifest_a
+    assert "a__b" in manifest_b
+
+    field_a = _field_node_id("x/a/b.json", "artifact_kind")
+    field_b = _field_node_id("x/a__b.json", "artifact_kind")
+    assert field_a != field_b
+    assert field_a.endswith("__artifact_kind")
+    assert field_b.endswith("__artifact_kind")
+
+    proxy_a = _proxy_node_id("m.json", "a/b")
+    proxy_b = _proxy_node_id("m.json", "a__b")
+    assert proxy_a != proxy_b
+    assert "a__b" in proxy_a
+    assert "a__b" in proxy_b
+
+    artifact_a = _artifact_node_id("a/b")
+    artifact_b = _artifact_node_id("a__b")
+    assert artifact_a != artifact_b
+    assert "a__b" in artifact_a
+    assert "a__b" in artifact_b


### PR DESCRIPTION
## Summary
Split the manifest lineage graph builder into smaller typed construction stages and add deterministic collision-safe graph node IDs.

Closes #2905.

## Linked Issues
- Closes `#2905`
- Relates to `#2659`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a deterministic hash-suffixed ID helper so manifest, lineage-field, proxy-source, and artifact-candidate node IDs do not collide when distinct inputs sanitize to the same string.
- Split `build_manifest_lineage_graph()` into `_build_contract_node`, `_build_manifest_subgraph`, and `_build_artifact_trace`, removing the broad `C901`/`PLR0915` suppression.
- Added helper-level and public graph-builder regression tests for sanitized path collisions.
- Updated `docs/context/issue_2659_lineage_schema_unification.md` with the node-ID compatibility note.

## Why It Matters
- Added value: lineage graph output is more robust and the builder is easier to review safely.
- Expected impact: artifact-quality improvement for lineage reports; no benchmark metric or claim boundary changes.
- Why this is worth merging now: it reduces follow-on risk for lineage schema/report work while the surrounding module is active.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: `NA - artifact-quality refactor; no research claim.`
- Comparator or baseline, if applicable: `NA`
- Evidence tier: `NA`
- Result classification: `NA`
- Decision or stop rule, if applicable: `NA`
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2659_lineage_schema_unification.md`
- New research/benchmark/metric/paper-facing analysis tool, if any: `NA - no new analysis tool or research interpretation.`

## Falsification / Non-Transfer Check
- Did the mechanism activate? `NA - no research mechanism claim.`
- Did the intervention change command source, selected command, trajectory, or route progress? `NA`
- Did the scenario actually contain the targeted failure mode? `NA`
- Result route: `NA`
- Follow-up question or issue for weak, negative, or non-transfer results: `NA`

## Next Empirical Action
- Rerun needed: `NA`
- Extractor or analysis tool needed: `NA`
- Artifact missing or unavailable: `NA`
- Stop / revise / continue decision: `NA`
- Proposed child issue or existing follow-up: `NA`

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_manifest_lineage_graph.py -q` PASS, 26 passed.
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/ -q -m 'not slow'` PASS, 15 passed, 1222 deselected.
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py` PASS.
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/manifest_lineage_graph.py tests/benchmark/test_manifest_lineage_graph.py` PASS.
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/manifest_lineage_graph.py --select C901,PLR0915` PASS.
  - `scripts/dev/check_docs_proof_consistency_diff.sh` PASS.
  - `git diff --check` PASS.
  - `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` PASS on amended head `8d3c53725d92e677d603599576fb3d5b8ba52cd2`: 6833 passed, 9 skipped, 8 warnings.
- Evidence that the change works here: public graph-builder regression test proves two distinct manifests whose paths previously sanitized to the same ID remain distinct with correct field edges.
- Benchmarks or smoke tests, if applicable: `NA - no benchmark execution or metric claim.`

## Risks / Rollout
- Compatibility risks: internal graph node `id` values now include compact hash suffixes; consumers that parse exact legacy IDs may need updates.
- Failure modes: 12-hex hash suffix collisions are theoretically possible but far less likely than the prior deterministic sanitization collision.
- Rollback or fallback plan: revert this refactor to restore legacy ID construction if an untracked downstream consumer depends on exact ID strings.

## Docs / Provenance
- Updated docs: `docs/context/issue_2659_lineage_schema_unification.md`
- Relevant design or provenance notes: the context note records that schema shape is unchanged while internal IDs differ.
- Any assumptions that need to be preserved: graph consumers should treat `id` as opaque and use labels/payloads for display semantics.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR.
- Claim map / benchmark report updated (yes/no/NA): `NA`
- Leaderboard / artifact catalog updated (yes/no/NA): `NA`
- Registry or config index updated (yes/no/NA): `NA`
- Context index / memory note updated (yes/no/NA): context note updated; index update not needed for this local compatibility paragraph.
- Follow-up issue opened for deferred propagation (yes/no/NA): `NA`
- Not applicable because: this is an internal artifact-quality refactor with no benchmark, registry, leaderboard, or claim-map propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: node ID compatibility note and the new collision regression.
- Any known limitations: IDs are collision-resistant, not mathematically collision-proof.
