### PR TITLE
Add worktree hygiene snapshot helper

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -323,6 +323,16 @@ label, merge, or publication decisions. Raw logs and broad CLI output are approp
 snapshot reports `ok: false`, stale claims, missing state, or insufficient fields.
 Worktree rows are capped by default; use `worktree_count` and `worktrees_truncated` to decide
 whether a larger `--worktree-limit` is worth the parent-thread context cost.
+For remote cleanup and branch-drift triage, use the read-only hygiene snapshot before broad
+`git worktree` output or stale-worktree cleanup:
+
+```bash
+uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --json
+```
+
+The payload reports total and included worktree counts, dirty worktrees, missing upstreams,
+ahead/behind drift, detached heads, and truncation status. Use `--filter <branch-or-path-substring>`
+or `--worktree-limit <n>` when remote hosts have many linked worktrees.
 
 For delegation routing and PR-review polling, treat `snapshot_pr_queue` as the entry point:
 

--- a/scripts/dev/worktree_hygiene_snapshot.py
+++ b/scripts/dev/worktree_hygiene_snapshot.py
@@ -132,8 +132,6 @@ def _parse_worktree_line(line: str, current: dict[str, str]) -> dict[str, str]:
         current["head_sha"] = value
     elif key == "branch":
         current["branch"] = value.removeprefix("refs/heads/")
-    elif key == "detached":
-        current["detached"] = "true"
     return current
 
 
@@ -274,7 +272,11 @@ def build_snapshot(
     selected = filtered if include_all_worktrees else filtered[:worktree_limit]
     worktrees = [_build_row(row, current_path) for row in selected]
     current_worktree = next(
-        (row.get("path") for row in parsed if Path(row.get("path", "")).resolve() == current_path),
+        (
+            row["path"]
+            for row in parsed
+            if row.get("path") and Path(row["path"]).resolve() == current_path
+        ),
         None,
     )
     issue_counts: dict[str, int] = {}

--- a/scripts/dev/worktree_hygiene_snapshot.py
+++ b/scripts/dev/worktree_hygiene_snapshot.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Emit a compact worktree hygiene snapshot.
+
+This helper is read-only. It summarizes branch drift, dirty worktrees, detached
+heads, and missing upstreams without printing full `git worktree` output. Use it
+before remote maintenance, stale-worktree cleanup planning, or broad PR loops.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+SCHEMA_VERSION = "worktree_hygiene_snapshot.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeHygiene:
+    """A compact per-worktree hygiene row."""
+
+    path: str
+    branch: str
+    head_sha: str
+    is_current: bool
+    is_detached: bool
+    dirty_entries: int
+    upstream: str | None
+    ahead: int | None
+    behind: int | None
+    issues: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class RepoStatus:
+    """Optional status for the current checkout."""
+
+    branch_status: str
+    dirty_entries: int
+    ahead: int | None
+    behind: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class HygieneSnapshot:
+    """Full worktree hygiene snapshot."""
+
+    schema: str
+    current_worktree: str | None
+    total_worktrees: int
+    included_worktrees: int
+    worktrees_truncated: bool
+    filters: list[str]
+    issue_counts: dict[str, int]
+    repo_status: RepoStatus | None
+    worktrees: list[WorktreeHygiene]
+    errors: list[str]
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    """Run a command and capture output."""
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=f"command timed out after {timeout} seconds",
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=127,
+            stdout="",
+            stderr=str(exc),
+        )
+
+
+def _parse_worktree_porcelain(stdout: str) -> list[dict[str, str]]:
+    """Parse `git worktree list --porcelain` rows."""
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        parts = line.split(" ", 1)
+        if len(parts) != 2:
+            if line == "detached":
+                current["detached"] = "true"
+            continue
+        key, value = parts
+        if key == "worktree":
+            if current:
+                worktrees.append(current)
+            current = {"path": value}
+        elif key == "HEAD":
+            current["head_sha"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key == "detached":
+            current["detached"] = "true"
+
+    if current:
+        worktrees.append(current)
+
+    return worktrees
+
+
+def _matches_filters(row: dict[str, str], filters: list[str]) -> bool:
+    """Return whether a worktree row matches any branch/path filter."""
+    if not filters:
+        return True
+    haystack = " ".join((row.get("path", ""), row.get("branch", ""))).lower()
+    return any(value.lower() in haystack for value in filters)
+
+
+def _dirty_entry_count(path: str) -> int:
+    """Count short-status rows for a worktree."""
+    result = _run_command(["git", "status", "--porcelain"], cwd=path)
+    if result.returncode != 0:
+        return -1
+    return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+def _upstream(path: str) -> str | None:
+    """Return the configured upstream branch, if any."""
+    result = _run_command(["git", "rev-parse", "--abbrev-ref", "@{upstream}"], cwd=path)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _ahead_behind(path: str, upstream: str | None) -> tuple[int | None, int | None]:
+    """Return ahead and behind counts relative to upstream."""
+    if not upstream:
+        return None, None
+    result = _run_command(
+        ["git", "rev-list", "--left-right", "--count", f"HEAD...{upstream}"], cwd=path
+    )
+    if result.returncode != 0:
+        return None, None
+    parts = result.stdout.split()
+    if len(parts) != 2:
+        return None, None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None, None
+
+
+def _classify_issues(
+    *,
+    branch: str,
+    is_detached: bool,
+    dirty_entries: int,
+    upstream: str | None,
+    ahead: int | None,
+    behind: int | None,
+) -> list[str]:
+    """Classify hygiene issues for a worktree."""
+    issues: list[str] = []
+    if is_detached:
+        issues.append("detached")
+    if dirty_entries < 0:
+        issues.append("status_failed")
+    elif dirty_entries > 0:
+        issues.append("dirty")
+    if branch and not upstream:
+        issues.append("missing_upstream")
+    if ahead:
+        issues.append("ahead")
+    if behind:
+        issues.append("behind")
+    return issues
+
+
+def _repo_status() -> RepoStatus | None:
+    """Build optional status for the current checkout."""
+    status = _run_command(["git", "status", "--short", "--branch"])
+    if status.returncode != 0:
+        return None
+    lines = status.stdout.splitlines()
+    branch_status = lines[0] if lines else ""
+    upstream = _upstream(".")
+    ahead, behind = _ahead_behind(".", upstream)
+    return RepoStatus(
+        branch_status=branch_status,
+        dirty_entries=max(0, len(lines) - 1),
+        ahead=ahead,
+        behind=behind,
+    )
+
+
+def _build_row(row: dict[str, str], current_path: Path) -> WorktreeHygiene:
+    """Build one hygiene row from a parsed worktree row."""
+    path = row.get("path", "")
+    branch = row.get("branch", "")
+    is_detached = row.get("detached") == "true" or not branch
+    dirty_entries = _dirty_entry_count(path)
+    upstream = None if is_detached else _upstream(path)
+    ahead, behind = _ahead_behind(path, upstream)
+    return WorktreeHygiene(
+        path=path,
+        branch=branch,
+        head_sha=row.get("head_sha", ""),
+        is_current=Path(path).resolve() == current_path.resolve(),
+        is_detached=is_detached,
+        dirty_entries=dirty_entries,
+        upstream=upstream,
+        ahead=ahead,
+        behind=behind,
+        issues=_classify_issues(
+            branch=branch,
+            is_detached=is_detached,
+            dirty_entries=dirty_entries,
+            upstream=upstream,
+            ahead=ahead,
+            behind=behind,
+        ),
+    )
+
+
+def build_snapshot(
+    *,
+    include_all_worktrees: bool = False,
+    worktree_limit: int = 40,
+    filters: list[str] | None = None,
+    include_repo_status: bool = False,
+) -> HygieneSnapshot:
+    """Build a read-only worktree hygiene snapshot."""
+    errors: list[str] = []
+    filter_values = filters or []
+    current_path = Path.cwd().resolve()
+    result = _run_command(["git", "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        errors.append("failed to list worktrees")
+        parsed: list[dict[str, str]] = []
+    else:
+        parsed = _parse_worktree_porcelain(result.stdout)
+
+    filtered = [row for row in parsed if _matches_filters(row, filter_values)]
+    selected = filtered if include_all_worktrees else filtered[:worktree_limit]
+    worktrees = [_build_row(row, current_path) for row in selected]
+    current_worktree = next(
+        (row.get("path") for row in parsed if Path(row.get("path", "")).resolve() == current_path),
+        None,
+    )
+    issue_counts: dict[str, int] = {}
+    for row in worktrees:
+        for issue in row.issues:
+            issue_counts[issue] = issue_counts.get(issue, 0) + 1
+
+    return HygieneSnapshot(
+        schema=SCHEMA_VERSION,
+        current_worktree=current_worktree,
+        total_worktrees=len(parsed),
+        included_worktrees=len(worktrees),
+        worktrees_truncated=len(filtered) > len(selected),
+        filters=filter_values,
+        issue_counts=issue_counts,
+        repo_status=_repo_status() if include_repo_status else None,
+        worktrees=worktrees,
+        errors=errors,
+    )
+
+
+def format_human(snapshot: HygieneSnapshot) -> str:
+    """Format snapshot as human-readable text."""
+    lines = [
+        f"Worktree Hygiene Snapshot (schema: {snapshot.schema})",
+        f"  Current: {snapshot.current_worktree or 'N/A'}",
+        f"  Total worktrees: {snapshot.total_worktrees}",
+        f"  Included worktrees: {snapshot.included_worktrees}",
+        f"  Truncated: {snapshot.worktrees_truncated}",
+    ]
+    if snapshot.filters:
+        lines.append(f"  Filters: {', '.join(snapshot.filters)}")
+    if snapshot.issue_counts:
+        counts = ", ".join(f"{key}={value}" for key, value in sorted(snapshot.issue_counts.items()))
+        lines.append(f"  Issue counts: {counts}")
+    if snapshot.repo_status:
+        repo = snapshot.repo_status
+        lines.append(
+            "  Repo status: "
+            f"{repo.branch_status}; dirty={repo.dirty_entries}; ahead={repo.ahead}; behind={repo.behind}"
+        )
+    if snapshot.worktrees:
+        lines.append("  Worktrees:")
+        for row in snapshot.worktrees:
+            issues = f" [{', '.join(row.issues)}]" if row.issues else ""
+            branch = row.branch or "detached"
+            drift = ""
+            if row.ahead is not None or row.behind is not None:
+                drift = f" ahead={row.ahead} behind={row.behind}"
+            lines.append(f"    - {branch}: {row.path}{drift}{issues}")
+    if snapshot.errors:
+        lines.append("  Errors:")
+        for error in snapshot.errors:
+            lines.append(f"    - {error}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--include-all-worktrees",
+        action="store_true",
+        help="Include all matching worktrees without applying --worktree-limit.",
+    )
+    parser.add_argument(
+        "--worktree-limit", type=int, default=40, help="Maximum worktrees to include."
+    )
+    parser.add_argument(
+        "--filter",
+        dest="filters",
+        action="append",
+        default=[],
+        help="Branch or path substring filter. May repeat.",
+    )
+    parser.add_argument(
+        "--repo-status", action="store_true", help="Include current checkout status."
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    try:
+        snapshot = build_snapshot(
+            include_all_worktrees=args.include_all_worktrees,
+            worktree_limit=args.worktree_limit,
+            filters=args.filters,
+            include_repo_status=args.repo_status,
+        )
+    except Exception as exc:
+        print(f"ERROR building worktree hygiene snapshot: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(asdict(snapshot), indent=2, sort_keys=True))
+    else:
+        print(format_human(snapshot))
+    return 0 if not snapshot.errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/worktree_hygiene_snapshot.py
+++ b/scripts/dev/worktree_hygiene_snapshot.py
@@ -104,27 +104,37 @@ def _parse_worktree_porcelain(stdout: str) -> list[dict[str, str]]:
                 worktrees.append(current)
                 current = {}
             continue
-        parts = line.split(" ", 1)
-        if len(parts) != 2:
-            if line == "detached":
-                current["detached"] = "true"
-            continue
-        key, value = parts
-        if key == "worktree":
+
+        new_row = _parse_worktree_line(line, current)
+        if new_row is not current:
             if current:
                 worktrees.append(current)
-            current = {"path": value}
-        elif key == "HEAD":
-            current["head_sha"] = value
-        elif key == "branch":
-            current["branch"] = value.removeprefix("refs/heads/")
-        elif key == "detached":
-            current["detached"] = "true"
+            current = new_row
 
     if current:
         worktrees.append(current)
 
     return worktrees
+
+
+def _parse_worktree_line(line: str, current: dict[str, str]) -> dict[str, str]:
+    """Apply one porcelain line to the current worktree row."""
+    parts = line.split(" ", 1)
+    if len(parts) != 2:
+        if line == "detached":
+            current["detached"] = "true"
+        return current
+
+    key, value = parts
+    if key == "worktree":
+        return {"path": value}
+    if key == "HEAD":
+        current["head_sha"] = value
+    elif key == "branch":
+        current["branch"] = value.removeprefix("refs/heads/")
+    elif key == "detached":
+        current["detached"] = "true"
+    return current
 
 
 def _matches_filters(row: dict[str, str], filters: list[str]) -> bool:

--- a/tests/dev/test_worktree_hygiene_snapshot.py
+++ b/tests/dev/test_worktree_hygiene_snapshot.py
@@ -200,3 +200,38 @@ def test_current_worktree_is_reported_when_truncated(monkeypatch, tmp_path: Path
     assert result.current_worktree == str(current)
     assert result.included_worktrees == 1
     assert result.worktrees_truncated is True
+
+
+def test_current_worktree_ignores_malformed_rows(monkeypatch, tmp_path: Path) -> None:
+    """Do not let rows without paths match the current checkout."""
+    current = tmp_path / "current"
+    current.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                "\n".join(
+                    [
+                        "HEAD malformed",
+                        "",
+                        f"worktree {current}",
+                        "HEAD aaa",
+                        "branch refs/heads/current",
+                    ]
+                )
+            )
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/current\n")
+        if args == ["git", "rev-list", "--left-right", "--count", "HEAD...origin/current"]:
+            return _result("0\t0\n")
+        raise AssertionError(f"unexpected command: {args} cwd={cwd}")
+
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot()
+
+    assert result.current_worktree == str(current)

--- a/tests/dev/test_worktree_hygiene_snapshot.py
+++ b/tests/dev/test_worktree_hygiene_snapshot.py
@@ -1,0 +1,196 @@
+"""Tests for worktree hygiene snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.dev import worktree_hygiene_snapshot as snapshot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return snapshot.subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_parse_worktree_porcelain_handles_branch_and_detached() -> None:
+    rows = snapshot._parse_worktree_porcelain(
+        "\n".join(
+            [
+                "worktree /repo/main",
+                "HEAD aaa",
+                "branch refs/heads/main",
+                "",
+                "worktree /repo/detached",
+                "HEAD bbb",
+                "detached",
+                "",
+            ]
+        )
+    )
+
+    assert rows == [
+        {"path": "/repo/main", "head_sha": "aaa", "branch": "main"},
+        {"path": "/repo/detached", "head_sha": "bbb", "detached": "true"},
+    ]
+
+
+def test_classify_issues_reports_dirty_missing_upstream_and_drift() -> None:
+    assert snapshot._classify_issues(
+        branch="feature",
+        is_detached=False,
+        dirty_entries=2,
+        upstream=None,
+        ahead=1,
+        behind=3,
+    ) == ["dirty", "missing_upstream", "ahead", "behind"]
+
+
+def test_build_snapshot_filters_and_counts(monkeypatch, tmp_path: Path) -> None:
+    main = tmp_path / "main"
+    feature = tmp_path / "feature"
+    main.mkdir()
+    feature.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                "\n".join(
+                    [
+                        f"worktree {main}",
+                        "HEAD aaa",
+                        "branch refs/heads/main",
+                        "",
+                        f"worktree {feature}",
+                        "HEAD bbb",
+                        "branch refs/heads/feature",
+                        "",
+                    ]
+                )
+            )
+        if args == ["git", "status", "--porcelain"]:
+            return _result(" M changed.py\n" if cwd == str(feature) else "")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            if cwd == str(feature):
+                return _result("origin/feature\n")
+            return _result("origin/main\n")
+        if args == ["git", "rev-list", "--left-right", "--count", "HEAD...origin/feature"]:
+            return _result("1\t2\n")
+        if args == ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"]:
+            return _result("0\t0\n")
+        raise AssertionError(f"unexpected command: {args} cwd={cwd}")
+
+    monkeypatch.chdir(main)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot(filters=["feature"], worktree_limit=10)
+
+    assert result.total_worktrees == 2
+    assert result.included_worktrees == 1
+    assert result.worktrees_truncated is False
+    assert result.issue_counts == {"ahead": 1, "behind": 1, "dirty": 1}
+    assert result.worktrees[0].branch == "feature"
+    assert result.worktrees[0].dirty_entries == 1
+    assert result.worktrees[0].ahead == 1
+    assert result.worktrees[0].behind == 2
+
+
+def test_repo_status_is_optional(monkeypatch, tmp_path: Path) -> None:
+    main = tmp_path / "main"
+    main.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del cwd, timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(f"worktree {main}\nHEAD aaa\nbranch refs/heads/main\n")
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "status", "--short", "--branch"]:
+            return _result("## main...origin/main\n M docs.md\n")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/main\n")
+        if args == ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"]:
+            return _result("0\t4\n")
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.chdir(main)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot(include_repo_status=True)
+
+    assert result.repo_status is not None
+    assert result.repo_status.branch_status == "## main...origin/main"
+    assert result.repo_status.dirty_entries == 1
+    assert result.repo_status.behind == 4
+
+
+def test_missing_worktree_path_marks_status_failed(monkeypatch, tmp_path: Path) -> None:
+    main = tmp_path / "main"
+    missing = tmp_path / "missing"
+    main.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(f"worktree {missing}\nHEAD aaa\nbranch refs/heads/gone\n")
+        if args == ["git", "status", "--porcelain"]:
+            return _result(stderr="missing", returncode=127)
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result(stderr="missing", returncode=127)
+        raise AssertionError(f"unexpected command: {args} cwd={cwd}")
+
+    monkeypatch.chdir(main)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot()
+
+    assert result.included_worktrees == 1
+    assert result.issue_counts == {"missing_upstream": 1, "status_failed": 1}
+    assert result.worktrees[0].dirty_entries == -1
+
+
+def test_current_worktree_is_reported_when_truncated(monkeypatch, tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    current = tmp_path / "current"
+    first.mkdir()
+    current.mkdir()
+
+    def fake_run(args: list[str], *, cwd: str | None = None, timeout: int = 30):
+        del timeout
+        if args == ["git", "worktree", "list", "--porcelain"]:
+            return _result(
+                "\n".join(
+                    [
+                        f"worktree {first}",
+                        "HEAD aaa",
+                        "branch refs/heads/first",
+                        "",
+                        f"worktree {current}",
+                        "HEAD bbb",
+                        "branch refs/heads/current",
+                    ]
+                )
+            )
+        if args == ["git", "status", "--porcelain"]:
+            return _result("")
+        if args == ["git", "rev-parse", "--abbrev-ref", "@{upstream}"]:
+            return _result("origin/first\n")
+        if args == ["git", "rev-list", "--left-right", "--count", "HEAD...origin/first"]:
+            return _result("0\t0\n")
+        raise AssertionError(f"unexpected command: {args} cwd={cwd}")
+
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(snapshot, "_run_command", fake_run)
+
+    result = snapshot.build_snapshot(worktree_limit=1)
+
+    assert result.current_worktree == str(current)
+    assert result.included_worktrees == 1
+    assert result.worktrees_truncated is True

--- a/tests/dev/test_worktree_hygiene_snapshot.py
+++ b/tests/dev/test_worktree_hygiene_snapshot.py
@@ -20,6 +20,7 @@ def _result(stdout: str = "", stderr: str = "", returncode: int = 0):
 
 
 def test_parse_worktree_porcelain_handles_branch_and_detached() -> None:
+    """Parse branch and detached rows from porcelain worktree output."""
     rows = snapshot._parse_worktree_porcelain(
         "\n".join(
             [
@@ -42,6 +43,7 @@ def test_parse_worktree_porcelain_handles_branch_and_detached() -> None:
 
 
 def test_classify_issues_reports_dirty_missing_upstream_and_drift() -> None:
+    """Report all hygiene issue classes represented by one row."""
     assert snapshot._classify_issues(
         branch="feature",
         is_detached=False,
@@ -53,6 +55,7 @@ def test_classify_issues_reports_dirty_missing_upstream_and_drift() -> None:
 
 
 def test_build_snapshot_filters_and_counts(monkeypatch, tmp_path: Path) -> None:
+    """Filter worktrees and aggregate issue counts in the snapshot."""
     main = tmp_path / "main"
     feature = tmp_path / "feature"
     main.mkdir()
@@ -103,6 +106,7 @@ def test_build_snapshot_filters_and_counts(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_repo_status_is_optional(monkeypatch, tmp_path: Path) -> None:
+    """Include current checkout status only when requested."""
     main = tmp_path / "main"
     main.mkdir()
 
@@ -132,6 +136,7 @@ def test_repo_status_is_optional(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_missing_worktree_path_marks_status_failed(monkeypatch, tmp_path: Path) -> None:
+    """Classify missing worktree paths as status failures."""
     main = tmp_path / "main"
     missing = tmp_path / "missing"
     main.mkdir()
@@ -157,6 +162,7 @@ def test_missing_worktree_path_marks_status_failed(monkeypatch, tmp_path: Path) 
 
 
 def test_current_worktree_is_reported_when_truncated(monkeypatch, tmp_path: Path) -> None:
+    """Preserve current worktree identity even when rows are truncated."""
     first = tmp_path / "first"
     current = tmp_path / "current"
     first.mkdir()


### PR DESCRIPTION
## Summary
- add a read-only `scripts/dev/worktree_hygiene_snapshot.py` helper for compact worktree hygiene snapshots
- report dirty entries, missing upstreams, ahead/behind drift, detached heads, stale missing paths, truncation, and optional repo status
- document the helper in the dev guide near the existing compact worktree snapshot workflow

## Validation
- `uv run python -m pytest tests/dev/test_worktree_hygiene_snapshot.py tests/dev/test_compact_worktree_snapshot.py tests/dev/test_stale_worktree_reaper.py`
- `uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --worktree-limit 5 --json`
- pre-commit ruff + ruff format during commit
